### PR TITLE
Ensure etc-hosts file permission 644, that processes run as non-root user can access it.

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -58,6 +58,7 @@ import (
 	remotecommandserver "k8s.io/kubernetes/pkg/kubelet/server/remotecommand"
 	"k8s.io/kubernetes/pkg/kubelet/status"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
+	"k8s.io/kubernetes/pkg/kubelet/util"
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
@@ -327,7 +328,10 @@ func ensureHostsFile(fileName string, hostIPs []string, hostName, hostDomainName
 		hostsFileContent = managedHostsFileContent(hostIPs, hostName, hostDomainName, hostAliases)
 	}
 
-	return ioutil.WriteFile(fileName, hostsFileContent, 0644)
+	oldMask, _ := util.Umask(0)
+	err = ioutil.WriteFile(fileName, hostsFileContent, 0644)
+	util.Umask(oldMask)
+	return err
 }
 
 // nodeHostsFileContent reads the content of node's hosts file.

--- a/pkg/kubelet/util/util_unix.go
+++ b/pkg/kubelet/util/util_unix.go
@@ -152,3 +152,9 @@ func IsUnixDomainSocket(filePath string) (bool, error) {
 func NormalizePath(path string) string {
 	return path
 }
+
+// Umask is a wrapper for `unix.Umask()` on non-Windows platforms
+func Umask(mask int) (old int, err error) {
+	return unix.Umask(mask), nil
+}
+

--- a/pkg/kubelet/util/util_unsupported.go
+++ b/pkg/kubelet/util/util_unsupported.go
@@ -52,3 +52,9 @@ func LocalEndpoint(path, file string) (string, error) {
 func GetBootTime() (time.Time, error) {
 	return time.Time{}, fmt.Errorf("GetBootTime is unsupported in this build")
 }
+
+// Umask empty implementation
+func Umask(mask int) (int, error) {
+	return 0, fmt.Errorf("platform and architecture is not supported")
+}
+

--- a/pkg/kubelet/util/util_windows.go
+++ b/pkg/kubelet/util/util_windows.go
@@ -151,3 +151,9 @@ func NormalizePath(path string) string {
 	}
 	return path
 }
+
+// Umask returns an error on Windows
+func Umask(mask int) (int, error) {
+	return 0, fmt.Errorf("platform and architecture is not supported")
+}
+


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/area kubelet
/priority important-soon

**What this PR does / why we need it:**

Reset umask before write/create etc-hosts file.
Restore umask after file created.

**Which issue(s) this PR fixes:**

Fixes #80668

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**

Fix a bug: If a POD's command run as a non-root user in a work node that system umask value is 0027(Or kubelet.service's UMask=0027), the file /etc/hosts permission in container is 640, that processes run as non-root user can not access it.
