### PR TITLE
Deletion of old cron jobs should consider deletion failure

### DIFF
--- a/pkg/controller/cronjob/cronjob_controller.go
+++ b/pkg/controller/cronjob/cronjob_controller.go
@@ -202,9 +202,12 @@ func removeOldestJobs(sj *batchv1beta1.CronJob, js []batchv1.Job, jc jobControlI
 	klog.V(4).Infof("Cleaning up %d/%d jobs from %s", numToDelete, len(js), nameForLog)
 
 	sort.Sort(byJobStartTime(js))
-	for i := 0; i < numToDelete; i++ {
+	for i := 0; i < numToDelete && i < len(js); i++ {
 		klog.V(4).Infof("Removing job %s from %s", js[i].Name, nameForLog)
-		deleteJob(sj, &js[i], jc, recorder)
+		if !deleteJob(sj, &js[i], jc, recorder) {
+			// the current job is not deleted. extend numToDelete to accommodate
+			numToDelete++
+		}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently in removeOldestJobs, the return value from deleteJob is ignored.

This PR checks the return value - if the deletion fails, numToDelete is incremented so that we try to achieve the expected number of (successful) deletions.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
