### PR TITLE
Demote HPA tests from release-blocking

### DIFF
--- a/test/e2e/autoscaling/horizontal_pod_autoscaling.go
+++ b/test/e2e/autoscaling/horizontal_pod_autoscaling.go
@@ -28,7 +28,7 @@ import (
 
 // These tests don't seem to be running properly in parallel: issue: #20338.
 //
-var _ = SIGDescribe("[HPA] Horizontal pod autoscaling (scale resource: CPU)", func() {
+var _ = SIGDescribe("[Feature:HPA] Horizontal pod autoscaling (scale resource: CPU)", func() {
 	var rc *common.ResourceConsumer
 	f := framework.NewDefaultFramework("horizontal-pod-autoscaling")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Add a `[Feature:HPA]` tag to these tests so they're not picked up by the release-blocking job that focuses on `[Serial]` tests (but excludes `[Feature:.*]` tests)

They take a combined 70 minutes on average. If they really need to be in release-blocking as implemented, we should consider a separate job to focus just on this feature.

**Which issue(s) this PR fixes**:

Addresses part of #81491

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/priority important-soon