### PR TITLE
Remove unused slice in initOpCache

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -173,7 +173,6 @@ func (d *namespacedResourcesDeleter) initOpCache() {
 	if len(resources) == 0 {
 		klog.Fatalf("Unable to get any supported resources from server: %v", err)
 	}
-	deletableGroupVersionResources := []schema.GroupVersionResource{}
 	for _, rl := range resources {
 		gv, err := schema.ParseGroupVersion(rl.GroupVersion)
 		if err != nil {
@@ -194,7 +193,6 @@ func (d *namespacedResourcesDeleter) initOpCache() {
 					d.opCache.setNotSupported(operationKey{operation: op, gvr: gvr})
 				}
 			}
-			deletableGroupVersionResources = append(deletableGroupVersionResources, gvr)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
deletableGroupVersionResources is not used in namespacedResourcesDeleter#initOpCache

This PR removes the slice.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
