### PR TITLE
Fix unexpected line end in override flags

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -109,7 +109,7 @@ __kubectl_override_flags()
     done
     for var in "${__kubectl_override_flag_list[@]##*-}"; do
         if eval "test -n \"\$${var}\""; then
-            eval "echo \${${var}}"
+            eval "echo -n \${${var}}' '"
         fi
     done
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
#70470 caused a bug in bash completion described in #80797.

**Which issue(s) this PR fixes**:
Fixes #80797

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fixed the bash completion error with override flags.
```