### PR TITLE
Fix printing of empty separator line in kubectl get all

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -509,6 +509,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 
 	// track if we write any output
 	trackingWriter := &trackingWriterWrapper{Delegate: o.Out}
+	previouslyWritten := trackingWriter.Written
 
 	w := utilprinters.GetNewTabWriter(trackingWriter)
 	for ix := range objs {
@@ -535,8 +536,9 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 			// TODO: this doesn't belong here
 			// add linebreak between resource groups (if there is more than one)
 			// skip linebreak above first resource group
-			if lastMapping != nil && !o.NoHeaders {
-				fmt.Fprintln(o.ErrOut)
+			if trackingWriter.Written > previouslyWritten && !o.NoHeaders {
+				fmt.Fprintln(w)
+				previouslyWritten = trackingWriter.Written
 			}
 
 			printer, err = o.ToPrinter(mapping, printWithNamespace, printWithKind)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Before this commit, kubectl get all would always print a blank separator
line between two objects of different kinds. When using server-side
printing, an object can be a table, which contains zero, one or more
objects of a certain kind. Kubectl get all would print the empty line
even if the table was empty. This commit ensures that the blank line is
printed only if the object printer actually prints something (i.e. the
table isn't empty).

**Which issue(s) this PR fixes**:
Fixes #79579

**Special notes for your reviewer**:
No unit test, because the existing test never checked what the command prints to stderr (the empty lines are printed there, not to stdout). 

**Does this PR introduce a user-facing change?**:
```release-note
Fixed unnecessary empty lines when running kubectl get all
```
