### PR TITLE
Factor PassiveClock out of clock.Clock

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
@@ -21,11 +21,18 @@ import (
 	"time"
 )
 
+// PassiveClock allows for injecting fake or real clocks into code
+// that needs to read the current time but does not support scheduling
+// activity in the future.
+type PassiveClock interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+}
+
 // Clock allows for injecting fake or real clocks into code that
 // needs to do arbitrary things based on time.
 type Clock interface {
-	Now() time.Time
-	Since(time.Time) time.Duration
+	PassiveClock
 	After(time.Duration) <-chan time.Time
 	NewTimer(time.Duration) Timer
 	Sleep(time.Duration)
@@ -66,10 +73,15 @@ func (RealClock) Sleep(d time.Duration) {
 	time.Sleep(d)
 }
 
-// FakeClock implements Clock, but returns an arbitrary time.
-type FakeClock struct {
+// FakePassiveClock implements PassiveClock, but returns an arbitrary time.
+type FakePassiveClock struct {
 	lock sync.RWMutex
 	time time.Time
+}
+
+// FakeClock implements Clock, but returns an arbitrary time.
+type FakeClock struct {
+	FakePassiveClock
 
 	// waiters are waiting for the fake time to pass their specified time
 	waiters []fakeClockWaiter
@@ -82,24 +94,37 @@ type fakeClockWaiter struct {
 	destChan      chan time.Time
 }
 
-func NewFakeClock(t time.Time) *FakeClock {
-	return &FakeClock{
+func NewFakePassiveClock(t time.Time) *FakePassiveClock {
+	return &FakePassiveClock{
 		time: t,
 	}
 }
 
+func NewFakeClock(t time.Time) *FakeClock {
+	return &FakeClock{
+		FakePassiveClock: *NewFakePassiveClock(t),
+	}
+}
+
 // Now returns f's time.
-func (f *FakeClock) Now() time.Time {
+func (f *FakePassiveClock) Now() time.Time {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	return f.time
 }
 
 // Since returns time since the time in f.
-func (f *FakeClock) Since(ts time.Time) time.Duration {
+func (f *FakePassiveClock) Since(ts time.Time) time.Duration {
 	f.lock.RLock()
 	defer f.lock.RUnlock()
 	return f.time.Sub(ts)
+}
+
+// Sets the time.
+func (f *FakePassiveClock) SetTime(t time.Time) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.time = t
 }
 
 // Fake version of time.After(d).


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
PassiveClock has the subset of Clock functionality that only involves
reading the clock.  Identifying this subset makes it possible to write
packages that are more clearly easy to test.

When a package is coded against Clock rather than PassiveClock this
adds two problems for the unit test functions.  One is that Clock
provides no way for the test function to know when the next activity
is scheduled for.  That could be added to FakeClock relatively easily.
The second problem is that when a package uses channels to schedule
future activity, once the Clock has advanced to such a future time the
Clock (and hence the test function) does not get informed when that
activity has completed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
This PR originally did two things, factor Clock and introduce EventClock.  You can see in the commentary why this PR has been reduced in scope.  You can see the current version of EventClock in https://github.com/kubernetes/kubernetes/blob/feature-rate-limiting/staging/src/k8s.io/apiserver/pkg/util/clock/event_clock.go and a use in https://github.com/kubernetes/kubernetes/blob/feature-rate-limiting/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/fq_test.go

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
