### PR TITLE
Add admission e2e tests for untested stable operations

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -74,6 +74,7 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/client-go/util/keyutil:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset:go_default_library",


### PR DESCRIPTION
Fixes https://github.com/kubernetes/kubernetes/issues/80767

Adds e2e tests for:

- update and patch of {Validating,Mutating}WebhookConfiguration, then ensuring changes are effective
- delete and deletecollection (filtered by label) of {Validating,Mutating}WebhookConfiguration, then ensuring removal is effective

/sig-apimachinery
/sig-testing
/cc @liggitt @roycaihw @caesarxuchao @sttts 

```release-note
None
```
