### PR TITLE
Remove Framework from Configurator

### DIFF
--- a/pkg/scheduler/api/compatibility/BUILD
+++ b/pkg/scheduler/api/compatibility/BUILD
@@ -9,6 +9,7 @@ go_test(
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/api/latest:go_default_library",
         "//pkg/scheduler/factory:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/scheduler/api/compatibility/compatibility_test.go
+++ b/pkg/scheduler/api/compatibility/compatibility_test.go
@@ -1099,7 +1099,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 
 		framework, err := framework.NewFramework(nil, nil, nil)
 		if err != nil {
-			t.Errorf("error initializing the scheduling framework: %v", err)
+			t.Fatalf("error initializing the scheduling framework: %v", err)
 		}
 		if _, err := factory.NewConfigFactory(&factory.ConfigFactoryArgs{
 			Client:                         client,

--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//pkg/scheduler/algorithm/priorities:go_default_library",
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/api/validation:go_default_library",
-        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/core:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -57,7 +57,7 @@ func TestCreate(t *testing.T) {
 	defer close(stopCh)
 	framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	factory := newConfigFactory(client, v1.DefaultHardPodAffinitySymmetricWeight, stopCh, framework)
 	factory.Create(framework)
@@ -74,7 +74,7 @@ func TestCreateFromConfig(t *testing.T) {
 	defer close(stopCh)
 	framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	factory := newConfigFactory(client, v1.DefaultHardPodAffinitySymmetricWeight, stopCh, framework)
 
@@ -118,7 +118,7 @@ func TestCreateFromConfigWithHardPodAffinitySymmetricWeight(t *testing.T) {
 	defer close(stopCh)
 	framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	factory := newConfigFactory(client, v1.DefaultHardPodAffinitySymmetricWeight, stopCh, framework)
 
@@ -163,7 +163,7 @@ func TestCreateFromEmptyConfig(t *testing.T) {
 	defer close(stopCh)
 	framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	factory := newConfigFactory(client, v1.DefaultHardPodAffinitySymmetricWeight, stopCh, framework)
 
@@ -184,7 +184,7 @@ func TestCreateFromConfigWithUnspecifiedPredicatesOrPriorities(t *testing.T) {
 	defer close(stopCh)
 	framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	factory := newConfigFactory(client, v1.DefaultHardPodAffinitySymmetricWeight, stopCh, framework)
 
@@ -223,7 +223,7 @@ func TestCreateFromConfigWithEmptyPredicatesOrPriorities(t *testing.T) {
 	defer close(stopCh)
 	framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	factory := newConfigFactory(client, v1.DefaultHardPodAffinitySymmetricWeight, stopCh, framework)
 
@@ -460,7 +460,7 @@ func TestInvalidHardPodAffinitySymmetricWeight(t *testing.T) {
 	stopCh := make(chan struct{})
 	framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	factory := newConfigFactory(client, -1, stopCh, framework)
 	defer close(stopCh)
@@ -495,7 +495,7 @@ func TestInvalidFactoryArgs(t *testing.T) {
 			stopCh := make(chan struct{})
 			framework, err := framework.NewFramework(framework.NewRegistry(), nil, []config.PluginConfig{})
 			if err != nil {
-				t.Errorf("error initializing the scheduling framework: %v", err)
+				t.Fatalf("error initializing the scheduling framework: %v", err)
 			}
 			factory := newConfigFactory(client, test.hardPodAffinitySymmetricWeight, stopCh, framework)
 			defer close(stopCh)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -607,7 +607,7 @@ func TestMultiScheduler(t *testing.T) {
 
 	framework, err := schedulerframework.NewFramework(schedulerframework.NewRegistry(), nil, []kubeschedulerconfig.PluginConfig{})
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	schedulerConfigFactory2 := factory.NewConfigFactory(createConfiguratorArgsWithPodInformer(fooScheduler, clientSet2, podInformer2, informerFactory2, stopCh), framework)
 	schedulerConfig2, err := schedulerConfigFactory2.Create(framework)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -605,9 +605,12 @@ func TestMultiScheduler(t *testing.T) {
 	stopCh := make(chan struct{})
 	defer close(stopCh)
 
-	schedulerConfigFactory2 := factory.NewConfigFactory(createConfiguratorArgsWithPodInformer(fooScheduler, clientSet2, podInformer2, informerFactory2, schedulerframework.NewRegistry(),
-		nil, []kubeschedulerconfig.PluginConfig{}, stopCh))
-	schedulerConfig2, err := schedulerConfigFactory2.Create()
+	framework, err := schedulerframework.NewFramework(schedulerframework.NewRegistry(), nil, []kubeschedulerconfig.PluginConfig{})
+	if err != nil {
+		t.Errorf("error initializing the scheduling framework: %v", err)
+	}
+	schedulerConfigFactory2 := factory.NewConfigFactory(createConfiguratorArgsWithPodInformer(fooScheduler, clientSet2, podInformer2, informerFactory2, stopCh), framework)
+	schedulerConfig2, err := schedulerConfigFactory2.Create(framework)
 	if err != nil {
 		t.Errorf("Couldn't create scheduler config: %v", err)
 	}

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -184,7 +184,7 @@ func initTestSchedulerWithOptions(
 		v1.DefaultSchedulerName, context.clientSet, podInformer, context.informerFactory, context.stopCh)
 	framework, err := schedulerframework.NewFramework(pluginRegistry, plugins, pluginConfig)
 	if err != nil {
-		t.Errorf("error initializing the scheduling framework: %v", err)
+		t.Fatalf("error initializing the scheduling framework: %v", err)
 	}
 	configFactory := factory.NewConfigFactory(context.schedulerConfigArgs, framework)
 

--- a/test/integration/util/BUILD
+++ b/test/integration/util/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/scheduler/algorithmprovider/defaults:go_default_library",
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/factory:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes framework from configurator as a step towards removing all other fields from the configurator, in order to make the `scheduler` independent of the `factory.configFactory` and `Configurator` types

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref #72547

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
