### PR TITLE
Drop GetPods from ActualStateOfWorld

### DIFF
--- a/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
+++ b/pkg/kubelet/volumemanager/cache/actual_state_of_world.go
@@ -145,11 +145,6 @@ type ActualStateOfWorld interface {
 	// no longer referenced and may be globally unmounted and detached.
 	GetUnmountedVolumes() []AttachedVolume
 
-	// GetPods generates and returns a map of pods in which map is indexed
-	// with pod's unique name. This map can be used to determine which pod is currently
-	// in actual state of world.
-	GetPods() map[volumetypes.UniquePodName]bool
-
 	// MarkFSResizeRequired marks each volume that is successfully attached and
 	// mounted for the specified pod as requiring file system resize (if the plugin for the
 	// volume indicates it requires file system resize).
@@ -747,21 +742,6 @@ func (asw *actualStateOfWorld) GetUnmountedVolumes() []AttachedVolume {
 	}
 
 	return unmountedVolumes
-}
-
-func (asw *actualStateOfWorld) GetPods() map[volumetypes.UniquePodName]bool {
-	asw.RLock()
-	defer asw.RUnlock()
-
-	podList := make(map[volumetypes.UniquePodName]bool)
-	for _, volumeObj := range asw.attachedVolumes {
-		for podName := range volumeObj.mountedPods {
-			if !podList[podName] {
-				podList[podName] = true
-			}
-		}
-	}
-	return podList
 }
 
 func (asw *actualStateOfWorld) newAttachedVolume(


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
ActualStateOfWorld#GetPods is not used by any class.

This PR removes the func.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
