### PR TITLE
Automated cherry pick of #80276: Don't expect pod to stay up during node upgrade

### DIFF
--- a/test/e2e/upgrades/apparmor.go
+++ b/test/e2e/upgrades/apparmor.go
@@ -69,7 +69,7 @@ func (t *AppArmorUpgradeTest) Setup(f *framework.Framework) {
 // pod can still consume the secret.
 func (t *AppArmorUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upgrade UpgradeType) {
 	<-done
-	if upgrade == MasterUpgrade || upgrade == ClusterUpgrade {
+	if upgrade == MasterUpgrade {
 		t.verifyPodStillUp(f)
 	}
 	t.verifyNodesAppArmorEnabled(f)


### PR DESCRIPTION
Cherry pick of #80276 on release-1.15.

#80276: Don't expect pod to stay up during node upgrade

```release-note
NONE
```

/kind failing-test
/priority important-soon
/assign @smarterclayton 