### PR TITLE
Improve validation against client connection.

### DIFF
--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -27,6 +27,10 @@ func ValidateClientConnectionConfiguration(cc *config.ClientConnectionConfigurat
 	if cc.Burst < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("burst"), cc.Burst, "must be non-negative"))
 	}
+
+	if int(cc.Burst) < int(cc.QPS) {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("burst"), cc.Burst, "must be equal to or greater than QPS"))
+	}
 	return allErrs
 }
 

--- a/staging/src/k8s.io/component-base/config/validation/validation_test.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation_test.go
@@ -39,6 +39,10 @@ func TestValidateClientConnectionConfiguration(t *testing.T) {
 	burstLessThanZero := validConfig.DeepCopy()
 	burstLessThanZero.Burst = -1
 
+	burstLessThanQPS := validConfig.DeepCopy()
+	burstLessThanQPS.Burst = 50
+	burstLessThanQPS.QPS = 100
+
 	scenarios := map[string]struct {
 		expectedToFail bool
 		config         *config.ClientConnectionConfiguration
@@ -51,9 +55,13 @@ func TestValidateClientConnectionConfiguration(t *testing.T) {
 			expectedToFail: false,
 			config:         qpsLessThanZero,
 		},
-		"bad-burst-less-then-zero": {
+		"bad-burst-less-than-zero": {
 			expectedToFail: true,
 			config:         burstLessThanZero,
+		},
+		"bad-burst-less-than-qps": {
+			expectedToFail: true,
+			config:         burstLessThanQPS,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Improve ClientConnection Validation to avoid the case Burst is greater than QPS.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
