### PR TITLE
do not return error, when the ds is not found

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/prepull.go
+++ b/cmd/kubeadm/app/phases/upgrade/prepull.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
@@ -85,7 +86,9 @@ func (d *DaemonSetPrepuller) WaitFunc(component string) {
 // DeleteFunc deletes the DaemonSet used for making the image available on every relevant node
 func (d *DaemonSetPrepuller) DeleteFunc(component string) error {
 	dsName := addPrepullPrefix(component)
-	if err := apiclient.DeleteDaemonSetForeground(d.client, metav1.NamespaceSystem, dsName); err != nil {
+	// TODO: The IsNotFound() check is required in cases where the DaemonSet is missing.
+	// Investigate why this happens: https://github.com/kubernetes/kubeadm/issues/1700
+	if err := apiclient.DeleteDaemonSetForeground(d.client, metav1.NamespaceSystem, dsName); err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrapf(err, "unable to cleanup the DaemonSet used for prepulling %s", component)
 	}
 	fmt.Printf("[upgrade/prepull] Prepulled image for component %s.\n", component)


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
when I upgrade my cluster from 1.13 to 1.14 using kubeadm, I came across the following error:
```sh
[upgrade/prepull] Will prepull images for components [kube-apiserver kube-controller-manager kube-scheduler]
[upgrade/prepull] Prepulling image for component kube-scheduler.
[upgrade/prepull] Prepulling image for component kube-apiserver.
[upgrade/prepull] Prepulling image for component kube-controller-manager.
[apiclient] Found 0 Pods for label selector k8s-app=upgrade-prepull-kube-scheduler
[apiclient] Found 0 Pods for label selector k8s-app=upgrade-prepull-kube-controller-manager
[apiclient] Found 0 Pods for label selector k8s-app=upgrade-prepull-kube-apiserver
[apiclient] Found 3 Pods for label selector k8s-app=upgrade-prepull-kube-controller-manager
[apiclient] Found 3 Pods for label selector k8s-app=upgrade-prepull-kube-apiserver
[upgrade/prepull] Prepulled image for component kube-controller-manager.
[upgrade/prepull] Prepulled image for component kube-apiserver.
[upgrade/prepull] Failed prepulled the images for the control plane components error: unable to cleanup the DaemonSet used for prepulling kube-scheduler: daemonsets.apps "upgrade-prepull-kube-scheduler" not found
``` 
I think we'd better not to return error, when we intend to delete the `ds` and the `ds` is not found.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: avoid double deletion of the upgrade prepull DaemonSet
```
