### PR TITLE
Read availability zone name from metadata

### DIFF
--- a/pkg/cloudprovider/providers/openstack/openstack_volumes.go
+++ b/pkg/cloudprovider/providers/openstack/openstack_volumes.go
@@ -725,15 +725,15 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 		return nil, nil
 	}
 
-	// Get Volume
-	volume, err := os.getVolume(pv.Spec.Cinder.VolumeID)
+	// Get metadata
+	md, err := getMetadata(os.metadataOpts.SearchOrder)
 	if err != nil {
 		return nil, err
 	}
 
 	// Construct Volume Labels
 	labels := make(map[string]string)
-	labels[v1.LabelZoneFailureDomain] = volume.AvailabilityZone
+	labels[v1.LabelZoneFailureDomain] = md.AvailabilityZone
 	labels[v1.LabelZoneRegion] = os.region
 	klog.V(4).Infof("The Volume %s has labels %v", pv.Spec.Cinder.VolumeID, labels)
 


### PR DESCRIPTION
Instead of making a request to Cinder we can read availability zone name from metadata