### PR TITLE
Add gen_openapi target to top-level Makefile.

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -555,7 +555,7 @@ ifeq ($(PRINT_HELP),y)
 generated_files:
 	@echo "$$GENERATED_FILES_HELP_INFO"
 else
-generated_files:
+generated_files gen_openapi:
 	$(MAKE) -f Makefile.generated_files $@ CALLED_FROM_MAIN_MAKEFILE=1
 endif
 


### PR DESCRIPTION
Could be further expanded with `gen_deepcopy`, `gen_defaulter`, `gen_conversion`, and `gen_bindata` targets, if useful. Comments in `Makefile.generated_files` suggest this was the original intention:

```
# This rule is the user-friendly entrypoint for openapi generation.
.PHONY: gen_openapi
```

/kind cleanup
/sig api-machinery
/area code-organization