### PR TITLE
[WIP] Keep connection alive during streaming operations

### DIFF
--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -48,6 +48,8 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//staging/src/k8s.io/client-go/util/jsonpath:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keepalive:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keepalive/restclient:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/rawhttp:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
@@ -73,6 +73,8 @@ type Connection interface {
 	CreateStream(headers http.Header) (Stream, error)
 	// Close resets all streams and closes the connection.
 	Close() error
+	// Ping pings the other end of the connection and returns the latency
+	Ping() (time.Duration, error)
 	// CloseChan returns a channel that is closed when the underlying connection is closed.
 	CloseChan() <-chan bool
 	// SetIdleTimeout sets the amount of time the connection may remain idle before

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/connection.go
@@ -90,6 +90,11 @@ func (c *connection) Close() error {
 	return c.conn.Close()
 }
 
+// Ping pings the other end of the connection and returns the latency
+func (c *connection) Ping() (time.Duration, error) {
+	return c.conn.Ping()
+}
+
 // CreateStream creates a new stream with the specified headers and registers
 // it with the connection.
 func (c *connection) CreateStream(headers http.Header) (httpstream.Stream, error) {

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/BUILD
@@ -16,6 +16,7 @@ go_library(
         "name_flags.go",
         "print_flags.go",
         "record_flags.go",
+        "stream_flags.go",
         "template_flags.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/cli-runtime/pkg/genericclioptions",

--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/stream_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/stream_flags.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package genericclioptions
+
+import (
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+type StreamFlags struct {
+	PingInterval time.Duration
+}
+
+func (o *StreamFlags) AddFlags(c *cobra.Command) {
+	// TODO: on `get`, only allow with `-w`
+	// TODO: on `logs`, only allow with `-f`
+	c.Flags().DurationVar(&o.PingInterval, "ping-interval", 1*time.Minute, "Perform ping on this interval to keep the connection alive")
+}

--- a/staging/src/k8s.io/client-go/BUILD
+++ b/staging/src/k8s.io/client-go/BUILD
@@ -89,6 +89,7 @@ filegroup(
         "//staging/src/k8s.io/client-go/util/flowcontrol:all-srcs",
         "//staging/src/k8s.io/client-go/util/homedir:all-srcs",
         "//staging/src/k8s.io/client-go/util/jsonpath:all-srcs",
+        "//staging/src/k8s.io/client-go/util/keepalive:all-srcs",
         "//staging/src/k8s.io/client-go/util/keyutil:all-srcs",
         "//staging/src/k8s.io/client-go/util/retry:all-srcs",
         "//staging/src/k8s.io/client-go/util/testing:all-srcs",

--- a/staging/src/k8s.io/client-go/rest/BUILD
+++ b/staging/src/k8s.io/client-go/rest/BUILD
@@ -76,6 +76,8 @@ go_library(
         "//staging/src/k8s.io/client-go/transport:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keepalive:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keepalive/http:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/staging/src/k8s.io/client-go/tools/remotecommand/BUILD
+++ b/staging/src/k8s.io/client-go/tools/remotecommand/BUILD
@@ -44,6 +44,8 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/transport/spdy:go_default_library",
         "//staging/src/k8s.io/client-go/util/exec:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keepalive:go_default_library",
+        "//staging/src/k8s.io/client-go/util/keepalive/spdy:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/util/keepalive/BUILD
+++ b/staging/src/k8s.io/client-go/util/keepalive/BUILD
@@ -1,0 +1,31 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["keepalive.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/util/keepalive",
+    importpath = "k8s.io/client-go/util/keepalive",
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//staging/src/k8s.io/client-go/util/keepalive/http:all-srcs",
+        "//staging/src/k8s.io/client-go/util/keepalive/restclient:all-srcs",
+        "//staging/src/k8s.io/client-go/util/keepalive/spdy:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/staging/src/k8s.io/client-go/util/keepalive/http/BUILD
+++ b/staging/src/k8s.io/client-go/util/keepalive/http/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["http.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/util/keepalive/http",
+    importpath = "k8s.io/client-go/util/keepalive/http",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/client-go/util/keepalive/http/http.go
+++ b/staging/src/k8s.io/client-go/util/keepalive/http/http.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"fmt"
+	"net/http"
+)
+
+type HttpPinger struct {
+	httpClient *http.Client
+	scheme     string
+	hostPort   string
+}
+
+func NewHttpPinger(httpClient *http.Client, scheme, hostPort string) HttpPinger {
+	return HttpPinger{
+		httpClient: httpClient,
+		scheme:     scheme,
+		hostPort:   hostPort,
+	}
+}
+
+func (p HttpPinger) Ping() error {
+	_, err := p.httpClient.Get(fmt.Sprintf("%s://%s/healthz", p.scheme, p.hostPort))
+	return err
+}

--- a/staging/src/k8s.io/client-go/util/keepalive/keepalive.go
+++ b/staging/src/k8s.io/client-go/util/keepalive/keepalive.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keepalive
+
+import (
+	"context"
+	"time"
+)
+
+type Pinger interface {
+	Ping() error
+}
+
+func KeepAliveWithPinger(ctx context.Context, pinger Pinger, pingInterval time.Duration) error {
+	if ctx == nil || pinger == nil || pingInterval == 0 {
+		return nil
+	}
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				pinger.Ping()
+				time.Sleep(pingInterval)
+			}
+		}
+	}()
+	return nil
+}

--- a/staging/src/k8s.io/client-go/util/keepalive/restclient/BUILD
+++ b/staging/src/k8s.io/client-go/util/keepalive/restclient/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["restclient.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/util/keepalive/restclient",
+    importpath = "k8s.io/client-go/util/keepalive/restclient",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/k8s.io/client-go/rest:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/client-go/util/keepalive/restclient/restclient.go
+++ b/staging/src/k8s.io/client-go/util/keepalive/restclient/restclient.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package restclient
+
+import (
+	"k8s.io/client-go/rest"
+)
+
+type RESTClientPinger struct {
+	restClient *rest.RESTClient
+}
+
+func NewRESTClientPinger(client *rest.RESTClient) RESTClientPinger {
+	return RESTClientPinger{
+		restClient: client,
+	}
+}
+
+func (p RESTClientPinger) Ping() error {
+	return p.restClient.Get().RequestURI("/healthz").Do().Error()
+}

--- a/staging/src/k8s.io/client-go/util/keepalive/spdy/BUILD
+++ b/staging/src/k8s.io/client-go/util/keepalive/spdy/BUILD
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["spdy.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/util/keepalive/spdy",
+    importpath = "k8s.io/client-go/util/keepalive/spdy",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/k8s.io/apimachinery/pkg/util/httpstream:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/client-go/util/keepalive/spdy/spdy.go
+++ b/staging/src/k8s.io/client-go/util/keepalive/spdy/spdy.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spdy
+
+import (
+	"k8s.io/apimachinery/pkg/util/httpstream"
+)
+
+type SpdyPinger struct {
+	spdyConnection httpstream.Connection
+}
+
+func NewSpdyPinger(connection httpstream.Connection) SpdyPinger {
+	return SpdyPinger{
+		spdyConnection: connection,
+	}
+}
+
+func (p SpdyPinger) Ping() error {
+	_, err := p.spdyConnection.Ping()
+	return err
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -139,6 +139,7 @@ type RunOptions struct {
 	TTY            bool
 
 	genericclioptions.IOStreams
+	genericclioptions.StreamFlags
 }
 
 func NewRunOptions(streams genericclioptions.IOStreams) *RunOptions {
@@ -171,6 +172,7 @@ func NewCmdRun(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 	o.DeleteFlags.AddFlags(cmd)
 	o.PrintFlags.AddFlags(cmd)
 	o.RecordFlags.AddFlags(cmd)
+	o.StreamFlags.AddFlags(cmd)
 
 	addRunFlags(cmd, o)
 	cmdutil.AddApplyAnnotationFlags(cmd)
@@ -576,7 +578,7 @@ func logOpts(restClientGetter genericclioptions.RESTClientGetter, pod *corev1.Po
 		return err
 	}
 	for _, request := range requests {
-		if err := logs.DefaultConsumeRequest(request, opts.Out); err != nil {
+		if err := logs.DefaultConsumeRequest(request, opts.Out, opts.PingInterval); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Certain operations will create a stream that can be open for a long
period of time in which there is no activity at all. This can happen
specially on certain commands:

- `kubectl exec -it`
- `kubectl logs -f`
- `kubectl attach`
- `kubectl get -w`

When this commands are still running, if some L4 component is between
the client and the apiserver, it can decide to close the connection
after a configured timeout because no activity happens at TCP level.

This patch introduces changes in the following components:

- `client-go`: Add `util/keepalive` package that can be used for this
   purpose. It extends the `ResponseWrapper` interface with a
   `StreamWithPing` command, so users of `Stream` function are not
   affected and its behavior will be the same as it was.

- `kubectl`: `exec`, `logs`, `get` and `attach` get a
  `--ping-interval` argument that can be used to force an interval to
  ping the other end of the connection, so L4 components in between
  will see traffic and won't close the connection. Since this timeout
  depends a lot on each use case and organization, leaving it as an
  argument to `kubectl` seems the best option, so the user can pick
  the interval they want in a specific run.

- `apimachinery`: extend the `httpstream` connection with a `Ping()`
  function that is implemented in the `spdy` backend as a native ping
  frame already implemented by Docker's `spdystream` project.

**Does this PR introduce a user-facing change?**:
```release-note
kubectl: `get`, `exec`, `logs` and `attach` have a new argument `--ping-interval` that will use the underlying connection to generate pings, so network components in between the client and the apiserver will see activity at TCP level.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
To be described
```

/cc @kubernetes/sig-cli-pr-reviews 
/cc @kubernetes/sig-api-machinery-pr-reviews
/cc @kubernetes/client-go-maintainers

/cc @aojea 
/cc @BenTheElder 