### PR TITLE
Send a reject message to permit plugin before deleting the Pod

### DIFF
--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -18,6 +18,7 @@ package scheduler
 
 import (
 	"fmt"
+	"k8s.io/kubernetes/staging/src/k8s.io/apimachinery/pkg/api/errors"
 	"testing"
 	"time"
 
@@ -1420,6 +1421,15 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 
 		perPlugin.reset()
 		cleanupPods(cs, t, []*v1.Pod{waitingPod, signallingPod})
+		_, err = cs.CoreV1().Pods(signallingPod.Namespace).Get(signallingPod.Name, metav1.GetOptions{})
+		if !errors.IsNotFound(err) {
+			cleanupPods(cs, t, []*v1.Pod{signallingPod})
+		}
+		_, err = cs.CoreV1().Pods(signallingPod.Namespace).Get(signallingPod.Name, metav1.GetOptions{})
+		if !errors.IsNotFound(err) {
+			t.Errorf("couldn't cleanup %q", signallingPod.Name)
+			t.FailNow()
+		}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In normal test run, you would see:
```
I0809 20:24:30.004273   59664 framework.go:568] rejected while waiting at permit: preempted
E0809 20:24:30.004331   59664 factory.go:573] Error scheduling preempt-with-permit-plugind293b1d9-a8cf-4db5-b662-38966d39a8ef/waiting-pod: rejected while waiting at permit: preempted; retrying
```
In the failed test run, the above was absent.

This PR sends reject message to permit plugin when preempting a WaitingPod before deleting the Pod.

**Which issue(s) this PR fixes**:
Fixes #81238

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
