### PR TITLE
Fix staticcheck failures for pkg/registry/...

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -6,13 +6,6 @@ pkg/controller/podautoscaler
 pkg/controller/replicaset
 pkg/controller/resourcequota
 pkg/controller/statefulset
-pkg/registry/autoscaling/horizontalpodautoscaler/storage
-pkg/registry/core/namespace/storage
-pkg/registry/core/persistentvolumeclaim/storage
-pkg/registry/core/resourcequota/storage
-pkg/registry/core/service/ipallocator
-pkg/registry/core/service/portallocator
-pkg/registry/core/service/storage
 pkg/util/coverage
 test/e2e/apps
 test/e2e/autoscaling

--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
@@ -205,6 +205,9 @@ func TestUpdateStatus(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	obj, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	autoscalerOut := obj.(*autoscaling.HorizontalPodAutoscaler)
 	// only compare the meaningful update b/c we can't compare due to metadata
 	if !apiequality.Semantic.DeepEqual(autoscalerIn.Status, autoscalerOut.Status) {

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -253,7 +253,9 @@ func ShouldDeleteNamespaceDuringUpdate(ctx context.Context, key string, obj, exi
 }
 
 func shouldHaveOrphanFinalizer(options *metav1.DeleteOptions, haveOrphanFinalizer bool) bool {
+	//lint:ignore SA1019 backwards compatibility
 	if options.OrphanDependents != nil {
+		//lint:ignore SA1019 backwards compatibility
 		return *options.OrphanDependents
 	}
 	if options.PropagationPolicy != nil {
@@ -263,7 +265,9 @@ func shouldHaveOrphanFinalizer(options *metav1.DeleteOptions, haveOrphanFinalize
 }
 
 func shouldHaveDeleteDependentsFinalizer(options *metav1.DeleteOptions, haveDeleteDependentsFinalizer bool) bool {
+	//lint:ignore SA1019 backwards compatibility
 	if options.OrphanDependents != nil {
+		//lint:ignore SA1019 backwards compatibility
 		return *options.OrphanDependents == false
 	}
 	if options.PropagationPolicy != nil {

--- a/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
+++ b/pkg/registry/core/persistentvolumeclaim/storage/storage_test.go
@@ -163,6 +163,9 @@ func TestUpdateStatus(t *testing.T) {
 	key, _ := storage.KeyFunc(ctx, "foo")
 	pvcStart := validNewPersistentVolumeClaim("foo", metav1.NamespaceDefault)
 	err := storage.Storage.Create(ctx, key, pvcStart, nil, 0, false)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 
 	pvc := &api.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/registry/core/resourcequota/storage/storage_test.go
+++ b/pkg/registry/core/resourcequota/storage/storage_test.go
@@ -200,6 +200,9 @@ func TestUpdateStatus(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	obj, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
 	rqOut := obj.(*api.ResourceQuota)
 	// only compare the meaningful update b/c we can't compare due to metadata
 	if !apiequality.Semantic.DeepEqual(resourcequotaIn.Status, rqOut.Status) {

--- a/pkg/registry/core/service/ipallocator/allocator_test.go
+++ b/pkg/registry/core/service/ipallocator/allocator_test.go
@@ -335,14 +335,14 @@ func TestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	other, err := NewCIDRRange(otherCidr)
+	_, err = NewCIDRRange(otherCidr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := r.Restore(otherCidr, dst.Data); err != ErrMismatchedNetwork {
 		t.Fatal(err)
 	}
-	other, err = NewCIDRRange(network)
+	other, err := NewCIDRRange(network)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/portallocator/allocator_test.go
+++ b/pkg/registry/core/service/portallocator/allocator_test.go
@@ -196,14 +196,14 @@ func TestSnapshot(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	other, err := NewPortAllocator(*otherPr)
+	_, err = NewPortAllocator(*otherPr)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if err := r.Restore(*otherPr, dst.Data); err != ErrMismatchedNetwork {
 		t.Fatal(err)
 	}
-	other, err = NewPortAllocator(*pr2)
+	other, err := NewPortAllocator(*pr2)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/registry/core/service/storage/rest_test.go
+++ b/pkg/registry/core/service/storage/rest_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package storage
 
 import (
-	"bytes"
 	"context"
 	"net"
 	"reflect"
@@ -1840,13 +1839,13 @@ func TestServiceRegistryResourceLocation(t *testing.T) {
 	}
 
 	// Test a non-existent name + port.
-	location, _, err = redirector.ResourceLocation(ctx, "foo:q")
+	_, _, err = redirector.ResourceLocation(ctx, "foo:q")
 	if err == nil {
 		t.Errorf("Unexpected nil error")
 	}
 
 	// Test a non-existent name + port (using second ip).
-	location, _, err = redirector.ResourceLocation(ctx, "foo-second-ip:q")
+	_, _, err = redirector.ResourceLocation(ctx, "foo-second-ip:q")
 	if err == nil {
 		t.Errorf("Unexpected nil error")
 	}
@@ -3171,22 +3170,22 @@ func TestAllocGetters(t *testing.T) {
 
 			alloc := storage.getAllocatorByClusterIP(tc.svc)
 			if tc.expectClusterIPPrimary {
-				if !bytes.Equal(alloc.CIDR().IP, storage.serviceIPs.CIDR().IP) {
+				if !net.IP.Equal(alloc.CIDR().IP, storage.serviceIPs.CIDR().IP) {
 					t.Fatalf("expected clusterIP primary allocator, but primary allocator was not selected")
 				}
 			} else {
-				if !bytes.Equal(alloc.CIDR().IP, storage.secondaryServiceIPs.CIDR().IP) {
+				if !net.IP.Equal(alloc.CIDR().IP, storage.secondaryServiceIPs.CIDR().IP) {
 					t.Errorf("expected clusterIP secondary allocator, but secondary allocator was not selected")
 				}
 			}
 
 			alloc = storage.getAllocatorBySpec(tc.svc)
 			if tc.expectSpecPrimary {
-				if !bytes.Equal(alloc.CIDR().IP, storage.serviceIPs.CIDR().IP) {
+				if !net.IP.Equal(alloc.CIDR().IP, storage.serviceIPs.CIDR().IP) {
 					t.Errorf("expected spec primary allocator, but primary allocator was not selected")
 				}
 			} else {
-				if !bytes.Equal(alloc.CIDR().IP, storage.secondaryServiceIPs.CIDR().IP) {
+				if !net.IP.Equal(alloc.CIDR().IP, storage.secondaryServiceIPs.CIDR().IP) {
 					t.Errorf("expected spec secondary allocator, but secondary allocator was not selected")
 				}
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/priority important-longterm

**What this PR does / why we need it**:

Cleanup the `pkg/registry/...` issues identified by staticcheck in #81189:

```
pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go:207:7: this value of err is never used (SA4006)
pkg/registry/core/namespace/storage/storage.go:256:5: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
pkg/registry/core/namespace/storage/storage.go:257:11: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
pkg/registry/core/namespace/storage/storage.go:266:5: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
pkg/registry/core/namespace/storage/storage.go:267:11: options.OrphanDependents is deprecated: please use the PropagationPolicy, this field will be deprecated in 1.7. Should the dependent objects be orphaned. If true/false, the "orphan" finalizer will be added to/removed from the object's finalizers list. Either this field or PropagationPolicy may be set, but not both. +optional  (SA1019)
pkg/registry/core/persistentvolumeclaim/storage/storage_test.go:165:2: this value of err is never used (SA4006)
pkg/registry/core/resourcequota/storage/storage_test.go:202:7: this value of err is never used (SA4006)
pkg/registry/core/service/ipallocator/allocator_test.go:338:2: this value of other is never used (SA4006)
pkg/registry/core/service/portallocator/allocator_test.go:199:2: this value of other is never used (SA4006)
pkg/registry/core/service/storage/rest_test.go:1843:2: this value of location is never used (SA4006)
pkg/registry/core/service/storage/rest_test.go:1849:2: this value of location is never used (SA4006)
pkg/registry/core/service/storage/rest_test.go:3174:20: use net.IP.Equal to compare net.IPs, not bytes.Equal (SA1021)
pkg/registry/core/service/storage/rest_test.go:3178:20: use net.IP.Equal to compare net.IPs, not bytes.Equal (SA1021)
pkg/registry/core/service/storage/rest_test.go:3185:20: use net.IP.Equal to compare net.IPs, not bytes.Equal (SA1021)
pkg/registry/core/service/storage/rest_test.go:3189:20: use net.IP.Equal to compare net.IPs, not bytes.Equal (SA1021)
```

**Which issue(s) this PR fixes**:

#36858, #81657, #92402

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```