### PR TITLE
Print ephemeral containers in kubectl describe

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -710,6 +710,13 @@ func describePod(pod *corev1.Pod, events *corev1.EventList) (string, error) {
 			describeContainers("Init Containers", pod.Spec.InitContainers, pod.Status.InitContainerStatuses, EnvValueRetriever(pod), w, "")
 		}
 		describeContainers("Containers", pod.Spec.Containers, pod.Status.ContainerStatuses, EnvValueRetriever(pod), w, "")
+		if len(pod.Spec.EphemeralContainers) > 0 {
+			var ec []corev1.Container
+			for i := range pod.Spec.EphemeralContainers {
+				ec = append(ec, corev1.Container(pod.Spec.EphemeralContainers[i].EphemeralContainerCommon))
+			}
+			describeContainers("Ephemeral Containers", ec, pod.Status.EphemeralContainerStatuses, EnvValueRetriever(pod), w, "")
+		}
 		if len(pod.Spec.ReadinessGates) > 0 {
 			w.Write(LEVEL_0, "Readiness Gates:\n  Type\tStatus\n")
 			for _, g := range pod.Spec.ReadinessGates {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: Ephemeral containers were added (in alpha) to the core API in #59416. This updates `kubectl describe` to print ephemeral containers if they exist.

**Which issue(s) this PR fixes**:
WIP #27140

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
Release notes are included in #59484
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://git.k8s.io/enhancements/keps/sig-node/20190212-ephemeral-containers.md
```
