### PR TITLE
kubeadm: print the stack trace of an error for klog level v>=5

### DIFF
--- a/cmd/kubeadm/BUILD
+++ b/cmd/kubeadm/BUILD
@@ -18,7 +18,10 @@ go_library(
     name = "go_default_library",
     srcs = ["kubeadm.go"],
     importpath = "k8s.io/kubernetes/cmd/kubeadm",
-    deps = ["//cmd/kubeadm/app:go_default_library"],
+    deps = [
+        "//cmd/kubeadm/app:go_default_library",
+        "//cmd/kubeadm/app/util:go_default_library",
+    ],
 )
 
 filegroup(

--- a/cmd/kubeadm/app/cmd/phases/workflow/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/workflow/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/kubeadm/app/util:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",

--- a/cmd/kubeadm/app/cmd/phases/workflow/runner.go
+++ b/cmd/kubeadm/app/cmd/phases/workflow/runner.go
@@ -18,12 +18,13 @@ package workflow
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
 // phaseSeparator defines the separator to be used when concatenating nested
@@ -346,10 +347,7 @@ func (e *Runner) BindToCommand(cmd *cobra.Command) {
 				// overrides the command triggering the Runner using the phaseCmd
 				e.runCmd = cmd
 				e.Options.FilterPhases = []string{phaseSelector}
-				if err := e.Run(args); err != nil {
-					fmt.Fprintln(os.Stderr, err)
-					os.Exit(1)
-				}
+				util.CheckErr(e.Run(args))
 			},
 		}
 

--- a/cmd/kubeadm/app/cmd/version.go
+++ b/cmd/kubeadm/app/cmd/version.go
@@ -62,7 +62,7 @@ func RunVersion(out io.Writer, cmd *cobra.Command) error {
 	const flag = "output"
 	of, err := cmd.Flags().GetString(flag)
 	if err != nil {
-		klog.Fatalf("error accessing flag %s for command %s: %v", flag, cmd.Name(), err)
+		return errors.Wrapf(err, "error accessing flag %s for command %s", flag, cmd.Name())
 	}
 
 	switch of {

--- a/cmd/kubeadm/app/util/error.go
+++ b/cmd/kubeadm/app/util/error.go
@@ -17,8 +17,10 @@ limitations under the License.
 package util
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
@@ -64,16 +66,35 @@ type preflightError interface {
 // checkErr formats a given error as a string and calls the passed handleErr
 // func with that string and an exit code.
 func checkErr(err error, handleErr func(string, int)) {
+
+	var msg string
+	if err != nil {
+		msg = fmt.Sprintf("%s\nTo see the stack trace of this error execute with --v=5 or higher", err.Error())
+		// check if the verbosity level in klog is high enough and print a stack trace.
+		f := flag.CommandLine.Lookup("v")
+		if f != nil {
+			// assume that the "v" flag contains a parseable Int32 as per klog's "Level" type alias,
+			// thus no error from ParseInt is handled here.
+			if v, e := strconv.ParseInt(f.Value.String(), 10, 32); e == nil {
+				// https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md
+				// klog.V(5) - Trace level verbosity
+				if v > 4 {
+					msg = fmt.Sprintf("%+v", err)
+				}
+			}
+		}
+	}
+
 	switch err.(type) {
 	case nil:
 		return
 	case preflightError:
-		handleErr(err.Error(), PreFlightExitCode)
+		handleErr(msg, PreFlightExitCode)
 	case errorsutil.Aggregate:
-		handleErr(err.Error(), ValidationExitCode)
+		handleErr(msg, ValidationExitCode)
 
 	default:
-		handleErr(err.Error(), DefaultErrorExitCode)
+		handleErr(msg, DefaultErrorExitCode)
 	}
 }
 

--- a/cmd/kubeadm/kubeadm.go
+++ b/cmd/kubeadm/kubeadm.go
@@ -17,13 +17,10 @@ limitations under the License.
 package main
 
 import (
-	"os"
-
 	"k8s.io/kubernetes/cmd/kubeadm/app"
+	"k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
 func main() {
-	if err := app.Run(); err != nil {
-		os.Exit(1)
-	}
+	util.CheckErr(app.Run())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- replace all stray calls of os.Exit() with util.CheckError() instead
- CheckError() now checks if the klog verbosity level is >=5
and shows a stack trace of the error.
- don't call klog.Fatal in version.go.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#1266

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: print the stack trace of an error for klog level --v>=5
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind feature
/priority backlog
@kubernetes/sig-cluster-lifecycle-pr-reviews 
