### PR TITLE
Fix flaky hugepages tests by decreasing page count

### DIFF
--- a/test/e2e_node/hugepages_test.go
+++ b/test/e2e_node/hugepages_test.go
@@ -84,9 +84,9 @@ func makePodToVerifyHugePages(baseName string, hugePagesLimit resource.Quantity)
 	return pod
 }
 
-// configureHugePages attempts to allocate 100Mi of 2Mi hugepages for testing purposes
+// configureHugePages attempts to allocate 10Mi of 2Mi hugepages for testing purposes
 func configureHugePages() error {
-	err := exec.Command("/bin/sh", "-c", "echo 50 > /proc/sys/vm/nr_hugepages").Run()
+	err := exec.Command("/bin/sh", "-c", "echo 5 > /proc/sys/vm/nr_hugepages").Run()
 	if err != nil {
 		return err
 	}
@@ -99,10 +99,10 @@ func configureHugePages() error {
 		return err
 	}
 	e2elog.Logf("HugePages_Total is set to %v", numHugePages)
-	if numHugePages == 50 {
+	if numHugePages == 5 {
 		return nil
 	}
-	return fmt.Errorf("expected hugepages %v, but found %v", 50, numHugePages)
+	return fmt.Errorf("expected hugepages %v, but found %v", 5, numHugePages)
 }
 
 // releaseHugePages releases all pre-allocated hugepages
@@ -154,7 +154,7 @@ func runHugePagesTests(f *framework.Framework) {
 							Limits: v1.ResourceList{
 								v1.ResourceName("cpu"):           resource.MustParse("10m"),
 								v1.ResourceName("memory"):        resource.MustParse("100Mi"),
-								v1.ResourceName("hugepages-2Mi"): resource.MustParse("50Mi"),
+								v1.ResourceName("hugepages-2Mi"): resource.MustParse("6Mi"),
 							},
 						},
 					},
@@ -163,7 +163,7 @@ func runHugePagesTests(f *framework.Framework) {
 		})
 		podUID := string(pod.UID)
 		ginkgo.By("checking if the expected hugetlb settings were applied")
-		verifyPod := makePodToVerifyHugePages("pod"+podUID, resource.MustParse("50Mi"))
+		verifyPod := makePodToVerifyHugePages("pod"+podUID, resource.MustParse("6Mi"))
 		f.PodClient().Create(verifyPod)
 		err := e2epod.WaitForPodSuccessInNamespace(f.ClientSet, verifyPod.Name, f.Namespace.Name)
 		framework.ExpectNoError(err)
@@ -194,7 +194,7 @@ var _ = SIGDescribe("HugePages [Serial] [Feature:HugePages][NodeFeature:HugePage
 			ginkgo.By("by waiting for hugepages resource to become available on the local node")
 			gomega.Eventually(func() string {
 				return pollResourceAsString(f, "hugepages-2Mi")
-			}, 30*time.Second, framework.Poll).Should(gomega.Equal("100Mi"))
+			}, 30*time.Second, framework.Poll).Should(gomega.Equal("10Mi"))
 		})
 
 		runHugePagesTests(f)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:

If requesting an substantial amount of huge page memory
(like the tests), it is recommended to to it as early
after boot as possible, or by using the kernel cmd line.

This pr decrease the amount of pages from 50 to 5.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #81726

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
