### PR TITLE
feat: add ReadOnlyBindAddress to kubelet configuraion.

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/defaults.go
+++ b/cmd/kubeadm/app/componentconfigs/defaults.go
@@ -109,6 +109,9 @@ func DefaultKubeletConfiguration(internalcfg *kubeadmapi.ClusterConfiguration) {
 
 	// Disable the readonly port of the kubelet, in order to not expose unnecessary information
 	externalkubeletcfg.ReadOnlyPort = 0
+	if externalkubeletcfg.ReadOnlyBindAddress == "" {
+		externalkubeletcfg.ReadOnlyBindAddress = externalkubeletcfg.Address
+	}
 
 	// Enables client certificate rotation for the kubelet
 	externalkubeletcfg.RotateCertificates = true

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal.yaml
@@ -146,6 +146,7 @@ ComponentConfigs:
     Port: 10250
     ProtectKernelDefaults: false
     QOSReserved: null
+    ReadOnlyBindAddress: 1.2.3.4
     ReadOnlyPort: 0
     RegistryBurst: 10
     RegistryPullQPS: 5

--- a/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal_non_linux.yaml
+++ b/cmd/kubeadm/app/util/config/testdata/conversion/controlplane/internal_non_linux.yaml
@@ -144,6 +144,7 @@ ComponentConfigs:
     Port: 10250
     ProtectKernelDefaults: false
     QOSReserved: null
+    ReadOnlyBindAddress: 1.2.3.4
     ReadOnlyPort: 0
     RegistryBurst: 10
     RegistryPullQPS: 5

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -447,6 +447,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.Var(utilflag.IPVar{Val: &c.Address}, "address", "The IP address for the Kubelet to serve on (set to `0.0.0.0` for all IPv4 interfaces and `::` for all IPv6 interfaces)")
 	fs.Int32Var(&c.Port, "port", c.Port, "The port for the Kubelet to serve on.")
 	fs.Int32Var(&c.ReadOnlyPort, "read-only-port", c.ReadOnlyPort, "The read-only port for the Kubelet to serve on with no authentication/authorization (set to 0 to disable)")
+	fs.Var(utilflag.IPVar{Val: &c.ReadOnlyBindAddress}, "read-only-bind-address", "The IP address for the readonly server to serve on (set to `0.0.0.0` for all IPv4 interfaces and `::` for all IPv6 interfaces), if unset, it will apply --address.")
 
 	// Authentication
 	fs.BoolVar(&c.Authentication.Anonymous.Enabled, "anonymous-auth", c.Authentication.Anonymous.Enabled, ""+

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1078,7 +1078,7 @@ func startKubelet(k kubelet.Bootstrap, podCfg *config.PodConfig, kubeCfg *kubele
 
 	}
 	if kubeCfg.ReadOnlyPort > 0 {
-		go k.ListenAndServeReadOnly(net.ParseIP(kubeCfg.Address), uint(kubeCfg.ReadOnlyPort), enableCAdvisorJSONEndpoints)
+		go k.ListenAndServeReadOnly(net.ParseIP(kubeCfg.ReadOnlyBindAddress), uint(kubeCfg.ReadOnlyPort), enableCAdvisorJSONEndpoints)
 	}
 	if utilfeature.DefaultFeatureGate.Enabled(features.KubeletPodResources) {
 		go k.ListenAndServePodResources()

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -72,6 +72,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 			obj.OOMScoreAdj = int32(qos.KubeletOOMScoreAdj)
 			obj.Port = ports.KubeletPort
+			obj.ReadOnlyBindAddress = "0.0.0.0"
 			obj.ReadOnlyPort = ports.KubeletReadOnlyPort
 			obj.RegistryBurst = 10
 			obj.RegistryPullQPS = 5

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -207,6 +207,7 @@ var (
 		"PodsPerCore",
 		"Port",
 		"ProtectKernelDefaults",
+		"ReadOnlyBindAddress",
 		"ReadOnlyPort",
 		"RegistryBurst",
 		"RegistryPullQPS",

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -94,6 +94,9 @@ type KubeletConfiguration struct {
 	// readOnlyPort is the read-only port for the Kubelet to serve on with
 	// no authentication/authorization (set to 0 to disable)
 	ReadOnlyPort int32
+	// readOnlyBindAddress is the IP address for the readonly server to serve on
+	// no authentication/authorization
+	ReadOnlyBindAddress string
 	// tlsCertFile is the file containing x509 Certificate for HTTPS.  (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -101,6 +101,9 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	if obj.HealthzBindAddress == "" {
 		obj.HealthzBindAddress = "127.0.0.1"
 	}
+	if obj.ReadOnlyBindAddress == "" {
+		obj.ReadOnlyBindAddress = obj.Address
+	}
 	if obj.OOMScoreAdj == nil {
 		obj.OOMScoreAdj = utilpointer.Int32Ptr(int32(qos.KubeletOOMScoreAdj))
 	}

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -216,6 +216,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
+	out.ReadOnlyBindAddress = in.ReadOnlyBindAddress
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))
@@ -348,6 +349,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.Address = in.Address
 	out.Port = in.Port
 	out.ReadOnlyPort = in.ReadOnlyPort
+	out.ReadOnlyBindAddress = in.ReadOnlyBindAddress
 	out.TLSCertFile = in.TLSCertFile
 	out.TLSPrivateKeyFile = in.TLSPrivateKeyFile
 	out.TLSCipherSuites = *(*[]string)(unsafe.Pointer(&in.TLSCipherSuites))

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -136,6 +136,12 @@ type KubeletConfiguration struct {
 	// Default: 0 (disabled)
 	// +optional
 	ReadOnlyPort int32 `json:"readOnlyPort,omitempty"`
+	// readOnlyBindAddress is the IP address for the readonly server to serve on
+	// Dynamic Kubelet Config (beta): If dynamically updating this field, consider that
+	// it may disrupt components that monitor Kubelet health.
+	// Default: ""
+	// +optional
+	ReadOnlyBindAddress string `json:"readOnlyBindAddress,omitempty"`
 	// tlsCertFile is the file containing x509 Certificate for HTTPS. (CA cert,
 	// if any, concatenated after server cert). If tlsCertFile and
 	// tlsPrivateKeyFile are not provided, a self-signed certificate


### PR DESCRIPTION

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

Currently, kubelet's readonly server (serve http) shares address with https server. Users have no chance to specify different addresses to serve http and https. For example, http serves on `127.0.0.1` and https serves on `0.0.0.0`.

This PR introduce new field on `KubeletConfiguraion` (new flag `--read-only-bind-address`) so that users can set another address for serving http.

**Which issue(s) this PR fixes**:

Fixes #https://github.com/kubernetes/enhancements/issues/1208

**Special notes for your reviewer**:

If the KEP is acceptable, I will supplement the related tests.

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
