### PR TITLE
Automated cherry pick of #80624: Bug fix: Set enableTcpReset of lb rules to true for Azure

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -85,6 +85,10 @@ const (
 	// to create both TCP and UDP protocols when creating load balancer rules.
 	ServiceAnnotationLoadBalancerMixedProtocols = "service.beta.kubernetes.io/azure-load-balancer-mixed-protocols"
 
+	// ServiceAnnotationLoadBalancerDisableTCPReset is the annotation used on the service
+	// to set enableTcpReset to false in load balancer rule. This only works for Azure standard load balancer backed service.
+	ServiceAnnotationLoadBalancerDisableTCPReset = "service.beta.kubernetes.io/azure-load-balancer-disable-tcp-reset"
+
 	// serviceTagKey is the service key applied for public IP tags.
 	serviceTagKey = "service"
 	// clusterNameKey is the cluster name key applied for public IP tags.
@@ -739,6 +743,9 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 
 	// update probes/rules
 	expectedProbes, expectedRules, err := az.reconcileLoadBalancerRule(service, wantLb, lbFrontendIPConfigID, lbBackendPoolID, lbName, lbIdleTimeout)
+	if err != nil {
+		return nil, err
+	}
 
 	// remove unwanted probes
 	dirtyProbes := false
@@ -899,6 +906,15 @@ func (az *Cloud) reconcileLoadBalancerRule(
 		ports = []v1.ServicePort{}
 	}
 
+	var enableTCPReset *bool
+	if az.useStandardLoadBalancer() {
+		enableTCPReset = to.BoolPtr(true)
+		if v, ok := service.Annotations[ServiceAnnotationLoadBalancerDisableTCPReset]; ok {
+			klog.V(2).Infof("reconcileLoadBalancerRule lb name (%s) flag(%s) is set to %s", lbName, ServiceAnnotationLoadBalancerDisableTCPReset, v)
+			enableTCPReset = to.BoolPtr(!strings.EqualFold(v, "true"))
+		}
+	}
+
 	var expectedProbes []network.Probe
 	var expectedRules []network.LoadBalancingRule
 	for _, port := range ports {
@@ -967,7 +983,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 					BackendPort:         to.Int32Ptr(port.Port),
 					EnableFloatingIP:    to.BoolPtr(true),
 					DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
-					EnableTCPReset:      to.BoolPtr(az.useStandardLoadBalancer()),
+					EnableTCPReset:      enableTCPReset,
 				},
 			}
 			if protocol == v1.ProtocolTCP {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -967,6 +967,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 					BackendPort:         to.Int32Ptr(port.Port),
 					EnableFloatingIP:    to.BoolPtr(true),
 					DisableOutboundSnat: to.BoolPtr(az.disableLoadBalancerOutboundSNAT()),
+					EnableTCPReset:      to.BoolPtr(az.useStandardLoadBalancer()),
 				},
 			}
 			if protocol == v1.ProtocolTCP {
@@ -1496,7 +1497,9 @@ func equalLoadBalancingRulePropertiesFormat(s *network.LoadBalancingRuleProperti
 		reflect.DeepEqual(s.LoadDistribution, t.LoadDistribution) &&
 		reflect.DeepEqual(s.FrontendPort, t.FrontendPort) &&
 		reflect.DeepEqual(s.BackendPort, t.BackendPort) &&
-		reflect.DeepEqual(s.EnableFloatingIP, t.EnableFloatingIP)
+		reflect.DeepEqual(s.EnableFloatingIP, t.EnableFloatingIP) &&
+		reflect.DeepEqual(s.EnableTCPReset, t.EnableTCPReset) &&
+		reflect.DeepEqual(s.DisableOutboundSnat, t.DisableOutboundSnat)
 
 	if wantLB {
 		return properties && reflect.DeepEqual(s.IdleTimeoutInMinutes, t.IdleTimeoutInMinutes)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-07-01/network"
@@ -534,5 +536,1150 @@ func TestGetServiceTags(t *testing.T) {
 	for i, c := range tests {
 		tags := getServiceTags(c.service)
 		assert.Equal(t, tags, c.expected, "TestCase[%d]: %s", i, c.desc)
+	}
+}
+
+func TestGetServiceLoadBalancer(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		existingLBs    []network.LoadBalancer
+		service        v1.Service
+		annotations    map[string]string
+		sku            string
+		wantLB         bool
+		expectedLB     *network.LoadBalancer
+		expectedStatus *v1.LoadBalancerStatus
+		expectedExists bool
+		expectedError  bool
+	}{
+		{
+			desc: "getServiceLoadBalancer shall return corresponding lb, status, exists if there are exsisted lbs",
+			existingLBs: []network.LoadBalancer{
+				{
+					Name: to.StringPtr("lb1"),
+					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+						FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
+							{
+								Name: to.StringPtr("atest1"),
+								FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+									PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+								},
+							},
+						},
+					},
+				},
+			},
+			service: getTestService("test1", v1.ProtocolTCP, 80),
+			wantLB:  false,
+			expectedLB: &network.LoadBalancer{
+				Name: to.StringPtr("lb1"),
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
+						{
+							Name: to.StringPtr("atest1"),
+							FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+								PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+							},
+						},
+					},
+				},
+			},
+			expectedStatus: &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "", Hostname: ""}}},
+			expectedExists: true,
+			expectedError:  false,
+		},
+		{
+			desc:           "getServiceLoadBalancer shall report error if there're loadbalancer mode annotations on a standard lb",
+			service:        getTestService("test1", v1.ProtocolTCP, 80),
+			annotations:    map[string]string{ServiceAnnotationLoadBalancerMode: "__auto__"},
+			sku:            "standard",
+			expectedExists: false,
+			expectedError:  true,
+		},
+		{
+			desc: "getServiceLoadBalancer shall select the lb with minimum lb rules if wantLb is true, the sku is " +
+				"not standard and there are existing lbs already",
+			existingLBs: []network.LoadBalancer{
+				{
+					Name: to.StringPtr("testCluster"),
+					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: &[]network.LoadBalancingRule{
+							{Name: to.StringPtr("rule1")},
+						},
+					},
+				},
+				{
+					Name: to.StringPtr("as-1"),
+					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: &[]network.LoadBalancingRule{
+							{Name: to.StringPtr("rule1")},
+							{Name: to.StringPtr("rule2")},
+						},
+					},
+				},
+				{
+					Name: to.StringPtr("as-2"),
+					LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+						LoadBalancingRules: &[]network.LoadBalancingRule{
+							{Name: to.StringPtr("rule1")},
+							{Name: to.StringPtr("rule2")},
+							{Name: to.StringPtr("rule3")},
+						},
+					},
+				},
+			},
+			service:     getTestService("test1", v1.ProtocolTCP, 80),
+			annotations: map[string]string{ServiceAnnotationLoadBalancerMode: "__auto__"},
+			wantLB:      true,
+			expectedLB: &network.LoadBalancer{
+				Name: to.StringPtr("testCluster"),
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+					LoadBalancingRules: &[]network.LoadBalancingRule{
+						{Name: to.StringPtr("rule1")},
+					},
+				},
+			},
+			expectedExists: false,
+			expectedError:  false,
+		},
+		{
+			desc:    "getServiceLoadBalancer shall create a new lb otherwise",
+			service: getTestService("test1", v1.ProtocolTCP, 80),
+			expectedLB: &network.LoadBalancer{
+				Name:                         to.StringPtr("testCluster"),
+				Location:                     to.StringPtr("westus"),
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{},
+			},
+			expectedExists: false,
+			expectedError:  false,
+		},
+	}
+
+	for i, test := range testCases {
+		az := getTestCloud()
+		clusterResources := getClusterResources(az, 3, 3)
+
+		for _, existingLB := range test.existingLBs {
+			_, err := az.LoadBalancerClient.CreateOrUpdate(context.TODO(), "rg", *existingLB.Name, existingLB, "")
+			if err != nil {
+				t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+			}
+		}
+		test.service.Annotations = test.annotations
+		az.LoadBalancerSku = test.sku
+		lb, status, exists, err := az.getServiceLoadBalancer(&test.service, testClusterName,
+			clusterResources.nodes, test.wantLB)
+		assert.Equal(t, test.expectedLB, lb, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedStatus, status, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedExists, exists, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestIsFrontendIPChanged(t *testing.T) {
+	testCases := []struct {
+		desc                   string
+		config                 network.FrontendIPConfiguration
+		service                v1.Service
+		lbFrontendIPConfigName string
+		annotations            string
+		loadBalancerIP         string
+		exsistingSubnet        network.Subnet
+		exsistingPIPs          []network.PublicIPAddress
+		expectedFlag           bool
+		expectedError          bool
+	}{
+		{
+			desc: "isFrontendIPChanged shall return true if config.Name has a prefix of lb's name and " +
+				"config.Name != lbFrontendIPConfigName",
+			config:                 network.FrontendIPConfiguration{Name: to.StringPtr("atest1-name")},
+			service:                getInternalTestService("test1", 80),
+			lbFrontendIPConfigName: "configName",
+			expectedFlag:           true,
+			expectedError:          false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return false if config.Name doesn't have a prefix of lb's name " +
+				"and config.Name != lbFrontendIPConfigName",
+			config:                 network.FrontendIPConfiguration{Name: to.StringPtr("btest1-name")},
+			service:                getInternalTestService("test1", 80),
+			lbFrontendIPConfigName: "configName",
+			expectedFlag:           false,
+			expectedError:          false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return false if the service is internal, no loadBalancerIP is given, " +
+				"subnetName == nil and config.PrivateIPAllocationMethod == network.Static",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("atest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: network.IPAllocationMethod("static"),
+				},
+			},
+			service:       getInternalTestService("test1", 80),
+			expectedFlag:  true,
+			expectedError: false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return false if the service is internal, no loadBalancerIP is given, " +
+				"subnetName == nil and config.PrivateIPAllocationMethod != network.Static",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: network.IPAllocationMethod("dynamic"),
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getInternalTestService("test1", 80),
+			expectedFlag:           false,
+			expectedError:          false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return true if the service is internal and " +
+				"config.Subnet.Name == subnet.Name",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					Subnet: &network.Subnet{Name: to.StringPtr("testSubnet")},
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getInternalTestService("test1", 80),
+			annotations:            "testSubnet",
+			exsistingSubnet:        network.Subnet{Name: to.StringPtr("testSubnet1")},
+			expectedFlag:           true,
+			expectedError:          false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return true if the service is internal, subnet == nil, " +
+				"loadBalancerIP != '' and config.PrivateIPAllocationMethod != 'static'",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: network.IPAllocationMethod("dynamic"),
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getInternalTestService("test1", 80),
+			loadBalancerIP:         "1.1.1.1",
+			expectedFlag:           true,
+			expectedError:          false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return true if the service is internal, subnet == nil and " +
+				"loadBalancerIP != config.PrivateIPAddress",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: network.IPAllocationMethod("static"),
+					PrivateIPAddress:          to.StringPtr("1.1.1.2"),
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getInternalTestService("test1", 80),
+			loadBalancerIP:         "1.1.1.1",
+			expectedFlag:           true,
+			expectedError:          false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return false if no loadbalancerIP is given",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PrivateIPAllocationMethod: network.IPAllocationMethod("static"),
+					PrivateIPAddress:          to.StringPtr("1.1.1.2"),
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getTestService("test1", v1.ProtocolTCP, 80),
+			expectedFlag:           false,
+			expectedError:          false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return false if config.PublicIPAddress == nil",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: nil,
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getTestService("test1", v1.ProtocolTCP, 80),
+			loadBalancerIP:         "1.1.1.1",
+			exsistingPIPs: []network.PublicIPAddress{
+				{
+					Name: to.StringPtr("pipName"),
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.1.1.1"),
+					},
+				},
+			},
+			expectedFlag:  false,
+			expectedError: false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return false if pip.ID == config.PublicIPAddress.ID",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription" +
+						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName")},
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getTestService("test1", v1.ProtocolTCP, 80),
+			loadBalancerIP:         "1.1.1.1",
+			exsistingPIPs: []network.PublicIPAddress{
+				{
+					Name: to.StringPtr("pipName"),
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.1.1.1"),
+					},
+				},
+			},
+			expectedFlag:  false,
+			expectedError: false,
+		},
+		{
+			desc: "isFrontendIPChanged shall return true if pip.ID != config.PublicIPAddress.ID",
+			config: network.FrontendIPConfiguration{
+				Name: to.StringPtr("btest1-name"),
+				FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+					PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription" +
+						"/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName1")},
+				},
+			},
+			lbFrontendIPConfigName: "btest1-name",
+			service:                getTestService("test1", v1.ProtocolTCP, 80),
+			loadBalancerIP:         "1.1.1.1",
+			exsistingPIPs: []network.PublicIPAddress{
+				{
+					Name: to.StringPtr("pipName"),
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.1.1.1"),
+					},
+				},
+			},
+			expectedFlag:  true,
+			expectedError: false,
+		},
+	}
+
+	for i, test := range testCases {
+		az := getTestCloud()
+		_, err := az.SubnetsClient.CreateOrUpdate(context.TODO(), "rg", "vnet", "testSubnet", test.exsistingSubnet)
+		if err != nil {
+			t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+		}
+		for _, existingPIP := range test.exsistingPIPs {
+			_, err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "pipName", existingPIP)
+			if err != nil {
+				t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+			}
+		}
+		test.service.Spec.LoadBalancerIP = test.loadBalancerIP
+		test.service.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = test.annotations
+		flag, err := az.isFrontendIPChanged("testCluster", test.config,
+			&test.service, test.lbFrontendIPConfigName)
+		assert.Equal(t, test.expectedFlag, flag, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestDeterminePublicIPName(t *testing.T) {
+	testCases := []struct {
+		desc           string
+		loadBalancerIP string
+		exsistingPIPs  []network.PublicIPAddress
+		expectedIP     string
+		expectedError  bool
+	}{
+		{
+			desc: "determinePublicIpName shall get public IP from az.getPublicIPName if no specific " +
+				"loadBalancerIP is given",
+			expectedIP:    "testCluster-atest1",
+			expectedError: false,
+		},
+		{
+			desc:           "determinePublicIpName shall report error if loadBalancerIP is not in the resource group",
+			loadBalancerIP: "1.2.3.4",
+			expectedIP:     "",
+			expectedError:  true,
+		},
+		{
+			desc: "determinePublicIpName shall return loadBalancerIP in service.Spec if it's in the " +
+				"resource group",
+			loadBalancerIP: "1.2.3.4",
+			exsistingPIPs: []network.PublicIPAddress{
+				{
+					Name: to.StringPtr("pipName"),
+					PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+						IPAddress: to.StringPtr("1.2.3.4"),
+					},
+				},
+			},
+			expectedIP:    "pipName",
+			expectedError: false,
+		},
+	}
+	for i, test := range testCases {
+		az := getTestCloud()
+		service := getTestService("test1", v1.ProtocolTCP, 80)
+		service.Spec.LoadBalancerIP = test.loadBalancerIP
+		for _, existingPIP := range test.exsistingPIPs {
+			_, err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "test", existingPIP)
+			if err != nil {
+				t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+			}
+		}
+		ip, err := az.determinePublicIPName("testCluster", &service)
+		assert.Equal(t, test.expectedIP, ip, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestReconcileLoadBalancerRule(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		service         v1.Service
+		loadBalancerSku string
+		wantLb          bool
+		expectedProbes  []network.Probe
+		expectedRules   []network.LoadBalancingRule
+		expectedErr     error
+	}{
+		{
+			desc:    "reconcileLoadBalancerRule shall return nil if wantLb is false",
+			service: getTestService("test1", v1.ProtocolTCP, 80),
+			wantLb:  false,
+		},
+		{
+			desc:    "reconcileLoadBalancerRule shall return corresponding probe and lbRule otherwise",
+			service: getTestService("test1", v1.ProtocolTCP, 80),
+			wantLb:  true,
+			expectedProbes: []network.Probe{
+				{
+					Name: to.StringPtr("atest1-TCP-80"),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Protocol:          network.ProbeProtocol("Tcp"),
+						Port:              to.Int32Ptr(10080),
+						IntervalInSeconds: to.Int32Ptr(5),
+						NumberOfProbes:    to.Int32Ptr(2),
+					},
+				},
+			},
+			expectedRules: []network.LoadBalancingRule{
+				{
+					Name: to.StringPtr("atest1-TCP-80"),
+					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+						Protocol: network.TransportProtocol("Tcp"),
+						FrontendIPConfiguration: &network.SubResource{
+							ID: to.StringPtr("frontendIPConfigID"),
+						},
+						BackendAddressPool: &network.SubResource{
+							ID: to.StringPtr("backendPoolID"),
+						},
+						LoadDistribution:     "Default",
+						FrontendPort:         to.Int32Ptr(80),
+						BackendPort:          to.Int32Ptr(80),
+						EnableFloatingIP:     to.BoolPtr(true),
+						DisableOutboundSnat:  to.BoolPtr(false),
+						IdleTimeoutInMinutes: to.Int32Ptr(0),
+						Probe: &network.SubResource{
+							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+								"Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-80"),
+						},
+						EnableTCPReset: to.BoolPtr(false),
+					},
+				},
+			},
+		},
+		{
+			desc:            "reconcileLoadBalancerRule shall return corresponding probe and lbRule otherwise",
+			service:         getTestService("test1", v1.ProtocolTCP, 80),
+			loadBalancerSku: "standard",
+			wantLb:          true,
+			expectedProbes: []network.Probe{
+				{
+					Name: to.StringPtr("atest1-TCP-80"),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Protocol:          network.ProbeProtocol("Tcp"),
+						Port:              to.Int32Ptr(10080),
+						IntervalInSeconds: to.Int32Ptr(5),
+						NumberOfProbes:    to.Int32Ptr(2),
+					},
+				},
+			},
+			expectedRules: []network.LoadBalancingRule{
+				{
+					Name: to.StringPtr("atest1-TCP-80"),
+					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+						Protocol: network.TransportProtocol("Tcp"),
+						FrontendIPConfiguration: &network.SubResource{
+							ID: to.StringPtr("frontendIPConfigID"),
+						},
+						BackendAddressPool: &network.SubResource{
+							ID: to.StringPtr("backendPoolID"),
+						},
+						LoadDistribution:     "Default",
+						FrontendPort:         to.Int32Ptr(80),
+						BackendPort:          to.Int32Ptr(80),
+						EnableFloatingIP:     to.BoolPtr(true),
+						DisableOutboundSnat:  to.BoolPtr(false),
+						IdleTimeoutInMinutes: to.Int32Ptr(0),
+						Probe: &network.SubResource{
+							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+								"Microsoft.Network/loadBalancers/lbname/probes/atest1-TCP-80"),
+						},
+						EnableTCPReset: to.BoolPtr(true),
+					},
+				},
+			},
+		},
+	}
+	for i, test := range testCases {
+		az := getTestCloud()
+		az.Config.LoadBalancerSku = test.loadBalancerSku
+		probe, lbrule, err := az.reconcileLoadBalancerRule(&test.service, test.wantLb,
+			"frontendIPConfigID", "backendPoolID", "lbname", to.Int32Ptr(0))
+		assert.Equal(t, test.expectedProbes, probe, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedRules, lbrule, "TestCase[%d]: %s", i, test.desc)
+		assert.Nil(t, err)
+	}
+}
+
+func getTestLoadBalancer(name, clusterName, identifier *string, service v1.Service, lbSku string) network.LoadBalancer {
+	lb := network.LoadBalancer{
+		Name: name,
+		Sku: &network.LoadBalancerSku{
+			Name: network.LoadBalancerSkuName(lbSku),
+		},
+		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
+				{
+					Name: identifier,
+					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+						PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+					},
+				},
+			},
+			BackendAddressPools: &[]network.BackendAddressPool{
+				{Name: clusterName},
+			},
+			Probes: &[]network.Probe{
+				{
+					Name: to.StringPtr(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
+						"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Port: to.Int32Ptr(10080),
+					},
+				},
+			},
+			LoadBalancingRules: &[]network.LoadBalancingRule{
+				{
+					Name: to.StringPtr(*identifier + "-" + string(service.Spec.Ports[0].Protocol) +
+						"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
+					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+						Protocol: network.TransportProtocol(strings.Title(
+							strings.ToLower(string(service.Spec.Ports[0].Protocol)))),
+						FrontendIPConfiguration: &network.SubResource{
+							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+								"Microsoft.Network/loadBalancers/" + *name + "/frontendIPConfigurations/atest1"),
+						},
+						BackendAddressPool: &network.SubResource{
+							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/" +
+								"Microsoft.Network/loadBalancers/" + *name + "/backendAddressPools/" + *clusterName),
+						},
+						LoadDistribution: network.LoadDistribution("Default"),
+						FrontendPort:     to.Int32Ptr(service.Spec.Ports[0].Port),
+						BackendPort:      to.Int32Ptr(service.Spec.Ports[0].Port),
+						EnableFloatingIP: to.BoolPtr(true),
+						EnableTCPReset:   to.BoolPtr(strings.EqualFold(lbSku, "standard")),
+						Probe: &network.SubResource{
+							ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/testCluster/probes/atest1-TCP-80"),
+						},
+					},
+				},
+			},
+		},
+	}
+	return lb
+}
+
+func TestReconcileLoadBalancer(t *testing.T) {
+	service := getTestService("test1", v1.ProtocolTCP, 80)
+
+	basicLb1 := getTestLoadBalancer(to.StringPtr("lb1"), to.StringPtr("testCluster"), to.StringPtr("atest1"), service, "Basic")
+	basicLb2 := getTestLoadBalancer(to.StringPtr("lb1"), to.StringPtr("testCluster"), to.StringPtr("btest1"), service, "Basic")
+	basicLb2.Name = to.StringPtr("testCluster")
+	basicLb2.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("btest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+			},
+		},
+	}
+	modifiedLb1 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("testCluster"), to.StringPtr("atest1"), service, "Basic")
+	modifiedLb1.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+			},
+		},
+		{
+			Name: to.StringPtr("btest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+			},
+		},
+	}
+	modifiedLb1.Probes = &[]network.Probe{
+		{
+			Name: to.StringPtr("atest1-" + string(service.Spec.Ports[0].Protocol) +
+				"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				Port: to.Int32Ptr(10080),
+			},
+		},
+		{
+			Name: to.StringPtr("atest1-" + string(service.Spec.Ports[0].Protocol) +
+				"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				Port: to.Int32Ptr(10081),
+			},
+		},
+	}
+	expectedLb1 := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("testCluster"), to.StringPtr("atest1"), service, "Basic")
+	(*expectedLb1.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(false)
+	expectedLb1.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("btest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+			},
+		},
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription/" +
+					"resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName")},
+			},
+		},
+	}
+
+	existingSLB := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("testCluster"), to.StringPtr("atest1"), service, "Standard")
+	existingSLB.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+			},
+		},
+		{
+			Name: to.StringPtr("btest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+			},
+		},
+	}
+	existingSLB.Probes = &[]network.Probe{
+		{
+			Name: to.StringPtr("atest1-" + string(service.Spec.Ports[0].Protocol) +
+				"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				Port: to.Int32Ptr(10080),
+			},
+		},
+		{
+			Name: to.StringPtr("atest1-" + string(service.Spec.Ports[0].Protocol) +
+				"-" + strconv.Itoa(int(service.Spec.Ports[0].Port))),
+			ProbePropertiesFormat: &network.ProbePropertiesFormat{
+				Port: to.Int32Ptr(10081),
+			},
+		},
+	}
+	// intentionally set the value to a wrong value, expect reconcileLoadBalancer to fix it
+	(*existingSLB.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].EnableTCPReset = to.BoolPtr(false)
+
+	expectedSLb := getTestLoadBalancer(to.StringPtr("testCluster"), to.StringPtr("testCluster"), to.StringPtr("atest1"), service, "Standard")
+	(*expectedSLb.LoadBalancerPropertiesFormat.LoadBalancingRules)[0].DisableOutboundSnat = to.BoolPtr(true)
+	expectedSLb.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("btest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("id1")},
+			},
+		},
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress: &network.PublicIPAddress{ID: to.StringPtr("/subscriptions/subscription/" +
+					"resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/pipName")},
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc                string
+		loadBalancerSku     string
+		disableOutboundSnat *bool
+		wantLb              bool
+		existingLB          network.LoadBalancer
+		expectedLB          network.LoadBalancer
+		expectedError       bool
+	}{
+		{
+			desc: "reconcileLoadBalancer shall return the lb deeply equal to the existingLB if there's no " +
+				"modification needed when wantLb == true",
+			loadBalancerSku: "basic",
+			existingLB:      basicLb1,
+			wantLb:          true,
+			expectedLB:      basicLb1,
+			expectedError:   false,
+		},
+		{
+			desc: "reconcileLoadBalancer shall return the lb deeply equal to the existingLB if there's no " +
+				"modification needed when wantLb == false",
+			loadBalancerSku: "basic",
+			existingLB:      basicLb2,
+			wantLb:          false,
+			expectedLB:      basicLb2,
+			expectedError:   false,
+		},
+		{
+			desc:            "reconcileLoadBalancer shall remove and reconstruct the correspoind field of lb",
+			loadBalancerSku: "basic",
+			existingLB:      modifiedLb1,
+			wantLb:          true,
+			expectedLB:      expectedLb1,
+			expectedError:   false,
+		},
+		{
+			desc:                "reconcileLoadBalancer shall remove and reconstruct the correspoind field of lb and set enableTcpReset to true in lbRule",
+			loadBalancerSku:     "standard",
+			disableOutboundSnat: to.BoolPtr(true),
+			existingLB:          existingSLB,
+			wantLb:              true,
+			expectedLB:          expectedSLb,
+			expectedError:       false,
+		},
+	}
+
+	for i, test := range testCases {
+		az := getTestCloud()
+		az.Config.LoadBalancerSku = test.loadBalancerSku
+		az.DisableOutboundSNAT = test.disableOutboundSnat
+
+		clusterResources := getClusterResources(az, 3, 3)
+		service.Spec.LoadBalancerIP = "1.2.3.4"
+
+		_, err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "pipName", network.PublicIPAddress{
+			Name: to.StringPtr("pipName"),
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				IPAddress: to.StringPtr("1.2.3.4"),
+			},
+		})
+		if err != nil {
+			t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+		}
+
+		_, err = az.LoadBalancerClient.CreateOrUpdate(context.TODO(), "rg", "lb1", test.existingLB, "")
+		if err != nil {
+			t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+		}
+
+		lb, err := az.reconcileLoadBalancer("testCluster", &service, clusterResources.nodes, test.wantLb)
+		assert.Equal(t, &test.expectedLB, lb, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestGetServiceLoadBalancerStatus(t *testing.T) {
+	az := getTestCloud()
+	service := getTestService("test1", v1.ProtocolTCP, 80)
+	internalService := getInternalTestService("test1", 80)
+
+	PIPClient := newFakeAzurePIPClient(az.Config.SubscriptionID)
+	PIPClient.setFakeStore(map[string]map[string]network.PublicIPAddress{
+		"rg": {"id1": network.PublicIPAddress{
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				IPAddress: to.StringPtr("1.2.3.4"),
+			},
+		}},
+	})
+	az.PublicIPAddressesClient = PIPClient
+
+	lb1 := getTestLoadBalancer(to.StringPtr("lb1"), to.StringPtr("testCluster"),
+		to.StringPtr("test1"), internalService, "Basic")
+	lb1.FrontendIPConfigurations = nil
+	lb2 := getTestLoadBalancer(to.StringPtr("lb2"), to.StringPtr("testCluster"),
+		to.StringPtr("test1"), internalService, "Basic")
+	lb2.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("id1")},
+				PrivateIPAddress: to.StringPtr("private"),
+			},
+		},
+	}
+	lb3 := getTestLoadBalancer(to.StringPtr("lb3"), to.StringPtr("testCluster"),
+		to.StringPtr("test1"), internalService, "Basic")
+	lb3.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("btest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("id1")},
+				PrivateIPAddress: to.StringPtr("private"),
+			},
+		},
+	}
+	lb4 := getTestLoadBalancer(to.StringPtr("lb4"), to.StringPtr("testCluster"),
+		to.StringPtr("test1"), service, "Basic")
+	lb4.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress:  &network.PublicIPAddress{ID: nil},
+				PrivateIPAddress: to.StringPtr("private"),
+			},
+		},
+	}
+	lb5 := getTestLoadBalancer(to.StringPtr("lb5"), to.StringPtr("testCluster"),
+		to.StringPtr("test1"), service, "Basic")
+	lb5.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress:  nil,
+				PrivateIPAddress: to.StringPtr("private"),
+			},
+		},
+	}
+	lb6 := getTestLoadBalancer(to.StringPtr("lb6"), to.StringPtr("testCluster"),
+		to.StringPtr("test1"), service, "Basic")
+	lb6.FrontendIPConfigurations = &[]network.FrontendIPConfiguration{
+		{
+			Name: to.StringPtr("atest1"),
+			FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+				PublicIPAddress:  &network.PublicIPAddress{ID: to.StringPtr("illegal/id/")},
+				PrivateIPAddress: to.StringPtr("private"),
+			},
+		},
+	}
+
+	testCases := []struct {
+		desc           string
+		service        *v1.Service
+		lb             *network.LoadBalancer
+		expectedStatus *v1.LoadBalancerStatus
+		expectedError  bool
+	}{
+		{
+			desc:    "getServiceLoadBalancer shall return nil if no lb is given",
+			service: &service,
+			lb:      nil,
+		},
+		{
+			desc:    "getServiceLoadBalancerStatus shall return nil if given lb has no front ip config",
+			service: &service,
+			lb:      &lb1,
+		},
+		{
+			desc:           "getServiceLoadBalancerStatus shall return private ip if service is internal",
+			service:        &internalService,
+			lb:             &lb2,
+			expectedStatus: &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "private"}}},
+		},
+		{
+			desc: "getServiceLoadBalancerStatus shall return nil if lb.FrontendIPConfigurations.name != " +
+				"az.getFrontendIPConfigName(service, subnet(service))",
+			service: &internalService,
+			lb:      &lb3,
+		},
+		{
+			desc: "getServiceLoadBalancerStatus shall report error if the id of lb's " +
+				"public ip address cannot be read",
+			service:       &service,
+			lb:            &lb4,
+			expectedError: true,
+		},
+		{
+			desc:          "getServiceLoadBalancerStatus shall report error if lb's public ip address cannot be read",
+			service:       &service,
+			lb:            &lb5,
+			expectedError: true,
+		},
+		{
+			desc:          "getServiceLoadBalancerStatus shall report error if id of lb's public ip address is illegal",
+			service:       &service,
+			lb:            &lb6,
+			expectedError: true,
+		},
+		{
+			desc: "getServiceLoadBalancerStatus shall return the corresponding " +
+				"lb status if everything is good",
+			service:        &service,
+			lb:             &lb2,
+			expectedStatus: &v1.LoadBalancerStatus{Ingress: []v1.LoadBalancerIngress{{IP: "1.2.3.4"}}},
+		},
+	}
+
+	for i, test := range testCases {
+		status, err := az.getServiceLoadBalancerStatus(test.service, test.lb)
+		assert.Equal(t, test.expectedStatus, status, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestReconcileSecurityGroup(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		service       v1.Service
+		lbIP          *string
+		wantLb        bool
+		existingSgs   map[string]network.SecurityGroup
+		expectedSg    *network.SecurityGroup
+		expectedError bool
+	}{
+		{
+			desc: "reconcileSecurityGroup shall report error if the sg is shared and no ports in service",
+			service: v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						ServiceAnnotationSharedSecurityRule: "true",
+					},
+				},
+			},
+			expectedError: true,
+		},
+		{
+			desc:          "reconcileSecurityGroup shall report error if no such sg can be found",
+			service:       getTestService("test1", v1.ProtocolTCP, 80),
+			expectedError: true,
+		},
+		{
+			desc:          "reconcileSecurityGroup shall report error if wantLb is true and lbIP is nil",
+			service:       getTestService("test1", v1.ProtocolTCP, 80),
+			wantLb:        true,
+			existingSgs:   map[string]network.SecurityGroup{"nsg": {}},
+			expectedError: true,
+		},
+		{
+			desc:        "reconcileSecurityGroup shall remain the existingSgs intact if nothing needs to be modified",
+			service:     getTestService("test1", v1.ProtocolTCP, 80),
+			existingSgs: map[string]network.SecurityGroup{"nsg": {}},
+			expectedSg:  &network.SecurityGroup{},
+		},
+		{
+			desc:    "reconcileSecurityGroup shall delete unwanted sgs and create needed ones",
+			service: getTestService("test1", v1.ProtocolTCP, 80),
+			existingSgs: map[string]network.SecurityGroup{"nsg": {
+				Name: to.StringPtr("nsg"),
+				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
+					SecurityRules: &[]network.SecurityRule{
+						{
+							Name: to.StringPtr("atest1-toBeDeleted"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								SourceAddressPrefix:      to.StringPtr("prefix"),
+								SourcePortRange:          to.StringPtr("range"),
+								DestinationAddressPrefix: to.StringPtr("desPrefix"),
+								DestinationPortRange:     to.StringPtr("desRange"),
+							},
+						},
+					},
+				},
+			}},
+			lbIP:   to.StringPtr("1.1.1.1"),
+			wantLb: true,
+			expectedSg: &network.SecurityGroup{
+				Name: to.StringPtr("nsg"),
+				SecurityGroupPropertiesFormat: &network.SecurityGroupPropertiesFormat{
+					SecurityRules: &[]network.SecurityRule{
+						{
+							Name: to.StringPtr("atest1-TCP-80-Internet"),
+							SecurityRulePropertiesFormat: &network.SecurityRulePropertiesFormat{
+								Protocol:                 network.SecurityRuleProtocol("Tcp"),
+								SourcePortRange:          to.StringPtr("*"),
+								DestinationPortRange:     to.StringPtr("80"),
+								SourceAddressPrefix:      to.StringPtr("Internet"),
+								DestinationAddressPrefix: to.StringPtr("1.1.1.1"),
+								Access:                   network.SecurityRuleAccess("Allow"),
+								Priority:                 to.Int32Ptr(500),
+								Direction:                network.SecurityRuleDirection("Inbound"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for i, test := range testCases {
+		az := getTestCloud()
+		for name, sg := range test.existingSgs {
+			_, err := az.SecurityGroupsClient.CreateOrUpdate(context.TODO(), "rg", name, sg, "")
+			if err != nil {
+				t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+			}
+		}
+		sg, err := az.reconcileSecurityGroup("testCluster", &test.service, test.lbIP, test.wantLb)
+		assert.Equal(t, test.expectedSg, sg, "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestSafeDeletePublicIP(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		pip           *network.PublicIPAddress
+		lb            *network.LoadBalancer
+		expectedError bool
+	}{
+		{
+			desc: "safeDeletePublicIP shall delete corresponding ip configurations and lb rules",
+			pip: &network.PublicIPAddress{
+				Name: to.StringPtr("pip1"),
+				PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+					IPConfiguration: &network.IPConfiguration{
+						ID: to.StringPtr("id1"),
+					},
+				},
+			},
+			lb: &network.LoadBalancer{
+				Name: to.StringPtr("lb1"),
+				LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+					FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
+						{
+							ID: to.StringPtr("id1"),
+							FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+								LoadBalancingRules: &[]network.SubResource{{ID: to.StringPtr("rules1")}},
+							},
+						},
+					},
+					LoadBalancingRules: &[]network.LoadBalancingRule{{ID: to.StringPtr("rules1")}},
+				},
+			},
+		},
+	}
+
+	for i, test := range testCases {
+		az := getTestCloud()
+		_, err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", "pip1", network.PublicIPAddress{
+			Name: to.StringPtr("pip1"),
+			PublicIPAddressPropertiesFormat: &network.PublicIPAddressPropertiesFormat{
+				IPConfiguration: &network.IPConfiguration{
+					ID: to.StringPtr("id1"),
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+		}
+		service := getTestService("test1", v1.ProtocolTCP, 80)
+		err = az.safeDeletePublicIP(&service, "rg", test.pip, test.lb)
+		assert.Equal(t, 0, len(*test.lb.FrontendIPConfigurations), "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, 0, len(*test.lb.LoadBalancingRules), "TestCase[%d]: %s", i, test.desc)
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestReconcilePublicIP(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		wantLb        bool
+		existingPIPs  []network.PublicIPAddress
+		expectedID    string
+		expectedPIP   *network.PublicIPAddress
+		expectedError bool
+	}{
+		{
+			desc:   "reconcilePublicIP shall return nil if there's no pip in service",
+			wantLb: false,
+		},
+		{
+			desc:   "reconcilePublicIP shall return nil if no pip is owned by service",
+			wantLb: false,
+			existingPIPs: []network.PublicIPAddress{
+				{
+					Name: to.StringPtr("pip1"),
+				},
+			},
+		},
+		{
+			desc:   "reconcilePublicIP shall delete unwanted pips and create a new one",
+			wantLb: true,
+			existingPIPs: []network.PublicIPAddress{
+				{
+					Name: to.StringPtr("pip1"),
+					Tags: map[string]*string{"service": to.StringPtr("default/test1")},
+				},
+			},
+			expectedID: "/subscriptions/subscription/resourceGroups/rg/providers/" +
+				"Microsoft.Network/publicIPAddresses/testCluster-atest1",
+		},
+	}
+
+	for i, test := range testCases {
+		az := getTestCloud()
+		service := getTestService("test1", v1.ProtocolTCP, 80)
+		for _, pip := range test.existingPIPs {
+			_, err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", to.String(pip.Name), pip)
+			if err != nil {
+				t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+			}
+		}
+		pip, err := az.reconcilePublicIP("testCluster", &service, "", test.wantLb)
+		if test.expectedID != "" {
+			assert.Equal(t, test.expectedID, to.String(pip.ID), "TestCase[%d]: %s", i, test.desc)
+		} else {
+			assert.Equal(t, test.expectedPIP, pip, "TestCase[%d]: %s", i, test.desc)
+		}
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
+	}
+}
+
+func TestEnsurePublicIPExists(t *testing.T) {
+	testCases := []struct {
+		desc          string
+		existingPIPs  []network.PublicIPAddress
+		expectedPIP   *network.PublicIPAddress
+		expectedID    string
+		expectedError bool
+	}{
+		{
+			desc:         "ensurePublicIPExists shall return existed PIP if there is any",
+			existingPIPs: []network.PublicIPAddress{{Name: to.StringPtr("pip1")}},
+			expectedPIP: &network.PublicIPAddress{
+				Name: to.StringPtr("pip1"),
+				ID: to.StringPtr("/subscriptions/subscription/resourceGroups/rg" +
+					"/providers/Microsoft.Network/publicIPAddresses/pip1"),
+			},
+		},
+		{
+			desc: "ensurePublicIPExists shall create a new pip if there is no existed pip",
+			expectedID: "/subscriptions/subscription/resourceGroups/rg/providers/" +
+				"Microsoft.Network/publicIPAddresses/pip1",
+		},
+	}
+
+	for i, test := range testCases {
+		az := getTestCloud()
+		service := getTestService("test1", v1.ProtocolTCP, 80)
+		for _, pip := range test.existingPIPs {
+			_, err := az.PublicIPAddressesClient.CreateOrUpdate(context.TODO(), "rg", to.String(pip.Name), pip)
+			if err != nil {
+				t.Fatalf("TestCase[%d] meets unexpected error: %v", i, err)
+			}
+		}
+		pip, err := az.ensurePublicIPExists(&service, "pip1", "", "")
+		if test.expectedID != "" {
+			assert.Equal(t, test.expectedID, to.String(pip.ID), "TestCase[%d]: %s", i, test.desc)
+		} else {
+			assert.Equal(t, test.expectedPIP, pip, "TestCase[%d]: %s", i, test.desc)
+		}
+		assert.Equal(t, test.expectedError, err != nil, "TestCase[%d]: %s", i, test.desc)
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -120,7 +120,7 @@ func TestParseConfig(t *testing.T) {
 
 // Test flipServiceInternalAnnotation
 func TestFlipServiceInternalAnnotation(t *testing.T) {
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	svcUpdated := flipServiceInternalAnnotation(&svc)
 	if !requiresInternalLoadBalancer(svcUpdated) {
 		t.Errorf("Expected svc to be an internal service")
@@ -145,7 +145,7 @@ func TestFlipServiceInternalAnnotation(t *testing.T) {
 // Test additional of a new service/port.
 func TestAddPort(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	svc.Spec.Ports = append(svc.Spec.Ports, v1.ServicePort{
@@ -200,7 +200,7 @@ func testLoadBalancerServiceDefaultModeSelection(t *testing.T, isInternal bool) 
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -255,7 +255,7 @@ func testLoadBalancerServiceAutoModeSelection(t *testing.T, isInternal bool) {
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 		setLoadBalancerAutoModeAnnotation(&svc)
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -318,7 +318,7 @@ func testLoadBalancerServicesSpecifiedSelection(t *testing.T, isInternal bool) {
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 		lbMode := fmt.Sprintf("%s,%s", selectedAvailabilitySetName1, selectedAvailabilitySetName2)
 		setLoadBalancerModeAnnotation(&svc, lbMode)
@@ -360,7 +360,7 @@ func testLoadBalancerMaxRulesServices(t *testing.T, isInternal bool) {
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -389,7 +389,7 @@ func testLoadBalancerMaxRulesServices(t *testing.T, isInternal bool) {
 		svc = getInternalTestService(svcName, 8081)
 		addTestSubnet(t, az, &svc)
 	} else {
-		svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+		svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 	}
 	_, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
 	if err == nil {
@@ -419,7 +419,7 @@ func testLoadBalancerServiceAutoModeDeleteSelection(t *testing.T, isInternal boo
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 		setLoadBalancerAutoModeAnnotation(&svc)
 		lbStatus, err := az.EnsureLoadBalancer(context.TODO(), testClusterName, &svc, clusterResources.nodes)
@@ -438,7 +438,7 @@ func testLoadBalancerServiceAutoModeDeleteSelection(t *testing.T, isInternal boo
 			svc = getInternalTestService(svcName, 8081)
 			addTestSubnet(t, az, &svc)
 		} else {
-			svc = getTestService(svcName, v1.ProtocolTCP, 8081)
+			svc = getTestService(svcName, v1.ProtocolTCP, nil, 8081)
 		}
 
 		setLoadBalancerAutoModeAnnotation(&svc)
@@ -482,7 +482,7 @@ func TestReconcileLoadBalancerAddServiceOnInternalSubnet(t *testing.T) {
 
 func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t *testing.T) {
 	az := getTestCloud()
-	svc1 := getTestService("serviceea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("serviceea", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = "192.168.0.0"
 	sg := getTestSecurityGroup(az)
 	// Simulate a pre-Kubernetes 1.8 NSG, where we do not specify the destination address prefix
@@ -499,7 +499,7 @@ func TestReconcileSecurityGroupFromAnyDestinationAddressPrefixToLoadBalancerIP(t
 
 func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 	az := getTestCloud()
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = ""
 	sg := getTestSecurityGroup(az)
 	dynamicallyAssignedIP := "192.168.0.0"
@@ -514,7 +514,7 @@ func TestReconcileSecurityGroupDynamicLoadBalancerIP(t *testing.T) {
 func TestReconcileLoadBalancerAddServicesOnMultipleSubnets(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc1 := getTestService("service1", v1.ProtocolTCP, 8081)
+	svc1 := getTestService("service1", v1.ProtocolTCP, nil, 8081)
 	svc2 := getInternalTestService("service2", 8081)
 
 	// Internal and External service cannot reside on the same LB resource
@@ -580,7 +580,7 @@ func TestReconcileLoadBalancerEditServiceSubnet(t *testing.T) {
 func TestReconcileLoadBalancerNodeHealth(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 	svc.Spec.HealthCheckNodePort = int32(32456)
 
@@ -601,7 +601,7 @@ func TestReconcileLoadBalancerNodeHealth(t *testing.T) {
 func TestReconcileLoadBalancerRemoveService(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
@@ -625,7 +625,7 @@ func TestReconcileLoadBalancerRemoveService(t *testing.T) {
 func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
@@ -633,7 +633,7 @@ func TestReconcileLoadBalancerRemoveAllPortsRemovesFrontendConfig(t *testing.T) 
 	}
 	validateLoadBalancer(t, lb, svc)
 
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil)
 	lb, err = az.reconcileLoadBalancer(testClusterName, &svcUpdated, clusterResources.nodes, false /* wantLb*/)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
@@ -652,13 +652,13 @@ func TestReconcileLoadBalancerRemovesPort(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
 
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
 	}
 
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP, 80)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	lb, err = az.reconcileLoadBalancer(testClusterName, &svcUpdated, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
@@ -671,8 +671,8 @@ func TestReconcileLoadBalancerRemovesPort(t *testing.T) {
 func TestReconcileLoadBalancerMultipleServices(t *testing.T) {
 	az := getTestCloud()
 	clusterResources := getClusterResources(az, 1, 1)
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80, 443)
-	svc2 := getTestService("serviceb", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
+	svc2 := getTestService("serviceb", v1.ProtocolTCP, nil, 80)
 
 	updatedLoadBalancer, err := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true /* wantLb */)
 	if err != nil {
@@ -698,7 +698,7 @@ func findLBRuleForPort(lbRules []network.LoadBalancingRule, port int32) (network
 
 func TestServiceDefaultsToNoSessionPersistence(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("service-sa-omitted", v1.ProtocolTCP, 7170)
+	svc := getTestService("service-sa-omitted", v1.ProtocolTCP, nil, 7170)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	lb, err := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true /* wantLb */)
@@ -718,7 +718,7 @@ func TestServiceDefaultsToNoSessionPersistence(t *testing.T) {
 
 func TestServiceRespectsNoSessionAffinity(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("service-sa-none", v1.ProtocolTCP, 7170)
+	svc := getTestService("service-sa-none", v1.ProtocolTCP, nil, 7170)
 	svc.Spec.SessionAffinity = v1.ServiceAffinityNone
 	clusterResources := getClusterResources(az, 1, 1)
 
@@ -741,7 +741,7 @@ func TestServiceRespectsNoSessionAffinity(t *testing.T) {
 
 func TestServiceRespectsClientIPSessionAffinity(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("service-sa-clientip", v1.ProtocolTCP, 7170)
+	svc := getTestService("service-sa-clientip", v1.ProtocolTCP, nil, 7170)
 	svc.Spec.SessionAffinity = v1.ServiceAffinityClientIP
 	clusterResources := getClusterResources(az, 1, 1)
 
@@ -765,7 +765,7 @@ func TestServiceRespectsClientIPSessionAffinity(t *testing.T) {
 func TestReconcileSecurityGroupNewServiceAddsPort(t *testing.T) {
 	az := getTestCloud()
 	getTestSecurityGroup(az)
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	clusterResources := getClusterResources(az, 1, 1)
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
 	lbStatus, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
@@ -797,8 +797,8 @@ func TestReconcileSecurityGroupNewInternalServiceAddsPort(t *testing.T) {
 
 func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 	az := getTestCloud()
-	service1 := getTestService("servicea", v1.ProtocolTCP, 81)
-	service2 := getTestService("serviceb", v1.ProtocolTCP, 82)
+	service1 := getTestService("servicea", v1.ProtocolTCP, nil, 81)
+	service2 := getTestService("serviceb", v1.ProtocolTCP, nil, 82)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &service1, clusterResources.nodes, true)
@@ -819,11 +819,11 @@ func TestReconcileSecurityGroupRemoveService(t *testing.T) {
 
 func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 	clusterResources := getClusterResources(az, 1, 1)
 
 	sg := getTestSecurityGroup(az, svc)
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP, 80)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc, clusterResources.nodes, true)
 	lbStatus, _ := az.getServiceLoadBalancerStatus(&svc, lb)
 
@@ -837,7 +837,7 @@ func TestReconcileSecurityGroupRemoveServiceRemovesPort(t *testing.T) {
 
 func TestReconcileSecurityWithSourceRanges(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 	svc.Spec.LoadBalancerSourceRanges = []string{
 		"192.168.0.0/24",
 		"10.0.0.0/32",
@@ -864,7 +864,7 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 	cachedSG.Etag = to.StringPtr("1111111-0000-0000-0000-000000000000")
 	az.nsgCache.Set(to.String(sg.Name), &cachedSG)
 
-	svc1 := getTestService("servicea", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	clusterResources := getClusterResources(az, 1, 1)
 	lb, _ := az.reconcileLoadBalancer(testClusterName, &svc1, clusterResources.nodes, true)
 	lbStatus, _ := az.getServiceLoadBalancerStatus(&svc1, lb)
@@ -877,7 +877,7 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 
 func TestReconcilePublicIPWithNewService(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 
 	pip, err := az.reconcilePublicIP(testClusterName, &svc, "", true /* wantLb*/)
 	if err != nil {
@@ -898,7 +898,7 @@ func TestReconcilePublicIPWithNewService(t *testing.T) {
 
 func TestReconcilePublicIPRemoveService(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicea", v1.ProtocolTCP, 80, 443)
+	svc := getTestService("servicea", v1.ProtocolTCP, nil, 80, 443)
 
 	pip, err := az.reconcilePublicIP(testClusterName, &svc, "", true /* wantLb*/)
 	if err != nil {
@@ -939,7 +939,7 @@ func TestReconcilePublicIPWithExternalAndInternalSwitch(t *testing.T) {
 	validatePublicIP(t, pip, &svc, true)
 
 	// Update to external service
-	svcUpdated := getTestService("servicea", v1.ProtocolTCP, 80)
+	svcUpdated := getTestService("servicea", v1.ProtocolTCP, nil, 80)
 	pip, err = az.reconcilePublicIP(testClusterName, &svcUpdated, "", true /* wantLb*/)
 	if err != nil {
 		t.Errorf("Unexpected error: %q", err)
@@ -1130,7 +1130,7 @@ func getBackendPort(port int32) int32 {
 	return port + 10000
 }
 
-func getTestService(identifier string, proto v1.Protocol, requestedPorts ...int32) v1.Service {
+func getTestService(identifier string, proto v1.Protocol, annotations map[string]string, requestedPorts ...int32) v1.Service {
 	ports := []v1.ServicePort{}
 	for _, port := range requestedPorts {
 		ports = append(ports, v1.ServicePort{
@@ -1150,19 +1150,23 @@ func getTestService(identifier string, proto v1.Protocol, requestedPorts ...int3
 	svc.Name = identifier
 	svc.Namespace = "default"
 	svc.UID = types.UID(identifier)
-	svc.Annotations = make(map[string]string)
+	if annotations == nil {
+		svc.Annotations = make(map[string]string)
+	} else {
+		svc.Annotations = annotations
+	}
 
 	return svc
 }
 
 func getInternalTestService(identifier string, requestedPorts ...int32) v1.Service {
-	svc := getTestService(identifier, v1.ProtocolTCP, requestedPorts...)
+	svc := getTestService(identifier, v1.ProtocolTCP, nil, requestedPorts...)
 	svc.Annotations[ServiceAnnotationLoadBalancerInternal] = "true"
 	return svc
 }
 
 func getResourceGroupTestService(identifier, resourceGroup, loadBalancerIP string, requestedPorts ...int32) v1.Service {
-	svc := getTestService(identifier, v1.ProtocolTCP, requestedPorts...)
+	svc := getTestService(identifier, v1.ProtocolTCP, nil, requestedPorts...)
 	svc.Spec.LoadBalancerIP = loadBalancerIP
 	svc.Annotations[ServiceAnnotationLoadBalancerResourceGroup] = resourceGroup
 	return svc
@@ -1868,7 +1872,7 @@ func addTestSubnet(t *testing.T, az *Cloud, svc *v1.Service) {
 
 func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicesr", v1.ProtocolTCP, 80)
+	svc := getTestService("servicesr", v1.ProtocolTCP, nil, 80)
 	svc.Spec.LoadBalancerIP = "192.168.77.88"
 	svc.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -1907,7 +1911,7 @@ func TestIfServiceSpecifiesSharedRuleAndRuleDoesNotExistItIsCreated(t *testing.T
 
 func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressAreAdded(t *testing.T) {
 	az := getTestCloud()
-	svc := getTestService("servicesr", v1.ProtocolTCP, 80)
+	svc := getTestService("servicesr", v1.ProtocolTCP, nil, 80)
 	svc.Spec.LoadBalancerIP = "192.168.77.88"
 	svc.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -1960,11 +1964,11 @@ func TestIfServiceSpecifiesSharedRuleAndRuleExistsThenTheServicesPortAndAddressA
 func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2029,11 +2033,11 @@ func TestIfServicesSpecifySharedRuleButDifferentPortsThenSeparateRulesAreCreated
 func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCreated(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolUDP, 4444)
+	svc2 := getTestService("servicesr2", v1.ProtocolUDP, nil, 4444)
 	svc2.Spec.LoadBalancerIP = "192.168.77.88"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2096,12 +2100,12 @@ func TestIfServicesSpecifySharedRuleButDifferentProtocolsThenSeparateRulesAreCre
 func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRulesAreCreated(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Spec.LoadBalancerSourceRanges = []string{"192.168.12.0/24"}
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 80)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 80)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Spec.LoadBalancerSourceRanges = []string{"192.168.34.0/24"}
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
@@ -2167,15 +2171,15 @@ func TestIfServicesSpecifySharedRuleButDifferentSourceAddressesThenSeparateRules
 func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSeparatedOrConsoliatedByPort(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2267,11 +2271,11 @@ func TestIfServicesSpecifySharedRuleButSomeAreOnDifferentPortsThenRulesAreSepara
 func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAddressAreRemoved(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 80)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 80)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 80)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 80)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2322,15 +2326,15 @@ func TestIfServiceSpecifiesSharedRuleAndServiceIsDeletedThenTheServicesPortAndAd
 func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2429,15 +2433,15 @@ func TestIfSomeServicesShareARuleAndOneIsDeletedItIsRemovedFromTheRightRule(t *t
 func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
@@ -2509,23 +2513,23 @@ func TestIfServiceSpecifiesSharedRuleAndLastServiceIsDeletedThenRuleIsDeleted(t 
 func TestCanCombineSharedAndPrivateRulesInSameGroup(t *testing.T) {
 	az := getTestCloud()
 
-	svc1 := getTestService("servicesr1", v1.ProtocolTCP, 4444)
+	svc1 := getTestService("servicesr1", v1.ProtocolTCP, nil, 4444)
 	svc1.Spec.LoadBalancerIP = "192.168.77.88"
 	svc1.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc2 := getTestService("servicesr2", v1.ProtocolTCP, 8888)
+	svc2 := getTestService("servicesr2", v1.ProtocolTCP, nil, 8888)
 	svc2.Spec.LoadBalancerIP = "192.168.33.44"
 	svc2.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc3 := getTestService("servicesr3", v1.ProtocolTCP, 4444)
+	svc3 := getTestService("servicesr3", v1.ProtocolTCP, nil, 4444)
 	svc3.Spec.LoadBalancerIP = "192.168.99.11"
 	svc3.Annotations[ServiceAnnotationSharedSecurityRule] = "true"
 
-	svc4 := getTestService("servicesr4", v1.ProtocolTCP, 4444)
+	svc4 := getTestService("servicesr4", v1.ProtocolTCP, nil, 4444)
 	svc4.Spec.LoadBalancerIP = "192.168.22.33"
 	svc4.Annotations[ServiceAnnotationSharedSecurityRule] = "false"
 
-	svc5 := getTestService("servicesr5", v1.ProtocolTCP, 8888)
+	svc5 := getTestService("servicesr5", v1.ProtocolTCP, nil, 8888)
 	svc5.Spec.LoadBalancerIP = "192.168.22.33"
 	svc5.Annotations[ServiceAnnotationSharedSecurityRule] = "false"
 


### PR DESCRIPTION
Cherry pick of #80624 on release-1.15.

#80624: Bug fix: Set enableTcpReset of lb rules to true for Azure