### PR TITLE
handle joinControPlaneDoneTemp.Execute errors

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -179,7 +179,8 @@ func NewCmdJoin(out io.Writer, joinOptions *joinOptions) *cobra.Command {
 					"KubeConfigPath": kubeadmconstants.GetAdminKubeConfigPath(),
 					"etcdMessage":    etcdMessage,
 				}
-				joinControPlaneDoneTemp.Execute(data.outputWriter, ctx)
+				err = joinControPlaneDoneTemp.Execute(data.outputWriter, ctx)
+				kubeadmutil.CheckErr(err)
 
 			} else {
 				// otherwise, if the node joined as a worker node;


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Handled errors returned by joinControPlaneDoneTemp.Execute

**Does this PR introduce a user-facing change?**:
```
NONE
```