### PR TITLE
kube-proxy: do not export network programming latency for deleted Endpoints

### DIFF
--- a/pkg/controller/endpoint/trigger_time_tracker.go
+++ b/pkg/controller/endpoint/trigger_time_tracker.go
@@ -143,7 +143,7 @@ func getPodTriggerTime(pod *v1.Pod) (triggerTime time.Time) {
 	if readyCondition := podutil.GetPodReadyCondition(pod.Status); readyCondition != nil {
 		triggerTime = readyCondition.LastTransitionTime.Time
 	}
-	// TODO(mm4tt): Implement missing cases: deletionTime set, pod label change
+	// TODO(#81360): Implement missing cases: deletionTime set, pod label change
 	return triggerTime
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
At the moment the annotation used for calculations is not set when Endpoint is deleted, causing skewed results.

Also improve logging: log name of the endpoint with its latency.

**Which issue(s) this PR fixes**:
ref https://github.com/kubernetes/kubernetes/issues/81360 
fixes https://github.com/kubernetes/perf-tests/issues/640

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
n/a
```


