### PR TITLE
Use the escalate verb for clusterroleaggregator rather than cluster-admin permissions

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -85,9 +85,8 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "clusterrole-aggregation-controller"},
 		Rules: []rbacv1.PolicyRule{
-			// this controller must have full permissions to allow it to mutate any role in any way
-			rbacv1helpers.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
-			rbacv1helpers.NewRule("*").URLs("*").RuleOrDie(),
+			// this controller must have full permissions on clusterroles to allow it to mutate them in any way
+			rbacv1helpers.NewRule("escalate", "get", "list", "watch", "update", "patch").Groups(rbacGroup).Resources("clusterroles").RuleOrDie(),
 		},
 	})
 	addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -119,15 +119,16 @@ items:
     name: system:controller:clusterrole-aggregation-controller
   rules:
   - apiGroups:
-    - '*'
+    - rbac.authorization.k8s.io
     resources:
-    - '*'
+    - clusterroles
     verbs:
-    - '*'
-  - nonResourceURLs:
-    - '*'
-    verbs:
-    - '*'
+    - escalate
+    - get
+    - list
+    - patch
+    - update
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRole
   metadata:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Allows the clusterrole aggregator to modify roles by granting explicit escalate permission on the clusterroles resource, rather than `*` on `*` permissions.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig auth
/cc @deads2k 