### PR TITLE
Add support for preemptible instances in node-e2e

### DIFF
--- a/build/root/Makefile
+++ b/build/root/Makefile
@@ -238,6 +238,8 @@ define TEST_E2E_NODE_HELP_INFO
 #    run tests against.  Defaults to "".
 #  DELETE_INSTANCES: For REMOTE=true only.  Delete any instances created as
 #    part of this test run.  Defaults to false.
+#  PREEMPTIBLE_INSTANCES: For REMOTE=true only.  Mark created gce instances
+#    as preemptible.  Defaults to false.
 #  ARTIFACTS: For REMOTE=true only.  Local directory to scp test artifacts into
 #    from the remote hosts.  Defaults to "/tmp/_artifacts".
 #  REPORT: For REMOTE=false only.  Local directory to write juntil xml results

--- a/hack/make-rules/test-e2e-node.sh
+++ b/hack/make-rules/test-e2e-node.sh
@@ -94,6 +94,7 @@ if [ "${remote}" = true ] ; then
   instance_prefix=${INSTANCE_PREFIX:-"test"}
   cleanup=${CLEANUP:-"true"}
   delete_instances=${DELETE_INSTANCES:-"false"}
+  preemptible_instances=${PREEMPTIBLE_INSTANCES:-"false"}
   test_suite=${TEST_SUITE:-"default"}
 
   # Get the compute zone
@@ -149,7 +150,7 @@ if [ "${remote}" = true ] ; then
     --image-project="${image_project}" --instance-name-prefix="${instance_prefix}" \
     --delete-instances="${delete_instances}" --test_args="${test_args}" --instance-metadata="${metadata}" \
     --image-config-file="${image_config_file}" --system-spec-name="${system_spec_name}" \
-    --extra-envs="${extra_envs}" --test-suite="${test_suite}" \
+    --preemptible-instances="${preemptible_instances}" --extra-envs="${extra_envs}" --test-suite="${test_suite}" \
     2>&1 | tee -i "${artifacts}/build-log.txt"
   exit $?
 

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -56,6 +56,7 @@ var imageConfigFile = flag.String("image-config-file", "", "yaml file describing
 var imageConfigDir = flag.String("image-config-dir", "", "(optional)path to image config files")
 var imageProject = flag.String("image-project", "", "gce project the hosts live in")
 var images = flag.String("images", "", "images to test")
+var preemptibleInstances = flag.Bool("preemptible-instances", false, "If true, gce instances will be configured to be preemptible")
 var hosts = flag.String("hosts", "", "hosts to test")
 var cleanup = flag.Bool("cleanup", true, "If true remove files from remote hosts and delete temporary instances")
 var deleteInstances = flag.Bool("delete-instances", true, "If true, delete any instances created")
@@ -599,14 +600,15 @@ func createInstance(imageConfig *internalGCEImage) (string, error) {
 		},
 	}
 
+	scheduling := compute.Scheduling{
+		Preemptible: *preemptibleInstances,
+	}
 	for _, accelerator := range imageConfig.resources.Accelerators {
 		if i.GuestAccelerators == nil {
 			autoRestart := true
 			i.GuestAccelerators = []*compute.AcceleratorConfig{}
-			i.Scheduling = &compute.Scheduling{
-				OnHostMaintenance: "TERMINATE",
-				AutomaticRestart:  &autoRestart,
-			}
+			scheduling.OnHostMaintenance = "TERMINATE"
+			scheduling.AutomaticRestart = &autoRestart
 		}
 		aType := fmt.Sprintf(acceleratorTypeResourceFormat, *project, *zone, accelerator.Type)
 		ac := &compute.AcceleratorConfig{
@@ -615,7 +617,7 @@ func createInstance(imageConfig *internalGCEImage) (string, error) {
 		}
 		i.GuestAccelerators = append(i.GuestAccelerators, ac)
 	}
-
+	i.Scheduling = &scheduling
 	i.Metadata = imageConfig.metadata
 	if _, err := computeService.Instances.Get(*project, *zone, i.Name).Do(); err != nil {
 		op, err := computeService.Instances.Insert(*project, *zone, i).Do()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:

Preemptible instances are cheaper, and the small chance of a vm being
killed doesn't matter when running during development. This is a
trade off the user should be able to decide on.

More info here:
https://cloud.google.com/compute/docs/instances/preemptible

The default setting is false, so unless setting
PREEMPTIBLE_INSTANCES=true, everything will behave as before.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

/sig testing

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
