### PR TITLE
Add credential-json parameter for gcp config

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
@@ -104,6 +104,10 @@ var (
 //       # golang reference time in the format that the expiration timestamp uses.
 //       # If omitted, defaults to time.RFC3339Nano
 //       "time-fmt": "2006-01-02 15:04:05.999999999"
+//
+//       # Raw JSON Options
+//       # If "credentials-json" is set, then the token source is constructed from those credentials.
+//       "credential-json": "{\"client_id\":\"my_client}"
 //     }
 //   }
 // }
@@ -153,6 +157,16 @@ func tokenSource(isCmd bool, gcpConfig map[string]string) (oauth2.TokenSource, e
 
 	// Google Application Credentials-based token source
 	scopes := parseScopes(gcpConfig)
+
+	credsJson := gcpConfig["credential-json"]
+	if len(credsJson) != 0 {
+		creds, err := google.CredentialsFromJSON(context.Background(), []byte(credsJson), scopes...)
+		if err != nil {
+			return nil, fmt.Errorf("cannot construct google credentials from json: %v", err)
+		}
+		return creds.TokenSource, nil
+	}
+
 	ts, err := google.DefaultTokenSource(context.Background(), scopes...)
 	if err != nil {
 		return nil, fmt.Errorf("cannot construct google default token source: %v", err)

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp_test.go
@@ -196,6 +196,26 @@ func Test_tokenSource_applicationDefaultCredentials(t *testing.T) {
 	}
 }
 
+func Test_tokenSource_jsonCredentials(t *testing.T) {
+	ts, err := tokenSource(false, map[string]string{
+		"credential-json": `{"type":"service_account"}`,
+	})
+	if err != nil {
+		t.Fatalf("failed to get a token source: %+v", err)
+	}
+	if ts == nil {
+		t.Fatal("returned nil token source")
+	}
+}
+
+func Test_tokenSource_jsonCredentials_fails(t *testing.T) {
+	if _, err := tokenSource(false, map[string]string{
+		"credential-json": `{"type":"service_account}`,
+	}); err == nil {
+		t.Fatalf("expected error because specified JSON is malformed")
+	}
+}
+
 func Test_parseScopes(t *testing.T) {
 	cases := []struct {
 		in  map[string]string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Adds the ability to pass Google OAuth Credentials JSON directly into the GCP Auth provider, rather than using the Default token creation, which reads credentials from a file.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Added `credential-json` field for GCP Auth provider.
```