### PR TITLE
Fix golint error in pkg/util/removeall

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -273,7 +273,6 @@ pkg/util/mount
 pkg/util/normalizer
 pkg/util/oom
 pkg/util/procfs
-pkg/util/removeall
 pkg/util/rlimit
 pkg/util/selinux
 pkg/util/sysctl/testing

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -143,7 +143,7 @@ func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*v1.Pod, runningPods []*kubecon
 		}
 
 		klog.V(3).Infof("Orphaned pod %q found, removing", uid)
-		if err := removeall.RemoveAllOneFilesystem(kl.mounter, kl.getPodDir(uid)); err != nil {
+		if err := removeall.OneFilesystem(kl.mounter, kl.getPodDir(uid)); err != nil {
 			klog.Errorf("Failed to remove orphaned pod %q dir; err: %v", uid, err)
 			orphanRemovalErrors = append(orphanRemovalErrors, err)
 		}

--- a/pkg/util/removeall/removeall.go
+++ b/pkg/util/removeall/removeall.go
@@ -25,14 +25,14 @@ import (
 	"k8s.io/kubernetes/pkg/util/mount"
 )
 
-// RemoveAllOneFilesystem removes path and any children it contains.
+// OneFilesystem removes path and any children it contains.
 // It removes everything it can but returns the first error
 // it encounters. If the path does not exist, RemoveAll
 // returns nil (no error).
 // It makes sure it does not cross mount boundary, i.e. it does *not* remove
 // files from another filesystems. Like 'rm -rf --one-file-system'.
 // It is copied from RemoveAll() sources, with IsLikelyNotMountPoint
-func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
+func OneFilesystem(mounter mount.Interface, path string) error {
 	// Simple case: if Remove works, we're done.
 	err := os.Remove(path)
 	if err == nil || os.IsNotExist(err) {
@@ -76,7 +76,7 @@ func RemoveAllOneFilesystem(mounter mount.Interface, path string) error {
 	for {
 		names, err1 := fd.Readdirnames(100)
 		for _, name := range names {
-			err1 := RemoveAllOneFilesystem(mounter, path+string(os.PathSeparator)+name)
+			err1 := OneFilesystem(mounter, path+string(os.PathSeparator)+name)
 			if err == nil {
 				err = err1
 			}

--- a/pkg/util/removeall/removeall_test.go
+++ b/pkg/util/removeall/removeall_test.go
@@ -43,7 +43,7 @@ func (f *fakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }
 
-func TestRemoveAllOneFilesystem(t *testing.T) {
+func TestOneFilesystem(t *testing.T) {
 	tests := []struct {
 		name string
 		// Items of the test directory. Directories end with "/".
@@ -129,7 +129,7 @@ func TestRemoveAllOneFilesystem(t *testing.T) {
 		}
 
 		mounter := &fakeMounter{}
-		err = RemoveAllOneFilesystem(mounter, tmpDir)
+		err = OneFilesystem(mounter, tmpDir)
 		if err == nil && test.expectError {
 			t.Errorf("test %q failed: expected error and got none", test.name)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fixes golint issues in pkg/util/removeall

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: https://github.com/kubernetes/kubernetes/issues/68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
