### PR TITLE
Check error return from VerifyUnmarshalStrict

### DIFF
--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -103,7 +103,9 @@ func documentMapToJoinConfiguration(gvkmap map[schema.GroupVersionKind][]byte, a
 		}
 
 		// verify the validity of the YAML
-		strict.VerifyUnmarshalStrict(bytes, gvk)
+		if err := strict.VerifyUnmarshalStrict(bytes, gvk); err != nil {
+			return nil, errors.Errorf("YAML verification failed %v", err)
+		}
 
 		joinBytes = bytes
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Though the comment above VerifyUnmarshalStrict call said:

		// verify the validity of the YAML

The error return was not checked.

This PR adds the check and returns upon non-nil error.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
