### PR TITLE
Leave Windows Defender enabled for clusters on GCE

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -100,7 +100,6 @@ try {
   Dump-DebugInfoToConsole
   Set-PrerequisiteOptions
   $kube_env = Fetch-KubeEnv
-  Disable-WindowsDefender
 
   if (Test-IsTestCluster $kube_env) {
     Log-Output 'Test cluster detected, installing OpenSSH.'

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -244,22 +244,6 @@ function Set-PrerequisiteOptions {
   Install-Module -Name powershell-yaml -Force
 }
 
-# Disables Windows Defender realtime scanning.
-# TODO: remove this workaround once the fix is rolled out the Windows image
-# https://github.com/kubernetes/kubernetes/issues/75148
-function Disable-WindowsDefender {
-  # Windows Defender periodically consumes 100% of the CPU, so disable realtime
-  # scanning. Uninstalling the Windows Feature will prevent the service from
-  # starting after a reboot.
-  # TODO(pjh): move this step to image preparation, since we don't want to do a
-  # full reboot here.
-  if ((Get-WindowsFeature -Name 'Windows-Defender').Installed) {
-    Log-Output "Disabling Windows Defender service"
-    Set-MpPreference -DisableRealtimeMonitoring $true
-    Uninstall-WindowsFeature -Name 'Windows-Defender'
-  }
-}
-
 # Creates directories where other functions in this module will read and write
 # data.
 # Note: C:\tmp is required for running certain kubernetes tests.


### PR DESCRIPTION
/kind cleanup

This PR stops disabling Windows Defender on nodes in clusters running on GCE. We had to disable Defender due to a Windows kernel issue (#75148) which we believe has been fixed in our Windows image from July.

Fixes #75148

```release-note
Windows nodes on GCE now run with Windows Defender enabled.
```