### PR TITLE
Change wardle.k8s.io to wardle.example.com

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/meta/testrestmapper/test_restmapper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/meta/testrestmapper/test_restmapper.go
@@ -152,7 +152,7 @@ var rootScopedKinds = map[schema.GroupKind]bool{
 
 	{Group: "metrics.k8s.io", Kind: "NodeMetrics"}: true,
 
-	{Group: "wardle.k8s.io", Kind: "Fischer"}: true,
+	{Group: "wardle.example.com", Kind: "Fischer"}: true,
 }
 
 // hardcoded is good enough for the test we're running

--- a/staging/src/k8s.io/sample-apiserver/README.md
+++ b/staging/src/k8s.io/sample-apiserver/README.md
@@ -187,19 +187,19 @@ only this superuser group is authorized.
 
    ``` shell
    curl -fv -k --cert client.p12:password \
-      https://localhost:8443/apis/wardle.k8s.io/v1alpha1/namespaces/default/flunders
+      https://localhost:8443/apis/wardle.example.com/v1alpha1/namespaces/default/flunders
    ```
 
    Or use wget:
    ``` shell
    wget -O- --no-check-certificate \
       --certificate client.crt --private-key client.key \
-      https://localhost:8443/apis/wardle.k8s.io/v1alpha1/namespaces/default/flunders
+      https://localhost:8443/apis/wardle.example.com/v1alpha1/namespaces/default/flunders
    ```
 
    Note: Recent OSX versions broke client certs with curl. On Mac try `brew install httpie` and then:
 
    ``` shell
    http --verify=no --cert client.crt --cert-key client.key \
-      https://localhost:8443/apis/wardle.k8s.io/v1alpha1/namespaces/default/flunders
+      https://localhost:8443/apis/wardle.example.com/v1alpha1/namespaces/default/flunders
    ```

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/apiservice.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/apiservice.yaml
@@ -1,10 +1,10 @@
 apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
-  name: v1alpha1.wardle.k8s.io
+  name: v1alpha1.wardle.example.com
 spec:
   insecureSkipTLSVerify: true
-  group: wardle.k8s.io
+  group: wardle.example.com
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/staging/src/k8s.io/sample-apiserver/artifacts/flunders/01-flunder.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/flunders/01-flunder.yaml
@@ -1,4 +1,4 @@
-apiVersion: wardle.k8s.io/v1alpha1
+apiVersion: wardle.example.com/v1alpha1
 kind: Flunder
 metadata:
   name: my-first-flunder

--- a/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
+++ b/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
@@ -106,5 +106,5 @@ kubectl get flunder my-first-flunder
 
 #outputs
 # NAME               KIND
-# my-first-flunder   Flunder.v1alpha1.wardle.k8s.io
+# my-first-flunder   Flunder.v1alpha1.wardle.example.com
 ```

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/doc.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/doc.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 // +k8s:deepcopy-gen=package
-// +groupName=wardle.k8s.io
+// +groupName=wardle.example.com
 
 // Package api is the internal version of the API.
 package wardle // import "k8s.io/sample-apiserver/pkg/apis/wardle"

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/register.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-const GroupName = "wardle.k8s.io"
+const GroupName = "wardle.example.com"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: runtime.APIVersionInternal}

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/doc.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/sample-apiserver/pkg/apis/wardle
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=wardle.k8s.io
+// +groupName=wardle.example.com
 
 // Package v1alpha1 is the v1alpha1 version of the API.
 package v1alpha1 // import "k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1"

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1/register.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-const GroupName = "wardle.k8s.io"
+const GroupName = "wardle.example.com"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/doc.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/doc.go
@@ -18,7 +18,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:conversion-gen=k8s.io/sample-apiserver/pkg/apis/wardle
 // +k8s:defaulter-gen=TypeMeta
-// +groupName=wardle.k8s.io
+// +groupName=wardle.example.com
 
 // Package v1beta1 is the v1beta1 version of the API.
 package v1beta1 // import "k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1"

--- a/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/register.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1beta1/register.go
@@ -23,7 +23,7 @@ import (
 )
 
 // GroupName holds the API group name.
-const GroupName = "wardle.k8s.io"
+const GroupName = "wardle.example.com"
 
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}

--- a/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/cmd/server/start.go
@@ -41,7 +41,7 @@ import (
 	sampleopenapi "k8s.io/sample-apiserver/pkg/generated/openapi"
 )
 
-const defaultEtcdPathPrefix = "/registry/wardle.kubernetes.io"
+const defaultEtcdPathPrefix = "/registry/wardle.example.com"
 
 // WardleServerOptions contains state for master/api server
 type WardleServerOptions struct {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
@@ -33,9 +33,9 @@ type FakeFischers struct {
 	Fake *FakeWardleV1alpha1
 }
 
-var fischersResource = schema.GroupVersionResource{Group: "wardle.k8s.io", Version: "v1alpha1", Resource: "fischers"}
+var fischersResource = schema.GroupVersionResource{Group: "wardle.example.com", Version: "v1alpha1", Resource: "fischers"}
 
-var fischersKind = schema.GroupVersionKind{Group: "wardle.k8s.io", Version: "v1alpha1", Kind: "Fischer"}
+var fischersKind = schema.GroupVersionKind{Group: "wardle.example.com", Version: "v1alpha1", Kind: "Fischer"}
 
 // Get takes name of the fischer, and returns the corresponding fischer object, and an error if there is any.
 func (c *FakeFischers) Get(name string, options v1.GetOptions) (result *v1alpha1.Fischer, err error) {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
@@ -34,9 +34,9 @@ type FakeFlunders struct {
 	ns   string
 }
 
-var flundersResource = schema.GroupVersionResource{Group: "wardle.k8s.io", Version: "v1alpha1", Resource: "flunders"}
+var flundersResource = schema.GroupVersionResource{Group: "wardle.example.com", Version: "v1alpha1", Resource: "flunders"}
 
-var flundersKind = schema.GroupVersionKind{Group: "wardle.k8s.io", Version: "v1alpha1", Kind: "Flunder"}
+var flundersKind = schema.GroupVersionKind{Group: "wardle.example.com", Version: "v1alpha1", Kind: "Flunder"}
 
 // Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
 func (c *FakeFlunders) Get(name string, options v1.GetOptions) (result *v1alpha1.Flunder, err error) {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
@@ -30,7 +30,7 @@ type WardleV1alpha1Interface interface {
 	FlundersGetter
 }
 
-// WardleV1alpha1Client is used to interact with features provided by the wardle.k8s.io group.
+// WardleV1alpha1Client is used to interact with features provided by the wardle.example.com group.
 type WardleV1alpha1Client struct {
 	restClient rest.Interface
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
@@ -34,9 +34,9 @@ type FakeFlunders struct {
 	ns   string
 }
 
-var flundersResource = schema.GroupVersionResource{Group: "wardle.k8s.io", Version: "v1beta1", Resource: "flunders"}
+var flundersResource = schema.GroupVersionResource{Group: "wardle.example.com", Version: "v1beta1", Resource: "flunders"}
 
-var flundersKind = schema.GroupVersionKind{Group: "wardle.k8s.io", Version: "v1beta1", Kind: "Flunder"}
+var flundersKind = schema.GroupVersionKind{Group: "wardle.example.com", Version: "v1beta1", Kind: "Flunder"}
 
 // Get takes name of the flunder, and returns the corresponding flunder object, and an error if there is any.
 func (c *FakeFlunders) Get(name string, options v1.GetOptions) (result *v1beta1.Flunder, err error) {

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
@@ -29,7 +29,7 @@ type WardleV1beta1Interface interface {
 	FlundersGetter
 }
 
-// WardleV1beta1Client is used to interact with features provided by the wardle.k8s.io group.
+// WardleV1beta1Client is used to interact with features provided by the wardle.example.com group.
 type WardleV1beta1Client struct {
 	restClient rest.Interface
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/generic.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/informers/externalversions/generic.go
@@ -53,13 +53,13 @@ func (f *genericInformer) Lister() cache.GenericLister {
 // TODO extend this to unknown resources with a client pool
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
-	// Group=wardle.k8s.io, Version=v1alpha1
+	// Group=wardle.example.com, Version=v1alpha1
 	case v1alpha1.SchemeGroupVersion.WithResource("fischers"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Wardle().V1alpha1().Fischers().Informer()}, nil
 	case v1alpha1.SchemeGroupVersion.WithResource("flunders"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Wardle().V1alpha1().Flunders().Informer()}, nil
 
-		// Group=wardle.k8s.io, Version=v1beta1
+		// Group=wardle.example.com, Version=v1beta1
 	case v1beta1.SchemeGroupVersion.WithResource("flunders"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Wardle().V1beta1().Flunders().Informer()}, nil
 

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -323,13 +323,13 @@ func TestAggregatedAPIServer(t *testing.T) {
 	}
 	aggregatorClient := aggregatorclient.NewForConfigOrDie(aggregatorClientConfig)
 	_, err = aggregatorClient.ApiregistrationV1beta1().APIServices().Create(&apiregistrationv1beta1.APIService{
-		ObjectMeta: metav1.ObjectMeta{Name: "v1alpha1.wardle.k8s.io"},
+		ObjectMeta: metav1.ObjectMeta{Name: "v1alpha1.wardle.example.com"},
 		Spec: apiregistrationv1beta1.APIServiceSpec{
 			Service: &apiregistrationv1beta1.ServiceReference{
 				Namespace: "kube-wardle",
 				Name:      "api",
 			},
-			Group:                "wardle.k8s.io",
+			Group:                "wardle.example.com",
 			Version:              "v1alpha1",
 			CABundle:             wardleCA,
 			GroupPriorityMinimum: 200,
@@ -391,7 +391,7 @@ func checkWardleUnavailableDiscoveryError(t *testing.T, err error) bool {
 		t.Logf("Unexpected failed groups: %v", err)
 		return false
 	}
-	groupVersion := schema.GroupVersion{Group: "wardle.k8s.io", Version: "v1alpha1"}
+	groupVersion := schema.GroupVersion{Group: "wardle.example.com", Version: "v1alpha1"}
 	groupVersionErr, ok := discoveryErr.Groups[groupVersion]
 	if !ok {
 		t.Logf("Unexpected failed group version: %v", err)
@@ -475,7 +475,7 @@ func testAPIGroupList(t *testing.T, client rest.Interface) {
 }
 
 func testAPIGroup(t *testing.T, client rest.Interface) {
-	contents, err := readResponse(client, "/apis/wardle.k8s.io")
+	contents, err := readResponse(client, "/apis/wardle.example.com")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -483,7 +483,7 @@ func testAPIGroup(t *testing.T, client rest.Interface) {
 	var apiGroup metav1.APIGroup
 	err = json.Unmarshal(contents, &apiGroup)
 	if err != nil {
-		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis/wardle.k8s.io", err)
+		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis/wardle.example.com", err)
 	}
 	assert.Equal(t, wardlev1alpha1.SchemeGroupVersion.Group, apiGroup.Name)
 	assert.Equal(t, 2, len(apiGroup.Versions))
@@ -493,7 +493,7 @@ func testAPIGroup(t *testing.T, client rest.Interface) {
 }
 
 func testAPIResourceList(t *testing.T, client rest.Interface) {
-	contents, err := readResponse(client, "/apis/wardle.k8s.io/v1alpha1")
+	contents, err := readResponse(client, "/apis/wardle.example.com/v1alpha1")
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -501,7 +501,7 @@ func testAPIResourceList(t *testing.T, client rest.Interface) {
 	var apiResourceList metav1.APIResourceList
 	err = json.Unmarshal(contents, &apiResourceList)
 	if err != nil {
-		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis/wardle.k8s.io/v1alpha1", err)
+		t.Fatalf("Error in unmarshalling response from server %s: %v", "/apis/wardle.example.com/v1alpha1", err)
 	}
 	assert.Equal(t, wardlev1alpha1.SchemeGroupVersion.String(), apiResourceList.GroupVersion)
 	assert.Equal(t, 2, len(apiResourceList.APIResources))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Renames the example API group to make it clear it is an example. This makes it read better in documentation, and allows filtering out by conformance test tools

Will split the e2e image push into a separate PR (https://github.com/kubernetes/kubernetes/pull/84735) that will build/merge after 1.17.0 ships so we can build an image from a shipped level of the API server

**Does this PR introduce a user-facing change?**:
```release-note
The example API server has renamed its `wardle.k8s.io` API group to `wardle.example.com`
```

/sig api-machinery
/cc @jpbetz @deads2k 