### PR TITLE
Internalize mount.Interface.IsMountPointMatch

### DIFF
--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -137,11 +137,6 @@ func (f *FakeMounter) List() ([]MountPoint, error) {
 	return f.MountPoints, nil
 }
 
-// IsMountPointMatch tests if dir and mp are the same path
-func (f *FakeMounter) IsMountPointMatch(mp MountPoint, dir string) bool {
-	return mp.Path == dir
-}
-
 // IsLikelyNotMountPoint determines whether a path is a mountpoint by checking
 // if the absolute path to file is in the in-memory mountpoints
 func (f *FakeMounter) IsLikelyNotMountPoint(file string) (bool, error) {

--- a/pkg/util/mount/mount.go
+++ b/pkg/util/mount/mount.go
@@ -41,8 +41,6 @@ type Interface interface {
 	// consistent (i.e. it could change between chunked reads). This is guaranteed
 	// to be consistent.
 	List() ([]MountPoint, error)
-	// IsMountPointMatch determines if the mountpoint matches the dir.
-	IsMountPointMatch(mp MountPoint, dir string) bool
 	// IsLikelyNotMountPoint uses heuristics to determine if a directory
 	// is not a mountpoint.
 	// It should return ErrNotExist when the directory does not exist.
@@ -162,7 +160,7 @@ func GetDeviceNameFromMount(mounter Interface, mountPath string) (string, int, e
 // IsNotMountPoint detects bind mounts in linux.
 // IsNotMountPoint enumerates all the mountpoints using List() and
 // the list of mountpoints may be large, then it uses
-// IsMountPointMatch to evaluate whether the directory is a mountpoint.
+// isMountPointMatch to evaluate whether the directory is a mountpoint.
 func IsNotMountPoint(mounter Interface, file string) (bool, error) {
 	// IsLikelyNotMountPoint provides a quick check
 	// to determine whether file IS A mountpoint.
@@ -195,7 +193,7 @@ func IsNotMountPoint(mounter Interface, file string) (bool, error) {
 		return notMnt, mountPointsErr
 	}
 	for _, mp := range mountPoints {
-		if mounter.IsMountPointMatch(mp, resolvedFile) {
+		if isMountPointMatch(mp, resolvedFile) {
 			notMnt = false
 			break
 		}

--- a/pkg/util/mount/mount_helper_unix.go
+++ b/pkg/util/mount/mount_helper_unix.go
@@ -131,3 +131,10 @@ func parseMountInfo(filename string) ([]mountInfo, error) {
 	}
 	return infos, nil
 }
+
+// isMountPointMatch returns true if the path in mp is the same as dir.
+// Handles case where mountpoint dir has been renamed due to stale NFS mount.
+func isMountPointMatch(mp MountPoint, dir string) bool {
+	deletedDir := fmt.Sprintf("%s\\040(deleted)", dir)
+	return ((mp.Path == dir) || (mp.Path == deletedDir))
+}

--- a/pkg/util/mount/mount_helper_windows.go
+++ b/pkg/util/mount/mount_helper_windows.go
@@ -91,3 +91,8 @@ func ValidateDiskNumber(disk string) error {
 
 	return nil
 }
+
+// isMountPointMatch determines if the mountpoint matches the dir
+func isMountPointMatch(mp MountPoint, dir string) bool {
+	return mp.Path == dir
+}

--- a/pkg/util/mount/mount_linux.go
+++ b/pkg/util/mount/mount_linux.go
@@ -213,12 +213,6 @@ func (*Mounter) List() ([]MountPoint, error) {
 	return ListProcMounts(procMountsPath)
 }
 
-// IsMountPointMatch returns true if the path in mp is the same as dir
-func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
-	deletedDir := fmt.Sprintf("%s\\040(deleted)", dir)
-	return ((mp.Path == dir) || (mp.Path == deletedDir))
-}
-
 // IsLikelyNotMountPoint determines if a directory is not a mountpoint.
 // It is fast but not necessarily ALWAYS correct. If the path is in fact
 // a bind mount from one part of a mount to another it will not be detected.

--- a/pkg/util/mount/mount_unsupported.go
+++ b/pkg/util/mount/mount_unsupported.go
@@ -53,11 +53,6 @@ func (mounter *Mounter) List() ([]MountPoint, error) {
 	return []MountPoint{}, errUnsupported
 }
 
-// IsMountPointMatch returns true if the path in mp is the same as dir
-func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
-	return (mp.Path == dir)
-}
-
 // IsLikelyNotMountPoint always returns an error on unsupported platforms
 func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, errUnsupported

--- a/pkg/util/mount/mount_windows.go
+++ b/pkg/util/mount/mount_windows.go
@@ -164,11 +164,6 @@ func (mounter *Mounter) List() ([]MountPoint, error) {
 	return []MountPoint{}, nil
 }
 
-// IsMountPointMatch determines if the mountpoint matches the dir
-func (mounter *Mounter) IsMountPointMatch(mp MountPoint, dir string) bool {
-	return mp.Path == dir
-}
-
 // IsLikelyNotMountPoint determines if a directory is not a mountpoint.
 func (mounter *Mounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	stat, err := os.Lstat(file)

--- a/pkg/volume/util/exec/exec_mount.go
+++ b/pkg/volume/util/exec/exec_mount.go
@@ -91,10 +91,6 @@ func (m *execMounter) List() ([]mount.MountPoint, error) {
 	return m.wrappedMounter.List()
 }
 
-func (m *execMounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {
-	return m.wrappedMounter.IsMountPointMatch(mp, dir)
-}
-
 // IsLikelyNotMountPoint determines whether a path is a mountpoint.
 func (m *execMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return m.wrappedMounter.IsLikelyNotMountPoint(file)

--- a/pkg/volume/util/exec/exec_mount_unsupported.go
+++ b/pkg/volume/util/exec/exec_mount_unsupported.go
@@ -46,10 +46,6 @@ func (mounter *execMounter) List() ([]mount.MountPoint, error) {
 	return []mount.MountPoint{}, nil
 }
 
-func (mounter *execMounter) IsMountPointMatch(mp mount.MountPoint, dir string) bool {
-	return (mp.Path == dir)
-}
-
 func (mounter *execMounter) IsLikelyNotMountPoint(file string) (bool, error) {
 	return true, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
IsMountPointMatch() had no callers outside of the mount package, and has
internal implementation details. This patch makes it no longer be
public.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
As part of https://github.com/kubernetes/utils/pull/100, it was asked why this method was needed rather than just being a simple `mp.Path == dir`. After looking closer, this method does not have an external callers and does not need to be public.

/assign @msau42

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
