### PR TITLE
use subtest for table units (pkg/scheduler/*)

### DIFF
--- a/pkg/api/v1/pod/util_test.go
+++ b/pkg/api/v1/pod/util_test.go
@@ -800,9 +800,10 @@ func TestGetPodPriority(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		if GetPodPriority(test.pod) != test.expectedPriority {
-			t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
-		}
-
+		t.Run(test.name, func(t *testing.T) {
+			if GetPodPriority(test.pod) != test.expectedPriority {
+				t.Errorf("expected pod priority: %v, got %v", test.expectedPriority, GetPodPriority(test.pod))
+			}
+		})
 	}
 }

--- a/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -26,18 +26,21 @@ import (
 
 func TestCopyAndReplace(t *testing.T) {
 	testCases := []struct {
+		name        string
 		set         sets.String
 		replaceWhat string
 		replaceWith string
 		expected    sets.String
 	}{
 		{
+			name:        "replace existing item",
 			set:         sets.String{"A": sets.Empty{}, "B": sets.Empty{}},
 			replaceWhat: "A",
 			replaceWith: "C",
 			expected:    sets.String{"B": sets.Empty{}, "C": sets.Empty{}},
 		},
 		{
+			name:        "replace nonexistent item",
 			set:         sets.String{"A": sets.Empty{}, "B": sets.Empty{}},
 			replaceWhat: "D",
 			replaceWith: "C",
@@ -45,10 +48,12 @@ func TestCopyAndReplace(t *testing.T) {
 		},
 	}
 	for _, testCase := range testCases {
-		result := copyAndReplace(testCase.set, testCase.replaceWhat, testCase.replaceWith)
-		if !result.Equal(testCase.expected) {
-			t.Errorf("expected %v got %v", testCase.expected, result)
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			result := copyAndReplace(testCase.set, testCase.replaceWhat, testCase.replaceWith)
+			if !result.Equal(testCase.expected) {
+				t.Errorf("expected %v got %v", testCase.expected, result)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/internal/cache/cache_test.go
+++ b/pkg/scheduler/internal/cache/cache_test.go
@@ -35,7 +35,7 @@ import (
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
-func deepEqualWithoutGeneration(t *testing.T, testcase int, actual *nodeInfoListItem, expected *schedulernodeinfo.NodeInfo) {
+func deepEqualWithoutGeneration(t *testing.T, actual *nodeInfoListItem, expected *schedulernodeinfo.NodeInfo) {
 	if (actual == nil) != (expected == nil) {
 		t.Error("One of the actual or expeted is nil and the other is not!")
 	}
@@ -47,7 +47,7 @@ func deepEqualWithoutGeneration(t *testing.T, testcase int, actual *nodeInfoList
 		expected.SetGeneration(0)
 	}
 	if actual != nil && !reflect.DeepEqual(actual.info, expected) {
-		t.Errorf("#%d: node info get=%s, want=%s", testcase, actual.info, expected)
+		t.Errorf("node info get=%s, want=%s", actual.info, expected)
 	}
 }
 
@@ -109,10 +109,11 @@ func TestAssumePodScheduled(t *testing.T) {
 	}
 
 	tests := []struct {
-		pods []*v1.Pod
-
+		name      string
+		pods      []*v1.Pod
 		wNodeInfo *schedulernodeinfo.NodeInfo
 	}{{
+		name: fmt.Sprintf("%v", testPods[0].ObjectMeta.Name),
 		pods: []*v1.Pod{testPods[0]},
 		wNodeInfo: newNodeInfo(
 			&schedulernodeinfo.Resource{
@@ -128,6 +129,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			make(map[string]*schedulernodeinfo.ImageStateSummary),
 		),
 	}, {
+		name: fmt.Sprintf("%v/%v", testPods[1].ObjectMeta.Name, testPods[2].ObjectMeta.Name),
 		pods: []*v1.Pod{testPods[1], testPods[2]},
 		wNodeInfo: newNodeInfo(
 			&schedulernodeinfo.Resource{
@@ -143,6 +145,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			make(map[string]*schedulernodeinfo.ImageStateSummary),
 		),
 	}, { // test non-zero request
+		name: fmt.Sprintf("%v", testPods[3].ObjectMeta.Name),
 		pods: []*v1.Pod{testPods[3]},
 		wNodeInfo: newNodeInfo(
 			&schedulernodeinfo.Resource{
@@ -158,6 +161,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			make(map[string]*schedulernodeinfo.ImageStateSummary),
 		),
 	}, {
+		name: fmt.Sprintf("%v/example.com/foo:3", testPods[4].ObjectMeta.Name),
 		pods: []*v1.Pod{testPods[4]},
 		wNodeInfo: newNodeInfo(
 			&schedulernodeinfo.Resource{
@@ -174,6 +178,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			make(map[string]*schedulernodeinfo.ImageStateSummary),
 		),
 	}, {
+		name: fmt.Sprintf("%v/%v/example.com/foo:5", testPods[4].ObjectMeta.Name, testPods[5].ObjectMeta.Name),
 		pods: []*v1.Pod{testPods[4], testPods[5]},
 		wNodeInfo: newNodeInfo(
 			&schedulernodeinfo.Resource{
@@ -190,6 +195,7 @@ func TestAssumePodScheduled(t *testing.T) {
 			make(map[string]*schedulernodeinfo.ImageStateSummary),
 		),
 	}, {
+		name: fmt.Sprintf("%v/random-invalid-extended-key:100", testPods[6].ObjectMeta.Name),
 		pods: []*v1.Pod{testPods[6]},
 		wNodeInfo: newNodeInfo(
 			&schedulernodeinfo.Resource{
@@ -207,24 +213,26 @@ func TestAssumePodScheduled(t *testing.T) {
 	},
 	}
 
-	for i, tt := range tests {
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		for _, pod := range tt.pods {
-			if err := cache.AssumePod(pod); err != nil {
-				t.Fatalf("AssumePod failed: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			for _, pod := range tt.pods {
+				if err := cache.AssumePod(pod); err != nil {
+					t.Fatalf("AssumePod failed: %v", err)
+				}
 			}
-		}
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, n, tt.wNodeInfo)
 
-		for _, pod := range tt.pods {
-			if err := cache.ForgetPod(pod); err != nil {
-				t.Fatalf("ForgetPod failed: %v", err)
+			for _, pod := range tt.pods {
+				if err := cache.ForgetPod(pod); err != nil {
+					t.Fatalf("ForgetPod failed: %v", err)
+				}
 			}
-		}
-		if cache.nodes[nodeName] != nil {
-			t.Errorf("NodeInfo should be cleaned for %s", nodeName)
-		}
+			if cache.nodes[nodeName] != nil {
+				t.Errorf("NodeInfo should be cleaned for %s", nodeName)
+			}
+		})
 	}
 }
 
@@ -253,17 +261,19 @@ func TestExpirePod(t *testing.T) {
 	now := time.Now()
 	ttl := 10 * time.Second
 	tests := []struct {
+		name        string
 		pods        []*testExpirePodStruct
 		cleanupTime time.Time
-
-		wNodeInfo *schedulernodeinfo.NodeInfo
-	}{{ // assumed pod would expires
+		wNodeInfo   *schedulernodeinfo.NodeInfo
+	}{{
+		name: "assumed pod would expire",
 		pods: []*testExpirePodStruct{
 			{pod: testPods[0], assumedTime: now},
 		},
 		cleanupTime: now.Add(2 * ttl),
 		wNodeInfo:   nil,
-	}, { // first one would expire, second one would not.
+	}, {
+		name: "first one would expire, second one would not.",
 		pods: []*testExpirePodStruct{
 			{pod: testPods[0], assumedTime: now},
 			{pod: testPods[1], assumedTime: now.Add(3 * ttl / 2)},
@@ -284,18 +294,20 @@ func TestExpirePod(t *testing.T) {
 		),
 	}}
 
-	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
 
-		for _, pod := range tt.pods {
-			if err := assumeAndFinishBinding(cache, pod.pod, pod.assumedTime); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+			for _, pod := range tt.pods {
+				if err := assumeAndFinishBinding(cache, pod.pod, pod.assumedTime); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
 			}
-		}
-		// pods that have assumedTime + ttl < cleanupTime will get expired and removed
-		cache.cleanupAssumedPods(tt.cleanupTime)
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+			// pods that have assumedTime + ttl < cleanupTime will get expired and removed
+			cache.cleanupAssumedPods(tt.cleanupTime)
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, n, tt.wNodeInfo)
+		})
 	}
 }
 
@@ -313,11 +325,12 @@ func TestAddPodWillConfirm(t *testing.T) {
 		makeBasePod(t, nodeName, "test-2", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
 	}
 	tests := []struct {
+		name         string
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
-
-		wNodeInfo *schedulernodeinfo.NodeInfo
-	}{{ // two pod were assumed at same time. But first one is called Add() and gets confirmed.
+		wNodeInfo    *schedulernodeinfo.NodeInfo
+	}{{
+		name:         "two pod were assumed at same time. But first one is called Add() and gets confirmed.",
 		podsToAssume: []*v1.Pod{testPods[0], testPods[1]},
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		wNodeInfo: newNodeInfo(
@@ -335,22 +348,24 @@ func TestAddPodWillConfirm(t *testing.T) {
 		),
 	}}
 
-	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
-			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			for _, podToAssume := range tt.podsToAssume {
+				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
 			}
-		}
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
+			for _, podToAdd := range tt.podsToAdd {
+				if err := cache.AddPod(podToAdd); err != nil {
+					t.Fatalf("AddPod failed: %v", err)
+				}
 			}
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
-		// check after expiration. confirmed pods shouldn't be expired.
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+			cache.cleanupAssumedPods(now.Add(2 * ttl))
+			// check after expiration. confirmed pods shouldn't be expired.
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, n, tt.wNodeInfo)
+		})
 	}
 }
 
@@ -364,39 +379,43 @@ func TestSnapshot(t *testing.T) {
 		makeBasePod(t, nodeName, "test-2", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),
 	}
 	tests := []struct {
+		name         string
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
-	}{{ // two pod were assumed at same time. But first one is called Add() and gets confirmed.
+	}{{
+		name:         "two pod were assumed at same time. But first one is called Add() and gets confirmed.",
 		podsToAssume: []*v1.Pod{testPods[0], testPods[1]},
 		podsToAdd:    []*v1.Pod{testPods[0]},
 	}}
 
 	for _, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
-			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Errorf("assumePod failed: %v", err)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			for _, podToAssume := range tt.podsToAssume {
+				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
+					t.Errorf("assumePod failed: %v", err)
+				}
 			}
-		}
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Errorf("AddPod failed: %v", err)
+			for _, podToAdd := range tt.podsToAdd {
+				if err := cache.AddPod(podToAdd); err != nil {
+					t.Errorf("AddPod failed: %v", err)
+				}
 			}
-		}
 
-		snapshot := cache.Snapshot()
-		if len(snapshot.Nodes) != len(cache.nodes) {
-			t.Errorf("Unequal number of nodes in the cache and its snapshot. expeted: %v, got: %v", len(cache.nodes), len(snapshot.Nodes))
-		}
-		for name, ni := range snapshot.Nodes {
-			nItem := cache.nodes[name]
-			if !reflect.DeepEqual(ni, nItem.info) {
-				t.Errorf("expect \n%+v; got \n%+v", nItem.info, ni)
+			snapshot := cache.Snapshot()
+			if len(snapshot.Nodes) != len(cache.nodes) {
+				t.Errorf("Unequal number of nodes in the cache and its snapshot. expeted: %v, got: %v", len(cache.nodes), len(snapshot.Nodes))
 			}
-		}
-		if !reflect.DeepEqual(snapshot.AssumedPods, cache.assumedPods) {
-			t.Errorf("expect \n%+v; got \n%+v", cache.assumedPods, snapshot.AssumedPods)
-		}
+			for name, ni := range snapshot.Nodes {
+				nItem := cache.nodes[name]
+				if !reflect.DeepEqual(ni, nItem.info) {
+					t.Errorf("expect \n%+v; got \n%+v", nItem.info, ni)
+				}
+			}
+			if !reflect.DeepEqual(snapshot.AssumedPods, cache.assumedPods) {
+				t.Errorf("expect \n%+v; got \n%+v", cache.assumedPods, snapshot.AssumedPods)
+			}
+		})
 	}
 }
 
@@ -408,58 +427,56 @@ func TestAddPodWillReplaceAssumed(t *testing.T) {
 	assumedPod := makeBasePod(t, "assumed-node-1", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 	addedPod := makeBasePod(t, "actual-node", "test-1", "100m", "500", "", []v1.ContainerPort{{HostPort: 80}})
 	updatedPod := makeBasePod(t, "actual-node", "test-1", "200m", "500", "", []v1.ContainerPort{{HostPort: 90}})
+	podsToAssume := []*v1.Pod{assumedPod.DeepCopy()}
+	podsToAdd := []*v1.Pod{addedPod.DeepCopy()}
+	podsToUpdate := [][]*v1.Pod{{addedPod.DeepCopy(), updatedPod.DeepCopy()}}
+	wNodeInfo := map[string]*schedulernodeinfo.NodeInfo{
+		"assumed-node": nil,
+		"actual-node": newNodeInfo(
+			&schedulernodeinfo.Resource{
+				MilliCPU: 200,
+				Memory:   500,
+			},
+			&schedulernodeinfo.Resource{
+				MilliCPU: 200,
+				Memory:   500,
+			},
+			[]*v1.Pod{updatedPod.DeepCopy()},
+			newHostPortInfoBuilder().add("TCP", "0.0.0.0", 90).build(),
+			make(map[string]*schedulernodeinfo.ImageStateSummary),
+		),
+	}
 
-	tests := []struct {
-		podsToAssume []*v1.Pod
-		podsToAdd    []*v1.Pod
-		podsToUpdate [][]*v1.Pod
+	cache := newSchedulerCache(ttl, time.Second, nil)
 
-		wNodeInfo map[string]*schedulernodeinfo.NodeInfo
-	}{{
-		podsToAssume: []*v1.Pod{assumedPod.DeepCopy()},
-		podsToAdd:    []*v1.Pod{addedPod.DeepCopy()},
-		podsToUpdate: [][]*v1.Pod{{addedPod.DeepCopy(), updatedPod.DeepCopy()}},
-		wNodeInfo: map[string]*schedulernodeinfo.NodeInfo{
-			"assumed-node": nil,
-			"actual-node": newNodeInfo(
-				&schedulernodeinfo.Resource{
-					MilliCPU: 200,
-					Memory:   500,
-				},
-				&schedulernodeinfo.Resource{
-					MilliCPU: 200,
-					Memory:   500,
-				},
-				[]*v1.Pod{updatedPod.DeepCopy()},
-				newHostPortInfoBuilder().add("TCP", "0.0.0.0", 90).build(),
-				make(map[string]*schedulernodeinfo.ImageStateSummary),
-			),
-		},
-	}}
-
-	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
+	t.Run("assumePod", func(t *testing.T) {
+		for _, podToAssume := range podsToAssume {
 			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+				t.Fatalf("failed: %v", err)
 			}
 		}
-		for _, podToAdd := range tt.podsToAdd {
+	})
+	t.Run("AddPod", func(t *testing.T) {
+		for _, podToAdd := range podsToAdd {
 			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
+				t.Fatalf("failed: %v", err)
 			}
 		}
-		for _, podToUpdate := range tt.podsToUpdate {
+	})
+	t.Run("UpdatePod", func(t *testing.T) {
+		for _, podToUpdate := range podsToUpdate {
 			if err := cache.UpdatePod(podToUpdate[0], podToUpdate[1]); err != nil {
-				t.Fatalf("UpdatePod failed: %v", err)
+				t.Fatalf("failed: %v", err)
 			}
 		}
-		for nodeName, expected := range tt.wNodeInfo {
+	})
+	t.Run("deepEqualWithoutGeneration", func(t *testing.T) {
+		for nodeName, expected := range wNodeInfo {
 			t.Log(nodeName)
 			n := cache.nodes[nodeName]
-			deepEqualWithoutGeneration(t, i, n, expected)
+			deepEqualWithoutGeneration(t, n, expected)
 		}
-	}
+	})
 }
 
 // TestAddPodAfterExpiration tests that a pod being Add()ed will be added back if expired.
@@ -470,11 +487,12 @@ func TestAddPodAfterExpiration(t *testing.T) {
 	ttl := 10 * time.Second
 	basePod := makeBasePod(t, nodeName, "test", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}})
 	tests := []struct {
-		pod *v1.Pod
-
+		name      string
+		pod       *v1.Pod
 		wNodeInfo *schedulernodeinfo.NodeInfo
 	}{{
-		pod: basePod,
+		name: "basepod",
+		pod:  basePod,
 		wNodeInfo: newNodeInfo(
 			&schedulernodeinfo.Resource{
 				MilliCPU: 100,
@@ -492,22 +510,24 @@ func TestAddPodAfterExpiration(t *testing.T) {
 
 	now := time.Now()
 	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		if err := assumeAndFinishBinding(cache, tt.pod, now); err != nil {
-			t.Fatalf("assumePod failed: %v", err)
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
-		// It should be expired and removed.
-		n := cache.nodes[nodeName]
-		if n != nil {
-			t.Errorf("#%d: expecting nil node info, but get=%v", i, n)
-		}
-		if err := cache.AddPod(tt.pod); err != nil {
-			t.Fatalf("AddPod failed: %v", err)
-		}
-		// check after expiration. confirmed pods shouldn't be expired.
-		n = cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			if err := assumeAndFinishBinding(cache, tt.pod, now); err != nil {
+				t.Fatalf("assumePod failed: %v", err)
+			}
+			cache.cleanupAssumedPods(now.Add(2 * ttl))
+			// It should be expired and removed.
+			n := cache.nodes[nodeName]
+			if n != nil {
+				t.Errorf("#%d: expecting nil node info, but get=%v", i, n)
+			}
+			if err := cache.AddPod(tt.pod); err != nil {
+				t.Fatalf("AddPod failed: %v", err)
+			}
+			// check after expiration. confirmed pods shouldn't be expired.
+			n = cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, n, tt.wNodeInfo)
+		})
 	}
 }
 
@@ -522,11 +542,12 @@ func TestUpdatePod(t *testing.T) {
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
 	}
 	tests := []struct {
+		name         string
 		podsToAdd    []*v1.Pod
 		podsToUpdate []*v1.Pod
-
-		wNodeInfo []*schedulernodeinfo.NodeInfo
-	}{{ // add a pod and then update it twice
+		wNodeInfo    []*schedulernodeinfo.NodeInfo
+	}{{
+		name:         "add a pod and then update it twice",
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		podsToUpdate: []*v1.Pod{testPods[0], testPods[1], testPods[0]},
 		wNodeInfo: []*schedulernodeinfo.NodeInfo{newNodeInfo(
@@ -557,24 +578,30 @@ func TestUpdatePod(t *testing.T) {
 	}}
 
 	for _, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
-			}
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			t.Run("AddPod", func(t *testing.T) {
+				for _, podToAdd := range tt.podsToAdd {
+					if err := cache.AddPod(podToAdd); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+				}
+			})
 
-		for i := range tt.podsToUpdate {
-			if i == 0 {
-				continue
-			}
-			if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
-				t.Fatalf("UpdatePod failed: %v", err)
-			}
-			// check after expiration. confirmed pods shouldn't be expired.
-			n := cache.nodes[nodeName]
-			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo[i-1])
-		}
+			t.Run("UpdatePod", func(t *testing.T) {
+				for i := range tt.podsToUpdate {
+					if i == 0 {
+						continue
+					}
+					if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
+						t.Fatalf("failed: %v", err)
+					}
+					// check after expiration. confirmed pods shouldn't be expired.
+					n := cache.nodes[nodeName]
+					deepEqualWithoutGeneration(t, n, tt.wNodeInfo[i-1])
+				}
+			})
+		})
 	}
 }
 
@@ -587,7 +614,8 @@ func TestUpdatePodAndGet(t *testing.T) {
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
 	}
 	tests := []struct {
-		pod *v1.Pod
+		name string
+		pod  *v1.Pod
 
 		podToUpdate *v1.Pod
 		handler     func(cache Cache, pod *v1.Pod) error
@@ -595,7 +623,8 @@ func TestUpdatePodAndGet(t *testing.T) {
 		assumePod bool
 	}{
 		{
-			pod: testPods[0],
+			name: "update, with assumed pod",
+			pod:  testPods[0],
 
 			podToUpdate: testPods[0],
 			handler: func(cache Cache, pod *v1.Pod) error {
@@ -604,7 +633,8 @@ func TestUpdatePodAndGet(t *testing.T) {
 			assumePod: true,
 		},
 		{
-			pod: testPods[0],
+			name: "update pod",
+			pod:  testPods[0],
 
 			podToUpdate: testPods[1],
 			handler: func(cache Cache, pod *v1.Pod) error {
@@ -615,25 +645,27 @@ func TestUpdatePodAndGet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
 
-		if err := tt.handler(cache, tt.pod); err != nil {
-			t.Fatalf("unexpected err: %v", err)
-		}
-
-		if !tt.assumePod {
-			if err := cache.UpdatePod(tt.pod, tt.podToUpdate); err != nil {
-				t.Fatalf("UpdatePod failed: %v", err)
+			if err := tt.handler(cache, tt.pod); err != nil {
+				t.Fatalf("unexpected err: %v", err)
 			}
-		}
 
-		cachedPod, err := cache.GetPod(tt.pod)
-		if err != nil {
-			t.Fatalf("GetPod failed: %v", err)
-		}
-		if !reflect.DeepEqual(tt.podToUpdate, cachedPod) {
-			t.Fatalf("pod get=%s, want=%s", cachedPod, tt.podToUpdate)
-		}
+			if !tt.assumePod {
+				if err := cache.UpdatePod(tt.pod, tt.podToUpdate); err != nil {
+					t.Fatalf("UpdatePod failed: %v", err)
+				}
+			}
+
+			cachedPod, err := cache.GetPod(tt.pod)
+			if err != nil {
+				t.Fatalf("GetPod failed: %v", err)
+			}
+			if !reflect.DeepEqual(tt.podToUpdate, cachedPod) {
+				t.Fatalf("pod get=%s, want=%s", cachedPod, tt.podToUpdate)
+			}
+		})
 	}
 }
 
@@ -648,12 +680,14 @@ func TestExpireAddUpdatePod(t *testing.T) {
 		makeBasePod(t, nodeName, "test", "200m", "1Ki", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 8080, Protocol: "TCP"}}),
 	}
 	tests := []struct {
+		name         string
 		podsToAssume []*v1.Pod
 		podsToAdd    []*v1.Pod
 		podsToUpdate []*v1.Pod
 
 		wNodeInfo []*schedulernodeinfo.NodeInfo
-	}{{ // Pod is assumed, expired, and added. Then it would be updated twice.
+	}{{
+		name:         "Pod is assumed, expired, and added. Then it would be updated twice.",
 		podsToAssume: []*v1.Pod{testPods[0]},
 		podsToAdd:    []*v1.Pod{testPods[0]},
 		podsToUpdate: []*v1.Pod{testPods[0], testPods[1], testPods[0]},
@@ -686,31 +720,33 @@ func TestExpireAddUpdatePod(t *testing.T) {
 
 	now := time.Now()
 	for _, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, podToAssume := range tt.podsToAssume {
-			if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+		t.Run(tt.name, func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			for _, podToAssume := range tt.podsToAssume {
+				if err := assumeAndFinishBinding(cache, podToAssume, now); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
 			}
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
+			cache.cleanupAssumedPods(now.Add(2 * ttl))
 
-		for _, podToAdd := range tt.podsToAdd {
-			if err := cache.AddPod(podToAdd); err != nil {
-				t.Fatalf("AddPod failed: %v", err)
+			for _, podToAdd := range tt.podsToAdd {
+				if err := cache.AddPod(podToAdd); err != nil {
+					t.Fatalf("AddPod failed: %v", err)
+				}
 			}
-		}
 
-		for i := range tt.podsToUpdate {
-			if i == 0 {
-				continue
+			for i := range tt.podsToUpdate {
+				if i == 0 {
+					continue
+				}
+				if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
+					t.Fatalf("UpdatePod failed: %v", err)
+				}
+				// check after expiration. confirmed pods shouldn't be expired.
+				n := cache.nodes[nodeName]
+				deepEqualWithoutGeneration(t, n, tt.wNodeInfo[i-1])
 			}
-			if err := cache.UpdatePod(tt.podsToUpdate[i-1], tt.podsToUpdate[i]); err != nil {
-				t.Fatalf("UpdatePod failed: %v", err)
-			}
-			// check after expiration. confirmed pods shouldn't be expired.
-			n := cache.nodes[nodeName]
-			deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo[i-1])
-		}
+		})
 	}
 }
 
@@ -761,21 +797,23 @@ func TestEphemeralStorageResource(t *testing.T) {
 		},
 	}
 	for i, tt := range tests {
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		if err := cache.AddPod(tt.pod); err != nil {
-			t.Fatalf("AddPod failed: %v", err)
-		}
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			if err := cache.AddPod(tt.pod); err != nil {
+				t.Fatalf("AddPod failed: %v", err)
+			}
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, n, tt.wNodeInfo)
 
-		if err := cache.RemovePod(tt.pod); err != nil {
-			t.Fatalf("RemovePod failed: %v", err)
-		}
+			if err := cache.RemovePod(tt.pod); err != nil {
+				t.Fatalf("RemovePod failed: %v", err)
+			}
 
-		n = cache.nodes[nodeName]
-		if n != nil {
-			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n.info)
-		}
+			n = cache.nodes[nodeName]
+			if n != nil {
+				t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n.info)
+			}
+		})
 	}
 }
 
@@ -806,21 +844,23 @@ func TestRemovePod(t *testing.T) {
 	}}
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		if err := cache.AddPod(tt.pod); err != nil {
-			t.Fatalf("AddPod failed: %v", err)
-		}
-		n := cache.nodes[nodeName]
-		deepEqualWithoutGeneration(t, i, n, tt.wNodeInfo)
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			if err := cache.AddPod(tt.pod); err != nil {
+				t.Fatalf("AddPod failed: %v", err)
+			}
+			n := cache.nodes[nodeName]
+			deepEqualWithoutGeneration(t, n, tt.wNodeInfo)
 
-		if err := cache.RemovePod(tt.pod); err != nil {
-			t.Fatalf("RemovePod failed: %v", err)
-		}
+			if err := cache.RemovePod(tt.pod); err != nil {
+				t.Fatalf("RemovePod failed: %v", err)
+			}
 
-		n = cache.nodes[nodeName]
-		if n != nil {
-			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n.info)
-		}
+			n = cache.nodes[nodeName]
+			if n != nil {
+				t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n.info)
+			}
+		})
 	}
 }
 
@@ -836,45 +876,47 @@ func TestForgetPod(t *testing.T) {
 	ttl := 10 * time.Second
 
 	for i, tt := range tests {
-		cache := newSchedulerCache(ttl, time.Second, nil)
-		for _, pod := range tt.pods {
-			if err := assumeAndFinishBinding(cache, pod, now); err != nil {
-				t.Fatalf("assumePod failed: %v", err)
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			cache := newSchedulerCache(ttl, time.Second, nil)
+			for _, pod := range tt.pods {
+				if err := assumeAndFinishBinding(cache, pod, now); err != nil {
+					t.Fatalf("assumePod failed: %v", err)
+				}
+				isAssumed, err := cache.IsAssumedPod(pod)
+				if err != nil {
+					t.Fatalf("IsAssumedPod failed: %v.", err)
+				}
+				if !isAssumed {
+					t.Fatalf("Pod is expected to be assumed.")
+				}
+				assumedPod, err := cache.GetPod(pod)
+				if err != nil {
+					t.Fatalf("GetPod failed: %v.", err)
+				}
+				if assumedPod.Namespace != pod.Namespace {
+					t.Errorf("assumedPod.Namespace != pod.Namespace (%s != %s)", assumedPod.Namespace, pod.Namespace)
+				}
+				if assumedPod.Name != pod.Name {
+					t.Errorf("assumedPod.Name != pod.Name (%s != %s)", assumedPod.Name, pod.Name)
+				}
 			}
-			isAssumed, err := cache.IsAssumedPod(pod)
-			if err != nil {
-				t.Fatalf("IsAssumedPod failed: %v.", err)
+			for _, pod := range tt.pods {
+				if err := cache.ForgetPod(pod); err != nil {
+					t.Fatalf("ForgetPod failed: %v", err)
+				}
+				isAssumed, err := cache.IsAssumedPod(pod)
+				if err != nil {
+					t.Fatalf("IsAssumedPod failed: %v.", err)
+				}
+				if isAssumed {
+					t.Fatalf("Pod is expected to be unassumed.")
+				}
 			}
-			if !isAssumed {
-				t.Fatalf("Pod is expected to be assumed.")
+			cache.cleanupAssumedPods(now.Add(2 * ttl))
+			if n := cache.nodes[nodeName]; n != nil {
+				t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n.info)
 			}
-			assumedPod, err := cache.GetPod(pod)
-			if err != nil {
-				t.Fatalf("GetPod failed: %v.", err)
-			}
-			if assumedPod.Namespace != pod.Namespace {
-				t.Errorf("assumedPod.Namespace != pod.Namespace (%s != %s)", assumedPod.Namespace, pod.Namespace)
-			}
-			if assumedPod.Name != pod.Name {
-				t.Errorf("assumedPod.Name != pod.Name (%s != %s)", assumedPod.Name, pod.Name)
-			}
-		}
-		for _, pod := range tt.pods {
-			if err := cache.ForgetPod(pod); err != nil {
-				t.Fatalf("ForgetPod failed: %v", err)
-			}
-			isAssumed, err := cache.IsAssumedPod(pod)
-			if err != nil {
-				t.Fatalf("IsAssumedPod failed: %v.", err)
-			}
-			if isAssumed {
-				t.Fatalf("Pod is expected to be unassumed.")
-			}
-		}
-		cache.cleanupAssumedPods(now.Add(2 * ttl))
-		if n := cache.nodes[nodeName]; n != nil {
-			t.Errorf("#%d: expecting pod deleted and nil node info, get=%s", i, n.info)
-		}
+		})
 	}
 }
 
@@ -1051,15 +1093,16 @@ func TestNodeOperators(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		expected := buildNodeInfo(test.node, test.pods)
-		node := test.node
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("node/%v", i), func(t *testing.T) {
+			expected := buildNodeInfo(test.node, test.pods)
+			node := test.node
 
-		cache := newSchedulerCache(time.Second, time.Second, nil)
-		cache.AddNode(node)
-		for _, pod := range test.pods {
-			cache.AddPod(pod)
-		}
+			cache := newSchedulerCache(time.Second, time.Second, nil)
+			cache.AddNode(node)
+			for _, pod := range test.pods {
+				cache.AddPod(pod)
+			}
 
 		// Case 1: the node was added into cache successfully.
 		got, found := cache.nodes[node.Name]
@@ -1070,40 +1113,40 @@ func TestNodeOperators(t *testing.T) {
 			t.Errorf("cache.nodeTree is not updated correctly after adding node: %v", node.Name)
 		}
 
-		// Generations are globally unique. We check in our unit tests that they are incremented correctly.
-		expected.SetGeneration(got.info.GetGeneration())
-		if !reflect.DeepEqual(got.info, expected) {
-			t.Errorf("Failed to add node into schedulercache:\n got: %+v \nexpected: %+v", got, expected)
-		}
+			// Generations are globally unique. We check in our unit tests that they are incremented correctly.
+			expected.SetGeneration(got.info.GetGeneration())
+			if !reflect.DeepEqual(got.info, expected) {
+				t.Errorf("Failed to add node into schedulercache:\n got: %+v \nexpected: %+v", got, expected)
+			}
 
-		// Case 2: dump cached nodes successfully.
-		cachedNodes := schedulernodeinfo.NewSnapshot()
-		cache.UpdateNodeInfoSnapshot(cachedNodes)
-		newNode, found := cachedNodes.NodeInfoMap[node.Name]
-		if !found || len(cachedNodes.NodeInfoMap) != 1 {
-			t.Errorf("failed to dump cached nodes:\n got: %v \nexpected: %v", cachedNodes, cache.nodes)
-		}
-		expected.SetGeneration(newNode.GetGeneration())
-		if !reflect.DeepEqual(newNode, expected) {
-			t.Errorf("Failed to clone node:\n got: %+v, \n expected: %+v", newNode, expected)
-		}
+			// Case 2: dump cached nodes successfully.
+			cachedNodes := schedulernodeinfo.NewSnapshot()
+			cache.UpdateNodeInfoSnapshot(cachedNodes)
+			newNode, found := cachedNodes.NodeInfoMap[node.Name]
+			if !found || len(cachedNodes.NodeInfoMap) != 1 {
+				t.Errorf("failed to dump cached nodes:\n got: %v \nexpected: %v", cachedNodes, cache.nodes)
+			}
+			expected.SetGeneration(newNode.GetGeneration())
+			if !reflect.DeepEqual(newNode, expected) {
+				t.Errorf("Failed to clone node:\n got: %+v, \n expected: %+v", newNode, expected)
+			}
 
-		// Case 3: update node attribute successfully.
-		node.Status.Allocatable[v1.ResourceMemory] = mem50m
-		allocatableResource := expected.AllocatableResource()
-		newAllocatableResource := &allocatableResource
-		newAllocatableResource.Memory = mem50m.Value()
-		expected.SetAllocatableResource(newAllocatableResource)
+			// Case 3: update node attribute successfully.
+			node.Status.Allocatable[v1.ResourceMemory] = mem50m
+			allocatableResource := expected.AllocatableResource()
+			newAllocatableResource := &allocatableResource
+			newAllocatableResource.Memory = mem50m.Value()
+			expected.SetAllocatableResource(newAllocatableResource)
 
-		cache.UpdateNode(nil, node)
-		got, found = cache.nodes[node.Name]
-		if !found {
-			t.Errorf("Failed to find node %v in schedulernodeinfo after UpdateNode.", node.Name)
-		}
-		if got.info.GetGeneration() <= expected.GetGeneration() {
-			t.Errorf("Generation is not incremented. got: %v, expected: %v", got.info.GetGeneration(), expected.GetGeneration())
-		}
-		expected.SetGeneration(got.info.GetGeneration())
+			cache.UpdateNode(nil, node)
+			got, found = cache.nodes[node.Name]
+			if !found {
+				t.Errorf("Failed to find node %v in schedulernodeinfo after UpdateNode.", node.Name)
+			}
+			if got.info.GetGeneration() <= expected.GetGeneration() {
+				t.Errorf("Generation is not incremented. got: %v, expected: %v", got.info.GetGeneration(), expected.GetGeneration())
+			}
+			expected.SetGeneration(got.info.GetGeneration())
 
 		if !reflect.DeepEqual(got.info, expected) {
 			t.Errorf("Failed to update node in schedulernodeinfo:\n got: %+v \nexpected: %+v", got, expected)

--- a/pkg/scheduler/nodeinfo/host_ports_test.go
+++ b/pkg/scheduler/nodeinfo/host_ports_test.go
@@ -27,13 +27,13 @@ type hostPortInfoParam struct {
 
 func TestHostPortInfo_AddRemove(t *testing.T) {
 	tests := []struct {
-		desc    string
+		name    string
 		added   []hostPortInfoParam
 		removed []hostPortInfoParam
 		length  int
 	}{
 		{
-			desc: "normal add case",
+			name: "normal add case",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -50,7 +50,7 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 			length: 8,
 		},
 		{
-			desc: "empty ip and protocol add should work",
+			name: "empty ip and protocol add should work",
 			added: []hostPortInfoParam{
 				{"", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -66,7 +66,7 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 			length: 8,
 		},
 		{
-			desc: "normal remove case",
+			name: "normal remove case",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -90,7 +90,7 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 			length: 0,
 		},
 		{
-			desc: "empty ip and protocol remove should work",
+			name: "empty ip and protocol remove should work",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -116,29 +116,31 @@ func TestHostPortInfo_AddRemove(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		hp := make(HostPortInfo)
-		for _, param := range test.added {
-			hp.Add(param.ip, param.protocol, param.port)
-		}
-		for _, param := range test.removed {
-			hp.Remove(param.ip, param.protocol, param.port)
-		}
-		if hp.Len() != test.length {
-			t.Errorf("%v failed: expect length %d; got %d", test.desc, test.length, hp.Len())
-			t.Error(hp)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			for _, param := range test.removed {
+				hp.Remove(param.ip, param.protocol, param.port)
+			}
+			if hp.Len() != test.length {
+				t.Errorf("%v failed: expect length %d; got %d", test.name, test.length, hp.Len())
+				t.Error(hp)
+			}
+		})
 	}
 }
 
 func TestHostPortInfo_Check(t *testing.T) {
 	tests := []struct {
-		desc   string
+		name   string
 		added  []hostPortInfoParam
 		check  hostPortInfoParam
 		expect bool
 	}{
 		{
-			desc: "empty check should check 0.0.0.0 and TCP",
+			name: "empty check should check 0.0.0.0 and TCP",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -146,7 +148,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "empty check should check 0.0.0.0 and TCP (conflicted)",
+			name: "empty check should check 0.0.0.0 and TCP (conflicted)",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -154,7 +156,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: true,
 		},
 		{
-			desc: "empty port check should pass",
+			name: "empty port check should pass",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -162,7 +164,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "0.0.0.0 should check all registered IPs",
+			name: "0.0.0.0 should check all registered IPs",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 80},
 			},
@@ -170,7 +172,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: true,
 		},
 		{
-			desc: "0.0.0.0 with different protocol should be allowed",
+			name: "0.0.0.0 with different protocol should be allowed",
 			added: []hostPortInfoParam{
 				{"UDP", "127.0.0.1", 80},
 			},
@@ -178,7 +180,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "0.0.0.0 with different port should be allowed",
+			name: "0.0.0.0 with different port should be allowed",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"TCP", "127.0.0.1", 81},
@@ -188,7 +190,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "normal ip should check all registered 0.0.0.0",
+			name: "normal ip should check all registered 0.0.0.0",
 			added: []hostPortInfoParam{
 				{"TCP", "0.0.0.0", 80},
 			},
@@ -196,7 +198,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: true,
 		},
 		{
-			desc: "normal ip with different port/protocol should be allowed (0.0.0.0)",
+			name: "normal ip with different port/protocol should be allowed (0.0.0.0)",
 			added: []hostPortInfoParam{
 				{"TCP", "0.0.0.0", 79},
 				{"UDP", "0.0.0.0", 80},
@@ -207,7 +209,7 @@ func TestHostPortInfo_Check(t *testing.T) {
 			expect: false,
 		},
 		{
-			desc: "normal ip with different port/protocol should be allowed",
+			name: "normal ip with different port/protocol should be allowed",
 			added: []hostPortInfoParam{
 				{"TCP", "127.0.0.1", 79},
 				{"UDP", "127.0.0.1", 80},
@@ -220,12 +222,14 @@ func TestHostPortInfo_Check(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		hp := make(HostPortInfo)
-		for _, param := range test.added {
-			hp.Add(param.ip, param.protocol, param.port)
-		}
-		if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
-			t.Errorf("%v failed, expected %t; got %t", test.desc, test.expect, !test.expect)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			hp := make(HostPortInfo)
+			for _, param := range test.added {
+				hp.Add(param.ip, param.protocol, param.port)
+			}
+			if hp.CheckConflict(test.check.ip, test.check.protocol, test.check.port) != test.expect {
+				t.Errorf("%v failed, expected %t; got %t", test.name, test.expect, !test.expect)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/nodeinfo/node_info_test.go
+++ b/pkg/scheduler/nodeinfo/node_info_test.go
@@ -33,14 +33,17 @@ import (
 
 func TestNewResource(t *testing.T) {
 	tests := []struct {
+		name         string
 		resourceList v1.ResourceList
 		expected     *Resource
 	}{
 		{
+			name:         "empty resource set",
 			resourceList: map[v1.ResourceName]resource.Quantity{},
 			expected:     &Resource{},
 		},
 		{
+			name: "has resources set",
 			resourceList: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:                      *resource.NewScaledQuantity(4, -3),
 				v1.ResourceMemory:                   *resource.NewQuantity(2000, resource.BinarySI),
@@ -60,19 +63,23 @@ func TestNewResource(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r := NewResource(test.resourceList)
-		if !reflect.DeepEqual(test.expected, r) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, r)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			r := NewResource(test.resourceList)
+			if !reflect.DeepEqual(test.expected, r) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			}
+		})
 	}
 }
 
 func TestResourceList(t *testing.T) {
 	tests := []struct {
+		name     string
 		resource *Resource
 		expected v1.ResourceList
 	}{
 		{
+			name:     "empty resource list",
 			resource: &Resource{},
 			expected: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:              *resource.NewScaledQuantity(0, -3),
@@ -82,6 +89,7 @@ func TestResourceList(t *testing.T) {
 			},
 		},
 		{
+			name: "has resource list set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -106,23 +114,28 @@ func TestResourceList(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		rl := test.resource.ResourceList()
-		if !reflect.DeepEqual(test.expected, rl) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, rl)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			rl := test.resource.ResourceList()
+			if !reflect.DeepEqual(test.expected, rl) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, rl)
+			}
+		})
 	}
 }
 
 func TestResourceClone(t *testing.T) {
 	tests := []struct {
+		name     string
 		resource *Resource
 		expected *Resource
 	}{
 		{
+			name:     "no resource to clone",
 			resource: &Resource{},
 			expected: &Resource{},
 		},
 		{
+			name: "has resource to clone",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -141,23 +154,27 @@ func TestResourceClone(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		r := test.resource.Clone()
-		// Modify the field to check if the result is a clone of the origin one.
-		test.resource.MilliCPU += 1000
-		if !reflect.DeepEqual(test.expected, r) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, r)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			r := test.resource.Clone()
+			// Modify the field to check if the result is a clone of the origin one.
+			test.resource.MilliCPU += 1000
+			if !reflect.DeepEqual(test.expected, r) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, r)
+			}
+		})
 	}
 }
 
 func TestResourceAddScalar(t *testing.T) {
 	tests := []struct {
+		name           string
 		resource       *Resource
 		scalarName     v1.ResourceName
 		scalarQuantity int64
 		expected       *Resource
 	}{
 		{
+			name:           "add scalar value to empty set",
 			resource:       &Resource{},
 			scalarName:     "scalar1",
 			scalarQuantity: 100,
@@ -166,6 +183,7 @@ func TestResourceAddScalar(t *testing.T) {
 			},
 		},
 		{
+			name: "add scalar value to existing set",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           2000,
@@ -186,20 +204,24 @@ func TestResourceAddScalar(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.resource.AddScalar(test.scalarName, test.scalarQuantity)
-		if !reflect.DeepEqual(test.expected, test.resource) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			test.resource.AddScalar(test.scalarName, test.scalarQuantity)
+			if !reflect.DeepEqual(test.expected, test.resource) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			}
+		})
 	}
 }
 
 func TestSetMaxResource(t *testing.T) {
 	tests := []struct {
+		name         string
 		resource     *Resource
 		resourceList v1.ResourceList
 		expected     *Resource
 	}{
 		{
+			name:     "set max for empty resource",
 			resource: &Resource{},
 			resourceList: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:              *resource.NewScaledQuantity(4, -3),
@@ -213,6 +235,7 @@ func TestSetMaxResource(t *testing.T) {
 			},
 		},
 		{
+			name: "set max for non-empty resource",
 			resource: &Resource{
 				MilliCPU:         4,
 				Memory:           4000,
@@ -236,10 +259,12 @@ func TestSetMaxResource(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test.resource.SetMaxResource(test.resourceList)
-		if !reflect.DeepEqual(test.expected, test.resource) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			test.resource.SetMaxResource(test.resourceList)
+			if !reflect.DeepEqual(test.expected, test.resource) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, test.resource)
+			}
+		})
 	}
 }
 
@@ -531,14 +556,16 @@ func TestNodeInfoClone(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		ni := test.nodeInfo.Clone()
-		// Modify the field to check if the result is a clone of the origin one.
-		test.nodeInfo.generation += 10
-		test.nodeInfo.usedPorts.Remove("127.0.0.1", "TCP", 80)
-		if !reflect.DeepEqual(test.expected, ni) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, ni)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case-%d", i), func(t *testing.T) {
+			ni := test.nodeInfo.Clone()
+			// Modify the field to check if the result is a clone of the origin one.
+			test.nodeInfo.generation += 10
+			test.nodeInfo.usedPorts.Remove("127.0.0.1", "TCP", 80)
+			if !reflect.DeepEqual(test.expected, ni) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, ni)
+			}
+		})
 	}
 }
 
@@ -941,29 +968,32 @@ func TestNodeInfoRemovePod(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		ni := fakeNodeInfo(pods...)
+		name := fmt.Sprintf("node: %s, pod: %s", test.pod.Spec.NodeName, test.pod.GetName())
+		t.Run(name, func(t *testing.T) {
+			ni := fakeNodeInfo(pods...)
 
-		gen := ni.generation
-		err := ni.RemovePod(test.pod)
-		if err != nil {
-			if test.errExpected {
-				expectedErrorMsg := fmt.Errorf("no corresponding pod %s in pods of node %s", test.pod.Name, ni.Node().Name)
-				if expectedErrorMsg == err {
-					t.Errorf("expected error: %v, got: %v", expectedErrorMsg, err)
+			gen := ni.generation
+			err := ni.RemovePod(test.pod)
+			if err != nil {
+				if test.errExpected {
+					expectedErrorMsg := fmt.Errorf("no corresponding pod %s in pods of node %s", test.pod.Name, ni.Node().Name)
+					if expectedErrorMsg == err {
+						t.Errorf("expected error: %v, got: %v", expectedErrorMsg, err)
+					}
+				} else {
+					t.Errorf("expected no error, got: %v", err)
 				}
 			} else {
-				t.Errorf("expected no error, got: %v", err)
+				if ni.generation <= gen {
+					t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
+				}
 			}
-		} else {
-			if ni.generation <= gen {
-				t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
-			}
-		}
 
-		test.expectedNodeInfo.generation = ni.generation
-		if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
-			t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
-		}
+			test.expectedNodeInfo.generation = ni.generation
+			if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
+				t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
+			}
+		})
 	}
 }
 

--- a/pkg/scheduler/nodeinfo/util_test.go
+++ b/pkg/scheduler/nodeinfo/util_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package nodeinfo
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
@@ -29,11 +30,13 @@ const mb int64 = 1024 * 1024
 
 func TestGetNodeImageStates(t *testing.T) {
 	tests := []struct {
+		name              string
 		node              *v1.Node
 		imageExistenceMap map[string]sets.String
 		expected          map[string]*ImageStateSummary
 	}{
 		{
+			name: "node-0",
 			node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{Name: "node-0"},
 				Status: v1.NodeStatus{
@@ -82,10 +85,12 @@ func TestGetNodeImageStates(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		imageStates := getNodeImageStates(test.node, test.imageExistenceMap)
-		if !reflect.DeepEqual(test.expected, imageStates) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, imageStates)
-		}
+		t.Run(test.name, func(t *testing.T) {
+			imageStates := getNodeImageStates(test.node, test.imageExistenceMap)
+			if !reflect.DeepEqual(test.expected, imageStates) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, imageStates)
+			}
+		})
 	}
 }
 
@@ -167,10 +172,12 @@ func TestCreateImageExistenceMap(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		imageMap := createImageExistenceMap(test.nodes)
-		if !reflect.DeepEqual(test.expected, imageMap) {
-			t.Errorf("expected: %#v, got: %#v", test.expected, imageMap)
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case:%d", i), func(t *testing.T) {
+			imageMap := createImageExistenceMap(test.nodes)
+			if !reflect.DeepEqual(test.expected, imageMap) {
+				t.Errorf("expected: %#v, got: %#v", test.expected, imageMap)
+			}
+		})
 	}
 }

--- a/pkg/scheduler/util/utils_test.go
+++ b/pkg/scheduler/util/utils_test.go
@@ -135,11 +135,13 @@ func TestGetContainerPorts(t *testing.T) {
 		},
 	}
 
-	for _, test := range tests {
-		result := GetContainerPorts(test.pod1, test.pod2)
-		if !reflect.DeepEqual(test.expected, result) {
-			t.Errorf("Got different result than expected.\nDifference detected on:\n%s", diff.ObjectGoPrintSideBySide(test.expected, result))
-		}
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("case%v", i), func(t *testing.T) {
+			result := GetContainerPorts(test.pod1, test.pod2)
+			if !reflect.DeepEqual(test.expected, result) {
+				t.Errorf("Got different result than expected.\nDifference detected on:\n%s", diff.ObjectGoPrintSideBySide(test.expected, result))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Update scheduler's unit table tests to use subtest

**Special notes for your reviewer**:
Original Issue: #63267

Packages:
- `pkg/scheduler/algorithmprovider/defaults`
- `pkg/scheduler/internal/cache`
- `pkg/scheduler/api/compatibility`
- `pkg/scheduler/util`
- `pkg/scheduler/nodeinfo`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```