### PR TITLE
Error code incorrectly hidden in recordEvent

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -203,9 +203,9 @@ func recordEvent(sink EventSink, event *v1beta1.Event) (*v1beta1.Event, bool) {
 	var err error
 	isEventSeries := event.Series != nil
 	if isEventSeries {
-		patch, err := createPatchBytesForSeries(event)
-		if err != nil {
-			klog.Errorf("Unable to calculate diff, no merge is possible: %v", err)
+		patch, patchBytesErr := createPatchBytesForSeries(event)
+		if patchBytesErr != nil {
+			klog.Errorf("Unable to calculate diff, no merge is possible: %v", patchBytesErr)
 			return nil, false
 		}
 		newEvent, err = sink.Patch(event, patch)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In recordEvent, err is declared at the beginning of the func.

However, return value from createPatchBytesForSeries creates another error variable with same name.
The sink.Patch call stores into the second error variable which wouldn't be checked by later code.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
