### PR TITLE
Fix Test for kubeadm/app/util/net.GetHostname

### DIFF
--- a/cmd/kubeadm/app/util/net_test.go
+++ b/cmd/kubeadm/app/util/net_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"errors"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -38,6 +39,12 @@ func TestGetHostname(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
+			desc:        "overridden hostname uppercase",
+			hostname:    "OVERRIDDEN",
+			result:      "overridden",
+			expectedErr: nil,
+		},
+		{
 			desc:        "hostname contains only spaces",
 			hostname:    " ",
 			result:      "",
@@ -46,7 +53,7 @@ func TestGetHostname(t *testing.T) {
 		{
 			desc:        "empty parameter",
 			hostname:    "",
-			result:      hostname,
+			result:      strings.ToLower(hostname),
 			expectedErr: err,
 		},
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fixes the test failing for cmd/kubeadm/app/util.GetHostname if the underlying hostname contains Uppercase letters.

[`util.GetHostname`](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubeadm/app/util/net.go#L28) Returns the hostname as lowercase. But the test didn't consider to make hostname lowercase while comparing. If the hostname contains any Uppercase letter the test fails.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
