### PR TITLE
Promote taint-based eviction e2e tests to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -218,6 +218,8 @@ test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if 
 test/e2e/scheduling/predicates.go: "validates that NodeSelector is respected if matching"
 test/e2e/scheduling/predicates.go: "validates that there is no conflict between pods with same hostPort but different hostIP and protocol"
 test/e2e/scheduling/predicates.go: "validates that there exists conflict between pods with same hostPort and protocol but one using 0.0.0.0 hostIP"
+test/e2e/scheduling/taints.go: "removing taint cancels eviction"
+test/e2e/scheduling/taints.go: "evicts pods with minTolerationSeconds"
 test/e2e/storage/empty_dir_wrapper.go: "should not conflict"
 test/e2e/storage/empty_dir_wrapper.go: "should not cause race condition when used for configmaps"
 test/e2e/storage/subpath.go: "should support subpaths with secret pod"

--- a/test/e2e/scheduling/taints.go
+++ b/test/e2e/scheduling/taints.go
@@ -277,23 +277,26 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		}
 	})
 
-	// 1. Run a pod with short toleration
-	// 2. Taint the node running this pod with a no-execute taint
-	// 3. Wait some time
-	// 4. Remove the taint
-	// 5. See if Pod won't be evicted.
-	ginkgo.It("removing taint cancels eviction", func() {
+	/*
+		Release : v1.16
+		Testname: Taint, Pod Eviction on taint removal
+		Description: The Pod with toleration timeout scheduled on a tainted Node MUST not be
+		evicted if the taint is removed before toleration time ends.
+	*/
+	framework.ConformanceIt("removing taint cancels eviction", func() {
 		podName := "taint-eviction-4"
 		pod := createPodForTaintsTest(true, 2*additionalWaitPerDeleteSeconds, podName, podName, ns)
 		observedDeletions := make(chan string, 100)
 		stopCh := make(chan struct{})
 		createTestController(cs, observedDeletions, stopCh, podName, ns)
 
+		// 1. Run a pod with short toleration
 		ginkgo.By("Starting pod...")
 		nodeName, err := testutils.RunPodAndGetNodeName(cs, pod, 2*time.Minute)
 		framework.ExpectNoError(err)
 		e2elog.Logf("Pod is running on %v. Tainting Node", nodeName)
 
+		// 2. Taint the node running this pod with a no-execute taint
 		ginkgo.By("Trying to apply a taint on the Node")
 		testTaint := getTestTaint()
 		framework.AddOrUpdateTaintOnNode(cs, nodeName, testTaint)
@@ -305,7 +308,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 			}
 		}()
 
-		// Wait a bit
+		// 3. Wait some time
 		ginkgo.By("Waiting short time to make sure Pod is queued for deletion")
 		timeoutChannel := time.NewTimer(additionalWaitPerDeleteSeconds).C
 		select {
@@ -315,9 +318,13 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 			e2elog.Failf("Pod was evicted despite toleration")
 			return
 		}
+
+		// 4. Remove the taint
 		e2elog.Logf("Removing taint from Node")
 		framework.RemoveTaintOffNode(cs, nodeName, testTaint)
 		taintRemoved = true
+
+		// 5. See if Pod won't be evicted.
 		ginkgo.By("Waiting some time to make sure that toleration time passed.")
 		timeoutChannel = time.NewTimer(time.Duration(kubeletPodDeletionDelaySeconds+3*additionalWaitPerDeleteSeconds) * time.Second).C
 		select {
@@ -400,15 +407,19 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 		}
 	})
 
-	// 1. Run two pods both with toleration; one with tolerationSeconds=5, the other with 25
-	// 2. Taint the nodes running those pods with a no-execute taint
-	// 3. See if both pods get evicted in between [5, 25] seconds
-	ginkgo.It("evicts pods with minTolerationSeconds", func() {
+	/*
+		Release : v1.16
+		Testname: Pod Eviction, Toleration limits
+		Description: In a multi-pods scenario with tolerationSeconds, the pods MUST be evicted as per
+		the toleration time limit.
+	*/
+	framework.ConformanceIt("evicts pods with minTolerationSeconds", func() {
 		podGroup := "taint-eviction-b"
 		observedDeletions := make(chan string, 100)
 		stopCh := make(chan struct{})
 		createTestController(cs, observedDeletions, stopCh, podGroup, ns)
 
+		// 1. Run two pods both with toleration; one with tolerationSeconds=5, the other with 25
 		pod1 := createPodForTaintsTest(true, additionalWaitPerDeleteSeconds, podGroup+"1", podGroup, ns)
 		pod2 := createPodForTaintsTest(true, 5*additionalWaitPerDeleteSeconds, podGroup+"2", podGroup, ns)
 
@@ -428,13 +439,14 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 		framework.ExpectNoError(err)
 		e2elog.Logf("Pod2 is running on %v. Tainting Node", nodeName)
 
+		// 2. Taint the nodes running those pods with a no-execute taint
 		ginkgo.By("Trying to apply a taint on the Node")
 		testTaint := getTestTaint()
 		framework.AddOrUpdateTaintOnNode(cs, nodeName, testTaint)
 		framework.ExpectNodeHasTaint(cs, nodeName, &testTaint)
 		defer framework.RemoveTaintOffNode(cs, nodeName, testTaint)
 
-		// Wait a bit
+		// 3. Wait to see if both pods get evicted in between [5, 25] seconds
 		ginkgo.By("Waiting for Pod1 and Pod2 to be deleted")
 		timeoutChannel := time.NewTimer(time.Duration(kubeletPodDeletionDelaySeconds+3*additionalWaitPerDeleteSeconds) * time.Second).C
 		var evicted int


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Promotes the following tests to Conformance
- `[sig-scheduling] NoExecuteTaintManager Multiple Pods [Serial] evicts pods with minTolerationSeconds`
- `[sig-scheduling] NoExecuteTaintManager Single Pod [Serial] removing taint cancels eviction`

**Special notes for your reviewer**:

This supercedes https://github.com/kubernetes/kubernetes/pull/77964 which can't merge due to CLA issues

It had `lgtm` and `approved` on it but couldn't merge due to release note and rebase issues at the time

```release-note
NONE
```

/cc @johnbelamaric
/assign @smarterclayton @bgrant0607