### PR TITLE
Omit namespace when kubectl get is for the cluster

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -581,8 +581,11 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	w.Flush()
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		// if we wrote no output, and had no errors, and are not ignoring NotFound, be sure we output something
-		noResourcesFoundFormat := fmt.Sprintf("No resources found in %s namespace.", o.Namespace)
-		fmt.Fprintln(o.ErrOut, noResourcesFoundFormat)
+		if !o.AllNamespaces {
+			fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found in %s namespace.", o.Namespace))
+		} else {
+			fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found"))
+		}
 	}
 	return utilerrors.NewAggregate(allErrs)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When kubectl get is for the cluster, the output shouldn't mention namespace.

**Which issue(s) this PR fixes**:
Fixes #80855

**Special notes for your reviewer**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
