### PR TITLE
Log when reject signal cannot be sent to wating pod

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -330,7 +330,9 @@ func (sched *Scheduler) preempt(fwk framework.Framework, preemptor *v1.Pod, sche
 			}
 			// If the victim is a WaitingPod, send a reject message to the PermitPlugin
 			if waitingPod := fwk.GetWaitingPod(victim.UID); waitingPod != nil {
-				waitingPod.Reject("preempted")
+				if !waitingPod.Reject("preempted") {
+					klog.Warningf("unable to deliver reject to %v", victim.UID)
+				}
 			}
 			sched.config.Recorder.Eventf(victim, preemptor, v1.EventTypeNormal, "Preempted", "Preempting", "Preempted by %v/%v on node %v", preemptor.Namespace, preemptor.Name, nodeName)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In Scheduler#preempt, we should log a line when reject signal cannot be sent to wating pod.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
