### PR TITLE
Return early in ApplyScoreWeights if there are no scores

### DIFF
--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -203,6 +203,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 				for _, existingPod := range nodeInfo.Pods() {
 					if err := processPod(existingPod); err != nil {
 						errCh.SendErrorWithCancel(err, cancel)
+						return
 					}
 				}
 			} else {
@@ -211,6 +212,7 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 				for _, existingPod := range nodeInfo.PodsWithAffinity() {
 					if err := processPod(existingPod); err != nil {
 						errCh.SendErrorWithCancel(err, cancel)
+						return
 					}
 				}
 			}

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -357,11 +357,13 @@ func (f *framework) RunNormalizeScorePlugins(pc *PluginContext, pod *v1.Pod, sco
 		if !ok {
 			err := fmt.Errorf("normalize score plugin %v has no corresponding scores in the PluginToNodeScoreMap", pl.Name())
 			errCh.SendErrorWithCancel(err, cancel)
+			return
 		}
 		status := pl.NormalizeScore(pc, pod, nodeScoreList)
 		if !status.IsSuccess() {
 			err := fmt.Errorf("normalize score plugin %v failed with error %v", pl.Name(), status.Message())
 			errCh.SendErrorWithCancel(err, cancel)
+			return
 		}
 	})
 
@@ -387,6 +389,7 @@ func (f *framework) ApplyScoreWeights(pc *PluginContext, pod *v1.Pod, scores Plu
 		if !ok {
 			err := fmt.Errorf("score plugin %v has no corresponding scores in the PluginToNodeScoreMap", pl.Name())
 			errCh.SendErrorWithCancel(err, cancel)
+			return
 		}
 		for i := range nodeScoreList {
 			nodeScoreList[i] = nodeScoreList[i] * weight


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In ApplyScoreWeights, when there are no scores, we can return early (after sending error to channel).

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
