### PR TITLE
Fix clearup of tmpDir

### DIFF
--- a/pkg/kubelet/cm/devicemanager/manager_test.go
+++ b/pkg/kubelet/cm/devicemanager/manager_test.go
@@ -64,7 +64,6 @@ func TestNewManagerImpl(t *testing.T) {
 	defer os.RemoveAll(socketDir)
 	_, err = newManagerImpl(socketName)
 	require.NoError(t, err)
-	os.RemoveAll(socketDir)
 }
 
 func TestNewManagerImplStart(t *testing.T) {
@@ -464,6 +463,7 @@ func TestCheckpoint(t *testing.T) {
 	as := assert.New(t)
 	tmpDir, err := ioutil.TempDir("", "checkpoint")
 	as.Nil(err)
+	defer os.RemoveAll(tmpDir)
 	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)
 	as.Nil(err)
 	testManager := &ManagerImpl{
@@ -861,6 +861,7 @@ func TestSanitizeNodeAllocatable(t *testing.T) {
 	monitorCallback := func(resourceName string, devices []pluginapi.Device) {}
 	tmpDir, err := ioutil.TempDir("", "checkpoint")
 	as.Nil(err)
+	defer os.RemoveAll(tmpDir)
 
 	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)
 	as.Nil(err)
@@ -960,6 +961,7 @@ func TestResetExtendedResource(t *testing.T) {
 	as := assert.New(t)
 	tmpDir, err := ioutil.TempDir("", "checkpoint")
 	as.Nil(err)
+	defer os.RemoveAll(tmpDir)
 	ckm, err := checkpointmanager.NewCheckpointManager(tmpDir)
 	as.Nil(err)
 	testManager := &ManagerImpl{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove duplicated clearup of socketDir and add clearup of tmpDir needed. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: