### PR TITLE
[FEATURE BRANCH] Better goroutine tracking in the API priority and fairness filter

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -538,6 +538,7 @@ func BuildRequestManagement(s *options.ServerRunOptions, extclient clientgoclien
 		fairqueuing.NewNoRestraintFactory( /* TODO: switch to real implementation */ ),
 		s.GenericServerRunOptions.MaxRequestsInFlight+s.GenericServerRunOptions.MaxMutatingRequestsInFlight,
 		s.GenericServerRunOptions.RequestTimeout/4,
+		nil,
 		flowcontrolbootstrap.PreservingFlowSchemas,
 		flowcontrolbootstrap.PreservingPriorityLevelConfigurations,
 	)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/recommended.go
@@ -121,7 +121,8 @@ func (o *RecommendedOptions) ApplyTo(config *server.RecommendedConfig) error {
 			kubernetes.NewForConfigOrDie(config.ClientConfig).FlowcontrolV1alpha1(),
 			fairqueuing.NewNoRestraintFactory( /* TODO: switch to real implementation */ ),
 			config.MaxRequestsInFlight+config.MaxMutatingRequestsInFlight,
-			config.RequestTimeout/4)
+			config.RequestTimeout/4,
+			nil)
 	}
 
 	return nil

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/BUILD
@@ -8,6 +8,7 @@ go_library(
         "integrator.go",
         "interface.go",
         "no-restraint.go",
+        "optionalwaitgroup.go",
         "types.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing",

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/fairqueuing_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/fairqueuing_test.go
@@ -167,7 +167,7 @@ func flowStdDevTest(t *testing.T, flows []flowDesc, expectedStdDev float64) {
 	// for i := range queues {
 	// 	fqqueues[i] = queues[i]
 	// }
-	fq := newQueueSetImpl(20000, len(flows), 20000, 5*time.Second, fc, nil)
+	fq := newQueueSetImpl(20000, len(flows), 20000, 5*time.Second, fc, NoWaitGroup())
 	for n := 0; n < len(flows); n++ {
 		genFlow(fq, &flows[n], n)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/optionalwaitgroup.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/optionalwaitgroup.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fairqueuing
+
+import (
+	"sync"
+)
+
+// OptionalWaitGroup is a WaitGroup or nothing.  Use it to track when
+// goroutines start or stop or begin or end waiting if the pointer is
+// not nil.  This abstraction is intended to make it easier to write a
+// package that can be unit tested by a function that advances a fake
+// clock once all the available work is done.  Real clients set the
+// pointer to nil because they do not need this tracking.
+type OptionalWaitGroup struct {
+	WG *sync.WaitGroup
+}
+
+// NoWaitGroup constructs an OptionalWaitGroup with a nil pointer
+func NoWaitGroup() OptionalWaitGroup {
+	return OptionalWaitGroup{WG: nil}
+}
+
+// WrapWaitGroupPointer is the abstraction function
+func WrapWaitGroupPointer(wg *sync.WaitGroup) OptionalWaitGroup {
+	return OptionalWaitGroup{WG: wg}
+}
+
+// Increment adds one to the count of active goroutines if and only if the pointer is not nil
+func (owg OptionalWaitGroup) Increment() {
+	if owg.WG != nil {
+		owg.WG.Add(1)
+	}
+}
+
+// Decrement subtracts one from the count of active goroutines if and only if the pointer is not nil
+func (owg OptionalWaitGroup) Decrement() {
+	if owg.WG != nil {
+		owg.WG.Add(-1)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/reqmgmt-config.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/reqmgmt-config.go
@@ -277,9 +277,12 @@ var _ fq.EmptyHandler = &emptyRelay{}
 
 func (er *emptyRelay) HandleEmpty() {
 	er.Lock()
-	defer func() { er.Unlock() }()
 	er.empty = true
+	// TODO: to support testing of the config controller, extend
+	// goroutine tracking to the config queue and worker
 	er.reqMgmt.configQueue.Add(0)
+	er.Unlock()
+	er.reqMgmt.wg.Decrement()
 }
 
 func (er *emptyRelay) IsEmpty() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Introduced `OptionalWaitGroup` as a convenient abstraction of
`*WaitGroup`.

Made emptyRelay::HandleEmpty and the fairqueuing functions that fork calls to the EmptyHandler update the OptionalWaitGroup and plumbed requestManagementSystem to be able to do that.  Making `HandleEmpty` update the OptionalWaitGroup illustrates how a test function that is testing the quiesce functionality of a QueueSet would do that.  This is also a step toward making requestManagementSystem update the OptionalWaitGroup properly when there are configuration changes; the remaining steps will include plumbing the OptionalWaitGroup through the work queue and its worker.

Even without this change it is already possible to test the
rest of QueueSet functionality without any special entry methods.  It
is also easy to test the functionality of a requestManagementSystem
excepting its config controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190228-priority-and-fairness.md
```
