### PR TITLE
Make kubeadm join discovery wait for a finite time

### DIFF
--- a/cmd/kubeadm/app/discovery/BUILD
+++ b/cmd/kubeadm/app/discovery/BUILD
@@ -27,7 +27,10 @@ go_test(
     name = "go_default_test",
     srcs = ["discovery_test.go"],
     embed = [":go_default_library"],
-    deps = ["//cmd/kubeadm/app/apis/kubeadm:go_default_library"],
+    deps = [
+        "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kubeadm/app/discovery/discovery.go
+++ b/cmd/kubeadm/app/discovery/discovery.go
@@ -75,9 +75,9 @@ func DiscoverValidatedKubeConfig(cfg *kubeadmapi.JoinConfiguration) (*clientcmda
 	case cfg.Discovery.File != nil:
 		kubeConfigPath := cfg.Discovery.File.KubeConfigPath
 		if isHTTPSURL(kubeConfigPath) {
-			return https.RetrieveValidatedConfigInfo(kubeConfigPath, kubeadmapiv1beta2.DefaultClusterName)
+			return https.RetrieveValidatedConfigInfo(kubeConfigPath, kubeadmapiv1beta2.DefaultClusterName, cfg.Discovery.Timeout.Duration)
 		}
-		return file.RetrieveValidatedConfigInfo(kubeConfigPath, kubeadmapiv1beta2.DefaultClusterName)
+		return file.RetrieveValidatedConfigInfo(kubeConfigPath, kubeadmapiv1beta2.DefaultClusterName, cfg.Discovery.Timeout.Duration)
 	case cfg.Discovery.BootstrapToken != nil:
 		return token.RetrieveValidatedConfigInfo(cfg)
 	default:

--- a/cmd/kubeadm/app/discovery/discovery_test.go
+++ b/cmd/kubeadm/app/discovery/discovery_test.go
@@ -18,7 +18,9 @@ package discovery
 
 import (
 	"testing"
+	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 )
 
@@ -69,7 +71,9 @@ func TestFor(t *testing.T) {
 	}
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			_, actual := For(&rt.d)
+			config := rt.d
+			config.Discovery.Timeout = &metav1.Duration{Duration: 5 * time.Minute}
+			_, actual := For(&config)
 			if (actual == nil) != rt.expect {
 				t.Errorf(
 					"failed For:\n\texpected: %t\n\t  actual: %t",

--- a/cmd/kubeadm/app/discovery/https/https.go
+++ b/cmd/kubeadm/app/discovery/https/https.go
@@ -19,6 +19,7 @@ package https
 import (
 	"io/ioutil"
 	"net/http"
+	"time"
 
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/tools/clientcmd"
@@ -29,7 +30,7 @@ import (
 // RetrieveValidatedConfigInfo connects to the API Server and makes sure it can talk
 // securely to the API Server using the provided CA cert and
 // optionally refreshes the cluster-info information from the cluster-info ConfigMap
-func RetrieveValidatedConfigInfo(httpsURL, clustername string) (*clientcmdapi.Config, error) {
+func RetrieveValidatedConfigInfo(httpsURL, clustername string, discoveryTimeout time.Duration) (*clientcmdapi.Config, error) {
 	client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
 	response, err := client.Get(httpsURL)
 	if err != nil {
@@ -46,5 +47,5 @@ func RetrieveValidatedConfigInfo(httpsURL, clustername string) (*clientcmdapi.Co
 	if err != nil {
 		return nil, err
 	}
-	return file.ValidateConfigInfo(config, clustername)
+	return file.ValidateConfigInfo(config, clustername, discoveryTimeout)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Add a timeout to discovery in `kubeadm join`, when using a discovery file.

Currently the discovery logic runs indefinitely. During review of #80675, @neolit123 requested to add a timeout: https://github.com/kubernetes/kubernetes/pull/80675#discussion_r308016782.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubeadm/issues/1693

**Special notes for your reviewer**:

Timeout value is `cfg.Discovery.Timeout.Duration`, which is already the timeout for token-based discovery. It can be customized in `JoinConfiguration` and defaults to `v1beta2.DefaultDiscoveryTimeout`, which is 5 minutes. This should be sufficient for worker nodes waiting for control-plane nodes in case of parallel provisioning.

**Does this PR introduce a user-facing change?**:

```release-note
"kubeadm join" fails if file-based discovery is too long, with a default timeout of 5 minutes.
```

/sig cluster-lifecycle
/cc fabriziopandini neolit123
/priority important-longterm