### PR TITLE
Refactor `kubectl scale` to patch scale subresource

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/rolling_updater.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollingupdate/rolling_updater.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -413,7 +412,7 @@ func (r *RollingUpdater) scaleDown(newRc, oldRc *corev1.ReplicationController, d
 // scalerScaleAndWait scales a controller using a Scaler and a real client.
 func (r *RollingUpdater) scaleAndWaitWithScaler(rc *corev1.ReplicationController, retry *scale.RetryParams, wait *scale.RetryParams) (*corev1.ReplicationController, error) {
 	scaler := scale.NewScaler(r.scaleClient)
-	if err := scaler.Scale(rc.Namespace, rc.Name, uint(valOrZero(rc.Spec.Replicas)), &scale.ScalePrecondition{Size: -1, ResourceVersion: ""}, retry, wait, schema.GroupResource{Resource: "replicationcontrollers"}); err != nil {
+	if err := scaler.Scale(rc.Namespace, rc.Name, uint(valOrZero(rc.Spec.Replicas)), &scale.ScalePrecondition{Size: -1, ResourceVersion: ""}, retry, wait, corev1.SchemeGroupVersion.WithResource("replicationcontrollers")); err != nil {
 		return nil, err
 	}
 	return r.rcClient.ReplicationControllers(rc.Namespace).Get(rc.Name, metav1.GetOptions{})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -227,7 +227,7 @@ func (o *ScaleOptions) RunScale() error {
 		}
 
 		mapping := info.ResourceMapping()
-		if err := o.scaler.Scale(info.Namespace, info.Name, uint(o.Replicas), precondition, retry, waitForReplicas, mapping.Resource.GroupResource()); err != nil {
+		if err := o.scaler.Scale(info.Namespace, info.Name, uint(o.Replicas), precondition, retry, waitForReplicas, mapping.Resource); err != nil {
 			return err
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/scale/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/scale/BUILD
@@ -9,8 +9,8 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/scale:go_default_library",
     ],
@@ -27,6 +27,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/client-go/scale:go_default_library",
         "//staging/src/k8s.io/client-go/scale/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",

--- a/test/e2e/framework/rc_util.go
+++ b/test/e2e/framework/rc_util.go
@@ -120,7 +120,7 @@ func DeleteRCAndWaitForGC(c clientset.Interface, ns, name string) error {
 
 // ScaleRC scales Replication Controller to be desired size.
 func ScaleRC(clientset clientset.Interface, scalesGetter scaleclient.ScalesGetter, ns, name string, size uint, wait bool) error {
-	return ScaleResource(clientset, scalesGetter, ns, name, size, wait, api.Kind("ReplicationController"), api.Resource("replicationcontrollers"))
+	return ScaleResource(clientset, scalesGetter, ns, name, size, wait, api.Kind("ReplicationController"), api.SchemeGroupVersion.WithResource("replicationcontrollers"))
 }
 
 // RunRC Launches (and verifies correctness) of a Replication Controller

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2221,10 +2221,10 @@ func ScaleResource(
 	size uint,
 	wait bool,
 	kind schema.GroupKind,
-	gr schema.GroupResource,
+	gvr schema.GroupVersionResource,
 ) error {
 	ginkgo.By(fmt.Sprintf("Scaling %v %s in namespace %s to %d", kind, name, ns, size))
-	if err := testutils.ScaleResourceWithRetries(scalesGetter, ns, name, size, gr); err != nil {
+	if err := testutils.ScaleResourceWithRetries(scalesGetter, ns, name, size, gvr); err != nil {
 		return fmt.Errorf("error while scaling RC %s to %d replicas: %v", name, size, err)
 	}
 	if !wait {

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -691,7 +691,7 @@ func scaleResource(wg *sync.WaitGroup, config testutils.RunObjectConfig, scaling
 		newSize,
 		true,
 		config.GetKind(),
-		config.GetGroupResource(),
+		config.GetGroupVersionResource(),
 	),
 		fmt.Sprintf("scaling %v %v", config.GetKind(), config.GetName()))
 

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -107,6 +107,7 @@ type RunObjectConfig interface {
 	GetReplicas() int
 	GetLabelValue(string) (string, bool)
 	GetGroupResource() schema.GroupResource
+	GetGroupVersionResource() schema.GroupVersionResource
 }
 
 type RCConfig struct {
@@ -298,6 +299,10 @@ func (config *DeploymentConfig) GetGroupResource() schema.GroupResource {
 	return extensionsinternal.Resource("deployments")
 }
 
+func (config *DeploymentConfig) GetGroupVersionResource() schema.GroupVersionResource {
+	return extensionsinternal.SchemeGroupVersion.WithResource("deployments")
+}
+
 func (config *DeploymentConfig) create() error {
 	deployment := &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
@@ -374,6 +379,10 @@ func (config *ReplicaSetConfig) GetGroupResource() schema.GroupResource {
 	return extensionsinternal.Resource("replicasets")
 }
 
+func (config *ReplicaSetConfig) GetGroupVersionResource() schema.GroupVersionResource {
+	return extensionsinternal.SchemeGroupVersion.WithResource("replicasets")
+}
+
 func (config *ReplicaSetConfig) create() error {
 	rs := &apps.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -444,6 +453,10 @@ func (config *JobConfig) GetKind() schema.GroupKind {
 
 func (config *JobConfig) GetGroupResource() schema.GroupResource {
 	return batchinternal.Resource("jobs")
+}
+
+func (config *JobConfig) GetGroupVersionResource() schema.GroupVersionResource {
+	return batchinternal.SchemeGroupVersion.WithResource("jobs")
 }
 
 func (config *JobConfig) create() error {
@@ -520,6 +533,10 @@ func (config *RCConfig) GetKind() schema.GroupKind {
 
 func (config *RCConfig) GetGroupResource() schema.GroupResource {
 	return api.Resource("replicationcontrollers")
+}
+
+func (config *RCConfig) GetGroupVersionResource() schema.GroupVersionResource {
+	return api.SchemeGroupVersion.WithResource("replicationcontrollers")
 }
 
 func (config *RCConfig) GetClient() clientset.Interface {

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -45,17 +45,17 @@ func RetryErrorCondition(condition wait.ConditionFunc) wait.ConditionFunc {
 	}
 }
 
-func ScaleResourceWithRetries(scalesGetter scaleclient.ScalesGetter, namespace, name string, size uint, gr schema.GroupResource) error {
+func ScaleResourceWithRetries(scalesGetter scaleclient.ScalesGetter, namespace, name string, size uint, gvr schema.GroupVersionResource) error {
 	scaler := scale.NewScaler(scalesGetter)
 	preconditions := &scale.ScalePrecondition{
 		Size:            -1,
 		ResourceVersion: "",
 	}
 	waitForReplicas := scale.NewRetryParams(waitRetryInterval, waitRetryTimeout)
-	cond := RetryErrorCondition(scale.ScaleCondition(scaler, preconditions, namespace, name, size, nil, gr))
+	cond := RetryErrorCondition(scale.ScaleCondition(scaler, preconditions, namespace, name, size, nil, gvr))
 	err := wait.PollImmediate(updateRetryInterval, updateRetryTimeout, cond)
 	if err == nil {
-		err = scale.WaitForScaleHasDesiredReplicas(scalesGetter, gr, name, namespace, size, waitForReplicas)
+		err = scale.WaitForScaleHasDesiredReplicas(scalesGetter, gvr.GroupResource(), name, namespace, size, waitForReplicas)
 	}
 	if err != nil {
 		return fmt.Errorf("Error while scaling %s to %d replicas: %v", name, size, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently `kubectl scale` would send a PUT request without `ResourceVersion`, which is introduced in https://github.com/kubernetes/kubernetes/pull/75210, and because of that custom resource cannot be scaled since custom resource [could not be updated unconditionally](https://github.com/kubernetes/kubernetes/pull/80572#issuecomment-515921985). 

Considered that PUT without resource version is not a best practice and we are not willing to do a GET before the request, so I choose to update kubectl to use PATCH instead of PUT.

**Which issue(s) this PR fixes**:
Part of #80515

**Special notes for your reviewer**:
Although I have created [another PR](https://github.com/kubernetes/kubernetes/pull/80572) to fix the problem, which requires changes on apiserver, the apiserver would not be updated as frequently as kubectl in reality, so it may be best to update both apiserver(make old kubectls work) and kubectl.

**Does this PR introduce a user-facing change?**:
```release-note
kubectl could scale custom resource again
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
