### PR TITLE
Fix the rejected label semantics in webhook metrics, add a counter metrics for webhook rejection with details 

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -81,6 +81,37 @@ func TestObserveWebhook(t *testing.T) {
 	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_duration_seconds", wantLabels, 1)
 }
 
+func TestObserveWebhookRejection(t *testing.T) {
+	Metrics.reset()
+	Metrics.ObserveWebhookRejection("x", stepAdmit, string(admission.Create), WebhookRejectionNoError, 500)
+	Metrics.ObserveWebhookRejection("x", stepAdmit, string(admission.Create), WebhookRejectionNoError, 654)
+	Metrics.ObserveWebhookRejection("x", stepValidate, string(admission.Update), WebhookRejectionCallingWebhookError, 0)
+	wantLabels := map[string]string{
+		"name":           "x",
+		"operation":      string(admission.Create),
+		"type":           "admit",
+		"error_type":     "no_error",
+		"rejection_code": "500",
+	}
+	wantLabels600 := map[string]string{
+		"name":           "x",
+		"operation":      string(admission.Create),
+		"type":           "admit",
+		"error_type":     "no_error",
+		"rejection_code": "600",
+	}
+	wantLabelsCallingWebhookError := map[string]string{
+		"name":           "x",
+		"operation":      string(admission.Update),
+		"type":           "validate",
+		"error_type":     "calling_webhook_error",
+		"rejection_code": "0",
+	}
+	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels600, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabelsCallingWebhookError, 1)
+}
+
 func TestWithMetrics(t *testing.T) {
 	Metrics.reset()
 

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/error.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/error.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package webhook
 
-import "fmt"
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
 
 // ErrCallingWebhook is returned for transport-layer errors calling webhooks. It
 // represents a failure to talk to the webhook, not the webhook rejecting a
@@ -31,4 +35,13 @@ func (e *ErrCallingWebhook) Error() string {
 		return fmt.Sprintf("failed calling webhook %q: %v", e.WebhookName, e.Reason)
 	}
 	return fmt.Sprintf("failed calling webhook %q; no further details available", e.WebhookName)
+}
+
+// ErrWebhookRejection represents a webhook properly rejecting a request.
+type ErrWebhookRejection struct {
+	Status *apierrors.StatusError
+}
+
+func (e *ErrWebhookRejection) Error() string {
+	return e.Status.Error()
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
The current webhook metrics logs if a webhook `rejected` a request, which could potentially be caused by:
1. an error occurred invoking the webhook (network failure, webhook response is malformed)
2. the webhook is invoked successfully, determines the request should be rejected, returns a rejection with optionally an HTTP status code
3. kube-apiserver hits an internal error

Moreover, the logged "rejection" can be ignored if 1) it's an error invoking the webhook and 2) the webhook is configured to ignore client call failure.

This PR fixes the semantics for the `rejected` label in existing metrics, and adds a new counter metrics `apiserver_admission_webhook_rejection_count` with details about the causing for a rejection.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The `rejected` label in `apiserver_admission_webhook_admission_duration_seconds` metrices now properly indicates if a request was rejected. Add a new counter metrics `apiserver_admission_webhook_rejection_count` with details about the causing for a webhook rejection.
```

/cc @logicalhan 