### PR TITLE
change deprecatedVersion type to string for static analysis parsing ease

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -55,7 +55,7 @@ func (c *Counter) setPrometheusCounter(counter prometheus.Counter) {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (c *Counter) DeprecatedVersion() *semver.Version {
-	return c.CounterOpts.DeprecatedVersion
+	return parseSemver(c.CounterOpts.DeprecatedVersion)
 }
 
 // initializeMetric invocation creates the actual underlying Counter. Until this method is called
@@ -102,7 +102,8 @@ func NewCounterVec(opts *CounterOpts, labels []string) *CounterVec {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (v *CounterVec) DeprecatedVersion() *semver.Version {
-	return v.CounterOpts.DeprecatedVersion
+	return parseSemver(v.CounterOpts.DeprecatedVersion)
+
 }
 
 // initializeMetric invocation creates the actual underlying CounterVec. Until this method is called

--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestCounter(t *testing.T) {
-	v114 := semver.MustParse("1.14.0")
-	v115 := semver.MustParse("1.15.0")
 	var tests = []struct {
 		desc string
 		*CounterOpts
@@ -53,7 +51,7 @@ func TestCounter(t *testing.T) {
 				Subsystem:         "subsystem",
 				Help:              "counter help",
 				StabilityLevel:    ALPHA,
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 			},
 			expectedMetricCount: 1,
 			expectedHelp:        "[ALPHA] (Deprecated since 1.15.0) counter help",
@@ -66,7 +64,7 @@ func TestCounter(t *testing.T) {
 				Subsystem:         "subsystem",
 				Help:              "counter help",
 				StabilityLevel:    ALPHA,
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 			},
 			expectedMetricCount: 0,
 		},
@@ -123,8 +121,6 @@ func TestCounter(t *testing.T) {
 }
 
 func TestCounterVec(t *testing.T) {
-	v115 := semver.MustParse("1.15.0")
-	v114 := semver.MustParse("1.14.0")
 	var tests = []struct {
 		desc string
 		*CounterOpts
@@ -152,7 +148,7 @@ func TestCounterVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "counter help",
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 			},
 			labels:                    []string{"label_a", "label_b"},
 			expectedMetricFamilyCount: 1,
@@ -165,7 +161,7 @@ func TestCounterVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "counter help",
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 			},
 			labels:                    []string{"label_a", "label_b"},
 			expectedMetricFamilyCount: 0,

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -55,7 +55,7 @@ func (g *Gauge) setPrometheusGauge(gauge prometheus.Gauge) {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (g *Gauge) DeprecatedVersion() *semver.Version {
-	return g.GaugeOpts.DeprecatedVersion
+	return parseSemver(g.GaugeOpts.DeprecatedVersion)
 }
 
 // initializeMetric invocation creates the actual underlying Gauge. Until this method is called
@@ -102,7 +102,7 @@ func NewGaugeVec(opts *GaugeOpts, labels []string) *GaugeVec {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (v *GaugeVec) DeprecatedVersion() *semver.Version {
-	return v.GaugeOpts.DeprecatedVersion
+	return parseSemver(v.GaugeOpts.DeprecatedVersion)
 }
 
 // initializeMetric invocation creates the actual underlying GaugeVec. Until this method is called

--- a/staging/src/k8s.io/component-base/metrics/gauge_test.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestGauge(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
-	v114 := semver.MustParse("1.14.0")
 	var tests = []struct {
 		desc string
 		GaugeOpts
@@ -51,7 +50,7 @@ func TestGauge(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "gauge help",
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 			},
 			registryVersion:     &v115,
 			expectedMetricCount: 1,
@@ -64,7 +63,7 @@ func TestGauge(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "gauge help",
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 			},
 			registryVersion:     &v115,
 			expectedMetricCount: 0,
@@ -117,7 +116,6 @@ func TestGauge(t *testing.T) {
 
 func TestGaugeVec(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
-	v114 := semver.MustParse("1.14.0")
 	var tests = []struct {
 		desc string
 		GaugeOpts
@@ -146,7 +144,7 @@ func TestGaugeVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "gauge help",
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,
@@ -160,7 +158,7 @@ func TestGaugeVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "gauge help",
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -19,7 +19,6 @@ package metrics
 import (
 	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/klog"
 )
 
 // Histogram is our internal representation for our wrapping struct around prometheus
@@ -55,7 +54,7 @@ func (h *Histogram) setPrometheusHistogram(histogram prometheus.Histogram) {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (h *Histogram) DeprecatedVersion() *semver.Version {
-	return h.HistogramOpts.DeprecatedVersion
+	return parseSemver(h.HistogramOpts.DeprecatedVersion)
 }
 
 // initializeMetric invokes the actual prometheus.Histogram object instantiation
@@ -87,11 +86,9 @@ type HistogramVec struct {
 // anything unless the collector is first registered, since the metric is lazily instantiated.
 func NewHistogramVec(opts *HistogramOpts, labels []string) *HistogramVec {
 	// todo: handle defaulting better
-	klog.Errorf("---%v---\n", opts)
 	if opts.StabilityLevel == "" {
 		opts.StabilityLevel = ALPHA
 	}
-	klog.Errorf("---%v---\n", opts)
 	v := &HistogramVec{
 		HistogramVec:   noopHistogramVec,
 		HistogramOpts:  opts,
@@ -104,7 +101,7 @@ func NewHistogramVec(opts *HistogramOpts, labels []string) *HistogramVec {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (v *HistogramVec) DeprecatedVersion() *semver.Version {
-	return v.HistogramOpts.DeprecatedVersion
+	return parseSemver(v.HistogramOpts.DeprecatedVersion)
 }
 
 func (v *HistogramVec) initializeMetric() {

--- a/staging/src/k8s.io/component-base/metrics/histogram_test.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestHistogram(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
-	v114 := semver.MustParse("1.14.0")
 	var tests = []struct {
 		desc string
 		HistogramOpts
@@ -53,7 +52,7 @@ func TestHistogram(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "histogram help message",
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 				Buckets:           prometheus.DefBuckets,
 			},
 			registryVersion:     &v115,
@@ -67,7 +66,7 @@ func TestHistogram(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "histogram help message",
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 				Buckets:           prometheus.DefBuckets,
 			},
 			registryVersion:     &v115,
@@ -122,7 +121,6 @@ func TestHistogram(t *testing.T) {
 
 func TestHistogramVec(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
-	v114 := semver.MustParse("1.14.0")
 	var tests = []struct {
 		desc string
 		HistogramOpts
@@ -152,7 +150,7 @@ func TestHistogramVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "histogram help message",
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 				Buckets:           prometheus.DefBuckets,
 			},
 			labels:              []string{"label_a", "label_b"},
@@ -167,7 +165,7 @@ func TestHistogramVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "histogram help message",
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 				Buckets:           prometheus.DefBuckets,
 			},
 			labels:              []string{"label_a", "label_b"},

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry_test.go
@@ -35,8 +35,6 @@ func init() {
 }
 
 var (
-	v115         = semver.MustParse("1.15.0")
-	v114         = semver.MustParse("1.14.0")
 	alphaCounter = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Namespace:      "some_namespace",
@@ -53,7 +51,7 @@ var (
 			Subsystem:         "subsystem",
 			StabilityLevel:    metrics.ALPHA,
 			Help:              "counter help",
-			DeprecatedVersion: &v115,
+			DeprecatedVersion: "1.15.0",
 		},
 	)
 	alphaHiddenCounter = metrics.NewCounter(
@@ -63,7 +61,7 @@ var (
 			Subsystem:         "subsystem",
 			StabilityLevel:    metrics.ALPHA,
 			Help:              "counter help",
-			DeprecatedVersion: &v114,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 )

--- a/staging/src/k8s.io/component-base/metrics/opts.go
+++ b/staging/src/k8s.io/component-base/metrics/opts.go
@@ -18,7 +18,6 @@ package metrics
 
 import (
 	"fmt"
-	"github.com/blang/semver"
 	"github.com/prometheus/client_golang/prometheus"
 	"sync"
 	"time"
@@ -36,7 +35,7 @@ type KubeOpts struct {
 	Name              string
 	Help              string
 	ConstLabels       prometheus.Labels
-	DeprecatedVersion *semver.Version
+	DeprecatedVersion string
 	deprecateOnce     sync.Once
 	annotateOnce      sync.Once
 	StabilityLevel    StabilityLevel
@@ -125,7 +124,7 @@ type HistogramOpts struct {
 	Help              string
 	ConstLabels       prometheus.Labels
 	Buckets           []float64
-	DeprecatedVersion *semver.Version
+	DeprecatedVersion string
 	deprecateOnce     sync.Once
 	annotateOnce      sync.Once
 	StabilityLevel    StabilityLevel
@@ -174,7 +173,7 @@ type SummaryOpts struct {
 	MaxAge            time.Duration
 	AgeBuckets        uint32
 	BufCap            uint32
-	DeprecatedVersion *semver.Version
+	DeprecatedVersion string
 	deprecateOnce     sync.Once
 	annotateOnce      sync.Once
 	StabilityLevel    StabilityLevel

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -44,7 +44,7 @@ var (
 			Subsystem:         "subsystem",
 			StabilityLevel:    ALPHA,
 			Help:              "counter help",
-			DeprecatedVersion: &v115,
+			DeprecatedVersion: "1.15.0",
 		},
 	)
 	alphaHiddenCounter = NewCounter(
@@ -54,7 +54,7 @@ var (
 			Subsystem:         "subsystem",
 			StabilityLevel:    ALPHA,
 			Help:              "counter help",
-			DeprecatedVersion: &v114,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 )
@@ -221,7 +221,7 @@ func TestShowHiddenMetric(t *testing.T) {
 			Subsystem:         "subsystem",
 			StabilityLevel:    ALPHA,
 			Help:              "counter help",
-			DeprecatedVersion: &v114,
+			DeprecatedVersion: "1.14.0",
 		},
 	))
 	expectedMetricCount = 1

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -58,7 +58,7 @@ func (s *Summary) setPrometheusSummary(summary prometheus.Summary) {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (s *Summary) DeprecatedVersion() *semver.Version {
-	return s.SummaryOpts.DeprecatedVersion
+	return parseSemver(s.SummaryOpts.DeprecatedVersion)
 }
 
 // initializeMetric invokes the actual prometheus.Summary object instantiation
@@ -108,7 +108,7 @@ func NewSummaryVec(opts *SummaryOpts, labels []string) *SummaryVec {
 
 // DeprecatedVersion returns a pointer to the Version or nil
 func (v *SummaryVec) DeprecatedVersion() *semver.Version {
-	return v.SummaryOpts.DeprecatedVersion
+	return parseSemver(v.SummaryOpts.DeprecatedVersion)
 }
 
 func (v *SummaryVec) initializeMetric() {

--- a/staging/src/k8s.io/component-base/metrics/summary_test.go
+++ b/staging/src/k8s.io/component-base/metrics/summary_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestSummary(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
-	v114 := semver.MustParse("1.14.0")
 	var tests = []struct {
 		desc string
 		SummaryOpts
@@ -52,7 +51,7 @@ func TestSummary(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "summary help message",
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 				StabilityLevel:    ALPHA,
 			},
 			registryVersion:     &v115,
@@ -66,7 +65,7 @@ func TestSummary(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "summary help message",
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 			},
 			registryVersion:     &v115,
 			expectedMetricCount: 0,
@@ -120,7 +119,6 @@ func TestSummary(t *testing.T) {
 
 func TestSummaryVec(t *testing.T) {
 	v115 := semver.MustParse("1.15.0")
-	v114 := semver.MustParse("1.14.0")
 	var tests = []struct {
 		desc string
 		SummaryOpts
@@ -149,7 +147,7 @@ func TestSummaryVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "summary help message",
-				DeprecatedVersion: &v115,
+				DeprecatedVersion: "1.15.0",
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,
@@ -163,7 +161,7 @@ func TestSummaryVec(t *testing.T) {
 				Name:              "metric_test_name",
 				Subsystem:         "subsystem",
 				Help:              "summary help message",
-				DeprecatedVersion: &v114,
+				DeprecatedVersion: "1.14.0",
 			},
 			labels:              []string{"label_a", "label_b"},
 			registryVersion:     &v115,

--- a/staging/src/k8s.io/component-base/metrics/version_parser.go
+++ b/staging/src/k8s.io/component-base/metrics/version_parser.go
@@ -31,6 +31,13 @@ var (
 	versionRe = regexp.MustCompile(versionRegexpString)
 )
 
+func parseSemver(s string) *semver.Version {
+	if s != "" {
+		sv := semver.MustParse(s)
+		return &sv
+	}
+	return nil
+}
 func parseVersion(ver apimachineryversion.Info) semver.Version {
 	matches := versionRe.FindAllStringSubmatch(ver.String(), -1)
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

It is currently difficult to analyze the deprecated version due to the fact that it is a pointer to some arbitrary struct. We've opted to simplify the type during metric instantiation so that we can more easily operate on the field for validation and verification.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig instrumentation
/cc @serathius 
/assign @brancz 
