### PR TITLE
Add verb to sig-node reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -211,6 +211,7 @@ aliases:
     - resouer
     - sjenning
     - tallclair
+    - verb
     - vishh
     - yifan-gu
     - yujuhong
@@ -413,6 +414,7 @@ aliases:
     - dchen1107
     - derekwaynecarr
     - tallclair
+    - verb
     - yujuhong
 
   sig-scalability-approvers:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: Add @verb to OWNERS for first-level sig-node reviews and sig-node-api-reviewers for api reviewer training.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
