### PR TITLE
Fix a racing issue in FakeFilterPlugin

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -142,7 +143,7 @@ var emptyFramework, _ = framework.NewFramework(EmptyPluginRegistry, nil, []sched
 
 // FakeFilterPlugin is a test filter plugin used by default scheduler.
 type FakeFilterPlugin struct {
-	numFilterCalled int
+	numFilterCalled int32
 	failFilter      bool
 }
 
@@ -162,7 +163,7 @@ func (fp *FakeFilterPlugin) reset() {
 // Filter is a test function that returns an error or nil, depending on the
 // value of "failFilter".
 func (fp *FakeFilterPlugin) Filter(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
-	fp.numFilterCalled++
+	atomic.AddInt32(&fp.numFilterCalled, 1)
 
 	if fp.failFilter {
 		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("injecting failure for pod %v", pod.Name))
@@ -171,7 +172,7 @@ func (fp *FakeFilterPlugin) Filter(pc *framework.PluginContext, pod *v1.Pod, nod
 	return nil
 }
 
-// NewFilterPlugin is the factory for filtler plugin.
+// NewFilterPlugin is the factory for filter plugin.
 func NewFilterPlugin(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
 	return filterPlugin, nil
 }


### PR DESCRIPTION
Filter() is called simultaneously in `generic_scheduler.go#findNodesThatFit()`, so the member of its (fake) implementation cannot be written without lock.

The issue can be triggered by:

`go test k8s.io/kubernetes/pkg/scheduler/core --race --count=50`

**What type of PR is this?**

/kind failing-test
/kind flake

**What this PR does / why we need it**:

pkg/scheduler/core/generic_scheduler_test.go can cause a racing issue:

```
==================
WARNING: DATA RACE
Read at 0x000003bd8560 by goroutine 967:
  k8s.io/kubernetes/pkg/scheduler/core.(*FakeFilterPlugin).Filter()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler_test.go:165 +0x41
  k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1.(*framework).RunFilterPlugins()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1/framework.go:316 +0xf9
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).findNodesThatFit.func1()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:508 +0x349
  k8s.io/client-go/util/workqueue.ParallelizeUntil.func1()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/workqueue/parallelizer.go:57 +0x9e

Previous write at 0x000003bd8560 by goroutine 965:
  k8s.io/kubernetes/pkg/scheduler/core.(*FakeFilterPlugin).Filter()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler_test.go:165 +0x5a
  k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1.(*framework).RunFilterPlugins()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1/framework.go:316 +0xf9
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).findNodesThatFit.func1()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:508 +0x349
  k8s.io/client-go/util/workqueue.ParallelizeUntil.func1()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/workqueue/parallelizer.go:57 +0x9e

Goroutine 967 (running) created at:
  k8s.io/client-go/util/workqueue.ParallelizeUntil()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/workqueue/parallelizer.go:49 +0x1a6
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).findNodesThatFit()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:535 +0x1028
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).Schedule()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:214 +0x5ed
  k8s.io/kubernetes/pkg/scheduler/core.TestGenericScheduler.func1()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler_test.go:654 +0x8f7
  testing.tRunner()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0x163

Goroutine 965 (finished) created at:
  k8s.io/client-go/util/workqueue.ParallelizeUntil()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/staging/src/k8s.io/client-go/util/workqueue/parallelizer.go:49 +0x1a6
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).findNodesThatFit()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:535 +0x1028
  k8s.io/kubernetes/pkg/scheduler/core.(*genericScheduler).Schedule()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler.go:214 +0x5ed
  k8s.io/kubernetes/pkg/scheduler/core.TestGenericScheduler.func1()
      /Users/wei.huang1/gospace/src/k8s.io/kubernetes/pkg/scheduler/core/generic_scheduler_test.go:654 +0x8f7
  testing.tRunner()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0x163
==================
--- FAIL: TestGenericScheduler (0.01s)
    --- FAIL: TestGenericScheduler/test_4 (0.00s)
        testing.go:809: race detected during execution of test
    testing.go:809: race detected during execution of test
```

**Which issue(s) this PR fixes**:

#81068 surfaced this issue up. CI log: https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/81068/pull-kubernetes-bazel-test/1159005890729218049

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/assign @draveness 
