### PR TITLE
Add CHANGELOG-1.16.md to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Development release:
 
+- [CHANGELOG-1.16.md](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.16.md)
 
 ## Current release:
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
Add CHANGELOG-1.16.md as the development release in CHANGELOG.md.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```