### PR TITLE
[WIP] Improve clarity/asks in PR template and request additional metadata

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,6 +16,11 @@ The following are additional useful links for PRs:
 
   Marking Unfinished PRs for Review or as a Work in Progress (WIP)
   https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+
+Has consideration been given to a test plan related to this PR? If appropriate, were tests added/modified to cover this PR? You can find more information in:
+
+  Testing Guide
+  https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
 -->
 
 **Which is the sponsoring or primary SIG associated with this PR?**
@@ -27,45 +32,28 @@ https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md#labels
 
 Add only ONE sig here via a /sig-primary <name> entry.
 -->
-/sig-primary ???
-
-> DISCUSSION REQUIRED
->
-> Should we use the above pattern and update the label prow plugin ? https://github.com/kubernetes/test-infra/tree/master/prow/plugins/label. Logic would have to ensure that there is only a single primary sig associated. This metadata can be leveraged by other processes outside of the release notes.
-> 
-> or, if this is ONLY relevant to release notes then, we can add here as a `` ```primary-sig`` code block.
+/sig-primary
 
 **What type of PR is this?**
-<!-- 
+<!--
 Label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. 
 
 For reference on required PR labels, you can find more details at:
 https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
 
-Add only ONE of the following /kind <type> entries.
-
-/kind api-change
-/kind bug
-/kind cleanup
-/kind design
-/kind documentation
-/kind failing-test
-/kind feature
-/kind flake
+Uncomment at least one of the following /kind entries that are relevant to this PR. You can do this by removing the strikethrough characters `~~` wrapping the entries you want associated with this PR.
 -->
-/kind ???
-
-> DISCUSSION REQUIRED
->
-> Should we include a kind type of `deprecation`? And should we then include a `` ```depracation-notes`` code block to provide specific detailed notes around the depracation.
-> 
-> Should we only allow a single kind to be specified? There are a number of examples where multiple kind values make sense.
+~~/kind api-change~~
+~~/kind bug~~
+~~/kind cleanup~~
+~~/kind design~~
+~~/kind documentation~~
+~~/kind failing-test~~
+~~/kind feature~~
+~~/kind flake~~
 
 **What this PR does / why we need it**:
-<!--
-Provide a description on what this PR does and/or why it is required.
--->
-Description here ...
+
 
 **Which issue(s) this PR fixes**:
 <!--
@@ -78,32 +66,16 @@ NOTE: The linked issue will automatically be closed when the PR is merged.
 
 If the PR is about failing-tests or flakes, please post the related issues/tests in a comment and do not use the Fixes templates above.
 -->
-Fixes #???
-
-**Have you added or run tests for your PR?**
-<!--
-Indicate whether you have added or run the appropriate tests for your PR by using ONE of the following responses:
-
-N/A
-Yes
-No
-
-More details can be found in the Testing Guide:
-https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
--->
-No
+Fixes #
 
 **Special notes for your reviewer**:
-<!--
-Provide any additional notes that may be helpful to the PR reviewers.
--->
-None
+
 
 **What user facing changes are introduced by this PR?**:
 <!--
 Indicate whether there are any user facing changes that should be added to the Release Notes. 
 
-If there are no user facing changes, leave the "None" text in the release-note block below. If your PR does introduce user facing changes, then a release note is required. Add your extended release note in the release-note block below.
+If there are no user facing changes, write "None" text in the release-note block below. If your PR does introduce user facing changes, then a release note is required and should be added in the release-note block below.
 
 If the PR requires additional action from users switching to the new release, start the release-notes block with the text "Action required".
 
@@ -111,6 +83,16 @@ Familiarise yourself with the instructions for writing a release note:
 https://git.k8s.io/community/contributors/guide/release-notes.md
 -->
 ```release-note
+
+```
+
+**Should this PR be associated with a deprecation notice?**
+<!--
+Indicate whether this PR implements a change that requires users to be informed of a deprecation of behaviour.
+
+If your PR does require a deprecation note, then remove the `None` from the deprecation-note block below and add your notes.
+-->
+```deprecation-note
 None
 ```
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,64 +1,131 @@
-<!--  Thanks for sending a pull request!  Here are some tips for you:
+<!--  
+Thanks for submitting a pull request!
 
-1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
-2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
-https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
-3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
-4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
+If this is your first time submitting a PR, please familiarise yourself with:
+
+  Contributor Guidelines 
+  https://git.k8s.io/community/contributors/guide#your-first-contribution
+
+  Developer Guide 
+  https://git.k8s.io/community/contributors/devel/development.md#development-guide
+
+The following are additional useful links for PRs:
+
+  Best Practices for Faster Reviews 
+  https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
+
+  Marking Unfinished PRs for Review or as a Work in Progress (WIP)
+  https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
 -->
 
-**What type of PR is this?**
-> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
+**Which is the sponsoring or primary SIG associated with this PR?**
+<!--
+Label the sponsoring or primary SIG associated with this PR.
+
+For reference on available SIGs, you can find more details at:
+https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md#labels-that-apply-to-all-repos-for-both-issues-and-prs
+
+Add only ONE sig here via a /sig-primary <name> entry.
+-->
+/sig-primary ???
+
+> DISCUSSION REQUIRED
 >
-> /kind api-change
-> /kind bug
-> /kind cleanup
-> /kind design
-> /kind documentation
-> /kind failing-test
-> /kind feature
-> /kind flake
+> Should we use the above pattern and update the label prow plugin ? https://github.com/kubernetes/test-infra/tree/master/prow/plugins/label. Logic would have to ensure that there is only a single primary sig associated. This metadata can be leveraged by other processes outside of the release notes.
+> 
+> or, if this is ONLY relevant to release notes then, we can add here as a `` ```primary-sig`` code block.
+
+**What type of PR is this?**
+<!-- 
+Label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. 
+
+For reference on required PR labels, you can find more details at:
+https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
+
+Add only ONE of the following /kind <type> entries.
+
+/kind api-change
+/kind bug
+/kind cleanup
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+-->
+/kind ???
+
+> DISCUSSION REQUIRED
+>
+> Should we include a kind type of `deprecation`? And should we then include a `` ```depracation-notes`` code block to provide specific detailed notes around the depracation.
+> 
+> Should we only allow a single kind to be specified? There are a number of examples where multiple kind values make sense.
 
 **What this PR does / why we need it**:
+<!--
+Provide a description on what this PR does and/or why it is required.
+-->
+Description here ...
 
 **Which issue(s) this PR fixes**:
 <!--
-*Automatically closes linked issue when PR is merged.
-Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
+Add references to issues that are fixed by this PR by using one or more of the following templates:
+
+Fixes #<issue number>
+Fixes <issue url>
+
+NOTE: The linked issue will automatically be closed when the PR is merged.
+
+If the PR is about failing-tests or flakes, please post the related issues/tests in a comment and do not use the Fixes templates above.
 -->
-Fixes #
+Fixes #???
+
+**Have you added or run tests for your PR?**
+<!--
+Indicate whether you have added or run the appropriate tests for your PR by using ONE of the following responses:
+
+N/A
+Yes
+No
+
+More details can be found in the Testing Guide:
+https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
+-->
+No
 
 **Special notes for your reviewer**:
-
-**Does this PR introduce a user-facing change?**:
 <!--
-If no, just write "NONE" in the release-note block below.
-If yes, a release note is required:
-Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
+Provide any additional notes that may be helpful to the PR reviewers.
+-->
+None
+
+**What user facing changes are introduced by this PR?**:
+<!--
+Indicate whether there are any user facing changes that should be added to the Release Notes. 
+
+If there are no user facing changes, leave the "None" text in the release-note block below. If your PR does introduce user facing changes, then a release note is required. Add your extended release note in the release-note block below.
+
+If the PR requires additional action from users switching to the new release, start the release-notes block with the text "Action required".
+
+Familiarise yourself with the instructions for writing a release note: 
+https://git.k8s.io/community/contributors/guide/release-notes.md
 -->
 ```release-note
-
+None
 ```
 
 **Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
-
 <!--
-This section can be blank if this pull request does not require a release note.
+Provide links to any additional relevant documentation in the docs block below ONLY if you have added a release note, otherwise leave it blank.
 
-When adding links which point to resources within git repositories, like
-KEPs or supporting documentation, please reference a specific commit and avoid
-linking directly to the master branch. This ensures that links reference a
-specific point in time, rather than a document that may change over time.
+The Kubernetes Release Notes website (https://relnotes.k8s.io) provides additional documentation to the end users about the changes in this PR.
 
-See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files
+If you decide to add links which point to resources within git repositories, please ensure that the appropriate revision is included in the link and not generic ones like `master`. The same applies to external documentation, which may be not available any more because it got updated to a more recent version.
 
-Please use the following format for linking documentation:
-- [KEP]: <link>
-- [Usage]: <link>
-- [Other doc]: <link>
+Use one or more of the following templates in the docs block for linking to documentation:
+- [KEP]: <url>
+- [Usage]: <url>
+- [Other doc]: <url>
 -->
 ```docs
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -102,7 +102,9 @@ Provide links to any additional relevant documentation in the docs block below O
 
 The Kubernetes Release Notes website (https://relnotes.k8s.io) provides additional documentation to the end users about the changes in this PR.
 
-If you decide to add links which point to resources within git repositories, please ensure that the appropriate revision is included in the link and not generic ones like `master`. The same applies to external documentation, which may be not available any more because it got updated to a more recent version.
+If you decide to add links which point to resources within git repositories, please ensure that the appropriate revision is included in the link and not generic ones like `master`. This ensures that links reference a specific point in time, rather than a document that may change over time. The same applies to external documentation, which may be not available any more because it got updated to a more recent version.
+
+See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files
 
 Use one or more of the following templates in the docs block for linking to documentation:
 - [KEP]: <url>


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR attempts the following:
- Improve clarity/asks in PR template and provide guidance/examples/defaults
- Add requests for **primary sig** and **deprecation** information requested in Issue [kubernetes/sig-release#668](https://github.com/kubernetes/sig-release/issues/668)

**Which issue(s) this PR fixes**:

Refers to Issue [kubernetes/sig-release#668](https://github.com/kubernetes/sig-release/issues/668)
References PR [kubernetes/kubernetes#81159](https://github.com/kubernetes/kubernetes/pull/81159)

**Special notes for your reviewer**:

This requires further discussion. There are sections in the `PULL_REQUEST_TEMPLATE.md` file marked asking for a discussion.

@saschagrunert @jeefy - I have taken the changes in [kubernetes/kubernetes#81159](https://github.com/kubernetes/kubernetes/pull/81159), reworked text based on @jeefy's comments, and rolled into the changes here.

This PR Template will require associated changes in the [prow label plugin](https://github.com/kubernetes/test-infra/tree/master/prow/plugins/label) and [release notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) depending on the outcome of the discussion.

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
/cc @saschagrunert  @onyiny-ang @justaugustus @jeefy @guineveresaenger @mrbobbytables 
/sig contributor-experience
/sig release
