### PR TITLE
scheduler: internal data structure optimization

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata_test.go
+++ b/pkg/scheduler/algorithm/predicates/metadata_test.go
@@ -385,7 +385,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 			// Remove the added pod and from existingPodsMeta1 an make sure it is equal
 			// to meta generated for existing pods.
 			existingPodsMeta2, _ := getMeta(st.FakePodLister(test.existingPods))
-			if err := existingPodsMeta1.RemovePod(test.addedPod); err != nil {
+			if err := existingPodsMeta1.RemovePod(test.addedPod, nil); err != nil {
 				t.Errorf("error removing pod from meta: %v", err)
 			}
 			if err := predicateMetadataEquivalent(existingPodsMeta1, existingPodsMeta2); err != nil {
@@ -512,37 +512,13 @@ func TestPredicateMetadata_ShallowCopy(t *testing.T) {
 				},
 			},
 		},
-		topologyPairsPodSpreadMap: &topologyPairsPodSpreadMap{
-			topologyKeyToMinPodsMap: map[string]int32{"name": 1},
-			topologyPairsMaps: &topologyPairsMaps{
-				topologyPairToPods: map[topologyPair]podSet{
-					{key: "name", value: "nodeA"}: {
-						&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p1", Labels: selector1},
-							Spec: v1.PodSpec{NodeName: "nodeA"},
-						}: struct{}{},
-					},
-					{key: "name", value: "nodeC"}: {
-						&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p2"},
-							Spec: v1.PodSpec{
-								NodeName: "nodeC",
-							},
-						}: struct{}{},
-						&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p6", Labels: selector1},
-							Spec: v1.PodSpec{NodeName: "nodeC"},
-						}: struct{}{},
-					},
-				},
-				podToTopologyPairs: map[string]topologyPairSet{
-					"p1_": {
-						topologyPair{key: "name", value: "nodeA"}: struct{}{},
-					},
-					"p2_": {
-						topologyPair{key: "name", value: "nodeC"}: struct{}{},
-					},
-					"p6_": {
-						topologyPair{key: "name", value: "nodeC"}: struct{}{},
-					},
-				},
+		podSpreadCache: &podSpreadCache{
+			tpKeyToCriticalPaths: map[string]*criticalPaths{
+				"name": {{"nodeA", 1}, {"nodeC", 2}},
+			},
+			tpPairToMatchNum: map[topologyPair]int32{
+				{key: "name", value: "nodeA"}: 1,
+				{key: "name", value: "nodeC"}: 2,
 			},
 		},
 		serviceAffinityInUse: true,
@@ -916,15 +892,12 @@ func TestPodMatchesSpreadConstraint(t *testing.T) {
 }
 
 func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
-	// we need to inject the exact pod pointers to want.topologyPairsMaps.topologyPairToPods
-	// otherwise, *pod (as key of a map) will always fail in reflect.DeepEqual()
 	tests := []struct {
-		name              string
-		pod               *v1.Pod
-		nodes             []*v1.Node
-		existingPods      []*v1.Pod
-		injectPodPointers map[topologyPair][]int
-		want              *topologyPairsPodSpreadMap
+		name         string
+		pod          *v1.Pod
+		nodes        []*v1.Node
+		existingPods []*v1.Pod
+		want         *podSpreadCache
 	}{
 		{
 			name: "clean cluster with one spreadConstraint",
@@ -937,16 +910,13 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				// denotes no existing pod is matched on this zone pair, but still needed to be
-				// calculated if incoming pod matches its own spread constraints
-				{key: "zone", value: "zone1"}: {},
-				{key: "zone", value: "zone2"}: {},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: make(map[string]topologyPairSet),
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 0}, {"zone2", 0}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 0,
+					{key: "zone", value: "zone2"}: 0,
 				},
 			},
 		},
@@ -968,22 +938,44 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				// denotes existingPods[0,1,2]
-				{key: "zone", value: "zone1"}: {0, 1, 2},
-				// denotes existingPods[3,4]
-				{key: "zone", value: "zone2"}: {3, 4},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone2", 2}, {"zone1", 3}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 3,
+					{key: "zone", value: "zone2"}: 2,
+				},
 			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 2},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1"),
-						"p-a2_": newPairSet("zone", "zone1"),
-						"p-b1_": newPairSet("zone", "zone1"),
-						"p-y1_": newPairSet("zone", "zone2"),
-						"p-y2_": newPairSet("zone", "zone2"),
-					},
+		},
+		{
+			name: "normal case with one spreadConstraint, on a 3-zone cluster",
+			pod: st.MakePod().Name("p").Label("foo", "").SpreadConstraint(
+				1, "zone", hardSpread, st.MakeLabelSelector().Exists("foo").Obj(),
+			).Obj(),
+			nodes: []*v1.Node{
+				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
+				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
+				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
+				st.MakeNode().Name("node-y").Label("zone", "zone2").Label("node", "node-y").Obj(),
+				st.MakeNode().Name("node-o").Label("zone", "zone3").Label("node", "node-o").Obj(),
+				st.MakeNode().Name("node-p").Label("zone", "zone3").Label("node", "node-p").Obj(),
+			},
+			existingPods: []*v1.Pod{
+				st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-a2").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Obj(),
+				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
+				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
+			},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone3", 0}, {"zone2", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 3,
+					{key: "zone", value: "zone2"}: 2,
+					{key: "zone", value: "zone3"}: 0,
 				},
 			},
 		},
@@ -1005,18 +997,13 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 				st.MakePod().Name("p-y1").Namespace("ns2").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y2").Node("node-y").Label("foo", "").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}: {0, 2},
-				{key: "zone", value: "zone2"}: {4},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1"),
-						"p-b1_": newPairSet("zone", "zone1"),
-						"p-y2_": newPairSet("zone", "zone2"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone2", 1}, {"zone1", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 2,
+					{key: "zone", value: "zone2"}: 1,
 				},
 			},
 		},
@@ -1041,26 +1028,18 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y4").Node("node-y").Label("foo", "").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {0, 1, 2},
-				{key: "zone", value: "zone2"}:  {3, 4, 5, 6},
-				{key: "node", value: "node-a"}: {0, 1},
-				{key: "node", value: "node-b"}: {2},
-				{key: "node", value: "node-x"}: {},
-				{key: "node", value: "node-y"}: {3, 4, 5, 6},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 3, "node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-a2_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-b1_": newPairSet("zone", "zone1", "node", "node-b"),
-						"p-y1_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y2_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y3_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y4_": newPairSet("zone", "zone2", "node", "node-y"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 3}, {"zone2", 4}},
+					"node": {{"node-x", 0}, {"node-b", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 0,
+					{key: "node", value: "node-y"}: 4,
 				},
 			},
 		},
@@ -1086,25 +1065,17 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y4").Node("node-y").Label("foo", "").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {0, 1, 2},
-				{key: "zone", value: "zone2"}:  {3, 4, 5, 6},
-				{key: "node", value: "node-a"}: {0, 1},
-				{key: "node", value: "node-b"}: {2},
-				{key: "node", value: "node-y"}: {3, 4, 5, 6},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 3, "node": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-a2_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-b1_": newPairSet("zone", "zone1", "node", "node-b"),
-						"p-y1_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y2_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y3_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y4_": newPairSet("zone", "zone2", "node", "node-y"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 3}, {"zone2", 4}},
+					"node": {{"node-b", 1}, {"node-a", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-y"}: 4,
 				},
 			},
 		},
@@ -1121,20 +1092,19 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 			},
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-a").Node("node-a").Label("foo", "").Obj(),
+				st.MakePod().Name("p-b").Node("node-b").Label("bar", "").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {0},
-				{key: "zone", value: "zone2"}:  {},
-				{key: "node", value: "node-a"}: {},
-				{key: "node", value: "node-b"}: {},
-				{key: "node", value: "node-y"}: {},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 0, "node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a_": newPairSet("zone", "zone1"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone2", 0}, {"zone1", 1}},
+					"node": {{"node-a", 0}, {"node-y", 0}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  0,
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-y"}: 0,
 				},
 			},
 		},
@@ -1158,25 +1128,17 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y4").Node("node-y").Label("foo", "").Label("bar", "").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {0, 1, 2},
-				{key: "zone", value: "zone2"}:  {3, 4, 5, 6},
-				{key: "node", value: "node-a"}: {1},
-				{key: "node", value: "node-b"}: {},
-				{key: "node", value: "node-y"}: {4, 6},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 3, "node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1"),
-						"p-a2_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-b1_": newPairSet("zone", "zone1"),
-						"p-y1_": newPairSet("zone", "zone2"),
-						"p-y2_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y3_": newPairSet("zone", "zone2"),
-						"p-y4_": newPairSet("zone", "zone2", "node", "node-y"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 3}, {"zone2", 4}},
+					"node": {{"node-b", 0}, {"node-a", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 0,
+					{key: "node", value: "node-y"}: 2,
 				},
 			},
 		},
@@ -1202,61 +1164,46 @@ func TestGetTPMapMatchingSpreadConstraints(t *testing.T) {
 				st.MakePod().Name("p-y3").Node("node-y").Label("foo", "").Obj(),
 				st.MakePod().Name("p-y4").Node("node-y").Label("foo", "").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {0, 1, 2},
-				{key: "zone", value: "zone2"}:  {3, 4, 5, 6},
-				{key: "node", value: "node-a"}: {0, 1},
-				{key: "node", value: "node-b"}: {2},
-				{key: "node", value: "node-y"}: {3, 4, 5, 6},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 3, "node": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-a2_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-b1_": newPairSet("zone", "zone1", "node", "node-b"),
-						"p-y1_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y2_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y3_": newPairSet("zone", "zone2", "node", "node-y"),
-						"p-y4_": newPairSet("zone", "zone2", "node", "node-y"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 3}, {"zone2", 4}},
+					"node": {{"node-b", 1}, {"node-a", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  4,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-y"}: 4,
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.want.topologyPairToPods = make(map[topologyPair]podSet)
-			for pair, indexes := range tt.injectPodPointers {
-				pSet := make(podSet)
-				for _, i := range indexes {
-					pSet[tt.existingPods[i]] = struct{}{}
-				}
-				tt.want.topologyPairToPods[pair] = pSet
-			}
 			nodeInfoMap := schedulernodeinfo.CreateNodeNameToInfoMap(tt.existingPods, tt.nodes)
-			if got, _ := getTPMapMatchingSpreadConstraints(tt.pod, nodeInfoMap); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getTPMapMatchingSpreadConstraints() = %v, want %v", got, tt.want)
+			got, _ := getExistingPodSpreadCache(tt.pod, nodeInfoMap)
+			got.sortCriticalPaths()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getExistingPodSpreadCache() = %v, want %v", *got, *tt.want)
 			}
 		})
 	}
 }
 
-func TestPodSpreadMap_addPod(t *testing.T) {
+func TestPodSpreadCache_addPod(t *testing.T) {
 	tests := []struct {
-		name              string
-		preemptorPod      *v1.Pod
-		addedPod          *v1.Pod
-		existingPods      []*v1.Pod
-		nodeIdx           int // denotes which node 'addedPod' belongs to
-		nodes             []*v1.Node
-		injectPodPointers map[topologyPair][]int // non-negative index refers to existingPods[i], negative index refers to addedPod
-		want              *topologyPairsPodSpreadMap
+		name         string
+		preemptor    *v1.Pod
+		addedPod     *v1.Pod
+		existingPods []*v1.Pod
+		nodeIdx      int // denotes which node 'addedPod' belongs to
+		nodes        []*v1.Node
+		want         *podSpreadCache
 	}{
 		{
 			name: "node a and b both impact current min match",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
 			addedPod:     st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
@@ -1266,24 +1213,19 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "node", value: "node-a"}: {-1},
-				{key: "node", value: "node-b"}: {},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// min match map shouldn't be changed b/c node-b is still on the critical path
-				// determining min match
-				topologyKeyToMinPodsMap: map[string]int32{"node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("node", "node-a"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"node": {{"node-b", 0}, {"node-a", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 0,
 				},
 			},
 		},
 		{
 			name: "only node a impacts current min match",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
 			addedPod: st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
@@ -1295,24 +1237,19 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "node", value: "node-a"}: {-1},
-				{key: "node", value: "node-b"}: {0},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// min match should be changed from 0 to 1
-				topologyKeyToMinPodsMap: map[string]int32{"node": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("node", "node-a"),
-						"p-b1_": newPairSet("node", "node-b"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"node": {{"node-a", 1}, {"node-b", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 1,
 				},
 			},
 		},
 		{
 			name: "add a pod with mis-matched namespace doesn't change topologyKeyToMinPodsMap",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
 			addedPod: st.MakePod().Name("p-a1").Namespace("ns1").Node("node-a").Label("foo", "").Obj(),
@@ -1324,24 +1261,19 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "node", value: "node-a"}: {},
-				{key: "node", value: "node-b"}: {0},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// min match remains the same
-				topologyKeyToMinPodsMap: map[string]int32{"node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						// "p-a1_": newPairSet("node", "node-a") shouldn't exist
-						"p-b1_": newPairSet("node", "node-b"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"node": {{"node-a", 0}, {"node-b", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 1,
 				},
 			},
 		},
 		{
 			name: "add pod on non-critical node won't trigger re-calculation",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
 			addedPod: st.MakePod().Name("p-b2").Node("node-b").Label("foo", "").Obj(),
@@ -1353,23 +1285,19 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "node", value: "node-a"}: {},
-				{key: "node", value: "node-b"}: {-1, 0},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-b1_": newPairSet("node", "node-b"),
-						"p-b2_": newPairSet("node", "node-b"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"node": {{"node-a", 0}, {"node-b", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 2,
 				},
 			},
 		},
 		{
 			name: "node a and x both impact topologyKeyToMinPodsMap on zone and node",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "zone", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
@@ -1380,24 +1308,22 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {-1},
-				{key: "zone", value: "zone2"}:  {},
-				{key: "node", value: "node-a"}: {-1},
-				{key: "node", value: "node-x"}: {},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 0, "node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone2", 0}, {"zone1", 1}},
+					"node": {{"node-x", 0}, {"node-a", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  0,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-x"}: 0,
 				},
 			},
 		},
 		{
 			name: "only node a impacts topologyKeyToMinPodsMap on zone and node",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "zone", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
@@ -1410,25 +1336,22 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-a").Label("zone", "zone1").Label("node", "node-a").Obj(),
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {-1},
-				{key: "zone", value: "zone2"}:  {0},
-				{key: "node", value: "node-a"}: {-1},
-				{key: "node", value: "node-x"}: {0},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1, "node": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-x1_": newPairSet("zone", "zone2", "node", "node-x"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 1}, {"zone2", 1}},
+					"node": {{"node-a", 1}, {"node-x", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-x"}: 1,
 				},
 			},
 		},
 		{
 			name: "node a impacts topologyKeyToMinPodsMap on node, node x impacts topologyKeyToMinPodsMap on zone",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").
 				SpreadConstraint(1, "zone", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				Obj(),
@@ -1444,35 +1367,30 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {-1, 0, 1},
-				{key: "zone", value: "zone2"}:  {2},
-				{key: "node", value: "node-a"}: {-1},
-				{key: "node", value: "node-b"}: {0, 1},
-				{key: "node", value: "node-x"}: {2},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1, "node": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-b1_": newPairSet("zone", "zone1", "node", "node-b"),
-						"p-b2_": newPairSet("zone", "zone1", "node", "node-b"),
-						"p-x1_": newPairSet("zone", "zone2", "node", "node-x"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone2", 1}, {"zone1", 3}},
+					"node": {{"node-a", 1}, {"node-x", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 2,
+					{key: "node", value: "node-x"}: 1,
 				},
 			},
 		},
 		{
-			name: "constraints hold different labelSelectors, node a impacts topologyKeyToMinPodsMap on node",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").Label("bar", "").
+			name: "constraints hold different labelSelectors, node a impacts topologyKeyToMinPodsMap on zone",
+			preemptor: st.MakePod().Name("p").Label("foo", "").Label("bar", "").
 				SpreadConstraint(1, "zone", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("bar").Obj()).
 				Obj(),
 			addedPod: st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Obj(),
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-b1").Node("node-b").Label("foo", "").Label("bar", "").Obj(),
-				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Obj(),
+				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Label("bar", "").Obj(),
 				st.MakePod().Name("p-x2").Node("node-x").Label("bar", "").Obj(),
 			},
 			nodeIdx: 0,
@@ -1481,35 +1399,30 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {-1, 0},
-				{key: "zone", value: "zone2"}:  {1},
-				{key: "node", value: "node-a"}: {},
-				{key: "node", value: "node-b"}: {0},
-				{key: "node", value: "node-x"}: {2},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1, "node": 0},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1"),
-						"p-b1_": newPairSet("zone", "zone1", "node", "node-b"),
-						"p-x1_": newPairSet("zone", "zone2"),
-						"p-x2_": newPairSet("node", "node-x"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone2", 1}, {"zone1", 2}},
+					"node": {{"node-a", 0}, {"node-b", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  2,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 0,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 2,
 				},
 			},
 		},
 		{
 			name: "constraints hold different labelSelectors, node a impacts topologyKeyToMinPodsMap on both zone and node",
-			preemptorPod: st.MakePod().Name("p").Label("foo", "").Label("bar", "").
+			preemptor: st.MakePod().Name("p").Label("foo", "").Label("bar", "").
 				SpreadConstraint(1, "zone", hardSpread, st.MakeLabelSelector().Exists("foo").Obj()).
 				SpreadConstraint(1, "node", hardSpread, st.MakeLabelSelector().Exists("bar").Obj()).
 				Obj(),
 			addedPod: st.MakePod().Name("p-a1").Node("node-a").Label("foo", "").Label("bar", "").Obj(),
 			existingPods: []*v1.Pod{
 				st.MakePod().Name("p-b1").Node("node-b").Label("bar", "").Obj(),
-				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Obj(),
+				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Label("bar", "").Obj(),
 				st.MakePod().Name("p-x2").Node("node-x").Label("bar", "").Obj(),
 			},
 			nodeIdx: 0,
@@ -1518,62 +1431,45 @@ func TestPodSpreadMap_addPod(t *testing.T) {
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 			},
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {-1},
-				{key: "zone", value: "zone2"}:  {1},
-				{key: "node", value: "node-a"}: {-1},
-				{key: "node", value: "node-b"}: {0},
-				{key: "node", value: "node-x"}: {2},
-			},
-			want: &topologyPairsPodSpreadMap{
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1, "node": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-b1_": newPairSet("node", "node-b"),
-						"p-x1_": newPairSet("zone", "zone2"),
-						"p-x2_": newPairSet("node", "node-x"),
-					},
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 1}, {"zone2", 1}},
+					"node": {{"node-a", 1}, {"node-b", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  1,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 1,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 2,
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.want.topologyPairToPods = make(map[topologyPair]podSet)
-			for pair, indexes := range tt.injectPodPointers {
-				pSet := make(podSet)
-				for _, i := range indexes {
-					if i >= 0 {
-						pSet[tt.existingPods[i]] = struct{}{}
-					} else {
-						pSet[tt.addedPod] = struct{}{}
-					}
-				}
-				tt.want.topologyPairToPods[pair] = pSet
-			}
-
 			nodeInfoMap := schedulernodeinfo.CreateNodeNameToInfoMap(tt.existingPods, tt.nodes)
-			podSpreadMap, _ := getTPMapMatchingSpreadConstraints(tt.preemptorPod, nodeInfoMap)
+			podSpreadCache, _ := getExistingPodSpreadCache(tt.preemptor, nodeInfoMap)
 
-			podSpreadMap.addPod(tt.addedPod, tt.preemptorPod, tt.nodes[tt.nodeIdx])
-			if !reflect.DeepEqual(podSpreadMap, tt.want) {
-				t.Errorf("podSpreadMap#addPod() = %v, want %v", podSpreadMap, tt.want)
+			podSpreadCache.addPod(tt.addedPod, tt.preemptor, tt.nodes[tt.nodeIdx])
+			podSpreadCache.sortCriticalPaths()
+			if !reflect.DeepEqual(podSpreadCache, tt.want) {
+				t.Errorf("podSpreadCache#addPod() = %v, want %v", podSpreadCache, tt.want)
 			}
 		})
 	}
 }
 
-func TestPodSpreadMap_removePod(t *testing.T) {
+func TestPodSpreadCache_removePod(t *testing.T) {
 	tests := []struct {
-		name              string
-		preemptor         *v1.Pod // preemptor pod
-		nodes             []*v1.Node
-		existingPods      []*v1.Pod
-		deletedPodIdx     int     // need to reuse *Pod of existingPods[i]
-		deletedPod        *v1.Pod // if deletedPodIdx is invalid, this field is bypassed
-		injectPodPointers map[topologyPair][]int
-		want              *topologyPairsPodSpreadMap
+		name          string
+		preemptor     *v1.Pod // preemptor pod
+		nodes         []*v1.Node
+		existingPods  []*v1.Pod
+		deletedPodIdx int     // need to reuse *Pod of existingPods[i]
+		deletedPod    *v1.Pod // this field is used only when deletedPodIdx is -1
+		nodeIdx       int     // denotes which node "deletedPod" belongs to
+		want          *podSpreadCache
 	}{
 		{
 			// A high priority pod may not be scheduled due to node taints or resource shortage.
@@ -1593,18 +1489,14 @@ func TestPodSpreadMap_removePod(t *testing.T) {
 				st.MakePod().Name("p-x1").Node("node-x").Label("foo", "").Obj(),
 			},
 			deletedPodIdx: 0, // remove pod "p-a1"
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}: {1},
-				{key: "zone", value: "zone2"}: {2},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// topologyKeyToMinPodsMap actually doesn't change
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-b1_": newPairSet("zone", "zone1"),
-						"p-x1_": newPairSet("zone", "zone2"),
-					},
+			nodeIdx:       0, // node-a
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 1}, {"zone2", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 1,
+					{key: "zone", value: "zone2"}: 1,
 				},
 			},
 		},
@@ -1626,20 +1518,14 @@ func TestPodSpreadMap_removePod(t *testing.T) {
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
 			deletedPodIdx: 0, // remove pod "p-a1"
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}: {1},
-				{key: "zone", value: "zone2"}: {2, 3},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// topologyKeyToMinPodsMap is expected to be re-calculated from {"zone": 2}
-				// to {"zone": 1}
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-b1_": newPairSet("zone", "zone1"),
-						"p-x1_": newPairSet("zone", "zone2"),
-						"p-y1_": newPairSet("zone", "zone2"),
-					},
+			nodeIdx:       0, // node-a
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 1}, {"zone2", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 1,
+					{key: "zone", value: "zone2"}: 2,
 				},
 			},
 		},
@@ -1662,20 +1548,14 @@ func TestPodSpreadMap_removePod(t *testing.T) {
 				st.MakePod().Name("p-y1").Node("node-y").Label("foo", "").Obj(),
 			},
 			deletedPodIdx: 0, // remove pod "p-a0"
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}: {1, 2},
-				{key: "zone", value: "zone2"}: {3, 4},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// topologyKeyToMinPodsMap is unchanged
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 2},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1"),
-						"p-b1_": newPairSet("zone", "zone1"),
-						"p-x1_": newPairSet("zone", "zone2"),
-						"p-y1_": newPairSet("zone", "zone2"),
-					},
+			nodeIdx:       0, // node-a
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 2}, {"zone2", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 2,
+					{key: "zone", value: "zone2"}: 2,
 				},
 			},
 		},
@@ -1698,20 +1578,14 @@ func TestPodSpreadMap_removePod(t *testing.T) {
 			},
 			deletedPodIdx: -1,
 			deletedPod:    st.MakePod().Name("p-a0").Node("node-a").Label("bar", "").Obj(),
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}: {0, 1},
-				{key: "zone", value: "zone2"}: {2, 3},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// topologyKeyToMinPodsMap is unchanged
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 2},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1"),
-						"p-b1_": newPairSet("zone", "zone1"),
-						"p-x1_": newPairSet("zone", "zone2"),
-						"p-y1_": newPairSet("zone", "zone2"),
-					},
+			nodeIdx:       0, // node-a
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone1", 2}, {"zone2", 2}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}: 2,
+					{key: "zone", value: "zone2"}: 2,
 				},
 			},
 		},
@@ -1734,41 +1608,26 @@ func TestPodSpreadMap_removePod(t *testing.T) {
 				st.MakePod().Name("p-x2").Node("node-x").Label("foo", "").Obj(),
 			},
 			deletedPodIdx: 3, // remove pod "p-x1"
-			injectPodPointers: map[topologyPair][]int{
-				{key: "zone", value: "zone1"}:  {0, 1, 2},
-				{key: "zone", value: "zone2"}:  {4},
-				{key: "node", value: "node-a"}: {0, 1},
-				{key: "node", value: "node-b"}: {2},
-				{key: "node", value: "node-x"}: {4},
-			},
-			want: &topologyPairsPodSpreadMap{
-				// topologyKeyToMinPodsMap is expected to be re-calculated from {"zone": 2, "node": 1}
-				// to {"zone": 1, "node": 1}
-				topologyKeyToMinPodsMap: map[string]int32{"zone": 1, "node": 1},
-				topologyPairsMaps: &topologyPairsMaps{
-					podToTopologyPairs: map[string]topologyPairSet{
-						"p-a1_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-a2_": newPairSet("zone", "zone1", "node", "node-a"),
-						"p-b1_": newPairSet("zone", "zone1", "node", "node-b"),
-						"p-x2_": newPairSet("zone", "zone2", "node", "node-x"),
-					},
+			nodeIdx:       2, // node-x
+			want: &podSpreadCache{
+				tpKeyToCriticalPaths: map[string]*criticalPaths{
+					"zone": {{"zone2", 1}, {"zone1", 3}},
+					"node": {{"node-b", 1}, {"node-x", 1}},
+				},
+				tpPairToMatchNum: map[topologyPair]int32{
+					{key: "zone", value: "zone1"}:  3,
+					{key: "zone", value: "zone2"}:  1,
+					{key: "node", value: "node-a"}: 2,
+					{key: "node", value: "node-b"}: 1,
+					{key: "node", value: "node-x"}: 1,
 				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tt.want.topologyPairToPods = make(map[topologyPair]podSet)
-			for pair, indexes := range tt.injectPodPointers {
-				pSet := make(podSet)
-				for _, i := range indexes {
-					pSet[tt.existingPods[i]] = struct{}{}
-				}
-				tt.want.topologyPairToPods[pair] = pSet
-			}
-
 			nodeInfoMap := schedulernodeinfo.CreateNodeNameToInfoMap(tt.existingPods, tt.nodes)
-			podSpreadMap, _ := getTPMapMatchingSpreadConstraints(tt.preemptor, nodeInfoMap)
+			podSpreadCache, _ := getExistingPodSpreadCache(tt.preemptor, nodeInfoMap)
 
 			var deletedPod *v1.Pod
 			if tt.deletedPodIdx < len(tt.existingPods) && tt.deletedPodIdx >= 0 {
@@ -1776,9 +1635,10 @@ func TestPodSpreadMap_removePod(t *testing.T) {
 			} else {
 				deletedPod = tt.deletedPod
 			}
-			podSpreadMap.removePod(deletedPod)
-			if !reflect.DeepEqual(podSpreadMap, tt.want) {
-				t.Errorf("podSpreadMap#removePod() = %v, want %v", podSpreadMap, tt.want)
+			podSpreadCache.removePod(deletedPod, tt.preemptor, tt.nodes[tt.nodeIdx])
+			podSpreadCache.sortCriticalPaths()
+			if !reflect.DeepEqual(podSpreadCache, tt.want) {
+				t.Errorf("podSpreadCache#removePod() = %v, want %v", podSpreadCache, tt.want)
 			}
 		})
 	}
@@ -1827,7 +1687,7 @@ func BenchmarkTestGetTPMapMatchingSpreadConstraints(b *testing.B) {
 			nodeNameToInfo := schedulernodeinfo.CreateNodeNameToInfoMap(existingPods, allNodes)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				getTPMapMatchingSpreadConstraints(tt.pod, nodeNameToInfo)
+				getExistingPodSpreadCache(tt.pod, nodeNameToInfo)
 			}
 		})
 	}
@@ -1845,4 +1705,15 @@ func newPairSet(kv ...string) topologyPairSet {
 		result[pair] = struct{}{}
 	}
 	return result
+}
+
+// sortCriticalPaths is only served for testing purpose.
+func (c *podSpreadCache) sortCriticalPaths() {
+	for _, paths := range c.tpKeyToCriticalPaths {
+		// If two paths both hold minimum matching number, and topologyValue is unordered.
+		if paths[0].matchNum == paths[1].matchNum && paths[0].topologyValue > paths[1].topologyValue {
+			// Swap topologyValue to make them sorted alphabetically.
+			paths[0].topologyValue, paths[1].topologyValue = paths[1].topologyValue, paths[0].topologyValue
+		}
+	}
 }

--- a/pkg/scheduler/algorithm/priorities/even_pods_spread_test.go
+++ b/pkg/scheduler/algorithm/priorities/even_pods_spread_test.go
@@ -31,8 +31,8 @@ func Test_topologySpreadConstraintsMap_initialize(t *testing.T) {
 		name                string
 		pod                 *v1.Pod
 		nodes               []*v1.Node
-		wantNodeNameMap     map[string]int64
-		wantTopologyPairMap map[topologyPair]*int64
+		wantNodeNameMap     map[string]int32
+		wantTopologyPairMap map[topologyPair]*int32
 	}{
 		{
 			name: "normal case",
@@ -45,17 +45,17 @@ func Test_topologySpreadConstraintsMap_initialize(t *testing.T) {
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 				st.MakeNode().Name("node-x").Label("zone", "zone2").Label("node", "node-x").Obj(),
 			},
-			wantNodeNameMap: map[string]int64{
+			wantNodeNameMap: map[string]int32{
 				"node-a": 0,
 				"node-b": 0,
 				"node-x": 0,
 			},
-			wantTopologyPairMap: map[topologyPair]*int64{
-				{key: "zone", value: "zone1"}:  new(int64),
-				{key: "zone", value: "zone2"}:  new(int64),
-				{key: "node", value: "node-a"}: new(int64),
-				{key: "node", value: "node-b"}: new(int64),
-				{key: "node", value: "node-x"}: new(int64),
+			wantTopologyPairMap: map[topologyPair]*int32{
+				{key: "zone", value: "zone1"}:  new(int32),
+				{key: "zone", value: "zone2"}:  new(int32),
+				{key: "node", value: "node-a"}: new(int32),
+				{key: "node", value: "node-b"}: new(int32),
+				{key: "node", value: "node-x"}: new(int32),
 			},
 		},
 		{
@@ -69,14 +69,14 @@ func Test_topologySpreadConstraintsMap_initialize(t *testing.T) {
 				st.MakeNode().Name("node-b").Label("zone", "zone1").Label("node", "node-b").Obj(),
 				st.MakeNode().Name("node-x").Label("node", "node-x").Obj(),
 			},
-			wantNodeNameMap: map[string]int64{
+			wantNodeNameMap: map[string]int32{
 				"node-a": 0,
 				"node-b": 0,
 			},
-			wantTopologyPairMap: map[topologyPair]*int64{
-				{key: "zone", value: "zone1"}:  new(int64),
-				{key: "node", value: "node-a"}: new(int64),
-				{key: "node", value: "node-b"}: new(int64),
+			wantTopologyPairMap: map[topologyPair]*int32{
+				{key: "zone", value: "zone1"}:  new(int32),
+				{key: "node", value: "node-a"}: new(int32),
+				{key: "node", value: "node-b"}: new(int32),
 			},
 		},
 	}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -1107,7 +1107,7 @@ func selectVictimsOnNode(
 	removePod := func(rp *v1.Pod) {
 		nodeInfoCopy.RemovePod(rp)
 		if meta != nil {
-			meta.RemovePod(rp)
+			meta.RemovePod(rp, nodeInfoCopy.Node())
 		}
 	}
 	addPod := func(ap *v1.Pod) {

--- a/pkg/scheduler/testing/BUILD
+++ b/pkg/scheduler/testing/BUILD
@@ -6,6 +6,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "fake_lister.go",
+        "workload_prep.go",
         "wrappers.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/scheduler/testing",

--- a/pkg/scheduler/testing/workload_prep.go
+++ b/pkg/scheduler/testing/workload_prep.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"fmt"
+
+	"k8s.io/api/core/v1"
+)
+
+// MakeNodesAndPods serves as a testing helper for EvenPodsSpread feature.
+// It builds a fake cluster containing running Pods and Nodes.
+// The size of Pods and Nodes are determined by input arguments.
+// The specs of Pods and Nodes are generated with the following rules:
+// - If `pod` has "node" as a topologyKey, each generated node is applied with a unique label: "node: node<i>".
+// - If `pod` has "zone" as a topologyKey, each generated node is applied with a rotating label: "zone: zone[0-9]".
+// - Depending on "lableSelector.MatchExpressions[0].Key" the `pod` has in each topologySpreadConstraint,
+//   each generated pod will be applied with label "key1", "key1,key2", ..., "key1,key2,...,keyN" in a rotating manner.
+func MakeNodesAndPods(pod *v1.Pod, existingPodsNum, allNodesNum, filteredNodesNum int) (existingPods []*v1.Pod, allNodes []*v1.Node, filteredNodes []*v1.Node) {
+	var topologyKeys []string
+	var labels []string
+	zones := 10
+	for _, c := range pod.Spec.TopologySpreadConstraints {
+		topologyKeys = append(topologyKeys, c.TopologyKey)
+		labels = append(labels, c.LabelSelector.MatchExpressions[0].Key)
+	}
+	// build nodes
+	for i := 0; i < allNodesNum; i++ {
+		nodeWrapper := MakeNode().Name(fmt.Sprintf("node%d", i))
+		for _, tpKey := range topologyKeys {
+			if tpKey == "zone" {
+				nodeWrapper = nodeWrapper.Label("zone", fmt.Sprintf("zone%d", i%zones))
+			} else if tpKey == "node" {
+				nodeWrapper = nodeWrapper.Label("node", fmt.Sprintf("node%d", i))
+			}
+		}
+		node := nodeWrapper.Obj()
+		allNodes = append(allNodes, node)
+		if len(filteredNodes) < filteredNodesNum {
+			filteredNodes = append(filteredNodes, node)
+		}
+	}
+	// build pods
+	for i := 0; i < existingPodsNum; i++ {
+		podWrapper := MakePod().Name(fmt.Sprintf("pod%d", i)).Node(fmt.Sprintf("node%d", i%allNodesNum))
+		// apply labels[0], labels[0,1], ..., labels[all] to each pod in turn
+		for _, label := range labels[:i%len(labels)+1] {
+			podWrapper = podWrapper.Label(label, "")
+		}
+		existingPods = append(existingPods, podWrapper.Obj())
+	}
+	return
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Optimize the data structure of ~~`topologySpreadMap`~~`podSpreadCache` to reduce memory and runtime overhead, and also boost the performance of predicates and preemption of EvenPodsSpread.

Here is the new structure:

```go
// podSpreadCache combines tpKeyToCriticalPaths and tpPairToMatchNum
// to represent:
// (1) critical paths where the least pods are matched on each spread constraint.
// (2) number of pods matched on each spread constraint.
type podSpreadCache struct {
	// We don't record all critical paths here.
	// If there is only one criticalPath, criticalPaths[0] always holds the minimum matchNum;
	// If there are multiple criticalPaths, keep arbitrary 2 of them holding the minimum matchNum.
	tpKeyToCriticalPaths map[string][2]*criticalPath
	// tpPairToMatchNum is keyed with topologyPair, and valued with the number of matching pods.
	tpPairToMatchNum map[topologyPair]int32
}
```

**CAVEAT**: this PR (in particular the `[2]critialPath` structure) can work is based on the implementation of the current preemption algorithm:
Fact 1: we only preempt pods on the **same** node, instead of pods on multiple nodes.
Fact 2: each node is evaluated on a separate copy of the metadata during its preemption cycle.
If we plan to turn to a more complex algorithm like "arbitrary pods on multiple nodes", this enhancement needs to be revisited.

**Which issue(s) this PR fixes**:

Part of #77284. Resolve [comment1](https://github.com/kubernetes/kubernetes/pull/77760#issuecomment-513126887) and [comment2](https://github.com/kubernetes/kubernetes/pull/79062#discussion_r305470724).

**Special notes for your reviewer**:

The performance looks good (~6X in time, ~4X in space). Let's focus on functionality reviewing.

#### Before

```
single-constraint-zone-8        100   16717361 ns/op  12650462 B/op  129741 allocs/op
single-constraint-node-8        100   17020951 ns/op  12674237 B/op  132412 allocs/op
two-constraints-zone-node-8      50   22534697 ns/op  16043751 B/op  203792 allocs/op

single-constraint-zone-8        100	  17250549 ns/op  12646159 B/op  129737 allocs/op
single-constraint-node-8        100	  14650029 ns/op  12672823 B/op  132416 allocs/op
two-constraints-zone-node-8      50	  21257976 ns/op  16043452 B/op  203793 allocs/op

single-constraint-zone-8        100	  14535822 ns/op  12651489 B/op  129740 allocs/op
single-constraint-node-8        100	  14415079 ns/op  12672163 B/op  132414 allocs/op
two-constraints-zone-node-8     100	  18504999 ns/op  16041346 B/op  203793 allocs/op
```

#### After

```
single-constraint-zone-8        500    2523942 ns/op  2796400 B/op   60027 allocs/op
single-constraint-node-8        500    2863317 ns/op  2984588 B/op   60051 allocs/op
two-constraints-zone-node-8     300	   5202418 ns/op  5753595 B/op  120058 allocs/op

single-constraint-zone-8        500	   2574097 ns/op  2795724 B/op   60027 allocs/op
single-constraint-node-8        500	   2824376 ns/op  2985523 B/op   60051 allocs/op
two-constraints-zone-node-8     300	   4965061 ns/op  5751401 B/op  120059 allocs/op

single-constraint-zone-8        500	   2488182 ns/op  2796486 B/op   60027 allocs/op
single-constraint-node-8        500	   2922101 ns/op  2988127 B/op   60051 allocs/op
two-constraints-zone-node-8     300	   5169896 ns/op  5751460 B/op  120059 allocs/op
```


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/assign @ahg-g @alculquicondor 
cc/ @bsalamat @liu-cong @draveness @krmayankk 
