### PR TITLE
publishing: remove redundant rules for kubectl

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -637,16 +637,3 @@ rules:
       dir: staging/src/k8s.io/kubectl
     name: release-1.15
     go: 1.12.5
-    dependencies:
-    - repository: api
-      branch: release-1.15
-    - repository: apimachinery
-      branch: release-1.15
-    - repository: client-go
-      branch: release-12.0
-    - repository: code-generator
-      branch: release-1.15
-    - repository: component-base
-      branch: release-1.15      
-    - repository: metrics
-      branch: release-1.15


### PR DESCRIPTION
Ref: https://github.com/kubernetes/kubernetes/pull/80876#discussion_r310031041

The release-1.15 branch for kubectl has no dependencies: https://github.com/kubernetes/kubernetes/blob/release-1.15/staging/src/k8s.io/kubectl/go.mod.

Adding dependencies in the rules leads to an extra unnecessary sync and is a no-op. Example - https://github.com/kubernetes/kubectl/commit/f16387a692113404c05291b3d41ec50bf51af635.

We have tests to catch extra dependencies added for the master branch, not for other branches. Checking for other branches would require us to checkout the `release-X` branch and then look at the rules file... which looks like a mix of bash + python code, which I'm not sure is worth it. :/

We can also not entirely block out changes to non-master branches because creating a release requires adding a new (non-master) branch.

/assign @dims @seans3 @sttts 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
