### PR TITLE
Unexport kubectl cmd profiling functions

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -502,7 +502,6 @@ staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1
 staging/src/k8s.io/kube-aggregator/pkg/apiserver
 staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister
 staging/src/k8s.io/kube-proxy/config/v1alpha1
-staging/src/k8s.io/kubectl/pkg/cmd
 staging/src/k8s.io/kubectl/pkg/cmd/annotate
 staging/src/k8s.io/kubectl/pkg/cmd/apply
 staging/src/k8s.io/kubectl/pkg/cmd/attach

--- a/pkg/kubectl/cmd/BUILD
+++ b/pkg/kubectl/cmd/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["cmd.go"],
+    srcs = [
+        "cmd.go",
+        "profiling.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/kubectl/cmd",
     visibility = ["//visibility:public"],
     deps = [
@@ -54,6 +57,7 @@ go_library(
         "//staging/src/k8s.io/kubectl/pkg/util/i18n:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/templates:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
+        "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )
 

--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -446,10 +446,10 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 		// Hook before and after Run initialize and write profiles to disk,
 		// respectively.
 		PersistentPreRunE: func(*cobra.Command, []string) error {
-			return cmdpkg.InitProfiling()
+			return initProfiling()
 		},
 		PersistentPostRunE: func(*cobra.Command, []string) error {
-			return cmdpkg.FlushProfiling()
+			return flushProfiling()
 		},
 		BashCompletionFunction: bashCompletionFunc,
 	}
@@ -461,7 +461,7 @@ func NewKubectlCommand(in io.Reader, out, err io.Writer) *cobra.Command {
 	// a.k.a. change all "_" to "-". e.g. glog package
 	flags.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
 
-	cmdpkg.AddProfilingFlags(flags)
+	addProfilingFlags(flags)
 
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
 	kubeConfigFlags.AddFlags(flags)

--- a/pkg/kubectl/cmd/profiling.go
+++ b/pkg/kubectl/cmd/profiling.go
@@ -30,12 +30,12 @@ var (
 	profileOutput string
 )
 
-func AddProfilingFlags(flags *pflag.FlagSet) {
+func addProfilingFlags(flags *pflag.FlagSet) {
 	flags.StringVar(&profileName, "profile", "none", "Name of profile to capture. One of (none|cpu|heap|goroutine|threadcreate|block|mutex)")
 	flags.StringVar(&profileOutput, "profile-output", "profile.pprof", "Name of the file to write the profile to")
 }
 
-func InitProfiling() error {
+func initProfiling() error {
 	switch profileName {
 	case "none":
 		return nil
@@ -63,7 +63,7 @@ func InitProfiling() error {
 	return nil
 }
 
-func FlushProfiling() error {
+func flushProfiling() error {
 	switch profileName {
 	case "none":
 		return nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/BUILD
@@ -2,10 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "alpha.go",
-        "profiling.go",
-    ],
+    srcs = ["alpha.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd",
     importpath = "k8s.io/kubectl/pkg/cmd",
     visibility = [
@@ -17,7 +14,6 @@ go_library(
         "//staging/src/k8s.io/kubectl/pkg/util/i18n:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/templates:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
-        "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )
 


### PR DESCRIPTION
* Unexports the `kubectl cmd` profiling functions, by moving the `profling.go` back to Kubernetes core.
* This `profiling.go` file will be moved to staging at the same time as `cmd.go` in the near future.

/kind cleanup
/sig cli
/area kubectl
/area code-organization
/priority important-soon

```release-note
NONE
```