### PR TITLE
Add critical section to protect m.allocatedDevices

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -824,6 +824,8 @@ func (m *ManagerImpl) sanitizeNodeAllocatable(node *schedulernodeinfo.NodeInfo) 
 }
 
 func (m *ManagerImpl) isDevicePluginResource(resource string) bool {
+	m.mutex.Lock()
+        defer m.mutex.Unlock()
 	_, registeredResource := m.healthyDevices[resource]
 	_, allocatedResource := m.allocatedDevices[resource]
 	// Return true if this is either an active device plugin resource or

--- a/pkg/kubelet/cm/devicemanager/manager.go
+++ b/pkg/kubelet/cm/devicemanager/manager.go
@@ -825,7 +825,7 @@ func (m *ManagerImpl) sanitizeNodeAllocatable(node *schedulernodeinfo.NodeInfo) 
 
 func (m *ManagerImpl) isDevicePluginResource(resource string) bool {
 	m.mutex.Lock()
-        defer m.mutex.Unlock()
+	defer m.mutex.Unlock()
 	_, registeredResource := m.healthyDevices[resource]
 	_, allocatedResource := m.allocatedDevices[resource]
 	// Return true if this is either an active device plugin resource or


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
m.allocatedDevices is a map. Among 10 usages of it, 9 are protected by `m.mutex.Lock()`, but the one at [line 828 of file kubernetes/pkg/kubelet/cm/devicemanager/manager.go](https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/cm/devicemanager/manager.go#L828) is not in critical section. There is a potential data race here.

**Special notes for your reviewer**:
I believe m.allocatedDevices always need a critical section, because there are four places writing a critical section specifically for it:
```Go
m.mutex.Lock()
m.allocatedDevices = m.podDevices.devices()
m.mutex.Unlock()
```

Fortunately, it seems that the buggy function is only used in manager_test.go, so it is not possible for hackers to explore this bug.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```
