### PR TITLE
Add security notices to changelogs

### DIFF
--- a/CHANGELOG-1.13.md
+++ b/CHANGELOG-1.13.md
@@ -218,9 +218,10 @@ filename | sha512 hash
 
 ## Changelog since v1.13.8
 
-**No notable changes for this release**
+* Fix CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl cp potential directory traversal ([#80436](https://github.com/kubernetes/kubernetes/pull/80436))
+* Fix CVE-2019-11247: API server allows access to custom resources via wrong scope ([#80750](https://github.com/kubernetes/kubernetes/pull/80750))
 
-
+See also the [security announcement for this release](https://groups.google.com/forum/#!topic/kubernetes-security-announce/vUtEcSEY6SM).
 
 # v1.13.8
 

--- a/CHANGELOG-1.14.md
+++ b/CHANGELOG-1.14.md
@@ -170,9 +170,10 @@ filename | sha512 hash
 
 ## Changelog since v1.14.4
 
-**No notable changes for this release**
+* Fix CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl cp potential directory traversal ([#80436](https://github.com/kubernetes/kubernetes/pull/80436))
+* Fix CVE-2019-11247: API server allows access to custom resources via wrong scope ([#80750](https://github.com/kubernetes/kubernetes/pull/80750))
 
-
+See also the [security announcement for this release](https://groups.google.com/forum/#!topic/kubernetes-security-announce/vUtEcSEY6SM).
 
 # v1.14.4
 

--- a/CHANGELOG-1.15.md
+++ b/CHANGELOG-1.15.md
@@ -176,9 +176,10 @@ filename | sha512 hash
 
 ## Changelog since v1.15.1
 
-**No notable changes for this release**
+* Fix CVE-2019-11249: Incomplete fixes for CVE-2019-1002101 and CVE-2019-11246, kubectl cp potential directory traversal ([#80436](https://github.com/kubernetes/kubernetes/pull/80436))
+* Fix CVE-2019-11247: API server allows access to custom resources via wrong scope ([#80750](https://github.com/kubernetes/kubernetes/pull/80750))
 
-
+See also the [security announcement for this release](https://groups.google.com/forum/#!topic/kubernetes-security-announce/vUtEcSEY6SM).
 
 # v1.15.1
 


### PR DESCRIPTION


**What type of PR is this?**

/kind documentation
/sig release

**What this PR does / why we need it**:

Add security notices to changelogs for releases v1.13.9, v1.14.5 and v1.15.2.

**Which issue(s) this PR fixes**:

Fixes #81011.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```