### PR TITLE
publishing: add rules for 1.16 and remove for 1.12

### DIFF
--- a/staging/publishing/rules-godeps.yaml
+++ b/staging/publishing/rules-godeps.yaml
@@ -8,11 +8,6 @@ rules:
 - destination: code-generator
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.12
-    go: 1.10.8
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/code-generator
     name: release-1.13
@@ -26,11 +21,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.12
-    go: 1.10.8
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/apimachinery
     name: release-1.13
@@ -43,14 +33,6 @@ rules:
 - destination: api
   library: true
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/api
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/api
@@ -70,16 +52,6 @@ rules:
 - destination: client-go
   library: true
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/client-go
-    name: release-9.0
-    go: 1.10.2
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/client-go
@@ -119,18 +91,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/apiserver
     name: release-1.13
@@ -158,20 +118,6 @@ rules:
         branch: release-1.14
 - destination: kube-aggregator
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiserver
-      branch: release-1.12
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-aggregator
@@ -204,24 +150,6 @@ rules:
         branch: release-1.14
 - destination: sample-apiserver
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiserver
-      branch: release-1.12
-    - repository: code-generator
-      branch: release-1.12
-    required-packages:
-    - k8s.io/code-generator
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/sample-apiserver
@@ -271,22 +199,6 @@ rules:
 - destination: sample-controller
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: code-generator
-      branch: release-1.12
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/sample-controller
     name: release-1.13
@@ -332,24 +244,6 @@ rules:
 - destination: apiextensions-apiserver
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiserver
-      branch: release-1.12
-    - repository: code-generator
-      branch: release-1.12
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.13
@@ -391,18 +285,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/metrics
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/metrics
     name: release-1.13
@@ -429,20 +311,6 @@ rules:
 - destination: csi-api
   library: true
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/csi-api
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-    - repository: apiextensions-apiserver
-      branch: release-1.12
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/csi-api
@@ -475,18 +343,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: api
-      branch: release-1.12
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.13
@@ -513,20 +369,6 @@ rules:
 - destination: sample-cli-plugin
   library: false
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: api
-      branch: release-1.12
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: cli-runtime
-      branch: release-1.12
-    - repository: client-go
-      branch: release-9.0
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/sample-cli-plugin
@@ -561,14 +403,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.13
@@ -589,16 +423,6 @@ rules:
 - destination: kubelet
   library: true
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: api
-      branch: release-1.12
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/kubelet
@@ -625,16 +449,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: apiserver
-      branch: release-1.12
-  - source:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.13
@@ -659,16 +473,6 @@ rules:
 - destination: kube-controller-manager
   library: true
   branches:
-  - source:
-      branch: release-1.12
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.12
-    go: 1.10.8
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.12
-    - repository: apiserver
-      branch: release-1.12
   - source:
       branch: release-1.13
       dir: staging/src/k8s.io/kube-controller-manager

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -16,6 +16,11 @@ rules:
       dir: staging/src/k8s.io/code-generator
     name: release-1.15
     go: 1.12.5
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.16
+    go: 1.12.7
 - destination: apimachinery
   library: true
   branches:
@@ -28,6 +33,11 @@ rules:
       dir: staging/src/k8s.io/apimachinery
     name: release-1.15
     go: 1.12.5
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.16
+    go: 1.12.7
 - destination: api
   library: true
   branches:
@@ -46,6 +56,14 @@ rules:
     dependencies:
       - repository: apimachinery
         branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/api
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.16
 - destination: client-go
   library: true
   branches:
@@ -68,6 +86,16 @@ rules:
         branch: release-1.15
       - repository: api
         branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/client-go
+    name: release-13.0
+    go: 1.12.7
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.16
+      - repository: api
+        branch: release-1.16
   smoke-test: |
     # assumes GO111MODULE=on
     go build ./...
@@ -90,6 +118,14 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/component-base
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
 - destination: apiserver
   library: true
   branches:
@@ -120,6 +156,20 @@ rules:
       branch: release-12.0
     - repository: component-base
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: component-base
+      branch: release-1.16
 - destination: kube-aggregator
   branches:
   - source:
@@ -157,6 +207,24 @@ rules:
       branch: release-1.15
     - repository: code-generator
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: apiserver
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
+    - repository: code-generator
+      branch: release-1.16
 - destination: sample-apiserver
   branches:
   - source:
@@ -198,6 +266,26 @@ rules:
       branch: release-1.15
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: apiserver
+      branch: release-1.16
+    - repository: code-generator
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
+    required-packages:
+    - k8s.io/code-generator
   smoke-test: |
     # assumes GO111MODULE=on
     go build .
@@ -232,6 +320,22 @@ rules:
       branch: release-12.0
     - repository: code-generator
       branch: release-1.15
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: code-generator
+      branch: release-1.16
     required-packages:
     - k8s.io/code-generator
   smoke-test: |
@@ -278,6 +382,26 @@ rules:
       branch: release-1.15
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: apiserver
+      branch: release-1.16
+    - repository: code-generator
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
   library: true
   branches:
@@ -308,6 +432,20 @@ rules:
       branch: release-12.0
     - repository: code-generator
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/metrics
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: code-generator
+      branch: release-1.16
 - destination: cli-runtime
   library: true
   branches:
@@ -334,6 +472,18 @@ rules:
       branch: release-1.15
     - repository: client-go
       branch: release-12.0
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: api
+      branch: release-1.16
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
 - destination: sample-cli-plugin
   library: false
   branches:
@@ -364,6 +514,20 @@ rules:
       branch: release-1.15
     - repository: client-go
       branch: release-12.0
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: api
+      branch: release-1.16
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: cli-runtime
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
 - destination: kube-proxy
   library: true
   branches:
@@ -386,6 +550,16 @@ rules:
       branch: release-1.15
     - repository: component-base
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
 - destination: kubelet
   library: true
   branches:
@@ -408,6 +582,16 @@ rules:
       branch: release-1.15
     - repository: api
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
 - destination: kube-scheduler
   library: true
   branches:
@@ -430,6 +614,16 @@ rules:
       branch: release-1.15
     - repository: component-base
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
 - destination: kube-controller-manager
   library: true
   branches:
@@ -452,6 +646,16 @@ rules:
       branch: release-1.15
     - repository: component-base
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
 - destination: cluster-bootstrap
   library: true
   branches:
@@ -474,6 +678,16 @@ rules:
       branch: release-1.15
     - repository: api
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: api
+      branch: release-1.16
 - destination: cloud-provider
   library: true
   branches:
@@ -500,6 +714,18 @@ rules:
       branch: release-1.15
     - repository: client-go
       branch: release-12.0
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: api
+      branch: release-1.16
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
 - destination: csi-translation-lib
   library: true
   branches:
@@ -530,6 +756,20 @@ rules:
       branch: release-12.0
     - repository: cloud-provider
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: api
+      branch: release-1.16
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: cloud-provider
+      branch: release-1.16
 - destination: legacy-cloud-providers
   library: true
   branches:
@@ -568,6 +808,26 @@ rules:
       branch: release-1.15
     - repository: csi-translation-lib
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: api
+      branch: release-1.16
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: cloud-provider
+      branch: release-1.16
+    - repository: csi-translation-lib
+      branch: release-1.16
+    - repository: apiserver
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
 - destination: node-api
   library: true
   branches:
@@ -598,6 +858,20 @@ rules:
       branch: release-12.0
     - repository: code-generator
       branch: release-1.15
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/node-api
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: api
+      branch: release-1.16
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: code-generator
+      branch: release-1.16
 - destination: cri-api
   library: true
   branches:
@@ -610,6 +884,11 @@ rules:
       dir: staging/src/k8s.io/cri-api
     name: release-1.15
     go: 1.12.5
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.16
+    go: 1.12.7
 - destination: kubectl
   library: true
   branches:
@@ -637,3 +916,23 @@ rules:
       dir: staging/src/k8s.io/kubectl
     name: release-1.15
     go: 1.12.5
+  - source:
+      branch: release-1.16
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.16
+    go: 1.12.7
+    dependencies:
+    - repository: api
+      branch: release-1.16
+    - repository: apimachinery
+      branch: release-1.16
+    - repository: cli-runtime
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
+    - repository: code-generator
+      branch: release-1.16
+    - repository: component-base
+      branch: release-1.16
+    - repository: metrics
+      branch: release-1.16


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/81354

1.16 branches will be created and the 1.12 jobs will be removed tomorrow, so I figured it would be good to have this PR in place before that: https://github.com/kubernetes/sig-release/tree/master/releases/release-1.16#timeline.

This PR also removes rules for publishing patch releases for 1.12.

/hold
until the branch is created + it is confirmed that 1.12 rules can be removed

/assign @feiskyer 
patch release manager, for the 1.12 rules removal

/assign @idealhack 
branch manager lead, for the 1.16 rules additions

/cc @dims @sttts 
publishing-bot owners

fyi @kubernetes/patch-release-team 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
