### PR TITLE
Add pending state to the list that can't run exec command

### DIFF
--- a/pkg/kubectl/cmd/exec/exec.go
+++ b/pkg/kubectl/cmd/exec/exec.go
@@ -307,7 +307,7 @@ func (p *ExecOptions) Run() error {
 
 	pod := p.Pod
 
-	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+	if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed || pod.Status.Phase == corev1.PodPending {
 		return fmt.Errorf("cannot exec into a container in a completed pod; current phase is %s", pod.Status.Phase)
 	}
 


### PR DESCRIPTION
/kind bug


**What this PR does / why we need it**:
Add pending state to the list that can't run exec command


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
   None

```


