### PR TITLE
Move pod related functions in file test/e2e/framework/util.go to its sub directory

### DIFF
--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -77,6 +77,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/deployment:go_default_library",
+        "//test/e2e/framework/kubelet:go_default_library",
         "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -40,6 +40,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -287,7 +288,7 @@ var _ = framework.KubeDescribe("Pods", func() {
 
 		ginkgo.By("verifying the kubelet observed the termination notice")
 		err = wait.Poll(time.Second*5, time.Second*30, func() (bool, error) {
-			podList, err := framework.GetKubeletPods(f.ClientSet, pod.Spec.NodeName)
+			podList, err := e2ekubelet.GetKubeletPods(f.ClientSet, pod.Spec.NodeName)
 			if err != nil {
 				e2elog.Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)
 				return false, nil

--- a/test/e2e/framework/kubelet/BUILD
+++ b/test/e2e/framework/kubelet/BUILD
@@ -2,9 +2,18 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["stats.go"],
+    srcs = [
+        "kubelet_pods.go",
+        "stats.go",
+    ],
     importpath = "k8s.io/kubernetes/test/e2e/framework/kubelet",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/master/ports:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
+    ],
 )
 
 filegroup(

--- a/test/e2e/framework/kubelet/kubelet_pods.go
+++ b/test/e2e/framework/kubelet/kubelet_pods.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	v1 "k8s.io/api/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/master/ports"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+)
+
+// GetKubeletPods retrieves the list of pods on the kubelet.
+func GetKubeletPods(c clientset.Interface, node string) (*v1.PodList, error) {
+	return getKubeletPods(c, node, "pods")
+}
+
+// GetKubeletRunningPods retrieves the list of running pods on the kubelet. The pods
+// includes necessary information (e.g., UID, name, namespace for
+// pods/containers), but do not contain the full spec.
+func GetKubeletRunningPods(c clientset.Interface, node string) (*v1.PodList, error) {
+	return getKubeletPods(c, node, "runningpods")
+}
+
+func getKubeletPods(c clientset.Interface, node, resource string) (*v1.PodList, error) {
+	result := &v1.PodList{}
+	client, err := e2enode.ProxyRequest(c, node, resource, ports.KubeletPort)
+	if err != nil {
+		return &v1.PodList{}, err
+	}
+	if err = client.Into(result); err != nil {
+		return &v1.PodList{}, err
+	}
+	return result, nil
+}

--- a/test/e2e/framework/kubelet_stats.go
+++ b/test/e2e/framework/kubelet_stats.go
@@ -503,7 +503,7 @@ func GetKubeletHeapStats(c clientset.Interface, nodeName string) (string, error)
 
 // PrintAllKubeletPods outputs status of all kubelet pods into log.
 func PrintAllKubeletPods(c clientset.Interface, nodeName string) {
-	podList, err := GetKubeletPods(c, nodeName)
+	podList, err := e2ekubelet.GetKubeletPods(c, nodeName)
 	if err != nil {
 		e2elog.Logf("Unable to retrieve kubelet pods for node %v: %v", nodeName, err)
 		return

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -81,6 +81,7 @@ import (
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
+	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
@@ -1782,7 +1783,7 @@ func DumpNodeDebugInfo(c clientset.Interface, nodeNames []string, logFunc func(f
 				e.Source, e.Type, e.Message, e.Reason, e.FirstTimestamp, e.LastTimestamp, e.InvolvedObject)
 		}
 		logFunc("\nLogging pods the kubelet thinks is on node %v", n)
-		podList, err := GetKubeletPods(c, n)
+		podList, err := e2ekubelet.GetKubeletPods(c, n)
 		if err != nil {
 			logFunc("Unable to retrieve kubelet pods for node %v: %v", n, err)
 			continue
@@ -2791,34 +2792,6 @@ func UnblockNetwork(from string, to string) {
 		e2elog.Failf("Failed to remove the iptable REJECT rule. Manual intervention is "+
 			"required on host %s: remove rule %s, if exists", from, iptablesRule)
 	}
-}
-
-// GetKubeletPods retrieves the list of pods on the kubelet.
-// TODO(alejandrox1): move to pod subpkg once node methods have been refactored.
-func GetKubeletPods(c clientset.Interface, node string) (*v1.PodList, error) {
-	return getKubeletPods(c, node, "pods")
-}
-
-// GetKubeletRunningPods retrieves the list of running pods on the kubelet. The pods
-// includes necessary information (e.g., UID, name, namespace for
-// pods/containers), but do not contain the full spec.
-// TODO(alejandrox1): move to pod subpkg once node methods have been refactored.
-func GetKubeletRunningPods(c clientset.Interface, node string) (*v1.PodList, error) {
-	return getKubeletPods(c, node, "runningpods")
-}
-
-// TODO(alejandrox1): move to pod subpkg once node methods have been
-// refactored.
-func getKubeletPods(c clientset.Interface, node, resource string) (*v1.PodList, error) {
-	result := &v1.PodList{}
-	client, err := e2enode.ProxyRequest(c, node, resource, ports.KubeletPort)
-	if err != nil {
-		return &v1.PodList{}, err
-	}
-	if err = client.Into(result); err != nil {
-		return &v1.PodList{}, err
-	}
-	return result, nil
 }
 
 // PingCommand is the type to hold ping command.

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	"k8s.io/kubernetes/test/e2e/framework/volume"
@@ -53,7 +54,7 @@ const (
 func getPodMatches(c clientset.Interface, nodeName string, podNamePrefix string, namespace string) sets.String {
 	matches := sets.NewString()
 	e2elog.Logf("Checking pods on node %v via /runningpods endpoint", nodeName)
-	runningPods, err := framework.GetKubeletPods(c, nodeName)
+	runningPods, err := e2ekubelet.GetKubeletPods(c, nodeName)
 	if err != nil {
 		e2elog.Logf("Error checking running pods on %v: %v", nodeName, err)
 		return matches

--- a/test/e2e/node/kubelet_perf.go
+++ b/test/e2e/node/kubelet_perf.go
@@ -54,7 +54,7 @@ type resourceTest struct {
 
 func logPodsOnNodes(c clientset.Interface, nodeNames []string) {
 	for _, n := range nodeNames {
-		podList, err := framework.GetKubeletRunningPods(c, n)
+		podList, err := e2ekubelet.GetKubeletRunningPods(c, n)
 		if err != nil {
 			e2elog.Logf("Unable to retrieve kubelet pods for node %v", n)
 			continue

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
@@ -142,7 +143,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			ginkgo.By("verifying the kubelet observed the termination notice")
 
 			err = wait.Poll(time.Second*5, time.Second*30, func() (bool, error) {
-				podList, err := framework.GetKubeletPods(f.ClientSet, pod.Spec.NodeName)
+				podList, err := e2ekubelet.GetKubeletPods(f.ClientSet, pod.Spec.NodeName)
 				if err != nil {
 					e2elog.Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)
 					return false, nil

--- a/test/e2e_node/resource_usage_test.go
+++ b/test/e2e_node/resource_usage_test.go
@@ -287,7 +287,7 @@ func verifyCPULimits(expected e2ekubelet.ContainersCPUSummary, actual e2ekubelet
 
 func logPods(c clientset.Interface) {
 	nodeName := framework.TestContext.NodeName
-	podList, err := framework.GetKubeletRunningPods(c, nodeName)
+	podList, err := e2ekubelet.GetKubeletRunningPods(c, nodeName)
 	if err != nil {
 		e2elog.Logf("Unable to retrieve kubelet pods for node %v", nodeName)
 	}


### PR DESCRIPTION
 /kind cleanup

**What this PR does / why we need it**:
Move pod related functions in file test/e2e/framework/util.go to its sub directory

```release-note
NONE
```
