### PR TITLE
Switch admission webhook config manager to v1

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/BUILD
@@ -15,7 +15,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
@@ -34,7 +34,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/admission/configuration",
     importpath = "k8s.io/apiserver/pkg/admission/configuration",
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
@@ -42,7 +42,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
-        "//staging/src/k8s.io/client-go/listers/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager.go
@@ -21,13 +21,13 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 	"k8s.io/client-go/informers"
-	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -41,7 +41,7 @@ type mutatingWebhookConfigurationManager struct {
 var _ generic.Source = &mutatingWebhookConfigurationManager{}
 
 func NewMutatingWebhookConfigurationManager(f informers.SharedInformerFactory) generic.Source {
-	informer := f.Admissionregistration().V1beta1().MutatingWebhookConfigurations()
+	informer := f.Admissionregistration().V1().MutatingWebhookConfigurations()
 	manager := &mutatingWebhookConfigurationManager{
 		configuration: &atomic.Value{},
 		lister:        informer.Lister(),
@@ -79,7 +79,7 @@ func (m *mutatingWebhookConfigurationManager) updateConfiguration() {
 	m.configuration.Store(mergeMutatingWebhookConfigurations(configurations))
 }
 
-func mergeMutatingWebhookConfigurations(configurations []*v1beta1.MutatingWebhookConfiguration) []webhook.WebhookAccessor {
+func mergeMutatingWebhookConfigurations(configurations []*v1.MutatingWebhookConfiguration) []webhook.WebhookAccessor {
 	// The internal order of webhooks for each configuration is provided by the user
 	// but configurations themselves can be in any order. As we are going to run these
 	// webhooks in serial, they are sorted here to have a deterministic order.
@@ -99,7 +99,7 @@ func mergeMutatingWebhookConfigurations(configurations []*v1beta1.MutatingWebhoo
 	return accessors
 }
 
-type MutatingWebhookConfigurationSorter []*v1beta1.MutatingWebhookConfiguration
+type MutatingWebhookConfigurationSorter []*v1.MutatingWebhookConfiguration
 
 func (a MutatingWebhookConfigurationSorter) ByName(i, j int) bool {
 	return a[i].Name < a[j].Name

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/mutating_webhook_manager_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -43,12 +43,12 @@ func TestGetMutatingWebhookConfig(t *testing.T) {
 		t.Errorf("expected empty webhooks, but got %v", configurations)
 	}
 
-	webhookConfiguration := &v1beta1.MutatingWebhookConfiguration{
+	webhookConfiguration := &v1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
-		Webhooks:   []v1beta1.MutatingWebhook{{Name: "webhook1.1"}},
+		Webhooks:   []v1.MutatingWebhook{{Name: "webhook1.1"}},
 	}
 
-	mutatingInformer := informerFactory.Admissionregistration().V1beta1().MutatingWebhookConfigurations()
+	mutatingInformer := informerFactory.Admissionregistration().V1().MutatingWebhookConfigurations()
 	mutatingInformer.Informer().GetIndexer().Add(webhookConfiguration)
 	configManager.updateConfiguration()
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager.go
@@ -21,13 +21,13 @@ import (
 	"sort"
 	"sync/atomic"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 	"k8s.io/client-go/informers"
-	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1beta1"
+	admissionregistrationlisters "k8s.io/client-go/listers/admissionregistration/v1"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -41,7 +41,7 @@ type validatingWebhookConfigurationManager struct {
 var _ generic.Source = &validatingWebhookConfigurationManager{}
 
 func NewValidatingWebhookConfigurationManager(f informers.SharedInformerFactory) generic.Source {
-	informer := f.Admissionregistration().V1beta1().ValidatingWebhookConfigurations()
+	informer := f.Admissionregistration().V1().ValidatingWebhookConfigurations()
 	manager := &validatingWebhookConfigurationManager{
 		configuration: &atomic.Value{},
 		lister:        informer.Lister(),
@@ -80,7 +80,7 @@ func (v *validatingWebhookConfigurationManager) updateConfiguration() {
 	v.configuration.Store(mergeValidatingWebhookConfigurations(configurations))
 }
 
-func mergeValidatingWebhookConfigurations(configurations []*v1beta1.ValidatingWebhookConfiguration) []webhook.WebhookAccessor {
+func mergeValidatingWebhookConfigurations(configurations []*v1.ValidatingWebhookConfiguration) []webhook.WebhookAccessor {
 	sort.SliceStable(configurations, ValidatingWebhookConfigurationSorter(configurations).ByName)
 	accessors := []webhook.WebhookAccessor{}
 	for _, c := range configurations {
@@ -97,7 +97,7 @@ func mergeValidatingWebhookConfigurations(configurations []*v1beta1.ValidatingWe
 	return accessors
 }
 
-type ValidatingWebhookConfigurationSorter []*v1beta1.ValidatingWebhookConfiguration
+type ValidatingWebhookConfigurationSorter []*v1.ValidatingWebhookConfiguration
 
 func (a ValidatingWebhookConfigurationSorter) ByName(i, j int) bool {
 	return a[i].Name < a[j].Name

--- a/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/configuration/validating_webhook_manager_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -44,12 +44,12 @@ func TestGetValidatingWebhookConfig(t *testing.T) {
 		t.Errorf("expected empty webhooks, but got %v", configurations)
 	}
 
-	webhookConfiguration := &v1beta1.ValidatingWebhookConfiguration{
+	webhookConfiguration := &v1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{Name: "webhook1"},
-		Webhooks:   []v1beta1.ValidatingWebhook{{Name: "webhook1.1"}},
+		Webhooks:   []v1.ValidatingWebhook{{Name: "webhook1.1"}},
 	}
 
-	validatingInformer := informerFactory.Admissionregistration().V1beta1().ValidatingWebhookConfigurations()
+	validatingInformer := informerFactory.Admissionregistration().V1().ValidatingWebhookConfigurations()
 	validatingInformer.Informer().GetIndexer().Add(webhookConfiguration)
 	if validatingConfig, ok := manager.(*validatingWebhookConfigurationManager); ok {
 		validatingConfig.updateConfiguration()

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
@@ -7,7 +7,7 @@ go_library(
     importpath = "k8s.io/apiserver/pkg/admission/plugin/webhook",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
@@ -49,7 +49,7 @@ go_test(
     srcs = ["accessors_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -19,7 +19,7 @@ package webhook
 import (
 	"sync"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
@@ -46,37 +46,37 @@ type WebhookAccessor interface {
 	// needed, use GetUID.
 	GetName() string
 	// GetClientConfig gets the webhook ClientConfig field.
-	GetClientConfig() v1beta1.WebhookClientConfig
+	GetClientConfig() v1.WebhookClientConfig
 	// GetRules gets the webhook Rules field.
-	GetRules() []v1beta1.RuleWithOperations
+	GetRules() []v1.RuleWithOperations
 	// GetFailurePolicy gets the webhook FailurePolicy field.
-	GetFailurePolicy() *v1beta1.FailurePolicyType
+	GetFailurePolicy() *v1.FailurePolicyType
 	// GetMatchPolicy gets the webhook MatchPolicy field.
-	GetMatchPolicy() *v1beta1.MatchPolicyType
+	GetMatchPolicy() *v1.MatchPolicyType
 	// GetNamespaceSelector gets the webhook NamespaceSelector field.
 	GetNamespaceSelector() *metav1.LabelSelector
 	// GetObjectSelector gets the webhook ObjectSelector field.
 	GetObjectSelector() *metav1.LabelSelector
 	// GetSideEffects gets the webhook SideEffects field.
-	GetSideEffects() *v1beta1.SideEffectClass
+	GetSideEffects() *v1.SideEffectClass
 	// GetTimeoutSeconds gets the webhook TimeoutSeconds field.
 	GetTimeoutSeconds() *int32
 	// GetAdmissionReviewVersions gets the webhook AdmissionReviewVersions field.
 	GetAdmissionReviewVersions() []string
 
 	// GetMutatingWebhook if the accessor contains a MutatingWebhook, returns it and true, else returns false.
-	GetMutatingWebhook() (*v1beta1.MutatingWebhook, bool)
+	GetMutatingWebhook() (*v1.MutatingWebhook, bool)
 	// GetValidatingWebhook if the accessor contains a ValidatingWebhook, returns it and true, else returns false.
-	GetValidatingWebhook() (*v1beta1.ValidatingWebhook, bool)
+	GetValidatingWebhook() (*v1.ValidatingWebhook, bool)
 }
 
 // NewMutatingWebhookAccessor creates an accessor for a MutatingWebhook.
-func NewMutatingWebhookAccessor(uid, configurationName string, h *v1beta1.MutatingWebhook) WebhookAccessor {
+func NewMutatingWebhookAccessor(uid, configurationName string, h *v1.MutatingWebhook) WebhookAccessor {
 	return &mutatingWebhookAccessor{uid: uid, configurationName: configurationName, MutatingWebhook: h}
 }
 
 type mutatingWebhookAccessor struct {
-	*v1beta1.MutatingWebhook
+	*v1.MutatingWebhook
 	uid               string
 	configurationName string
 
@@ -126,19 +126,19 @@ func (m *mutatingWebhookAccessor) GetName() string {
 	return m.Name
 }
 
-func (m *mutatingWebhookAccessor) GetClientConfig() v1beta1.WebhookClientConfig {
+func (m *mutatingWebhookAccessor) GetClientConfig() v1.WebhookClientConfig {
 	return m.ClientConfig
 }
 
-func (m *mutatingWebhookAccessor) GetRules() []v1beta1.RuleWithOperations {
+func (m *mutatingWebhookAccessor) GetRules() []v1.RuleWithOperations {
 	return m.Rules
 }
 
-func (m *mutatingWebhookAccessor) GetFailurePolicy() *v1beta1.FailurePolicyType {
+func (m *mutatingWebhookAccessor) GetFailurePolicy() *v1.FailurePolicyType {
 	return m.FailurePolicy
 }
 
-func (m *mutatingWebhookAccessor) GetMatchPolicy() *v1beta1.MatchPolicyType {
+func (m *mutatingWebhookAccessor) GetMatchPolicy() *v1.MatchPolicyType {
 	return m.MatchPolicy
 }
 
@@ -150,7 +150,7 @@ func (m *mutatingWebhookAccessor) GetObjectSelector() *metav1.LabelSelector {
 	return m.ObjectSelector
 }
 
-func (m *mutatingWebhookAccessor) GetSideEffects() *v1beta1.SideEffectClass {
+func (m *mutatingWebhookAccessor) GetSideEffects() *v1.SideEffectClass {
 	return m.SideEffects
 }
 
@@ -162,21 +162,21 @@ func (m *mutatingWebhookAccessor) GetAdmissionReviewVersions() []string {
 	return m.AdmissionReviewVersions
 }
 
-func (m *mutatingWebhookAccessor) GetMutatingWebhook() (*v1beta1.MutatingWebhook, bool) {
+func (m *mutatingWebhookAccessor) GetMutatingWebhook() (*v1.MutatingWebhook, bool) {
 	return m.MutatingWebhook, true
 }
 
-func (m *mutatingWebhookAccessor) GetValidatingWebhook() (*v1beta1.ValidatingWebhook, bool) {
+func (m *mutatingWebhookAccessor) GetValidatingWebhook() (*v1.ValidatingWebhook, bool) {
 	return nil, false
 }
 
 // NewValidatingWebhookAccessor creates an accessor for a ValidatingWebhook.
-func NewValidatingWebhookAccessor(uid, configurationName string, h *v1beta1.ValidatingWebhook) WebhookAccessor {
+func NewValidatingWebhookAccessor(uid, configurationName string, h *v1.ValidatingWebhook) WebhookAccessor {
 	return &validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
 }
 
 type validatingWebhookAccessor struct {
-	*v1beta1.ValidatingWebhook
+	*v1.ValidatingWebhook
 	uid               string
 	configurationName string
 
@@ -226,19 +226,19 @@ func (v *validatingWebhookAccessor) GetName() string {
 	return v.Name
 }
 
-func (v *validatingWebhookAccessor) GetClientConfig() v1beta1.WebhookClientConfig {
+func (v *validatingWebhookAccessor) GetClientConfig() v1.WebhookClientConfig {
 	return v.ClientConfig
 }
 
-func (v *validatingWebhookAccessor) GetRules() []v1beta1.RuleWithOperations {
+func (v *validatingWebhookAccessor) GetRules() []v1.RuleWithOperations {
 	return v.Rules
 }
 
-func (v *validatingWebhookAccessor) GetFailurePolicy() *v1beta1.FailurePolicyType {
+func (v *validatingWebhookAccessor) GetFailurePolicy() *v1.FailurePolicyType {
 	return v.FailurePolicy
 }
 
-func (v *validatingWebhookAccessor) GetMatchPolicy() *v1beta1.MatchPolicyType {
+func (v *validatingWebhookAccessor) GetMatchPolicy() *v1.MatchPolicyType {
 	return v.MatchPolicy
 }
 
@@ -250,7 +250,7 @@ func (v *validatingWebhookAccessor) GetObjectSelector() *metav1.LabelSelector {
 	return v.ObjectSelector
 }
 
-func (v *validatingWebhookAccessor) GetSideEffects() *v1beta1.SideEffectClass {
+func (v *validatingWebhookAccessor) GetSideEffects() *v1.SideEffectClass {
 	return v.SideEffects
 }
 
@@ -262,11 +262,11 @@ func (v *validatingWebhookAccessor) GetAdmissionReviewVersions() []string {
 	return v.AdmissionReviewVersions
 }
 
-func (v *validatingWebhookAccessor) GetMutatingWebhook() (*v1beta1.MutatingWebhook, bool) {
+func (v *validatingWebhookAccessor) GetMutatingWebhook() (*v1.MutatingWebhook, bool) {
 	return nil, false
 }
 
-func (v *validatingWebhookAccessor) GetValidatingWebhook() (*v1beta1.ValidatingWebhook, bool) {
+func (v *validatingWebhookAccessor) GetValidatingWebhook() (*v1.ValidatingWebhook, bool) {
 	return v.ValidatingWebhook, true
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors_test.go
@@ -22,7 +22,7 @@ import (
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
@@ -30,7 +30,7 @@ func TestMutatingWebhookAccessor(t *testing.T) {
 	f := fuzz.New()
 	for i := 0; i < 100; i++ {
 		t.Run(fmt.Sprintf("Run %d/100", i), func(t *testing.T) {
-			orig := &v1beta1.MutatingWebhook{}
+			orig := &v1.MutatingWebhook{}
 			f.Fuzz(orig)
 
 			// zero out any accessor type specific fields not included in the accessor
@@ -51,7 +51,7 @@ func TestMutatingWebhookAccessor(t *testing.T) {
 			if _, ok := accessor.GetValidatingWebhook(); ok {
 				t.Errorf("expected GetValidatingWebhook to be nil for mutating webhook accessor")
 			}
-			copy := &v1beta1.MutatingWebhook{
+			copy := &v1.MutatingWebhook{
 				Name:                    accessor.GetName(),
 				ClientConfig:            accessor.GetClientConfig(),
 				Rules:                   accessor.GetRules(),
@@ -74,7 +74,7 @@ func TestValidatingWebhookAccessor(t *testing.T) {
 	f := fuzz.New()
 	for i := 0; i < 100; i++ {
 		t.Run(fmt.Sprintf("Run %d/100", i), func(t *testing.T) {
-			orig := &v1beta1.ValidatingWebhook{}
+			orig := &v1.ValidatingWebhook{}
 			f.Fuzz(orig)
 			uid := fmt.Sprintf("test.configuration.admission/%s/0", orig.Name)
 			accessor := NewValidatingWebhookAccessor(uid, "test.configuration.admission", orig)
@@ -91,7 +91,7 @@ func TestValidatingWebhookAccessor(t *testing.T) {
 			if _, ok := accessor.GetMutatingWebhook(); ok {
 				t.Errorf("expected GetMutatingWebhook to be nil for validating webhook accessor")
 			}
-			copy := &v1beta1.ValidatingWebhook{
+			copy := &v1.ValidatingWebhook{
 				Name:                    accessor.GetName(),
 				ClientConfig:            accessor.GetClientConfig(),
 				Rules:                   accessor.GetRules(),

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/BUILD
@@ -13,7 +13,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/admission/v1:go_default_library",
         "//staging/src/k8s.io/api/admission/v1beta1:go_default_library",
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
@@ -52,7 +52,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/webhook.go
@@ -23,7 +23,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
@@ -155,7 +155,7 @@ func (a *Webhook) ShouldCallHook(h webhook.WebhookAccessor, attr admission.Attri
 			break
 		}
 	}
-	if invocation == nil && h.GetMatchPolicy() != nil && *h.GetMatchPolicy() == v1beta1.Equivalent {
+	if invocation == nil && h.GetMatchPolicy() != nil && *h.GetMatchPolicy() == v1.Equivalent {
 		attrWithOverride := &attrWithResourceOverride{Attributes: attr}
 		equivalents := o.GetEquivalentResourceMapper().EquivalentResourcesFor(attr.GetResource(), attr.GetSubresource())
 		// honor earlier rules first

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -13,7 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/admission/v1:go_default_library",
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/BUILD
@@ -27,7 +27,7 @@ go_test(
     srcs = ["matcher_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	registrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	registrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -115,7 +115,7 @@ func TestGetNamespaceLabels(t *testing.T) {
 }
 
 func TestNotExemptClusterScopedResource(t *testing.T) {
-	hook := &registrationv1beta1.ValidatingWebhook{
+	hook := &registrationv1.ValidatingWebhook{
 		NamespaceSelector: &metav1.LabelSelector{},
 	}
 	attr := admission.NewAttributesRecord(nil, nil, schema.GroupVersionKind{}, "", "mock-name", schema.GroupVersionResource{Version: "v1", Resource: "nodes"}, "", admission.Create, &metav1.CreateOptions{}, false, nil)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/BUILD
@@ -39,7 +39,7 @@ go_test(
     srcs = ["matcher_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher_test.go
@@ -19,7 +19,7 @@ package object
 import (
 	"testing"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -52,7 +52,7 @@ func TestObjectSelector(t *testing.T) {
 		},
 	}
 	matcher := &Matcher{}
-	allScopes := v1beta1.AllScopes
+	allScopes := v1.AllScopes
 	testcases := []struct {
 		name string
 
@@ -106,12 +106,12 @@ func TestObjectSelector(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		hook := &v1beta1.ValidatingWebhook{
+		hook := &v1.ValidatingWebhook{
 			NamespaceSelector: &metav1.LabelSelector{},
 			ObjectSelector:    testcase.objectSelector,
-			Rules: []v1beta1.RuleWithOperations{{
-				Operations: []v1beta1.OperationType{"*"},
-				Rule:       v1beta1.Rule{APIGroups: []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"}, Scope: &allScopes},
+			Rules: []v1.RuleWithOperations{{
+				Operations: []v1.OperationType{"*"},
+				Rule:       v1.Rule{APIGroups: []string{"*"}, APIVersions: []string{"*"}, Resources: []string{"*"}, Scope: &allScopes},
 			}}}
 
 		t.Run(testcase.name, func(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/BUILD
@@ -42,7 +42,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/admission/v1:go_default_library",
         "//staging/src/k8s.io/api/admission/v1beta1:go_default_library",
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/authentication/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview_test.go
@@ -25,7 +25,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -486,14 +486,14 @@ func TestCreateAdmissionObjects(t *testing.T) {
 		{
 			name: "no supported versions",
 			invocation: &generic.WebhookInvocation{
-				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1beta1.MutatingWebhook{}),
+				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1.MutatingWebhook{}),
 			},
 			expectErr: "webhook does not accept known AdmissionReview versions",
 		},
 		{
 			name: "no known supported versions",
 			invocation: &generic.WebhookInvocation{
-				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1beta1.MutatingWebhook{
+				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1.MutatingWebhook{
 					AdmissionReviewVersions: []string{"vX"},
 				}),
 			},
@@ -510,7 +510,7 @@ func TestCreateAdmissionObjects(t *testing.T) {
 				Resource:    schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"},
 				Subresource: "",
 				Kind:        schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"},
-				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1beta1.MutatingWebhook{
+				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1.MutatingWebhook{
 					AdmissionReviewVersions: []string{"v1", "v1beta1"},
 				}),
 			},
@@ -553,7 +553,7 @@ func TestCreateAdmissionObjects(t *testing.T) {
 				Resource:    schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"},
 				Subresource: "",
 				Kind:        schema.GroupVersionKind{Group: "extensions", Version: "v1beta1", Kind: "Deployment"},
-				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1beta1.MutatingWebhook{
+				Webhook: webhook.NewMutatingWebhookAccessor("mywebhook", "mycfg", &admissionregistrationv1.MutatingWebhook{
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},
 				}),
 			},

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/rules/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/rules/BUILD
@@ -7,7 +7,7 @@ go_library(
     importpath = "k8s.io/apiserver/pkg/admission/plugin/webhook/rules",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
@@ -19,7 +19,7 @@ go_test(
     srcs = ["rules_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/rules/rules.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/rules/rules.go
@@ -19,7 +19,7 @@ package rules
 import (
 	"strings"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
@@ -27,7 +27,7 @@ import (
 
 // Matcher determines if the Attr matches the Rule.
 type Matcher struct {
-	Rule v1beta1.RuleWithOperations
+	Rule v1.RuleWithOperations
 	Attr admission.Attributes
 }
 
@@ -56,15 +56,15 @@ func exactOrWildcard(items []string, requested string) bool {
 var namespaceResource = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
 
 func (r *Matcher) scope() bool {
-	if r.Rule.Scope == nil || *r.Rule.Scope == v1beta1.AllScopes {
+	if r.Rule.Scope == nil || *r.Rule.Scope == v1.AllScopes {
 		return true
 	}
 	// attr.GetNamespace() is set to the name of the namespace for requests of the namespace object itself.
 	switch *r.Rule.Scope {
-	case v1beta1.NamespacedScope:
+	case v1.NamespacedScope:
 		// first make sure that we are not requesting a namespace object (namespace objects are cluster-scoped)
 		return r.Attr.GetResource() != namespaceResource && r.Attr.GetNamespace() != metav1.NamespaceNone
-	case v1beta1.ClusterScope:
+	case v1.ClusterScope:
 		// also return true if the request is for a namespace object (namespace objects are cluster-scoped)
 		return r.Attr.GetResource() == namespaceResource || r.Attr.GetNamespace() == metav1.NamespaceNone
 	default:
@@ -83,12 +83,12 @@ func (r *Matcher) version() bool {
 func (r *Matcher) operation() bool {
 	attrOp := r.Attr.GetOperation()
 	for _, op := range r.Rule.Operations {
-		if op == v1beta1.OperationAll {
+		if op == v1.OperationAll {
 			return true
 		}
 		// The constants are the same such that this is a valid cast (and this
 		// is tested).
-		if op == v1beta1.OperationType(attrOp) {
+		if op == v1.OperationType(attrOp) {
 			return true
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/rules/rules_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/rules/rules_test.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"testing"
 
-	adreg "k8s.io/api/admissionregistration/v1beta1"
+	adreg "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/BUILD
@@ -13,7 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/admission/v1beta1:go_default_library",
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -11,7 +11,7 @@ go_library(
     importpath = "k8s.io/apiserver/pkg/admission/plugin/webhook/validating",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/admissionregistration/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -95,13 +95,13 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 			defer wg.Done()
 			hook, ok := invocation.Webhook.GetValidatingWebhook()
 			if !ok {
-				utilruntime.HandleError(fmt.Errorf("validating webhook dispatch requires v1beta1.ValidatingWebhook, but got %T", hook))
+				utilruntime.HandleError(fmt.Errorf("validating webhook dispatch requires v1.ValidatingWebhook, but got %T", hook))
 				return
 			}
 			versionedAttr := versionedAttrs[invocation.Kind]
 			t := time.Now()
 			err := d.callHook(ctx, hook, invocation, versionedAttr)
-			ignoreClientCallFailures := hook.FailurePolicy != nil && *hook.FailurePolicy == v1beta1.Ignore
+			ignoreClientCallFailures := hook.FailurePolicy != nil && *hook.FailurePolicy == v1.Ignore
 			rejected := false
 			if err != nil {
 				switch err := err.(type) {
@@ -161,12 +161,12 @@ func (d *validatingDispatcher) Dispatch(ctx context.Context, attr admission.Attr
 	return errs[0]
 }
 
-func (d *validatingDispatcher) callHook(ctx context.Context, h *v1beta1.ValidatingWebhook, invocation *generic.WebhookInvocation, attr *generic.VersionedAttributes) error {
+func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWebhook, invocation *generic.WebhookInvocation, attr *generic.VersionedAttributes) error {
 	if attr.Attributes.IsDryRun() {
 		if h.SideEffects == nil {
 			return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: fmt.Errorf("Webhook SideEffects is nil")}
 		}
-		if !(*h.SideEffects == v1beta1.SideEffectClassNone || *h.SideEffects == v1beta1.SideEffectClassNoneOnDryRun) {
+		if !(*h.SideEffects == v1.SideEffectClassNone || *h.SideEffects == v1.SideEffectClassNoneOnDryRun) {
 			return webhookerrors.NewDryRunUnsupportedErr(h.Name)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind feature

**What this PR does / why we need it**:

Follow up from https://github.com/kubernetes/kubernetes/pull/79549

Switches admission plugin informer and config use from v1beta1 to v1.

**Does this PR introduce a user-facing change?**:
```release-note
The mutating and validating admission webhook plugins now read configuration from the admissionregistration.k8s.io/v1 API.
```