### PR TITLE
Remove fail argument from ReadOrDie()

### DIFF
--- a/test/e2e/examples.go
+++ b/test/e2e/examples.go
@@ -155,5 +155,5 @@ var _ = framework.KubeDescribe("[Feature:Example]", func() {
 
 func readFile(test, file string) string {
 	from := filepath.Join(test, file)
-	return commonutils.SubstituteImageName(string(testfiles.ReadOrDie(from, ginkgo.Fail)))
+	return commonutils.SubstituteImageName(string(testfiles.ReadOrDie(from)))
 }

--- a/test/e2e/framework/deviceplugin/BUILD
+++ b/test/e2e/framework/deviceplugin/BUILD
@@ -12,7 +12,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/deviceplugin/device_plugin_util.go
+++ b/test/e2e/framework/deviceplugin/device_plugin_util.go
@@ -23,8 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
-
-	"github.com/onsi/ginkgo"
 )
 
 const (
@@ -54,7 +52,7 @@ func NumberOfSampleResources(node *v1.Node) int64 {
 
 // GetSampleDevicePluginPod returns the Device Plugin pod for sample resources in e2e tests
 func GetSampleDevicePluginPod() *v1.Pod {
-	ds := ReadDaemonSetV1OrDie(testfiles.ReadOrDie(sampleDevicePluginDSYAML, ginkgo.Fail))
+	ds := ReadDaemonSetV1OrDie(testfiles.ReadOrDie(sampleDevicePluginDSYAML))
 	p := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      sampleDevicePluginName,

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -399,10 +399,10 @@ func NewIngressTestJig(c clientset.Interface) *TestJig {
 func (j *TestJig) CreateIngress(manifestPath, ns string, ingAnnotations map[string]string, svcAnnotations map[string]string) {
 	var err error
 	read := func(file string) string {
-		return string(testfiles.ReadOrDie(filepath.Join(manifestPath, file), ginkgo.Fail))
+		return string(testfiles.ReadOrDie(filepath.Join(manifestPath, file)))
 	}
 	exists := func(file string) bool {
-		return testfiles.Exists(filepath.Join(manifestPath, file), ginkgo.Fail)
+		return testfiles.Exists(filepath.Join(manifestPath, file))
 	}
 
 	j.Logger.Infof("creating replication controller")
@@ -844,7 +844,7 @@ type NginxIngressController struct {
 // Init initializes the NginxIngressController
 func (cont *NginxIngressController) Init() {
 	read := func(file string) string {
-		return string(testfiles.ReadOrDie(filepath.Join(IngressManifestPath, "nginx", file), ginkgo.Fail))
+		return string(testfiles.ReadOrDie(filepath.Join(IngressManifestPath, "nginx", file)))
 	}
 	e2elog.Logf("initializing nginx ingress controller")
 	framework.RunKubectlOrDieInput(read("rc.yaml"), "create", "-f", "-", fmt.Sprintf("--namespace=%v", cont.Ns))

--- a/test/e2e/framework/testfiles/BUILD
+++ b/test/e2e/framework/testfiles/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = ["testfiles.go"],
     importpath = "k8s.io/kubernetes/test/e2e/framework/testfiles",
     visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/onsi/ginkgo:go_default_library"],
 )
 
 filegroup(

--- a/test/e2e/framework/testfiles/testfiles.go
+++ b/test/e2e/framework/testfiles/testfiles.go
@@ -33,6 +33,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/onsi/ginkgo"
 )
 
 var filesources []FileSource
@@ -64,20 +66,14 @@ type FileSource interface {
 	DescribeFiles() string
 }
 
-// Fail is an error handler function with the same prototype and
-// semantic as ginkgo.Fail. Typically ginkgo.Fail is what callers
-// of ReadOrDie and Exists will pass. This way this package
-// avoids depending on Ginkgo.
-type Fail func(failure string, callerSkip ...int)
-
 // ReadOrDie tries to retrieve the desired file content from
 // one of the registered file sources. In contrast to FileSource, it
 // will either return a valid slice or abort the test by calling the fatal function,
 // i.e. the caller doesn't have to implement error checking.
-func ReadOrDie(filePath string, fail Fail) []byte {
+func ReadOrDie(filePath string) []byte {
 	data, err := Read(filePath)
 	if err != nil {
-		fail(err.Error(), 1)
+		ginkgo.Fail(err.Error(), 1)
 	}
 	return data
 }
@@ -110,11 +106,11 @@ func Read(filePath string) ([]byte, error) {
 // Exists checks whether a file could be read. Unexpected errors
 // are handled by calling the fail function, which then should
 // abort the current test.
-func Exists(filePath string, fail Fail) bool {
+func Exists(filePath string) bool {
 	for _, filesource := range filesources {
 		data, err := filesource.ReadTestFile(filePath)
 		if err != nil {
-			fail(fmt.Sprintf("fatal error looking for test file %s: %s", filePath, err), 1)
+			ginkgo.Fail(fmt.Sprintf("fatal error looking for test file %s: %s", filePath, err), 1)
 		}
 		if data != nil {
 			return true

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -133,7 +133,7 @@ func cleanupKubectlInputs(fileContents string, ns string, selectors ...string) {
 }
 
 func readTestFileOrDie(file string) []byte {
-	return testfiles.ReadOrDie(path.Join(kubeCtlManifestPath, file), ginkgo.Fail)
+	return testfiles.ReadOrDie(path.Join(kubeCtlManifestPath, file))
 }
 
 func runKubectlRetryOrDie(args ...string) string {
@@ -275,8 +275,8 @@ var _ = SIGDescribe("Kubectl client", func() {
 		var nautilus, kitten string
 		ginkgo.BeforeEach(func() {
 			updateDemoRoot := "test/fixtures/doc-yaml/user-guide/update-demo"
-			nautilus = commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "nautilus-rc.yaml.in"), ginkgo.Fail)))
-			kitten = commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "kitten-rc.yaml.in"), ginkgo.Fail)))
+			nautilus = commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "nautilus-rc.yaml.in"))))
+			kitten = commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(updateDemoRoot, "kitten-rc.yaml.in"))))
 		})
 		/*
 			Release : v1.9
@@ -340,7 +340,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 				"redis-master-deployment.yaml.in",
 				"redis-slave-deployment.yaml.in",
 			} {
-				contents := commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(guestbookRoot, gbAppFile), ginkgo.Fail)))
+				contents := commonutils.SubstituteImageName(string(testfiles.ReadOrDie(filepath.Join(guestbookRoot, gbAppFile))))
 				run(contents)
 			}
 		}

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -94,7 +94,7 @@ func installFlex(c clientset.Interface, node *v1.Node, vendor, driver, filePath 
 	cmd := fmt.Sprintf("sudo mkdir -p %s", flexDir)
 	sshAndLog(cmd, host, true /*failOnError*/)
 
-	data := testfiles.ReadOrDie(filePath, ginkgo.Fail)
+	data := testfiles.ReadOrDie(filePath)
 	cmd = fmt.Sprintf("sudo tee <<'EOF' %s\n%s\nEOF", flexFile, string(data))
 	sshAndLog(cmd, host, true /*failOnError*/)
 

--- a/test/e2e/upgrades/cassandra.go
+++ b/test/e2e/upgrades/cassandra.go
@@ -61,7 +61,7 @@ func (CassandraUpgradeTest) Skip(upgCtx UpgradeContext) bool {
 }
 
 func cassandraKubectlCreate(ns, file string) {
-	input := string(testfiles.ReadOrDie(filepath.Join(cassandraManifestPath, file), ginkgo.Fail))
+	input := string(testfiles.ReadOrDie(filepath.Join(cassandraManifestPath, file)))
 	framework.RunKubectlOrDieInput(input, "create", "-f", "-", fmt.Sprintf("--namespace=%s", ns))
 }
 

--- a/test/e2e/upgrades/etcd.go
+++ b/test/e2e/upgrades/etcd.go
@@ -60,7 +60,7 @@ func (EtcdUpgradeTest) Skip(upgCtx UpgradeContext) bool {
 }
 
 func kubectlCreate(ns, file string) {
-	input := string(testfiles.ReadOrDie(filepath.Join(manifestPath, file), ginkgo.Fail))
+	input := string(testfiles.ReadOrDie(filepath.Join(manifestPath, file)))
 	framework.RunKubectlOrDieInput(input, "create", "-f", "-", fmt.Sprintf("--namespace=%s", ns))
 }
 

--- a/test/e2e/upgrades/mysql.go
+++ b/test/e2e/upgrades/mysql.go
@@ -62,7 +62,7 @@ func (MySQLUpgradeTest) Skip(upgCtx UpgradeContext) bool {
 }
 
 func mysqlKubectlCreate(ns, file string) {
-	input := string(testfiles.ReadOrDie(filepath.Join(mysqlManifestPath, file), ginkgo.Fail))
+	input := string(testfiles.ReadOrDie(filepath.Join(mysqlManifestPath, file)))
 	framework.RunKubectlOrDieInput(input, "create", "-f", "-", fmt.Sprintf("--namespace=%s", ns))
 }
 


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Every caller of ReadOrDie() specified ginkgo.Fail as fail argument,
and that was intentional to avoid depending on Ginkgo.
However that just spreaded the dependency on Ginkgo to caller sides.
Especially that was unnecessary e2e test framework "ingress" depended
on Ginkgo only for the above reason.
Now we are cleaning up the dependencies on e2e tests, so let's just
remove such dependencies.

Ref: https://github.com/kubernetes/kubernetes/issues/81232

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
