### PR TITLE
WIP: feat: add the default binder plugin with the scheduling framework

### DIFF
--- a/cmd/kube-scheduler/app/BUILD
+++ b/cmd/kube-scheduler/app/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//pkg/util/flag:go_default_library",
         "//pkg/version:go_default_library",
         "//pkg/version/verflag:go_default_library",
+        "//plugin/pkg/scheduling/defaultbinder:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -52,6 +52,8 @@ import (
 	"k8s.io/kubernetes/pkg/version"
 	"k8s.io/kubernetes/pkg/version/verflag"
 
+	"k8s.io/kubernetes/plugin/pkg/scheduling/defaultbinder"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
@@ -167,6 +169,8 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}, regis
 			return err
 		}
 	}
+
+	registry.Register(defaultbinder.Name, defaultbinder.New)
 
 	// Create the scheduler.
 	sched, err := scheduler.New(cc.Client,

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -139,7 +139,7 @@ func getNodeReducePriority(pod *v1.Pod, meta interface{}, nodeNameToInfo map[str
 
 // EmptyPluginRegistry is a test plugin set used by the default scheduler.
 var EmptyPluginRegistry = framework.Registry{}
-var emptyFramework, _ = framework.NewFramework(EmptyPluginRegistry, nil, []schedulerconfig.PluginConfig{})
+var emptyFramework, _ = framework.NewFramework(EmptyPluginRegistry, nil, []schedulerconfig.PluginConfig{}, nil)
 
 // FakeFilterPlugin is a test filter plugin used by default scheduler.
 type FakeFilterPlugin struct {
@@ -267,7 +267,7 @@ func TestGenericScheduler(t *testing.T) {
 				},
 			},
 		},
-	}, []schedulerconfig.PluginConfig{})
+	}, []schedulerconfig.PluginConfig{}, nil)
 	if err != nil {
 		t.Errorf("Unexpected error when initialize scheduling framework, err :%v", err.Error())
 	}

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -222,7 +222,7 @@ func NewConfigFactory(args *ConfigFactoryArgs) *Configurator {
 	}
 	schedulerCache := internalcache.New(30*time.Second, stopEverything)
 
-	framework, err := framework.NewFramework(args.Registry, args.Plugins, args.PluginConfig)
+	framework, err := framework.NewFramework(args.Registry, args.Plugins, args.PluginConfig, args.Client)
 	if err != nil {
 		klog.Fatalf("error initializing the scheduling framework: %v", err)
 	}

--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -240,7 +240,7 @@ func TestInitFrameworkWithScorePlugins(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := NewFramework(registry, tt.plugins, args)
+			_, err := NewFramework(registry, tt.plugins, args, nil)
 			if tt.initErr && err == nil {
 				t.Fatal("Framework initialization should fail")
 			}
@@ -476,7 +476,7 @@ func TestRunNormalizeScorePlugins(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f, err := NewFramework(tt.registry, tt.plugins, args)
+			f, err := NewFramework(tt.registry, tt.plugins, args, nil)
 			if err != nil {
 				t.Fatalf("Failed to create framework for testing: %v", err)
 			}
@@ -662,7 +662,7 @@ func TestApplyScoreWeights(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f, err := NewFramework(registry, tt.plugins, args)
+			f, err := NewFramework(registry, tt.plugins, args, nil)
 			if err != nil {
 				t.Fatalf("Failed to create framework for testing: %v", err)
 			}

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -374,4 +375,7 @@ type FrameworkHandle interface {
 
 	// GetWaitingPod returns a waiting pod given its UID.
 	GetWaitingPod(uid types.UID) WaitingPod
+
+	// Clientset returns a kubernetes clientset.
+	Clientset() clientset.Interface
 }

--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -40,6 +40,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],
 )

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
+	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
@@ -214,6 +215,10 @@ func (*fakeFramework) RunPermitPlugins(pc *framework.PluginContext, pod *v1.Pod,
 func (*fakeFramework) IterateOverWaitingPods(callback func(framework.WaitingPod)) {}
 
 func (*fakeFramework) GetWaitingPod(uid types.UID) framework.WaitingPod {
+	return nil
+}
+
+func (*fakeFramework) Clientset() clientset.Interface {
 	return nil
 }
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -63,7 +63,7 @@ var (
 	emptyPluginConfig []kubeschedulerconfig.PluginConfig
 	// emptyFramework is an empty framework used in tests.
 	// Note: If the test runs in goroutine, please don't use this variable to avoid a race condition.
-	emptyFramework, _ = framework.NewFramework(emptyPluginRegistry, nil, emptyPluginConfig)
+	emptyFramework, _ = framework.NewFramework(emptyPluginRegistry, nil, emptyPluginConfig, nil)
 )
 
 type fakeBinder struct {
@@ -695,7 +695,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 }
 
 func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, scache internalcache.Cache, informerFactory informers.SharedInformerFactory, predicateMap map[string]predicates.FitPredicate, stop chan struct{}, bindingTime time.Duration) (*Scheduler, chan *v1.Binding) {
-	framework, _ := framework.NewFramework(emptyPluginRegistry, nil, []kubeschedulerconfig.PluginConfig{})
+	framework, _ := framework.NewFramework(emptyPluginRegistry, nil, []kubeschedulerconfig.PluginConfig{}, nil)
 	algo := core.NewGenericScheduler(
 		scache,
 		internalqueue.NewSchedulingQueue(nil, nil),

--- a/plugin/BUILD
+++ b/plugin/BUILD
@@ -40,6 +40,7 @@ filegroup(
         "//plugin/pkg/admission/storage/storageclass/setdefault:all-srcs",
         "//plugin/pkg/admission/storage/storageobjectinuseprotection:all-srcs",
         "//plugin/pkg/auth:all-srcs",
+        "//plugin/pkg/scheduling/defaultbinder:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/plugin/pkg/scheduling/OWNERS
+++ b/plugin/pkg/scheduling/OWNERS
@@ -1,0 +1,8 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- sig-scheduling-maintainers
+reviewers:
+- sig-scheduling
+labels:
+- sig/scheduling

--- a/plugin/pkg/scheduling/defaultbinder/BUILD
+++ b/plugin/pkg/scheduling/defaultbinder/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["plugin.go"],
+    importpath = "k8s.io/kubernetes/plugin/pkg/scheduling/defaultbinder",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["plugin_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/plugin/pkg/scheduling/defaultbinder/plugin.go
+++ b/plugin/pkg/scheduling/defaultbinder/plugin.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultbinder
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientset "k8s.io/client-go/kubernetes"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+// DefaultBinder .
+type DefaultBinder struct {
+	Client clientset.Interface
+}
+
+var _ framework.BindPlugin = &DefaultBinder{}
+
+// Name is the name of the default binder plugin
+const Name = "default-binder-plugin"
+
+// Name returns default binder's name.
+func (p DefaultBinder) Name() string {
+	return Name
+}
+
+// Bind binds the pod to the given node.
+func (p DefaultBinder) Bind(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+	binding := &v1.Binding{
+		ObjectMeta: metav1.ObjectMeta{Namespace: pod.Namespace, Name: pod.Name, UID: pod.UID},
+		Target: v1.ObjectReference{
+			Kind: "Node",
+			Name: nodeName,
+		},
+	}
+
+	if err := p.Client.CoreV1().Pods(binding.Namespace).Bind(binding); err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
+
+	return nil
+}
+
+// New returns a default binder plugin.
+func New(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
+	return &DefaultBinder{
+		Client: handle.Clientset(),
+	}, nil
+}

--- a/plugin/pkg/scheduling/defaultbinder/plugin_test.go
+++ b/plugin/pkg/scheduling/defaultbinder/plugin_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package defaultbinder


### PR DESCRIPTION
/kind feature
/sig scheduling
/priority important-soon

**What this PR does / why we need it**:

All extension points of the scheduling framework have already been built into the scheduler, we could use the bind extension point to refactor the current scheduler, this PR implements the default binder plugin with the scheduling framework:

1. Add kubernetes clientset in the framework handle;
2. Implement default binder plugin with the scheduling framework;

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #79215


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @bsalamat @ahg-g @Huang-Wei 