### PR TITLE
Add ephemeral containers to streamLocation name suggestions

### DIFF
--- a/pkg/registry/core/pod/BUILD
+++ b/pkg/registry/core/pod/BUILD
@@ -47,6 +47,7 @@ go_test(
         "//pkg/api/testing:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/core/install:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/kubelet/client:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
@@ -56,7 +57,9 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
     ],
 )
 


### PR DESCRIPTION
This combines container names into a single list because separating them into a long, variable length string isn't particularly useful in the context of a streaming error message. Continuing to conditionally append separate lists of strings would lead to the following potential error messages:

```
- a container name must be specified for pod test, choose one of: [container1 container2]
- a container name must be specified for pod test, choose one of: [container1 container2] or one of the init containers: [initcontainer1] or one of the ephemeral containers: [debugcontainer1]"
- a container name must be specified for pod test, choose one of: [container1 container2] or one of the init containers: [initcontainer1]
- a container name must be specified for pod test, choose one of: [container1 container2] or one of the ephemeral containers: [debugcontainer1]"
```

These long error messages with embedded lists make it hard to find container names at a glance, and the variable ordering makes it easy to mistake the container types. This isn't overly important since the container types aren't important in the context of someone who needs to type a container name in `kubectl`, but if the type is unimportant then we shouldn't display it in the first place.

The replacement error message proposed here displays all container names a single, consistently located list that is easy to find at a glance:

```
a container name must be specified for pod test, choose one of: [initcontainer1 container1 container2 debugger]
```

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: Ephemeral containers are available as a streaming location.

**Which issue(s) this PR fixes**:
WIP #27140

**Special notes for your reviewer**: I expect removing container type from this error message will be controversial, and I'm not married to it, but this is how I think it should be solved so let's start there.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
