### PR TITLE
Fix some unreasonable places int csi ut

### DIFF
--- a/pkg/volume/csi/csi_mounter_test.go
+++ b/pkg/volume/csi/csi_mounter_test.go
@@ -84,10 +84,10 @@ func TestMounterGetPath(t *testing.T) {
 		}
 		csiMounter := mounter.(*csiMountMgr)
 
-		path := csiMounter.GetPath()
+		mountPath := csiMounter.GetPath()
 
-		if tc.path != path {
-			t.Errorf("expecting path %s, got %s", tc.path, path)
+		if tc.path != mountPath {
+			t.Errorf("expecting path %s, got %s", tc.path, mountPath)
 		}
 	}
 }
@@ -215,10 +215,10 @@ func MounterSetUpTests(t *testing.T, podInfoEnabled bool) {
 				t.Errorf("default value of file system type was overridden by type %s", csiMounter.spec.PersistentVolume.Spec.CSI.FSType)
 			}
 
-			path := csiMounter.GetPath()
-			if _, err := os.Stat(path); err != nil {
+			mountPath := csiMounter.GetPath()
+			if _, err := os.Stat(mountPath); err != nil {
 				if os.IsNotExist(err) {
-					t.Errorf("SetUp() failed, volume path not created: %s", path)
+					t.Errorf("SetUp() failed, volume path not created: %s", mountPath)
 				} else {
 					t.Errorf("SetUp() failed: %v", err)
 				}

--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -549,12 +549,11 @@ func TestPluginNewMounter(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		plug, tmpDir := newTestPlugin(t, nil)
-		defer os.RemoveAll(tmpDir)
-
-		registerFakePlugin(testDriver, "endpoint", []string{"1.2.0"}, t)
-
 		t.Run(test.name, func(t *testing.T) {
+			plug, tmpDir := newTestPlugin(t, nil)
+			defer os.RemoveAll(tmpDir)
+
+			registerFakePlugin(testDriver, "endpoint", []string{"1.2.0"}, t)
 			mounter, err := plug.NewMounter(
 				test.spec,
 				&api.Pod{ObjectMeta: meta.ObjectMeta{UID: test.podUID, Namespace: test.namespace}},
@@ -668,12 +667,11 @@ func TestPluginNewMounterWithInline(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		plug, tmpDir := newTestPlugin(t, nil)
-		defer os.RemoveAll(tmpDir)
-
-		registerFakePlugin(testDriver, "endpoint", []string{"1.2.0"}, t)
-
 		t.Run(test.name, func(t *testing.T) {
+			plug, tmpDir := newTestPlugin(t, nil)
+			defer os.RemoveAll(tmpDir)
+
+			registerFakePlugin(testDriver, "endpoint", []string{"1.2.0"}, t)
 			mounter, err := plug.NewMounter(
 				test.spec,
 				&api.Pod{ObjectMeta: meta.ObjectMeta{UID: test.podUID, Namespace: test.namespace}},

--- a/pkg/volume/csi/expander_test.go
+++ b/pkg/volume/csi/expander_test.go
@@ -64,31 +64,33 @@ func TestNodeExpand(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		plug, tmpDir := newTestPlugin(t, nil)
-		defer os.RemoveAll(tmpDir)
+		t.Run(tc.name, func(t *testing.T) {
+			plug, tmpDir := newTestPlugin(t, nil)
+			defer os.RemoveAll(tmpDir)
 
-		spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, "expandable", "test-vol"), false)
+			spec := volume.NewSpecFromPersistentVolume(makeTestPV("test-pv", 10, "expandable", "test-vol"), false)
 
-		newSize, _ := resource.ParseQuantity("20Gi")
+			newSize, _ := resource.ParseQuantity("20Gi")
 
-		resizeOptions := volume.NodeResizeOptions{
-			VolumeSpec:      spec,
-			NewSize:         newSize,
-			DeviceMountPath: "/foo/bar",
-			CSIVolumePhase:  tc.volumePhase,
-		}
-		csiSource, _ := getCSISourceFromSpec(resizeOptions.VolumeSpec)
-
-		csClient := setupClientWithExpansion(t, tc.nodeStageSet, tc.nodeExpansion)
-
-		ok, err := plug.nodeExpandWithClient(resizeOptions, csiSource, csClient)
-		if ok != tc.success {
-			if err != nil {
-				t.Errorf("For %s : expected %v got %v with %v", tc.name, tc.success, ok, err)
-			} else {
-				t.Errorf("For %s : expected %v got %v", tc.name, tc.success, ok)
+			resizeOptions := volume.NodeResizeOptions{
+				VolumeSpec:      spec,
+				NewSize:         newSize,
+				DeviceMountPath: "/foo/bar",
+				CSIVolumePhase:  tc.volumePhase,
 			}
+			csiSource, _ := getCSISourceFromSpec(resizeOptions.VolumeSpec)
 
-		}
+			csClient := setupClientWithExpansion(t, tc.nodeStageSet, tc.nodeExpansion)
+
+			ok, err := plug.nodeExpandWithClient(resizeOptions, csiSource, csClient)
+			if ok != tc.success {
+				if err != nil {
+					t.Errorf("For %s : expected %v got %v with %v", tc.name, tc.success, ok, err)
+				} else {
+					t.Errorf("For %s : expected %v got %v", tc.name, tc.success, ok)
+				}
+
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind bug
/kind cleanup


**What this PR does / why we need it**:

Fix some unreasonable places int csi ut

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
