### PR TITLE
Apply zero TerminationGracePeriodSeconds to preemption victims

### DIFF
--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -1596,8 +1596,9 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 	}
 
 	// Create two pods.
-	waitingPod, err := createPausePod(cs,
-		initPausePod(cs, &pausePodConfig{Name: "waiting-pod", Namespace: context.ns.Name, Priority: &lowPriority, Resources: &resourceRequest}))
+	waitingPod := initPausePod(cs, &pausePodConfig{Name: "waiting-pod", Namespace: context.ns.Name, Priority: &lowPriority, Resources: &resourceRequest})
+	waitingPod.Spec.TerminationGracePeriodSeconds = new(int64)
+	waitingPod, err = createPausePod(cs, waitingPod)
 	if err != nil {
 		t.Errorf("Error while creating the waiting pod: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In the integration test, if we want to verify preemption, the victim pods should be applied with `spec.TerminationGracePeriodSeconds` = 0 to avoid the chances that the victim pods are alive up to termination second (30 seconds).

**Updated:** although apiserver can detect if a pod is "unbound" (nodeName as "") and then set the grace period to 0 in server side, this PR should be still valuable to set (and follow) a clear pattern for integration testcase which relies on Pod deletions.

Sample usage can be found in:

- test/integration/scheduler/preemption_test.go
- test/integration/scheduler/predicates_test.go

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/cc @hex108 