### PR TITLE
apiextensions: ignore path conflict and resolve definition conflict when merging openapi spec

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -7,6 +7,7 @@ go 1.12
 require (
 	github.com/coreos/etcd v3.3.15+incompatible
 	github.com/emicklei/go-restful v2.9.5+incompatible
+	github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4 // indirect
 	github.com/go-openapi/errors v0.19.2
 	github.com/go-openapi/spec v0.19.2
 	github.com/go-openapi/strfmt v0.19.0

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -64,6 +64,8 @@ github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4 h1:bRzFpEzvausOAt4va+I/22BZ1vXDtERngp0BNYDKej0=
+github.com/ghodss/yaml v0.0.0-20180820084758-c7ce16629ff4/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8 h1:DujepqpGd1hyOd7aW59XpK7Qymp8iy83xq74fLr21is=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/aggregator:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/builder:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -218,7 +218,11 @@ func (c *Controller) updateSpecLocked() error {
 			crdSpecs = append(crdSpecs, s)
 		}
 	}
-	return c.openAPIService.UpdateSpec(builder.MergeSpecs(c.staticSpec, crdSpecs...))
+	mergedSpec, err := builder.MergeSpecs(c.staticSpec, crdSpecs...)
+	if err != nil {
+		return fmt.Errorf("failed to merge specs: %v", err)
+	}
+	return c.openAPIService.UpdateSpec(mergedSpec)
 }
 
 func (c *Controller) addCustomResourceDefinition(obj interface{}) {

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package master
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,16 +27,26 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/spec"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kube-aggregator/pkg/apis/apiregistration"
 	kubeapiservertesting "k8s.io/kubernetes/cmd/kube-apiserver/app/testing"
+	"k8s.io/kubernetes/test/integration/etcd"
 	"k8s.io/kubernetes/test/integration/framework"
+)
+
+const (
+	// testApiextensionsOverlapProbeString is a probe string which identifies whether
+	// a CRD change triggers an OpenAPI spec change
+	testApiextensionsOverlapProbeString = "testApiextensionsOverlapProbeField"
 )
 
 func TestRun(t *testing.T) {
@@ -188,6 +199,204 @@ func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
 	if !matchedRegistration {
 		t.Errorf("missing path: %q", registrationPrefix)
 	}
+}
+
+func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
+	server := kubeapiservertesting.StartTestServerOrDie(t, nil, nil, framework.SharedEtcd())
+	defer server.TearDownFn()
+	apiextensionsclient, err := apiextensionsclientset.NewForConfig(server.ClientConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	crdPath, exist, err := getOpenAPIPath(apiextensionsclient, `/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}`)
+	if err != nil {
+		t.Fatalf("unexpected error getting CRD OpenAPI path: %v", err)
+	}
+	if !exist {
+		t.Fatalf("unexpected error: apiextensions OpenAPI path doesn't exist")
+	}
+
+	// Create a CRD that overlaps OpenAPI path with the CRD API
+	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "customresourcedefinitions.apiextensions.k8s.io",
+			Annotations: map[string]string{"api-approved.kubernetes.io": "unapproved, test-only"},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "apiextensions.k8s.io",
+			Version: "v1beta1",
+			Scope:   apiextensionsv1beta1.ClusterScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   "customresourcedefinitions",
+				Singular: "customresourcedefinition",
+				Kind:     "CustomResourceDefinition",
+				ListKind: "CustomResourceDefinitionList",
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						testApiextensionsOverlapProbeString: {Type: "boolean"},
+					},
+				},
+			},
+		},
+	}
+	etcd.CreateTestCRDs(t, apiextensionsclient, false, crd)
+
+	// Create a probe CRD foo that triggers an OpenAPI spec change
+	if err := triggerSpecUpdateWithProbeCRD(t, apiextensionsclient, "foo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect the CRD path to not change
+	path, _, err := getOpenAPIPath(apiextensionsclient, `/apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/{name}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	pathBytes, err := json.Marshal(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	crdPathBytes, err := json.Marshal(crdPath)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal(pathBytes, crdPathBytes) {
+		t.Fatalf("expected CRD OpenAPI path to not change, but got different results: want %q, got %q", string(crdPathBytes), string(pathBytes))
+	}
+
+	// Expect the orphan definition to be pruned from the spec
+	exist, err = specHasProbe(apiextensionsclient, testApiextensionsOverlapProbeString)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if exist {
+		t.Fatalf("unexpected error: orphan definition isn't pruned")
+	}
+
+	// Create a CRD that overlaps OpenAPI definition with the CRD API
+	crd = &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "customresourcedefinitions.apiextensions.apis.pkg.apiextensions-apiserver.k8s.io",
+			Annotations: map[string]string{"api-approved.kubernetes.io": "unapproved, test-only"},
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "apiextensions.apis.pkg.apiextensions-apiserver.k8s.io",
+			Version: "v1beta1",
+			Scope:   apiextensionsv1beta1.ClusterScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   "customresourcedefinitions",
+				Singular: "customresourcedefinition",
+				Kind:     "CustomResourceDefinition",
+				ListKind: "CustomResourceDefinitionList",
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						testApiextensionsOverlapProbeString: {Type: "boolean"},
+					},
+				},
+			},
+		},
+	}
+	etcd.CreateTestCRDs(t, apiextensionsclient, false, crd)
+
+	// Create a probe CRD bar that triggers an OpenAPI spec change
+	if err := triggerSpecUpdateWithProbeCRD(t, apiextensionsclient, "bar"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Expect the apiextensions definition to not change, since the overlapping definition will get renamed.
+	apiextensionsDefinition, exist, err := getOpenAPIDefinition(apiextensionsclient, `io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinition`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !exist {
+		t.Fatalf("unexpected error: apiextensions definition doesn't exist")
+	}
+	bytes, err := json.Marshal(apiextensionsDefinition)
+	if exist := strings.Contains(string(bytes), testApiextensionsOverlapProbeString); exist {
+		t.Fatalf("unexpected error: apiextensions definition gets overlapped")
+	}
+}
+
+// triggerSpecUpdateWithProbeCRD creates a probe CRD with suffix in name, and waits until
+// the path and definition for the probe CRD show up in the OpenAPI spec
+func triggerSpecUpdateWithProbeCRD(t *testing.T, apiextensionsclient *apiextensionsclientset.Clientset, suffix string) error {
+	// Create a probe CRD that triggers OpenAPI spec change
+	name := fmt.Sprintf("integration-test-%s-crd", suffix)
+	kind := fmt.Sprintf("Integration-test-%s-crd", suffix)
+	group := "probe.test.com"
+	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{Name: name + "s." + group},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   group,
+			Version: "v1",
+			Scope:   apiextensionsv1beta1.ClusterScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural:   name + "s",
+				Singular: name,
+				Kind:     kind,
+				ListKind: kind + "List",
+			},
+		},
+	}
+	etcd.CreateTestCRDs(t, apiextensionsclient, false, crd)
+
+	// Expect the probe CRD path to show up in the OpenAPI spec
+	// TODO(roycaihw): expose response header in rest client and utilize etag here
+	if err := wait.Poll(1*time.Second, wait.ForeverTestTimeout, func() (bool, error) {
+		_, exist, err := getOpenAPIPath(apiextensionsclient, fmt.Sprintf(`/apis/%s/v1/%ss/{name}`, group, name))
+		if err != nil {
+			return false, err
+		}
+		return exist, nil
+	}); err != nil {
+		return fmt.Errorf("failed to observe probe CRD path in the spec: %v", err)
+	}
+	return nil
+}
+
+func specHasProbe(clientset *apiextensionsclientset.Clientset, probe string) (bool, error) {
+	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(string(bs), probe), nil
+}
+
+func getOpenAPIPath(clientset *apiextensionsclientset.Clientset, path string) (spec.PathItem, bool, error) {
+	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+	if err != nil {
+		return spec.PathItem{}, false, err
+	}
+	s := spec.Swagger{}
+	if err := json.Unmarshal(bs, &s); err != nil {
+		return spec.PathItem{}, false, err
+	}
+	if s.SwaggerProps.Paths == nil {
+		return spec.PathItem{}, false, fmt.Errorf("unexpected empty path")
+	}
+	value, ok := s.SwaggerProps.Paths.Paths[path]
+	return value, ok, nil
+}
+
+func getOpenAPIDefinition(clientset *apiextensionsclientset.Clientset, definition string) (spec.Schema, bool, error) {
+	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+	if err != nil {
+		return spec.Schema{}, false, err
+	}
+	s := spec.Swagger{}
+	if err := json.Unmarshal(bs, &s); err != nil {
+		return spec.Schema{}, false, err
+	}
+	if s.SwaggerProps.Definitions == nil {
+		return spec.Schema{}, false, fmt.Errorf("unexpected empty path")
+	}
+	value, ok := s.SwaggerProps.Definitions[definition]
+	return value, ok, nil
 }
 
 // return the unique endpoint IPs


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
partially fixes https://github.com/kubernetes/kubernetes/issues/78706#issuecomment-521477342

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix a bug in CRD openapi controller that user-defined CRD can overwrite OpenAPI definition/path for the CRD API.
```