### PR TITLE
change BeTrue to Equal or BeNumerically in e2e test

### DIFF
--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -849,7 +849,7 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 		framework.ExpectNoError(e2enode.WaitForReadyNodes(c, nodeCount-minSize+1, resizeTimeout))
 		ngNodes, err := framework.GetGroupNodes(minMig)
 		framework.ExpectNoError(err)
-		gomega.Expect(len(ngNodes)).To(gomega.Equal(1))
+		framework.ExpectEqual(len(ngNodes), 1)
 		node, err := f.ClientSet.CoreV1().Nodes().Get(ngNodes[0], metav1.GetOptions{})
 		ginkgo.By(fmt.Sprintf("Target node for scale-down: %s", node.Name))
 		framework.ExpectNoError(err)

--- a/test/e2e/autoscaling/cluster_size_autoscaling.go
+++ b/test/e2e/autoscaling/cluster_size_autoscaling.go
@@ -849,7 +849,7 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 		framework.ExpectNoError(e2enode.WaitForReadyNodes(c, nodeCount-minSize+1, resizeTimeout))
 		ngNodes, err := framework.GetGroupNodes(minMig)
 		framework.ExpectNoError(err)
-		gomega.Expect(len(ngNodes) == 1).To(gomega.BeTrue())
+		gomega.Expect(len(ngNodes)).To(gomega.Equal(1))
 		node, err := f.ClientSet.CoreV1().Nodes().Get(ngNodes[0], metav1.GetOptions{})
 		ginkgo.By(fmt.Sprintf("Target node for scale-down: %s", node.Name))
 		framework.ExpectNoError(err)
@@ -900,7 +900,7 @@ var _ = SIGDescribe("Cluster size autoscaling [Slow]", func() {
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})
 		framework.ExpectNoError(err)
-		gomega.Expect(nodesToBreakCount <= len(nodes.Items)).To(gomega.BeTrue())
+		gomega.Expect(nodesToBreakCount).To(gomega.BeNumerically("<=", len(nodes.Items)))
 		nodesToBreak := nodes.Items[:nodesToBreakCount]
 
 		// TestUnderTemporaryNetworkFailure only removes connectivity to a single node,

--- a/test/e2e/upgrades/cassandra.go
+++ b/test/e2e/upgrades/cassandra.go
@@ -201,19 +201,19 @@ func (t *CassandraUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 	}, 10*time.Millisecond, done)
 	e2elog.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
 
-	gomega.Expect(lastUserCount >= t.successfulWrites).To(gomega.BeTrue())
+	gomega.Expect(lastUserCount).To(gomega.BeNumerically(">=", t.successfulWrites))
 	ratio := float64(success) / float64(success+failures)
 	e2elog.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
 	ratio = float64(t.successfulWrites) / float64(writeAttempts)
 	e2elog.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
 	e2elog.Logf("Errors: %v", errors)
 	// TODO(maisem): tweak this value once we have a few test runs.
-	gomega.Expect(ratio > 0.75).To(gomega.BeTrue())
+	gomega.Expect(ratio).To(gomega.BeNumerically(">", 075))
 }
 
 // Teardown does one final check of the data's availability.
 func (t *CassandraUpgradeTest) Teardown(f *framework.Framework) {
 	users, err := t.listUsers()
 	framework.ExpectNoError(err)
-	gomega.Expect(len(users) >= t.successfulWrites).To(gomega.BeTrue())
+	gomega.Expect(len(users)).To(gomega.BeNumerically(">=", t.successfulWrites))
 }

--- a/test/e2e/upgrades/etcd.go
+++ b/test/e2e/upgrades/etcd.go
@@ -189,19 +189,19 @@ func (t *EtcdUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upg
 	}, 10*time.Millisecond, done)
 	e2elog.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
 
-	gomega.Expect(lastUserCount >= t.successfulWrites).To(gomega.BeTrue())
+	gomega.Expect(lastUserCount).To(gomega.BeNumerically(">=", t.successfulWrites))
 	ratio := float64(success) / float64(success+failures)
 	e2elog.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
 	ratio = float64(t.successfulWrites) / float64(writeAttempts)
 	e2elog.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
 	e2elog.Logf("Errors: %v", errors)
 	// TODO(maisem): tweak this value once we have a few test runs.
-	gomega.Expect(ratio > 0.75).To(gomega.BeTrue())
+	gomega.Expect(ratio).To(gomega.BeNumerically(">", 0.75))
 }
 
 // Teardown does one final check of the data's availability.
 func (t *EtcdUpgradeTest) Teardown(f *framework.Framework) {
 	users, err := t.listUsers()
 	framework.ExpectNoError(err)
-	gomega.Expect(len(users) >= t.successfulWrites).To(gomega.BeTrue())
+	gomega.Expect(len(users)).To(gomega.BeNumerically(">=", t.successfulWrites))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

 /kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
e2e test contains like gomega.Expect(xxxx == 1).To(gomega.BeTrue()).
When the test fails, the following result is output. From the result, it is difficult to understand what happens.

```
Expected
      <bool>: false
  to be true
```
This PR changes to use Equal or BeNumerically function and the result is changed to the following message. We can get more information from that when test fails.

```
Expected
      <int>: 2
  to equal
      <int>: 1
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
