### PR TITLE
Fix static check failures for pkg/controller/replicaset, pkg/controller/resourcequota, pkg/controller/statefulset

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -18,9 +18,6 @@ pkg/controller/nodeipam
 pkg/controller/nodeipam/ipam/cidrset
 pkg/controller/podautoscaler
 pkg/controller/podgc
-pkg/controller/replicaset
-pkg/controller/resourcequota
-pkg/controller/statefulset
 pkg/credentialprovider
 pkg/credentialprovider/aws
 pkg/kubeapiserver/admission

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -931,7 +931,7 @@ func TestDeleteControllerAndExpectations(t *testing.T) {
 	informers.Apps().V1().ReplicaSets().Informer().GetIndexer().Delete(rs)
 	manager.syncReplicaSet(GetKey(rs, t))
 
-	if _, exists, err = manager.expectations.GetExpectations(rsKey); exists {
+	if _, exists, _ = manager.expectations.GetExpectations(rsKey); exists {
 		t.Errorf("Found expectaions, expected none since the ReplicaSet has been deleted.")
 	}
 

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -1138,7 +1138,7 @@ func expectSyncNotBlocked(fakeDiscoveryClient *fakeServerResources, workerLock *
 	workerLockAcquired := make(chan struct{})
 	go func() {
 		workerLock.Lock()
-		workerLock.Unlock()
+		defer workerLock.Unlock()
 		close(workerLockAcquired)
 	}()
 	select {

--- a/pkg/controller/statefulset/stateful_set_control_test.go
+++ b/pkg/controller/statefulset/stateful_set_control_test.go
@@ -237,7 +237,7 @@ func ReplacesPods(t *testing.T, set *apps.StatefulSet, invariants invariantFunc)
 		if err != nil {
 			t.Fatalf("Error getting updated StatefulSet: %v", err)
 		}
-		if pods, err = spc.setPodReady(set, i); err != nil {
+		if _, err = spc.setPodReady(set, i); err != nil {
 			t.Error(err)
 		}
 	}

--- a/pkg/controller/statefulset/stateful_set_test.go
+++ b/pkg/controller/statefulset/stateful_set_test.go
@@ -93,11 +93,11 @@ func TestStatefulSetControllerRespectsTermination(t *testing.T) {
 	if set.Status.Replicas != 3 {
 		t.Errorf("set.Status.Replicas = %v; want 3", set.Status.Replicas)
 	}
-	pods, err := spc.addTerminatingPod(set, 3)
+	_, err := spc.addTerminatingPod(set, 3)
 	if err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.addTerminatingPod(set, 4)
+	pods, err := spc.addTerminatingPod(set, 4)
 	if err != nil {
 		t.Error(err)
 	}
@@ -147,7 +147,7 @@ func TestStatefulSetControllerBlocksScaling(t *testing.T) {
 	*set.Spec.Replicas = 5
 	fakeResourceVersion(set)
 	spc.setsIndexer.Update(set)
-	pods, err := spc.setPodTerminated(set, 0)
+	_, err := spc.setPodTerminated(set, 0)
 	if err != nil {
 		t.Error("Failed to set pod terminated at ordinal 0")
 	}
@@ -157,7 +157,7 @@ func TestStatefulSetControllerBlocksScaling(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	pods, err = spc.podsLister.Pods(set.Namespace).List(selector)
+	pods, err := spc.podsLister.Pods(set.Namespace).List(selector)
 	if err != nil {
 		t.Error(err)
 	}
@@ -622,11 +622,10 @@ func scaleUpStatefulSetController(set *apps.StatefulSet, ssc *StatefulSetControl
 			return err
 		}
 		ord := len(pods) - 1
-		pod := getPodAtOrdinal(pods, ord)
 		if pods, err = spc.setPodPending(set, ord); err != nil {
 			return err
 		}
-		pod = getPodAtOrdinal(pods, ord)
+		pod := getPodAtOrdinal(pods, ord)
 		ssc.addPod(pod)
 		fakeWorker(ssc)
 		pod = getPodAtOrdinal(pods, ord)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes the follwoing static check errors for replicaset, resourcequota and statefulset controller pkg:
```
pkg/controller/replicaset/replica_set_test.go:934:16: this value of err is never used (SA4006)
pkg/controller/resourcequota/resource_quota_controller_test.go:1141:3: empty critical section (SA2001)
pkg/controller/statefulset/stateful_set_control_test.go:240:6: this value of pods is never used (SA4006)
pkg/controller/statefulset/stateful_set_test.go:96:2: this value of pods is never used (SA4006)
pkg/controller/statefulset/stateful_set_test.go:150:2: this value of pods is never used (SA4006)
pkg/controller/statefulset/stateful_set_test.go:625:3: this value of pod is never used (SA4006)
pkg/controller/statefulset/stateful_set_utils.go:38:7: const maxUpdateRetries is unused (U1000)
pkg/controller/statefulset/stateful_set_utils.go:42:5: var updateConflictError is unused (U1000)
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

Ref #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
