### PR TITLE
Fix static failure from package: staging/src/k8s.io/kube-aggregator

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -274,10 +274,6 @@ vendor/k8s.io/code-generator/cmd/client-gen/generators/fake
 vendor/k8s.io/code-generator/cmd/client-gen/generators/util
 vendor/k8s.io/code-generator/cmd/go-to-protobuf/protobuf
 vendor/k8s.io/component-base/metrics
-vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration
-vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper
-vendor/k8s.io/kube-aggregator/pkg/controllers/autoregister
-vendor/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator
 vendor/k8s.io/kubectl/pkg/cmd/annotate
 vendor/k8s.io/kubectl/pkg/cmd/apply
 vendor/k8s.io/kubectl/pkg/cmd/certificates

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers_test.go
@@ -24,7 +24,6 @@ import (
 var (
 	a APIServiceConditionType = "A"
 	b APIServiceConditionType = "B"
-	c APIServiceConditionType = "C"
 )
 
 func TestGetAPIServiceConditionByType(t *testing.T) {

--- a/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper/helpers_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper/helpers_test.go
@@ -26,7 +26,6 @@ import (
 var (
 	a v1.APIServiceConditionType = "A"
 	b v1.APIServiceConditionType = "B"
-	c v1.APIServiceConditionType = "C"
 )
 
 func TestIsAPIServiceConditionTrue(t *testing.T) {

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller_test.go
@@ -51,15 +51,6 @@ func newAutoRegisterManagedModifiedAPIService(name string) *apiregistrationv1.AP
 	}
 }
 
-func newAutoRegisterManagedOnStartModifiedAPIService(name string) *apiregistrationv1.APIService {
-	return &apiregistrationv1.APIService{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{AutoRegisterManagedLabel: string("onstart")}},
-		Spec: apiregistrationv1.APIServiceSpec{
-			Group: "something",
-		},
-	}
-}
-
 func newAPIService(name string) *apiregistrationv1.APIService {
 	return &apiregistrationv1.APIService{
 		ObjectMeta: metav1.ObjectMeta{Name: name},

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go
@@ -110,8 +110,11 @@ func BuildAndRegisterAggregator(downloader *Downloader, delegationTarget server.
 	}
 
 	// Install handler
-	s.openAPIVersionedService, err = handler.RegisterOpenAPIVersionedService(
-		specToServe, "/openapi/v2", pathHandler)
+	s.openAPIVersionedService, err = handler.NewOpenAPIService(specToServe)
+	if err != nil {
+		return nil, err
+	}
+	err = s.openAPIVersionedService.RegisterOpenAPIVersionedService("/openapi/v2", pathHandler)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixing Static Check Failures for the following packages:
```
vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration	
vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper	
vendor/k8s.io/kube-aggregator/pkg/controllers/autoregister	
vendor/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator
```

**Which issue(s) this PR fixes**:
Ref https://github.com/kubernetes/kubernetes/issues/81657

**Special notes for your reviewer**:
Following errors has been fixed.
```
vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/helpers_test.go:27:2: var c is unused (U1000)
vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper/helpers_test.go:29:2: var c is unused (U1000)
vendor/k8s.io/kube-aggregator/pkg/controllers/autoregister/autoregister_controller_test.go:54:6: func newAutoRegisterManagedOnStartModifiedAPIService is unused (U1000)
vendor/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/aggregator.go:113:35: handler.RegisterOpenAPIVersionedService is deprecated: use OpenAPIService.RegisterOpenAPIVersionedService instead.  (SA1019)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
