### PR TITLE
Fix static failure for package: staging/src/k8s.io/code-generator

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -210,9 +210,6 @@ vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/restmapper
 vendor/k8s.io/client-go/tools/leaderelection
 vendor/k8s.io/client-go/transport
-vendor/k8s.io/code-generator/cmd/client-gen/generators/fake
-vendor/k8s.io/code-generator/cmd/client-gen/generators/util
-vendor/k8s.io/code-generator/cmd/go-to-protobuf/protobuf
 vendor/k8s.io/component-base/metrics
 vendor/k8s.io/kubectl/pkg/cmd/annotate
 vendor/k8s.io/kubectl/pkg/cmd/certificates

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go
@@ -165,10 +165,3 @@ func (c *Clientset) $.GroupGoName$$.Version$() $.PackageAlias$.$.GroupGoName$$.V
 	return &fake$.PackageAlias$.Fake$.GroupGoName$$.Version${Fake: &c.Fake}
 }
 `
-
-var clientsetInterfaceDefaultVersionImpl = `
-// $.GroupGoName$ retrieves the $.GroupGoName$$.Version$Client
-func (c *Clientset) $.GroupGoName$() $.PackageAlias$.$.GroupGoName$$.Version$Interface {
-	return &fake$.PackageAlias$.Fake$.GroupGoName$$.Version${Fake: &c.Fake}
-}
-`

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/util/tags.go
@@ -190,7 +190,7 @@ func MustParseClientGenTags(lines []string) Tags {
 func ParseClientGenTags(lines []string) (Tags, error) {
 	ret := Tags{}
 	values := types.ExtractCommentTags("+", lines)
-	value := []string{}
+	var value []string
 	value, ret.GenerateClient = values["genclient"]
 	// Check the old format and error when used to avoid generating client when //+genclient=false
 	if len(value) > 0 && len(value[0]) > 0 {

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go
@@ -279,7 +279,7 @@ func Run(g *Generator) {
 		cmd := exec.Command("protoc", append(args, path)...)
 		out, err := cmd.CombinedOutput()
 		if len(out) > 0 {
-			log.Printf(string(out))
+			log.Print(string(out))
 		}
 		if err != nil {
 			log.Println(strings.Join(cmd.Args, " "))
@@ -300,7 +300,7 @@ func Run(g *Generator) {
 		cmd = exec.Command("goimports", "-w", outputPath)
 		out, err = cmd.CombinedOutput()
 		if len(out) > 0 {
-			log.Printf(string(out))
+			log.Print(string(out))
 		}
 		if err != nil {
 			log.Println(strings.Join(cmd.Args, " "))
@@ -311,7 +311,7 @@ func Run(g *Generator) {
 		cmd = exec.Command("gofmt", "-s", "-w", outputPath)
 		out, err = cmd.CombinedOutput()
 		if len(out) > 0 {
-			log.Printf(string(out))
+			log.Print(string(out))
 		}
 		if err != nil {
 			log.Println(strings.Join(cmd.Args, " "))


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixing Static Check Failures for the following packages:
```
-vendor/k8s.io/code-generator/cmd/client-gen/generators/fake
-vendor/k8s.io/code-generator/cmd/client-gen/generators/util
-vendor/k8s.io/code-generator/cmd/go-to-protobuf/protobuf
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref #https://github.com/kubernetes/kubernetes/issues/81657

**Special notes for your reviewer**:
```
Errors from staticcheck:
vendor/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_clientset.go:169:5: var clientsetInterfaceDefaultVersionImpl is unused (U1000)
vendor/k8s.io/code-generator/cmd/client-gen/generators/util/tags.go:193:2: this value of value is never used (SA4006)
vendor/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go:282:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
vendor/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go:303:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
vendor/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/cmd.go:314:15: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

