### PR TITLE
Bump vertical autoscaler to v0.8.1

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/cpvpa-amd64:v0.7.1
+        - image: k8s.gcr.io/cpvpa-amd64:v0.8.1
           name: autoscaler
           command:
             - /cpvpa

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       containers:
-        - image: k8s.gcr.io/cpvpa-amd64:v0.7.1
+        - image: k8s.gcr.io/cpvpa-amd64:v0.8.1
           name: autoscaler
           command:
             - /cpvpa


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Vertical autoscaler v0.8.1 adds support for apps/v1, otherwise it is essentially not working. Ref https://github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/issues/19 and https://github.com/kubernetes/kubernetes/pull/80536.

Release link: https://github.com/kubernetes-incubator/cluster-proportional-vertical-autoscaler/releases/tag/v0.8.1

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #NONE

**Special notes for your reviewer**:
/assign @caseydavenport @lzang 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
