### PR TITLE
test: add cases to test that no images present in node status.

### DIFF
--- a/pkg/scheduler/nodeinfo/util_test.go
+++ b/pkg/scheduler/nodeinfo/util_test.go
@@ -68,6 +68,17 @@ func TestGetNodeImageStates(t *testing.T) {
 				},
 			},
 		},
+		{
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "node-0"},
+				Status:     v1.NodeStatus{},
+			},
+			imageExistenceMap: map[string]sets.String{
+				"gcr.io/10:v1":  sets.NewString("node-1"),
+				"gcr.io/200:v1": sets.NewString(),
+			},
+			expected: map[string]*ImageStateSummary{},
+		},
 	}
 
 	for _, test := range tests {
@@ -120,6 +131,37 @@ func TestCreateImageExistenceMap(t *testing.T) {
 			},
 			expected: map[string]sets.String{
 				"gcr.io/10:v1":  sets.NewString("node-0", "node-1"),
+				"gcr.io/200:v1": sets.NewString("node-1"),
+			},
+		},
+		{
+			nodes: []*v1.Node{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-0"},
+					Status:     v1.NodeStatus{},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "node-1"},
+					Status: v1.NodeStatus{
+						Images: []v1.ContainerImage{
+							{
+								Names: []string{
+									"gcr.io/10:v1",
+								},
+								SizeBytes: int64(10 * mb),
+							},
+							{
+								Names: []string{
+									"gcr.io/200:v1",
+								},
+								SizeBytes: int64(200 * mb),
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]sets.String{
+				"gcr.io/10:v1":  sets.NewString("node-1"),
 				"gcr.io/200:v1": sets.NewString("node-1"),
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

Add test cases to test when no images in node status. There are two cases

1. No images present on node.
2. kubelet's NodeStatusMaxImages flag is set to 0.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/sig scheduling