### PR TITLE
Put ControlleeExpectations's method together and make receiver name c…

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -206,13 +206,6 @@ func (r *ControllerExpectations) SatisfiedExpectations(controllerKey string) boo
 	return true
 }
 
-// TODO: Extend ExpirationCache to support explicit expiration.
-// TODO: Make this possible to disable in tests.
-// TODO: Support injection of clock.
-func (exp *ControlleeExpectations) isExpired() bool {
-	return clock.RealClock{}.Since(exp.timestamp) > ExpectationsTimeout
-}
-
 // SetExpectations registers new expectations for the given controller. Forgets existing expectations.
 func (r *ControllerExpectations) SetExpectations(controllerKey string, add, del int) error {
 	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: clock.RealClock{}.Now()}
@@ -269,6 +262,13 @@ type ControlleeExpectations struct {
 	del       int64
 	key       string
 	timestamp time.Time
+}
+
+// TODO: Extend ExpirationCache to support explicit expiration.
+// TODO: Make this possible to disable in tests.
+// TODO: Support injection of clock.
+func (e *ControlleeExpectations) isExpired() bool {
+	return clock.RealClock{}.Since(e.timestamp) > ExpectationsTimeout
 }
 
 // Add increments the add and del counters.


### PR DESCRIPTION
What type of PR is this?
/kind cleanup

What this PR does / why we need it:
ControlleeExpectations's name is very similar to ControllerExpectations's. It's confusing to mix code together, so I put ControlleeExpectations's code in his own area.

Which issue(s) this PR fixes:
Fixes #

/release-note-none
/priority backlog