### PR TITLE
Issue 81523: do not ignore writable layer when on a device other than rootFS

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -497,12 +497,7 @@ func (m *managerImpl) podEphemeralStorageLimitEviction(podStats statsapi.PodStat
 	}
 
 	podEphemeralStorageTotalUsage := &resource.Quantity{}
-	var fsStatsSet []fsStatsType
-	if *m.dedicatedImageFs {
-		fsStatsSet = []fsStatsType{fsStatsLogs, fsStatsLocalVolumeSource}
-	} else {
-		fsStatsSet = []fsStatsType{fsStatsRoot, fsStatsLogs, fsStatsLocalVolumeSource}
-	}
+	fsStatsSet := []fsStatsType{fsStatsRoot, fsStatsLogs, fsStatsLocalVolumeSource}
 	podEphemeralUsage, err := podLocalEphemeralStorageUsage(podStats, pod, fsStatsSet)
 	if err != nil {
 		klog.Errorf("eviction manager: error getting pod disk usage %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Writable layer ephemeral space consumption is ignored when the runtime imageFS is not on the Kubernetes root filesystem.

**Which issue(s) this PR fixes**:
Fixes #81523

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**: Yes
```release-note
Depending upon node configuration, eviction for overconsumption of local ephemeral storage does not happen when the storage consumed is in the container writable layer (e. g. /tmp).  The conditions under which this does not work are that the runtime image storage (e. g. /var/lib/crio, /var/lib/docker) is not on the same filesystem device as the Kubernetes root filesystem.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: