### PR TITLE
Move docker specific const to dockershim.

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -67,13 +67,6 @@ import (
 )
 
 const (
-	// The percent of the machine memory capacity. The value is used to calculate
-	// docker memory resource container's hardlimit to workaround docker memory
-	// leakage issue. Please see kubernetes/issues/9881 for more detail.
-	DockerMemoryLimitThresholdPercent = 70
-	// The minimum memory limit allocated to docker container: 150Mi
-	MinDockerMemoryLimit = 150 * 1024 * 1024
-
 	dockerProcessName     = "docker"
 	dockerPidFile         = "/var/run/docker.pid"
 	containerdProcessName = "docker-containerd"

--- a/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -37,11 +37,13 @@ import (
 )
 
 const (
-	// The percent of the machine memory capacity.
-	dockerMemoryLimitThresholdPercent = kubecm.DockerMemoryLimitThresholdPercent
+	// The percent of the machine memory capacity. The value is used to calculate
+	// docker memory resource container's hardlimit to workaround docker memory
+	// leakage issue. Please see kubernetes/issues/9881 for more detail.
+	dockerMemoryLimitThresholdPercent = 70
 
-	// The minimum memory limit allocated to docker container.
-	minDockerMemoryLimit = kubecm.MinDockerMemoryLimit
+	// The minimum memory limit allocated to docker container: 150Mi
+	minDockerMemoryLimit = 150 * 1024 * 1024
 
 	// The Docker OOM score adjustment.
 	dockerOOMScoreAdj = qos.DockerOOMScoreAdj


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`DockerMemoryLimitThresholdPercent` and `MinDockerMemoryLimit` are docker specific config, and only used in `pkg/kubelet/dockershim/cm/container_manager_linux.go`, so move these const to dockershim.

Also, this is a piece of work related to https://github.com/kubernetes/enhancements/pull/866.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
