### PR TITLE
Rename MetricsForE2E for golint failure

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -556,7 +556,6 @@ staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1
 staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer
 staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder
 test/e2e/common
-test/e2e/framework/metrics
 test/e2e/lifecycle/bootstrap
 test/e2e/storage/vsphere
 test/e2e_kubeadm

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -250,7 +250,7 @@ func gatherMetrics(f *framework.Framework) {
 		if err != nil {
 			e2elog.Logf("MetricsGrabber failed grab metrics. Skipping metrics gathering.")
 		} else {
-			summary = (*e2emetrics.MetricsForE2E)(&received)
+			summary = (*e2emetrics.ComponentCollection)(&received)
 			e2elog.Logf(summary.PrintHumanReadable())
 		}
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -372,8 +372,8 @@ func (f *Framework) AfterEach() {
 			if err != nil {
 				e2elog.Logf("MetricsGrabber failed to grab some of the metrics: %v", err)
 			}
-			(*e2emetrics.MetricsForE2E)(&received).ComputeClusterAutoscalerMetricsDelta(f.clusterAutoscalerMetricsBeforeTest)
-			f.TestSummaries = append(f.TestSummaries, (*e2emetrics.MetricsForE2E)(&received))
+			(*e2emetrics.ComponentCollection)(&received).ComputeClusterAutoscalerMetricsDelta(f.clusterAutoscalerMetricsBeforeTest)
+			f.TestSummaries = append(f.TestSummaries, (*e2emetrics.ComponentCollection)(&received))
 		}
 	}
 

--- a/test/e2e/framework/metrics/e2e_metrics.go
+++ b/test/e2e/framework/metrics/e2e_metrics.go
@@ -33,10 +33,10 @@ const (
 	caFunctionMetricLabel = "function"
 )
 
-// MetricsForE2E is metrics collection of components.
-type MetricsForE2E Collection
+// ComponentCollection is metrics collection of components.
+type ComponentCollection Collection
 
-func (m *MetricsForE2E) filterMetrics() {
+func (m *ComponentCollection) filterMetrics() {
 	apiServerMetrics := make(APIServerMetrics)
 	for _, metric := range interestingAPIServerMetrics {
 		apiServerMetrics[metric] = (*m).APIServerMetrics[metric]
@@ -78,7 +78,7 @@ func printSample(sample *model.Sample) string {
 }
 
 // PrintHumanReadable returns e2e metrics with JSON format.
-func (m *MetricsForE2E) PrintHumanReadable() string {
+func (m *ComponentCollection) PrintHumanReadable() string {
 	buf := bytes.Buffer{}
 	for _, interestingMetric := range interestingAPIServerMetrics {
 		buf.WriteString(fmt.Sprintf("For %v:\n", interestingMetric))
@@ -126,14 +126,14 @@ func PrettyPrintJSON(metrics interface{}) string {
 }
 
 // PrintJSON returns e2e metrics with JSON format.
-func (m *MetricsForE2E) PrintJSON() string {
+func (m *ComponentCollection) PrintJSON() string {
 	m.filterMetrics()
 	return PrettyPrintJSON(m)
 }
 
 // SummaryKind returns the summary of e2e metrics.
-func (m *MetricsForE2E) SummaryKind() string {
-	return "MetricsForE2E"
+func (m *ComponentCollection) SummaryKind() string {
+	return "ComponentCollection"
 }
 
 func makeKey(a, b model.LabelValue) string {
@@ -142,7 +142,7 @@ func makeKey(a, b model.LabelValue) string {
 
 // ComputeClusterAutoscalerMetricsDelta computes the change in cluster
 // autoscaler metrics.
-func (m *MetricsForE2E) ComputeClusterAutoscalerMetricsDelta(before Collection) {
+func (m *ComponentCollection) ComputeClusterAutoscalerMetricsDelta(before Collection) {
 	if beforeSamples, found := before.ClusterAutoscalerMetrics[caFunctionMetric]; found {
 		if afterSamples, found := m.ClusterAutoscalerMetrics[caFunctionMetric]; found {
 			beforeSamplesMap := make(map[string]*model.Sample)

--- a/test/e2e/framework/suites.go
+++ b/test/e2e/framework/suites.go
@@ -180,7 +180,7 @@ func gatherTestSuiteMetrics() error {
 		return fmt.Errorf("failed to grab metrics: %v", err)
 	}
 
-	metricsForE2E := (*e2emetrics.MetricsForE2E)(&received)
+	metricsForE2E := (*e2emetrics.ComponentCollection)(&received)
 	metricsJSON := metricsForE2E.PrintJSON()
 	if TestContext.ReportDir != "" {
 		filePath := path.Join(TestContext.ReportDir, "MetricsForE2ESuite_"+time.Now().Format(time.RFC3339)+".json")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This renames MetricsForE2E to ComponentCollection for solving golint failure.
This is a follow-up of https://github.com/kubernetes/kubernetes/pull/79753

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @timothysc 