### PR TITLE
Fix shellcheck failure in cluster/test-e2e.sh

### DIFF
--- a/cluster/test-e2e.sh
+++ b/cluster/test-e2e.sh
@@ -26,8 +26,6 @@ source "${KUBE_ROOT}/cluster/kube-util.sh"
 
 echo "Testing cluster with provider: ${KUBERNETES_PROVIDER}" 1>&2
 
-TEST_ARGS="$@"
-
 echo "Running e2e tests:" 1>&2
-echo "./hack/ginkgo-e2e.sh ${TEST_ARGS}" 1>&2
+echo "./hack/ginkgo-e2e.sh $*" 1>&2
 exec "${KUBE_ROOT}/hack/ginkgo-e2e.sh" "$@"

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -13,7 +13,6 @@
 ./cluster/gce/util.sh
 ./cluster/log-dump/log-dump.sh
 ./cluster/pre-existing/util.sh
-./cluster/test-e2e.sh
 ./cluster/validate-cluster.sh
 ./hack/lib/test.sh
 ./hack/test-integration.sh


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix shellcheck failure of cluster/test-e2e.sh

shellcheck detects the following failure.
```
In ./cluster/test-e2e.sh line 29:
TEST_ARGS="$@"
          ^--^ SC2124: Assigning an array to a string! Assign as array, or use * instead of @ to concatenate.
```
TEST_ARGS is only used in `echo` just after the line as far as I have checked.
So, this PR removes TEST_ARGS variable and changes `echo` line.

**Which issue(s) this PR fixes**:
Ref #72956

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/priority backlog