### PR TITLE
Use framework functions under test/e2e/node/

### DIFF
--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -37,7 +37,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -273,7 +272,7 @@ var _ = SIGDescribe("kubelet", func() {
 			nodeLabels["kubelet_cleanup"] = "true"
 			nodes := framework.GetReadySchedulableNodesOrDie(c)
 			numNodes = len(nodes.Items)
-			gomega.Expect(numNodes).NotTo(gomega.BeZero())
+			framework.ExpectNotEqual(numNodes, 0)
 			nodeNames = sets.NewString()
 			// If there are a lot of nodes, we don't want to use all of them
 			// (if there are 1000 nodes in the cluster, starting 10 pods/node

--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -28,7 +28,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 func preparePod(name string, node *v1.Node, propagation *v1.MountPropagationMode, hostDir string) *v1.Pod {
@@ -88,7 +87,7 @@ var _ = SIGDescribe("Mount propagation", func() {
 
 		// Pick a node where all pods will run.
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		gomega.Expect(len(nodes.Items)).NotTo(gomega.BeZero(), "No available nodes for scheduling")
+		framework.ExpectNotEqual(len(nodes.Items), 0, "No available nodes for scheduling")
 		node := &nodes.Items[0]
 
 		// Fail the test if the namespace is not set. We expect that the

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -36,7 +36,6 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -163,8 +162,8 @@ var _ = SIGDescribe("Pods Extended", func() {
 			})
 			framework.ExpectNoError(err, "kubelet never observed the termination notice")
 
-			gomega.Expect(lastPod.DeletionTimestamp).ToNot(gomega.BeNil())
-			gomega.Expect(lastPod.Spec.TerminationGracePeriodSeconds).ToNot(gomega.BeZero())
+			framework.ExpectNotEqual(lastPod.DeletionTimestamp, nil)
+			framework.ExpectNotEqual(lastPod.Spec.TerminationGracePeriodSeconds, 0)
 
 			selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 			options = metav1.ListOptions{LabelSelector: selector.String()}
@@ -222,7 +221,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			ginkgo.By("verifying QOS class is set on the pod")
 			pod, err := podClient.Get(name, metav1.GetOptions{})
 			framework.ExpectNoError(err, "failed to query for pod")
-			gomega.Expect(pod.Status.QOSClass == v1.PodQOSGuaranteed)
+			framework.ExpectEqual(pod.Status.QOSClass, v1.PodQOSGuaranteed)
 		})
 	})
 })

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -213,9 +213,9 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	testContent := "hello"
 	testFilePath := mountPath + "/TEST"
 	err = f.WriteFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, testFilePath, testContent)
-	gomega.Expect(err).To(gomega.BeNil())
+	framework.ExpectNoError(err)
 	content, err := f.ReadFileViaContainer(pod.Name, pod.Spec.Containers[0].Name, testFilePath)
-	gomega.Expect(err).To(gomega.BeNil())
+	framework.ExpectNoError(err)
 	gomega.Expect(content).To(gomega.ContainSubstring(testContent))
 
 	foundPod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(pod.Name, metav1.GetOptions{})

--- a/test/e2e/node/ttlafterfinished.go
+++ b/test/e2e/node/ttlafterfinished.go
@@ -28,7 +28,6 @@ import (
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const dummyFinalizer = "k8s.io/dummy-finalizer"
@@ -88,11 +87,11 @@ func testFinishedJob(f *framework.Framework) {
 	framework.ExpectNoError(err)
 	finishTime := jobutil.FinishTime(job)
 	finishTimeUTC := finishTime.UTC()
-	gomega.Expect(finishTime.IsZero()).NotTo(gomega.BeTrue())
+	framework.ExpectNotEqual(finishTime.IsZero(), true)
 
 	deleteAtUTC := job.ObjectMeta.DeletionTimestamp.UTC()
-	gomega.Expect(deleteAtUTC).NotTo(gomega.BeNil())
+	framework.ExpectNotEqual(deleteAtUTC, nil)
 
 	expireAtUTC := finishTimeUTC.Add(time.Duration(ttl) * time.Second)
-	gomega.Expect(deleteAtUTC.Before(expireAtUTC)).To(gomega.BeFalse())
+	framework.ExpectEqual(deleteAtUTC.Before(expireAtUTC), false)
 }


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There are some functions of e2e test framework and it is useful to
read the test code by using these functions.
This replaces gomega calls with these functions under test/e2e/node/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
