### PR TITLE
Setup directories for Metrics validation and verification KEP

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -18,6 +18,7 @@ filegroup(
         "//test/e2e_node:all-srcs",
         "//test/fixtures:all-srcs",
         "//test/images:all-srcs",
+        "//test/instrumentation:all-srcs",
         "//test/integration:all-srcs",
         "//test/kubemark:all-srcs",
         "//test/list:all-srcs",

--- a/test/instrumentation/BUILD
+++ b/test/instrumentation/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/kubernetes/test/instrumentation",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "instrumentation",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/instrumentation/OWNERS
+++ b/test/instrumentation/OWNERS
@@ -1,0 +1,12 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- piosz
+- brancz
+- logicalhan
+reviewers:
+- piosz
+- brancz
+- logicalhan
+labels:
+- sig/instrumentation

--- a/test/instrumentation/README.md
+++ b/test/instrumentation/README.md
@@ -1,0 +1,3 @@
+This is a WIP directory for ensuring stability rules around kubernetes metrics.
+
+Design [Metrics validation and verification](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-validation-and-verification.md)

--- a/test/instrumentation/main.go
+++ b/test/instrumentation/main.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+func main() {
+
+}

--- a/test/instrumentation/testdata/OWNERS
+++ b/test/instrumentation/testdata/OWNERS
@@ -1,0 +1,11 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- piosz
+- brancz
+reviewers:
+- piosz
+- brancz
+- logicalhan
+labels:
+- sig/instrumentation


### PR DESCRIPTION
This PR add directories and setups directory OWNERS for implementation of KEP

Issue: https://github.com/kubernetes/enhancements/issues/1209

/kind feature
/sig instrumentation

```release-note
NONE
```

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-validation-and-verification.md
```
/cc @logicalhan 
FYI @danielmk