### PR TITLE
Update Kubelet Timed Pod Deletion Test Name to use Literal String

### DIFF
--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -335,8 +335,6 @@ var _ = SIGDescribe("kubelet", func() {
 			//   - a bug in graceful termination (if it is enabled)
 			//   - docker slow to delete pods (or resource problems causing slowness)
 			start := time.Now()
-			err = waitTillNPodsRunningOnNodes(f.ClientSet, nodeNames, rcName, ns, 0, 1*time.Minute)
-			framework.ExpectNoError(err)
 			e2elog.Logf("Deleting %d pods on %d nodes completed in %v after the RC was deleted", totalPods, len(nodeNames),
 				time.Since(start))
 			if resourceMonitor != nil {

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -314,7 +314,7 @@ var _ = SIGDescribe("kubelet", func() {
 				Replicas:     totalPods,
 				NodeSelector: nodeLabels,
 			})
-			framework.ExpectNoError(err)
+			framework.ExpectNoError(err, "failed creating a ReplicationController")
 			if resourceMonitor != nil {
 				resourceMonitor.LogLatest()
 			}

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -310,9 +310,7 @@ var _ = SIGDescribe("kubelet", func() {
 		})
 
 		for _, itArg := range deleteTests {
-			name := fmt.Sprintf(
-				"kubelet should be able to delete %d pods per node in %v.", itArg.podsPerNode, itArg.timeout)
-			ginkgo.It(name, func() {
+			ginkgo.It("should let Kubelet delete x pods per node in n minutes", func() {
 				totalPods := itArg.podsPerNode * numNodes
 				ginkgo.By(fmt.Sprintf("Creating a RC of %d pods and wait until all pods of this RC are running", totalPods))
 				rcName := fmt.Sprintf("cleanup%d-%s", totalPods, string(uuid.NewUUID()))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind cleanup

**What this PR does / why we need it**:

There [was interest](https://github.com/kubernetes/kubernetes/pull/79630) in promoting this test to Conformance, but[ it was blocked](https://github.com/kubernetes/kubernetes/pull/79630#issuecomment-510251819) due to Conformance tooling requiring that test names be literal strings.

This PR updates the test name to be a literal string.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NOTE
```

/area conformance
/area test