### PR TITLE
Remove duplicated check in ObserveEventAfterAction

### DIFF
--- a/test/e2e/common/events.go
+++ b/test/e2e/common/events.go
@@ -121,7 +121,7 @@ func ObserveEventAfterAction(f *framework.Framework, eventPredicate func(*v1.Eve
 				e, ok := obj.(*v1.Event)
 				ginkgo.By(fmt.Sprintf("Considering event: \nType = [%s], Name = [%s], Reason = [%s], Message = [%s]", e.Type, e.Name, e.Reason, e.Message))
 				framework.ExpectEqual(ok, true)
-				if ok && eventPredicate(e) {
+				if eventPredicate(e) {
 					observedMatchingEvent = true
 				}
 			},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In ObserveEventAfterAction(), observedMatchingEvent is set if ok is
true. Now the ok is already checked with framework.ExpectEqual().
So this removes duplicated check for code cleanup.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
