### PR TITLE
[WIP] Change ionice and nice for kube-logrotate

### DIFF
--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -101,7 +101,7 @@ write_files:
 
       [Service]
       Type=oneshot
-      ExecStart=-/usr/sbin/logrotate /etc/logrotate.conf
+      ExecStart=-/usr/bin/nice -n19 /usr/bin/ionice -c3 /usr/sbin/logrotate /etc/logrotate.conf
 
       [Install]
       WantedBy=kubernetes.target


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

We (sig-scalability) constantly see different issues correlating with logrotate runs (e.g. kube-addon-manager spikes). I think we should consider mitigating them with changing ionice for logrotate process to "idle" or some other reasonable value.

It's just a proposal, I don't expect this PR to be submitted without proper verification if this changes anything.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @wojtek-t @jpbetz @krzysied