### PR TITLE
Automated cherry pick of #80861: Update kube-addon-manager to v9.0.2.

### DIFF
--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -14,7 +14,7 @@ spec:
   - name: kube-addon-manager
     # When updating version also bump it in:
     # - test/kubemark/resources/manifests/kube-addon-manager.yaml
-    image: k8s.gcr.io/kube-addon-manager:v9.0.1
+    image: k8s.gcr.io/kube-addon-manager:v9.0.2
     command:
     - /bin/bash
     - -c

--- a/test/kubemark/resources/manifests/kube-addon-manager.yaml
+++ b/test/kubemark/resources/manifests/kube-addon-manager.yaml
@@ -9,7 +9,7 @@ spec:
   hostNetwork: true
   containers:
   - name: kube-addon-manager
-    image: {{kube_docker_registry}}/kube-addon-manager:v9.0.1
+    image: {{kube_docker_registry}}/kube-addon-manager:v9.0.2
     command:
     - /bin/bash
     - -c


### PR DESCRIPTION
Cherry pick of #80861 on release-1.15.

#80861: Update kube-addon-manager to v9.0.2.