### PR TITLE
Automated cherry pick of #73484: have local specs come first

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator.go
@@ -148,6 +148,12 @@ func (a byPriority) Len() int      { return len(a.specs) }
 func (a byPriority) Swap(i, j int) { a.specs[i], a.specs[j] = a.specs[j], a.specs[i] }
 func (a byPriority) Less(i, j int) bool {
 	// All local specs will come first
+	if a.specs[i].apiService.Spec.Service == nil && a.specs[j].apiService.Spec.Service != nil {
+		return true
+	}
+	if a.specs[i].apiService.Spec.Service != nil && a.specs[j].apiService.Spec.Service == nil {
+		return false
+	}
 	// WARNING: This will result in not following priorities for local APIServices.
 	if a.specs[i].apiService.Spec.Service == nil {
 		// Sort local specs with their name. This is the order in the delegation chain (aggregator first).

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator_test.go
@@ -38,6 +38,15 @@ func newAPIServiceForTest(name, group string, minGroupPriority, versionPriority 
 	return r
 }
 
+func newLocalAPIServiceForTest(name, group string, minGroupPriority, versionPriority int32) apiregistration.APIService {
+	r := apiregistration.APIService{}
+	r.Spec.Group = group
+	r.Spec.GroupPriorityMinimum = minGroupPriority
+	r.Spec.VersionPriority = versionPriority
+	r.Name = name
+	return r
+}
+
 func assertSortedServices(t *testing.T, actual []openAPISpecInfo, expectedNames []string) {
 	actualNames := []string{}
 	for _, a := range actual {
@@ -66,9 +75,21 @@ func TestAPIServiceSort(t *testing.T) {
 			apiService: newAPIServiceForTest("ThirdService", "Group3", 15, 3),
 			spec:       &spec.Swagger{},
 		},
+		{
+			apiService: newLocalAPIServiceForTest("FirstLocalSpec", "Group1", 15, 5),
+			spec:       &spec.Swagger{},
+		},
+		{
+			apiService: newLocalAPIServiceForTest("SecondLocalSpec", "Group2", 14, 6),
+			spec:       &spec.Swagger{},
+		},
+		{
+			apiService: newLocalAPIServiceForTest("ThirdLocalSpec", "Group3", 16, 3),
+			spec:       &spec.Swagger{},
+		},
 	}
 	sortByPriority(list)
-	assertSortedServices(t, list, []string{"FirstService", "FirstServiceInternal", "SecondService", "ThirdService"})
+	assertSortedServices(t, list, []string{"FirstLocalSpec", "SecondLocalSpec", "ThirdLocalSpec", "FirstService", "FirstServiceInternal", "SecondService", "ThirdService"})
 }
 
 type handlerTest struct {


### PR DESCRIPTION
Cherry pick of #73484 on release-1.13.

#73484: have local specs come first