### PR TITLE
Automated cherry pick of #79851: Return MetricsError with ErrCodeNotSupported code

### DIFF
--- a/pkg/volume/csi/csi_metrics.go
+++ b/pkg/volume/csi/csi_metrics.go
@@ -61,9 +61,11 @@ func (mc *metricsCsi) GetMetrics() (*volume.Metrics, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	// if plugin doesnot support volume status, return.
 	if !volumeStatsSet {
-		return nil, nil
+		return nil, volume.NewNotSupportedErrorWithDriverName(
+			string(mc.csiClientGetter.driverName))
 	}
 	// Get Volumestatus
 	metrics, err := csiClient.NodeGetVolumeStats(ctx, mc.volumeID, mc.targetPath)

--- a/pkg/volume/metrics_errors.go
+++ b/pkg/volume/metrics_errors.go
@@ -35,7 +35,16 @@ func NewNotSupportedError() *MetricsError {
 	}
 }
 
-// NewNoPathDefined creates a new MetricsError with code NoPathDefined.
+// NewNotSupportedErrorWithDriverName creates a new MetricsError with code NotSupported.
+// driver name is added to the error message.
+func NewNotSupportedErrorWithDriverName(name string) *MetricsError {
+	return &MetricsError{
+		Code: ErrCodeNotSupported,
+		Msg:  fmt.Sprintf("metrics are not supported for %s volumes", name),
+	}
+}
+
+// NewNoPathDefinedError creates a new MetricsError with code NoPathDefined.
 func NewNoPathDefinedError() *MetricsError {
 	return &MetricsError{
 		Code: ErrCodeNoPathDefined,


### PR DESCRIPTION
Cherry pick of #79851 on release-1.15.

#79851: Return MetricsError with ErrCodeNotSupported code