### PR TITLE
feat:  return error when score is out of range

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/util:go_default_library",

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -431,8 +431,16 @@ func (f *framework) ApplyScoreWeights(pc *PluginContext, pod *v1.Pod, scores Plu
 			errCh.SendErrorWithCancel(err, cancel)
 			return
 		}
-		for i := range nodeScoreList {
-			nodeScoreList[i].Score = nodeScoreList[i].Score * weight
+
+		for i, nodeScore := range nodeScoreList {
+			// return error if score plugin returns invalid score.
+			if nodeScore.Score > MaxNodeScore || nodeScore.Score < MinNodeScore {
+				err := fmt.Errorf("score plugin %q returns an invalid score %q, it should in the range of [MinNodeScore, MaxNodeScore] after normalizing", pl.Name(), nodeScore.Score)
+				errCh.SendErrorWithCancel(err, cancel)
+				return
+			}
+
+			nodeScoreList[i].Score = nodeScore.Score * weight
 		}
 	})
 

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -604,6 +604,60 @@ func TestApplyScoreWeights(t *testing.T) {
 			},
 			err: true,
 		},
+		{
+			name:    "Score plugin return score greater than MaxNodeScore",
+			plugins: plugin1And2,
+			input: PluginToNodeScores{
+				scorePlugin1: {
+					{
+						Name:  "node1",
+						Score: MaxNodeScore + 1,
+					},
+					{
+						Name:  "node2",
+						Score: 3,
+					},
+				},
+				scorePlugin2: {
+					{
+						Name:  "node1",
+						Score: MinNodeScore,
+					},
+					{
+						Name:  "node2",
+						Score: 5,
+					},
+				},
+			},
+			err: true,
+		},
+		{
+			name:    "Score plugin return score less than MinNodeScore",
+			plugins: plugin1And2,
+			input: PluginToNodeScores{
+				scorePlugin1: {
+					{
+						Name:  "node1",
+						Score: MaxNodeScore,
+					},
+					{
+						Name:  "node2",
+						Score: 3,
+					},
+				},
+				scorePlugin2: {
+					{
+						Name:  "node1",
+						Score: MinNodeScore - 1,
+					},
+					{
+						Name:  "node2",
+						Score: 5,
+					},
+				},
+			},
+			err: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
 
@@ -63,7 +64,7 @@ const (
 
 const (
 	// MaxNodeScore is the maximum score a Score plugin is expected to return.
-	MaxNodeScore int = 10
+	MaxNodeScore int = schedulerapi.MaxPriority
 
 	// MinNodeScore is the minimum score a Score plugin is expected to return.
 	MinNodeScore int = 0

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -61,6 +61,14 @@ const (
 	Skip
 )
 
+const (
+	// MaxNodeScore is the maximum score a Score plugin is expected to return.
+	MaxNodeScore int = 10
+
+	// MinNodeScore is the minimum score a Score plugin is expected to return.
+	MinNodeScore int = 0
+)
+
 // Status indicates the result of running a plugin. It consists of a code and a
 // message. When the status code is not `Success`, the status message should
 // explain why.

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -152,11 +152,11 @@ func (sp *ScorePlugin) Score(pc *framework.PluginContext, p *v1.Pod, nodeName st
 		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", p.Name))
 	}
 
-	score := 10
+	score := 1
 	if sp.numScoreCalled == 1 {
 		// The first node is scored the highest, the rest is scored lower.
 		sp.highScoreNode = nodeName
-		score = 100
+		score = framework.MaxNodeScore
 	}
 	return score, nil
 }


### PR DESCRIPTION
/kind feature
/sig scheduling
/priority important-soon
/hold

**What this PR does / why we need it**:

Per discussion in https://github.com/kubernetes/enhancements/pull/1178, we'll

1. Expand the original range to [0, 100] 
2. Return an error when score plugins returns a score which is out of range [0, 100]

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/80784 #81281

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Return error when the scoring plugin returns score out of range [0, 100].
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20180409-scheduling-framework.md
```
