### PR TITLE
Constant time password comparison

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -259,6 +259,7 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 		fs.StringVar(&s.PasswordFile.BasicAuthFile, "basic-auth-file", s.PasswordFile.BasicAuthFile, ""+
 			"If set, the file that will be used to admit requests to the secure port of the API server "+
 			"via http basic authentication.")
+		fs.MarkDeprecated("basic-auth-file", "Basic authentication mode is deprecated and will be removed in a future release. It is not recommended for production environments.")
 	}
 
 	if s.RequestHeader != nil {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile.go
@@ -18,6 +18,7 @@ package passwordfile
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/csv"
 	"fmt"
 	"io"
@@ -85,7 +86,7 @@ func (a *PasswordAuthenticator) AuthenticatePassword(ctx context.Context, userna
 	if !ok {
 		return nil, false, nil
 	}
-	if user.password != password {
+	if subtle.ConstantTimeCompare([]byte(user.password), []byte(password)) == 0 {
 		return nil, false, nil
 	}
 	return &authenticator.Response{User: user.info}, true, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR uses constant time password comparison to fix issue #81126

**Which issue(s) this PR fixes**:
fixes #81126

```release-note
kube-apiserver: the `--basic-auth-file` flag and authentication mode is deprecated and will be removed in a future release. It is not recommended for production environments.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
