### PR TITLE
Move PodPriorityResolution e2e to integration

### DIFF
--- a/plugin/pkg/admission/priority/admission_test.go
+++ b/plugin/pkg/admission/priority/admission_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 )
 
-func addPriorityClasses(ctrl *priorityPlugin, priorityClasses []*scheduling.PriorityClass) error {
+func addPriorityClasses(ctrl *Plugin, priorityClasses []*scheduling.PriorityClass) error {
 	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
 	ctrl.SetExternalKubeInformerFactory(informerFactory)
 	// First add the existing classes to the cache.
@@ -173,7 +173,7 @@ func TestPriorityClassAdmission(t *testing.T) {
 	for _, test := range tests {
 		klog.V(4).Infof("starting test %q", test.name)
 
-		ctrl := newPlugin()
+		ctrl := NewPlugin()
 		// Add existing priority classes.
 		if err := addPriorityClasses(ctrl, test.existingClasses); err != nil {
 			t.Errorf("Test %q: unable to add object to informer: %v", test.name, err)
@@ -274,7 +274,7 @@ func TestDefaultPriority(t *testing.T) {
 
 	for _, test := range tests {
 		klog.V(4).Infof("starting test %q", test.name)
-		ctrl := newPlugin()
+		ctrl := NewPlugin()
 		if err := addPriorityClasses(ctrl, test.classesBefore); err != nil {
 			t.Errorf("Test %q: unable to add object to informer: %v", test.name, err)
 		}
@@ -682,7 +682,7 @@ func TestPodAdmission(t *testing.T) {
 	for _, test := range tests {
 		klog.V(4).Infof("starting test %q", test.name)
 
-		ctrl := newPlugin()
+		ctrl := NewPlugin()
 		// Add existing priority classes.
 		if err := addPriorityClasses(ctrl, test.existingClasses); err != nil {
 			t.Errorf("Test %q: unable to add object to informer: %v", test.name, err)

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -221,43 +221,6 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 	})
 })
 
-var _ = SIGDescribe("PodPriorityResolution [Serial]", func() {
-	var cs clientset.Interface
-	var ns string
-	f := framework.NewDefaultFramework("sched-pod-priority")
-
-	ginkgo.BeforeEach(func() {
-		cs = f.ClientSet
-		ns = f.Namespace.Name
-
-		err := framework.CheckTestingNSDeletedExcept(cs, ns)
-		framework.ExpectNoError(err)
-	})
-
-	// This test verifies that system critical priorities are created automatically and resolved properly.
-	ginkgo.It("validates critical system priorities are created and resolved", func() {
-		// Create pods that use system critical priorities and
-		ginkgo.By("Create pods that use critical system priorities.")
-		systemPriorityClasses := []string{
-			scheduling.SystemNodeCritical, scheduling.SystemClusterCritical,
-		}
-		for i, spc := range systemPriorityClasses {
-			pod := createPausePod(f, pausePodConfig{
-				Name:              fmt.Sprintf("pod%d-%v", i, spc),
-				Namespace:         metav1.NamespaceSystem,
-				PriorityClassName: spc,
-			})
-			defer func() {
-				// Clean-up the pod.
-				err := f.ClientSet.CoreV1().Pods(pod.Namespace).Delete(pod.Name, metav1.NewDeleteOptions(0))
-				framework.ExpectNoError(err)
-			}()
-			gomega.Expect(pod.Spec.Priority).NotTo(gomega.BeNil())
-			framework.Logf("Created pod: %v", pod.Name)
-		}
-	})
-})
-
 // construct a fakecpu so as to set it to status of Node object
 // otherwise if we update CPU/Memory/etc, those values will be corrected back by kubelet
 var fakecpu v1.ResourceName = "example.com/fakecpu"

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -24,6 +24,7 @@ go_test(
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/api/v1/pod:go_default_library",
+        "//pkg/apis/scheduling:go_default_library",
         "//pkg/controller/nodelifecycle:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/scheduler:go_default_library",
@@ -37,6 +38,7 @@ go_test(
         "//pkg/scheduler/testing:go_default_library",
         "//plugin/pkg/admission/podtolerationrestriction:go_default_library",
         "//plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction:go_default_library",
+        "//plugin/pkg/admission/priority:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -462,6 +462,7 @@ type pausePodConfig struct {
 	NodeName                          string
 	SchedulerName                     string
 	Priority                          *int32
+	PriorityClassName                 string
 }
 
 // initPausePod initializes a pod API object from the given config. It is used
@@ -483,10 +484,11 @@ func initPausePod(cs clientset.Interface, conf *pausePodConfig) *v1.Pod {
 					Image: imageutils.GetPauseImageName(),
 				},
 			},
-			Tolerations:   conf.Tolerations,
-			NodeName:      conf.NodeName,
-			SchedulerName: conf.SchedulerName,
-			Priority:      conf.Priority,
+			Tolerations:       conf.Tolerations,
+			NodeName:          conf.NodeName,
+			SchedulerName:     conf.SchedulerName,
+			Priority:          conf.Priority,
+			PriorityClassName: conf.PriorityClassName,
 		},
 	}
 	if conf.Resources != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Following https://github.com/kubernetes/kubernetes/pull/80821, this moves the e2e test checking pod priority resolution to integration to free up e2e resources


```release-note
NONE
```
/sig scheduling
