### PR TITLE
use subtest for table units (pkg/scheduler/util)

### DIFF
--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -55,7 +56,9 @@ func TestGetPodPriority(t *testing.T) {
 	}
 	for _, test := range tests {
 		if GetPodPriority(test.pod) != test.expectedPriority {
-			t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
+			t.Run(test.name, func(t *testing.T) {
+				t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
+			})
 		}
 
 	}
@@ -89,10 +92,12 @@ func TestSortableList(t *testing.T) {
 		t.Errorf("expected length of list was 10, got: %v", len(podList.Items))
 	}
 	var prevPriority = int32(10)
-	for _, p := range podList.Items {
-		if *p.(*v1.Pod).Spec.Priority >= prevPriority {
-			t.Errorf("Pods are not soreted. Current pod pririty is %v, while previous one was %v.", *p.(*v1.Pod).Spec.Priority, prevPriority)
-		}
+	for i, p := range podList.Items {
+		t.Run(fmt.Sprintf("pod:%v", i), func(t *testing.T) {
+			if *p.(*v1.Pod).Spec.Priority >= prevPriority {
+				t.Errorf("Pods are not soreted. Current pod pririty is %v, while previous one was %v.", *p.(*v1.Pod).Spec.Priority, prevPriority)
+			}
+		})
 	}
 }
 
@@ -200,10 +205,12 @@ func TestGetContainerPorts(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		result := GetContainerPorts(test.pod1, test.pod2)
-		if !reflect.DeepEqual(test.expected, result) {
-			t.Errorf("Got different result than expected.\nDifference detected on:\n%s", diff.ObjectGoPrintSideBySide(test.expected, result))
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case:%v", i), func(t *testing.T) {
+			result := GetContainerPorts(test.pod1, test.pod2)
+			if !reflect.DeepEqual(test.expected, result) {
+				t.Errorf("Got different result than expected.\nDifference detected on:\n%s", diff.ObjectGoPrintSideBySide(test.expected, result))
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Update scheduler's unit table tests to use subtest

**Special notes for your reviewer**:
Breaks up PR: #63281
Original Issue: #63267
Original PR: #63710

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
