### PR TITLE
move OpenLocalPort to package utils

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1803,45 +1803,7 @@ type listenPortOpener struct{}
 
 // OpenLocalPort holds the given local port open.
 func (l *listenPortOpener) OpenLocalPort(lp *utilproxy.LocalPort) (utilproxy.Closeable, error) {
-	return openLocalPort(lp)
-}
-
-func openLocalPort(lp *utilproxy.LocalPort) (utilproxy.Closeable, error) {
-	// For ports on node IPs, open the actual port and hold it, even though we
-	// use ipvs to redirect traffic.
-	// This ensures a) that it's safe to use that port and b) that (a) stays
-	// true.  The risk is that some process on the node (e.g. sshd or kubelet)
-	// is using a port and we give that same port out to a Service.  That would
-	// be bad because ipvs would silently claim the traffic but the process
-	// would never know.
-	// NOTE: We should not need to have a real listen()ing socket - bind()
-	// should be enough, but I can't figure out a way to e2e test without
-	// it.  Tools like 'ss' and 'netstat' do not show sockets that are
-	// bind()ed but not listen()ed, and at least the default debian netcat
-	// has no way to avoid about 10 seconds of retries.
-	var socket utilproxy.Closeable
-	switch lp.Protocol {
-	case "tcp":
-		listener, err := net.Listen("tcp", net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port)))
-		if err != nil {
-			return nil, err
-		}
-		socket = listener
-	case "udp":
-		addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port)))
-		if err != nil {
-			return nil, err
-		}
-		conn, err := net.ListenUDP("udp", addr)
-		if err != nil {
-			return nil, err
-		}
-		socket = conn
-	default:
-		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
-	}
-	klog.V(2).Infof("Opened local port %s", lp.String())
-	return socket, nil
+	return utilproxy.OpenLocalPort(lp)
 }
 
 // ipvs Proxier fall back on iptables when it needs to do SNAT for engress packets

--- a/pkg/proxy/util/port.go
+++ b/pkg/proxy/util/port.go
@@ -65,3 +65,41 @@ func RevertPorts(replacementPortsMap, originalPortsMap map[LocalPort]Closeable) 
 		}
 	}
 }
+
+func OpenLocalPort(lp *LocalPort) (Closeable, error) {
+	// For ports on node IPs, open the actual port and hold it, even though we
+	// use iptables or ipvs to redirect traffic.
+	// This ensures a) that it's safe to use that port and b) that (a) stays
+	// true.  The risk is that some process on the node (e.g. sshd or kubelet)
+	// is using a port and we give that same port out to a Service.  That would
+	// be bad because iptables or ipvs would silently claim the traffic but the process
+	// would never know.
+	// NOTE: We should not need to have a real listen()ing socket - bind()
+	// should be enough, but I can't figure out a way to e2e test without
+	// it.  Tools like 'ss' and 'netstat' do not show sockets that are
+	// bind()ed but not listen()ed, and at least the default debian netcat
+	// has no way to avoid about 10 seconds of retries.
+	var socket Closeable
+	switch lp.Protocol {
+	case "tcp":
+		listener, err := net.Listen("tcp", net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port)))
+		if err != nil {
+			return nil, err
+		}
+		socket = listener
+	case "udp":
+		addr, err := net.ResolveUDPAddr("udp", net.JoinHostPort(lp.IP, strconv.Itoa(lp.Port)))
+		if err != nil {
+			return nil, err
+		}
+		conn, err := net.ListenUDP("udp", addr)
+		if err != nil {
+			return nil, err
+		}
+		socket = conn
+	default:
+		return nil, fmt.Errorf("unknown protocol %q", lp.Protocol)
+	}
+	klog.V(2).Infof("Opened local port %s", lp.String())
+	return socket, nil
+}


### PR DESCRIPTION
The function `openLocalPort` is exactly the same in file `iptables/proxier.go` and `ipvs/proxier.go`.
It is better to move the function to package `utils` to get better code reusing.

/sig network

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
NA
**Which issue(s) this PR fixes**:
NA
**Special notes for your reviewer**:
NA
**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

