### PR TITLE
Rename mount.MountPoint to mount.Point

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -238,7 +238,6 @@ pkg/util/goroutinemap/exponentialbackoff
 pkg/util/iptables
 pkg/util/iptables/testing
 pkg/util/labels
-pkg/util/mount
 pkg/util/oom
 pkg/util/procfs
 pkg/util/removeall

--- a/pkg/kubelet/cm/container_manager_linux_test.go
+++ b/pkg/kubelet/cm/container_manager_linux_test.go
@@ -32,7 +32,7 @@ import (
 
 func fakeContainerMgrMountInt() mount.Interface {
 	return &mount.FakeMounter{
-		MountPoints: []mount.MountPoint{
+		MountPoints: []mount.Point{
 			{
 				Device: "cgroup",
 				Type:   "cgroup",
@@ -65,7 +65,7 @@ func TestCgroupMountValidationSuccess(t *testing.T) {
 
 func TestCgroupMountValidationMemoryMissing(t *testing.T) {
 	mountInt := &mount.FakeMounter{
-		MountPoints: []mount.MountPoint{
+		MountPoints: []mount.Point{
 			{
 				Device: "cgroup",
 				Type:   "cgroup",
@@ -89,7 +89,7 @@ func TestCgroupMountValidationMemoryMissing(t *testing.T) {
 
 func TestCgroupMountValidationMultipleSubsystem(t *testing.T) {
 	mountInt := &mount.FakeMounter{
-		MountPoints: []mount.MountPoint{
+		MountPoints: []mount.Point{
 			{
 				Device: "cgroup",
 				Type:   "cgroup",
@@ -119,7 +119,7 @@ func TestSoftRequirementsValidationSuccess(t *testing.T) {
 	req.NoError(ioutil.WriteFile(path.Join(tempDir, "cpu.cfs_period_us"), []byte("0"), os.ModePerm))
 	req.NoError(ioutil.WriteFile(path.Join(tempDir, "cpu.cfs_quota_us"), []byte("0"), os.ModePerm))
 	mountInt := &mount.FakeMounter{
-		MountPoints: []mount.MountPoint{
+		MountPoints: []mount.Point{
 			{
 				Device: "cgroup",
 				Type:   "cgroup",

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -27,7 +27,7 @@ import (
 
 // FakeMounter implements mount.Interface for tests.
 type FakeMounter struct {
-	MountPoints []MountPoint
+	MountPoints []Point
 	Log         []FakeAction
 	// Error to return for a path when calling IsLikelyNotMountPoint
 	MountCheckErrors map[string]error
@@ -98,7 +98,7 @@ func (f *FakeMounter) Mount(source string, target string, fstype string, options
 	if err != nil {
 		absTarget = target
 	}
-	f.MountPoints = append(f.MountPoints, MountPoint{Device: source, Path: absTarget, Type: fstype, Opts: opts})
+	f.MountPoints = append(f.MountPoints, Point{Device: source, Path: absTarget, Type: fstype, Opts: opts})
 	klog.V(5).Infof("Fake mounter: mounted %s to %s", source, absTarget)
 	f.Log = append(f.Log, FakeAction{Action: FakeActionMount, Target: absTarget, Source: source, FSType: fstype})
 	return nil
@@ -115,14 +115,14 @@ func (f *FakeMounter) Unmount(target string) error {
 		absTarget = target
 	}
 
-	newMountpoints := []MountPoint{}
+	newMountpoints := []Point{}
 	for _, mp := range f.MountPoints {
 		if mp.Path == absTarget {
 			klog.V(5).Infof("Fake mounter: unmounted %s from %s", mp.Device, absTarget)
 			// Don't copy it to newMountpoints
 			continue
 		}
-		newMountpoints = append(newMountpoints, MountPoint{Device: mp.Device, Path: mp.Path, Type: mp.Type})
+		newMountpoints = append(newMountpoints, Point{Device: mp.Device, Path: mp.Path, Type: mp.Type})
 	}
 	f.MountPoints = newMountpoints
 	f.Log = append(f.Log, FakeAction{Action: FakeActionUnmount, Target: absTarget})
@@ -131,7 +131,7 @@ func (f *FakeMounter) Unmount(target string) error {
 }
 
 // List returns all the in-memory mountpoints for FakeMounter
-func (f *FakeMounter) List() ([]MountPoint, error) {
+func (f *FakeMounter) List() ([]Point, error) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
@@ -139,7 +139,7 @@ func (f *FakeMounter) List() ([]MountPoint, error) {
 }
 
 // IsMountPointMatch tests if dir and mp are the same path
-func (f *FakeMounter) IsMountPointMatch(mp MountPoint, dir string) bool {
+func (f *FakeMounter) IsMountPointMatch(mp Point, dir string) bool {
 	return mp.Path == dir
 }
 
@@ -188,7 +188,7 @@ func (f *FakeMounter) GetMountRefs(pathname string) ([]string, error) {
 
 // FakeHostUtil is a fake mount.HostUtils implementation for testing
 type FakeHostUtil struct {
-	MountPoints []MountPoint
+	MountPoints []Point
 	Filesystem  map[string]FileType
 
 	mutex sync.Mutex

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -57,9 +57,9 @@ type Interface interface {
 	// On some platforms, reading mounts directly from the OS is not guaranteed
 	// consistent (i.e. it could change between chunked reads). This is guaranteed
 	// to be consistent.
-	List() ([]MountPoint, error)
+	List() ([]Point, error)
 	// IsMountPointMatch determines if the mountpoint matches the dir.
-	IsMountPointMatch(mp MountPoint, dir string) bool
+	IsMountPointMatch(mp Point, dir string) bool
 	// IsLikelyNotMountPoint uses heuristics to determine if a directory
 	// is not a mountpoint.
 	// It should return ErrNotExist when the directory does not exist.
@@ -119,8 +119,8 @@ var _ Interface = &Mounter{}
 // the HostUtils Interface.
 var _ HostUtils = &hostUtil{}
 
-// MountPoint represents a single line in /proc/mounts or /etc/fstab.
-type MountPoint struct {
+// Point represents a single line in /proc/mounts or /etc/fstab.
+type Point struct {
 	Device string
 	Path   string
 	Type   string

--- a/pkg/util/mount/mount_helper_test.go
+++ b/pkg/util/mount/mount_helper_test.go
@@ -41,35 +41,35 @@ func TestDoCleanupMountPoint(t *testing.T) {
 		// the given base directory.
 		// Returns a fake MountPoint, a fake error for the mount point,
 		// and error if the prepare function encountered a fatal error.
-		prepare   func(base string) (MountPoint, error, error)
+		prepare   func(base string) (Point, error, error)
 		expectErr bool
 	}{
 		"mount-ok": {
-			prepare: func(base string) (MountPoint, error, error) {
+			prepare: func(base string) (Point, error, error) {
 				path := filepath.Join(base, testMount)
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
-					return MountPoint{}, nil, err
+					return Point{}, nil, err
 				}
-				return MountPoint{Device: "/dev/sdb", Path: path}, nil, nil
+				return Point{Device: "/dev/sdb", Path: path}, nil, nil
 			},
 		},
 		"mount-corrupted": {
-			prepare: func(base string) (MountPoint, error, error) {
+			prepare: func(base string) (Point, error, error) {
 				path := filepath.Join(base, testMount)
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
-					return MountPoint{}, nil, err
+					return Point{}, nil, err
 				}
-				return MountPoint{Device: "/dev/sdb", Path: path}, os.NewSyscallError("fake", syscall.ESTALE), nil
+				return Point{Device: "/dev/sdb", Path: path}, os.NewSyscallError("fake", syscall.ESTALE), nil
 			},
 			corruptedMnt: true,
 		},
 		"mount-err-not-corrupted": {
-			prepare: func(base string) (MountPoint, error, error) {
+			prepare: func(base string) (Point, error, error) {
 				path := filepath.Join(base, testMount)
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
-					return MountPoint{}, nil, err
+					return Point{}, nil, err
 				}
-				return MountPoint{Device: "/dev/sdb", Path: path}, os.NewSyscallError("fake", syscall.ETIMEDOUT), nil
+				return Point{Device: "/dev/sdb", Path: path}, os.NewSyscallError("fake", syscall.ETIMEDOUT), nil
 			},
 			expectErr: true,
 		},
@@ -94,7 +94,7 @@ func TestDoCleanupMountPoint(t *testing.T) {
 			}
 
 			fake := &FakeMounter{
-				MountPoints:      []MountPoint{mountPoint},
+				MountPoints:      []Point{mountPoint},
 				MountCheckErrors: map[string]error{mountPoint.Path: mountError},
 			}
 

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -216,12 +216,12 @@ func (mounter *Mounter) Unmount(target string) error {
 }
 
 // List returns a list of all mounted filesystems.
-func (*Mounter) List() ([]MountPoint, error) {
+func (*Mounter) List() ([]Point, error) {
 	return ListProcMounts(procMountsPath)
 }
 
 // IsMountPointMatch returns true if the path in mp is the same as dir
-func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
+func (mounter *Mounter) IsMountPointMatch(mp Point, dir string) bool {
 	deletedDir := fmt.Sprintf("%s\\040(deleted)", dir)
 	return ((mp.Path == dir) || (mp.Path == deletedDir))
 }
@@ -407,7 +407,7 @@ func (mounter *SafeFormatAndMount) GetDiskFormat(disk string) (string, error) {
 }
 
 // ListProcMounts is shared with NsEnterMounter
-func ListProcMounts(mountFilePath string) ([]MountPoint, error) {
+func ListProcMounts(mountFilePath string) ([]Point, error) {
 	content, err := utilio.ConsistentRead(mountFilePath, maxListTries)
 	if err != nil {
 		return nil, err
@@ -415,8 +415,8 @@ func ListProcMounts(mountFilePath string) ([]MountPoint, error) {
 	return parseProcMounts(content)
 }
 
-func parseProcMounts(content []byte) ([]MountPoint, error) {
-	out := []MountPoint{}
+func parseProcMounts(content []byte) ([]Point, error) {
+	out := []Point{}
 	lines := strings.Split(string(content), "\n")
 	for _, line := range lines {
 		if line == "" {
@@ -428,7 +428,7 @@ func parseProcMounts(content []byte) ([]MountPoint, error) {
 			return nil, fmt.Errorf("wrong number of fields (expected %d, got %d): %s", expectedNumFieldsPerLine, len(fields), line)
 		}
 
-		mp := MountPoint{
+		mp := Point{
 			Device: fields[0],
 			Path:   fields[1],
 			Type:   fields[2],

--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -45,15 +45,15 @@ func TestReadProcMountsFrom(t *testing.T) {
 	if len(mounts) != 3 {
 		t.Fatalf("expected 3 mounts, got %d", len(mounts))
 	}
-	mp := MountPoint{"/dev/0", "/path/to/0", "type0", []string{"flags"}, 0, 0}
+	mp := Point{"/dev/0", "/path/to/0", "type0", []string{"flags"}, 0, 0}
 	if !mountPointsEqual(&mounts[0], &mp) {
 		t.Errorf("got unexpected MountPoint[0]: %#v", mounts[0])
 	}
-	mp = MountPoint{"/dev/1", "/path/to/1", "type1", []string{"flags"}, 1, 1}
+	mp = Point{"/dev/1", "/path/to/1", "type1", []string{"flags"}, 1, 1}
 	if !mountPointsEqual(&mounts[1], &mp) {
 		t.Errorf("got unexpected MountPoint[1]: %#v", mounts[1])
 	}
-	mp = MountPoint{"/dev/2", "/path/to/2", "type2", []string{"flags", "1", "2=3"}, 2, 2}
+	mp = Point{"/dev/2", "/path/to/2", "type2", []string{"flags", "1", "2=3"}, 2, 2}
 	if !mountPointsEqual(&mounts[2], &mp) {
 		t.Errorf("got unexpected MountPoint[2]: %#v", mounts[2])
 	}
@@ -71,7 +71,7 @@ func TestReadProcMountsFrom(t *testing.T) {
 	}
 }
 
-func mountPointsEqual(a, b *MountPoint) bool {
+func mountPointsEqual(a, b *Point) bool {
 	if a.Device != b.Device || a.Path != b.Path || a.Type != b.Type || !reflect.DeepEqual(a.Opts, b.Opts) || a.Pass != b.Pass || a.Freq != b.Freq {
 		return false
 	}
@@ -80,7 +80,7 @@ func mountPointsEqual(a, b *MountPoint) bool {
 
 func TestGetMountRefs(t *testing.T) {
 	fm := &FakeMounter{
-		MountPoints: []MountPoint{
+		MountPoints: []Point{
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd"},
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd-in-pod"},
 			{Device: "/dev/sdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd2"},
@@ -144,7 +144,7 @@ func setEquivalent(set1, set2 []string) bool {
 
 func TestGetDeviceNameFromMount(t *testing.T) {
 	fm := &FakeMounter{
-		MountPoints: []MountPoint{
+		MountPoints: []Point{
 			{Device: "/dev/disk/by-path/prefix-lun-1",
 				Path: "/mnt/111"},
 			{Device: "/dev/disk/by-path/prefix-lun-1",
@@ -173,7 +173,7 @@ func TestGetDeviceNameFromMount(t *testing.T) {
 
 func TestGetMountRefsByDev(t *testing.T) {
 	fm := &FakeMounter{
-		MountPoints: []MountPoint{
+		MountPoints: []Point{
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd"},
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~gce-pd/gce-pd-in-pod"},
 			{Device: "/dev/sdc", Path: "/var/lib/kubelet/plugins/kubernetes.io/gce-pd/mounts/gce-pd2"},

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -50,12 +50,12 @@ func (mounter *Mounter) Unmount(target string) error {
 }
 
 // List always returns an error on unsupported platforms
-func (mounter *Mounter) List() ([]MountPoint, error) {
-	return []MountPoint{}, errUnsupported
+func (mounter *Mounter) List() ([]Point, error) {
+	return []Point{}, errUnsupported
 }
 
 // IsMountPointMatch returns true if the path in mp is the same as dir
-func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
+func (mounter *Mounter) IsMountPointMatch(mp Point, dir string) bool {
 	return (mp.Path == dir)
 }
 

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -164,12 +164,12 @@ func (mounter *Mounter) Unmount(target string) error {
 }
 
 // List returns a list of all mounted filesystems. todo
-func (mounter *Mounter) List() ([]MountPoint, error) {
-	return []MountPoint{}, nil
+func (mounter *Mounter) List() ([]Point, error) {
+	return []Point{}, nil
 }
 
 // IsMountPointMatch determines if the mountpoint matches the dir
-func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
+func (mounter *Mounter) IsMountPointMatch(mp Point, dir string) bool {
 	return mp.Path == dir
 }
 

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -138,7 +138,7 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 	)
 
 	if config.idempotent {
-		physicalMounter.MountPoints = []mount.MountPoint{
+		physicalMounter.MountPoints = []mount.Point{
 			{
 				Path: volumePath,
 			},

--- a/pkg/volume/fc/fc_test.go
+++ b/pkg/volume/fc/fc_test.go
@@ -24,7 +24,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
@@ -438,7 +438,7 @@ func Test_ConstructVolumeSpec(t *testing.T) {
 		t.Skipf("Test_ConstructVolumeSpec is not supported on GOOS=%s", runtime.GOOS)
 	}
 	fm := &mount.FakeMounter{
-		MountPoints: []mount.MountPoint{
+		MountPoints: []mount.Point{
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1"},
 			{Device: "/dev/sdb", Path: "/var/lib/kubelet/plugins/kubernetes.io/fc/50060e801049cfd1-lun-0"},
 			{Device: "/dev/sdc", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod2"},
@@ -489,7 +489,7 @@ func Test_ConstructVolumeSpec(t *testing.T) {
 
 func Test_ConstructVolumeSpecNoRefs(t *testing.T) {
 	fm := &mount.FakeMounter{
-		MountPoints: []mount.MountPoint{
+		MountPoints: []mount.Point{
 			{Device: "/dev/sdd", Path: "/var/lib/kubelet/pods/some-pod/volumes/kubernetes.io~fc/fc-in-pod1"},
 		},
 	}

--- a/pkg/volume/util/exec/exec_mount.go
+++ b/pkg/volume/util/exec/exec_mount.go
@@ -87,11 +87,11 @@ func (m *execMounter) Unmount(target string) error {
 }
 
 // List returns a list of all mounted filesystems.
-func (m *execMounter) List() ([]mount.MountPoint, error) {
+func (m *execMounter) List() ([]mount.Point, error) {
 	return m.wrappedMounter.List()
 }
 
-func (m *execMounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {
+func (m *execMounter) IsMountPointMatch(mp mount.Point, dir string) bool {
 	return m.wrappedMounter.IsMountPointMatch(mp, dir)
 }
 

--- a/pkg/volume/util/exec/exec_mount_unsupported.go
+++ b/pkg/volume/util/exec/exec_mount_unsupported.go
@@ -42,11 +42,11 @@ func (mounter *execMounter) Unmount(target string) error {
 	return nil
 }
 
-func (mounter *execMounter) List() ([]mount.MountPoint, error) {
-	return []mount.MountPoint{}, nil
+func (mounter *execMounter) List() ([]mount.Point, error) {
+	return []mount.Point{}, nil
 }
 
-func (mounter *execMounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {
+func (mounter *execMounter) IsMountPointMatch(mp mount.Point, dir string) bool {
 	return (mp.Path == dir)
 }
 

--- a/pkg/volume/util/fsquota/quota_linux_test.go
+++ b/pkg/volume/util/fsquota/quota_linux_test.go
@@ -21,6 +21,10 @@ package fsquota
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -28,9 +32,6 @@ import (
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume/util/fsquota/common"
-	"os"
-	"strings"
-	"testing"
 )
 
 const dummyMountData = `sysfs /sys sysfs rw,nosuid,nodev,noexec,relatime 0 0
@@ -63,7 +64,7 @@ const dummyMountTest = `/dev/sda1 / ext4 rw,noatime 0 0
 
 func dummyFakeMount1() mount.Interface {
 	return &mount.FakeMounter{
-		MountPoints: []mount.MountPoint{
+		MountPoints: []mount.Point{
 			{
 				Device: "tmpfs",
 				Path:   "/tmp",
@@ -224,7 +225,7 @@ func TestDetectMountPoint(t *testing.T) {
 	}
 }
 
-var dummyMountPoints = []mount.MountPoint{
+var dummyMountPoints = []mount.Point{
 	{
 		Device: "/dev/sda2",
 		Path:   "/quota1",

--- a/pkg/volume/util/nsenter/nsenter_mount.go
+++ b/pkg/volume/util/nsenter/nsenter_mount.go
@@ -140,12 +140,12 @@ func (n *Mounter) Unmount(target string) error {
 }
 
 // List returns a list of all mounted filesystems in the host's mount namespace.
-func (*Mounter) List() ([]mount.MountPoint, error) {
+func (*Mounter) List() ([]mount.Point, error) {
 	return mount.ListProcMounts(hostProcMountsPath)
 }
 
 // IsMountPointMatch tests if dir and mp are the same path
-func (*Mounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {
+func (*Mounter) IsMountPointMatch(mp mount.Point, dir string) bool {
 	deletedDir := fmt.Sprintf("%s\\040(deleted)", dir)
 	return (mp.Path == dir) || (mp.Path == deletedDir)
 }

--- a/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
+++ b/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
@@ -50,12 +50,12 @@ func (*Mounter) Unmount(target string) error {
 }
 
 // List returns a list of all mounted filesystems. It is a noop for unsupported systems
-func (*Mounter) List() ([]mount.MountPoint, error) {
-	return []mount.MountPoint{}, nil
+func (*Mounter) List() ([]mount.Point, error) {
+	return []mount.Point{}, nil
 }
 
 // IsMountPointMatch tests if dir and mp are the same path
-func (*Mounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {
+func (*Mounter) IsMountPointMatch(mp mount.Point, dir string) bool {
 	return (mp.Path == dir)
 }
 

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -405,14 +405,14 @@ func TestCleanSubPaths(t *testing.T) {
 		name string
 		// Function that prepares directory structure for the test under given
 		// base.
-		prepare func(base string) ([]mount.MountPoint, error)
+		prepare func(base string) ([]mount.Point, error)
 		// Function that validates directory structure after the test
 		validate    func(base string) error
 		expectError bool
 	}{
 		{
 			name: "not-exists",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				return nil, nil
 			},
 			validate: func(base string) error {
@@ -422,7 +422,7 @@ func TestCleanSubPaths(t *testing.T) {
 		},
 		{
 			name: "subpath-not-mount",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				return nil, os.MkdirAll(filepath.Join(base, containerSubPathDirectoryName, testVol, "container1", "0"), defaultPerm)
 			},
 			validate: func(base string) error {
@@ -432,7 +432,7 @@ func TestCleanSubPaths(t *testing.T) {
 		},
 		{
 			name: "subpath-file",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1")
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
 					return nil, err
@@ -446,7 +446,7 @@ func TestCleanSubPaths(t *testing.T) {
 		},
 		{
 			name: "subpath-container-not-dir",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol)
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
 					return nil, err
@@ -460,7 +460,7 @@ func TestCleanSubPaths(t *testing.T) {
 		},
 		{
 			name: "subpath-multiple-container-not-dir",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol)
 				if err := os.MkdirAll(filepath.Join(path, "container1"), defaultPerm); err != nil {
 					return nil, err
@@ -478,12 +478,12 @@ func TestCleanSubPaths(t *testing.T) {
 		},
 		{
 			name: "subpath-mount",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1", "0")
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
 					return nil, err
 				}
-				mounts := []mount.MountPoint{{Device: "/dev/sdb", Path: path}}
+				mounts := []mount.Point{{Device: "/dev/sdb", Path: path}}
 				return mounts, nil
 			},
 			validate: func(base string) error {
@@ -492,7 +492,7 @@ func TestCleanSubPaths(t *testing.T) {
 		},
 		{
 			name: "subpath-mount-multiple",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1", "0")
 				path2 := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1", "1")
 				path3 := filepath.Join(base, containerSubPathDirectoryName, testVol, "container2", "1")
@@ -505,7 +505,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(path3, defaultPerm); err != nil {
 					return nil, err
 				}
-				mounts := []mount.MountPoint{
+				mounts := []mount.Point{
 					{Device: "/dev/sdb", Path: path},
 					{Device: "/dev/sdb", Path: path3},
 				}
@@ -517,7 +517,7 @@ func TestCleanSubPaths(t *testing.T) {
 		},
 		{
 			name: "subpath-mount-multiple-vols",
-			prepare: func(base string) ([]mount.MountPoint, error) {
+			prepare: func(base string) ([]mount.Point, error) {
 				path := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1", "0")
 				path2 := filepath.Join(base, containerSubPathDirectoryName, "vol2", "container1", "1")
 				if err := os.MkdirAll(path, defaultPerm); err != nil {
@@ -526,7 +526,7 @@ func TestCleanSubPaths(t *testing.T) {
 				if err := os.MkdirAll(path2, defaultPerm); err != nil {
 					return nil, err
 				}
-				mounts := []mount.MountPoint{
+				mounts := []mount.Point{
 					{Device: "/dev/sdb", Path: path},
 				}
 				return mounts, nil
@@ -578,9 +578,9 @@ var (
 )
 
 func setupFakeMounter(testMounts []string) *mount.FakeMounter {
-	mounts := []mount.MountPoint{}
+	mounts := []mount.Point{}
 	for _, mountPoint := range testMounts {
-		mounts = append(mounts, mount.MountPoint{Device: "/foo", Path: mountPoint})
+		mounts = append(mounts, mount.Point{Device: "/foo", Path: mountPoint})
 	}
 	return &mount.FakeMounter{MountPoints: mounts}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
This patch renames the mount.MountPoint struct to mount.Point in order
to satisfy the Go linter about stuttering names.

As part of moving the `mount` package out of k/k, we need the Go linter to pass.

This [was discussed](https://github.com/kubernetes/utils/pull/100#issuecomment-511564803) a good bit in https://github.com/kubernetes/utils/pull/100.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @msau42 @saad-ali @jsafrane 