### PR TITLE
increase timeout for maximum-startup-sequence-duration as a stopgap

### DIFF
--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -98,7 +98,7 @@ func TestStartupSequenceHealthzAndReadyz(t *testing.T) {
 	instanceOptions := &kubeapiservertesting.TestServerInstanceOptions{
 		InjectedHealthzChecker: hc,
 	}
-	server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{"--maximum-startup-sequence-duration", "5s"}, framework.SharedEtcd())
+	server := kubeapiservertesting.StartTestServerOrDie(t, instanceOptions, []string{"--maximum-startup-sequence-duration", "15s"}, framework.SharedEtcd())
 	defer server.TearDownFn()
 
 	client, err := kubernetes.NewForConfig(server.ClientConfig)


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

TestStartupSequenceHealthzAndReadyz is flaking (#80748). This is likely due to a race condition in the bootup sequence during TestStartupServerOrDie (which takes longer than 5s to become healthy on CI) and thus never becomes healthy. 

In the short term, we can increase the maximum-startup-sequence-duration value such that we give the system more time to actually become healthy before we start the test. In the longer term, @liggitt makes a few compelling arguments for adding a livez endpoint (rather than repurposing healthz the way that I did). If we opt down this path, then we can make corresponding changes to this test. 

```release-note
NONE
```
/cc @sttts 