### PR TITLE
Fix a static check failure in controller-manager

### DIFF
--- a/cmd/controller-manager/app/serve.go
+++ b/cmd/controller-manager/app/serve.go
@@ -63,6 +63,7 @@ func NewBaseHandler(c *componentbaseconfig.DebuggingConfiguration, checks ...hea
 		}
 	}
 	configz.InstallHandler(mux)
+	//lint:ignore SA1019 See the Metrics Stability Migration KEP
 	mux.Handle("/metrics", legacyregistry.Handler())
 
 	return mux

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,6 +1,5 @@
 cluster/images/etcd-version-monitor
 cluster/images/etcd/migrate
-cmd/controller-manager/app
 cmd/kube-controller-manager/app
 cmd/kube-proxy/app
 cmd/kube-scheduler/app


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fix a static check failure in controller-manager

```
cmd/controller-manager/app/serve.go:65:25: prometheus.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead.  (SA1019)
```

**Which issue(s) this PR fixes**:

Ref: #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
