### PR TITLE
Fix verify-generated-files to error on untracked files

### DIFF
--- a/hack/verify-generated-files.sh
+++ b/hack/verify-generated-files.sh
@@ -39,11 +39,11 @@ git clean -ffxd
 # regenerate any generated code
 make generated_files
 
-diff=$(git diff --name-only)
+changed_files=$(git status --porcelain)
 
-if [[ -n "${diff}" ]]; then
+if [[ -n "${changed_files}" ]]; then
   echo "!!! Generated code is out of date:" >&2
-  echo "${diff}" >&2
+  echo "${changed_files}" >&2
   echo >&2
   echo "Please run make generated_files." >&2
   exit 1


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
verify-generated-files was only tracking when there was existing files in the index that hadn't been regenerated, but it doesn't track when the generator code generates a new, untracked file.

This changes the git logic so it'll track any changed OR untracked file that is created or modified by the generated_files make target.

/assign @BenTheElder 
cc: @sttts @munnerz @liggitt 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
