### PR TITLE
Ephemeral Volume check should include secret volume type

### DIFF
--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -544,7 +544,7 @@ func GetPluginMountDir(host volume.VolumeHost, name string) string {
 // IsLocalEphemeralVolume determines whether the argument is a local ephemeral
 // volume vs. some other type
 func IsLocalEphemeralVolume(volume v1.Volume) bool {
-	return volume.GitRepo != nil ||
+	return volume.Secret != nil || volume.GitRepo != nil ||
 		(volume.EmptyDir != nil && volume.EmptyDir.Medium != v1.StorageMediumMemory) ||
 		volume.ConfigMap != nil || volume.DownwardAPI != nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #81317 stated, Ephemeral Volume check should include secret volume type.

**Which issue(s) this PR fixes**:
Fixes #81317

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
