### PR TITLE
Update existing node lease with retry.

### DIFF
--- a/pkg/kubelet/nodelease/controller.go
+++ b/pkg/kubelet/nodelease/controller.go
@@ -98,12 +98,10 @@ func (c *controller) sync() {
 		// If at some point other agents will also be frequently updating the Lease object, this
 		// can result in performance degradation, because we will end up with calling additional
 		// GET/PUT - at this point this whole "if" should be removed.
-		lease, err := c.leaseClient.Update(c.newLease(c.latestLease))
+		err := c.retryUpdateLease(c.newLease(c.latestLease))
 		if err == nil {
-			c.latestLease = lease
 			return
 		}
-
 		klog.Infof("failed to update lease using latest lease, fallback to ensure lease, err: %v", err)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Retry update latest lease early when failure happens rather than walk to `backoffEnsureLease` which will call `GET` anyway.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/sig node