### PR TITLE
Move HandleFlags to e2e package

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -20,6 +20,7 @@ go_test(
         "//test/e2e/cloud:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/config:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",
         "//test/e2e/framework/viperconfig:go_default_library",
         "//test/e2e/generated:go_default_library",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -31,6 +31,7 @@ import (
 	// "github.com/onsi/ginkgo"
 
 	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/kubernetes/test/e2e/framework/config"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
 	"k8s.io/kubernetes/test/e2e/framework/viperconfig"
 	"k8s.io/kubernetes/test/e2e/generated"
@@ -60,9 +61,17 @@ import (
 
 var viperConfig = flag.String("viper-config", "", "The name of a viper config file (https://github.com/spf13/viper#what-is-viper). All e2e command line parameters can also be configured in such a file. May contain a path and may or may not contain the file suffix. The default is to look for an optional file with `e2e` as base name. If a file is specified explicitly, it must be present.")
 
+// handleFlags sets up all flags and parses the command line.
+func handleFlags() {
+	config.CopyFlags(config.Flags, flag.CommandLine)
+	framework.RegisterCommonFlags(flag.CommandLine)
+	framework.RegisterClusterFlags(flag.CommandLine)
+	flag.Parse()
+}
+
 func init() {
-	// Register framework and test flags, then parse flags.
-	framework.HandleFlags()
+	// Register test flags, then parse flags.
+	handleFlags()
 
 	// Now that we know which Viper config (if any) was chosen,
 	// parse it and update those options which weren't already set via command line flags

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -84,7 +84,6 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/remotecommand:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
-        "//test/e2e/framework/config:go_default_library",
         "//test/e2e/framework/ginkgowrapper:go_default_library",
         "//test/e2e/framework/kubelet:go_default_library",
         "//test/e2e/framework/log:go_default_library",

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -33,7 +33,6 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
-	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
@@ -361,14 +360,6 @@ func RegisterNodeFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.ImageDescription, "image-description", "", "The description of the image which the test will be running on.")
 	flags.StringVar(&TestContext.SystemSpecName, "system-spec-name", "", "The name of the system spec (e.g., gke) that's used in the node e2e test. The system specs are in test/e2e_node/system/specs/. This is used by the test framework to determine which tests to run for validating the system requirements.")
 	flags.Var(cliflag.NewMapStringString(&TestContext.ExtraEnvs), "extra-envs", "The extra environment variables needed for node e2e tests. Format: a list of key=value pairs, e.g., env1=val1,env2=val2")
-}
-
-// HandleFlags sets up all flags and parses the command line.
-func HandleFlags() {
-	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
-	RegisterCommonFlags(flag.CommandLine)
-	RegisterClusterFlags(flag.CommandLine)
-	flag.Parse()
 }
 
 func createKubeConfig(clientCfg *restclient.Config) *clientcmdapi.Config {


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

HandleFlags() was used at e2e package and it depends on sub e2e
framework "config" in core e2e framework. That was invalid dependency.
So this moves HandleFlags() to e2e package for simple dependency.

Ref: https://github.com/kubernetes/kubernetes/issues/81245

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
