### PR TITLE
tests: Replaces images used with agnhost (part 4)

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -303,7 +303,8 @@ func testWebServerPodSpec(readinessProbe, livenessProbe *v1.Probe, containerName
 			Containers: []v1.Container{
 				{
 					Name:           containerName,
-					Image:          imageutils.GetE2EImage(imageutils.TestWebserver),
+					Image:          imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:           []string{"test-webserver"},
 					Ports:          []v1.ContainerPort{{ContainerPort: int32(port)}},
 					LivenessProbe:  livenessProbe,
 					ReadinessProbe: readinessProbe,

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -68,7 +68,6 @@ var CommonImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.MounttestUser),
 	imageutils.GetE2EImage(imageutils.Nginx),
 	imageutils.GetE2EImage(imageutils.Httpd),
-	imageutils.GetE2EImage(imageutils.TestWebserver),
 	imageutils.GetE2EImage(imageutils.VolumeNFSServer),
 	imageutils.GetE2EImage(imageutils.VolumeGlusterServer),
 	imageutils.GetE2EImage(imageutils.NonRoot),

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -64,8 +64,7 @@ const (
 )
 
 var (
-	resourceConsumerImage           = imageutils.GetE2EImage(imageutils.ResourceConsumer)
-	resourceConsumerControllerImage = imageutils.GetE2EImage(imageutils.ResourceController)
+	resourceConsumerImage = imageutils.GetE2EImage(imageutils.ResourceConsumer)
 )
 
 var (
@@ -500,12 +499,12 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, ns, name st
 	dnsClusterFirst := v1.DNSClusterFirst
 	controllerRcConfig := testutils.RCConfig{
 		Client:    c,
-		Image:     resourceConsumerControllerImage,
+		Image:     imageutils.GetE2EImage(imageutils.Agnhost),
 		Name:      controllerName,
 		Namespace: ns,
 		Timeout:   timeoutRC,
 		Replicas:  1,
-		Command:   []string{"/controller", "--consumer-service-name=" + name, "--consumer-service-namespace=" + ns, "--consumer-port=80"},
+		Command:   []string{"/agnhost", "resource-consumer-controller", "--consumer-service-name=" + name, "--consumer-service-namespace=" + ns, "--consumer-port=80"},
 		DNSPolicy: &dnsClusterFirst,
 	}
 	framework.ExpectNoError(e2erc.RunRC(controllerRcConfig))

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -396,7 +396,8 @@ func createDNSPod(namespace, wheezyProbeCmd, jessieProbeCmd, podHostName, servic
 				// TODO: Consider scraping logs instead of running a webserver.
 				{
 					Name:  "webserver",
-					Image: imageutils.GetE2EImage(imageutils.TestWebserver),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"test-webserver"},
 					Ports: []v1.ContainerPort{
 						{
 							Name:          "http",

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -139,8 +139,9 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 			replicas,
 			map[string]string{"test": "dual-stack-server"},
 			"dualstack-test-server",
-			imageutils.GetE2EImage(imageutils.TestWebserver),
+			imageutils.GetE2EImage(imageutils.Agnhost),
 			appsv1.RollingUpdateDeploymentStrategyType)
+		serverDeploymentSpec.Spec.Template.Spec.Containers[0].Args = []string{"test-webserver"}
 
 		// to ensure all the pods land on different nodes and we can thereby
 		// validate connectivity across all nodes.

--- a/test/e2e/network/fixture.go
+++ b/test/e2e/network/fixture.go
@@ -60,7 +60,7 @@ func NewServerTest(client clientset.Interface, namespace string, serviceName str
 	t.services = make(map[string]bool)
 
 	t.Name = "webserver"
-	t.Image = imageutils.GetE2EImage(imageutils.TestWebserver)
+	t.Image = imageutils.GetE2EImage(imageutils.Agnhost)
 
 	return t
 }

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -127,7 +127,8 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 				Containers: []v1.Container{
 					{
 						Name:  "secret-test",
-						Image: imageutils.GetE2EImage(imageutils.TestWebserver),
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"test-webserver"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      volumeName,

--- a/test/e2e/windows/hybrid_network.go
+++ b/test/e2e/windows/hybrid_network.go
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	windowsBusyBoximage = imageutils.GetE2EImage(imageutils.TestWebserver)
+	windowsBusyBoximage = imageutils.GetE2EImage(imageutils.Agnhost)
 	linuxBusyBoxImage   = "docker.io/library/nginx:1.15-alpine"
 )
 
@@ -53,6 +53,7 @@ var _ = SIGDescribe("Hybrid cluster network", func() {
 			ginkgo.By("creating linux and windows pods")
 			linuxPod := createTestPod(f, linuxBusyBoxImage, linuxOS)
 			windowsPod := createTestPod(f, windowsBusyBoximage, windowsOS)
+			windowsPod.Spec.Containers[0].Args = []string{"test-webserver"}
 
 			ginkgo.By("checking connectivity to 8.8.8.8 53 (google.com) from Linux")
 			assertConsistentConnectivity(f, linuxPod.ObjectMeta.Name, linuxOS, linuxCheck("8.8.8.8", 53))

--- a/test/e2e_node/container_manager_test.go
+++ b/test/e2e_node/container_manager_test.go
@@ -220,7 +220,8 @@ var _ = framework.KubeDescribe("Container Manager Misc [Serial]", func() {
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{
 							{
-								Image: imageutils.GetE2EImage(imageutils.TestWebserver),
+								Image: imageutils.GetE2EImage(imageutils.Agnhost),
+								Args:  []string{"test-webserver"},
 								Name:  podName,
 								Resources: v1.ResourceRequirements{
 									Requests: v1.ResourceList{

--- a/test/images/agnhost/README.md
+++ b/test/images/agnhost/README.md
@@ -40,7 +40,7 @@ For example, let's consider the following `pod.yaml` file:
       containers:
       - args:
         - dns-suffix
-        image: gcr.io/kubernetes-e2e-test-images/agnhost:2.10
+        image: us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.10
         name: agnhost
       dnsConfig:
         nameservers:
@@ -207,7 +207,7 @@ Usage:
 
 ```console
 guestbook="test/e2e/testing-manifests/guestbook"
-sed_expr="s|{{.AgnhostImage}}|gcr.io/kubernetes-e2e-test-images/agnhost:2.8|"
+sed_expr="s|{{.AgnhostImage}}|us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.10|"
 
 # create the services.
 kubectl create -f ${guestbook}/frontend-service.yaml
@@ -290,14 +290,14 @@ Examples:
 
 ```console
 docker run -i \
-  gcr.io/kubernetes-e2e-test-images/agnhost:2.10 \
+  us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.10 \
   logs-generator --log-lines-total 10 --run-duration 1s
 ```
 
 ```console
 kubectl run logs-generator \
   --generator=run-pod/v1 \
-  --image=gcr.io/kubernetes-e2e-test-images/agnhost:2.10 \
+  --image=us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.10 \
   --restart=Never \
   -- logs-generator -t 10 -d 1s
 ```
@@ -455,7 +455,7 @@ Usage:
 ```console
     kubectl run test-agnhost \
       --generator=run-pod/v1 \
-      --image=gcr.io/kubernetes-e2e-test-images/agnhost:2.10 \
+      --image=us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.10 \
       --restart=Never \
       --env "POD_IP=<POD_IP>" \
       --env "NODE_IP=<NODE_IP>" \
@@ -510,7 +510,7 @@ Usage:
 ```console
     kubectl run test-agnhost \
       --generator=run-pod/v1 \
-      --image=gcr.io/kubernetes-e2e-test-images/agnhost:2.10 \
+      --image=us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.10 \
       --restart=Never \
       --env "BIND_ADDRESS=localhost" \
       --env "BIND_PORT=8080" \
@@ -631,6 +631,6 @@ The image contains `iperf`, `curl`, `dns-tools` (including `dig`), CoreDNS.
 
 ## Image
 
-The image can be found at `gcr.io/kubernetes-e2e-test-images/agnhost:2.10` for Linux
-containers, and `e2eteam/agnhost:2.8` for Windows containers. In the future, the same
+The image can be found at `us.gcr.io/k8s-artifacts-prod/e2e-test-images/agnhost:2.10` for Linux
+containers, and `e2eteam/agnhost:2.10` for Windows containers. In the future, the same
 repository can be used for both OSes.

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -31,6 +31,7 @@ type RegistryList struct {
 	DockerLibraryRegistry   string `yaml:"dockerLibraryRegistry"`
 	DockerGluster           string `yaml:"dockerGluster"`
 	E2eRegistry             string `yaml:"e2eRegistry"`
+	PromoterE2eRegistry     string `yaml:"promoterE2eRegistry"`
 	InvalidRegistry         string `yaml:"invalidRegistry"`
 	GcRegistry              string `yaml:"gcRegistry"`
 	GcrReleaseRegistry      string `yaml:"gcrReleaseRegistry"`
@@ -69,6 +70,7 @@ func initReg() RegistryList {
 		DockerLibraryRegistry:   "docker.io/library",
 		DockerGluster:           "docker.io/gluster",
 		E2eRegistry:             "gcr.io/kubernetes-e2e-test-images",
+		PromoterE2eRegistry:     "us.gcr.io/k8s-artifacts-prod/e2e-test-images",
 		InvalidRegistry:         "invalid.com/invalid",
 		GcRegistry:              "k8s.gcr.io",
 		GcrReleaseRegistry:      "gcr.io/gke-release",
@@ -100,6 +102,7 @@ var (
 	dockerLibraryRegistry   = registry.DockerLibraryRegistry
 	dockerGluster           = registry.DockerGluster
 	e2eRegistry             = registry.E2eRegistry
+	promoterE2eRegistry     = registry.PromoterE2eRegistry
 	gcAuthenticatedRegistry = registry.GcAuthenticatedRegistry
 	gcRegistry              = registry.GcRegistry
 	gcrReleaseRegistry      = registry.GcrReleaseRegistry
@@ -187,14 +190,10 @@ const (
 	RegressionIssue74839
 	// ResourceConsumer image
 	ResourceConsumer
-	// ResourceController image
-	ResourceController
 	// SdDummyExporter image
 	SdDummyExporter
 	// StartupScript image
 	StartupScript
-	// TestWebserver image
-	TestWebserver
 	// VolumeNFSServer image
 	VolumeNFSServer
 	// VolumeISCSIServer image
@@ -207,7 +206,7 @@ const (
 
 func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.8"}
+	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.10"}
 	configs[AgnhostPrivate] = Config{PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}
@@ -243,10 +242,8 @@ func initImageConfigs() map[int]Config {
 	configs[Redis] = Config{dockerLibraryRegistry, "redis", "5.0.5-alpine"}
 	configs[RegressionIssue74839] = Config{e2eRegistry, "regression-issue-74839-amd64", "1.0"}
 	configs[ResourceConsumer] = Config{e2eRegistry, "resource-consumer", "1.5"}
-	configs[ResourceController] = Config{e2eRegistry, "resource-consumer-controller", "1.0"}
 	configs[SdDummyExporter] = Config{gcRegistry, "sd-dummy-exporter", "v0.2.0"}
 	configs[StartupScript] = Config{googleContainerRegistry, "startup-script", "v1"}
-	configs[TestWebserver] = Config{e2eRegistry, "test-webserver", "1.0"}
 	configs[VolumeNFSServer] = Config{e2eRegistry, "volume/nfs", "1.0"}
 	configs[VolumeISCSIServer] = Config{e2eRegistry, "volume/iscsi", "2.0"}
 	configs[VolumeGlusterServer] = Config{e2eRegistry, "volume/gluster", "1.0"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

/sig testing
/sig windows
/area conformance

**What this PR does / why we need it**:

Quite a few images are only used a few times in a few tests. Thus, the images are being centralized into the agnhost image, reducing the number of images that have to be pulled and used.

This PR replaces the usage of the following images with agnhost:

- resource-consumer-controller
- test-webserver

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: #76342

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
