### PR TITLE
Admit existing pod for RequiredDuringSchedulingIgnoredDuringExecution

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -229,7 +229,7 @@ func getTPMapMatchingSpreadConstraints(pod *v1.Pod, nodeInfoMap map[string]*sche
 		}
 		// In accordance to design, if NodeAffinity or NodeSelector is defined,
 		// spreading is applied to nodes that pass those filters.
-		if !PodMatchesNodeSelectorAndAffinityTerms(pod, node) {
+		if !PodMatchesNodeSelectorAndAffinityTerms(pod, nodeInfo) {
 			return
 		}
 

--- a/pkg/scheduler/algorithm/priorities/even_pods_spread.go
+++ b/pkg/scheduler/algorithm/priorities/even_pods_spread.go
@@ -108,7 +108,7 @@ func CalculateEvenPodsSpreadPriority(pod *v1.Pod, nodeNameToInfo map[string]*sch
 		}
 		// (1) `node` should satisfy incoming pod's NodeSelector/NodeAffinity
 		// (2) All topologyKeys need to be present in `node`
-		if !predicates.PodMatchesNodeSelectorAndAffinityTerms(pod, node) ||
+		if !predicates.PodMatchesNodeSelectorAndAffinityTerms(pod, nodeInfo) ||
 			!predicates.NodeLabelsMatchSpreadConstraints(node.Labels, constraints) {
 			return
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR checks whether the pod is an existing pod when RequiredDuringSchedulingIgnoredDuringExecution is in effect.
If so, admit the pod.

**Which issue(s) this PR fixes**:
Fixes #76322

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
