### PR TITLE
Add condition check to avoid waiting forever on invalid condition

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -384,8 +384,12 @@ func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (ru
 		var gottenObj *unstructured.Unstructured
 		// List with a name field selector to get the current resourceVersion to watch from (not the object's resourceVersion)
 		resource := info.Mapping.Resource.Resource
-		if !contains(conditionMap[resource], w.conditionName) {
-			return nil, false, fmt.Errorf("available condition on resource %s are %s", resource, conditionMap[resource])
+
+		// Avoid fast fail on CRD, no item in conditionMap of CRD
+		if conditions, ok := conditionMap[resource]; ok {
+			if !contains(conditions, w.conditionName) {
+				return nil, false, fmt.Errorf("available condition on resource %s are %s", resource, conditions)
+			}
 		}
 
 		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(metav1.ListOptions{FieldSelector: nameSelector})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Add condition check to avoid `kubectl wait` waiting forever.

Current, if we wait condition=ready on deploy/example, it will never met since deploy takes no condition=ready, it only can be one of [Available Progressing RepicaFailure]
```
./kubectl wait --for=condition=ready deploy/example --timeout=10s
error: timed out waiting for the condition on deployments/example
```
This PR I will fast fails if condition=ready on deploy/example.
```
./kubectl wait --for=condition=ready deploy/example --timeout=10s
error: available condition on resource deployments are [Available Progressing RepicaFailure]
./kubectl wait --for=condition=progressing deploy/example --timeout=10s
deployment.extensions/example condition met
```
**Which issue(s) this PR fixes**:
Fixes #80828

**Special notes for your reviewer**:
Request for comments whether there is a better solution. This PR is a PoC and not complete very well, if it is accepted, I will complete it.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
