### PR TITLE
Apply hash to label(controller-revision-hash) of statefulsetPod

### DIFF
--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -480,7 +480,7 @@ func TestStatefulSetControlScaleDownDeleteError(t *testing.T) {
 	}
 }
 
-func TestStatefulSetControl_getSetRevisions(t *testing.T) {
+func TestStatefulSetControlGetSetRevisions(t *testing.T) {
 	type testcase struct {
 		name            string
 		existing        []*apps.ControllerRevision
@@ -555,12 +555,12 @@ func TestStatefulSetControl_getSetRevisions(t *testing.T) {
 	rev0 := newRevisionOrDie(set, 1)
 	set1 := set.DeepCopy()
 	set1.Spec.Template.Spec.Containers[0].Image = "foo"
-	set1.Status.CurrentRevision = rev0.Name
+	set1.Status.CurrentRevision, _ = getControllerRevisionHash(rev0)
 	set1.Status.CollisionCount = new(int32)
 	rev1 := newRevisionOrDie(set1, 2)
 	set2 := set1.DeepCopy()
 	set2.Spec.Template.Labels["new"] = "label"
-	set2.Status.CurrentRevision = rev0.Name
+	set2.Status.CurrentRevision, _ = getControllerRevisionHash(rev0)
 	set2.Status.CollisionCount = new(int32)
 	rev2 := newRevisionOrDie(set2, 3)
 	tests := []testcase{

--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -20,9 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"strconv"
-
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -32,6 +29,8 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"regexp"
+	"strconv"
 )
 
 // maxUpdateRetries is the maximum number of retries used for update conflict resolution prior to failure
@@ -402,4 +401,11 @@ func (ao ascendingOrdinal) Swap(i, j int) {
 
 func (ao ascendingOrdinal) Less(i, j int) bool {
 	return getOrdinal(ao[i]) < getOrdinal(ao[j])
+}
+
+func getControllerRevisionHash(cr *apps.ControllerRevision) (string, error) {
+	if hash, ok := cr.Labels[history.ControllerRevisionHashLabel]; ok{
+		return hash, nil
+	}
+	return "", fmt.Errorf("Fail to get hash from controllerrevision %s for revision label not found", cr.Name)
 }

--- a/pkg/controller/statefulset/stateful_set_utils_test.go
+++ b/pkg/controller/statefulset/stateful_set_utils_test.go
@@ -436,3 +436,22 @@ func newStatefulSet(replicas int) *apps.StatefulSet {
 	}
 	return newStatefulSetWithVolumes(replicas, "foo", petMounts, podMounts)
 }
+
+func TestGetControllerRevisionHash(t *testing.T) {
+	cr := &apps.ControllerRevision{}
+	cr.Name = "abc"
+
+	if _, err := getControllerRevisionHash(cr); err == nil {
+		t.Errorf("Expected error but not found")
+	}
+
+	cr.Labels= make(map[string]string)
+	cr.Labels[history.ControllerRevisionHashLabel] = "qwe123"
+	hash, err := getControllerRevisionHash(cr)
+	if err != nil {
+		t.Errorf("Found unexpected error")
+	}
+	if got,want := hash, "qwe123"; got != want {
+		t.Errorf("hash of controllerrevision name = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind bug

**What this PR does / why we need it**:
1. DaemoSet and StatefulSet are both using ControllerRevision. And pods the two created own label: "controller-revision-hash", but contents are different:

// in StatefulSet pod's Labels:
"controller-revision-hash": "<statefulset_name>-<hash>"

// in DaemonSet pod's Labels:
"controller-revision-hash": "<hash>"

This pr try to make them consistent.

2. If statefulset's name is too long, like 60bytes, controller will fail to create pods, because the value of label: "controller-revision-hash" exceeds length limition.

**Which issue(s) this PR fixes**:
Fixes #79337

**Special notes for your reviewer**:
@kow3ns