### PR TITLE
Remove core dependency from deployment e2e fw

### DIFF
--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -76,7 +76,6 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/deployment:go_default_library",
         "//test/e2e/framework/kubelet:go_default_library",
         "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/node:go_default_library",

--- a/test/e2e/common/autoscaling_utils.go
+++ b/test/e2e/common/autoscaling_utils.go
@@ -32,7 +32,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2edeploy "k8s.io/kubernetes/test/e2e/framework/deployment"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/framework/replicaset"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
@@ -479,7 +478,7 @@ func runServiceAndWorkloadForResourceConsumer(c clientset.Interface, ns, name st
 		dpConfig := testutils.DeploymentConfig{
 			RCConfig: rcConfig,
 		}
-		framework.ExpectNoError(e2edeploy.RunDeployment(dpConfig))
+		framework.ExpectNoError(runDeployment(dpConfig))
 		break
 	case KindReplicaSet:
 		rsConfig := testutils.ReplicaSetConfig{
@@ -553,4 +552,12 @@ func CreateCPUHorizontalPodAutoscaler(rc *ResourceConsumer, cpu, minReplicas, ma
 
 func DeleteHorizontalPodAutoscaler(rc *ResourceConsumer, autoscalerName string) {
 	rc.clientSet.AutoscalingV1().HorizontalPodAutoscalers(rc.nsName).Delete(autoscalerName, nil)
+}
+
+// runDeployment runs a delopyment with the specified config.
+func runDeployment(config testutils.DeploymentConfig) error {
+	ginkgo.By(fmt.Sprintf("creating deployment %s in namespace %s", config.Name, config.Namespace))
+	config.NodeDumpFunc = framework.DumpNodeDebugInfo
+	config.ContainerDumpFunc = framework.LogFailedContainers
+	return testutils.RunDeployment(config)
 }

--- a/test/e2e/framework/deployment/BUILD
+++ b/test/e2e/framework/deployment/BUILD
@@ -20,11 +20,9 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
-        "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/log:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/deployment/fixtures.go
+++ b/test/e2e/framework/deployment/fixtures.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/onsi/ginkgo"
-
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,7 +30,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	watchtools "k8s.io/client-go/tools/watch"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
-	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -157,14 +154,6 @@ func GetPodsForDeployment(client clientset.Interface, deployment *appsv1.Deploym
 		return nil, fmt.Errorf("Failed to list Pods of Deployment %q: %v", deployment.Name, err)
 	}
 	return podList, nil
-}
-
-// RunDeployment runs a delopyment with the specified config.
-func RunDeployment(config testutils.DeploymentConfig) error {
-	ginkgo.By(fmt.Sprintf("creating deployment %s in namespace %s", config.Name, config.Namespace))
-	config.NodeDumpFunc = framework.DumpNodeDebugInfo
-	config.ContainerDumpFunc = framework.LogFailedContainers
-	return testutils.RunDeployment(config)
 }
 
 // testDeployment creates a deployment definition based on the namespace. The deployment references the PVC's


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

RunDeployment() of the deployment e2e framework was used in
autoscaling_utils only. In addition, the deployment e2e framework
imported the core of e2e framework only for the function.
So this moves the function into autoscaling_utils then we can remove
dependency of core framework from the deployment e2e framework.

Ref: #81232

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
