### PR TITLE
Use RWMutex in watchBasedManager

### DIFF
--- a/pkg/kubelet/util/manager/watch_based_manager.go
+++ b/pkg/kubelet/util/manager/watch_based_manager.go
@@ -61,7 +61,7 @@ type objectCache struct {
 	newObject     newObjectFunc
 	groupResource schema.GroupResource
 
-	lock  sync.Mutex
+	lock  sync.RWMutex
 	items map[objectKey]*objectCacheItem
 }
 
@@ -117,7 +117,7 @@ func (c *objectCache) AddReference(namespace, name string) {
 	key := objectKey{namespace: namespace, name: name}
 
 	// AddReference is called from RegisterPod thus it needs to be efficient.
-	// Thus, it is only increaisng refCount and in case of first registration
+	// Thus, it is only increasing refCount and in case of first registration
 	// of a given object it starts corresponding reflector.
 	// It's responsibility of the first Get operation to wait until the
 	// reflector propagated the store.
@@ -158,9 +158,9 @@ func (c *objectCache) key(namespace, name string) string {
 func (c *objectCache) Get(namespace, name string) (runtime.Object, error) {
 	key := objectKey{namespace: namespace, name: name}
 
-	c.lock.Lock()
+	c.lock.RLock()
 	item, exists := c.items[key]
-	c.lock.Unlock()
+	c.lock.RUnlock()
 
 	if !exists {
 		return nil, fmt.Errorf("object %q/%q not registered", namespace, name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Use RWMutex in watchBasedManager to replace Mutex to accelerate map operation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @draveness 
I made mistake in this PR https://github.com/kubernetes/kubernetes/pull/81283, I mismatched my local branches, PTAL thanks