### PR TITLE
Inline/simplify two used-only-once service test helper functions

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -879,34 +879,6 @@ func (j *TestJig) CheckServiceReachability(namespace string, svc *v1.Service, po
 	}
 }
 
-// LaunchNetexecPodOnNode launches a netexec pod on the given node.
-func (j *TestJig) LaunchNetexecPodOnNode(f *framework.Framework, nodeName, podName string, httpPort, udpPort int32, hostNetwork bool) {
-	e2elog.Logf("Creating netexec pod %q on node %v in namespace %q", podName, nodeName, f.Namespace.Name)
-	pod := newNetexecPodSpec(podName, httpPort, udpPort, hostNetwork)
-	pod.Spec.NodeName = nodeName
-	pod.ObjectMeta.Labels = j.Labels
-	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
-	_, err := podClient.Create(pod)
-	framework.ExpectNoError(err)
-	framework.ExpectNoError(f.WaitForPodRunning(podName))
-	e2elog.Logf("Netexec pod  %q in namespace %q running", pod.Name, f.Namespace.Name)
-}
-
-// LaunchEchoserverPodOnNode launches a pod serving http on port 8080 to act
-// as the target for source IP preservation test. The client's source ip would
-// be echoed back by the web server.
-func (j *TestJig) LaunchEchoserverPodOnNode(f *framework.Framework, nodeName, podName string) {
-	e2elog.Logf("Creating echo server pod %q in namespace %q", podName, f.Namespace.Name)
-	pod := newEchoServerPodSpec(podName)
-	pod.Spec.NodeName = nodeName
-	pod.ObjectMeta.Labels = j.Labels
-	podClient := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
-	_, err := podClient.Create(pod)
-	framework.ExpectNoError(err)
-	framework.ExpectNoError(f.WaitForPodRunning(podName))
-	e2elog.Logf("Echo server pod %q in namespace %q running", pod.Name, f.Namespace.Name)
-}
-
 // TestReachableHTTP tests that the given host serves HTTP on the given port.
 func (j *TestJig) TestReachableHTTP(host string, port int, timeout time.Duration) {
 	j.TestReachableHTTPWithRetriableErrorCodes(host, port, []int{}, timeout)

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -27,7 +27,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
-	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
 // GetServicesProxyRequest returns a request for a service proxy.
@@ -108,62 +107,6 @@ func DescribeSvc(ns string) {
 	desc, _ := framework.RunKubectl(
 		"describe", "svc", fmt.Sprintf("--namespace=%v", ns))
 	e2elog.Logf(desc)
-}
-
-// newNetexecPodSpec returns the pod spec of netexec pod
-func newNetexecPodSpec(podName string, httpPort, udpPort int32, hostNetwork bool) *v1.Pod {
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:  "netexec",
-					Image: framework.NetexecImageName,
-					Args: []string{
-						"netexec",
-						fmt.Sprintf("--http-port=%d", httpPort),
-						fmt.Sprintf("--udp-port=%d", udpPort),
-					},
-					Ports: []v1.ContainerPort{
-						{
-							Name:          "http",
-							ContainerPort: httpPort,
-						},
-						{
-							Name:          "udp",
-							ContainerPort: udpPort,
-						},
-					},
-				},
-			},
-			HostNetwork: hostNetwork,
-		},
-	}
-	return pod
-}
-
-// newEchoServerPodSpec returns the pod spec of echo server pod
-func newEchoServerPodSpec(podName string) *v1.Pod {
-	port := 8080
-	pod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: podName,
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:  "echoserver",
-					Image: imageutils.GetE2EImage(imageutils.Agnhost),
-					Args:  []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
-					Ports: []v1.ContainerPort{{ContainerPort: int32(port)}},
-				},
-			},
-			RestartPolicy: v1.RestartPolicyNever,
-		},
-	}
-	return pod
 }
 
 // GetServiceLoadBalancerCreationTimeout returns a timeout value for creating a load balancer of a service.


### PR DESCRIPTION
**What this PR does / why we need it**:
`e2eservice.TestJig` is full of crap. This gets rid of a little bit of it.

/kind cleanup
/priority important-longterm
/sig network

```release-note
NONE
```