### PR TITLE
Disable RemoveSelfLink featuregate

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -321,7 +321,10 @@ func checkName(obj runtime.Object, name, namespace string, namer ScopeNamer) err
 //   interfaces
 func setObjectSelfLink(ctx context.Context, obj runtime.Object, req *http.Request, namer ScopeNamer) error {
 	if utilfeature.DefaultFeatureGate.Enabled(features.RemoveSelfLink) {
-		return nil
+		// TODO(#81191): Not setting selflink break CSI volume tests with alpha features,
+		// as they need to update the client-go dependency (to fix GetReferences function).
+		// Reenable it once new versions of CSI drivers are used by tests.
+		// return nil
 	}
 
 	// We only generate list links on objects that implement ListInterface - historically we duck typed this


### PR DESCRIPTION
We were aware of this problem, before https://github.com/kubernetes/kubernetes/pull/80978 was merged, but I completely forgot about the existence of alpha-features test suites.

If we can't fix those tests quick enough, we can disable the ability to switch of self-links temporarily until this is fixed.

Ref: https://github.com/kubernetes/kubernetes/issues/81191

/assign @msau42 

@liggitt - FYI