### PR TITLE
Fixes all-namespaces flag being ignored by ToBuilder() in builder_flags.go

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
@@ -130,6 +130,10 @@ func (o *ResourceBuilderFlags) ToBuilder(restClientGetter RESTClientGetter, reso
 	builder := resource.NewBuilder(restClientGetter).
 		NamespaceParam(namespace).DefaultNamespace()
 
+	if o.AllNamespaces != nil {
+		builder.AllNamespaces(*o.AllNamespaces)
+	}
+
 	if o.Scheme != nil {
 		builder.WithScheme(o.Scheme, o.Scheme.PrioritizedVersionsAllGroups()...)
 	} else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/sig cli

**What this PR does / why we need it**:

`ToBuilder()` was ignoring `--all-namespaces` flag in `builder_flags.go`. I am not sure if it was intended but this was causing `--all-namespaces` flag to be ignored in `kubectl wait`. This PR corrects this behavior in order to address the filed issue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/699


```release-note
kubectl: the --all-namespaces flag is now honored by `kubectl wait`
```