### PR TITLE
Check whether label or controllerRef changes first in DaemonSetsController#updatePod

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -572,6 +572,10 @@ func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
 		return
 	}
 
+	labelChanged := !reflect.DeepEqual(curPod.Labels, oldPod.Labels)
+	if !labelChanged && !controllerRefChanged {
+		return
+	}
 	// Otherwise, it's an orphan. If anything changed, sync matching controllers
 	// to see if anyone wants to adopt it now.
 	dss := dsc.getDaemonSetsForPod(curPod)
@@ -579,11 +583,8 @@ func (dsc *DaemonSetsController) updatePod(old, cur interface{}) {
 		return
 	}
 	klog.V(4).Infof("Orphan Pod %s updated.", curPod.Name)
-	labelChanged := !reflect.DeepEqual(curPod.Labels, oldPod.Labels)
-	if labelChanged || controllerRefChanged {
-		for _, ds := range dss {
-			dsc.enqueueDaemonSet(ds)
-		}
+	for _, ds := range dss {
+		dsc.enqueueDaemonSet(ds)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In DaemonSetsController#updatePod, we don't need to call DaemonSets if neither label nor controllerRef changes.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
