### PR TITLE
Add instruction for "Application Default Credentials" to run e2e tests locally

### DIFF
--- a/cluster/gce/windows/README-GCE-Windows-kube-up.md
+++ b/cluster/gce/windows/README-GCE-Windows-kube-up.md
@@ -23,6 +23,15 @@ rm -rf ./kubernetes/; rm -f kubernetes.tar.gz; rm -f ~/.kube/config
 # if you're working with multiple projects and don't want to repeatedly switch
 # between gcloud config configurations.
 export CLOUDSDK_CORE_PROJECT=<your_project_name>
+
+# To run e2e test locally, make sure "Application Default Credentials" is set in any of the places:
+# References: https://cloud.google.com/sdk/docs/authorizing#authorizing_with_a_service_account
+#             https://cloud.google.com/sdk/gcloud/reference/auth/application-default/
+#    1. $HOME/.config/gcloud/application_default_credentials.json, if doesn't exist, run this command:
+gcloud auth application-default login
+# Or 2. Create a json format credential file as per http://cloud/docs/authentication/production,
+#       then export to environment variable
+export GOOGLE_APPLICATION_CREDENTIAL=[path_to_the_json_file]
 ```
 
 ### 1. Build Kubernetes


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
We missed the instruction to setup "Application Default Credentials" to run e2e tests locally.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add instruction to setup "Application Default Credentials" to run GCE Windows e2e tests locally. 
```
