### PR TITLE
override stackdriver endpoint in event-exporter in test cluster

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,11 +29,11 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: event-exporter-v0.2.5
+  name: event-exporter-v0.3.0
   namespace: kube-system
   labels:
     k8s-app: event-exporter
-    version: v0.2.5
+    version: v0.3.0
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -41,20 +41,20 @@ spec:
   selector:
     matchLabels:
       k8s-app: event-exporter
-      version: v0.2.5
+      version: v0.3.0
   template:
     metadata:
       labels:
         k8s-app: event-exporter
-        version: v0.2.5
+        version: v0.3.0
     spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: k8s.gcr.io/event-exporter:v0.2.5
+        image: k8s.gcr.io/event-exporter:v0.3.0
         command:
         - /event-exporter
-        - -sink-opts=-stackdriver-resource-model={{ exporter_sd_resource_model }}
+        - -sink-opts=-stackdriver-resource-model={{ exporter_sd_resource_model }} -endpoint={{ exporter_sd_endpoint }}
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
         image: k8s.gcr.io/prometheus-to-sd:v0.5.0

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2547,6 +2547,7 @@ function update-daemon-set-prometheus-to-sd-parameters {
 function update-event-exporter {
     local -r stackdriver_resource_model="${LOGGING_STACKDRIVER_RESOURCE_TYPES:-old}"
     sed -i -e "s@{{ exporter_sd_resource_model }}@${stackdriver_resource_model}@g" "$1"
+    sed -i -e "s@{{ exporter_sd_endpoint }}@${STACKDRIVER_TEST_ENDPOINT:-}@g" "$1"
 }
 
 function update-dashboard-controller {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
[`Event-Exporter`](https://github.com/GoogleCloudPlatform/k8s-stackdriver/tree/master/event-exporter) is modified to accept Stackdriver base endpoint override ([PR here](https://github.com/GoogleCloudPlatform/k8s-stackdriver/pull/276)).
This PR is to take advantage of the new `event-exporter` override option, so that we can avoid test clusters sending events to production Stackdriver.

**Special notes for your reviewer**:
* `STACKDRIVER_TEST_ENDPOINT` is a `kube-env` var introduced in kube-env (currently under review), which will be set to test Stackdriver endpoint URL if the cluster is a test cluster.
* This PR doesn't necessarily have to be merged after `STACKDRIVER_TEST_ENDPOINT` is in place. If the env var is not set, we just leave the param to `event-exporter` blank. Then `event-exporter` will use the prod Stackdriver endpoint by default.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```