### PR TITLE
Group managedFieldsEntries for update by manager name

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields_test.go
@@ -169,7 +169,7 @@ manager: foo
 operation: Update
 time: "2001-02-03T04:05:06Z"
 `,
-			expected: "{\"manager\":\"foo\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2001-02-03T04:05:06Z\"}",
+			expected: "{\"manager\":\"foo\",\"operation\":\"Update\",\"apiVersion\":\"v1\"}",
 		},
 		{
 			managedFieldsEntry: `


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This is to reduce the total number of entries @apelisse @lavalamp 

Previously we would include a separate entry in managedFields for each update operation (POST, PUT, PATCH), even if the same manager was making multiple modifications. This allowed us to see the update times of each individual operation, but also creates a lot of separate entries in the list. By grouping all update entries by the same manager together, we lose the times of each operation (we still have the last update time for that manager), but also reduce the number of entries in the list. This also allows us to store the last update time for appliers now, in the same way.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```