### PR TITLE
Add http response code 301 and 503 to check.

### DIFF
--- a/cmd/linkcheck/links.go
+++ b/cmd/linkcheck/links.go
@@ -129,7 +129,10 @@ func newWalkFunc(invalidLink *bool, client *http.Client) filepath.WalkFunc {
 				if err != nil {
 					break
 				}
-				if resp.StatusCode == http.StatusTooManyRequests {
+				// This header is used in 301, 429 and 503.
+				// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
+				// And Go client will follow redirects automatically so the 301 check is probably unnecessary.
+				if resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode == http.StatusServiceUnavailable {
 					retryAfter := resp.Header.Get("Retry-After")
 					if seconds, err := strconv.Atoi(retryAfter); err != nil {
 						backoff = seconds + 10


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Retry-After` header would be used in `301` and `503`, these should be checked as well

**Which issue(s) this PR fixes**:

xref #81143

**Special notes for your reviewer**:

This PR just fix one bug (No.3) mentioned in the issue.

> 1. strconv.Atoi uses strconv.ParseInt, which has edge cases for parser failures, which will return MAXINT for values too large and zero for values that fail to parse as integers.
> 2. linkcheck does not set an explicit redirect policy via CheckRedirect, meaning that Go’s core HTTP library will follow redirects. While linkcheck has a whitelist for URLs, redirects are not checked against the whitelist.
> 3. The Retry-After response header is used only in the case of “Too many Requests” (HTTP status code 429). However, the Retry-After header may also be returned with both 301 (Redirect) and 503 (Service Unavailable) status codes as well.

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
