### PR TITLE
Fix golint error for staging/src/k8s.io/client-go/discovery/fake

### DIFF
--- a/cmd/kube-controller-manager/app/core_test.go
+++ b/cmd/kube-controller-manager/app/core_test.go
@@ -45,9 +45,9 @@ func (m TestClientBuilder) ClientOrDie(name string) clientset.Interface {
 	return m.clientset
 }
 
-// FakeDiscoveryWithError inherits DiscoveryInterface(via FakeDiscovery) with some methods accepting testing data.
+// FakeDiscoveryWithError inherits DiscoveryInterface(via Discovery) with some methods accepting testing data.
 type FakeDiscoveryWithError struct {
-	fakediscovery.FakeDiscovery
+	fakediscovery.Discovery
 	PossibleResources []*metav1.APIResourceList
 	Err               error
 }

--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -204,9 +204,9 @@ func getClient(file string, dryRun bool) (clientset.Interface, error) {
 		// Print GET and LIST requests
 		dryRunOpts.PrintGETAndLIST = true
 		fakeclient := apiclient.NewDryRunClientWithOpts(dryRunOpts)
-		// As we know the return of Discovery() of the fake clientset is of type *fakediscovery.FakeDiscovery
+		// As we know the return of Discovery() of the fake clientset is of type *fakediscovery.Discovery
 		// we can convert it to that struct.
-		fakeclientDiscovery, ok := fakeclient.Discovery().(*fakediscovery.FakeDiscovery)
+		fakeclientDiscovery, ok := fakeclient.Discovery().(*fakediscovery.Discovery)
 		if !ok {
 			return nil, errors.New("couldn't set fake discovery's server version")
 		}

--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -432,7 +432,6 @@ staging/src/k8s.io/cli-runtime/pkg/printers
 staging/src/k8s.io/cli-runtime/pkg/resource
 staging/src/k8s.io/client-go/deprecated-dynamic
 staging/src/k8s.io/client-go/discovery
-staging/src/k8s.io/client-go/discovery/fake
 staging/src/k8s.io/client-go/dynamic
 staging/src/k8s.io/client-go/dynamic/fake
 staging/src/k8s.io/client-go/examples/workqueue

--- a/plugin/pkg/admission/gc/gc_admission_test.go
+++ b/plugin/pkg/admission/gc/gc_admission_test.go
@@ -101,7 +101,7 @@ func newGCPermissionsEnforcement() (*gcPermissionsEnforcement, error) {
 	}
 
 	genericPluginInitializer := initializer.New(nil, nil, fakeAuthorizer{})
-	fakeDiscoveryClient := &fakediscovery.FakeDiscovery{Fake: &coretesting.Fake{}}
+	fakeDiscoveryClient := &fakediscovery.Discovery{Fake: &coretesting.Fake{}}
 	fakeDiscoveryClient.Resources = []*metav1.APIResourceList{
 		{
 			GroupVersion: corev1.SchemeGroupVersion.String(),

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -42,7 +42,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -62,7 +62,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake/clientset_generated.go
@@ -42,7 +42,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -62,7 +62,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/fake/clientset_generated.go
@@ -42,7 +42,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -62,7 +62,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -34,7 +34,7 @@ type resourceMapEntry struct {
 }
 
 type fakeDiscovery struct {
-	*fake.FakeDiscovery
+	*fake.Discovery
 
 	lock         sync.Mutex
 	groupList    *metav1.APIGroupList

--- a/staging/src/k8s.io/client-go/discovery/fake/discovery.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery.go
@@ -29,16 +29,16 @@ import (
 	"k8s.io/client-go/testing"
 )
 
-// FakeDiscovery implements discovery.DiscoveryInterface and sometimes calls testing.Fake.Invoke with an action,
+// Discovery implements discovery.DiscoveryInterface and sometimes calls testing.Fake.Invoke with an action,
 // but doesn't respect the return value if any. There is a way to fake static values like ServerVersion by using the Faked... fields on the struct.
-type FakeDiscovery struct {
+type Discovery struct {
 	*testing.Fake
 	FakedServerVersion *version.Info
 }
 
 // ServerResourcesForGroupVersion returns the supported resources for a group
 // and version.
-func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+func (c *Discovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	action := testing.ActionImpl{
 		Verb:     "get",
 		Resource: schema.GroupVersionResource{Resource: "resource"},
@@ -54,13 +54,13 @@ func (c *FakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*me
 
 // ServerResources returns the supported resources for all groups and versions.
 // Deprecated: use ServerGroupsAndResources instead.
-func (c *FakeDiscovery) ServerResources() ([]*metav1.APIResourceList, error) {
+func (c *Discovery) ServerResources() ([]*metav1.APIResourceList, error) {
 	_, rs, err := c.ServerGroupsAndResources()
 	return rs, err
 }
 
 // ServerGroupsAndResources returns the supported groups and resources for all groups and versions.
-func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+func (c *Discovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	sgs, err := c.ServerGroups()
 	if err != nil {
 		return nil, nil, err
@@ -80,19 +80,19 @@ func (c *FakeDiscovery) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav
 
 // ServerPreferredResources returns the supported resources with the version
 // preferred by the server.
-func (c *FakeDiscovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+func (c *Discovery) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
 }
 
 // ServerPreferredNamespacedResources returns the supported namespaced resources
 // with the version preferred by the server.
-func (c *FakeDiscovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+func (c *Discovery) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
 }
 
 // ServerGroups returns the supported groups, with information like supported
 // versions and the preferred version.
-func (c *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+func (c *Discovery) ServerGroups() (*metav1.APIGroupList, error) {
 	action := testing.ActionImpl{
 		Verb:     "get",
 		Resource: schema.GroupVersionResource{Resource: "group"},
@@ -134,7 +134,7 @@ func (c *FakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
 }
 
 // ServerVersion retrieves and parses the server's version.
-func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
+func (c *Discovery) ServerVersion() (*version.Info, error) {
 	action := testing.ActionImpl{}
 	action.Verb = "get"
 	action.Resource = schema.GroupVersionResource{Resource: "version"}
@@ -149,12 +149,12 @@ func (c *FakeDiscovery) ServerVersion() (*version.Info, error) {
 }
 
 // OpenAPISchema retrieves and parses the swagger API schema the server supports.
-func (c *FakeDiscovery) OpenAPISchema() (*openapi_v2.Document, error) {
+func (c *Discovery) OpenAPISchema() (*openapi_v2.Document, error) {
 	return &openapi_v2.Document{}, nil
 }
 
 // RESTClient returns a RESTClient that is used to communicate with API server
 // by this client implementation.
-func (c *FakeDiscovery) RESTClient() restclient.Interface {
+func (c *Discovery) RESTClient() restclient.Interface {
 	return nil
 }

--- a/staging/src/k8s.io/client-go/discovery/fake/discovery_test.go
+++ b/staging/src/k8s.io/client-go/discovery/fake/discovery_test.go
@@ -26,9 +26,9 @@ import (
 
 func TestFakingServerVersion(t *testing.T) {
 	client := fakeclientset.NewSimpleClientset()
-	fakeDiscovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
+	fakeDiscovery, ok := client.Discovery().(*fakediscovery.Discovery)
 	if !ok {
-		t.Fatalf("couldn't convert Discovery() to *FakeDiscovery")
+		t.Fatalf("couldn't convert Discovery() to *Discovery")
 	}
 
 	testGitCommit := "v1.0.0"

--- a/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
+++ b/staging/src/k8s.io/client-go/kubernetes/fake/clientset_generated.go
@@ -114,7 +114,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -134,7 +134,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -55,7 +55,7 @@ func defaultHeaders() http.Header {
 }
 
 func fakeScaleClient(t *testing.T) (ScalesGetter, []schema.GroupResource) {
-	fakeDiscoveryClient := &fakedisco.FakeDiscovery{Fake: &coretesting.Fake{}}
+	fakeDiscoveryClient := &fakedisco.Discovery{Fake: &coretesting.Fake{}}
 	fakeDiscoveryClient.Resources = []*metav1.APIResourceList{
 		{
 			GroupVersion: corev1.SchemeGroupVersion.String(),

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/fake/clientset_generated.go
@@ -42,7 +42,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -62,7 +62,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/fake/clientset_generated.go
@@ -42,7 +42,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -62,7 +62,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/fake/clientset_generated.go
@@ -44,7 +44,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -64,7 +64,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/fake/clientset_generated.go
@@ -44,7 +44,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -64,7 +64,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/fake/clientset_generated.go
@@ -44,7 +44,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -64,7 +64,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -122,7 +122,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -142,7 +142,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake/clientset_generated.go
@@ -44,7 +44,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -64,7 +64,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -44,7 +44,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -64,7 +64,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -42,7 +42,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -62,7 +62,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -44,7 +44,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -64,7 +64,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/clientset_generated.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/fake/clientset_generated.go
@@ -42,7 +42,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 	}
 
 	cs := &Clientset{tracker: o}
-	cs.discovery = &fakediscovery.FakeDiscovery{Fake: &cs.Fake}
+	cs.discovery = &fakediscovery.Discovery{Fake: &cs.Fake}
 	cs.AddReactor("*", "*", testing.ObjectReaction(o))
 	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
 		gvr := action.GetResource()
@@ -62,7 +62,7 @@ func NewSimpleClientset(objects ...runtime.Object) *Clientset {
 // you want to test easier.
 type Clientset struct {
 	testing.Fake
-	discovery *fakediscovery.FakeDiscovery
+	discovery *fakediscovery.Discovery
 	tracker   testing.ObjectTracker
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix golint errors from `staging/src/k8s.io/client-go/discovery/fake` and remove the directory from `hack/.golint_failures`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Errors from golint:

> staging/src/k8s.io/client-go/discovery/fake/discovery.go:34:6: type name will be used as fake.FakeDiscovery by other packages, and that stutters; consider calling this Discovery

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: