### PR TITLE
Automated cherry pick of #80559: Bump github.com/libopenstorage/openstorage to v1.0.0.

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -3183,7 +3183,7 @@
 		},
 		{
 			"ImportPath": "github.com/robfig/cron",
-			"Comment": "v1-53-gdf38d32658d878",
+			"Comment": "v1.0.0-53-gdf38d32658d878",
 			"Rev": "df38d32658d8788cd446ba74db4bb5375c4b0cb3"
 		},
 		{

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2569,30 +2569,37 @@
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api",
+			"Comment": "v1.0.0",
 			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api/client",
+			"Comment": "v1.0.0",
 			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api/client/volume",
+			"Comment": "v1.0.0",
 			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/api/spec",
+			"Comment": "v1.0.0",
 			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/pkg/parser",
+			"Comment": "v1.0.0",
 			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/pkg/units",
+			"Comment": "v1.0.0",
 			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
 		},
 		{
 			"ImportPath": "github.com/libopenstorage/openstorage/volume",
+			"Comment": "v1.0.0",
 			"Rev": "093a0c3888753c2056e7373183693d670c6bba01"
 		},
 		{


### PR DESCRIPTION
Cherry pick of #80559 on release-1.14.

#80559: Bump github.com/libopenstorage/openstorage to v1.0.0.