### PR TITLE
feat: update scheduling queue with options

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -207,6 +207,8 @@ pluginConfig:
 
 	defaultSource := "DefaultProvider"
 	defaultBindTimeoutSeconds := int64(600)
+	defaultPodInitialBackoffSeconds := int64(1)
+	defaultPodMaxBackoffSeconds := int64(10)
 
 	testcases := []struct {
 		name             string
@@ -275,8 +277,10 @@ pluginConfig:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
-				Plugins:            nil,
+				BindTimeoutSeconds:       &defaultBindTimeoutSeconds,
+				PodInitialBackoffSeconds: &defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:     &defaultPodMaxBackoffSeconds,
+				Plugins:                  nil,
 			},
 		},
 		{
@@ -355,7 +359,9 @@ pluginConfig:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
+				BindTimeoutSeconds:       &defaultBindTimeoutSeconds,
+				PodInitialBackoffSeconds: &defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:     &defaultPodMaxBackoffSeconds,
 			},
 		},
 		{
@@ -416,7 +422,9 @@ pluginConfig:
 					Burst:       100,
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
-				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
+				BindTimeoutSeconds:       &defaultBindTimeoutSeconds,
+				PodInitialBackoffSeconds: &defaultPodInitialBackoffSeconds,
+				PodMaxBackoffSeconds:     &defaultPodMaxBackoffSeconds,
 				Plugins: &kubeschedulerconfig.Plugins{
 					Reserve: &kubeschedulerconfig.PluginSet{
 						Enabled: []kubeschedulerconfig.Plugin{

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -190,6 +190,8 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}, regis
 		scheduler.WithFrameworkRegistry(registry),
 		scheduler.WithFrameworkPlugins(cc.ComponentConfig.Plugins),
 		scheduler.WithFrameworkPluginConfig(cc.ComponentConfig.PluginConfig),
+		scheduler.WithPodMaxBackoffSeconds(*cc.ComponentConfig.PodMaxBackoffSeconds),
+		scheduler.WithPodInitialBackoffSeconds(*cc.ComponentConfig.PodInitialBackoffSeconds),
 	)
 	if err != nil {
 		return err

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -88,6 +88,16 @@ type KubeSchedulerConfiguration struct {
 	// If this value is nil, the default value will be used.
 	BindTimeoutSeconds *int64
 
+	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
+	// If specified, it must be greater than 0. If this value is null, the default value (1s)
+	// will be used.
+	PodInitialBackoffSeconds *int64
+
+	// PodMaxBackoffSeconds is the max backoff for unschedulable pods.
+	// If specified, it must be greater than podInitialBackoffSeconds. If this value is null,
+	// the default value (10s) will be used.
+	PodMaxBackoffSeconds *int64
+
 	// Plugins specify the set of plugins that should be enabled or disabled. Enabled plugins are the
 	// ones that should be enabled in addition to the default plugins. Disabled plugins are any of the
 	// default plugins that should be disabled.

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -98,4 +98,14 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubeschedulerconfigv1alpha1.Kub
 		defaultBindTimeoutSeconds := int64(600)
 		obj.BindTimeoutSeconds = &defaultBindTimeoutSeconds
 	}
+
+	if obj.PodInitialBackoffSeconds == nil {
+		defaultPodInitialBackoffSeconds := int64(1)
+		obj.PodInitialBackoffSeconds = &defaultPodInitialBackoffSeconds
+	}
+
+	if obj.PodMaxBackoffSeconds == nil {
+		defaultPodMaxBackoffSeconds := int64(10)
+		obj.PodMaxBackoffSeconds = &defaultPodMaxBackoffSeconds
+	}
 }

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
@@ -170,6 +170,8 @@ func autoConvert_v1alpha1_KubeSchedulerConfiguration_To_config_KubeSchedulerConf
 	out.DisablePreemption = in.DisablePreemption
 	out.PercentageOfNodesToScore = in.PercentageOfNodesToScore
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
+	out.PodInitialBackoffSeconds = (*int64)(unsafe.Pointer(in.PodInitialBackoffSeconds))
+	out.PodMaxBackoffSeconds = (*int64)(unsafe.Pointer(in.PodMaxBackoffSeconds))
 	out.Plugins = (*config.Plugins)(unsafe.Pointer(in.Plugins))
 	out.PluginConfig = *(*[]config.PluginConfig)(unsafe.Pointer(&in.PluginConfig))
 	return nil
@@ -200,6 +202,8 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1alpha1_KubeSchedulerConf
 	out.DisablePreemption = in.DisablePreemption
 	out.PercentageOfNodesToScore = in.PercentageOfNodesToScore
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
+	out.PodInitialBackoffSeconds = (*int64)(unsafe.Pointer(in.PodInitialBackoffSeconds))
+	out.PodMaxBackoffSeconds = (*int64)(unsafe.Pointer(in.PodMaxBackoffSeconds))
 	out.Plugins = (*v1alpha1.Plugins)(unsafe.Pointer(in.Plugins))
 	out.PluginConfig = *(*[]v1alpha1.PluginConfig)(unsafe.Pointer(&in.PluginConfig))
 	return nil

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -47,6 +47,18 @@ func ValidateKubeSchedulerConfiguration(cc *config.KubeSchedulerConfiguration) f
 		allErrs = append(allErrs, field.Invalid(field.NewPath("percentageOfNodesToScore"),
 			cc.PercentageOfNodesToScore, "not in valid range 0-100"))
 	}
+	if cc.PodInitialBackoffSeconds == nil {
+		allErrs = append(allErrs, field.Required(field.NewPath("podInitialBackoffSeconds"), ""))
+	} else if *cc.PodInitialBackoffSeconds <= 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("podInitialBackoffSeconds"),
+			cc.PodInitialBackoffSeconds, "must be greater than 0"))
+	}
+	if cc.PodMaxBackoffSeconds == nil {
+		allErrs = append(allErrs, field.Required(field.NewPath("podMaxBackoffSeconds"), ""))
+	} else if cc.PodInitialBackoffSeconds != nil && *cc.PodMaxBackoffSeconds < *cc.PodInitialBackoffSeconds {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("podMaxBackoffSeconds"),
+			cc.PodMaxBackoffSeconds, "must be greater than or equal to PodInitialBackoffSeconds"))
+	}
 	return allErrs
 }
 

--- a/pkg/scheduler/apis/config/validation/validation_test.go
+++ b/pkg/scheduler/apis/config/validation/validation_test.go
@@ -27,6 +27,8 @@ import (
 
 func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 	testTimeout := int64(0)
+	podInitialBackoffSeconds := int64(1)
+	podMaxBackoffSeconds := int64(1)
 	validConfig := &config.KubeSchedulerConfiguration{
 		SchedulerName:                  "me",
 		HealthzBindAddress:             "0.0.0.0:10254",
@@ -57,6 +59,8 @@ func TestValidateKubeSchedulerConfiguration(t *testing.T) {
 				ResourceName:      "name",
 			},
 		},
+		PodInitialBackoffSeconds: &podInitialBackoffSeconds,
+		PodMaxBackoffSeconds:     &podMaxBackoffSeconds,
 		BindTimeoutSeconds:       &testTimeout,
 		PercentageOfNodesToScore: 35,
 	}

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -37,6 +37,16 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodInitialBackoffSeconds != nil {
+		in, out := &in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds
+		*out = new(int64)
+		**out = **in
+	}
+	if in.PodMaxBackoffSeconds != nil {
+		in, out := &in.PodMaxBackoffSeconds, &out.PodMaxBackoffSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = new(Plugins)

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -52,8 +52,10 @@ import (
 )
 
 const (
-	disablePodPreemption = false
-	bindTimeoutSeconds   = 600
+	disablePodPreemption             = false
+	bindTimeoutSeconds               = 600
+	podInitialBackoffDurationSeconds = 1
+	podMaxBackoffDurationSeconds     = 10
 )
 
 func TestCreate(t *testing.T) {
@@ -254,7 +256,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 	defer close(stopCh)
 
 	timestamp := time.Now()
-	queue := internalqueue.NewPriorityQueueWithClock(nil, clock.NewFakeClock(timestamp), nil)
+	queue := internalqueue.NewPriorityQueue(nil, nil, internalqueue.WithClock(clock.NewFakeClock(timestamp)))
 	schedulerCache := internalcache.New(30*time.Second, stopCh)
 	errFunc := MakeDefaultErrorFunc(client, queue, schedulerCache, stopCh)
 
@@ -494,6 +496,8 @@ func newConfigFactoryWithFrameworkRegistry(
 		disablePodPreemption,
 		schedulerapi.DefaultPercentageOfNodesToScore,
 		bindTimeoutSeconds,
+		podMaxBackoffDurationSeconds,
+		podInitialBackoffDurationSeconds,
 		stopCh,
 		registry,
 		nil,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -122,6 +122,8 @@ type schedulerOptions struct {
 	disablePreemption               bool
 	percentageOfNodesToScore        int32
 	bindTimeoutSeconds              int64
+	podInitialBackoffSeconds        int64
+	podMaxBackoffSeconds            int64
 	frameworkRegistry               framework.Registry
 	frameworkConfigProducerRegistry *frameworkplugins.ConfigProducerRegistry
 	frameworkPlugins                *kubeschedulerconfig.Plugins
@@ -194,12 +196,28 @@ func WithFrameworkPluginConfig(pluginConfig []kubeschedulerconfig.PluginConfig) 
 	}
 }
 
+// WithPodInitialBackoffSeconds sets podInitialBackoffSeconds for Scheduler, the default value is 1
+func WithPodInitialBackoffSeconds(podInitialBackoffSeconds int64) Option {
+	return func(o *schedulerOptions) {
+		o.podInitialBackoffSeconds = podInitialBackoffSeconds
+	}
+}
+
+// WithPodMaxBackoffSeconds sets podMaxBackoffSeconds for Scheduler, the default value is 10
+func WithPodMaxBackoffSeconds(podMaxBackoffSeconds int64) Option {
+	return func(o *schedulerOptions) {
+		o.podMaxBackoffSeconds = podMaxBackoffSeconds
+	}
+}
+
 var defaultSchedulerOptions = schedulerOptions{
 	schedulerName:                   v1.DefaultSchedulerName,
 	hardPodAffinitySymmetricWeight:  v1.DefaultHardPodAffinitySymmetricWeight,
 	disablePreemption:               false,
 	percentageOfNodesToScore:        schedulerapi.DefaultPercentageOfNodesToScore,
 	bindTimeoutSeconds:              BindTimeoutSeconds,
+	podInitialBackoffSeconds:        int64(internalqueue.DefaultPodInitialBackoffDuration.Seconds()),
+	podMaxBackoffSeconds:            int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
 	frameworkRegistry:               frameworkplugins.NewDefaultRegistry(),
 	frameworkConfigProducerRegistry: frameworkplugins.NewDefaultConfigProducerRegistry(),
 	// The plugins and pluginConfig options are currently nil because we currently don't have
@@ -253,6 +271,8 @@ func New(client clientset.Interface,
 		DisablePreemption:              options.disablePreemption,
 		PercentageOfNodesToScore:       options.percentageOfNodesToScore,
 		BindTimeoutSeconds:             options.bindTimeoutSeconds,
+		PodInitialBackoffSeconds:       options.podInitialBackoffSeconds,
+		PodMaxBackoffSeconds:           options.podMaxBackoffSeconds,
 		Registry:                       options.frameworkRegistry,
 		PluginConfigProducerRegistry:   options.frameworkConfigProducerRegistry,
 		Plugins:                        options.frameworkPlugins,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -197,6 +197,8 @@ func TestSchedulerCreation(t *testing.T) {
 		eventBroadcaster.NewRecorder(scheme.Scheme, "scheduler"),
 		kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &testSource},
 		stopCh,
+		WithPodInitialBackoffSeconds(1),
+		WithPodMaxBackoffSeconds(10),
 	)
 
 	if err != nil {

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -84,6 +84,16 @@ type KubeSchedulerConfiguration struct {
 	// If this value is nil, the default value will be used.
 	BindTimeoutSeconds *int64 `json:"bindTimeoutSeconds"`
 
+	// PodInitialBackoffSeconds is the initial backoff for unschedulable pods.
+	// If specified, it must be greater than 0. If this value is null, the default value (1s)
+	// will be used.
+	PodInitialBackoffSeconds *int64 `json:"podInitialBackoffSeconds"`
+
+	// PodMaxBackoffSeconds is the max backoff for unschedulable pods.
+	// If specified, it must be greater than podInitialBackoffSeconds. If this value is null,
+	// the default value (10s) will be used.
+	PodMaxBackoffSeconds *int64 `json:"podMaxBackoffSeconds"`
+
 	// Plugins specify the set of plugins that should be enabled or disabled. Enabled plugins are the
 	// ones that should be enabled in addition to the default plugins. Disabled plugins are any of the
 	// default plugins that should be disabled.

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/zz_generated.deepcopy.go
@@ -37,6 +37,16 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		*out = new(int64)
 		**out = **in
 	}
+	if in.PodInitialBackoffSeconds != nil {
+		in, out := &in.PodInitialBackoffSeconds, &out.PodInitialBackoffSeconds
+		*out = new(int64)
+		**out = **in
+	}
+	if in.PodMaxBackoffSeconds != nil {
+		in, out := &in.PodMaxBackoffSeconds, &out.PodMaxBackoffSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = new(Plugins)


### PR DESCRIPTION
/kind feature
/sig scheduling
/assign @bsalamat @NickrenREN 

**What this PR does / why we need it**:

Use priorityQueueOptions to refactor the priority queue which could make it easier to do configuration.

> Add pod max backoff duration to the scheduler API would cause an API review, we could do this in a follow-up PR if the implementation here makes sense.


**Which issue(s) this PR fixes**:

ref: https://github.com/kubernetes/kubernetes/issues/81214

**Does this PR introduce a user-facing change?**:

```release-note
Add "podInitialBackoffDurationSeconds" and "podMaxBackoffDurationSeconds" to the scheduler config API
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
