### PR TITLE
Validation: len is measured in bytes

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -204,7 +204,7 @@ func Forbidden(field *Path, detail string) *Error {
 // Invalid, but the returned error will not include the too-long
 // value.
 func TooLong(field *Path, value interface{}, maxLength int) *Error {
-	return &Error{ErrorTypeTooLong, field.String(), value, fmt.Sprintf("must have at most %d characters", maxLength)}
+	return &Error{ErrorTypeTooLong, field.String(), value, fmt.Sprintf("must have at most %d bytes", maxLength)}
 }
 
 // TooMany returns a *Error indicating "too many". This is used to

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -313,7 +313,7 @@ func TestObjectSizeResponses(t *testing.T) {
 	expectedMsgFor1MB := `etcdserver: request is too large`
 	expectedMsgFor2MB := `rpc error: code = ResourceExhausted desc = trying to send message larger than max`
 	expectedMsgFor3MB := `Request entity too large: limit is 3145728`
-	expectedMsgForLargeAnnotation := `metadata.annotations: Too long: must have at most 262144 characters`
+	expectedMsgForLargeAnnotation := `metadata.annotations: Too long: must have at most 262144 bytes`
 
 	deployment1 := constructBody("a", DeploymentMegabyteSize, "labels", t)      // >1 MB file
 	deployment2 := constructBody("a", DeploymentTwoMegabyteSize, "labels", t)   // >2 MB file


### PR DESCRIPTION
The `TooLong` validation message mentioned characters, but the `len`
function actually measures bytes, no characters.  This switches it over
to say bytes.

Characters are mostly an illusory concept anyway -- a vain attempt to
shield our minds against the lovecraftian nightmares that comes from
attemping to truly comprehend that eldritch treatise known as the
Unicode standard.  Which is to say: measuring things in characters is
hard and mostly ambiguous, and probably not what we meant to do.

/kind bug

```release-note
Fix validation message to mention bytes, not characters.
```
