### PR TITLE
`kubectl get` does not count binaryData keys on ConfigMap

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1696,7 +1696,7 @@ func printConfigMap(obj *api.ConfigMap, options printers.PrintOptions) ([]metav1
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, int64(len(obj.Data)), translateTimestampSince(obj.CreationTimestamp))
+	row.Cells = append(row.Cells, obj.Name, int64(len(obj.Data)+len(obj.BinaryData)), translateTimestampSince(obj.CreationTimestamp))
 	return []metav1beta1.TableRow{row}, nil
 }
 


### PR DESCRIPTION
Running `kubectl get` against a configmap with only binary keys
returned a `0` for the number of keys which is incorrect.

/kind bug

```release-note
kubectl get did not correctly count the number of binaryData keys when listing config maps.
```

```docs
```