### PR TITLE
fix orphaned pod flexvolume  can not be cleaned up

### DIFF
--- a/pkg/volume/flexvolume/flexvolume_test.go
+++ b/pkg/volume/flexvolume/flexvolume_test.go
@@ -124,11 +124,11 @@ func TestCanSupport(t *testing.T) {
 	runner := exec.New()
 	installPluginUnderTest(t, "kubernetes.io", "fakeAttacher", tmpDir, execScriptTempl1, nil)
 	plugMgr.InitPlugins(nil, GetDynamicPluginProber(tmpDir, runner), volumetest.NewFakeVolumeHost(t, "fake", nil, nil))
-	plugin, err := plugMgr.FindPluginByName("flexvolume-kubernetes.io/fakeAttacher")
+	plugin, err := plugMgr.FindPluginByName("kubernetes.io/fakeAttacher")
 	if err != nil {
 		t.Fatalf("Can't find the plugin by name")
 	}
-	if plugin.GetPluginName() != "flexvolume-kubernetes.io/fakeAttacher" {
+	if plugin.GetPluginName() != "kubernetes.io/fakeAttacher" {
 		t.Errorf("Wrong name: %s", plugin.GetPluginName())
 	}
 	if !plugin.CanSupport(&volume.Spec{Volume: &v1.Volume{VolumeSource: v1.VolumeSource{FlexVolume: &v1.FlexVolumeSource{Driver: "kubernetes.io/fakeAttacher"}}}}) {
@@ -154,7 +154,7 @@ func TestGetAccessModes(t *testing.T) {
 	installPluginUnderTest(t, "kubernetes.io", "fakeAttacher", tmpDir, execScriptTempl1, nil)
 	plugMgr.InitPlugins(nil, GetDynamicPluginProber(tmpDir, runner), volumetest.NewFakeVolumeHost(t, tmpDir, nil, nil))
 
-	plugin, err := plugMgr.FindPersistentPluginByName("flexvolume-kubernetes.io/fakeAttacher")
+	plugin, err := plugMgr.FindPersistentPluginByName("kubernetes.io/fakeAttacher")
 	if err != nil {
 		t.Fatalf("Can't find the plugin by name")
 	}

--- a/pkg/volume/flexvolume/plugin.go
+++ b/pkg/volume/flexvolume/plugin.go
@@ -34,8 +34,7 @@ import (
 )
 
 const (
-	flexVolumePluginName       = "kubernetes.io/flexvolume"
-	flexVolumePluginNamePrefix = "flexvolume-"
+	flexVolumePluginName = "kubernetes.io/flexvolume"
 )
 
 // FlexVolumePlugin object.
@@ -114,7 +113,7 @@ func (plugin *flexVolumePlugin) getExecutable() string {
 
 // Name is part of the volume.VolumePlugin interface.
 func (plugin *flexVolumePlugin) GetPluginName() string {
-	return flexVolumePluginNamePrefix + plugin.driverName
+	return plugin.driverName
 }
 
 // GetVolumeName is part of the volume.VolumePlugin interface.

--- a/pkg/volume/flexvolume/probe.go
+++ b/pkg/volume/flexvolume/probe.go
@@ -140,7 +140,7 @@ func (prober *flexVolumeProber) newProbeEvent(driverDirName string, op volume.Pr
 		probeEvent.PluginName = plugin.GetPluginName()
 	} else if op == volume.ProbeRemove {
 		driverName := utilstrings.UnescapeQualifiedName(driverDirName)
-		probeEvent.PluginName = flexVolumePluginNamePrefix + driverName
+		probeEvent.PluginName = driverName
 
 	} else {
 		return probeEvent, fmt.Errorf("Unknown Operation on directory: %s. ", driverDirName)

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -707,7 +707,7 @@ func (pm *VolumePluginMgr) FindPluginByName(name string) (VolumePlugin, error) {
 	}
 
 	if len(matches) == 0 {
-		return nil, fmt.Errorf("no volume plugin matched")
+		return nil, fmt.Errorf("no volume plugin matched name: %s", name)
 	}
 	if len(matches) > 1 {
 		matchedPluginNames := []string{}

--- a/test/e2e/storage/detach_mounted.go
+++ b/test/e2e/storage/detach_mounted.go
@@ -126,7 +126,7 @@ var _ = utils.SIGDescribe("Detaching volumes", func() {
 })
 
 func getUniqueVolumeName(pod *v1.Pod, driverName string) string {
-	return fmt.Sprintf("flexvolume-k8s/%s/%s", driverName, pod.Spec.Volumes[0].Name)
+	return fmt.Sprintf("k8s/%s/%s", driverName, pod.Spec.Volumes[0].Name)
 }
 
 func waitForVolumesNotInUse(client clientset.Interface, nodeName, volumeName string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug
/kind cleanup

**What this PR does / why we need it**:

The main reason is :

flexvolume `GetPath`  returns `hulk~lvm`, kubelet create mount path based on `GetPath`  .

but flexvolume is registered as `flexvolume-hulk~lvm`

kubelet can't find flexvolume plugin by  orphaned pod volume path like `/var/lib/kubelet/pods/bb07fd8d-b737-11e9-a203-0022ac9722f5/volumes/hulk~lvm`

flexVolumePluginNamePrefix must be blank now, otherwise kubelet will create a new volume for the existing pod

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
https://github.com/kubernetes/kubernetes/issues/80972
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig storage