### PR TITLE
Move ConfirmStatefulPodCount to e2e test

### DIFF
--- a/test/e2e/framework/statefulset/BUILD
+++ b/test/e2e/framework/statefulset/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/log:go_default_library",
-        "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/manifest:go_default_library",
         "//test/utils/image:go_default_library",
     ],

--- a/test/e2e/framework/statefulset/rest.go
+++ b/test/e2e/framework/statefulset/rest.go
@@ -33,7 +33,6 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	e2efwk "k8s.io/kubernetes/test/e2e/framework"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
-	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e/manifest"
 )
 
@@ -218,29 +217,6 @@ func Restart(c clientset.Interface, ss *appsv1.StatefulSet) {
 	// before we scale it back up.
 	WaitForStatusReplicas(c, ss, 0)
 	update(c, ss.Namespace, ss.Name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = oldReplicas })
-}
-
-// ConfirmStatefulPodCount asserts that the current number of Pods in ss is count, waiting up to timeout for ss to
-// to scale to count.
-func ConfirmStatefulPodCount(c clientset.Interface, count int, ss *appsv1.StatefulSet, timeout time.Duration, hard bool) {
-	start := time.Now()
-	deadline := start.Add(timeout)
-	for t := time.Now(); t.Before(deadline); t = time.Now() {
-		podList := GetPodList(c, ss)
-		statefulPodCount := len(podList.Items)
-		if statefulPodCount != count {
-			e2epod.LogPodStates(podList.Items)
-			if hard {
-				e2elog.Failf("StatefulSet %v scaled unexpectedly scaled to %d -> %d replicas", ss.Name, count, len(podList.Items))
-			} else {
-				e2elog.Logf("StatefulSet %v has not reached scale %d, at %d", ss.Name, count, statefulPodCount)
-			}
-			time.Sleep(1 * time.Second)
-			continue
-		}
-		e2elog.Logf("Verifying statefulset %v doesn't scale past %d for another %+v", ss.Name, count, deadline.Sub(t))
-		time.Sleep(1 * time.Second)
-	}
 }
 
 // GetStatefulSet gets the StatefulSet named name in namespace.


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

ConfirmStatefulPodCount() was used at e2e statefulset test only,
and that added dependency on another sub framework to statefulset
sub framework. This moves ConfirmStatefulPodCount() to the e2e test
for clean dependency.

Ref: https://github.com/kubernetes/kubernetes/issues/81232

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
