### PR TITLE
split coredns dependency to decouple kubeadm and kube-up

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -62,7 +62,7 @@ dependencies:
       match: cniVersion[\t\n\f\r ]*=
       
 
-  - name: "coredns"
+  - name: "coredns-kube-up"
     version: 1.3.1
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
@@ -71,6 +71,10 @@ dependencies:
       match: k8s.gcr.io/coredns
     - path: cluster/addons/dns/coredns/coredns.yaml.sed
       match: k8s.gcr.io/coredns
+
+  - name: "coredns-kubeadm"
+    version: 1.3.1
+    refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =
 


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What type of PR is this?**

/kind bug
/sig release
/sig architecture
/priority important-soon

**What this PR does / why we need it**: decouples kubeadm and kube-up and allows bumping coredns separately. Unblocks #78033

**Which issue(s) this PR fixes**: ref #80546

**Special notes for your reviewer**:

/assign @cblecker @neolit123 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
