### PR TITLE
kubenet: update link in comment to host-local ipam repo

### DIFF
--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
@@ -65,7 +65,7 @@ const (
 	dedupChain = utilebtables.Chain("KUBE-DEDUP")
 
 	// defaultIPAMDir is the default location for the checkpoint files stored by host-local ipam
-	// https://github.com/containernetworking/cni/tree/master/plugins/ipam/host-local#backends
+	// https://github.com/containernetworking/plugins/blob/master/plugins/ipam/host-local/README.md
 	defaultIPAMDir = "/var/lib/cni/networks"
 
 	zeroCIDRv6 = "::/0"


### PR DESCRIPTION
Looks like the plugin related code was moved out of https://github.com/containernetworking/cni in https://github.com/containernetworking/cni/commit/bc0d09e5728a8a634e7d802a4e6ef410a582e4ef (May 2017).

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Fixes a broken link to the CNI host-local IPAM plugin.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
