### PR TITLE
Promote ConfigMap patch test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -45,6 +45,7 @@ test/e2e/auth/service_accounts.go: "should allow opting out of API token automou
 test/e2e/common/configmap.go: "should be consumable via environment variable"
 test/e2e/common/configmap.go: "should be consumable via the environment"
 test/e2e/common/configmap.go: "should fail to create ConfigMap with empty key"
+test/e2e/common/configmap.go: "should patch ConfigMap successfully"
 test/e2e/common/configmap_volume.go: "should be consumable from pods in volume"
 test/e2e/common/configmap_volume.go: "should be consumable from pods in volume with defaultMode set"
 test/e2e/common/configmap_volume.go: "should be consumable from pods in volume as non-root"

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -135,7 +135,12 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 		framework.ExpectError(err, "created configMap %q with empty key in namespace %q", configMap.Name, f.Namespace.Name)
 	})
 
-	ginkgo.It("should patch ConfigMap successfully", func() {
+	/*
+	   Release : v1.16
+	   Testname: ConfigMap: Patch Validation
+	   Description: Create a ConfigMap, and proceed to update it. Value of ConfigMap data MUST change after update.
+	*/
+	framework.ConformanceIt("should patch ConfigMap successfully", func() {
 		name := "configmap-test-" + string(uuid.NewUUID())
 		configMap := newConfigMap(f, name)
 		ginkgo.By(fmt.Sprintf("Creating configMap %v/%v", f.Namespace.Name, configMap.Name))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Promotes the following e2e test to Conformance: `test/e2e/common/configmap.go: "should patch ConfigMap successfully"`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
**Special notes for your reviewer**:

Part of umbrella issue https://github.com/kubernetes/kubernetes/issues/80997

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area conformance
/area test

@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg
