### PR TITLE
Move MakeFile/Dir from HostUtil to host_path vol

### DIFF
--- a/pkg/util/mount/fake_hostutil.go
+++ b/pkg/util/mount/fake_hostutil.go
@@ -71,18 +71,6 @@ func (hu *FakeHostUtil) GetFileType(pathname string) (FileType, error) {
 	return FileType("Directory"), nil
 }
 
-// MakeDir creates a new directory.
-// No-op for testing
-func (hu *FakeHostUtil) MakeDir(pathname string) error {
-	return nil
-}
-
-// MakeFile creates a new file.
-// No-op for testing
-func (hu *FakeHostUtil) MakeFile(pathname string) error {
-	return nil
-}
-
 // PathExists checks if pathname exists.
 func (hu *FakeHostUtil) PathExists(pathname string) (bool, error) {
 	if _, ok := hu.Filesystem[pathname]; ok {

--- a/pkg/util/mount/hostutil.go
+++ b/pkg/util/mount/hostutil.go
@@ -57,10 +57,6 @@ type HostUtils interface {
 	MakeRShared(path string) error
 	// GetFileType checks for file/directory/socket/block/character devices.
 	GetFileType(pathname string) (FileType, error)
-	// MakeFile creates an empty file.
-	MakeFile(pathname string) error
-	// MakeDir creates a new directory.
-	MakeDir(pathname string) error
 	// PathExists tests if the given path already exists
 	// Error is returned on any other error than "file not found".
 	PathExists(pathname string) (bool, error)

--- a/pkg/util/mount/hostutil_linux.go
+++ b/pkg/util/mount/hostutil_linux.go
@@ -140,27 +140,6 @@ func (hu *hostUtil) GetFileType(pathname string) (FileType, error) {
 	return getFileType(pathname)
 }
 
-func (hu *hostUtil) MakeDir(pathname string) error {
-	err := os.MkdirAll(pathname, os.FileMode(0755))
-	if err != nil {
-		if !os.IsExist(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-func (hu *hostUtil) MakeFile(pathname string) error {
-	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
-	defer f.Close()
-	if err != nil {
-		if !os.IsExist(err) {
-			return err
-		}
-	}
-	return nil
-}
-
 func (hu *hostUtil) PathExists(pathname string) (bool, error) {
 	return utilpath.Exists(utilpath.CheckFollowSymlink, pathname)
 }

--- a/pkg/util/mount/hostutil_windows.go
+++ b/pkg/util/mount/hostutil_windows.go
@@ -91,29 +91,6 @@ func (hu *(hostUtil)) GetFileType(pathname string) (FileType, error) {
 	return getFileType(pathname)
 }
 
-// MakeFile creates a new directory
-func (hu *hostUtil) MakeDir(pathname string) error {
-	err := os.MkdirAll(pathname, os.FileMode(0755))
-	if err != nil {
-		if !os.IsExist(err) {
-			return err
-		}
-	}
-	return nil
-}
-
-// MakeFile creates an empty file
-func (hu *hostUtil) MakeFile(pathname string) error {
-	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
-	defer f.Close()
-	if err != nil {
-		if !os.IsExist(err) {
-			return err
-		}
-	}
-	return nil
-}
-
 // PathExists checks whether the path exists
 func (hu *hostUtil) PathExists(pathname string) (bool, error) {
 	return utilpath.Exists(utilpath.CheckFollowSymlink, pathname)

--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -377,7 +377,7 @@ func (ftc *fileTypeChecker) IsFile() bool {
 }
 
 func (ftc *fileTypeChecker) MakeFile() error {
-	return ftc.hu.MakeFile(ftc.path)
+	return makeFile(ftc.path)
 }
 
 func (ftc *fileTypeChecker) IsDir() bool {
@@ -392,7 +392,7 @@ func (ftc *fileTypeChecker) IsDir() bool {
 }
 
 func (ftc *fileTypeChecker) MakeDir() error {
-	return ftc.hu.MakeDir(ftc.path)
+	return makeDir(ftc.path)
 }
 
 func (ftc *fileTypeChecker) IsBlock() bool {
@@ -468,5 +468,31 @@ func checkTypeInternal(ftc hostPathTypeChecker, pathType *v1.HostPathType) error
 		return fmt.Errorf("%s is an invalid volume type", *pathType)
 	}
 
+	return nil
+}
+
+// makeDir creates a new directory.
+// If pathname already exists as a directory, no error is returned.
+// If pathname already exists as a file, an error is returned.
+func makeDir(pathname string) error {
+	err := os.MkdirAll(pathname, os.FileMode(0755))
+	if err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
+	return nil
+}
+
+// makeFile creates an empty file.
+// If pathname already exists, whether a file or directory, no error is returned.
+func makeFile(pathname string) error {
+	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
+	defer f.Close()
+	if err != nil {
+		if !os.IsExist(err) {
+			return err
+		}
+	}
 	return nil
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
This clarification was requested as part of https://github.com/kubernetes/utils/pull/100

The MakeFile and MakeDir methods in the HostUtil interface only had one
caller -- the Host Path volume plugin. This patch relocates MakeFile and
MakeDir to the Host Path plugin itself.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
