### PR TITLE
Use correct value getter for ResourceCPU

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -72,7 +72,7 @@ func (n *NodeMetricsSorter) Less(i, j int) bool {
 	case "cpu":
 		qi := n.usages[i][v1.ResourceCPU]
 		qj := n.usages[j][v1.ResourceCPU]
-		return qi.Value() > qj.Value()
+		return qi.MilliValue() > qj.MilliValue()
 	case "memory":
 		qi := n.usages[i][v1.ResourceMemory]
 		qj := n.usages[j][v1.ResourceMemory]
@@ -119,7 +119,7 @@ func (p *PodMetricsSorter) Less(i, j int) bool {
 	case "cpu":
 		qi := p.podMetrics[i][v1.ResourceCPU]
 		qj := p.podMetrics[j][v1.ResourceCPU]
-		return qi.Value() > qj.Value()
+		return qi.MilliValue() > qj.MilliValue()
 	case "memory":
 		qi := p.podMetrics[i][v1.ResourceMemory]
 		qj := p.podMetrics[j][v1.ResourceMemory]


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As stated in #81270, the --sort-by=cpu option doesn't work for top node / top pod.

This was due to wrong value getter being used.

This PR fixes the bug by using correct value getter.

**Which issue(s) this PR fixes**:
Fixes #81270

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
