### PR TITLE
use subtest for table units (pkg/scheduler/nodeinfo)

### DIFF
--- a/pkg/scheduler/nodeinfo/host_ports_test.go
+++ b/pkg/scheduler/nodeinfo/host_ports_test.go
@@ -27,13 +27,13 @@ type hostPortInfoParam struct {
 
 func TestHostPortInfo_AddRemove(t *testing.T) {
 	tests := []struct {
-		desc    string
+		name    string
 		added   []hostPortInfoParam
 		removed []hostPortInfoParam
 		length  int
 	}{
 		{
-			desc: "normal add case",
+			name: "normal add case",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -50,7 +50,7 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 			length: 8,
 		},
 		{
-			desc: "empty ip and protocol add should work",
+			name: "empty ip and protocol add should work",
 			added: []hostPortInfoParam{
 				{"", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -66,7 +66,7 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 			length: 8,
 		},
 		{
-			desc: "normal remove case",
+			name: "normal remove case",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -90,7 +90,7 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 			length: 0,
 		},
 		{
-			desc: "empty ip and protocol remove should work",
+			name: "empty ip and protocol remove should work",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -116,29 +116,31 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		hp := make(HostPortInfo)
-		for _, param := range test.added {
-			hp.Add(param.ip, param.protocol, param.port)
-		}
-		for _, param := range test.removed {
-			hp.Remove(param.ip, param.protocol, param.port)
-		}
-		if hp.Len() != test.length {
-			t.Errorf("%v failed: expect length %d; got %d", test.desc, test.length, hp.Len())
-			t.Error(hp)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			for _, param := range test.removed {
+				hp.Remove(param.ip, param.protocol, param.port)
+			}
+			if hp.Len() != test.length {
+				t.Errorf("%v failed: expect length %d; got %d", test.name, test.length, hp.Len())
+				t.Error(hp)
+			}
+		})
 	}
 }
 
 func TestHostPortInfo_Check(t *testing.T) {
 	tests := []struct {
-		desc   string
+		name   string
 		added  []hostPortInfoParam
 		check  hostPortInfoParam
 		expect bool
 	}{
 		{
-			desc: "empty check should check 0.0.0.0 and TCP",
+			name: "empty check should check 0.0.0.0 and TCP",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -146,7 +148,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "empty check should check 0.0.0.0 and TCP (conflicted)",
+			name: "empty check should check 0.0.0.0 and TCP (conflicted)",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -154,7 +156,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: true,
 		},
 		{
-			desc: "empty port check should pass",
+			name: "empty port check should pass",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -162,7 +164,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "0.0.0.0 should check all registered IPs",
+			name: "0.0.0.0 should check all registered IPs",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -170,7 +172,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: true,
 		},
 		{
-			desc: "0.0.0.0 with different protocol should be allowed",
+			name: "0.0.0.0 with different protocol should be allowed",
 			added: []hostPortInfoParam{
 				{"UDP", "127.0.0.1", 80},
 			},
@@ -178,7 +180,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "0.0.0.0 with different port should be allowed",
+			name: "0.0.0.0 with different port should be allowed",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"TCP", "127.0.0.1", 81},
@@ -188,7 +190,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "normal ip should check all registered 0.0.0.0",
+			name: "normal ip should check all registered 0.0.0.0",
 			added: []hostPortInfoParam{
 				{"TCP", "0.0.0.0", 80},
 			},
@@ -196,7 +198,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: true,
 		},
 		{
-			desc: "normal ip with different port/protocol should be allowed (0.0.0.0)",
+			name: "normal ip with different port/protocol should be allowed (0.0.0.0)",
 			added: []hostPortInfoParam{
 				{"TCP", "0.0.0.0", 79},
 				{"UDP", "0.0.0.0", 80},
@@ -207,7 +209,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "normal ip with different port/protocol should be allowed",
+			name: "normal ip with different port/protocol should be allowed",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -220,12 +222,14 @@ func TestHostPortInfo_Check(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		hp := make(HostPortInfo)
-		for _, param := range test.added {
-			hp.Add(param.ip, param.protocol, param.port)
-		}
-		if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
-			t.Errorf("%v failed, expected %t; got %t", test.desc, test.expect, !test.expect)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
+				t.Errorf("%v failed, expected %t; got %t", test.name, test.expect, !test.expect)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/nodeinfo/node_info_test.go
+++ b/pkg/scheduler/nodeinfo/node_info_test.go
@@ -33,14 +33,17 @@ import (
 
 func TestNewResource(t *testing.T) {
 	tests := []struct {
+		name         string
 		resourceList v1.ResourceList
 		expected     *Resource
 	}{
 		{
+			name:         "empty resource set",
 			resourceList: map[v1.ResourceName]resource.Quantity{},
 			expected:     &Resource{},
 		},
 		{
+			name: "has resources set",
 			resourceList: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:                      *resource.NewScaledQuantity(4, -3),
 				v1.ResourceMemory:                   *resource.NewQuantity(2000, resource.BinarySI),
@@ -59,8 +62,8 @@ func TestNewResource(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			r := NewResource(test.resourceList)
 			if !reflect.DeepEqual(test.expected, r) {
 				t.Errorf("expected: %#v, got: %#v", test.expected, r)
@@ -71,10 +74,12 @@ func TestNewResource(t *testing.T) {
 
 func TestResourceList(t *testing.T) {
 	tests := []struct {
+		name     string
 		resource *Resource
 		expected v1.ResourceList
 	}{
 		{
+			name:     "empty resource list",
 			resource: &Resource{},
 			expected: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:              *resource.NewScaledQuantity(0, -3),
@@ -84,6 +89,7 @@ func TestResourceList(t *testing.T) {
 			},
 		},
 		{
+			name: "has resource list set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -107,8 +113,8 @@ func TestResourceList(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			rl := test.resource.ResourceList()
 			if !reflect.DeepEqual(test.expected, rl) {
 				t.Errorf("expected: %#v, got: %#v", test.expected, rl)
@@ -119,14 +125,17 @@ func TestResourceList(t *testing.T) {
 
 func TestResourceClone(t *testing.T) {
 	tests := []struct {
+		name     string
 		resource *Resource
 		expected *Resource
 	}{
 		{
+			name:     "no resource to clone",
 			resource: &Resource{},
 			expected: &Resource{},
 		},
 		{
+			name: "has resource to clone",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -144,8 +153,8 @@ func TestResourceClone(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			r := test.resource.Clone()
 			// Modify the field to check if the result is a clone of the origin one.
 			test.resource.MilliCPU += 1000
@@ -158,12 +167,14 @@ func TestResourceClone(t *testing.T) {
 
 func TestResourceAddScalar(t *testing.T) {
 	tests := []struct {
+		name           string
 		resource       *Resource
 		scalarName     v1.ResourceName
 		scalarQuantity int64
 		expected       *Resource
 	}{
 		{
+			name:           "add scalar value to empty set",
 			resource:       &Resource{},
 			scalarName:     "scalar1",
 			scalarQuantity: 100,
@@ -172,6 +183,7 @@ func TestResourceAddScalar(t *testing.T) {
 			},
 		},
 		{
+			name: "add scalar value to existing set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -192,7 +204,7 @@ func TestResourceAddScalar(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run(fmt.Sprintf("scalarName: %s, scalarQuantity: %d", test.scalarName, test.scalarQuantity), func(t *testing.T) {
+		t.Run(test.name, func(t *testing.T) {
 			test.resource.AddScalar(test.scalarName, test.scalarQuantity)
 			if !reflect.DeepEqual(test.expected, test.resource) {
 				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
@@ -203,11 +215,13 @@ func TestResourceAddScalar(t *testing.T) {
 
 func TestSetMaxResource(t *testing.T) {
 	tests := []struct {
+		name         string
 		resource     *Resource
 		resourceList v1.ResourceList
 		expected     *Resource
 	}{
 		{
+			name:     "set max for empty resource",
 			resource: &Resource{},
 			resourceList: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:              *resource.NewScaledQuantity(4, -3),
@@ -221,6 +235,7 @@ func TestSetMaxResource(t *testing.T) {
 			},
 		},
 		{
+			name: "set max for non-empty resource",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           4000,
@@ -243,8 +258,8 @@ func TestSetMaxResource(t *testing.T) {
 		},
 	}
 
-	for i, test := range tests {
-		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
 			test.resource.SetMaxResource(test.resourceList)
 			if !reflect.DeepEqual(test.expected, test.resource) {
 				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)

--- a/pkg/scheduler/nodeinfo/util_test.go
+++ b/pkg/scheduler/nodeinfo/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfo
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -29,11 +30,13 @@ const mb int64 = 1024 * 1024
 
 func TestGetNodeImageStates(t *testing.T) {
 	tests := []struct {
+		name              string
 		node              *v1.Node
 		imageExistenceMap map[string]sets.String
 		expected          map[string]*ImageStateSummary
 	}{
 		{
+			name: "node-0",
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "node-0"},
 				Status: v1.NodeStatus{
@@ -71,10 +74,12 @@ func TestGetNodeImageStates(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		imageStates := getNodeImageStates(test.node, test.imageExistenceMap)
-		if !reflect.DeepEqual(test.expected, imageStates) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, imageStates)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			imageStates := getNodeImageStates(test.node, test.imageExistenceMap)
+			if !reflect.DeepEqual(test.expected, imageStates) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, imageStates)
+			}
+		})
 	}
 }
 
@@ -125,10 +130,12 @@ func TestCreateImageExistenceMap(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		imageMap := createImageExistenceMap(test.nodes)
-		if !reflect.DeepEqual(test.expected, imageMap) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, imageMap)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case:%d", i), func(t *testing.T) {
+			imageMap := createImageExistenceMap(test.nodes)
+			if !reflect.DeepEqual(test.expected, imageMap) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, imageMap)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Update scheduler's unit table tests to use subtest

**Special notes for your reviewer**:
Breaks up PR: #63281
Original Issue: #63267

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
