### PR TITLE
Add code check for framework.ExpectEqual()

### DIFF
--- a/hack/verify-test-code.sh
+++ b/hack/verify-test-code.sh
@@ -42,6 +42,15 @@ do
     fi
 done
 
+errors_expect_equal=()
+for file in "${all_e2e_files[@]}"
+do
+    if grep -E "Expect\(.*\)\.To\((gomega\.Equal|Equal)" "${file}" > /dev/null
+    then
+        errors_expect_equal+=( "${file}" )
+    fi
+done
+
 if [ ${#errors_expect_no_error[@]} -ne 0 ]; then
   {
     echo "Errors:"
@@ -65,6 +74,20 @@ if [ ${#errors_expect_error[@]} -ne 0 ]; then
     echo
     echo 'The above files need to use framework.ExpectError(err) instead of '
     echo 'Expect(err).To(HaveOccurred()) or gomega.Expect(err).To(gomega.HaveOccurred())'
+    echo
+  } >&2
+  exit 1
+fi
+
+if [ ${#errors_expect_equal[@]} -ne 0 ]; then
+  {
+    echo "Errors:"
+    for err in "${errors_expect_equal[@]}"; do
+      echo "$err"
+    done
+    echo
+    echo 'The above files need to use framework.ExpectEqual(foo, bar) instead of '
+    echo 'Expect(foo).To(Equal(bar)) or gomega.Expect(foo).To(gomega.Equal(bar))'
     echo
   } >&2
   exit 1


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This adds code check for using framework.ExpectEqual(foo, bar) in
e2e tests for keeping the test code simple.

Close: https://github.com/kubernetes/kubernetes/issues/79686

**Special notes for your reviewer**:

When we finish all tasks in https://github.com/kubernetes/kubernetes/issues/79686 this PR can be merged.

