### PR TITLE
update scale client to support non-namespaced resources

### DIFF
--- a/staging/src/k8s.io/client-go/scale/client.go
+++ b/staging/src/k8s.io/client-go/scale/client.go
@@ -150,7 +150,7 @@ func (c *namespacedScaleClient) Get(resource schema.GroupResource, name string) 
 
 	result := c.client.clientBase.Get().
 		AbsPath(path).
-		Namespace(c.namespace).
+		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(gvr.Resource).
 		Name(name).
 		SubResource("scale").
@@ -191,7 +191,7 @@ func (c *namespacedScaleClient) Update(resource schema.GroupResource, scale *aut
 
 	result := c.client.clientBase.Put().
 		AbsPath(path).
-		Namespace(c.namespace).
+		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(gvr.Resource).
 		Name(scale.Name).
 		SubResource("scale").
@@ -211,7 +211,7 @@ func (c *namespacedScaleClient) Patch(gvr schema.GroupVersionResource, name stri
 	groupVersion := gvr.GroupVersion()
 	result := c.client.clientBase.Patch(pt).
 		AbsPath(c.client.apiPathFor(groupVersion)).
-		Namespace(c.namespace).
+		NamespaceIfScoped(c.namespace, c.namespace != "").
 		Resource(gvr.Resource).
 		Name(name).
 		SubResource("scale").

--- a/staging/src/k8s.io/client-go/scale/interfaces.go
+++ b/staging/src/k8s.io/client-go/scale/interfaces.go
@@ -23,8 +23,9 @@ import (
 )
 
 // ScalesGetter can produce a ScaleInterface
-// for a particular namespace.
 type ScalesGetter interface {
+	// Scales produces a ScaleInterface for a particular namespace.
+	// Set namespace to the empty string for non-namespaced resources.
 	Scales(namespace string) ScaleInterface
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, the scale client (`k8s.io/client-go/scale`) doesn't work for non-namespaced resources e.g. cluster-scoped CRDs.
This PR updates the `Scales` function in `ScalesGetter` to provide such support.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #81380

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
