### PR TITLE
Differentiate error message for PDB violation

### DIFF
--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -203,8 +203,9 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 		// budgets, we can sometimes compute a sensible suggested value.  But
 		// even without that, we can give a suggestion (10 minutes?) that
 		// prevents well-behaved clients from hammering us.
-		err := errors.NewTooManyRequests("Cannot evict pod as it would violate the pod's disruption budget.", 0)
-		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{Type: "DisruptionBudget", Message: fmt.Sprintf("The disruption budget %s is still being processed by the server.", pdb.Name)})
+		msg := fmt.Sprintf("The disruption budget %s is still being processed by the server.", pdb.Name)
+		err := errors.NewTooManyRequests("Cannot evict pod as it would violate the pod's disruption budget. "+msg, 0)
+		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{Type: "DisruptionBudget", Message: msg})
 		return err
 	}
 	if pdb.Status.PodDisruptionsAllowed < 0 {
@@ -214,8 +215,9 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 		return errors.NewForbidden(policy.Resource("poddisruptionbudget"), pdb.Name, fmt.Errorf("DisruptedPods map too big - too many evictions not confirmed by PDB controller"))
 	}
 	if pdb.Status.PodDisruptionsAllowed == 0 {
-		err := errors.NewTooManyRequests("Cannot evict pod as it would violate the pod's disruption budget.", 0)
-		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{Type: "DisruptionBudget", Message: fmt.Sprintf("The disruption budget %s needs %d healthy pods and has %d currently", pdb.Name, pdb.Status.DesiredHealthy, pdb.Status.CurrentHealthy)})
+		msg := fmt.Sprintf("The disruption budget %s needs %d healthy pods and has %d currently", pdb.Name, pdb.Status.DesiredHealthy, pdb.Status.CurrentHealthy)
+		err := errors.NewTooManyRequests("Cannot evict pod as it would violate the pod's disruption budget. "+msg, 0)
+		err.ErrStatus.Details.Causes = append(err.ErrStatus.Details.Causes, metav1.StatusCause{Type: "DisruptionBudget", Message: msg})
 		return err
 	}
 

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -177,7 +177,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 
 			if c.shouldDeny {
 				err = cs.CoreV1().Pods(ns).Evict(e)
-				gomega.Expect(err).Should(gomega.MatchError("Cannot evict pod as it would violate the pod's disruption budget."))
+				gomega.Expect(err).Should(gomega.HavePrefix("Cannot evict pod as it would violate the pod's disruption budget."))
 			} else {
 				// Only wait for running pods in the "allow" case
 				// because one of shouldDeny cases relies on the
@@ -215,7 +215,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 			},
 		}
 		err = cs.CoreV1().Pods(ns).Evict(e)
-		gomega.Expect(err).Should(gomega.MatchError("Cannot evict pod as it would violate the pod's disruption budget."))
+		gomega.Expect(err).Should(gomega.HavePrefix("Cannot evict pod as it would violate the pod's disruption budget."))
 
 		ginkgo.By("Updating the pdb to allow a pod to be evicted")
 		updatePDBMinAvailableOrDie(cs, ns, intstr.FromInt(2))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As #72320 showed:
```
error when evicting pod "postgresql-2" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
```
There are two conditions in EvictionREST#checkAndDecrement which would lead to the above message.

This PR differentiates the error message so that more detail is given.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
