### PR TITLE
feat: enhance Azure cloud provider code to support both AAD and ADFS authentication.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
@@ -32,7 +32,7 @@ import (
 var (
 	// ErrorNoAuth indicates that no credentials are provided.
 	ErrorNoAuth = fmt.Errorf("no credentials provided for Azure cloud provider")
-	// Tenenatid value for Azure Stack ADFS case.
+	// ADFSIdentitySystem indicates value of tenantId for ADFS on Azure Stack.
 	ADFSIdentitySystem = "ADFS"
 )
 
@@ -64,11 +64,11 @@ type AzureAuthConfig struct {
 
 // GetServicePrincipalToken creates a new service principal token based on the configuration
 func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (*adal.ServicePrincipalToken, error) {
-	var tenantId string
+	var tenantID string
 	if strings.EqualFold(config.IdentitySystem, ADFSIdentitySystem) {
-		tenantId = "adfs"
+		tenantID = "adfs"
 	} else {
-		tenantId = config.TenantID
+		tenantID = config.TenantID
 	}
 
 	if config.UseManagedIdentityExtension {
@@ -89,7 +89,7 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (
 			env.ServiceManagementEndpoint)
 	}
 
-	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantId)
+	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("creating the OAuth config: %v", err)
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
@@ -21,6 +21,7 @@ import (
 	"crypto/x509"
 	"fmt"
 	"io/ioutil"
+	"strings"
 
 	"github.com/Azure/go-autorest/autorest/adal"
 	"github.com/Azure/go-autorest/autorest/azure"
@@ -31,6 +32,8 @@ import (
 var (
 	// ErrorNoAuth indicates that no credentials are provided.
 	ErrorNoAuth = fmt.Errorf("no credentials provided for Azure cloud provider")
+	// Tenenatid value for Azure Stack ADFS case.
+	ADFSIdentitySystem = "ADFS"
 )
 
 // AzureAuthConfig holds auth related part of cloud config
@@ -55,10 +58,19 @@ type AzureAuthConfig struct {
 	UserAssignedIdentityID string `json:"userAssignedIdentityID,omitempty" yaml:"userAssignedIdentityID,omitempty"`
 	// The ID of the Azure Subscription that the cluster is deployed in
 	SubscriptionID string `json:"subscriptionId,omitempty" yaml:"subscriptionId,omitempty"`
+	// Identity system value for the deployment. This gets populate for Azure Stack case.
+	IdentitySystem string `json:"identitySystem,omitempty" yaml:"identitySystem,omitempty"`
 }
 
 // GetServicePrincipalToken creates a new service principal token based on the configuration
 func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (*adal.ServicePrincipalToken, error) {
+	var tenantId string
+	if strings.EqualFold(config.IdentitySystem, ADFSIdentitySystem) {
+		tenantId = "adfs"
+	} else {
+		tenantId = config.TenantID
+	}
+
 	if config.UseManagedIdentityExtension {
 		klog.V(2).Infoln("azure: using managed identity extension to retrieve access token")
 		msiEndpoint, err := adal.GetMSIVMEndpoint()
@@ -77,7 +89,7 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (
 			env.ServiceManagementEndpoint)
 	}
 
-	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, config.TenantID)
+	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantId)
 	if err != nil {
 		return nil, fmt.Errorf("creating the OAuth config: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
On Azure Stack customer can have two type of deployment
AAD
ADFS.
Currently Azure Cloud provider only support AAD and not ADFS.

**Which issue(s) this PR fixes**:
Fixes #80840

**Special notes for your reviewer**:
We need to enhance Azure cloud provider code to support both AAD and ADFS authentication.
It is needed because Azure Stack supports both AAD and ADFS authentication.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
enhance Azure cloud provider code to support both AAD and ADFS authentication.
```

/kind feature
/assign @feiskyer
cc @hongbin