### PR TITLE
Fix flaky test TestPreemptWithPermitPlugin

### DIFF
--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -419,8 +419,6 @@ func NewUnreservePlugin(_ *runtime.Unknown, _ framework.FrameworkHandle) (framew
 	return unresPlugin, nil
 }
 
-var perPlugin = &PermitPlugin{}
-
 // Name returns name of the plugin.
 func (pp *PermitPlugin) Name() string {
 	return permitPluginName
@@ -476,10 +474,12 @@ func (pp *PermitPlugin) reset() {
 	pp.allowPermit = false
 }
 
-// NewPermitPlugin is the factory for permit plugin.
-func NewPermitPlugin(_ *runtime.Unknown, fh framework.FrameworkHandle) (framework.Plugin, error) {
-	perPlugin.fh = fh
-	return perPlugin, nil
+// NewPermitPlugin returns a factory for permit plugin with specified PermitPlugin.
+func NewPermitPlugin(permitPlugin *PermitPlugin) framework.PluginFactory {
+	return func(_ *runtime.Unknown, fh framework.FrameworkHandle) (framework.Plugin, error) {
+		permitPlugin.fh = fh
+		return permitPlugin, nil
+	}
 }
 
 // TestPrefilterPlugin tests invocation of prefilter plugins.
@@ -1221,7 +1221,8 @@ func TestPostbindPlugin(t *testing.T) {
 // TestPermitPlugin tests invocation of permit plugins.
 func TestPermitPlugin(t *testing.T) {
 	// Create a plugin registry for testing. Register only a permit plugin.
-	registry := framework.Registry{permitPluginName: NewPermitPlugin}
+	perPlugin := &PermitPlugin{}
+	registry := framework.Registry{permitPluginName: NewPermitPlugin(perPlugin)}
 
 	// Setup initial permit plugin for testing.
 	plugins := &schedulerconfig.Plugins{
@@ -1332,7 +1333,8 @@ func TestPermitPlugin(t *testing.T) {
 // TestCoSchedulingWithPermitPlugin tests invocation of permit plugins.
 func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 	// Create a plugin registry for testing. Register only a permit plugin.
-	registry := framework.Registry{permitPluginName: NewPermitPlugin}
+	perPlugin := &PermitPlugin{}
+	registry := framework.Registry{permitPluginName: NewPermitPlugin(perPlugin)}
 
 	// Setup initial permit plugin for testing.
 	plugins := &schedulerconfig.Plugins{
@@ -1544,7 +1546,8 @@ func TestPostFilterPlugin(t *testing.T) {
 // TestPreemptWithPermitPlugin tests preempt with permit plugins.
 func TestPreemptWithPermitPlugin(t *testing.T) {
 	// Create a plugin registry for testing. Register only a permit plugin.
-	registry := framework.Registry{permitPluginName: NewPermitPlugin}
+	perPlugin := &PermitPlugin{}
+	registry := framework.Registry{permitPluginName: NewPermitPlugin(perPlugin)}
 
 	// Setup initial permit plugin for testing.
 	plugins := &schedulerconfig.Plugins{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

In all logs for flaky test `TestPreemptWithPermitPlugin`. We could find following logs:

```
6134 I0812 17:47:13.471713   16108 framework.go:558] waiting for 30s for pod "waiting-pod" at permit
...
6136 I0812 17:47:13.473895   16108 factory.go:622] Attempting to bind waiting-pod to test-node-0
```

`waiting-pod` should be in waiting pod for `30s`, but scheduler tried to bind it immediately. It is because that **TestXXX run concurrently**, and `perPlugin` is shared by test `TestPermitPlugin`, `TestCoSchedulingWithPermitPlugin` and `TestPreemptWithPermitPlugin`.  When `TestPreemptWithPermitPlugin` ran, its `waiting-pod` was permitted by other test. Then `waiting-pod` was bound to a node, and apiserver waited for a graceful time(30s by default) for it to be deleted when scheduler preempted it, that is why the test `TestPreemptWithPermitPlugin` timeouts. If `waiting-pod` had not been bound to a node, its graceful delete time is 0s(ref https://github.com/kubernetes/kubernetes/blob/master/pkg/registry/core/pod/strategy.go#L133), it will be deleted immediately.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #81238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
