### PR TITLE
Toleration priority function score computation

### DIFF
--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -221,30 +221,8 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 		// make the nodes have balanced cpu,mem usage ratio
 		err := createBalancedPodForNodes(f, cs, ns, nodeList.Items, podRequestedResource, 0.5)
 		framework.ExpectNoError(err)
-		//we need apply more taints on a node, because one match toleration only count 1
-		ginkgo.By("Trying to apply 10 taint on the nodes except first one.")
+		// Apply 10 taints to first node
 		nodeName := nodeList.Items[0].Name
-
-		for index, node := range nodeList.Items {
-			if index == 0 {
-				continue
-			}
-			for i := 0; i < 10; i++ {
-				testTaint := addRandomTaitToNode(cs, node.Name)
-				defer framework.RemoveTaintOffNode(cs, node.Name, *testTaint)
-			}
-		}
-		ginkgo.By("Create a pod without any tolerations")
-		tolerationPodName := "without-tolerations"
-		pod := createPausePod(f, pausePodConfig{
-			Name: tolerationPodName,
-		})
-		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
-
-		ginkgo.By("Pod should prefer scheduled to the node don't have the taint.")
-		tolePod, err := cs.CoreV1().Pods(ns).Get(tolerationPodName, metav1.GetOptions{})
-		framework.ExpectNoError(err)
-		framework.ExpectEqual(tolePod.Spec.NodeName, nodeName)
 
 		ginkgo.By("Trying to apply 10 taint on the first node.")
 		var tolerations []v1.Toleration
@@ -253,16 +231,16 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 			tolerations = append(tolerations, v1.Toleration{Key: testTaint.Key, Value: testTaint.Value, Effect: testTaint.Effect})
 			defer framework.RemoveTaintOffNode(cs, nodeName, *testTaint)
 		}
-		tolerationPodName = "with-tolerations"
+		tolerationPodName := "with-tolerations"
 		ginkgo.By("Create a pod that tolerates all the taints of the first node.")
-		pod = createPausePod(f, pausePodConfig{
+		pod := createPausePod(f, pausePodConfig{
 			Name:        tolerationPodName,
 			Tolerations: tolerations,
 		})
 		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 
 		ginkgo.By("Pod should prefer scheduled to the node that pod can tolerate.")
-		tolePod, err = cs.CoreV1().Pods(ns).Get(tolerationPodName, metav1.GetOptions{})
+		tolePod, err := cs.CoreV1().Pods(ns).Get(tolerationPodName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 		framework.ExpectEqual(tolePod.Spec.NodeName, nodeName)
 	})


### PR DESCRIPTION
I think, if a pod doesn't have any tolerations, we don't prefer node without taints to
the one which has taints in https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/algorithm/priorities/taint_toleration.go#L29, so there is no point in testing that particular functionality. The side effect of the above is, since we're going round-robin in every scheduling cycle sometimes we're choosing first node and in the next cycle we'd move onto next node(where taints are not being applied), so it's causing problem unnecessarily

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
 /kind cleanup

**What this PR does / why we need it**:
I think, if a pod doesn't have any tolerations, we don't prefer node without taints to
the one which has taints in https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/algorithm/priorities/taint_toleration.go#L29, so there is no point in testing that particular functionality. The side effect of the above is, since we're going round-robin in every scheduling cycle sometimes we're choosing first node and in the next cycle we'd move onto next node(where taints are not being applied), so it's causing problem unnecessarily and the test sometimes flakes downstream where the nodes are heavily utilized"


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
