### PR TITLE
kubeadm: add a defer to kubelet bootstrap token deletion

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -93,12 +93,15 @@ func getKubeletStartJoinData(c workflow.RunData) (*kubeadmapi.JoinConfiguration,
 // runKubeletStartJoinPhase executes the kubelet TLS bootstrap process.
 // This process is executed by the kubelet and completes with the node joining the cluster
 // with a dedicates set of credentials as required by the node authorizer
-func runKubeletStartJoinPhase(c workflow.RunData) error {
+func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 	cfg, initCfg, tlsBootstrapCfg, err := getKubeletStartJoinData(c)
 	if err != nil {
 		return err
 	}
 	bootstrapKubeConfigFile := kubeadmconstants.GetBootstrapKubeletKubeConfigPath()
+
+	// Deletes the bootstrapKubeConfigFile, so the credential used for TLS bootstrap is removed from disk
+	defer os.Remove(bootstrapKubeConfigFile)
 
 	// Write the bootstrap kubelet config file or the TLS-Bootstrapped kubelet config file down to disk
 	klog.V(1).Infof("[kubelet-start] writing bootstrap kubelet config file at %s", bootstrapKubeConfigFile)
@@ -165,11 +168,6 @@ func runKubeletStartJoinPhase(c workflow.RunData) error {
 	klog.V(1).Infoln("[kubelet-start] preserving the crisocket information for the node")
 	if err := patchnodephase.AnnotateCRISocket(client, cfg.NodeRegistration.Name, cfg.NodeRegistration.CRISocket); err != nil {
 		return errors.Wrap(err, "error uploading crisocket")
-	}
-
-	// Deletes the bootstrapKubeConfigFile, so the credential used for TLS bootstrap are removed from disk
-	if err := os.Remove(bootstrapKubeConfigFile); err != nil {
-		return errors.Wrapf(err, "error deleting %s", bootstrapKubeConfigFile)
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR wraps the `bootstrap-kubelet.conf` deletion in a defer statement so that it is not unintentionally left behind when an error occurs

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1699

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cluster-lifecycle
/assign @fabriziopandini 
/assign @stealthybox
