### PR TITLE
moving ShuffleStrings to pkg/proxy

### DIFF
--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/proxy"
@@ -240,7 +240,7 @@ func (lb *LoadBalancerRR) OnEndpointsAdd(endpoints *v1.Endpoints) {
 			// if one does not already exist.  The affinity will be updated
 			// later, once NewService is called.
 			state = lb.newServiceInternal(svcPort, v1.ServiceAffinity(""), 0)
-			state.endpoints = slice.ShuffleStrings(newEndpoints)
+			state.endpoints = util.ShuffleStrings(newEndpoints)
 
 			// Reset the round-robin index.
 			state.index = 0
@@ -274,7 +274,7 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 			// if one does not already exist.  The affinity will be updated
 			// later, once NewService is called.
 			state = lb.newServiceInternal(svcPort, v1.ServiceAffinity(""), 0)
-			state.endpoints = slice.ShuffleStrings(newEndpoints)
+			state.endpoints = util.ShuffleStrings(newEndpoints)
 
 			// Reset the round-robin index.
 			state.index = 0

--- a/pkg/proxy/util/BUILD
+++ b/pkg/proxy/util/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/apis/core/v1/helper:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/proxy/util/utils.go
+++ b/pkg/proxy/util/utils.go
@@ -23,8 +23,9 @@ import (
 	"net"
 	"strconv"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
 	helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
@@ -270,4 +271,18 @@ func AppendPortIfNeeded(addr string, port int32) string {
 		return fmt.Sprintf("%s:%d", addr, port)
 	}
 	return fmt.Sprintf("[%s]:%d", addr, port)
+}
+
+// ShuffleStrings copies strings from the specified slice into a copy in random
+// order. It returns a new slice.
+func ShuffleStrings(s []string) []string {
+	if s == nil {
+		return nil
+	}
+	shuffled := make([]string, len(s))
+	perm := utilrand.Perm(len(s))
+	for i, j := range perm {
+		shuffled[j] = s[i]
+	}
+	return shuffled
 }

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -22,7 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -507,6 +507,33 @@ func TestAppendPortIfNeeded(t *testing.T) {
 		got := AppendPortIfNeeded(testCases[i].addr, testCases[i].port)
 		if testCases[i].expect != got {
 			t.Errorf("case %s: expected %v, got %v", testCases[i].name, testCases[i].expect, got)
+		}
+	}
+}
+
+func TestShuffleStrings(t *testing.T) {
+	var src []string
+	dest := ShuffleStrings(src)
+
+	if dest != nil {
+		t.Errorf("ShuffleStrings for a nil slice got a non-nil slice")
+	}
+
+	src = []string{"a", "b", "c", "d", "e", "f"}
+	dest = ShuffleStrings(src)
+
+	if len(src) != len(dest) {
+		t.Errorf("Shuffled slice is wrong length, expected %v got %v", len(src), len(dest))
+	}
+
+	m := make(map[string]bool, len(dest))
+	for _, s := range dest {
+		m[s] = true
+	}
+
+	for _, k := range src {
+		if _, exists := m[k]; !exists {
+			t.Errorf("Element %v missing from shuffled slice", k)
 		}
 	}
 }

--- a/pkg/proxy/winuserspace/roundrobin.go
+++ b/pkg/proxy/winuserspace/roundrobin.go
@@ -24,7 +24,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/proxy"
@@ -230,7 +230,7 @@ func (lb *LoadBalancerRR) OnEndpointsAdd(endpoints *v1.Endpoints) {
 			// if one does not already exist.  The affinity will be updated
 			// later, once NewService is called.
 			state = lb.newServiceInternal(svcPort, v1.ServiceAffinity(""), 0)
-			state.endpoints = slice.ShuffleStrings(newEndpoints)
+			state.endpoints = util.ShuffleStrings(newEndpoints)
 
 			// Reset the round-robin index.
 			state.index = 0
@@ -264,7 +264,7 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 			// if one does not already exist.  The affinity will be updated
 			// later, once NewService is called.
 			state = lb.newServiceInternal(svcPort, v1.ServiceAffinity(""), 0)
-			state.endpoints = slice.ShuffleStrings(newEndpoints)
+			state.endpoints = util.ShuffleStrings(newEndpoints)
 
 			// Reset the round-robin index.
 			state.index = 0

--- a/pkg/util/slice/BUILD
+++ b/pkg/util/slice/BUILD
@@ -10,7 +10,6 @@ go_library(
     name = "go_default_library",
     srcs = ["slice.go"],
     importpath = "k8s.io/kubernetes/pkg/util/slice",
-    deps = ["//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library"],
 )
 
 go_test(

--- a/pkg/util/slice/slice.go
+++ b/pkg/util/slice/slice.go
@@ -19,8 +19,6 @@ package slice
 
 import (
 	"sort"
-
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 )
 
 // CopyStrings copies the contents of the specified string slice
@@ -39,20 +37,6 @@ func CopyStrings(s []string) []string {
 func SortStrings(s []string) []string {
 	sort.Strings(s)
 	return s
-}
-
-// ShuffleStrings copies strings from the specified slice into a copy in random
-// order. It returns a new slice.
-func ShuffleStrings(s []string) []string {
-	if s == nil {
-		return nil
-	}
-	shuffled := make([]string, len(s))
-	perm := utilrand.Perm(len(s))
-	for i, j := range perm {
-		shuffled[j] = s[i]
-	}
-	return shuffled
 }
 
 // ContainsString checks if a given slice of strings contains the provided string.

--- a/pkg/util/slice/slice_test.go
+++ b/pkg/util/slice/slice_test.go
@@ -63,33 +63,6 @@ func TestSortStrings(t *testing.T) {
 	}
 }
 
-func TestShuffleStrings(t *testing.T) {
-	var src []string
-	dest := ShuffleStrings(src)
-
-	if dest != nil {
-		t.Errorf("ShuffleStrings for a nil slice got a non-nil slice")
-	}
-
-	src = []string{"a", "b", "c", "d", "e", "f"}
-	dest = ShuffleStrings(src)
-
-	if len(src) != len(dest) {
-		t.Errorf("Shuffled slice is wrong length, expected %v got %v", len(src), len(dest))
-	}
-
-	m := make(map[string]bool, len(dest))
-	for _, s := range dest {
-		m[s] = true
-	}
-
-	for _, k := range src {
-		if _, exists := m[k]; !exists {
-			t.Errorf("Element %v missing from shuffled slice", k)
-		}
-	}
-}
-
 func TestContainsString(t *testing.T) {
 	src := []string{"aa", "bb", "cc"}
 	if !ContainsString(src, "bb", nil) {


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What type of PR is this?**

/kind cleanup
/sig api-machinery

**What this PR does / why we need it**: this moves the `slice` package to apimachinery repository in order to be able to move some controllers out k/k

**Which issue(s) this PR fixes**: part of #81172

**Special notes for your reviewer**:

/assign @liggitt @dims 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
