### PR TITLE
Add support for vSphere volume mount/attach on Windows

### DIFF
--- a/pkg/volume/vsphere_volume/BUILD
+++ b/pkg/volume/vsphere_volume/BUILD
@@ -13,6 +13,9 @@ go_library(
         "vsphere_volume.go",
         "vsphere_volume_block.go",
         "vsphere_volume_util.go",
+        "vsphere_volume_util_linux.go",
+        "vsphere_volume_util_unsupported.go",
+        "vsphere_volume_util_windows.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/volume/vsphere_volume",
     deps = [

--- a/pkg/volume/vsphere_volume/attacher.go
+++ b/pkg/volume/vsphere_volume/attacher.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"k8s.io/api/core/v1"
@@ -205,12 +206,17 @@ func (plugin *vsphereVolumePlugin) GetDeviceMountRefs(deviceMountPath string) ([
 
 // MountDevice mounts device to global mount point.
 func (attacher *vsphereVMDKAttacher) MountDevice(spec *volume.Spec, devicePath string, deviceMountPath string) error {
+	klog.Info("vsphere MountDevice", devicePath, deviceMountPath)
 	mounter := attacher.host.GetMounter(vsphereVolumePluginName)
 	notMnt, err := mounter.IsLikelyNotMountPoint(deviceMountPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			if err := os.MkdirAll(deviceMountPath, 0750); err != nil {
-				klog.Errorf("Failed to create directory at %#v. err: %s", deviceMountPath, err)
+			dir := deviceMountPath
+			if runtime.GOOS == "windows" {
+				dir = filepath.Dir(deviceMountPath)
+			}
+			if err := os.MkdirAll(dir, 0750); err != nil {
+				klog.Errorf("Failed to create directory at %#v. err: %s", dir, err)
 				return err
 			}
 			notMnt = true

--- a/pkg/volume/vsphere_volume/vsphere_volume_util.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util.go
@@ -27,7 +27,6 @@ import (
 	cloudprovider "k8s.io/cloud-provider"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/legacy-cloud-providers/vsphere"
@@ -73,16 +72,6 @@ type VolumeSpec struct {
 	StoragePolicyID   string
 	StoragePolicyName string
 	Labels            map[string]string
-}
-
-func verifyDevicePath(path string) (string, error) {
-	if pathExists, err := mount.PathExists(path); err != nil {
-		return "", fmt.Errorf("Error checking if path exists: %v", err)
-	} else if pathExists {
-		return path, nil
-	}
-
-	return "", nil
 }
 
 // CreateVolume creates a vSphere volume.

--- a/pkg/volume/vsphere_volume/vsphere_volume_util_linux.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util_linux.go
@@ -1,0 +1,35 @@
+// +build linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere_volume
+
+import (
+	"fmt"
+
+	"k8s.io/kubernetes/pkg/util/mount"
+)
+
+func verifyDevicePath(path string) (string, error) {
+	if pathExists, err := mount.PathExists(path); err != nil {
+		return "", fmt.Errorf("Error checking if path exists: %v", err)
+	} else if pathExists {
+		return path, nil
+	}
+
+	return "", nil
+}

--- a/pkg/volume/vsphere_volume/vsphere_volume_util_unsupported.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util_unsupported.go
@@ -1,0 +1,25 @@
+// +build !linux,!windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere_volume
+
+import "errors"
+
+func verifyDevicePath(path string) (string, error) {
+	return "", errors.New("unsupported")
+}

--- a/pkg/volume/vsphere_volume/vsphere_volume_util_windows.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_util_windows.go
@@ -1,0 +1,63 @@
+// +build windows
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vsphere_volume
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"k8s.io/klog"
+)
+
+type diskInfoResult struct {
+	Number       json.Number
+	SerialNumber string
+}
+
+func verifyDevicePath(path string) (string, error) {
+	if !strings.Contains(path, diskByIDPath) {
+		// If this volume has already been mounted then
+		// its devicePath will have already been converted to a disk number
+		klog.V(4).Infof("Found vSphere disk attached with disk number %v", path)
+		return path, nil
+	}
+	cmd := exec.Command("powershell", "/c", "Get-Disk | Select Number, SerialNumber | ConvertTo-JSON")
+	output, err := cmd.Output()
+	if err != nil {
+		klog.Errorf("Get-Disk failed, error: %v, output: %q", err, string(output))
+		return "", err
+	}
+
+	var results []diskInfoResult
+	if err = json.Unmarshal(output, &results); err != nil {
+		klog.Errorf("Failed to unmarshal Get-Disk json, output: %q", string(output))
+		return "", err
+	}
+	serialNumber := strings.TrimPrefix(path, diskByIDPath+diskSCSIPrefix)
+	for _, v := range results {
+		if v.SerialNumber == serialNumber {
+			klog.V(4).Infof("Found vSphere disk attached with serial %v", serialNumber)
+			return v.Number.String(), nil
+		}
+	}
+
+	return "", fmt.Errorf("unable to find vSphere disk with serial %v", serialNumber)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds support for attaching and mounting vSphere volumes on Windows. Analogous to this AWS PR https://github.com/kubernetes/kubernetes/pull/79552

**Special notes for your reviewer**:
ReadOnly volumes do not work. It seems like other Windows-compatible volume drivers also have this limitation right now.

**Does this PR introduce a user-facing change?**:
```release-note
Adds support for vSphere volumes on Windows
```
