### PR TITLE
kubeadm: update the version constants for 1.16

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/BUILD
+++ b/cmd/kubeadm/app/cmd/upgrade/BUILD
@@ -57,7 +57,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/phases/upgrade:go_default_library",
+        "//vendor/github.com/pkg/errors:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/cmd/upgrade/common_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common_test.go
@@ -23,16 +23,15 @@ import (
 	"testing"
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
-)
-
-const (
-	validConfig = `apiVersion: kubeadm.k8s.io/v1beta2
-kind: ClusterConfiguration
-kubernetesVersion: 1.13.0
-`
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
 func TestGetK8sVersionFromUserInput(t *testing.T) {
+	currentVersion := "v" + constants.CurrentKubernetesVersion.String()
+	validConfig := "apiVersion: kubeadm.k8s.io/v1beta2\n" +
+		"kind: ClusterConfiguration\n" +
+		"kubernetesVersion: " + currentVersion
+
 	var tcases = []struct {
 		name               string
 		isVersionMandatory bool
@@ -62,7 +61,7 @@ func TestGetK8sVersionFromUserInput(t *testing.T) {
 			name:               "Valid config, but no version specified",
 			isVersionMandatory: true,
 			clusterConfig:      validConfig,
-			expectedVersion:    "v1.13.0",
+			expectedVersion:    currentVersion,
 		},
 		{
 			name:               "Valid config and different version specified",
@@ -105,7 +104,7 @@ func TestGetK8sVersionFromUserInput(t *testing.T) {
 				t.Errorf("Unexpected error: %+v", err)
 			}
 			if userVersion != tt.expectedVersion {
-				t.Errorf("Expected '%s', but got '%s'", tt.expectedVersion, userVersion)
+				t.Errorf("Expected %q, but got %q", tt.expectedVersion, userVersion)
 			}
 		})
 	}

--- a/cmd/kubeadm/app/cmd/upgrade/diff_test.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff_test.go
@@ -18,15 +18,48 @@ package upgrade
 
 import (
 	"io/ioutil"
+	"os"
 	"testing"
+
+	"github.com/pkg/errors"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
 
-const (
-	testUpgradeDiffConfig   = `testdata/diff_controlplane_config.yaml`
-	testUpgradeDiffManifest = `testdata/diff_dummy_manifest.yaml`
-)
+func createTestRunDiffFile(contents []byte) (string, error) {
+	file, err := ioutil.TempFile("", "kubeadm-upgrade-diff-config-*.yaml")
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create temporary test file")
+	}
+	if _, err := file.Write([]byte(contents)); err != nil {
+		return "", errors.Wrap(err, "failed to write to temporary test file")
+	}
+	if err := file.Close(); err != nil {
+		return "", errors.Wrap(err, "failed to close temporary test file")
+	}
+	return file.Name(), nil
+}
 
 func TestRunDiff(t *testing.T) {
+	currentVersion := "v" + constants.CurrentKubernetesVersion.String()
+
+	// create a temporary file with valid ClusterConfiguration
+	testUpgradeDiffConfigContents := []byte("apiVersion: kubeadm.k8s.io/v1beta2\n" +
+		"kind: ClusterConfiguration\n" +
+		"kubernetesVersion: " + currentVersion)
+	testUpgradeDiffConfig, err := createTestRunDiffFile(testUpgradeDiffConfigContents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testUpgradeDiffConfig)
+
+	// create a temporary manifest file with dummy contents
+	testUpgradeDiffManifestContents := []byte("some-contents")
+	testUpgradeDiffManifest, err := createTestRunDiffFile(testUpgradeDiffManifestContents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testUpgradeDiffManifest)
+
 	flags := &diffFlags{
 		cfgPath: "",
 		out:     ioutil.Discard,

--- a/cmd/kubeadm/app/cmd/upgrade/testdata/diff_controlplane_config.yaml
+++ b/cmd/kubeadm/app/cmd/upgrade/testdata/diff_controlplane_config.yaml
@@ -1,3 +1,0 @@
-apiVersion: kubeadm.k8s.io/v1beta2
-kind: ClusterConfiguration
-kubernetesVersion: 1.13.0

--- a/cmd/kubeadm/app/cmd/upgrade/testdata/diff_dummy_manifest.yaml
+++ b/cmd/kubeadm/app/cmd/upgrade/testdata/diff_dummy_manifest.yaml
@@ -1,1 +1,0 @@
-some-empty-file-to-diff

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -404,13 +404,13 @@ var (
 	ControlPlaneComponents = []string{KubeAPIServer, KubeControllerManager, KubeScheduler}
 
 	// MinimumControlPlaneVersion specifies the minimum control plane version kubeadm can deploy
-	MinimumControlPlaneVersion = version.MustParseSemantic("v1.13.0")
+	MinimumControlPlaneVersion = version.MustParseSemantic("v1.15.0")
 
 	// MinimumKubeletVersion specifies the minimum version of kubelet which kubeadm supports
-	MinimumKubeletVersion = version.MustParseSemantic("v1.13.0")
+	MinimumKubeletVersion = version.MustParseSemantic("v1.15.0")
 
 	// CurrentKubernetesVersion specifies current Kubernetes version supported by kubeadm
-	CurrentKubernetesVersion = version.MustParseSemantic("v1.14.0")
+	CurrentKubernetesVersion = version.MustParseSemantic("v1.16.0")
 
 	// SupportedEtcdVersion lists officially supported etcd versions with corresponding Kubernetes releases
 	SupportedEtcdVersion = map[uint8]string{

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -93,13 +93,12 @@ func TestEnforceVersionPolicies(t *testing.T) {
 		{
 			name: "downgrading two minor versions in one go is not supported",
 			vg: &fakeVersionGetter{
-				clusterVersion: "v1.15.3",
-				kubeletVersion: "v1.15.3",
-				kubeadmVersion: "v1.15.0",
+				clusterVersion: constants.CurrentKubernetesVersion.WithMinor(constants.CurrentKubernetesVersion.Minor() + 2).String(),
+				kubeletVersion: constants.CurrentKubernetesVersion.WithMinor(constants.CurrentKubernetesVersion.Minor() + 2).String(),
+				kubeadmVersion: constants.CurrentKubernetesVersion.String(),
 			},
-			newK8sVersion:         constants.MinimumControlPlaneVersion.WithPatch(3).String(),
+			newK8sVersion:         constants.CurrentKubernetesVersion.String(),
 			expectedMandatoryErrs: 1, // can't downgrade two minor versions
-			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm
 		},
 		{
 			name: "kubeadm version must be higher than the new kube version. However, patch version skews may be forced",
@@ -213,10 +212,10 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			}
 
 			if len(actualSkewErrs.Skippable) != rt.expectedSkippableErrs {
-				t.Errorf("failed TestEnforceVersionPolicies\n\texpected skippable errors: %d\n\tgot skippable errors: %d %v", rt.expectedSkippableErrs, len(actualSkewErrs.Skippable), *rt.vg)
+				t.Errorf("failed TestEnforceVersionPolicies\n\texpected skippable errors: %d\n\tgot skippable errors: %d\n%#v\n%#v", rt.expectedSkippableErrs, len(actualSkewErrs.Skippable), *rt.vg, actualSkewErrs)
 			}
 			if len(actualSkewErrs.Mandatory) != rt.expectedMandatoryErrs {
-				t.Errorf("failed TestEnforceVersionPolicies\n\texpected mandatory errors: %d\n\tgot mandatory errors: %d %v", rt.expectedMandatoryErrs, len(actualSkewErrs.Mandatory), *rt.vg)
+				t.Errorf("failed TestEnforceVersionPolicies\n\texpected mandatory errors: %d\n\tgot mandatory errors: %d\n%#v\n%#v", rt.expectedMandatoryErrs, len(actualSkewErrs.Mandatory), *rt.vg, actualSkewErrs)
 			}
 		})
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
- first commit: apply test fixes that prevent seemless version bumps
commit description has details.
- second commit: bump the versions.

this is still an issue:
https://github.com/kubernetes/kubeadm/issues/1260

we are defaulting ClusterConfiguration with a version that resolves a label from the internet and this is such a can of worms.

unit tests wrongly end up calling:
https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/config/common.go#L91

and if the bumped minimal CP version in constants.go _is newer_ than the latest stable version from the label we use, this can end up in:
```
this version of kubeadm only supports deploying clusters with the control plane version >= 1.16.0. Current version: v1.15.1
```
in a large number of unit tests...

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref https://github.com/kubernetes/kubeadm/issues/1260

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @fabriziopandini @rosti 
/cc @yagonobre 
/priority critical-urgent
/kind cleanup
