### PR TITLE
Store key in TimestampedEntry

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache.go
@@ -74,6 +74,7 @@ func (p *TTLPolicy) IsExpired(obj *TimestampedEntry) bool {
 type TimestampedEntry struct {
 	Obj       interface{}
 	Timestamp time.Time
+	key       string
 }
 
 // getTimestampedEntry returns the TimestampedEntry stored under the given key.
@@ -129,10 +130,8 @@ func (c *ExpirationCache) List() []interface{} {
 
 	list := make([]interface{}, 0, len(items))
 	for _, item := range items {
-		obj := item.(*TimestampedEntry).Obj
-		if key, err := c.keyFunc(obj); err != nil {
-			list = append(list, obj)
-		} else if obj, exists := c.getOrExpire(key); exists {
+		key := item.(*TimestampedEntry).key
+		if obj, exists := c.getOrExpire(key); exists {
 			list = append(list, obj)
 		}
 	}
@@ -154,7 +153,7 @@ func (c *ExpirationCache) Add(obj interface{}) error {
 	c.expirationLock.Lock()
 	defer c.expirationLock.Unlock()
 
-	c.cacheStorage.Add(key, &TimestampedEntry{obj, c.clock.Now()})
+	c.cacheStorage.Add(key, &TimestampedEntry{obj, c.clock.Now(), key})
 	return nil
 }
 
@@ -187,7 +186,7 @@ func (c *ExpirationCache) Replace(list []interface{}, resourceVersion string) er
 		if err != nil {
 			return KeyError{item, err}
 		}
-		items[key] = &TimestampedEntry{item, ts}
+		items[key] = &TimestampedEntry{item, ts, key}
 	}
 	c.expirationLock.Lock()
 	defer c.expirationLock.Unlock()

--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache_test.go
@@ -168,7 +168,9 @@ func TestTTLPolicy(t *testing.T) {
 	expiredTime := fakeTime.Add(-(ttl + 1))
 
 	policy := TTLPolicy{ttl, clock.NewFakeClock(fakeTime)}
-	fakeTimestampedEntry := &TimestampedEntry{Obj: struct{}{}, Timestamp: exactlyOnTTL}
+	item := testStoreObject{id: "foo", val: "bar"}
+	itemkey, _ := testStoreKeyFunc(item)
+	fakeTimestampedEntry := &TimestampedEntry{Obj: item, Timestamp: exactlyOnTTL, key: itemkey}
 	if policy.IsExpired(fakeTimestampedEntry) {
 		t.Errorf("TTL cache should not expire entries exactly on ttl")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In ExpirationCache#List, when the error return from keyFunc is not nil, we should not return the obj to the caller.
Since changing the List func signature would introduce widespread refactoring, we avoid keyFunc by storing key in TimestampedEntry.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
