### PR TITLE
Rename HostUtils.ExistsPath to PathExists

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -32,7 +32,7 @@ import (
 	"strings"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -195,7 +195,7 @@ func makeMounts(pod *v1.Pod, podDir string, container *v1.Container, hostName, h
 			volumePath := hostPath
 			hostPath = filepath.Join(volumePath, subPath)
 
-			if subPathExists, err := hu.ExistsPath(hostPath); err != nil {
+			if subPathExists, err := hu.PathExists(hostPath); err != nil {
 				klog.Errorf("Could not determine if subPath %s exists; will not attempt to change its permissions", hostPath)
 			} else if !subPathExists {
 				// Create the sub path now because if it's auto-created later when referenced, it may have an

--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -247,8 +247,8 @@ func (hu *FakeHostUtil) MakeFile(pathname string) error {
 	return nil
 }
 
-// ExistsPath checks if pathname exists.
-func (hu *FakeHostUtil) ExistsPath(pathname string) (bool, error) {
+// PathExists checks if pathname exists.
+func (hu *FakeHostUtil) PathExists(pathname string) (bool, error) {
 	if _, ok := hu.Filesystem[pathname]; ok {
 		return true, nil
 	}

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -91,8 +91,9 @@ type HostUtils interface {
 	MakeFile(pathname string) error
 	// MakeDir creates a new directory.
 	MakeDir(pathname string) error
+	// PathExists tests if the given path already exists
 	// Error is returned on any other error than "file not found".
-	ExistsPath(pathname string) (bool, error)
+	PathExists(pathname string) (bool, error)
 	// EvalHostSymlinks returns the path name after evaluating symlinks.
 	EvalHostSymlinks(pathname string) (string, error)
 	// GetFSGroup returns FSGroup of the path.

--- a/pkg/util/mount/mount_helper_common.go
+++ b/pkg/util/mount/mount_helper_common.go
@@ -28,8 +28,6 @@ import (
 // called instead of IsLikelyNotMountPoint. IsNotMountPoint is more expensive
 // but properly handles bind mounts within the same fs.
 func CleanupMountPoint(mountPath string, mounter Interface, extensiveMountPointCheck bool) error {
-	// mounter.ExistsPath cannot be used because for containerized kubelet, we need to check
-	// the path in the kubelet container, not on the host.
 	pathExists, pathErr := PathExists(mountPath)
 	if !pathExists {
 		klog.Warningf("Warning: Unmount skipped because path does not exist: %v", mountPath)

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -582,7 +582,7 @@ func (hu *hostUtil) MakeFile(pathname string) error {
 	return nil
 }
 
-func (hu *hostUtil) ExistsPath(pathname string) (bool, error) {
+func (hu *hostUtil) PathExists(pathname string) (bool, error) {
 	return utilpath.Exists(utilpath.CheckFollowSymlink, pathname)
 }
 

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -121,7 +121,7 @@ func (hu *hostUtil) MakeDir(pathname string) error {
 	return errUnsupported
 }
 
-func (hu *hostUtil) ExistsPath(pathname string) (bool, error) {
+func (hu *hostUtil) PathExists(pathname string) (bool, error) {
 	return true, errUnsupported
 }
 

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -186,7 +186,7 @@ func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 			return true, fmt.Errorf("readlink error: %v", err)
 		}
 		hu := NewHostUtil()
-		exists, err := hu.ExistsPath(target)
+		exists, err := hu.PathExists(target)
 		if err != nil {
 			return true, err
 		}
@@ -393,8 +393,8 @@ func (hu *hostUtil) MakeFile(pathname string) error {
 	return nil
 }
 
-// ExistsPath checks whether the path exists
-func (hu *hostUtil) ExistsPath(pathname string) (bool, error) {
+// PathExists checks whether the path exists
+func (hu *hostUtil) PathExists(pathname string) (bool, error) {
 	return utilpath.Exists(utilpath.CheckFollowSymlink, pathname)
 }
 

--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -21,7 +21,7 @@ import (
 	"os"
 	"regexp"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
@@ -364,7 +364,7 @@ type fileTypeChecker struct {
 }
 
 func (ftc *fileTypeChecker) Exists() bool {
-	exists, err := ftc.hu.ExistsPath(ftc.path)
+	exists, err := ftc.hu.PathExists(ftc.path)
 	return exists && err == nil
 }
 

--- a/pkg/volume/util/nsenter/nsenter_mount.go
+++ b/pkg/volume/util/nsenter/nsenter_mount.go
@@ -316,9 +316,9 @@ func (hu *hostUtil) MakeFile(pathname string) error {
 	return nil
 }
 
-// ExistsPath checks if pathname exists.
+// PathExists checks if pathname exists.
 // Error is returned on any other error than "file not found".
-func (hu *hostUtil) ExistsPath(pathname string) (bool, error) {
+func (hu *hostUtil) PathExists(pathname string) (bool, error) {
 	// Resolve the symlinks but allow the target not to exist. EvalSymlinks
 	// would return an generic error when the target does not exist.
 	hostPath, err := hu.ne.EvalSymlinks(pathname, false /* mustExist */)

--- a/pkg/volume/util/nsenter/nsenter_mount_test.go
+++ b/pkg/volume/util/nsenter/nsenter_mount_test.go
@@ -170,8 +170,8 @@ func TestNsenterExistsFile(t *testing.T) {
 
 				return path, nil
 			},
-			expectedOutput: isRoot,  // ExistsPath success when running as root
-			expectError:    !isRoot, // ExistsPath must fail when running as not-root
+			expectedOutput: isRoot,  // PathExists success when running as root
+			expectError:    !isRoot, // PathExists must fail when running as not-root
 		},
 		{
 			name: "relative symlink to existing file",
@@ -278,7 +278,7 @@ func TestNsenterExistsFile(t *testing.T) {
 			continue
 		}
 
-		out, err := hu.ExistsPath(path)
+		out, err := hu.PathExists(path)
 		if err != nil && !test.expectError {
 			t.Errorf("Test %q: unexpected error: %s", test.name, err)
 		}

--- a/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
+++ b/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
@@ -122,9 +122,9 @@ func (*hostUtil) MakeFile(pathname string) error {
 	return nil
 }
 
-// ExistsPath checks if pathname exists. Always returns an error on unsupported
+// PathExists checks if pathname exists. Always returns an error on unsupported
 // platforms
-func (*hostUtil) ExistsPath(pathname string) (bool, error) {
+func (*hostUtil) PathExists(pathname string) (bool, error) {
 	return true, errors.New("not implemented")
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
As part of @thockin's review of https://github.com/kubernetes/utils/pull/100, this renaming was requested.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @msau42 