### PR TITLE
Fix multi-version CRD + admission webhook

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/api/admission/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic/conversion_test.go
@@ -126,6 +126,27 @@ func TestConvertToGVK(t *testing.T) {
 				},
 			},
 		},
+		"no-op conversion for Unstructured object whose gvk does not match the desired gvk": {
+			obj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "mygroup.k8s.io/v1",
+					"kind":       "Flunder",
+					"data": map[string]interface{}{
+						"Key": "Value",
+					},
+				},
+			},
+			gvk: schema.GroupVersionKind{Group: "mygroup.k8s.io", Version: "v2", Kind: "Flunder"},
+			expectedObj: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "mygroup.k8s.io/v2",
+					"kind":       "Flunder",
+					"data": map[string]interface{}{
+						"Key": "Value",
+					},
+				},
+			},
+		},
 	}
 
 	for name, test := range table {

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -133,7 +133,7 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		defer testcrd.CleanUp()
 		webhookCleanup := registerWebhookForCustomResource(f, context, testcrd)
 		defer webhookCleanup()
-		testCustomResourceWebhook(f, testcrd.Crd, testcrd.DynamicClient)
+		testCustomResourceWebhook(f, testcrd.Crd, testcrd.GetV1DynamicClient())
 	})
 
 	It("Should unconditionally reject operations on fail closed webhook", func() {
@@ -168,7 +168,7 @@ var _ = SIGDescribe("AdmissionWebhook", func() {
 		defer testcrd.CleanUp()
 		webhookCleanup := registerMutatingWebhookForCustomResource(f, context, testcrd)
 		defer webhookCleanup()
-		testMutatingCustomResourceWebhook(f, testcrd.Crd, testcrd.DynamicClient)
+		testMutatingCustomResourceWebhook(f, testcrd.Crd, testcrd.GetV1DynamicClient())
 	})
 
 	It("Should deny crd creation", func() {
@@ -1088,7 +1088,7 @@ func registerWebhookForCustomResource(f *framework.Framework, context *certConte
 					Operations: []v1beta1.OperationType{v1beta1.Create},
 					Rule: v1beta1.Rule{
 						APIGroups:   []string{testcrd.ApiGroup},
-						APIVersions: []string{testcrd.ApiVersion},
+						APIVersions: testcrd.GetAPIVersions(),
 						Resources:   []string{testcrd.GetPluralName()},
 					},
 				}},
@@ -1129,7 +1129,7 @@ func registerMutatingWebhookForCustomResource(f *framework.Framework, context *c
 					Operations: []v1beta1.OperationType{v1beta1.Create},
 					Rule: v1beta1.Rule{
 						APIGroups:   []string{testcrd.ApiGroup},
-						APIVersions: []string{testcrd.ApiVersion},
+						APIVersions: testcrd.GetAPIVersions(),
 						Resources:   []string{testcrd.GetPluralName()},
 					},
 				}},
@@ -1148,7 +1148,7 @@ func registerMutatingWebhookForCustomResource(f *framework.Framework, context *c
 					Operations: []v1beta1.OperationType{v1beta1.Create},
 					Rule: v1beta1.Rule{
 						APIGroups:   []string{testcrd.ApiGroup},
-						APIVersions: []string{testcrd.ApiVersion},
+						APIVersions: testcrd.GetAPIVersions(),
 						Resources:   []string{testcrd.GetPluralName()},
 					},
 				}},
@@ -1272,12 +1272,18 @@ func testCRDDenyWebhook(f *framework.Framework) {
 	name := fmt.Sprintf("e2e-test-%s-%s-crd", f.BaseName, "deny")
 	kind := fmt.Sprintf("E2e-test-%s-%s-crd", f.BaseName, "deny")
 	group := fmt.Sprintf("%s-crd-test.k8s.io", f.BaseName)
-	apiVersion := "v1"
+	apiVersions := []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		{
+			Name:    "v1",
+			Served:  true,
+			Storage: true,
+		},
+	}
 	testcrd := &framework.TestCrd{
 		Name:       name,
 		Kind:       kind,
 		ApiGroup:   group,
-		ApiVersion: apiVersion,
+		Versions:   apiVersions,
 	}
 
 	// Creating a custom resource definition for use by assorted tests.
@@ -1299,8 +1305,8 @@ func testCRDDenyWebhook(f *framework.Framework) {
 			},
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   testcrd.ApiGroup,
-			Version: testcrd.ApiVersion,
+			Group:    testcrd.ApiGroup,
+			Versions: testcrd.Versions,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural:   testcrd.GetPluralName(),
 				Singular: testcrd.Name,

--- a/test/e2e/framework/crd_util.go
+++ b/test/e2e/framework/crd_util.go
@@ -35,25 +35,23 @@ type TestCrd struct {
 	Name               string
 	Kind               string
 	ApiGroup           string
-	ApiVersion         string
+	Versions           []apiextensionsv1beta1.CustomResourceDefinitionVersion
 	ApiExtensionClient *crdclientset.Clientset
 	Crd                *apiextensionsv1beta1.CustomResourceDefinition
-	DynamicClient      dynamic.ResourceInterface
+	DynamicClients     map[string]dynamic.ResourceInterface
 	CleanUp            CleanCrdFn
 }
 
 // CreateTestCRD creates a new CRD specifically for the calling test.
-func CreateTestCRD(f *Framework) (*TestCrd, error) {
+func CreateMultiVersionTestCRD(f *Framework, group string, apiVersions []apiextensionsv1beta1.CustomResourceDefinitionVersion) (*TestCrd, error) {
 	suffix := randomSuffix()
 	name := fmt.Sprintf("e2e-test-%s-%s-crd", f.BaseName, suffix)
 	kind := fmt.Sprintf("E2e-test-%s-%s-crd", f.BaseName, suffix)
-	group := fmt.Sprintf("%s-crd-test.k8s.io", f.BaseName)
-	apiVersion := "v1"
 	testcrd := &TestCrd{
-		Name:       name,
-		Kind:       kind,
-		ApiGroup:   group,
-		ApiVersion: apiVersion,
+		Name:     name,
+		Kind:     kind,
+		ApiGroup: group,
+		Versions: apiVersions,
 	}
 
 	// Creating a custom resource definition for use by assorted tests.
@@ -82,12 +80,17 @@ func CreateTestCRD(f *Framework) (*TestCrd, error) {
 		return nil, err
 	}
 
-	gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: crd.Spec.Version, Resource: crd.Spec.Names.Plural}
-	resourceClient := dynamicClient.Resource(gvr).Namespace(f.Namespace.Name)
+	resourceClients := map[string]dynamic.ResourceInterface{}
+	for _, v := range crd.Spec.Versions {
+		if v.Served {
+			gvr := schema.GroupVersionResource{Group: crd.Spec.Group, Version: v.Name, Resource: crd.Spec.Names.Plural}
+			resourceClients[v.Name] = dynamicClient.Resource(gvr).Namespace(f.Namespace.Name)
+		}
+	}
 
 	testcrd.ApiExtensionClient = apiExtensionClient
 	testcrd.Crd = crd
-	testcrd.DynamicClient = resourceClient
+	testcrd.DynamicClients = resourceClients
 	testcrd.CleanUp = func() error {
 		err := fixtures.DeleteCustomResourceDefinition(crd, apiExtensionClient)
 		if err != nil {
@@ -98,13 +101,44 @@ func CreateTestCRD(f *Framework) (*TestCrd, error) {
 	return testcrd, nil
 }
 
+// CreateTestCRD creates a new CRD specifically for the calling test.
+func CreateTestCRD(f *Framework) (*TestCrd, error) {
+	group := fmt.Sprintf("%s-crd-test.k8s.io", f.BaseName)
+	apiVersions := []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		{
+			Name:    "v1",
+			Served:  true,
+			Storage: true,
+		},
+	}
+	return CreateMultiVersionTestCRD(f, group, apiVersions)
+}
+
+// CreateTestCRD creates a new CRD specifically for the calling test.
+func CreateMultiVersionTestCRDWithV1Storage(f *Framework) (*TestCrd, error) {
+	group := fmt.Sprintf("%s-multiversion-crd-test.k8s.io", f.BaseName)
+	apiVersions := []apiextensionsv1beta1.CustomResourceDefinitionVersion{
+		{
+			Name:    "v1",
+			Served:  true,
+			Storage: true,
+		},
+		{
+			Name:    "v2",
+			Served:  true,
+			Storage: false,
+		},
+	}
+	return CreateMultiVersionTestCRD(f, group, apiVersions)
+}
+
 // newCRDForTest generates a CRD definition for the test
 func newCRDForTest(testcrd *TestCrd) *apiextensionsv1beta1.CustomResourceDefinition {
 	return &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{Name: testcrd.GetMetaName()},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   testcrd.ApiGroup,
-			Version: testcrd.ApiVersion,
+			Group:    testcrd.ApiGroup,
+			Versions: testcrd.Versions,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
 				Plural:   testcrd.GetPluralName(),
 				Singular: testcrd.Name,
@@ -129,4 +163,18 @@ func (c *TestCrd) GetPluralName() string {
 // GetListName returns the name for the CRD list resources
 func (c *TestCrd) GetListName() string {
 	return c.Name + "List"
+}
+
+func (c *TestCrd) GetAPIVersions() []string {
+	ret := []string{}
+	for _, v := range c.Versions {
+		if v.Served {
+			ret = append(ret, v.Name)
+		}
+	}
+	return ret
+}
+
+func (c *TestCrd) GetV1DynamicClient() dynamic.ResourceInterface {
+	return c.DynamicClients["v1"]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
xref #73752

**Special notes for your reviewer**:

Cherry picking changes needed to backport a fix that was originally backported into 1.13 in https://github.com/kubernetes/kubernetes/pull/79495.

> This is a smaller workaround to address #73752 specifically for no-op schema conversion in CRDs (which is the only type of conversion supported in 1.13). Backporting the 1.14 fix in #74154 would change 100+ files and change the Admission interface signature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Resolves a bug that prevented sending a multi-version custom resource to an admission webhook.
```
