### PR TITLE
kubeadm: delete bootstrap-kubelet.conf after TLS bootstrap

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -167,6 +167,11 @@ func runKubeletStartJoinPhase(c workflow.RunData) error {
 		return errors.Wrap(err, "error uploading crisocket")
 	}
 
+	// Deletes the bootstrapKubeConfigFile, so the credential used for TLS bootstrap are removed from disk
+	if err := os.Remove(bootstrapKubeConfigFile); err != nil {
+		return errors.Wrapf(err, "error deleting %s", bootstrapKubeConfigFile)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kubernetes/kubernetes#66482 enabled  `kubeadm join --discovery-file` with a discovery file with embedded credentials. This PR makes sure that kubeadm removes the bootstrap-kubelet.conf after completing the TLS bootstrap process, so copies of the above credentials won't be left around.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubeadm/issues/1689

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
ACTION REQUIRED:
kubeadm now deletes the bootstrap-kubelet.conf file after TLS bootstrap
User relying on bootstrap-kubelet.conf should switch to kubelet.conf that contains node credentials
```

/sig cluster-lifecycle
/priority important-soon
/assign @timothysc
/assign @neolit123