### PR TITLE
[WIP] Remove unnecessary closer from portforward interface.

### DIFF
--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -127,7 +127,7 @@ func (r *Mock) RemoveImage(image ImageSpec) error {
 	return args.Error(0)
 }
 
-func (r *Mock) PortForward(pod *Pod, port uint16, stream io.ReadWriteCloser) error {
+func (r *Mock) PortForward(pod *Pod, port uint16, stream io.ReadWriter) error {
 	args := r.Called(pod, port, stream)
 	return args.Error(0)
 }

--- a/pkg/kubelet/dockershim/docker_streaming.go
+++ b/pkg/kubelet/dockershim/docker_streaming.go
@@ -64,7 +64,7 @@ func (r *streamingRuntime) Attach(containerID string, in io.Reader, out, errw io
 	return attachContainer(r.client, containerID, in, out, errw, tty, resize)
 }
 
-func (r *streamingRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (r *streamingRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriter) error {
 	if port < 0 || port > math.MaxUint16 {
 		return fmt.Errorf("invalid port %d", port)
 	}

--- a/pkg/kubelet/dockershim/docker_streaming_others.go
+++ b/pkg/kubelet/dockershim/docker_streaming_others.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/klog"
 )
 
-func (r *streamingRuntime) portForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (r *streamingRuntime) portForward(podSandboxID string, port int32, stream io.ReadWriter) error {
 	container, err := r.client.InspectContainer(podSandboxID)
 	if err != nil {
 		return err

--- a/pkg/kubelet/dockershim/docker_streaming_windows.go
+++ b/pkg/kubelet/dockershim/docker_streaming_windows.go
@@ -26,7 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/ioutils"
 )
 
-func (r *streamingRuntime) portForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (r *streamingRuntime) portForward(podSandboxID string, port int32, stream io.ReadWriter) error {
 	stderr := new(bytes.Buffer)
 	err := r.exec(podSandboxID, []string{"wincat.exe", "localhost", fmt.Sprint(port)}, stream, stream, ioutils.WriteCloserWrapper(stderr), false, nil, 0)
 	if err != nil {

--- a/pkg/kubelet/server/portforward/portforward.go
+++ b/pkg/kubelet/server/portforward/portforward.go
@@ -30,7 +30,7 @@ import (
 // in a pod.
 type PortForwarder interface {
 	// PortForwarder copies data between a data stream and a port in a pod.
-	PortForward(name string, uid types.UID, port int32, stream io.ReadWriteCloser) error
+	PortForward(name string, uid types.UID, port int32, stream io.ReadWriter) error
 }
 
 // ServePortForward handles a port forwarding request.  A single request is

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -145,7 +145,7 @@ func (fk *fakeKubelet) RunInContainer(podFullName string, uid types.UID, contain
 type fakeRuntime struct {
 	execFunc        func(string, []string, io.Reader, io.WriteCloser, io.WriteCloser, bool, <-chan remotecommand.TerminalSize) error
 	attachFunc      func(string, io.Reader, io.WriteCloser, io.WriteCloser, bool, <-chan remotecommand.TerminalSize) error
-	portForwardFunc func(string, int32, io.ReadWriteCloser) error
+	portForwardFunc func(string, int32, io.ReadWriter) error
 }
 
 func (f *fakeRuntime) Exec(containerID string, cmd []string, stdin io.Reader, stdout, stderr io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error {
@@ -156,7 +156,7 @@ func (f *fakeRuntime) Attach(containerID string, stdin io.Reader, stdout, stderr
 	return f.attachFunc(containerID, stdin, stdout, stderr, tty, resize)
 }
 
-func (f *fakeRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (f *fakeRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriter) error {
 	return f.portForwardFunc(podSandboxID, port, stream)
 }
 
@@ -1449,7 +1449,7 @@ func TestServePortForward(t *testing.T) {
 				}
 			}
 
-			ss.fakeRuntime.portForwardFunc = func(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+			ss.fakeRuntime.portForwardFunc = func(podSandboxID string, port int32, stream io.ReadWriter) error {
 				defer close(portForwardFuncDone)
 				assert.Equal(t, testPodSandboxID, podSandboxID, "pod sandbox id")
 				// The port should be valid if it reaches here.

--- a/pkg/kubelet/server/server_websocket_test.go
+++ b/pkg/kubelet/server/server_websocket_test.go
@@ -79,7 +79,7 @@ func TestServeWSPortForward(t *testing.T) {
 				}
 			}
 
-			ss.fakeRuntime.portForwardFunc = func(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+			ss.fakeRuntime.portForwardFunc = func(podSandboxID string, port int32, stream io.ReadWriter) error {
 				defer close(portForwardFuncDone)
 				assert.Equal(t, testPodSandboxID, podSandboxID, "pod sandbox id")
 				// The port should be valid if it reaches here.
@@ -172,7 +172,7 @@ func TestServeWSMultiplePortForward(t *testing.T) {
 		assert.Equal(t, podNamespace, namespace, "pod namespace")
 	}
 
-	ss.fakeRuntime.portForwardFunc = func(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+	ss.fakeRuntime.portForwardFunc = func(podSandboxID string, port int32, stream io.ReadWriter) error {
 		defer portForwardWG.Done()
 		assert.Equal(t, testPodSandboxID, podSandboxID, "pod sandbox id")
 

--- a/pkg/kubelet/server/streaming/server.go
+++ b/pkg/kubelet/server/streaming/server.go
@@ -63,7 +63,7 @@ type Server interface {
 type Runtime interface {
 	Exec(containerID string, cmd []string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
 	Attach(containerID string, in io.Reader, out, err io.WriteCloser, tty bool, resize <-chan remotecommand.TerminalSize) error
-	PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error
+	PortForward(podSandboxID string, port int32, stream io.ReadWriter) error
 }
 
 // Config defines the options used for running the stream server.
@@ -377,6 +377,6 @@ func (a *criAdapter) AttachContainer(podName string, podUID types.UID, container
 	return a.Runtime.Attach(container, in, out, err, tty, resize)
 }
 
-func (a *criAdapter) PortForward(podName string, podUID types.UID, port int32, stream io.ReadWriteCloser) error {
+func (a *criAdapter) PortForward(podName string, podUID types.UID, port int32, stream io.ReadWriter) error {
 	return a.Runtime.PortForward(podName, port, stream)
 }

--- a/pkg/kubelet/server/streaming/server_test.go
+++ b/pkg/kubelet/server/streaming/server_test.go
@@ -426,7 +426,7 @@ func (f *fakeRuntime) Attach(containerID string, stdin io.Reader, stdout, stderr
 	return nil
 }
 
-func (f *fakeRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
+func (f *fakeRuntime) PortForward(podSandboxID string, port int32, stream io.ReadWriter) error {
 	assert.Equal(f.t, testPodSandboxID, podSandboxID)
 	assert.EqualValues(f.t, testPort, port)
 	doServerStreams(f.t, "portforward", stream, stream, nil)


### PR DESCRIPTION
Signed-off-by: Lantao Liu <lantaol@google.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The portforward stream is not expected to be closed by the runtime in the current implementation.
* It is closed by the streaming server: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/server/portforward/httpstream.go#L239
* It is not closed by any runtime today:
  * Not in dockershim: https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/docker_streaming_others.go
  * Not in containerd: https://github.com/containerd/cri/blob/master/pkg/server/sandbox_portforward.go
  * Not in cri-o: https://github.com/cri-o/cri-o/blob/8f32010f7f4a83b614cf8d2840b57b12fbe493be/internal/oci/runtime_oci.go#L810

Let's just remove the `Closer` from the interface to avoid confusion like https://github.com/containerd/cri/pull/1221#issuecomment-518443393.

/cc @yujuhong @tallclair @feiskyer @jterry75 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
none
```
