### PR TITLE
Demote regular resource tracking tests from release-blocking

### DIFF
--- a/test/e2e/node/kubelet_perf.go
+++ b/test/e2e/node/kubelet_perf.go
@@ -215,7 +215,7 @@ var _ = SIGDescribe("Kubelet [Serial] [Slow]", func() {
 		result := om.GetLatestRuntimeOperationErrorRate()
 		e2elog.Logf("runtime operation error metrics:\n%s", e2ekubelet.FormatRuntimeOperationErrorRate(result))
 	})
-	SIGDescribe("regular resource usage tracking", func() {
+	SIGDescribe("regular resource usage tracking [Feature:RegularResourceUsageTracking]", func() {
 		// We assume that the scheduler will make reasonable scheduling choices
 		// and assign ~N pods on the node.
 		// Although we want to track N pods per node, there are N + add-on pods


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Add a `[Feature:RegularResourceUsageTracking]` tag to these tests so they're not picked up by the release-blocking job that focuses on `[Serial]` tests (but excludes `[Feature:.*]` tests)

They take a combined 65 minutes on average. If they really need to be in release-blocking as implemented, we should consider a separate job to focus just on this feature.

**Which issue(s) this PR fixes**:

Addresses part of #81490

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```