### PR TITLE
Use crypto/rand.Read to seed random number generator

### DIFF
--- a/cmd/cloud-controller-manager/BUILD
+++ b/cmd/cloud-controller-manager/BUILD
@@ -23,7 +23,9 @@ go_library(
         "//pkg/cloudprovider/providers:go_default_library",
         "//pkg/util/prometheusclientgo:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/cloud-controller-manager/controller-manager.go
+++ b/cmd/cloud-controller-manager/controller-manager.go
@@ -20,11 +20,11 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/cloud-controller-manager/app"
 
 	// NOTE: Importing all in-tree cloud-providers is not required when
@@ -35,7 +35,11 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := app.NewCloudControllerManagerCommand()
 

--- a/cmd/hyperkube/BUILD
+++ b/cmd/hyperkube/BUILD
@@ -27,10 +27,12 @@ go_library(
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/kubectl/cmd:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/hyperkube/main.go
+++ b/cmd/hyperkube/main.go
@@ -21,16 +21,15 @@ package main
 
 import (
 	goflag "flag"
-	"math/rand"
-	"os"
-	"path/filepath"
-	"time"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"os"
+	"path/filepath"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	cloudcontrollermanager "k8s.io/kubernetes/cmd/cloud-controller-manager/app"
 	kubeapiserver "k8s.io/kubernetes/cmd/kube-apiserver/app"
 	kubecontrollermanager "k8s.io/kubernetes/cmd/kube-controller-manager/app"
@@ -43,7 +42,11 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	hyperkubeCommand, allCommandFns := NewHyperKubeCommand()
 

--- a/cmd/kube-apiserver/BUILD
+++ b/cmd/kube-apiserver/BUILD
@@ -22,7 +22,9 @@ go_library(
         "//cmd/kube-apiserver/app:go_default_library",
         "//pkg/util/prometheusclientgo:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kube-apiserver/apiserver.go
+++ b/cmd/kube-apiserver/apiserver.go
@@ -19,18 +19,22 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kube-apiserver/app"
 	_ "k8s.io/kubernetes/pkg/util/prometheusclientgo" // load all the prometheus client-go plugins
 	_ "k8s.io/kubernetes/pkg/version/prometheus"      // for version metric registration
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := app.NewAPIServerCommand()
 

--- a/cmd/kube-controller-manager/BUILD
+++ b/cmd/kube-controller-manager/BUILD
@@ -22,7 +22,9 @@ go_library(
         "//cmd/kube-controller-manager/app:go_default_library",
         "//pkg/util/prometheusclientgo:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kube-controller-manager/controller-manager.go
+++ b/cmd/kube-controller-manager/controller-manager.go
@@ -21,18 +21,22 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kube-controller-manager/app"
 	_ "k8s.io/kubernetes/pkg/util/prometheusclientgo" // load all the prometheus client-go plugin
 	_ "k8s.io/kubernetes/pkg/version/prometheus"      // for version metric registration
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := app.NewControllerManagerCommand()
 

--- a/cmd/kube-proxy/BUILD
+++ b/cmd/kube-proxy/BUILD
@@ -22,9 +22,11 @@ go_library(
         "//cmd/kube-proxy/app:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kube-proxy/proxy.go
+++ b/cmd/kube-proxy/proxy.go
@@ -18,21 +18,24 @@ package main
 
 import (
 	goflag "flag"
-	"math/rand"
-	"os"
-	"time"
-
 	"github.com/spf13/pflag"
+	"os"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kube-proxy/app"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := app.NewProxyCommand()
 

--- a/cmd/kube-scheduler/BUILD
+++ b/cmd/kube-scheduler/BUILD
@@ -22,9 +22,11 @@ go_library(
         "//cmd/kube-scheduler/app:go_default_library",
         "//pkg/util/prometheusclientgo:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kube-scheduler/scheduler.go
+++ b/cmd/kube-scheduler/scheduler.go
@@ -17,21 +17,24 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
-	"os"
-	"time"
-
 	"github.com/spf13/pflag"
+	"os"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 	_ "k8s.io/kubernetes/pkg/util/prometheusclientgo" // load all the prometheus client-go plugins
 	_ "k8s.io/kubernetes/pkg/version/prometheus"      // for version metric registration
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := app.NewSchedulerCommand()
 

--- a/cmd/kubectl/BUILD
+++ b/cmd/kubectl/BUILD
@@ -20,10 +20,12 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/kubectl/cmd:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/client-go/plugin/pkg/client/auth:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/logs:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kubectl/kubectl.go
+++ b/cmd/kubectl/kubectl.go
@@ -18,13 +18,13 @@ package main
 
 import (
 	goflag "flag"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/spf13/pflag"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	cliflag "k8s.io/component-base/cli/flag"
+	"k8s.io/klog"
 	"k8s.io/kubectl/pkg/util/logs"
 	"k8s.io/kubernetes/pkg/kubectl/cmd"
 
@@ -33,7 +33,11 @@ import (
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := cmd.NewDefaultKubectlCommand()
 

--- a/cmd/kubelet/BUILD
+++ b/cmd/kubelet/BUILD
@@ -21,7 +21,9 @@ go_library(
         "//cmd/kubelet/app:go_default_library",
         "//pkg/client/metrics/prometheus:go_default_library",
         "//pkg/version/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/component-base/logs:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kubelet/kubelet.go
+++ b/cmd/kubelet/kubelet.go
@@ -21,18 +21,22 @@ limitations under the License.
 package main
 
 import (
-	"math/rand"
 	"os"
-	"time"
 
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kubelet/app"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 )
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := app.NewKubeletCommand()
 	logs.InitLogs()

--- a/cmd/kubemark/BUILD
+++ b/cmd/kubemark/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//pkg/version/prometheus:go_default_library",
         "//pkg/version/verflag:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -20,15 +20,14 @@ import (
 	"errors"
 	goflag "flag"
 	"fmt"
-	"math/rand"
 	"os"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
+	apirand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	clientset "k8s.io/client-go/kubernetes"
@@ -37,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
+	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/api/legacyscheme"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
 	"k8s.io/kubernetes/pkg/features"
@@ -104,7 +104,11 @@ func (c *hollowNodeConfig) createClientConfigFromFile() (*restclient.Config, err
 }
 
 func main() {
-	rand.Seed(time.Now().UnixNano())
+	err := apirand.InitMathRand()
+	if err != nil {
+		klog.Fatalf("cannot seed random: %v", err)
+		os.Exit(2)
+	}
 
 	command := newHollowNodeCommand()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Mentioned over #81138, we should use less predictable seed for random number generator.

This PR adopts crypto/rand.Read
See https://stackoverflow.com/questions/12321133/golang-random-number-generator-how-to-seed-properly

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
