### PR TITLE
Consider EphemeralContainers in GetResourceRequest

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -830,6 +830,10 @@ func GetResourceRequest(pod *v1.Pod) *schedulernodeinfo.Resource {
 		result.SetMaxResource(container.Resources.Requests)
 	}
 
+	for _, container := range pod.Spec.EphemeralContainers {
+		result.Add(container.Resources.Requests)
+	}
+
 	// If Overhead is being utilized, add to the total requests for the pod
 	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
 		result.Add(pod.Spec.Overhead)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently resource requests from EphemeralContainers are not counted in GetResourceRequest.

This PR adds resource requests from EphemeralContainers to the result.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
