### PR TITLE
Improve `pkg/kubelet/kubelet.go` readability

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -179,32 +179,337 @@ const (
 	minDeadContainerInPod = 1
 )
 
-// SyncHandler is an interface implemented by Kubelet, for testability
-type SyncHandler interface {
-	HandlePodAdditions(pods []*v1.Pod)
-	HandlePodUpdates(pods []*v1.Pod)
-	HandlePodRemoves(pods []*v1.Pod)
-	HandlePodReconcile(pods []*v1.Pod)
-	HandlePodSyncs(pods []*v1.Pod)
-	HandlePodCleanups() error
+// Kubelet is the main kubelet implementation.
+type Kubelet struct {
+	kubeletConfiguration kubeletconfiginternal.KubeletConfiguration
+
+	// hostname is the hostname the kubelet detected or was given via flag/config
+	hostname string
+	// hostnameOverridden indicates the hostname was overridden via flag/config
+	hostnameOverridden bool
+
+	nodeName        types.NodeName
+	runtimeCache    kubecontainer.RuntimeCache
+	kubeClient      clientset.Interface
+	heartbeatClient clientset.Interface
+	iptClient       utilipt.Interface
+	rootDirectory   string
+
+	lastObservedNodeAddressesMux sync.RWMutex
+	lastObservedNodeAddresses    []v1.NodeAddress
+
+	// onRepeatedHeartbeatFailure is called when a heartbeat operation fails more than once. optional.
+	onRepeatedHeartbeatFailure func()
+
+	// podWorkers handle syncing Pods in response to events.
+	podWorkers PodWorkers
+
+	// resyncInterval is the interval between periodic full reconciliations of
+	// pods on this node.
+	resyncInterval time.Duration
+
+	// sourcesReady records the sources seen by the kubelet, it is thread-safe.
+	sourcesReady config.SourcesReady
+
+	// podManager is a facade that abstracts away the various sources of pods
+	// this Kubelet services.
+	podManager kubepod.Manager
+
+	// Needed to observe and respond to situations that could impact node stability
+	evictionManager eviction.Manager
+
+	// Optional, defaults to /logs/ from /var/log
+	logServer http.Handler
+	// Optional, defaults to simple Docker implementation
+	runner kubecontainer.ContainerCommandRunner
+
+	// cAdvisor used for container information.
+	cadvisor cadvisor.Interface
+
+	// Set to true to have the node register itself with the apiserver.
+	registerNode bool
+	// List of taints to add to a node object when the kubelet registers itself.
+	registerWithTaints []api.Taint
+	// Set to true to have the node register itself as schedulable.
+	registerSchedulable bool
+	// for internal book keeping; access only from within registerWithApiserver
+	registrationCompleted bool
+
+	// dnsConfigurer is used for setting up DNS resolver configuration when launching pods.
+	dnsConfigurer *dns.Configurer
+
+	// masterServiceNamespace is the namespace that the master service is exposed in.
+	masterServiceNamespace string
+	// serviceLister knows how to list services
+	serviceLister serviceLister
+	// nodeInfo knows how to get information about the node for this kubelet.
+	nodeInfo predicates.NodeInfo
+
+	// a list of node labels to register
+	nodeLabels map[string]string
+
+	// Last timestamp when runtime responded on ping.
+	// Mutex is used to protect this value.
+	runtimeState *runtimeState
+
+	// Volume plugins.
+	volumePluginMgr *volume.VolumePluginMgr
+
+	// Handles container probing.
+	probeManager prober.Manager
+	// Manages container health check results.
+	livenessManager proberesults.Manager
+
+	// How long to keep idle streaming command execution/port forwarding
+	// connections open before terminating them
+	streamingConnectionIdleTimeout time.Duration
+
+	// The EventRecorder to use
+	recorder record.EventRecorder
+
+	// Policy for handling garbage collection of dead containers.
+	containerGC kubecontainer.ContainerGC
+
+	// Manager for image garbage collection.
+	imageManager images.ImageGCManager
+
+	// Manager for container logs.
+	containerLogManager logs.ContainerLogManager
+
+	// Secret manager.
+	secretManager secret.Manager
+
+	// ConfigMap manager.
+	configMapManager configmap.Manager
+
+	// Cached MachineInfo returned by cadvisor.
+	machineInfo *cadvisorapi.MachineInfo
+
+	// Handles certificate rotations.
+	serverCertificateManager certificate.Manager
+
+	// Syncs pods statuses with apiserver; also used as a cache of statuses.
+	statusManager status.Manager
+
+	// VolumeManager runs a set of asynchronous loops that figure out which
+	// volumes need to be attached/mounted/unmounted/detached based on the pods
+	// scheduled on this node and makes it so.
+	volumeManager volumemanager.VolumeManager
+
+	// Cloud provider interface.
+	cloud cloudprovider.Interface
+	// Handles requests to cloud provider with timeout
+	cloudResourceSyncManager cloudresource.SyncManager
+
+	// Indicates that the node initialization happens in an external cloud controller
+	externalCloudProvider bool
+	// Reference to this node.
+	nodeRef *v1.ObjectReference
+
+	// The name of the container runtime
+	containerRuntimeName string
+
+	// redirectContainerStreaming enables container streaming redirect.
+	redirectContainerStreaming bool
+
+	// Container runtime.
+	containerRuntime kubecontainer.Runtime
+
+	// Streaming runtime handles container streaming.
+	streamingRuntime kubecontainer.StreamingRuntime
+
+	// Container runtime service (needed by container runtime Start()).
+	// TODO(CD): try to make this available without holding a reference in this
+	//           struct. For example, by adding a getter to generic runtime.
+	runtimeService internalapi.RuntimeService
+
+	// reasonCache caches the failure reason of the last creation of all containers, which is
+	// used for generating ContainerStatus.
+	reasonCache *ReasonCache
+
+	// nodeStatusUpdateFrequency specifies how often kubelet computes node status. If node lease
+	// feature is not enabled, it is also the frequency that kubelet posts node status to master.
+	// In that case, be cautious when changing the constant, it must work with nodeMonitorGracePeriod
+	// in nodecontroller. There are several constraints:
+	// 1. nodeMonitorGracePeriod must be N times more than nodeStatusUpdateFrequency, where
+	//    N means number of retries allowed for kubelet to post node status. It is pointless
+	//    to make nodeMonitorGracePeriod be less than nodeStatusUpdateFrequency, since there
+	//    will only be fresh values from Kubelet at an interval of nodeStatusUpdateFrequency.
+	//    The constant must be less than podEvictionTimeout.
+	// 2. nodeStatusUpdateFrequency needs to be large enough for kubelet to generate node
+	//    status. Kubelet may fail to update node status reliably if the value is too small,
+	//    as it takes time to gather all necessary node information.
+	nodeStatusUpdateFrequency time.Duration
+
+	// nodeStatusReportFrequency is the frequency that kubelet posts node
+	// status to master. It is only used when node lease feature is enabled.
+	nodeStatusReportFrequency time.Duration
+
+	// lastStatusReportTime is the time when node status was last reported.
+	lastStatusReportTime time.Time
+
+	// syncNodeStatusMux is a lock on updating the node status, because this path is not thread-safe.
+	// This lock is used by Kubelet.syncNodeStatus function and shouldn't be used anywhere else.
+	syncNodeStatusMux sync.Mutex
+
+	// updatePodCIDRMux is a lock on updating pod CIDR, because this path is not thread-safe.
+	// This lock is used by Kubelet.syncNodeStatus function and shouldn't be used anywhere else.
+	updatePodCIDRMux sync.Mutex
+
+	// updateRuntimeMux is a lock on updating runtime, because this path is not thread-safe.
+	// This lock is used by Kubelet.updateRuntimeUp function and shouldn't be used anywhere else.
+	updateRuntimeMux sync.Mutex
+
+	// nodeLeaseController claims and renews the node lease for this Kubelet
+	nodeLeaseController nodelease.Controller
+
+	// Generates pod events.
+	pleg pleg.PodLifecycleEventGenerator
+
+	// Store kubecontainer.PodStatus for all pods.
+	podCache kubecontainer.Cache
+
+	// os is a facade for various syscalls that need to be mocked during testing.
+	os kubecontainer.OSInterface
+
+	// Watcher of out of memory events.
+	oomWatcher oomwatcher.Watcher
+
+	// Monitor resource usage
+	resourceAnalyzer serverstats.ResourceAnalyzer
+
+	// Whether or not we should have the QOS cgroup hierarchy for resource management
+	cgroupsPerQOS bool
+
+	// If non-empty, pass this to the container runtime as the root cgroup.
+	cgroupRoot string
+
+	// Mounter to use for volumes.
+	mounter mount.Interface
+
+	// hostutil to interact with filesystems
+	hostutil mount.HostUtils
+
+	// subpather to execute subpath actions
+	subpather subpath.Interface
+
+	// Manager of non-Runtime containers.
+	containerManager cm.ContainerManager
+
+	// Maximum Number of Pods which can be run by this Kubelet
+	maxPods int
+
+	// Monitor Kubelet's sync loop
+	syncLoopMonitor atomic.Value
+
+	// Container restart Backoff
+	backOff *flowcontrol.Backoff
+
+	// Channel for sending pods to kill.
+	podKillingCh chan *kubecontainer.PodPair
+
+	// Information about the ports which are opened by daemons on Node running this Kubelet server.
+	daemonEndpoints *v1.NodeDaemonEndpoints
+
+	// A queue used to trigger pod workers.
+	workQueue queue.WorkQueue
+
+	// oneTimeInitializer is used to initialize modules that are dependent on the runtime to be up.
+	oneTimeInitializer sync.Once
+
+	// If non-nil, use this IP address for the node
+	nodeIP net.IP
+
+	// use this function to validate the kubelet nodeIP
+	nodeIPValidator func(net.IP) error
+
+	// If non-nil, this is a unique identifier for the node in an external database, eg. cloudprovider
+	providerID string
+
+	// clock is an interface that provides time related functionality in a way that makes it
+	// easy to test the code.
+	clock clock.Clock
+
+	// handlers called during the tryUpdateNodeStatus cycle
+	setNodeStatusFuncs []func(*v1.Node) error
+
+	lastNodeUnschedulableLock sync.Mutex
+	// maintains Node.Spec.Unschedulable value from previous run of tryUpdateNodeStatus()
+	lastNodeUnschedulable bool
+
+	// TODO: think about moving this to be centralized in PodWorkers in follow-on.
+	// the list of handlers to call during pod admission.
+	admitHandlers lifecycle.PodAdmitHandlers
+
+	// softAdmithandlers are applied to the pod after it is admitted by the Kubelet, but before it is
+	// run. A pod rejected by a softAdmitHandler will be left in a Pending state indefinitely. If a
+	// rejected pod should not be recreated, or the scheduler is not aware of the rejection rule, the
+	// admission rule should be applied by a softAdmitHandler.
+	softAdmitHandlers lifecycle.PodAdmitHandlers
+
+	// the list of handlers to call during pod sync loop.
+	lifecycle.PodSyncLoopHandlers
+
+	// the list of handlers to call during pod sync.
+	lifecycle.PodSyncHandlers
+
+	// the number of allowed pods per core
+	podsPerCore int
+
+	// enableControllerAttachDetach indicates the Attach/Detach controller
+	// should manage attachment/detachment of volumes scheduled to this node,
+	// and disable kubelet from executing any attach/detach operations
+	enableControllerAttachDetach bool
+
+	// trigger deleting containers in a pod
+	containerDeletor *podContainerDeletor
+
+	// config iptables util rules
+	makeIPTablesUtilChains bool
+
+	// The bit of the fwmark space to mark packets for SNAT.
+	iptablesMasqueradeBit int
+
+	// The bit of the fwmark space to mark packets for dropping.
+	iptablesDropBit int
+
+	// The AppArmor validator for checking whether AppArmor is supported.
+	appArmorValidator apparmor.Validator
+
+	// The handler serving CRI streaming calls (exec/attach/port-forward).
+	criHandler http.Handler
+
+	// experimentalHostUserNamespaceDefaulting sets userns=true when users request host namespaces (pid, ipc, net),
+	// are using non-namespaced capabilities (mknod, sys_time, sys_module), the pod contains a privileged container,
+	// or using host path volumes.
+	// This should only be enabled when the container runtime is performing user remapping AND if the
+	// experimental behavior is desired.
+	experimentalHostUserNamespaceDefaulting bool
+
+	// dockerLegacyService contains some legacy methods for backward compatibility.
+	// It should be set only when docker is using non json-file logging driver.
+	dockerLegacyService dockershim.DockerLegacyService
+
+	// StatsProvider provides the node and the container stats.
+	*stats.StatsProvider
+
+	// This flag, if set, instructs the kubelet to keep volumes from terminated pods mounted to the node.
+	// This can be useful for debugging volume related issues.
+	keepTerminatedPodVolumes bool // DEPRECATED
+
+	// pluginmanager runs a set of asynchronous loops that figure out which
+	// plugins need to be registered/unregistered based on this node and makes it so.
+	pluginManager pluginmanager.PluginManager
+
+	// This flag sets a maximum number of images to report in the node status.
+	nodeStatusMaxImages int32
+
+	// Handles RuntimeClass objects for the Kubelet.
+	runtimeClassManager *runtimeclass.Manager
 }
 
-// Option is a functional option type for Kubelet
-type Option func(*Kubelet)
-
-// Bootstrap is a bootstrapping interface for kubelet, targets the initialization protocol
-type Bootstrap interface {
-	GetConfiguration() kubeletconfiginternal.KubeletConfiguration
-	BirthCry()
-	StartGarbageCollection()
-	ListenAndServe(address net.IP, port uint, tlsOptions *server.TLSOptions, auth server.AuthInterface, enableCAdvisorJSONEndpoints, enableDebuggingHandlers, enableContentionProfiling bool)
-	ListenAndServeReadOnly(address net.IP, port uint, enableCAdvisorJSONEndpoints bool)
-	ListenAndServePodResources()
-	Run(<-chan kubetypes.PodUpdate)
-	RunOnce(<-chan kubetypes.PodUpdate) ([]RunPodResult, error)
-}
-
-// Builder creates and initializes a Kubelet instance
+// Builder creates and initializes a Kubelet instance.
+// NewMainKubelet implements the `Builder` interface.
 type Builder func(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	kubeDeps *Dependencies,
 	crOptions *config.ContainerRuntimeOptions,
@@ -237,6 +542,18 @@ type Builder func(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	bootstrapCheckpointPath string,
 	nodeStatusMaxImages int32) (Bootstrap, error)
 
+// Bootstrap is a bootstrapping interface for kubelet, targets the initialization protocol
+type Bootstrap interface {
+	GetConfiguration() kubeletconfiginternal.KubeletConfiguration
+	BirthCry()
+	StartGarbageCollection()
+	ListenAndServe(address net.IP, port uint, tlsOptions *server.TLSOptions, auth server.AuthInterface, enableCAdvisorJSONEndpoints, enableDebuggingHandlers, enableContentionProfiling bool)
+	ListenAndServeReadOnly(address net.IP, port uint, enableCAdvisorJSONEndpoints bool)
+	ListenAndServePodResources()
+	Run(<-chan kubetypes.PodUpdate)
+	RunOnce(<-chan kubetypes.PodUpdate) ([]RunPodResult, error)
+}
+
 // Dependencies is a bin for things we might consider "injected dependencies" -- objects constructed
 // at runtime that are necessary for running the Kubelet. This is a temporary solution for grouping
 // these objects while we figure out a more comprehensive dependency injection story for the Kubelet.
@@ -266,67 +583,11 @@ type Dependencies struct {
 	KubeletConfigController *kubeletconfig.Controller
 }
 
-// makePodSourceConfig creates a config.PodConfig from the given
-// KubeletConfiguration or returns an error.
-func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, kubeDeps *Dependencies, nodeName types.NodeName, bootstrapCheckpointPath string) (*config.PodConfig, error) {
-	manifestURLHeader := make(http.Header)
-	if len(kubeCfg.StaticPodURLHeader) > 0 {
-		for k, v := range kubeCfg.StaticPodURLHeader {
-			for i := range v {
-				manifestURLHeader.Add(k, v[i])
-			}
-		}
-	}
+// Option is a functional option type for Kubelet
+type Option func(*Kubelet)
 
-	// source of all configuration
-	cfg := config.NewPodConfig(config.PodConfigNotificationIncremental, kubeDeps.Recorder)
-
-	// define file config source
-	if kubeCfg.StaticPodPath != "" {
-		klog.Infof("Adding pod path: %v", kubeCfg.StaticPodPath)
-		config.NewSourceFile(kubeCfg.StaticPodPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(kubetypes.FileSource))
-	}
-
-	// define url config source
-	if kubeCfg.StaticPodURL != "" {
-		klog.Infof("Adding pod url %q with HTTP header %v", kubeCfg.StaticPodURL, manifestURLHeader)
-		config.NewSourceURL(kubeCfg.StaticPodURL, manifestURLHeader, nodeName, kubeCfg.HTTPCheckFrequency.Duration, cfg.Channel(kubetypes.HTTPSource))
-	}
-
-	// Restore from the checkpoint path
-	// NOTE: This MUST happen before creating the apiserver source
-	// below, or the checkpoint would override the source of truth.
-
-	var updatechannel chan<- interface{}
-	if bootstrapCheckpointPath != "" {
-		klog.Infof("Adding checkpoint path: %v", bootstrapCheckpointPath)
-		updatechannel = cfg.Channel(kubetypes.ApiserverSource)
-		err := cfg.Restore(bootstrapCheckpointPath, updatechannel)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if kubeDeps.KubeClient != nil {
-		klog.Infof("Watching apiserver")
-		if updatechannel == nil {
-			updatechannel = cfg.Channel(kubetypes.ApiserverSource)
-		}
-		config.NewSourceApiserver(kubeDeps.KubeClient, nodeName, updatechannel)
-	}
-	return cfg, nil
-}
-
-func getRuntimeAndImageServices(remoteRuntimeEndpoint string, remoteImageEndpoint string, runtimeRequestTimeout metav1.Duration) (internalapi.RuntimeService, internalapi.ImageManagerService, error) {
-	rs, err := remote.NewRemoteRuntimeService(remoteRuntimeEndpoint, runtimeRequestTimeout.Duration)
-	if err != nil {
-		return nil, nil, err
-	}
-	is, err := remote.NewRemoteImageService(remoteImageEndpoint, runtimeRequestTimeout.Duration)
-	if err != nil {
-		return nil, nil, err
-	}
-	return rs, is, err
+type serviceLister interface {
+	List(labels.Selector) ([]*v1.Service, error)
 }
 
 // NewMainKubelet instantiates a new Kubelet object along with all the required internal modules.
@@ -892,337 +1153,67 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	return klet, nil
 }
 
-type serviceLister interface {
-	List(labels.Selector) ([]*v1.Service, error)
+// makePodSourceConfig creates a config.PodConfig from the given
+// KubeletConfiguration or returns an error.
+func makePodSourceConfig(kubeCfg *kubeletconfiginternal.KubeletConfiguration, kubeDeps *Dependencies, nodeName types.NodeName, bootstrapCheckpointPath string) (*config.PodConfig, error) {
+	manifestURLHeader := make(http.Header)
+	if len(kubeCfg.StaticPodURLHeader) > 0 {
+		for k, v := range kubeCfg.StaticPodURLHeader {
+			for i := range v {
+				manifestURLHeader.Add(k, v[i])
+			}
+		}
+	}
+
+	// source of all configuration
+	cfg := config.NewPodConfig(config.PodConfigNotificationIncremental, kubeDeps.Recorder)
+
+	// define file config source
+	if kubeCfg.StaticPodPath != "" {
+		klog.Infof("Adding pod path: %v", kubeCfg.StaticPodPath)
+		config.NewSourceFile(kubeCfg.StaticPodPath, nodeName, kubeCfg.FileCheckFrequency.Duration, cfg.Channel(kubetypes.FileSource))
+	}
+
+	// define url config source
+	if kubeCfg.StaticPodURL != "" {
+		klog.Infof("Adding pod url %q with HTTP header %v", kubeCfg.StaticPodURL, manifestURLHeader)
+		config.NewSourceURL(kubeCfg.StaticPodURL, manifestURLHeader, nodeName, kubeCfg.HTTPCheckFrequency.Duration, cfg.Channel(kubetypes.HTTPSource))
+	}
+
+	// Restore from the checkpoint path
+	// NOTE: This MUST happen before creating the apiserver source
+	// below, or the checkpoint would override the source of truth.
+
+	var updatechannel chan<- interface{}
+	if bootstrapCheckpointPath != "" {
+		klog.Infof("Adding checkpoint path: %v", bootstrapCheckpointPath)
+		updatechannel = cfg.Channel(kubetypes.ApiserverSource)
+		err := cfg.Restore(bootstrapCheckpointPath, updatechannel)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if kubeDeps.KubeClient != nil {
+		klog.Infof("Watching apiserver")
+		if updatechannel == nil {
+			updatechannel = cfg.Channel(kubetypes.ApiserverSource)
+		}
+		config.NewSourceApiserver(kubeDeps.KubeClient, nodeName, updatechannel)
+	}
+	return cfg, nil
 }
 
-// Kubelet is the main kubelet implementation.
-type Kubelet struct {
-	kubeletConfiguration kubeletconfiginternal.KubeletConfiguration
-
-	// hostname is the hostname the kubelet detected or was given via flag/config
-	hostname string
-	// hostnameOverridden indicates the hostname was overridden via flag/config
-	hostnameOverridden bool
-
-	nodeName        types.NodeName
-	runtimeCache    kubecontainer.RuntimeCache
-	kubeClient      clientset.Interface
-	heartbeatClient clientset.Interface
-	iptClient       utilipt.Interface
-	rootDirectory   string
-
-	lastObservedNodeAddressesMux sync.RWMutex
-	lastObservedNodeAddresses    []v1.NodeAddress
-
-	// onRepeatedHeartbeatFailure is called when a heartbeat operation fails more than once. optional.
-	onRepeatedHeartbeatFailure func()
-
-	// podWorkers handle syncing Pods in response to events.
-	podWorkers PodWorkers
-
-	// resyncInterval is the interval between periodic full reconciliations of
-	// pods on this node.
-	resyncInterval time.Duration
-
-	// sourcesReady records the sources seen by the kubelet, it is thread-safe.
-	sourcesReady config.SourcesReady
-
-	// podManager is a facade that abstracts away the various sources of pods
-	// this Kubelet services.
-	podManager kubepod.Manager
-
-	// Needed to observe and respond to situations that could impact node stability
-	evictionManager eviction.Manager
-
-	// Optional, defaults to /logs/ from /var/log
-	logServer http.Handler
-	// Optional, defaults to simple Docker implementation
-	runner kubecontainer.ContainerCommandRunner
-
-	// cAdvisor used for container information.
-	cadvisor cadvisor.Interface
-
-	// Set to true to have the node register itself with the apiserver.
-	registerNode bool
-	// List of taints to add to a node object when the kubelet registers itself.
-	registerWithTaints []api.Taint
-	// Set to true to have the node register itself as schedulable.
-	registerSchedulable bool
-	// for internal book keeping; access only from within registerWithApiserver
-	registrationCompleted bool
-
-	// dnsConfigurer is used for setting up DNS resolver configuration when launching pods.
-	dnsConfigurer *dns.Configurer
-
-	// masterServiceNamespace is the namespace that the master service is exposed in.
-	masterServiceNamespace string
-	// serviceLister knows how to list services
-	serviceLister serviceLister
-	// nodeInfo knows how to get information about the node for this kubelet.
-	nodeInfo predicates.NodeInfo
-
-	// a list of node labels to register
-	nodeLabels map[string]string
-
-	// Last timestamp when runtime responded on ping.
-	// Mutex is used to protect this value.
-	runtimeState *runtimeState
-
-	// Volume plugins.
-	volumePluginMgr *volume.VolumePluginMgr
-
-	// Handles container probing.
-	probeManager prober.Manager
-	// Manages container health check results.
-	livenessManager proberesults.Manager
-
-	// How long to keep idle streaming command execution/port forwarding
-	// connections open before terminating them
-	streamingConnectionIdleTimeout time.Duration
-
-	// The EventRecorder to use
-	recorder record.EventRecorder
-
-	// Policy for handling garbage collection of dead containers.
-	containerGC kubecontainer.ContainerGC
-
-	// Manager for image garbage collection.
-	imageManager images.ImageGCManager
-
-	// Manager for container logs.
-	containerLogManager logs.ContainerLogManager
-
-	// Secret manager.
-	secretManager secret.Manager
-
-	// ConfigMap manager.
-	configMapManager configmap.Manager
-
-	// Cached MachineInfo returned by cadvisor.
-	machineInfo *cadvisorapi.MachineInfo
-
-	// Handles certificate rotations.
-	serverCertificateManager certificate.Manager
-
-	// Syncs pods statuses with apiserver; also used as a cache of statuses.
-	statusManager status.Manager
-
-	// VolumeManager runs a set of asynchronous loops that figure out which
-	// volumes need to be attached/mounted/unmounted/detached based on the pods
-	// scheduled on this node and makes it so.
-	volumeManager volumemanager.VolumeManager
-
-	// Cloud provider interface.
-	cloud cloudprovider.Interface
-	// Handles requests to cloud provider with timeout
-	cloudResourceSyncManager cloudresource.SyncManager
-
-	// Indicates that the node initialization happens in an external cloud controller
-	externalCloudProvider bool
-	// Reference to this node.
-	nodeRef *v1.ObjectReference
-
-	// The name of the container runtime
-	containerRuntimeName string
-
-	// redirectContainerStreaming enables container streaming redirect.
-	redirectContainerStreaming bool
-
-	// Container runtime.
-	containerRuntime kubecontainer.Runtime
-
-	// Streaming runtime handles container streaming.
-	streamingRuntime kubecontainer.StreamingRuntime
-
-	// Container runtime service (needed by container runtime Start()).
-	// TODO(CD): try to make this available without holding a reference in this
-	//           struct. For example, by adding a getter to generic runtime.
-	runtimeService internalapi.RuntimeService
-
-	// reasonCache caches the failure reason of the last creation of all containers, which is
-	// used for generating ContainerStatus.
-	reasonCache *ReasonCache
-
-	// nodeStatusUpdateFrequency specifies how often kubelet computes node status. If node lease
-	// feature is not enabled, it is also the frequency that kubelet posts node status to master.
-	// In that case, be cautious when changing the constant, it must work with nodeMonitorGracePeriod
-	// in nodecontroller. There are several constraints:
-	// 1. nodeMonitorGracePeriod must be N times more than nodeStatusUpdateFrequency, where
-	//    N means number of retries allowed for kubelet to post node status. It is pointless
-	//    to make nodeMonitorGracePeriod be less than nodeStatusUpdateFrequency, since there
-	//    will only be fresh values from Kubelet at an interval of nodeStatusUpdateFrequency.
-	//    The constant must be less than podEvictionTimeout.
-	// 2. nodeStatusUpdateFrequency needs to be large enough for kubelet to generate node
-	//    status. Kubelet may fail to update node status reliably if the value is too small,
-	//    as it takes time to gather all necessary node information.
-	nodeStatusUpdateFrequency time.Duration
-
-	// nodeStatusReportFrequency is the frequency that kubelet posts node
-	// status to master. It is only used when node lease feature is enabled.
-	nodeStatusReportFrequency time.Duration
-
-	// lastStatusReportTime is the time when node status was last reported.
-	lastStatusReportTime time.Time
-
-	// syncNodeStatusMux is a lock on updating the node status, because this path is not thread-safe.
-	// This lock is used by Kubelet.syncNodeStatus function and shouldn't be used anywhere else.
-	syncNodeStatusMux sync.Mutex
-
-	// updatePodCIDRMux is a lock on updating pod CIDR, because this path is not thread-safe.
-	// This lock is used by Kubelet.syncNodeStatus function and shouldn't be used anywhere else.
-	updatePodCIDRMux sync.Mutex
-
-	// updateRuntimeMux is a lock on updating runtime, because this path is not thread-safe.
-	// This lock is used by Kubelet.updateRuntimeUp function and shouldn't be used anywhere else.
-	updateRuntimeMux sync.Mutex
-
-	// nodeLeaseController claims and renews the node lease for this Kubelet
-	nodeLeaseController nodelease.Controller
-
-	// Generates pod events.
-	pleg pleg.PodLifecycleEventGenerator
-
-	// Store kubecontainer.PodStatus for all pods.
-	podCache kubecontainer.Cache
-
-	// os is a facade for various syscalls that need to be mocked during testing.
-	os kubecontainer.OSInterface
-
-	// Watcher of out of memory events.
-	oomWatcher oomwatcher.Watcher
-
-	// Monitor resource usage
-	resourceAnalyzer serverstats.ResourceAnalyzer
-
-	// Whether or not we should have the QOS cgroup hierarchy for resource management
-	cgroupsPerQOS bool
-
-	// If non-empty, pass this to the container runtime as the root cgroup.
-	cgroupRoot string
-
-	// Mounter to use for volumes.
-	mounter mount.Interface
-
-	// hostutil to interact with filesystems
-	hostutil mount.HostUtils
-
-	// subpather to execute subpath actions
-	subpather subpath.Interface
-
-	// Manager of non-Runtime containers.
-	containerManager cm.ContainerManager
-
-	// Maximum Number of Pods which can be run by this Kubelet
-	maxPods int
-
-	// Monitor Kubelet's sync loop
-	syncLoopMonitor atomic.Value
-
-	// Container restart Backoff
-	backOff *flowcontrol.Backoff
-
-	// Channel for sending pods to kill.
-	podKillingCh chan *kubecontainer.PodPair
-
-	// Information about the ports which are opened by daemons on Node running this Kubelet server.
-	daemonEndpoints *v1.NodeDaemonEndpoints
-
-	// A queue used to trigger pod workers.
-	workQueue queue.WorkQueue
-
-	// oneTimeInitializer is used to initialize modules that are dependent on the runtime to be up.
-	oneTimeInitializer sync.Once
-
-	// If non-nil, use this IP address for the node
-	nodeIP net.IP
-
-	// use this function to validate the kubelet nodeIP
-	nodeIPValidator func(net.IP) error
-
-	// If non-nil, this is a unique identifier for the node in an external database, eg. cloudprovider
-	providerID string
-
-	// clock is an interface that provides time related functionality in a way that makes it
-	// easy to test the code.
-	clock clock.Clock
-
-	// handlers called during the tryUpdateNodeStatus cycle
-	setNodeStatusFuncs []func(*v1.Node) error
-
-	lastNodeUnschedulableLock sync.Mutex
-	// maintains Node.Spec.Unschedulable value from previous run of tryUpdateNodeStatus()
-	lastNodeUnschedulable bool
-
-	// TODO: think about moving this to be centralized in PodWorkers in follow-on.
-	// the list of handlers to call during pod admission.
-	admitHandlers lifecycle.PodAdmitHandlers
-
-	// softAdmithandlers are applied to the pod after it is admitted by the Kubelet, but before it is
-	// run. A pod rejected by a softAdmitHandler will be left in a Pending state indefinitely. If a
-	// rejected pod should not be recreated, or the scheduler is not aware of the rejection rule, the
-	// admission rule should be applied by a softAdmitHandler.
-	softAdmitHandlers lifecycle.PodAdmitHandlers
-
-	// the list of handlers to call during pod sync loop.
-	lifecycle.PodSyncLoopHandlers
-
-	// the list of handlers to call during pod sync.
-	lifecycle.PodSyncHandlers
-
-	// the number of allowed pods per core
-	podsPerCore int
-
-	// enableControllerAttachDetach indicates the Attach/Detach controller
-	// should manage attachment/detachment of volumes scheduled to this node,
-	// and disable kubelet from executing any attach/detach operations
-	enableControllerAttachDetach bool
-
-	// trigger deleting containers in a pod
-	containerDeletor *podContainerDeletor
-
-	// config iptables util rules
-	makeIPTablesUtilChains bool
-
-	// The bit of the fwmark space to mark packets for SNAT.
-	iptablesMasqueradeBit int
-
-	// The bit of the fwmark space to mark packets for dropping.
-	iptablesDropBit int
-
-	// The AppArmor validator for checking whether AppArmor is supported.
-	appArmorValidator apparmor.Validator
-
-	// The handler serving CRI streaming calls (exec/attach/port-forward).
-	criHandler http.Handler
-
-	// experimentalHostUserNamespaceDefaulting sets userns=true when users request host namespaces (pid, ipc, net),
-	// are using non-namespaced capabilities (mknod, sys_time, sys_module), the pod contains a privileged container,
-	// or using host path volumes.
-	// This should only be enabled when the container runtime is performing user remapping AND if the
-	// experimental behavior is desired.
-	experimentalHostUserNamespaceDefaulting bool
-
-	// dockerLegacyService contains some legacy methods for backward compatibility.
-	// It should be set only when docker is using non json-file logging driver.
-	dockerLegacyService dockershim.DockerLegacyService
-
-	// StatsProvider provides the node and the container stats.
-	*stats.StatsProvider
-
-	// This flag, if set, instructs the kubelet to keep volumes from terminated pods mounted to the node.
-	// This can be useful for debugging volume related issues.
-	keepTerminatedPodVolumes bool // DEPRECATED
-
-	// pluginmanager runs a set of asynchronous loops that figure out which
-	// plugins need to be registered/unregistered based on this node and makes it so.
-	pluginManager pluginmanager.PluginManager
-
-	// This flag sets a maximum number of images to report in the node status.
-	nodeStatusMaxImages int32
-
-	// Handles RuntimeClass objects for the Kubelet.
-	runtimeClassManager *runtimeclass.Manager
+func getRuntimeAndImageServices(remoteRuntimeEndpoint string, remoteImageEndpoint string, runtimeRequestTimeout metav1.Duration) (internalapi.RuntimeService, internalapi.ImageManagerService, error) {
+	rs, err := remote.NewRemoteRuntimeService(remoteRuntimeEndpoint, runtimeRequestTimeout.Duration)
+	if err != nil {
+		return nil, nil, err
+	}
+	is, err := remote.NewRemoteImageService(remoteImageEndpoint, runtimeRequestTimeout.Duration)
+	if err != nil {
+		return nil, nil, err
+	}
+	return rs, is, err
 }
 
 // setupDataDirs creates:
@@ -1810,6 +1801,16 @@ func (kl *Kubelet) canRunPod(pod *v1.Pod) lifecycle.PodAdmitResult {
 	}
 
 	return lifecycle.PodAdmitResult{Admit: true}
+}
+
+// SyncHandler is an interface implemented by Kubelet, for testability
+type SyncHandler interface {
+	HandlePodAdditions(pods []*v1.Pod)
+	HandlePodUpdates(pods []*v1.Pod)
+	HandlePodRemoves(pods []*v1.Pod)
+	HandlePodReconcile(pods []*v1.Pod)
+	HandlePodSyncs(pods []*v1.Pod)
+	HandlePodCleanups() error
 }
 
 // syncLoop is the main loop for processing changes. It watches for changes from


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Small organizational refactor to improve the readability of the Kubelet.

The changes here purely relate to the order in which the code is
specified in the file. Previously, the most important types and
functions `Kubelet` and `NewMainKubelet` were somewhat buried in the
file. This diff makes `Kubelet` the first type defined and
`NewMainKubelet` the first function defined. I'd argue this is a good
idea because many people new to the kubelet will first look at
`pkg/kubelet/kubelet.go`, and we want to show them the most important,
foundational types/functions as early as possible.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
