### PR TITLE
Update configz doc to use non-default muxer

### DIFF
--- a/pkg/util/configz/configz.go
+++ b/pkg/util/configz/configz.go
@@ -34,8 +34,9 @@ limitations under the License.
 //  	}
 //  	pcz.Set(planeConfig)
 //
-//  	configz.InstallHandler(http.DefaultServeMux)
-//  	http.ListenAndServe(":8080", http.DefaultServeMux)
+//      mux := http.NewServeMux()
+//  	configz.InstallHandler(mux)
+//  	http.ListenAndServe(":8080", mux)
 //  }
 package configz
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/area security

**What this PR does / why we need it**:

Document an example of a non-default http mux to prevent issues like [CVE-2019-11248](https://github.com/kubernetes/kubernetes/pull/78313)

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

CC @tallclair 

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A