### PR TITLE
Fix verb reporting in metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -213,10 +213,16 @@ func Record(req *http.Request, requestInfo *request.RequestInfo, component, cont
 		requestInfo = &request.RequestInfo{Verb: req.Method, Path: req.URL.Path}
 	}
 	scope := CleanScope(requestInfo)
+	// We don't use verb from <requestInfo>, as for the healthy path
+	// MonitorRequest is called from InstrumentRouteFunc which is registered
+	// in installer.go with predefined list of verbs (different than those
+	// translated to RequestInfo).
+	// However, we need to tweak it e.g. to differentiate GET from LIST.
+	verb := canonicalVerb(strings.ToUpper(req.Method), scope)
 	if requestInfo.IsResourceRequest {
-		MonitorRequest(req, strings.ToUpper(requestInfo.Verb), requestInfo.APIGroup, requestInfo.APIVersion, requestInfo.Resource, requestInfo.Subresource, scope, component, contentType, code, responseSizeInBytes, elapsed)
+		MonitorRequest(req, verb, requestInfo.APIGroup, requestInfo.APIVersion, requestInfo.Resource, requestInfo.Subresource, scope, component, contentType, code, responseSizeInBytes, elapsed)
 	} else {
-		MonitorRequest(req, strings.ToUpper(requestInfo.Verb), "", "", "", requestInfo.Path, scope, component, contentType, code, responseSizeInBytes, elapsed)
+		MonitorRequest(req, verb, "", "", "", requestInfo.Path, scope, component, contentType, code, responseSizeInBytes, elapsed)
 	}
 }
 
@@ -228,7 +234,12 @@ func RecordLongRunning(req *http.Request, requestInfo *request.RequestInfo, comp
 	}
 	var g prometheus.Gauge
 	scope := CleanScope(requestInfo)
-	reportedVerb := cleanVerb(strings.ToUpper(requestInfo.Verb), req)
+	// We don't use verb from <requestInfo>, as for the healthy path
+	// MonitorRequest is called from InstrumentRouteFunc which is registered
+	// in installer.go with predefined list of verbs (different than those
+	// translated to RequestInfo).
+	// However, we need to tweak it e.g. to differentiate GET from LIST.
+	reportedVerb := cleanVerb(canonicalVerb(strings.ToUpper(req.Method), scope), req)
 	if requestInfo.IsResourceRequest {
 		g = longRunningRequestGauge.WithLabelValues(reportedVerb, requestInfo.APIGroup, requestInfo.APIVersion, requestInfo.Resource, requestInfo.Subresource, scope, component)
 	} else {
@@ -318,6 +329,18 @@ func CleanScope(requestInfo *request.RequestInfo) string {
 	}
 	// this is the empty scope
 	return ""
+}
+
+func canonicalVerb(verb string, scope string) string {
+	switch verb {
+	case "GET", "HEAD":
+		if scope != "resource" {
+			return "LIST"
+		}
+		return "GET"
+	default:
+		return verb
+	}
 }
 
 func cleanVerb(verb string, request *http.Request) string {


### PR DESCRIPTION
Currently, based on the codepath, we were reporting different verbs in metrics:

1. when going via InstrumentRouteFunc:
https://github.com/kubernetes/kubernetes/blob/d6035f3e0d79dd05628ef42231beae97806a06ad/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go#L691
(which then calls MonitorRequest)
we were reporting Verb as define in install.go (POST, PUT, ...)

2. when going via to metrics.Record via:
https://github.com/kubernetes/kubernetes/blob/d6035f3e0d79dd05628ef42231beae97806a06ad/staging/src/k8s.io/apiserver/pkg/server/filters/maxinflight.go#L181
or
https://github.com/kubernetes/kubernetes/blob/d6035f3e0d79dd05628ef42231beae97806a06ad/staging/src/k8s.io/apiserver/pkg/server/filters/timeout.go#L61
we were reporting verb from RequestInfo, that was previous translated in:
https://github.com/kubernetes/kubernetes/blob/d6035f3e0d79dd05628ef42231beae97806a06ad/staging/src/k8s.io/apiserver/pkg/endpoints/request/requestinfo.go#L162

This PR is unifying the two path to always report the incoming Verb.