### PR TITLE
Fix `kubectl top` description

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top.go
@@ -41,7 +41,7 @@ var (
 
 		The top command allows you to see the resource consumption for nodes or pods.
 
-		This command requires Heapster to be correctly configured and working on the server. `))
+		This command requires a working implementation of the Resource Metrics API (such as the Metrics Server) or Heapster.`))
 )
 
 func NewCmdTop(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Since #56206, `kubectl top` uses the Resource Metrics API (metrics.k8s.io)
and falls back to Heapster, which is deprecated. This commit updates the
description of command `kubectl top` to reflect this behavior.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

N/A

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

N/A

/sig cli
