### PR TITLE
Rename HostUtils.GetFSGroup to HostUtils.GetOwner

### DIFF
--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -261,10 +261,10 @@ func (hu *FakeHostUtil) EvalHostSymlinks(pathname string) (string, error) {
 	return pathname, nil
 }
 
-// GetFSGroup returns FSGroup of pathname.
+// GetOwner returns the integer ID for the user and group of the given path
 // Not implemented for testing
-func (hu *FakeHostUtil) GetFSGroup(pathname string) (int64, error) {
-	return -1, errors.New("GetFSGroup not implemented")
+func (hu *FakeHostUtil) GetOwner(pathname string) (int64, int64, error) {
+	return -1, -1, errors.New("GetOwner not implemented")
 }
 
 // GetSELinuxSupport tests if pathname is on a mount that supports SELinux.

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -95,8 +95,8 @@ type HostUtils interface {
 	ExistsPath(pathname string) (bool, error)
 	// EvalHostSymlinks returns the path name after evaluating symlinks.
 	EvalHostSymlinks(pathname string) (string, error)
-	// GetFSGroup returns FSGroup of the path.
-	GetFSGroup(pathname string) (int64, error)
+	// GetOwner returns the integer ID for the user and group of the given path
+	GetOwner(pathname string) (int64, int64, error)
 	// GetSELinuxSupport returns true if given path is on a mount that supports
 	// SELinux.
 	GetSELinuxSupport(pathname string) (bool, error)

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -758,26 +758,28 @@ func (hu *hostUtil) GetSELinuxSupport(pathname string) (bool, error) {
 	return GetSELinux(pathname, procMountInfoPath)
 }
 
-func (hu *hostUtil) GetFSGroup(pathname string) (int64, error) {
+// GetOwner returns the integer ID for the user and group of the given path
+func (hu *hostUtil) GetOwner(pathname string) (int64, int64, error) {
 	realpath, err := filepath.EvalSymlinks(pathname)
 	if err != nil {
-		return 0, err
+		return -1, -1, err
 	}
-	return GetFSGroupLinux(realpath)
+	return GetOwnerLinux(realpath)
 }
 
 func (hu *hostUtil) GetMode(pathname string) (os.FileMode, error) {
 	return GetModeLinux(pathname)
 }
 
-// GetFSGroupLinux is shared between Linux and NsEnterMounter
+// GetOwnerLinux is shared between Linux and NsEnterMounter
 // pathname must already be evaluated for symlinks
-func GetFSGroupLinux(pathname string) (int64, error) {
+func GetOwnerLinux(pathname string) (int64, int64, error) {
 	info, err := os.Stat(pathname)
 	if err != nil {
-		return 0, err
+		return -1, -1, err
 	}
-	return int64(info.Sys().(*syscall.Stat_t).Gid), nil
+	stat := info.Sys().(*syscall.Stat_t)
+	return int64(stat.Uid), int64(stat.Gid), nil
 }
 
 // GetModeLinux is shared between Linux and NsEnterMounter

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -130,8 +130,9 @@ func (hu *hostUtil) EvalHostSymlinks(pathname string) (string, error) {
 	return "", errUnsupported
 }
 
-func (hu *hostUtil) GetFSGroup(pathname string) (int64, error) {
-	return -1, errUnsupported
+// GetOwner returns the integer ID for the user and group of the given path
+func (hu *hostUtil) GetOwner(pathname string) (int64, int64, error) {
+	return -1, -1, errUnsupported
 }
 
 func (hu *hostUtil) GetSELinuxSupport(pathname string) (bool, error) {

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -403,10 +403,11 @@ func (hu *hostUtil) EvalHostSymlinks(pathname string) (string, error) {
 	return filepath.EvalSymlinks(pathname)
 }
 
-// Note that on windows, it always returns 0. We actually don't set FSGroup on
+// GetOwner returns the integer ID for the user and group of the given path
+// Note that on windows, it always returns 0. We actually don't set Group on
 // windows platform, see SetVolumeOwnership implementation.
-func (hu *hostUtil) GetFSGroup(pathname string) (int64, error) {
-	return 0, nil
+func (hu *hostUtil) GetOwner(pathname string) (int64, int64, error) {
+	return -1, -1, nil
 }
 
 func (hu *hostUtil) GetSELinuxSupport(pathname string) (bool, error) {

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -480,7 +480,7 @@ func (m *localVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs)
 		refs = m.filterPodMounts(refs)
 		if len(refs) > 0 {
 			fsGroupNew := int64(*mounterArgs.FsGroup)
-			fsGroupOld, err := m.hostUtil.GetFSGroup(m.globalPath)
+			_, fsGroupOld, err := m.hostUtil.GetOwner(m.globalPath)
 			if err != nil {
 				return fmt.Errorf("failed to check fsGroup for %s (%v)", m.globalPath, err)
 			}

--- a/pkg/volume/util/nsenter/nsenter_mount.go
+++ b/pkg/volume/util/nsenter/nsenter_mount.go
@@ -334,14 +334,14 @@ func (hu *hostUtil) EvalHostSymlinks(pathname string) (string, error) {
 	return hu.ne.EvalSymlinks(pathname, true)
 }
 
-// GetFSGroup returns FSGroup of pathname.
-func (hu *hostUtil) GetFSGroup(pathname string) (int64, error) {
+// GetOwner returns the integer ID for the user and group of the given path
+func (hu *hostUtil) GetOwner(pathname string) (int64, int64, error) {
 	hostPath, err := hu.ne.EvalSymlinks(pathname, true /* mustExist */)
 	if err != nil {
-		return -1, err
+		return -1, -1, err
 	}
 	kubeletpath := hu.ne.KubeletPath(hostPath)
-	return mount.GetFSGroupLinux(kubeletpath)
+	return mount.GetOwnerLinux(kubeletpath)
 }
 
 // GetSELinuxSupport tests if pathname is on a mount that supports SELinux.

--- a/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
+++ b/pkg/volume/util/nsenter/nsenter_mount_unsupported.go
@@ -134,9 +134,9 @@ func (*hostUtil) EvalHostSymlinks(pathname string) (string, error) {
 	return "", errors.New("not implemented")
 }
 
-// GetFSGroup returns FSGroup of pathname. Always returns an error on unsupported platforms
-func (*hostUtil) GetFSGroup(pathname string) (int64, error) {
-	return -1, errors.New("not implemented")
+// GetOwner returns the integer ID for the user and group of the given path
+func (*hostUtil) GetOwner(pathname string) (int64, int64, error) {
+	return -1, -1, errors.New("not implemented")
 }
 
 // GetSELinuxSupport tests if pathname is on a mount that supports SELinux.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
This patch renames GetFSGroup (a process property) to GetOwner (a file
property), returning both the uid and gid of the given pathname. This
method is only used in one place in the k/k codebase, but having
"GetOwner" instead of "GetGroup" seems to have more utility.

This came up as part of the review for https://github.com/kubernetes/utils/pull/100.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
@msau42 A quick [code search](https://cs.k8s.io/?q=GetFSGroup&i=nope&files=&repos=) shows this method only has [one caller](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/local/local.go#L483). Should we consider removing it entirely?

One reason I changed it to `GetOwner` instead of `GetGroup` was taking Tim's suggestion to just do them both. It seems to be more useful that way, but this doesn't seem to be an API that anyone is needing... Thoughts?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @msau42 