### PR TITLE
aggregator: add myself to approvers

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/OWNERS
+++ b/staging/src/k8s.io/kube-aggregator/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - deads2k
 - lavalamp
 - smarterclayton
+- sttts
 reviewers:
 - caesarxuchao
 - deads2k


### PR DESCRIPTION
```
$ git log --oneline staging/src/k8s.io/kube-aggregator | grep sttts
0adbd6989d0 Merge pull request #76385 from sttts/sttts-kube-aggregator-openapi-fix-existing
ef8aa4fd7fb Merge pull request #76550 from sttts/sttts-code-gen-tools-complete
f8024ab087b Merge pull request #74904 from sttts/sttts-proto-tests
c5242f0368e Merge pull request #74244 from sttts/sttts-apiservice-metrics-typo
7944fed44b8 Merge pull request #73953 from sttts/sttts-simplify-kube-aggregator-openapi
6912bbb153e Merge pull request #71223 from sttts/sttts-openapi-aggreation-without-clone
5ed26a348b0 Merge pull request #67543 from sttts/sttts-auth-skip-paths
a160fe94a5b Merge pull request #64517 from sttts/sttts-apiserver-sectioned-flags
a9be647e65c Merge pull request #65645 from sttts/sttts-gengo-import-aliases
d1f5cb2348d Merge pull request #65050 from sttts/sttts-deepcopy-update
ef3539e69e4 Merge pull request #60373 from sttts/sttts-1.10-cfssl
8deab517675 Merge pull request #56403 from sttts/sttts-client-gen-main-reuse
aaf14d4619d Merge pull request #53525 from sttts/sttts-scheme-copier-romoval
3ba46ee9fab Merge pull request #52710 from sttts/sttts-less-aggressive-staging-godep-mangling
9f902fef246 Merge pull request #50094 from sttts/sttts-no-importprefix
1f45c4846ba Merge pull request #45766 from sttts/sttts-audit-event-in-context
2c2b5f7379a Merge pull request #45085 from sttts/sttts-aggregator-upgrade
49e54355290 Merge pull request #45403 from sttts/sttts-tri-state-watch-capacity
1a46a167f3c Merge pull request #41882 from sttts/sttts-loopback-selfsigned-cert
e49f44d89c7 Merge pull request #41486 from sttts/sttts-clientset-scheme
```

```release-note
NONE
```
