### PR TITLE
Move GetGPUDevicePluginImage to the test

### DIFF
--- a/test/e2e/framework/gpu/BUILD
+++ b/test/e2e/framework/gpu/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/gpu/gpu_util.go
+++ b/test/e2e/framework/gpu/gpu_util.go
@@ -20,7 +20,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	"k8s.io/klog"
 	"k8s.io/kubernetes/test/e2e/framework"
 )
 
@@ -61,22 +60,4 @@ func NVIDIADevicePlugin() *v1.Pod {
 	// Remove node affinity
 	p.Spec.Affinity = nil
 	return p
-}
-
-// GetGPUDevicePluginImage returns the image of GPU device plugin.
-func GetGPUDevicePluginImage() string {
-	ds, err := framework.DsFromManifest(GPUDevicePluginDSYAML)
-	if err != nil {
-		klog.Errorf("Failed to parse the device plugin image: %v", err)
-		return ""
-	}
-	if ds == nil {
-		klog.Errorf("Failed to parse the device plugin image: the extracted DaemonSet is nil")
-		return ""
-	}
-	if len(ds.Spec.Template.Spec.Containers) < 1 {
-		klog.Errorf("Failed to parse the device plugin image: cannot extract the container from YAML")
-		return ""
-	}
-	return ds.Spec.Template.Spec.Containers[0].Image
 }

--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -53,7 +53,7 @@ var NodeImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Perl),
 	imageutils.GetE2EImage(imageutils.Nonewprivs),
 	imageutils.GetPauseImageName(),
-	gpu.GetGPUDevicePluginImage(),
+	getGPUDevicePluginImage(),
 	"gcr.io/kubernetes-e2e-test-images/node-perf/npb-is:1.0",
 	"gcr.io/kubernetes-e2e-test-images/node-perf/npb-ep:1.0",
 	"gcr.io/kubernetes-e2e-test-images/node-perf/tf-wide-deep-amd64:1.0",
@@ -166,4 +166,22 @@ func PrePullAllImages() error {
 		}
 	}
 	return nil
+}
+
+// getGPUDevicePluginImage returns the image of GPU device plugin.
+func getGPUDevicePluginImage() string {
+	ds, err := framework.DsFromManifest(gpu.GPUDevicePluginDSYAML)
+	if err != nil {
+		klog.Errorf("Failed to parse the device plugin image: %v", err)
+		return ""
+	}
+	if ds == nil {
+		klog.Errorf("Failed to parse the device plugin image: the extracted DaemonSet is nil")
+		return ""
+	}
+	if len(ds.Spec.Template.Spec.Containers) < 1 {
+		klog.Errorf("Failed to parse the device plugin image: cannot extract the container from YAML")
+		return ""
+	}
+	return ds.Spec.Template.Spec.Containers[0].Image
 }


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

GetGPUDevicePluginImage() was called in some e2e node test only.
So it is not worth keeping the function as a part of e2e test
framework. This moves GetGPUDevicePluginImage() to the e2e node
test for code cleanup.

Ref: https://github.com/kubernetes/kubernetes/issues/81232
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
