### PR TITLE
Make backoff durations (initial, max) configurable in scheduler to alleviate starvation when a lot of unscheduleable pods are in the queue

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -182,6 +182,8 @@ pluginConfig:
 
 	defaultSource := "DefaultProvider"
 	defaultBindTimeoutSeconds := int64(600)
+	defaultBackOffInitialDurationSecond := int32(1)
+	defaultBackOffMaxDurationSecond := int32(10)
 
 	testcases := []struct {
 		name             string
@@ -250,6 +252,8 @@ pluginConfig:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
+				BackOffInitialDurationSecond: defaultBackOffInitialDurationSecond,
+				BackOffMaxDurationSecond: defaultBackOffMaxDurationSecond,
 				Plugins:            nil,
 			},
 		},
@@ -330,6 +334,8 @@ pluginConfig:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
+				BackOffInitialDurationSecond: defaultBackOffInitialDurationSecond,
+				BackOffMaxDurationSecond: defaultBackOffMaxDurationSecond,
 			},
 		},
 		{
@@ -391,6 +397,8 @@ pluginConfig:
 					ContentType: "application/vnd.kubernetes.protobuf",
 				},
 				BindTimeoutSeconds: &defaultBindTimeoutSeconds,
+				BackOffInitialDurationSecond: defaultBackOffInitialDurationSecond,
+				BackOffMaxDurationSecond: defaultBackOffMaxDurationSecond,
 				Plugins: &kubeschedulerconfig.Plugins{
 					Reserve: &kubeschedulerconfig.PluginSet{
 						Enabled: []kubeschedulerconfig.Plugin{

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -191,7 +191,10 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}, regis
 		scheduler.WithHardPodAffinitySymmetricWeight(cc.ComponentConfig.HardPodAffinitySymmetricWeight),
 		scheduler.WithPreemptionDisabled(cc.ComponentConfig.DisablePreemption),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),
-		scheduler.WithBindTimeoutSeconds(*cc.ComponentConfig.BindTimeoutSeconds))
+		scheduler.WithBindTimeoutSeconds(*cc.ComponentConfig.BindTimeoutSeconds),
+		scheduler.WithBackOffInitialDurationSecond(cc.ComponentConfig.BackOffInitialDurationSecond),
+		scheduler.WithBackOffMaxDurationSecond(cc.ComponentConfig.BackOffMaxDurationSecond),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -88,6 +88,12 @@ type KubeSchedulerConfiguration struct {
 	// If this value is nil, the default value will be used.
 	BindTimeoutSeconds *int64
 
+	// Initial backoff duration for unschedulable pods.
+	BackOffInitialDurationSecond int32
+
+	// Max backoff duration for unschedulable pods.
+	BackOffMaxDurationSecond int32
+
 	// Plugins specify the set of plugins that should be enabled or disabled. Enabled plugins are the
 	// ones that should be enabled in addition to the default plugins. Disabled plugins are any of the
 	// default plugins that should be disabled.

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -103,4 +103,11 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubeschedulerconfigv1alpha1.Kub
 		defaultBindTimeoutSeconds := int64(600)
 		obj.BindTimeoutSeconds = &defaultBindTimeoutSeconds
 	}
+
+	if obj.BackOffInitialDurationSecond == 0 {
+		obj.BackOffInitialDurationSecond = 1
+	}
+	if obj.BackOffMaxDurationSecond == 0 {
+		obj.BackOffMaxDurationSecond = 10
+	}
 }

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
@@ -170,6 +170,8 @@ func autoConvert_v1alpha1_KubeSchedulerConfiguration_To_config_KubeSchedulerConf
 	out.DisablePreemption = in.DisablePreemption
 	out.PercentageOfNodesToScore = in.PercentageOfNodesToScore
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
+	out.BackOffInitialDurationSecond = in.BackOffInitialDurationSecond
+	out.BackOffMaxDurationSecond = in.BackOffMaxDurationSecond
 	out.Plugins = (*config.Plugins)(unsafe.Pointer(in.Plugins))
 	out.PluginConfig = *(*[]config.PluginConfig)(unsafe.Pointer(&in.PluginConfig))
 	return nil
@@ -200,6 +202,8 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1alpha1_KubeSchedulerConf
 	out.DisablePreemption = in.DisablePreemption
 	out.PercentageOfNodesToScore = in.PercentageOfNodesToScore
 	out.BindTimeoutSeconds = (*int64)(unsafe.Pointer(in.BindTimeoutSeconds))
+	out.BackOffInitialDurationSecond = in.BackOffInitialDurationSecond
+	out.BackOffMaxDurationSecond = in.BackOffMaxDurationSecond
 	out.Plugins = (*v1alpha1.Plugins)(unsafe.Pointer(in.Plugins))
 	out.PluginConfig = *(*[]v1alpha1.PluginConfig)(unsafe.Pointer(&in.PluginConfig))
 	return nil

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -47,6 +47,14 @@ func ValidateKubeSchedulerConfiguration(cc *config.KubeSchedulerConfiguration) f
 		allErrs = append(allErrs, field.Invalid(field.NewPath("percentageOfNodesToScore"),
 			cc.PercentageOfNodesToScore, "not in valid range 0-100"))
 	}
+	if cc.BackOffInitialDurationSecond < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("backOffInitialDurationSecond"),
+			cc.BackOffInitialDurationSecond, "not in valid range 0-"))
+	}
+	if cc.BackOffMaxDurationSecond < 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("backOffMaxDurationSecond"),
+			cc.BackOffMaxDurationSecond, "not in valid range 0-"))
+	}
 	return allErrs
 }
 

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -207,6 +207,8 @@ type ConfigFactoryArgs struct {
 	DisablePreemption              bool
 	PercentageOfNodesToScore       int32
 	BindTimeoutSeconds             int64
+	BackOffInitialDurationSecond   int32
+	BackOffMaxDurationSecond       int32
 	StopCh                         <-chan struct{}
 	Registry                       framework.Registry
 	Plugins                        *config.Plugins
@@ -240,7 +242,9 @@ func NewConfigFactory(args *ConfigFactoryArgs) *Configurator {
 
 	c := &Configurator{
 		client:                         args.Client,
-		podQueue:                       internalqueue.NewSchedulingQueue(stopEverything, framework),
+		podQueue:                       internalqueue.NewSchedulingQueueWithBackOffDurations(
+			stopEverything, framework, args.BackOffInitialDurationSecond, args.BackOffMaxDurationSecond,
+		),
 		pVLister:                       args.PvInformer.Lister(),
 		pVCLister:                      args.PvcInformer.Lister(),
 		serviceLister:                  args.ServiceInformer.Lister(),

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -257,7 +257,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 	defer close(stopCh)
 
 	timestamp := time.Now()
-	queue := internalqueue.NewPriorityQueueWithClock(nil, clock.NewFakeClock(timestamp), nil)
+	queue := internalqueue.NewPriorityQueueWithClockAndBackOffDurations(nil, clock.NewFakeClock(timestamp), nil, internalqueue.BackOffInitialDurationSecond, internalqueue.BackOffMaxDurationSecond)
 	schedulerCache := internalcache.New(30*time.Second, stopCh)
 	errFunc := MakeDefaultErrorFunc(client, queue, schedulerCache, stopCh)
 

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -1198,7 +1198,7 @@ func TestPodTimestamp(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			queue := NewPriorityQueueWithClock(nil, clock.NewFakeClock(timestamp), nil)
+			queue := NewPriorityQueueWithClockAndBackOffDurations(nil, clock.NewFakeClock(timestamp), nil, BackOffInitialDurationSecond, BackOffMaxDurationSecond)
 			var podInfoList []*framework.PodInfo
 
 			for i, op := range test.operations {
@@ -1328,7 +1328,7 @@ func TestPendingPodsMetric(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			resetMetrics()
-			queue := NewPriorityQueueWithClock(nil, clock.NewFakeClock(timestamp), nil)
+			queue := NewPriorityQueueWithClockAndBackOffDurations(nil, clock.NewFakeClock(timestamp), nil, BackOffInitialDurationSecond, BackOffMaxDurationSecond)
 			for i, op := range test.operations {
 				for _, pInfo := range test.operands[i] {
 					op(queue, pInfo)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -50,6 +50,8 @@ import (
 const (
 	// BindTimeoutSeconds defines the default bind timeout
 	BindTimeoutSeconds = 100
+	BackOffInitialDurationSecond = 1
+	BackOffMaxDurationSecond = 10
 	// SchedulerError is the reason recorded for events when an error occurs during scheduling a pod.
 	SchedulerError = "SchedulerError"
 )
@@ -114,6 +116,8 @@ type schedulerOptions struct {
 	disablePreemption              bool
 	percentageOfNodesToScore       int32
 	bindTimeoutSeconds             int64
+	backOffInitialDurationSecond   int32
+	backOffMaxDurationSecond       int32
 }
 
 // Option configures a Scheduler
@@ -154,12 +158,28 @@ func WithBindTimeoutSeconds(bindTimeoutSeconds int64) Option {
 	}
 }
 
+// WithBackOffInitialDurationSecond sets backOffInitialDurationSecond for Scheduler, the default value is 1
+func WithBackOffInitialDurationSecond(backOffInitialDurationSecond int32) Option {
+	return func(o *schedulerOptions) {
+		o.backOffInitialDurationSecond = backOffInitialDurationSecond
+	}
+}
+
+// WithBackOffMaxDurationSecond sets backOffMaxDurationSecond for Scheduler, the default value is 10
+func WithBackOffMaxDurationSecond(backOffMaxDurationSecond int32) Option {
+	return func(o *schedulerOptions) {
+		o.backOffMaxDurationSecond = backOffMaxDurationSecond
+	}
+}
+
 var defaultSchedulerOptions = schedulerOptions{
 	schedulerName:                  v1.DefaultSchedulerName,
 	hardPodAffinitySymmetricWeight: v1.DefaultHardPodAffinitySymmetricWeight,
 	disablePreemption:              false,
 	percentageOfNodesToScore:       schedulerapi.DefaultPercentageOfNodesToScore,
 	bindTimeoutSeconds:             BindTimeoutSeconds,
+	backOffInitialDurationSecond:   BackOffInitialDurationSecond,
+	backOffMaxDurationSecond:       BackOffMaxDurationSecond,
 }
 
 // New returns a Scheduler
@@ -205,6 +225,8 @@ func New(client clientset.Interface,
 		DisablePreemption:              options.disablePreemption,
 		PercentageOfNodesToScore:       options.percentageOfNodesToScore,
 		BindTimeoutSeconds:             options.bindTimeoutSeconds,
+		BackOffInitialDurationSecond:   options.backOffInitialDurationSecond,
+		BackOffMaxDurationSecond:       options.backOffMaxDurationSecond,
 		Registry:                       registry,
 		Plugins:                        plugins,
 		PluginConfig:                   pluginConfig,

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -84,6 +84,12 @@ type KubeSchedulerConfiguration struct {
 	// If this value is nil, the default value will be used.
 	BindTimeoutSeconds *int64 `json:"bindTimeoutSeconds"`
 
+	// Initial backoff duration for unschedulable pods.
+	BackOffInitialDurationSecond int32 `json:"backOffInitialDurationSecond"`
+
+	// Max backoff duration for unschedulable pods.
+	BackOffMaxDurationSecond int32 `json:"backOffMaxDurationSecond"`
+
 	// Plugins specify the set of plugins that should be enabled or disabled. Enabled plugins are the
 	// ones that should be enabled in addition to the default plugins. Disabled plugins are any of the
 	// default plugins that should be disabled.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind api-change
/kind feature

**What this PR does / why we need it**:

/sig scheduling

Current kube-scheduler have backoff mechanism in unschedulable pods in order to avoid starvation.  But  [hard-coded](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/internal/queue/scheduling_queue.go#L184) initial and max backoff durations are not enough for the situation which a bunch of higher-priority and unschedulable pods and lower-priority&schedulable pods. Longer backoff configuration will alleviate this situation.   In contrast,  longer backoff might cause more preemption.  it is a trade-off.

If blocking high-priority&unschedulable pods and starved low-priority&schedulable pods will be scheduled in completely different failure domains or nodes?  For example, assume there exists two kinds of pods in the queue,

- a bunch of high&unschedulable priority pods which should be scheduled to failure domain `az-1`, and
  - it means `az-1` does not have enough resources
- several low&schedulable priority pods which should be scheduled to failure domain `az-2`
  - it means `az-2` does have enough resources

Then, there exists a case which backoffs for high&unschedulable pods are reset continuously.  In this case, it causes high priority pods will go back to the active queue continuously and they will block low&unschedulable pods in the head of the active queue.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

This PR makes backoff durations (initial and max) configurable in `KubeSchedulerConfiguration`

**Special notes for your reviewer**:

I'm not an active contributor.  I'm very appreciated if you shepherded me.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Make backoff durations configurable in scheduler to alleviate starvation of pods in a cluster with a large number of unschedulable pods.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

none.