### PR TITLE
Replace self defined const StatusTooManyRequests with http.StatusTooM…

### DIFF
--- a/plugin/pkg/admission/eventratelimit/admission_test.go
+++ b/plugin/pkg/admission/eventratelimit/admission_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package eventratelimit
 
 import (
+	"net/http"
 	"testing"
 	"time"
 
@@ -516,7 +517,7 @@ func TestEventRateLimiting(t *testing.T) {
 				}
 				if err != nil {
 					statusErr, ok := err.(*errors.StatusError)
-					if ok && statusErr.ErrStatus.Code != errors.StatusTooManyRequests {
+					if ok && statusErr.ErrStatus.Code != http.StatusTooManyRequests {
 						t.Fatalf("%v: Request %v should yield a 429 response: %v", tc.name, rqIndex, err)
 					}
 				}

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -30,11 +30,11 @@ import (
 )
 
 const (
-	// DEPRECATED: please use http.StatusTooManyRequests, this will be removed in
-	// the future version.
 	// StatusTooManyRequests means the server experienced too many requests within a
 	// given window and that the client must wait to perform the action again.
-	StatusTooManyRequests = 429
+	// DEPRECATED: please use http.StatusTooManyRequests, this will be removed in
+	// the future version.
+	StatusTooManyRequests = http.StatusTooManyRequests
 )
 
 // StatusError is an error intended for consumption by a REST API server; it can also be

--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -30,6 +30,8 @@ import (
 )
 
 const (
+	// DEPRECATED: please use http.StatusTooManyRequests, this will be removed in
+	// the future version.
 	// StatusTooManyRequests means the server experienced too many requests within a
 	// given window and that the client must wait to perform the action again.
 	StatusTooManyRequests = 429
@@ -349,7 +351,7 @@ func NewTimeoutError(message string, retryAfterSeconds int) *StatusError {
 func NewTooManyRequestsError(message string) *StatusError {
 	return &StatusError{metav1.Status{
 		Status:  metav1.StatusFailure,
-		Code:    StatusTooManyRequests,
+		Code:    http.StatusTooManyRequests,
 		Reason:  metav1.StatusReasonTooManyRequests,
 		Message: fmt.Sprintf("Too many requests: %s", message),
 	}}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Replace the self defined const `StatusTooManyRequests` with `http.StatusTooManyRequests` to make status code more consistent.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
