### PR TITLE
Don't overwrite PVC with nil/empty object returned by failed Update

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -470,8 +470,9 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 
 				ginkgo.By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
-				pvc, err = testsuites.ExpandPVCSize(pvc, newSize, m.cs)
+				newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, m.cs)
 				framework.ExpectNoError(err, "While updating pvc for more size")
+				pvc = newPVC
 				gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 				pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]
@@ -561,8 +562,9 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 
 				ginkgo.By("Expanding current pvc")
 				newSize := resource.MustParse("6Gi")
-				pvc, err = testsuites.ExpandPVCSize(pvc, newSize, m.cs)
+				newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, m.cs)
 				framework.ExpectNoError(err, "While updating pvc for more size")
+				pvc = newPVC
 				gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 				pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]

--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -159,8 +159,9 @@ var _ = utils.SIGDescribe("Mounted flexvolume expand[Slow]", func() {
 
 		ginkgo.By("Expanding current pvc")
 		newSize := resource.MustParse("6Gi")
-		pvc, err = testsuites.ExpandPVCSize(pvc, newSize, c)
+		newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, c)
 		framework.ExpectNoError(err, "While updating pvc for more size")
+		pvc = newPVC
 		gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 		pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]

--- a/test/e2e/storage/flexvolume_online_resize.go
+++ b/test/e2e/storage/flexvolume_online_resize.go
@@ -157,8 +157,9 @@ var _ = utils.SIGDescribe("Mounted flexvolume volume expand [Slow] [Feature:Expa
 
 		ginkgo.By("Expanding current pvc")
 		newSize := resource.MustParse("6Gi")
-		pvc, err = testsuites.ExpandPVCSize(pvc, newSize, c)
+		newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, c)
 		framework.ExpectNoError(err, "While updating pvc for more size")
+		pvc = newPVC
 		gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 		pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]

--- a/test/e2e/storage/mounted_volume_resize.go
+++ b/test/e2e/storage/mounted_volume_resize.go
@@ -131,8 +131,9 @@ var _ = utils.SIGDescribe("Mounted volume expand", func() {
 
 		ginkgo.By("Expanding current pvc")
 		newSize := resource.MustParse("6Gi")
-		pvc, err = testsuites.ExpandPVCSize(pvc, newSize, c)
+		newPVC, err := testsuites.ExpandPVCSize(pvc, newSize, c)
 		framework.ExpectNoError(err, "While updating pvc for more size")
+		pvc = newPVC
 		gomega.Expect(pvc).NotTo(gomega.BeNil())
 
 		pvcSize := pvc.Spec.Resources.Requests[v1.ResourceStorage]

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -143,7 +143,7 @@ func (v *volumeExpandTestSuite) defineTests(driver TestDriver, pattern testpatte
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(resource.MustParse("1Gi"))
 			e2elog.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-			l.resource.pvc, err = ExpandPVCSize(l.resource.pvc, newSize, f.ClientSet)
+			_, err = ExpandPVCSize(l.resource.pvc, newSize, f.ClientSet)
 			framework.ExpectError(err, "While updating non-expandable PVC")
 		})
 	} else {
@@ -170,8 +170,9 @@ func (v *volumeExpandTestSuite) defineTests(driver TestDriver, pattern testpatte
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(resource.MustParse("1Gi"))
 			e2elog.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-			l.resource.pvc, err = ExpandPVCSize(l.resource.pvc, newSize, f.ClientSet)
+			newPVC, err := ExpandPVCSize(l.resource.pvc, newSize, f.ClientSet)
 			framework.ExpectNoError(err, "While updating pvc for more size")
+			l.resource.pvc = newPVC
 			gomega.Expect(l.resource.pvc).NotTo(gomega.BeNil())
 
 			pvcSize := l.resource.pvc.Spec.Resources.Requests[v1.ResourceStorage]
@@ -231,8 +232,9 @@ func (v *volumeExpandTestSuite) defineTests(driver TestDriver, pattern testpatte
 			newSize := currentPvcSize.DeepCopy()
 			newSize.Add(resource.MustParse("1Gi"))
 			e2elog.Logf("currentPvcSize %v, newSize %v", currentPvcSize, newSize)
-			l.resource.pvc, err = ExpandPVCSize(l.resource.pvc, newSize, f.ClientSet)
+			newPVC, err := ExpandPVCSize(l.resource.pvc, newSize, f.ClientSet)
 			framework.ExpectNoError(err, "While updating pvc for more size")
+			l.resource.pvc = newPVC
 			gomega.Expect(l.resource.pvc).NotTo(gomega.BeNil())
 
 			pvcSize := l.resource.pvc.Spec.Resources.Requests[v1.ResourceStorage]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: On a successful/expected test run, ExpandPVCSize will return an error and a non-empty but useless PVC object. Overwriting l.resource.pvc means it can't get cleaned up later and the test fails just due to that. Since we only care about the error in this case, simply ignore the PVC returned by ExpandPVCSize.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/cc @mkimuram 
thanks for your work refactoring these tests! caught this issue while running them against ebs.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
