### PR TITLE
Update e2e testing nodePort service listening on same port but different protocols

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -859,13 +859,30 @@ func (j *TestJig) CheckServiceReachability(namespace string, svc *v1.Service, po
 	}
 }
 
-// CreateServicePods creates a replication controller with the label same as service
+// CreateServicePods creates a replication controller with the label same as service. Service listens to HTTP.
 func (j *TestJig) CreateServicePods(c clientset.Interface, ns string, replica int) {
 	config := testutils.RCConfig{
 		Client:       c,
 		Name:         j.Name,
 		Image:        framework.ServeHostnameImage,
 		Command:      []string{"/agnhost", "serve-hostname"},
+		Namespace:    ns,
+		Labels:       j.Labels,
+		PollInterval: 3 * time.Second,
+		Timeout:      framework.PodReadyBeforeTimeout,
+		Replicas:     replica,
+	}
+	err := framework.RunRC(config)
+	framework.ExpectNoError(err, "Replica must be created")
+}
+
+// CreateTCPUDPServicePods creates a replication controller with the label same as service. Service listens to TCP and UDP.
+func (j *TestJig) CreateTCPUDPServicePods(c clientset.Interface, ns string, replica int) {
+	config := testutils.RCConfig{
+		Client:       c,
+		Name:         j.Name,
+		Image:        framework.ServeHostnameImage,
+		Command:      []string{"/agnhost", "serve-hostname", "--http=false", "--tcp", "--udp"},
 		Namespace:    ns,
 		Labels:       j.Labels,
 		PollInterval: 3 * time.Second,


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
1. Updates `should be able to update NodePorts with two same port numbers but different protocols` to test service reachability and improved e2e Name and behavior.
2. Removes `should use same NodePort with same port but different protocols` as this behaviour would be tested by above updated e2e.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #81418

**Special notes for your reviewer**:
Changes are made to make e2e eligible for Conformance.
Source of Issue : https://github.com/kubernetes/kubernetes/pull/77865#issuecomment-492849235

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/area conformance
/sig testing
@kubernetes/cncf-conformance-wg
@kubernetes/sig-node-pr-reviews
@kubernetes/sig-architecture-pr-reviews