### PR TITLE
Improve client connection config validation.

### DIFF
--- a/staging/src/k8s.io/component-base/config/validation/validation.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation.go
@@ -27,6 +27,10 @@ func ValidateClientConnectionConfiguration(cc *config.ClientConnectionConfigurat
 	if cc.Burst < 0 {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("burst"), cc.Burst, "must be non-negative"))
 	}
+
+	if cc.QPS > 0 && cc.Burst == 0 {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("burst"), cc.Burst, "must be greater than 0 when QPS is set to be greater than 0"))
+	}
 	return allErrs
 }
 

--- a/staging/src/k8s.io/component-base/config/validation/validation_test.go
+++ b/staging/src/k8s.io/component-base/config/validation/validation_test.go
@@ -39,6 +39,9 @@ func TestValidateClientConnectionConfiguration(t *testing.T) {
 	burstLessThanZero := validConfig.DeepCopy()
 	burstLessThanZero.Burst = -1
 
+	burstIsZero := validConfig.DeepCopy()
+	burstIsZero.Burst = 0
+
 	scenarios := map[string]struct {
 		expectedToFail bool
 		config         *config.ClientConnectionConfiguration
@@ -51,9 +54,13 @@ func TestValidateClientConnectionConfiguration(t *testing.T) {
 			expectedToFail: false,
 			config:         qpsLessThanZero,
 		},
-		"bad-burst-less-then-zero": {
+		"bad-burst-less-than-zero": {
 			expectedToFail: true,
 			config:         burstLessThanZero,
+		},
+		"bad-burst-is-zero": {
+			expectedToFail: true,
+			config:         burstIsZero,
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:

Check invalid configuration qps > 0 and burst == 0, in this case, client will not serve any requests, since the bucket size (burst) will be zero.

BTW, fix a typo.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
