### PR TITLE
Fix two race issues in schedule_queue

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -100,10 +100,10 @@ var highPriorityPod, highPriNominatedPod, medPriorityPod, unschedulablePod = v1.
 		},
 	}
 
-func addOrUpdateUnschedulablePod(p *PriorityQueue, pod *v1.Pod) {
+func addOrUpdateUnschedulablePod(p *PriorityQueue, podInfo *framework.PodInfo) {
 	p.lock.Lock()
 	defer p.lock.Unlock()
-	p.unschedulableQ.addOrUpdate(p.newPodInfo(pod))
+	p.unschedulableQ.addOrUpdate(podInfo)
 }
 
 func getUnschedulablePod(p *PriorityQueue, pod *v1.Pod) *v1.Pod {
@@ -235,7 +235,7 @@ func TestPriorityQueue_AddWithReversePriorityLessFunc(t *testing.T) {
 
 func TestPriorityQueue_AddIfNotPresent(t *testing.T) {
 	q := NewPriorityQueue(nil, nil)
-	addOrUpdateUnschedulablePod(q, &highPriNominatedPod)
+	addOrUpdateUnschedulablePod(q, q.newPodInfo(&highPriNominatedPod))
 	q.AddIfNotPresent(&highPriNominatedPod) // Must not add anything.
 	q.AddIfNotPresent(&medPriorityPod)
 	q.AddIfNotPresent(&unschedulablePod)
@@ -351,6 +351,7 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
 		q.AddUnschedulableIfNotPresent(unschedulablePod, oldCycle)
 	}
 
+	q.lock.RLock()
 	// Since there was a move request at the same cycle as "oldCycle", these pods
 	// should be in the backoff queue.
 	for i := 1; i < totalNum; i++ {
@@ -358,6 +359,7 @@ func TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff(t *testing.T) {
 			t.Errorf("Expected %v to be added to podBackoffQ.", expectedPods[i].Name)
 		}
 	}
+	q.lock.RUnlock()
 }
 
 func TestPriorityQueue_Pop(t *testing.T) {
@@ -440,8 +442,8 @@ func TestPriorityQueue_Delete(t *testing.T) {
 func TestPriorityQueue_MoveAllToActiveQueue(t *testing.T) {
 	q := NewPriorityQueue(nil, nil)
 	q.Add(&medPriorityPod)
-	addOrUpdateUnschedulablePod(q, &unschedulablePod)
-	addOrUpdateUnschedulablePod(q, &highPriorityPod)
+	addOrUpdateUnschedulablePod(q, q.newPodInfo(&unschedulablePod))
+	addOrUpdateUnschedulablePod(q, q.newPodInfo(&highPriorityPod))
 	q.MoveAllToActiveQueue()
 	if q.activeQ.Len() != 3 {
 		t.Error("Expected all items to be in activeQ.")
@@ -487,8 +489,8 @@ func TestPriorityQueue_AssignedPodAdded(t *testing.T) {
 	q := NewPriorityQueue(nil, nil)
 	q.Add(&medPriorityPod)
 	// Add a couple of pods to the unschedulableQ.
-	addOrUpdateUnschedulablePod(q, &unschedulablePod)
-	addOrUpdateUnschedulablePod(q, affinityPod)
+	addOrUpdateUnschedulablePod(q, q.newPodInfo(&unschedulablePod))
+	addOrUpdateUnschedulablePod(q, q.newPodInfo(affinityPod))
 	// Simulate addition of an assigned pod. The pod has matching labels for
 	// affinityPod. So, affinityPod should go to activeQ.
 	q.AssignedPodAdded(&labelPod)
@@ -532,8 +534,8 @@ func TestPriorityQueue_PendingPods(t *testing.T) {
 
 	q := NewPriorityQueue(nil, nil)
 	q.Add(&medPriorityPod)
-	addOrUpdateUnschedulablePod(q, &unschedulablePod)
-	addOrUpdateUnschedulablePod(q, &highPriorityPod)
+	addOrUpdateUnschedulablePod(q, q.newPodInfo(&unschedulablePod))
+	addOrUpdateUnschedulablePod(q, q.newPodInfo(&highPriorityPod))
 	expectedSet := makeSet([]*v1.Pod{&medPriorityPod, &unschedulablePod, &highPriorityPod})
 	if !reflect.DeepEqual(expectedSet, makeSet(q.PendingPods())) {
 		t.Error("Unexpected list of pending Pods.")
@@ -1053,10 +1055,12 @@ func TestHighPriorityFlushUnschedulableQLeftover(t *testing.T) {
 		Message: "fake scheduling failure",
 	})
 
-	addOrUpdateUnschedulablePod(q, &highPod)
-	addOrUpdateUnschedulablePod(q, &midPod)
-	q.unschedulableQ.podInfoMap[util.GetPodFullName(&highPod)].Timestamp = time.Now().Add(-1 * unschedulableQTimeInterval)
-	q.unschedulableQ.podInfoMap[util.GetPodFullName(&midPod)].Timestamp = time.Now().Add(-1 * unschedulableQTimeInterval)
+	highPodInfo := q.newPodInfo(&highPod)
+	highPodInfo.Timestamp = time.Now().Add(-1 * unschedulableQTimeInterval)
+	midPodInfo := q.newPodInfo(&midPod)
+	midPodInfo.Timestamp = time.Now().Add(-1 * unschedulableQTimeInterval)
+	addOrUpdateUnschedulablePod(q, highPodInfo)
+	addOrUpdateUnschedulablePod(q, midPodInfo)
 
 	if p, err := q.Pop(); err != nil || p != &highPod {
 		t.Errorf("Expected: %v after Pop, but got: %v", highPriorityPod.Name, p.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug
**What this PR does / why we need it**:
Run: `go test k8s.io/kubernetes/pkg/scheduler/internal/queue --race --count=50`

You can get:

```
WARNING: DATA RACE
Write at 0x00c000386120 by goroutine 39:
  runtime.mapdelete_faststr()
      /usr/local/Cellar/go/1.12.7/libexec/src/runtime/map_faststr.go:297 +0x0
  k8s.io/kubernetes/pkg/scheduler/util.(*heapData).Pop()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/util/heap.go:113 +0x203
  container/heap.Pop()
      /usr/local/Cellar/go/1.12.7/libexec/src/container/heap/heap.go:64 +0xb0
  k8s.io/kubernetes/pkg/scheduler/util.(*Heap).Pop()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/util/heap.go:200 +0x5b
  k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).flushBackoffQCompleted()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:356 +0x490
  k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).flushBackoffQCompleted-fm()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:334 +0x41
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x61
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.JitterUntil()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0x108
  k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait.Until()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x5a

Previous read at 0x00c000386120 by goroutine 38:
  runtime.mapaccess2_faststr()
      /usr/local/Cellar/go/1.12.7/libexec/src/runtime/map_faststr.go:107 +0x0
  k8s.io/kubernetes/pkg/scheduler/util.(*Heap).Get()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/util/heap.go:221 +0x11d
  k8s.io/kubernetes/pkg/scheduler/internal/queue.TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue_test.go:357 +0xa12
  testing.tRunner()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0x163

Goroutine 39 (running) created at:
  k8s.io/kubernetes/pkg/scheduler/internal/queue.(*PriorityQueue).run()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:200 +0xd0
  k8s.io/kubernetes/pkg/scheduler/internal/queue.NewPriorityQueueWithClock()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:193 +0x9af
  k8s.io/kubernetes/pkg/scheduler/internal/queue.TestPriorityQueue_AddUnschedulableIfNotPresent_Backoff()
      /Users/wangguoliang/Documents/mos/src/k8s.io/kubernetes/pkg/scheduler/internal/queue/scheduling_queue.go:164 +0x70
  testing.tRunner()
      /usr/local/Cellar/go/1.12.7/libexec/src/testing/testing.go:865 +0x163
````

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
