### PR TITLE
prevents adding finalizers for GC when an object is already being del…

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -737,6 +737,9 @@ func deletionFinalizersForGarbageCollection(ctx context.Context, e *Store, acces
 	if !e.EnableGarbageCollection {
 		return false, []string{}
 	}
+	if accessor.GetDeletionTimestamp() != nil {
+		return false, []string{}
+	}
 	shouldOrphan := shouldOrphanDependents(ctx, e, accessor, options)
 	shouldDeleteDependentInForeground := shouldDeleteDependents(ctx, e, accessor, options)
 	newFinalizers := []string{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR resolves the following issue:
1. Create an arbitrary `CRD`
2. Create an arbitrary `CR` of that `CRD`
3. Set a custom `finalizer`
4. Do a [foregreound](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#setting-the-cascading-deletion-policy) delete
5. Wait until the `foregreoundDelete` finalizer disappears
6. Do another [foregreound](https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/#setting-the-cascading-deletion-policy)  delete
7. The finalizer(`foregroundDeletion`) will be back

After step `7`, `GC` will not remove the finalizer again and the `CR` is stuck.
The reason why `GC` doesn’t remove/process the second `foregoundDeletion` is https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/garbagecollector/graph_builder.go#L446.
It cannot detect the transition of the object from "not delete" to "delete"


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
