### PR TITLE
Removed awk from kubeadm reset

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/BUILD
+++ b/cmd/kubeadm/app/cmd/phases/reset/BUILD
@@ -7,6 +7,8 @@ go_library(
         "data.go",
         "preflight.go",
         "removeetcdmember.go",
+        "unmount.go",
+        "unmount_linux.go",
         "updateclusterstatus.go",
     ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/reset",

--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"k8s.io/klog"
@@ -100,13 +99,10 @@ func absoluteKubeletRunDirectory() (string, error) {
 		klog.Warningf("[reset] Failed to evaluate the %q directory. Skipping its unmount and cleanup: %v\n", kubeadmconstants.KubeletRunDirectory, err)
 		return "", err
 	}
-
-	// Only unmount mount points which start with "/var/lib/kubelet" or absolute path of symbolic link, and avoid using empty absoluteKubeletRunDirectory
-	umountDirsCmd := fmt.Sprintf("awk '$2 ~ path {print $2}' path=%s/ /proc/mounts | xargs -r umount", absoluteKubeletRunDirectory)
-	klog.V(1).Infof("[reset] Executing command %q", umountDirsCmd)
-	umountOutputBytes, err := exec.Command("sh", "-c", umountDirsCmd).Output()
+	err = unmountKubeletDirectory(absoluteKubeletRunDirectory)
 	if err != nil {
-		klog.Warningf("[reset] Failed to unmount mounted directories in %s: %s\n", kubeadmconstants.KubeletRunDirectory, string(umountOutputBytes))
+		klog.Warningf("[reset] Failed to unmount mounted directories in %s \n", kubeadmconstants.KubeletRunDirectory)
+		return "", err
 	}
 	return absoluteKubeletRunDirectory, nil
 }

--- a/cmd/kubeadm/app/cmd/phases/reset/unmount.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/unmount.go
@@ -1,0 +1,29 @@
+// +build !linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"k8s.io/klog"
+)
+
+// unmountKubeletDirectory is a NOOP on all but linux.
+func unmountKubeletDirectory(absoluteKubeletRunDirectory string) error {
+	klog.Warning("Cannot unmount filesystems on current OS, all mounted file systems will need to be manually unmounted")
+	return nil
+}

--- a/cmd/kubeadm/app/cmd/phases/reset/unmount_linux.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/unmount_linux.go
@@ -1,0 +1,46 @@
+// +build linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package phases
+
+import (
+	"io/ioutil"
+	"strings"
+	"syscall"
+
+	"k8s.io/klog"
+)
+
+// unmountKubeletDirectory unmounts all paths that contain KubeletRunDirectory
+func unmountKubeletDirectory(absoluteKubeletRunDirectory string) error {
+	raw, err := ioutil.ReadFile("/proc/mounts")
+	if err != nil {
+		return err
+	}
+	mounts := strings.Split(string(raw), "\n")
+	for _, mount := range mounts {
+		m := strings.Split(mount, " ")
+		if len(m) < 2 || !strings.HasPrefix(m[1], absoluteKubeletRunDirectory) {
+			continue
+		}
+		if err := syscall.Unmount(m[1], 0); err != nil {
+			klog.Warningf("[reset] Failed to unmount mounted directory in %s: %s", absoluteKubeletRunDirectory, m[1])
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
removed awk usage from `kubeadm reset` in favor of native golang calls
that are not vulnerable to expansion.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> 
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR was created based on results from the security assessment, 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
xref#/kubernetes/kubeadm/issues/1715

**Special notes for your reviewer**:

@neolit123 :
Wanted to get feedback. in it's current state it's not very testable. But at the same time I did not want to pollute the core change with changes not related to removing awk. 

also, I would not expect a function called `absoluteKubeletRunDirectory` to unmount directories. but again thought this change would pollute the core change. If it is acceptable I will make a new PR later this week to address this. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm reset: unmount directories under "/var/lib/kubelet" for linux only
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
