### PR TITLE
Refine watcher count calculation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -163,7 +163,6 @@ func (i *indexedWatchers) terminateAll(objectType reflect.Type, done func(*cache
 // As we don't need a high precision here, we keep all watchers timeout within a
 // second in a bucket, and pop up them once at the timeout. To be more specific,
 // if you set fire time at X, you can get the bookmark within (X-1,X+1) period.
-// This is NOT thread-safe.
 type watcherBookmarkTimeBuckets struct {
 	lock            sync.Mutex
 	watchersBuckets map[int64][]*cacheWatcher

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -647,7 +647,12 @@ func TestCacherNoLeakWithMultipleWatchers(t *testing.T) {
 	cacher.bookmarkWatchers.lock.Lock()
 	defer cacher.bookmarkWatchers.lock.Unlock()
 	if len(cacher.bookmarkWatchers.watchersBuckets) != 0 {
-		t.Errorf("unexpected bookmark watchers %v", len(cacher.bookmarkWatchers.watchersBuckets))
+		numWatchers := 0
+		for bucketID, v := range cacher.bookmarkWatchers.watchersBuckets {
+			numWatchers += len(v)
+			t.Errorf("there are %v watchers at bucket Id %v with start Id %v", len(v), bucketID, cacher.bookmarkWatchers.startBucketID)
+		}
+		t.Errorf("unexpected bookmark watchers %v", numWatchers)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The TestCacherNoLeakWithMultipleWatchers incorrectly reports the number of leaked watchers because each entry in watchersBuckets has some watchers in the value.

This PR corrects the number of leaked watchers reported.
I also enhance the failure log with the bucket Id where the leak occurred.

Also removes the thread unsafe comment for watcherBookmarkTimeBuckets.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
