### PR TITLE
Automated cherry pick of #79623: quote container name in container already use error matching

### DIFF
--- a/pkg/kubelet/dockershim/docker_container_test.go
+++ b/pkg/kubelet/dockershim/docker_container_test.go
@@ -248,7 +248,7 @@ func TestContainerCreationConflict(t *testing.T) {
 	containerName := makeContainerName(sConfig, config)
 	const sandboxId = "sandboxid"
 	const containerId = "containerid"
-	conflictError := fmt.Errorf("Error response from daemon: Conflict. The name \"/%s\" is already in use by container %s. You have to remove (or rename) that container to be able to reuse that name.",
+	conflictError := fmt.Errorf("Error response from daemon: Conflict. The name \"/%s\" is already in use by container %q. You have to remove (or rename) that container to be able to reuse that name.",
 		containerName, containerId)
 	noContainerError := fmt.Errorf("Error response from daemon: No such container: %s", containerId)
 	randomError := fmt.Errorf("random error")

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -43,7 +43,7 @@ const (
 )
 
 var (
-	conflictRE = regexp.MustCompile(`Conflict. (?:.)+ is already in use by container ([0-9a-z]+)`)
+	conflictRE = regexp.MustCompile(`Conflict. (?:.)+ is already in use by container \"?([0-9a-z]+)\"?`)
 
 	// this is hacky, but extremely common.
 	// if a container starts but the executable file is not found, runc gives a message that matches

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -121,11 +121,16 @@ func TestGetUserFromImageUser(t *testing.T) {
 
 func TestParsingCreationConflictError(t *testing.T) {
 	// Expected error message from docker.
-	msg := "Conflict. The name \"/k8s_POD_pfpod_e2e-tests-port-forwarding-dlxt2_81a3469e-99e1-11e6-89f2-42010af00002_0\" is already in use by container 24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e. You have to remove (or rename) that container to be able to reuse that name."
+	msgs := []string{
+		"Conflict. The name \"/k8s_POD_pfpod_e2e-tests-port-forwarding-dlxt2_81a3469e-99e1-11e6-89f2-42010af00002_0\" is already in use by container 24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e. You have to remove (or rename) that container to be able to reuse that name.",
+		"Conflict. The name \"/k8s_POD_pfpod_e2e-tests-port-forwarding-dlxt2_81a3469e-99e1-11e6-89f2-42010af00002_0\" is already in use by container \"24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e\". You have to remove (or rename) that container to be able to reuse that name.",
+	}
 
-	matches := conflictRE.FindStringSubmatch(msg)
-	require.Len(t, matches, 2)
-	require.Equal(t, matches[1], "24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e")
+	for _, msg := range msgs {
+		matches := conflictRE.FindStringSubmatch(msg)
+		require.Len(t, matches, 2)
+		require.Equal(t, matches[1], "24666ab8c814d16f986449e504ea0159468ddf8da01897144a770f66dce0e14e")
+	}
 }
 
 // writeDockerConfig will write a config file into a temporary dir, and return that dir.


### PR DESCRIPTION
Cherry pick of #79623 on release-1.14.

#79623: quote container name in container already use error matching