### PR TITLE
Support Kubelet PluginWatcher in Windows

### DIFF
--- a/pkg/kubelet/pluginmanager/pluginwatcher/BUILD
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kubelet/pluginmanager/cache:go_default_library",
         "//pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta1:go_default_library",
         "//pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta2:go_default_library",
+        "//pkg/kubelet/util:go_default_library",
         "//pkg/util/filesystem:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",

--- a/pkg/kubelet/util/BUILD
+++ b/pkg/kubelet/util/BUILD
@@ -16,14 +16,18 @@ go_test(
     deps = select({
         "@io_bazel_rules_go//go/platform:darwin": [
             "//vendor/github.com/stretchr/testify/assert:go_default_library",
+            "//vendor/github.com/stretchr/testify/require:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//vendor/github.com/stretchr/testify/assert:go_default_library",
+            "//vendor/github.com/stretchr/testify/require:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//vendor/github.com/stretchr/testify/assert:go_default_library",
+            "//vendor/github.com/stretchr/testify/require:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [
+            "//vendor/github.com/Microsoft/go-winio:go_default_library",
             "//vendor/github.com/stretchr/testify/assert:go_default_library",
             "//vendor/github.com/stretchr/testify/require:go_default_library",
         ],

--- a/pkg/kubelet/util/util_unix.go
+++ b/pkg/kubelet/util/util_unix.go
@@ -135,3 +135,20 @@ func LocalEndpoint(path, file string) (string, error) {
 	}
 	return filepath.Join(u.String(), file+".sock"), nil
 }
+
+// IsUnixDomainSocket returns whether a given file is a AF_UNIX socket file
+func IsUnixDomainSocket(filePath string) (bool, error) {
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return false, fmt.Errorf("stat file %s failed: %v", filePath, err)
+	}
+	if fi.Mode()&os.ModeSocket == 0 {
+		return false, nil
+	}
+	return true, nil
+}
+
+// NormalizePath is a no-op for Linux for now
+func NormalizePath(path string) string {
+	return path
+}

--- a/pkg/kubelet/util/util_unix_test.go
+++ b/pkg/kubelet/util/util_unix_test.go
@@ -19,9 +19,13 @@ limitations under the License.
 package util
 
 import (
+	"io/ioutil"
+	"net"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseEndpoint(t *testing.T) {
@@ -68,4 +72,64 @@ func TestParseEndpoint(t *testing.T) {
 		assert.Equal(t, test.expectedAddr, addr)
 	}
 
+}
+
+func TestIsUnixDomainSocket(t *testing.T) {
+	tests := []struct {
+		label          string
+		listenOnSocket bool
+		expectSocket   bool
+		expectError    bool
+		invalidFile    bool
+	}{
+		{
+			label:          "Domain Socket file",
+			listenOnSocket: true,
+			expectSocket:   true,
+			expectError:    false,
+		},
+		{
+			label:       "Non Existent file",
+			invalidFile: true,
+			expectError: true,
+		},
+		{
+			label:          "Regular file",
+			listenOnSocket: false,
+			expectSocket:   false,
+			expectError:    false,
+		},
+	}
+	for _, test := range tests {
+		f, err := ioutil.TempFile("", "test-domain-socket")
+		require.NoErrorf(t, err, "Failed to create file for test purposes: %v while setting up: %s", err, test.label)
+		addr := f.Name()
+		f.Close()
+		var ln *net.UnixListener
+		if test.listenOnSocket {
+			os.Remove(addr)
+			ta, err := net.ResolveUnixAddr("unix", addr)
+			require.NoErrorf(t, err, "Failed to ResolveUnixAddr: %v while setting up: %s", err, test.label)
+			ln, err = net.ListenUnix("unix", ta)
+			require.NoErrorf(t, err, "Failed to ListenUnix: %v while setting up: %s", err, test.label)
+		}
+		fileToTest := addr
+		if test.invalidFile {
+			fileToTest = fileToTest + ".invalid"
+		}
+		result, err := IsUnixDomainSocket(fileToTest)
+		if test.listenOnSocket {
+			// this takes care of removing the file associated with the domain socket
+			ln.Close()
+		} else {
+			// explicitly remove regular file
+			os.Remove(addr)
+		}
+		if test.expectError {
+			assert.NotNil(t, err, "Unexpected nil error from IsUnixDomainSocket for %s", test.label)
+		} else {
+			assert.Nil(t, err, "Unexpected error invoking IsUnixDomainSocket for %s", test.label)
+		}
+		assert.Equal(t, result, test.expectSocket, "Unexpected result from IsUnixDomainSocket: %v for %s", result, test.label)
+	}
 }

--- a/pkg/kubelet/util/util_windows_test.go
+++ b/pkg/kubelet/util/util_windows_test.go
@@ -19,8 +19,14 @@ limitations under the License.
 package util
 
 import (
+	"io/ioutil"
+	"math/rand"
+	"net"
+	"os"
 	"testing"
+	"time"
 
+	winio "github.com/Microsoft/go-winio"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -89,4 +95,101 @@ func TestParseEndpoint(t *testing.T) {
 		assert.Equal(t, test.expectedAddr, addr)
 	}
 
+}
+
+func testPipe(t *testing.T, label string) {
+	generatePipeName := func(suffixlen int) string {
+		rand.Seed(time.Now().UnixNano())
+		letter := []rune("abcdef0123456789")
+		b := make([]rune, suffixlen)
+		for i := range b {
+			b[i] = letter[rand.Intn(len(letter))]
+		}
+		return "\\\\.\\pipe\\test-pipe" + string(b)
+	}
+	testFile := generatePipeName(4)
+	pipeln, err := winio.ListenPipe(testFile, &winio.PipeConfig{SecurityDescriptor: "D:P(A;;GA;;;BA)(A;;GA;;;SY)"})
+	defer pipeln.Close()
+
+	require.NoErrorf(t, err, "Failed to listen on named pipe for test purposes: %v while setting up: %s", err, label)
+	result, err := IsUnixDomainSocket(testFile)
+	assert.Nil(t, err, "Unexpected error: %v from IsUnixDomainSocket for %s", err, label)
+	assert.False(t, result, "Unexpected result: true from IsUnixDomainSocket: %v for %s", result, label)
+}
+
+func testRegularFile(t *testing.T, label string, exists bool) {
+	f, err := ioutil.TempFile("", "test-file")
+	require.NoErrorf(t, err, "Failed to create file for test purposes: %v while setting up: %s", err, label)
+	testFile := f.Name()
+	if !exists {
+		testFile = testFile + ".absent"
+	}
+	f.Close()
+	result, err := IsUnixDomainSocket(testFile)
+	os.Remove(f.Name())
+	assert.Nil(t, err, "Unexpected error: %v from IsUnixDomainSocket for %s", err, label)
+	assert.False(t, result, "Unexpected result: true from IsUnixDomainSocket: %v for %s", result, label)
+}
+
+func testUnixDomainSocket(t *testing.T, label string) {
+	f, err := ioutil.TempFile("", "test-domain-socket")
+	require.NoErrorf(t, err, "Failed to create file for test purposes: %v while setting up: %s", err, label)
+	testFile := f.Name()
+	f.Close()
+	os.Remove(testFile)
+	ta, err := net.ResolveUnixAddr("unix", testFile)
+	require.NoErrorf(t, err, "Failed to ResolveUnixAddr: %v while setting up: %s", err, label)
+	unixln, err := net.ListenUnix("unix", ta)
+	require.NoErrorf(t, err, "Failed to ListenUnix: %v while setting up: %s", err, label)
+	result, err := IsUnixDomainSocket(testFile)
+	unixln.Close()
+	assert.Nil(t, err, "Unexpected error: %v from IsUnixDomainSocket for %s", err, label)
+	assert.True(t, result, "Unexpected result: false from IsUnixDomainSocket: %v for %s", result, label)
+}
+
+func TestIsUnixDomainSocket(t *testing.T) {
+	testPipe(t, "Named Pipe")
+	testRegularFile(t, "Regular File that Exists", true)
+	testRegularFile(t, "Regular File that Does Not Exist", false)
+	testUnixDomainSocket(t, "Unix Domain Socket File")
+}
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		originalpath   string
+		normalizedPath string
+	}{
+		{
+			originalpath:   "\\path\\to\\file",
+			normalizedPath: "c:\\path\\to\\file",
+		},
+		{
+			originalpath:   "/path/to/file",
+			normalizedPath: "c:\\path\\to\\file",
+		},
+		{
+			originalpath:   "/path/to/dir/",
+			normalizedPath: "c:\\path\\to\\dir\\",
+		},
+		{
+			originalpath:   "\\path\\to\\dir\\",
+			normalizedPath: "c:\\path\\to\\dir\\",
+		},
+		{
+			originalpath:   "/file",
+			normalizedPath: "c:\\file",
+		},
+		{
+			originalpath:   "\\file",
+			normalizedPath: "c:\\file",
+		},
+		{
+			originalpath:   "fileonly",
+			normalizedPath: "fileonly",
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.normalizedPath, NormalizePath(test.originalpath))
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR enhances the kubelet plugin watcher to work with files associated with Unix Domain Sockets on Windows by correctly detecting such files using `FSCTL_GET_REPARSE_POINT`. In Windows, `os.ModeSocket` does not get set correctly by golang (https://github.com/golang/go/issues/33357).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Once golang adds support for `os.ModeSocket` for Windows (https://github.com/golang/go/issues/33357), the function `IsUnixDomainSocket` introduced here may be removed.

**Does this PR introduce a user-facing change?**:
```release-note
Support Kubelet plugin watcher on Windows nodes.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-windows/20190714-windows-csi-support.md
```
