### PR TITLE
Check the error return from listener close

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -208,7 +208,10 @@ func (poc PortOpenCheck) Check() (warnings, errorList []error) {
 		errorList = []error{errors.Errorf("Port %d is in use", poc.port)}
 	}
 	if ln != nil {
-		ln.Close()
+		if err = ln.Close(); err != nil {
+			warnings = append(warnings,
+				errors.Errorf("when closing port %d, encountered %v", poc.port, err))
+		}
 	}
 
 	return nil, errorList


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently the error return from listener close is ignored in PortOpenCheck#Check .

This PR adds checking of the error return and appends to the warnings.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
