### PR TITLE
Utilize VisitContainers for findContainerInPod

### DIFF
--- a/pkg/api/v1/resource/BUILD
+++ b/pkg/api/v1/resource/BUILD
@@ -26,6 +26,7 @@ go_library(
     srcs = ["helpers.go"],
     importpath = "k8s.io/kubernetes/pkg/api/v1/resource",
     deps = [
+        "//pkg/api/v1/pod:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR makes use of podutil.VisitContainers to simplify container traversal for findContainerInPod

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
