### PR TITLE
add delete to counterVec wrapper, since we require it in the kubelet

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -149,3 +149,17 @@ func (v *CounterVec) With(labels prometheus.Labels) CounterMetric {
 	}
 	return v.CounterVec.With(labels)
 }
+
+// Delete deletes the metric where the variable labels are the same as those
+// passed in as labels. It returns true if a metric was deleted.
+//
+// It is not an error if the number and names of the Labels are inconsistent
+// with those of the VariableLabels in Desc. However, such inconsistent Labels
+// can never match an actual metric, so the method will always return false in
+// that case.
+func (v *CounterVec) Delete(labels prometheus.Labels) bool {
+	if !v.IsCreated() {
+		return false // since we haven't created the metric, we haven't deleted a metric with the passed in values
+	}
+	return v.CounterVec.Delete(labels)
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Kubelet metrics use Delete on counterVec, so we require a corresponding wrapper for that function. 

```release-note
NONE
```
/sig instrumentation
/assign @brancz 