### PR TITLE
topologymanager: Add Merge method to Policy

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -29,13 +29,6 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 )
 
-func topologyHintLessThan(a topologymanager.TopologyHint, b topologymanager.TopologyHint) bool {
-	if a.Preferred != b.Preferred {
-		return a.Preferred == true
-	}
-	return a.NUMANodeAffinity.IsNarrowerThan(b.NUMANodeAffinity)
-}
-
 func TestGetTopologyHints(t *testing.T) {
 	testPod1 := makePod("2", "2")
 	testContainer1 := &testPod1.Spec.Containers[0]
@@ -168,10 +161,10 @@ func TestGetTopologyHints(t *testing.T) {
 			continue
 		}
 		sort.SliceStable(hints, func(i, j int) bool {
-			return topologyHintLessThan(hints[i], hints[j])
+			return hints[i].LessThan(hints[j])
 		})
 		sort.SliceStable(tc.expectedHints, func(i, j int) bool {
-			return topologyHintLessThan(tc.expectedHints[i], tc.expectedHints[j])
+			return tc.expectedHints[i].LessThan(tc.expectedHints[j])
 		})
 		if !reflect.DeepEqual(tc.expectedHints, hints) {
 			t.Errorf("Expected in result to be %v , got %v", tc.expectedHints, hints)

--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -44,13 +44,6 @@ func makeNUMADevice(id string, numa int) pluginapi.Device {
 	}
 }
 
-func topologyHintLessThan(a topologymanager.TopologyHint, b topologymanager.TopologyHint) bool {
-	if a.Preferred != b.Preferred {
-		return a.Preferred == true
-	}
-	return a.NUMANodeAffinity.IsNarrowerThan(b.NUMANodeAffinity)
-}
-
 func makeSocketMask(sockets ...int) bitmask.BitMask {
 	mask, _ := bitmask.NewBitMask(sockets...)
 	return mask
@@ -292,10 +285,10 @@ func TestGetTopologyHints(t *testing.T) {
 
 		for r := range tc.expectedHints {
 			sort.SliceStable(hints[r], func(i, j int) bool {
-				return topologyHintLessThan(hints[r][i], hints[r][j])
+				return hints[r][i].LessThan(hints[r][j])
 			})
 			sort.SliceStable(tc.expectedHints[r], func(i, j int) bool {
-				return topologyHintLessThan(tc.expectedHints[r][i], tc.expectedHints[r][j])
+				return tc.expectedHints[r][i].LessThan(tc.expectedHints[r][j])
 			})
 			if !reflect.DeepEqual(hints[r], tc.expectedHints[r]) {
 				t.Errorf("%v: Expected result to be %v, got %v", tc.description, tc.expectedHints[r], hints[r])

--- a/pkg/kubelet/cm/topologymanager/policy.go
+++ b/pkg/kubelet/cm/topologymanager/policy.go
@@ -24,8 +24,7 @@ import (
 type Policy interface {
 	// Returns Policy Name
 	Name() string
-	// Returns Pod Admit Handler Response based on hints and policy type
-	CanAdmitPodResult(hint *TopologyHint) lifecycle.PodAdmitResult
 	// Returns a merged TopologyHint based on input from hint providers
-	Merge(providersHints []map[string][]TopologyHint, numaNodes []int) TopologyHint
+	// and a Pod Admit Handler Response based on hints and policy type
+	Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult)
 }

--- a/pkg/kubelet/cm/topologymanager/policy.go
+++ b/pkg/kubelet/cm/topologymanager/policy.go
@@ -20,10 +20,12 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
-//Policy interface for Topology Manager Pod Admit Result
+// Policy interface for Topology Manager Pod Admit Result
 type Policy interface {
-	//Returns Policy Name
+	// Returns Policy Name
 	Name() string
-	//Returns Pod Admit Handler Response based on hints and policy type
+	// Returns Pod Admit Handler Response based on hints and policy type
 	CanAdmitPodResult(hint *TopologyHint) lifecycle.PodAdmitResult
+	// Returns a merged TopologyHint based on input from hint providers
+	Merge(providersHints []map[string][]TopologyHint, numaNodes []int) TopologyHint
 }

--- a/pkg/kubelet/cm/topologymanager/policy_best_effort_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_best_effort_test.go
@@ -20,6 +20,24 @@ import (
 	"testing"
 )
 
+func TestPolicyBestEffortName(t *testing.T) {
+	tcases := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "New Best Effort Policy",
+			expected: "best-effort",
+		},
+	}
+	for _, tc := range tcases {
+		policy := NewBestEffortPolicy()
+		if policy.Name() != tc.expected {
+			t.Errorf("Expected Policy Name to be %s, got %s", tc.expected, policy.Name())
+		}
+	}
+}
+
 func TestPolicyBestEffortCanAdmitPodResult(t *testing.T) {
 	tcases := []struct {
 		name     string
@@ -44,6 +62,411 @@ func TestPolicyBestEffortCanAdmitPodResult(t *testing.T) {
 
 		if result.Admit != tc.expected {
 			t.Errorf("Expected Admit field in result to be %t, got %t", tc.expected, result.Admit)
+		}
+	}
+}
+
+func TestPolicyBestEffortMerge(t *testing.T) {
+	testOptimalMerge(t, NewBestEffortPolicy())
+}
+
+func testOptimalMerge(t *testing.T, policy Policy) {
+	numaNodes := []int{0, 1}
+
+	tcases := []struct {
+		name           string
+		providersHints []map[string][]TopologyHint
+		expected       TopologyHint
+	}{
+		{
+			name:           "Empty providers Hints",
+			providersHints: []map[string][]TopologyHint{},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(numaNodes...),
+				Preferred:        true,
+			},
+		},
+		{
+			name:           "providers Hints with nil map",
+			providersHints: []map[string][]TopologyHint{nil},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(numaNodes...),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "providersHints with resource and nil []TopologyHint",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource": nil,
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(numaNodes...),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "providersHints with empty non-nil []TopologyHint",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource": {},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(numaNodes...),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "Single TopologyHint with Preferred as true and NUMANodeAffinity as nil",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource": {
+						{
+							NUMANodeAffinity: nil,
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(numaNodes...),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Single TopologyHint with Preferred as false and NUMANodeAffinity as nil",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource": {
+						{
+							NUMANodeAffinity: nil,
+							Preferred:        false,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(numaNodes...),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Two resources, 1 hint each, same mask, both preferred 1/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Two resources, 1 hint each, same mask, both preferred 2/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Two resources, 1 hint each, 1 wider mask, both preferred 1/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+					},
+				},
+				{
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0, 1),
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Two resources, 1 hint each, 1 wider mask, both preferred 2/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0, 1),
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Two resources, 1 hint each, no common mask",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(numaNodes...),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "Two resources, 1 hint each, same mask, 1 preferred, 1 not 1/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        false,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "Two resources, 1 hint each, same mask, 1 preferred, 1 not 2/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        false,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "Two resources, 1 with 2 hints, 1 with single hint matching 1/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Two resources, 1 with 2 hints, 1 with single hint matching 2/2",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Two resources, 1 with 2 hints, 1 with single non-preferred hint matching",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0, 1),
+							Preferred:        false,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0),
+				Preferred:        false,
+			},
+		},
+		{
+			name: "Two resources, both with 2 hints, matching narrower preferred hint from both",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(0, 1),
+							Preferred:        false,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(0),
+				Preferred:        true,
+			},
+		},
+		{
+			name: "Ensure less narrow preferred hints are chosen over narrower non-preferred hints",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource1": {
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(0, 1),
+							Preferred:        false,
+						},
+					},
+					"resource2": {
+						{
+							NUMANodeAffinity: NewTestBitMask(0),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(1),
+							Preferred:        true,
+						},
+						{
+							NUMANodeAffinity: NewTestBitMask(0, 1),
+							Preferred:        false,
+						},
+					},
+				},
+			},
+			expected: TopologyHint{
+				NUMANodeAffinity: NewTestBitMask(1),
+				Preferred:        true,
+			},
+		},
+	}
+
+	for _, tc := range tcases {
+		result := policy.Merge(tc.providersHints, numaNodes)
+		if !result.IsEqual(tc.expected) {
+			t.Errorf("Test Case: %s: Expected merge hint to be %v, got %v", tc.name, tc.expected.String(), result.String())
 		}
 	}
 }

--- a/pkg/kubelet/cm/topologymanager/policy_none.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none.go
@@ -41,3 +41,7 @@ func (p *nonePolicy) CanAdmitPodResult(hint *TopologyHint) lifecycle.PodAdmitRes
 		Admit: true,
 	}
 }
+
+func (p *nonePolicy) Merge(providersHints []map[string][]TopologyHint, numaNodes []int) TopologyHint {
+	return TopologyHint{}
+}

--- a/pkg/kubelet/cm/topologymanager/policy_none.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none.go
@@ -36,12 +36,6 @@ func (p *nonePolicy) Name() string {
 	return PolicyNone
 }
 
-func (p *nonePolicy) CanAdmitPodResult(hint *TopologyHint) lifecycle.PodAdmitResult {
-	return lifecycle.PodAdmitResult{
-		Admit: true,
-	}
-}
-
-func (p *nonePolicy) Merge(providersHints []map[string][]TopologyHint, numaNodes []int) TopologyHint {
-	return TopologyHint{}
+func (p *nonePolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult) {
+	return TopologyHint{}, lifecycle.PodAdmitResult{Admit: true}
 }

--- a/pkg/kubelet/cm/topologymanager/policy_none_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestName(t *testing.T) {
+func TestPolicyNoneName(t *testing.T) {
 	tcases := []struct {
 		name     string
 		expected string
@@ -62,6 +62,39 @@ func TestPolicyNoneCanAdmitPodResult(t *testing.T) {
 
 		if result.Admit != tc.expected {
 			t.Errorf("Expected Admit field in result to be %t, got %t", tc.expected, result.Admit)
+		}
+	}
+}
+
+func TestPolicyNoneMerge(t *testing.T) {
+	numaNodes := []int{0, 1}
+
+	tcases := []struct {
+		name           string
+		providersHints []map[string][]TopologyHint
+		expected       TopologyHint
+	}{
+		{
+			name:           "merged empty providers hints",
+			providersHints: []map[string][]TopologyHint{},
+			expected:       TopologyHint{},
+		},
+		{
+			name: "merge with a single provider with a single resource",
+			providersHints: []map[string][]TopologyHint{
+				{
+					"resource": {{NUMANodeAffinity: NewTestBitMask(0, 1), Preferred: true}},
+				},
+			},
+			expected: TopologyHint{},
+		},
+	}
+
+	for _, tc := range tcases {
+		policy := NewNonePolicy()
+		result := policy.Merge(tc.providersHints, numaNodes)
+		if !result.IsEqual(tc.expected) {
+			t.Errorf("Test Case: %s: Expected merge hint to be %v, got %v", tc.name, tc.expected.String(), result.String())
 		}
 	}
 }

--- a/pkg/kubelet/cm/topologymanager/policy_restricted.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted.go
@@ -20,7 +20,9 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
 
-type restrictedPolicy struct{}
+type restrictedPolicy struct {
+	bestEffortPolicy
+}
 
 var _ Policy = &restrictedPolicy{}
 

--- a/pkg/kubelet/cm/topologymanager/policy_restricted.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted.go
@@ -30,15 +30,15 @@ var _ Policy = &restrictedPolicy{}
 const PolicyRestricted string = "restricted"
 
 // NewRestrictedPolicy returns restricted policy.
-func NewRestrictedPolicy() Policy {
-	return &restrictedPolicy{}
+func NewRestrictedPolicy(numaNodes []int) Policy {
+	return &restrictedPolicy{bestEffortPolicy{numaNodes: numaNodes}}
 }
 
 func (p *restrictedPolicy) Name() string {
 	return PolicyRestricted
 }
 
-func (p *restrictedPolicy) CanAdmitPodResult(hint *TopologyHint) lifecycle.PodAdmitResult {
+func (p *restrictedPolicy) canAdmitPodResult(hint *TopologyHint) lifecycle.PodAdmitResult {
 	if !hint.Preferred {
 		return lifecycle.PodAdmitResult{
 			Admit:   false,
@@ -49,4 +49,10 @@ func (p *restrictedPolicy) CanAdmitPodResult(hint *TopologyHint) lifecycle.PodAd
 	return lifecycle.PodAdmitResult{
 		Admit: true,
 	}
+}
+
+func (p *restrictedPolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult) {
+	hint := p.merge(providersHints)
+	admit := p.canAdmitPodResult(&hint)
+	return hint, admit
 }

--- a/pkg/kubelet/cm/topologymanager/policy_restricted_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted_test.go
@@ -20,6 +20,24 @@ import (
 	"testing"
 )
 
+func TestPolicyRestrictedName(t *testing.T) {
+	tcases := []struct {
+		name     string
+		expected string
+	}{
+		{
+			name:     "New Restricted Policy",
+			expected: "restricted",
+		},
+	}
+	for _, tc := range tcases {
+		policy := NewRestrictedPolicy()
+		if policy.Name() != tc.expected {
+			t.Errorf("Expected Policy Name to be %s, got %s", tc.expected, policy.Name())
+		}
+	}
+}
+
 func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 	tcases := []struct {
 		name     string
@@ -55,4 +73,8 @@ func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 			}
 		}
 	}
+}
+
+func TestPolicyRestrictedMerge(t *testing.T) {
+	testOptimalMerge(t, NewRestrictedPolicy())
 }

--- a/pkg/kubelet/cm/topologymanager/policy_restricted_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted_test.go
@@ -31,7 +31,7 @@ func TestPolicyRestrictedName(t *testing.T) {
 		},
 	}
 	for _, tc := range tcases {
-		policy := NewRestrictedPolicy()
+		policy := NewRestrictedPolicy([]int{0, 1})
 		if policy.Name() != tc.expected {
 			t.Errorf("Expected Policy Name to be %s, got %s", tc.expected, policy.Name())
 		}
@@ -57,8 +57,8 @@ func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 	}
 
 	for _, tc := range tcases {
-		policy := NewRestrictedPolicy()
-		result := policy.CanAdmitPodResult(&tc.hint)
+		policy := NewRestrictedPolicy([]int{0, 1})
+		result := policy.(*restrictedPolicy).canAdmitPodResult(&tc.hint)
 
 		if result.Admit != tc.expected {
 			t.Errorf("Expected Admit field in result to be %t, got %t", tc.expected, result.Admit)
@@ -76,5 +76,6 @@ func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 }
 
 func TestPolicyRestrictedMerge(t *testing.T) {
-	testOptimalMerge(t, NewRestrictedPolicy())
+	numaNodes := []int{0, 1}
+	testOptimalMerge(t, NewRestrictedPolicy(numaNodes), numaNodes)
 }

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
@@ -17,7 +17,10 @@ limitations under the License.
 package topologymanager
 
 import (
+	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
+	"sort"
 )
 
 type singleNumaNodePolicy struct{}
@@ -47,4 +50,135 @@ func (p *singleNumaNodePolicy) CanAdmitPodResult(hint *TopologyHint) lifecycle.P
 	return lifecycle.PodAdmitResult{
 		Admit: true,
 	}
+}
+
+// Get the narrowest hint aligned to one socket
+// assumption: allResourcesHints are not empty, all hints have SocketAffinity != nil,
+// all hints have exactly one socket set in SocketAffinity
+func (p *singleNumaNodePolicy) getHintMatch(allResourcesHints [][]TopologyHint) (bool, TopologyHint) {
+	// Sort all resources hints
+	for _, resource := range allResourcesHints {
+		sort.Slice(resource, func(i, j int) bool {
+			if resource[i].NUMANodeAffinity.GetBits()[0] < resource[j].NUMANodeAffinity.GetBits()[0] {
+				return true
+			}
+			return false
+		})
+
+	}
+	// find a match by searching a hint of one resource in the rest
+	var match TopologyHint
+	var foundMatch bool
+
+	if len(allResourcesHints) == 1 {
+		match = allResourcesHints[0][0]
+		match.Preferred = true
+		return true, match
+	}
+	for _, candidate := range allResourcesHints[0] {
+		foundMatch = true
+		for _, hints := range allResourcesHints[1:] {
+			res := sort.Search(len(hints), func(i int) bool {
+				return hints[i].NUMANodeAffinity.GetBits()[0] >= candidate.NUMANodeAffinity.GetBits()[0]
+			})
+			if res >= len(hints) ||
+				!hints[res].NUMANodeAffinity.IsEqual(candidate.NUMANodeAffinity) {
+				// hint not found, move to next hint from allResourcesHints[0]
+				foundMatch = false
+				break
+			}
+		}
+		if foundMatch {
+			match = candidate
+			match.Preferred = true
+			break
+		}
+	}
+	return foundMatch, match
+}
+
+// Return hints that have valid bitmasks with exactly one bit set
+func (p *singleNumaNodePolicy) filterHints(allResourcesHints [][]TopologyHint) [][]TopologyHint {
+	var filteredResourcesHints [][]TopologyHint
+	if len(allResourcesHints) > 0 {
+		for _, oneResourceHints := range allResourcesHints {
+			var filtered []TopologyHint
+			if len(oneResourceHints) > 0 {
+				for _, hint := range oneResourceHints {
+					if hint.NUMANodeAffinity != nil && hint.NUMANodeAffinity.Count() == 1 {
+						filtered = append(filtered, hint)
+					}
+				}
+			}
+			filteredResourcesHints = append(filteredResourcesHints, filtered)
+		}
+	}
+	return filteredResourcesHints
+}
+
+func (p *singleNumaNodePolicy) Merge(providersHints []map[string][]TopologyHint, numaNodes []int) TopologyHint {
+	// Set the default hint to return from this function as an any-socket
+	// affinity with an unpreferred allocation. This will only be returned if
+	// no better hint can be found when merging hints from each hint provider.
+	defaultAffinity, _ := bitmask.NewBitMask(numaNodes...)
+	defaultHint := TopologyHint{defaultAffinity, false}
+
+	// Loop through all provider hints and save an accumulated list of the
+	// hints returned by each hint provider. If no hints are provided, assume
+	// that provider has no preference for topology-aware allocation.
+	var allResourcesHints [][]TopologyHint
+	for _, hints := range providersHints {
+		if len(hints) == 0 {
+			klog.Infof("[topologymanager] Hint Provider has no preference for socket affinity with any resource, " +
+				"skipping.")
+			continue
+		}
+
+		// Otherwise, accumulate the hints for each resource type into allProviderHints.
+		for resource := range hints {
+			if hints[resource] == nil {
+				klog.Infof("[topologymanager] Hint Provider has no preference for socket affinity with resource "+
+					"'%s', skipping.", resource)
+				continue
+			}
+
+			if len(hints[resource]) == 0 {
+				klog.Infof("[topologymanager] Hint Provider has no possible socket affinities for resource '%s'",
+					resource)
+				// return defaultHint which will fail pod admission
+				return defaultHint
+			}
+			klog.Infof("[topologymanager] TopologyHints for resource '%v': %v", resource, hints[resource])
+			allResourcesHints = append(allResourcesHints, hints[resource])
+		}
+	}
+	// In case allProviderHints length is zero it means that we have no
+	// preference for socket affinity. In that case update default hint preferred
+	// to true to allow scheduling.
+	if len(allResourcesHints) == 0 {
+		klog.Infof("[topologymanager] No preference for socket affinity from all providers")
+		defaultHint.Preferred = true
+		return defaultHint
+	}
+
+	allResourcesHints = p.filterHints(allResourcesHints)
+	// if no hints or there is a resource with empty hints after filtering, then policy cannot be satisfied
+	if len(allResourcesHints) == 0 {
+		klog.Infof("[topologymanager] No hints that align to a single socket.")
+		return defaultHint
+	}
+	for _, hints := range allResourcesHints {
+		if len(hints) == 0 {
+			klog.Infof("[topologymanager] No hints that align to a single socket for resource.")
+			return defaultHint
+		}
+	}
+
+	found, match := p.getHintMatch(allResourcesHints)
+	if found {
+		klog.Infof("[topologymanager] Strict Policy match: %v", match)
+		return match
+	}
+	klog.Infof("[topologymanager] Strict Policy no match: %v", defaultHint)
+	return defaultHint
 }

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
@@ -44,10 +44,11 @@ func TestPolicySingleNumaNodeCanAdmitPodResult(t *testing.T) {
 		},
 	}
 
+	numaNodes := []int{0, 1}
 	for _, tc := range tcases {
-		policy := NewSingleNumaNodePolicy()
+		policy := NewSingleNumaNodePolicy(numaNodes)
 		hint := tc.hint
-		result := policy.CanAdmitPodResult(&hint)
+		result := policy.(*singleNumaNodePolicy).canAdmitPodResult(&hint)
 
 		if result.Admit != tc.expected {
 			t.Errorf("Expected Admit field in result to be %t, got %t", tc.expected, result.Admit)
@@ -164,8 +165,9 @@ func TestPolicySingleNumaNodeFilterHints(t *testing.T) {
 		},
 	}
 
+	numaNodes := []int{0, 1, 2, 3}
 	for _, tc := range tcases {
-		policy := NewSingleNumaNodePolicy()
+		policy := NewSingleNumaNodePolicy(numaNodes)
 		actual := policy.(*singleNumaNodePolicy).filterHints(tc.allResources)
 		if !reflect.DeepEqual(tc.expectedResources, actual) {
 			t.Errorf("Test Case: %s", tc.name)
@@ -315,8 +317,9 @@ func TestPolicySingleNumaNodeGetHintMatch(t *testing.T) {
 		},
 	}
 
+	numaNodes := []int{0, 1, 2, 3, 4, 5}
 	for _, tc := range tcases {
-		policy := NewSingleNumaNodePolicy()
+		policy := NewSingleNumaNodePolicy(numaNodes)
 		found, match := policy.(*singleNumaNodePolicy).getHintMatch(tc.resources)
 		if found != tc.expectedFound {
 			t.Errorf("Test Case: %s", tc.name)
@@ -730,11 +733,11 @@ func TestPolicySingleNumaNodeMerge(t *testing.T) {
 	}
 
 	for _, tc := range tcases {
-		policy := NewSingleNumaNodePolicy()
-		actual := policy.Merge(tc.providersHints, numaNodes)
+		policy := NewSingleNumaNodePolicy(numaNodes)
+		actual := policy.(*singleNumaNodePolicy).merge(tc.providersHints)
 		if !actual.IsEqual(tc.expected) {
 			t.Errorf("Test Case: %s", tc.name)
-			t.Errorf("Expected result to be %v, got %v", tc.expected.String(), actual.String())
+			t.Errorf("Expected result to be %v, got %v", tc.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:
In the current design the Topology Manager generates the merged
hints and select the best hint and the policy indicates whether
or not to admit the pod.

This patch adds Merge abstraction to Topology Manager policies which
allow the them to control on how to merge the permutation hints.
It also update the strict policy to admit only if all resources
aligned to same NUMA.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This implements the change proposed in https://github.com/kubernetes/enhancements/pull/1160
Only the non-merge commits are part of the actual PR, 
This PR is depened on https://github.com/kubernetes/kubernetes/pull/80569 and https://github.com/kubernetes/kubernetes/pull/80570

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
