### PR TITLE
kubeadm: support any Linux kernel version newer than 3.10

### DIFF
--- a/cmd/kubeadm/app/util/system/kernel_validator_test.go
+++ b/cmd/kubeadm/app/util/system/kernel_validator_test.go
@@ -31,7 +31,7 @@ func TestValidateKernelVersion(t *testing.T) {
 	// they may be different.
 	// This is fine, because the test mainly tests the kernel version validation logic,
 	// not the DefaultSysSpec. The DefaultSysSpec should be tested with node e2e.
-	testRegex := []string{`3\.[1-9][0-9].*`, `4\..*`}
+	testRegex := []string{`^3\.[1-9][0-9].*$`, `^([4-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`}
 	for _, test := range []struct {
 		name    string
 		version string
@@ -53,9 +53,19 @@ func TestValidateKernelVersion(t *testing.T) {
 			err:     true,
 		},
 		{
-			name:    "5.0.0 no version regex matches",
+			name:    "5.0.0 one of version regexes matches",
 			version: "5.0.0",
-			err:     true,
+			err:     false,
+		},
+		{
+			name:    "10.21.1 one of version regexes matches",
+			version: "10.21.1",
+			err:     false,
+		},
+		{
+			name:    "99.12.12 one of version regexes matches",
+			version: "99.12.12",
+			err:     false,
 		},
 		{
 			name:    "3.9.0 no version regex matches",

--- a/cmd/kubeadm/app/util/system/types_unix.go
+++ b/cmd/kubeadm/app/util/system/types_unix.go
@@ -30,7 +30,7 @@ const dockerEndpoint = "unix:///var/run/docker.sock"
 var DefaultSysSpec = SysSpec{
 	OS: "Linux",
 	KernelSpec: KernelSpec{
-		Versions: []string{`3\.[1-9][0-9].*`, `4\..*`, `5\..*`}, // Requires 3.10+, 4+ or 5+
+		Versions: []string{`^3\.[1-9][0-9].*$`, `^([4-9]|[1-9][0-9]+)\.([0-9]+)\.([0-9]+).*$`}, // Requires 3.10+, or newer
 		// TODO(random-liu): Add more config
 		// TODO(random-liu): Add description for each kernel configuration:
 		Required: []KernelConfig{


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems undesirable that Kubernetes as a system should be
blocking a node if it's Linux kernel is way too new.

If such a problem even occurs we should exclude versions from
the list of supported versions instead of blocking users
from trying e.g. the latest 7.0.0-beta kernel because our
validators are not aware of this new version yet.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: support any Linux kernel version newer than 3.10
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind cleanup
/priority important-longterm
/assign @rosti @yastij 
