### PR TITLE
kubelet: add UID to kubelet_container_log_filesystem_used_bytes metric

### DIFF
--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -28,6 +28,7 @@ var (
 		"kubelet_container_log_filesystem_used_bytes",
 		"Bytes used by the container's logs on the filesystem.",
 		[]string{
+			"uid",
 			"namespace",
 			"pod",
 			"container",
@@ -67,6 +68,7 @@ func (c *logMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 					descLogSize,
 					prometheus.GaugeValue,
 					float64(*c.Logs.UsedBytes),
+					ps.PodRef.UID,
 					ps.PodRef.Namespace,
 					ps.PodRef.Name,
 					c.Name,

--- a/pkg/kubelet/metrics/collectors/log_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics_test.go
@@ -51,6 +51,7 @@ func TestMetricsCollected(t *testing.T) {
 					PodRef: statsapi.PodReference{
 						Namespace: "some-namespace",
 						Name:      "podName1",
+						UID:       "UID_some_id",
 					},
 					Containers: []statsapi.ContainerStats{
 						{
@@ -68,7 +69,7 @@ func TestMetricsCollected(t *testing.T) {
 	err := testutil.CollectAndCompare(collector, strings.NewReader(`
 		# HELP kubelet_container_log_filesystem_used_bytes Bytes used by the container's logs on the filesystem.
 		# TYPE kubelet_container_log_filesystem_used_bytes gauge
-		kubelet_container_log_filesystem_used_bytes{container="containerName1",namespace="some-namespace",pod="podName1"} 18
+		kubelet_container_log_filesystem_used_bytes{container="containerName1",namespace="some-namespace",pod="podName1",uid="UID_some_id"} 18
 `), "kubelet_container_log_filesystem_used_bytes")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
[buildPodRef](https://github.com/kubernetes/kubernetes/blob/946087b422e38dba37a8418860b0f2ede8597394/pkg/kubelet/stats/cadvisor_stats_provider.go#L267) creates a unique key with the {podName, namespace, UID}
tuple. By omitting the UID in the metric, duplicate metrics can be sent
to prometheus causing 500's on the /metrics endpoint.

This change adds the UID to the `kubelet_container_log_filesystem_used_bytes` metric so it is unique and doesn't cause errors like:

```
"An error has occurred during metrics collection:\n\ncollected metric kubelet_container_log_filesystem_used_bytes label:<name:\"container\" value:\"prometheus\" > label:<name:\"namespace\" value:\"openshift-monitoring\" > label:<name:\"pod\" value:\"prometheus-k8s-0\" > gauge:<value:40960 >  was collected before with the same name and label values\n"
```

**Which issue(s) this PR fixes**:
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1731827

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

