### PR TITLE
Remove check for addIPv6Checks which evaluates to true

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -984,11 +984,9 @@ func RunJoinNodeChecks(execer utilsexec.Interface, cfg *kubeadmapi.JoinConfigura
 			checks = append(checks,
 				HTTPProxyCheck{Proto: "https", Host: ipstr},
 			)
-			if !addIPv6Checks {
-				if ip := net.ParseIP(ipstr); ip != nil {
-					if utilsnet.IsIPv6(ip) {
-						addIPv6Checks = true
-					}
+			if ip := net.ParseIP(ipstr); ip != nil {
+				if utilsnet.IsIPv6(ip) {
+					addIPv6Checks = true
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In RunJoinNodeChecks, the first check of addIPv6Checks always evaluates to true.

This PR removes the unnecessary check.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
