### PR TITLE
Remove unnecessary factory layer

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata.go
+++ b/pkg/scheduler/algorithm/predicates/metadata.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/util/workqueue"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	priorityutil "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	schedutil "k8s.io/kubernetes/pkg/scheduler/util"
@@ -44,11 +43,6 @@ type PredicateMetadata interface {
 
 // PredicateMetadataProducer is a function that computes predicate metadata for a given pod.
 type PredicateMetadataProducer func(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo) PredicateMetadata
-
-// PredicateMetadataFactory defines a factory of predicate metadata.
-type PredicateMetadataFactory struct {
-	podLister algorithm.PodLister
-}
 
 // AntiAffinityTerm's topology key value used in predicate metadata
 type topologyPair struct {
@@ -190,16 +184,8 @@ func RegisterPredicateMetadataProducerWithExtendedResourceOptions(ignoredExtende
 	})
 }
 
-// NewPredicateMetadataFactory creates a PredicateMetadataFactory.
-func NewPredicateMetadataFactory(podLister algorithm.PodLister) PredicateMetadataProducer {
-	factory := &PredicateMetadataFactory{
-		podLister,
-	}
-	return factory.GetMetadata
-}
-
-// GetMetadata returns the predicateMetadata used which will be used by various predicates.
-func (pfactory *PredicateMetadataFactory) GetMetadata(pod *v1.Pod, nodeNameToInfoMap map[string]*schedulernodeinfo.NodeInfo) PredicateMetadata {
+// GetPredicateMetadata returns the predicateMetadata which will be used by various predicates.
+func GetPredicateMetadata(pod *v1.Pod, nodeNameToInfoMap map[string]*schedulernodeinfo.NodeInfo) PredicateMetadata {
 	// If we cannot compute metadata, just return nil
 	if pod == nil {
 		return nil

--- a/pkg/scheduler/algorithm/predicates/metadata_test.go
+++ b/pkg/scheduler/algorithm/predicates/metadata_test.go
@@ -364,8 +364,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 				}
 				_, precompute := NewServiceAffinityPredicate(lister, st.FakeServiceLister(test.services), FakeNodeListInfo(nodeList), nil)
 				RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", precompute)
-				pmf := PredicateMetadataFactory{lister}
-				meta := pmf.GetMetadata(test.pendingPod, nodeInfoMap)
+				meta := GetPredicateMetadata(test.pendingPod, nodeInfoMap)
 				return meta.(*predicateMetadata), nodeInfoMap
 			}
 

--- a/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -93,12 +93,6 @@ func newResourceOverheadPod(pod *v1.Pod, overhead v1.ResourceList) *v1.Pod {
 	pod.Spec.Overhead = overhead
 	return pod
 }
-
-func GetPredicateMetadata(p *v1.Pod, nodeInfo map[string]*schedulernodeinfo.NodeInfo) PredicateMetadata {
-	pm := PredicateMetadataFactory{st.FakePodLister{p}}
-	return pm.GetMetadata(p, nodeInfo)
-}
-
 func TestPodFitsResources(t *testing.T) {
 
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()

--- a/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
@@ -23,10 +23,7 @@ import (
 
 func init() {
 	// Register functions that extract metadata used by predicates computations.
-	factory.RegisterPredicateMetadataProducerFactory(
-		func(args factory.PluginFactoryArgs) predicates.PredicateMetadataProducer {
-			return predicates.NewPredicateMetadataFactory(args.PodLister)
-		})
+	factory.RegisterPredicateMetadataProducer(predicates.GetPredicateMetadata)
 
 	// IMPORTANT NOTES for predicate developers:
 	// Registers predicates and priorities that are not enabled by default, but user can pick when creating their

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -634,7 +634,7 @@ func TestGenericScheduler(t *testing.T) {
 
 			predMetaProducer := algorithmpredicates.EmptyPredicateMetadataProducer
 			if test.buildPredMeta {
-				predMetaProducer = algorithmpredicates.NewPredicateMetadataFactory(schedulertesting.FakePodLister(test.pods))
+				predMetaProducer = algorithmpredicates.GetPredicateMetadata
 			}
 			scheduler := NewGenericScheduler(
 				cache,
@@ -969,7 +969,7 @@ func (n FakeNodeInfo) GetNodeInfo(nodeName string) (*v1.Node, error) {
 }
 
 func PredicateMetadata(p *v1.Pod, nodeInfo map[string]*schedulernodeinfo.NodeInfo) algorithmpredicates.PredicateMetadata {
-	return algorithmpredicates.NewPredicateMetadataFactory(schedulertesting.FakePodLister{p})(p, nodeInfo)
+	return algorithmpredicates.GetPredicateMetadata(p, nodeInfo)
 }
 
 var smallContainers = []v1.Container{
@@ -1912,7 +1912,7 @@ func TestPreempt(t *testing.T) {
 			}
 			predMetaProducer := algorithmpredicates.EmptyPredicateMetadataProducer
 			if test.buildPredMeta {
-				predMetaProducer = algorithmpredicates.NewPredicateMetadataFactory(schedulertesting.FakePodLister(test.pods))
+				predMetaProducer = algorithmpredicates.GetPredicateMetadata
 			}
 			scheduler := NewGenericScheduler(
 				cache,

--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -475,11 +475,7 @@ func (c *Configurator) getPriorityMetadataProducer() (priorities.PriorityMetadat
 // GetPredicateMetadataProducer returns a function to build Predicate Metadata.
 // It is used by the scheduler and other components, such as k8s.io/autoscaler/cluster-autoscaler.
 func (c *Configurator) GetPredicateMetadataProducer() (predicates.PredicateMetadataProducer, error) {
-	pluginArgs, err := c.getPluginArgs()
-	if err != nil {
-		return nil, err
-	}
-	return getPredicateMetadataProducer(*pluginArgs)
+	return getPredicateMetadataProducer()
 }
 
 // GetPredicates returns the predicate functions.

--- a/pkg/scheduler/factory/plugins.go
+++ b/pkg/scheduler/factory/plugins.go
@@ -88,7 +88,7 @@ var (
 
 	// Registered metadata producers
 	priorityMetadataProducer  PriorityMetadataProducerFactory
-	predicateMetadataProducer PredicateMetadataProducerFactory
+	predicateMetadataProducer predicates.PredicateMetadataProducer
 )
 
 const (
@@ -313,11 +313,11 @@ func RegisterPriorityMetadataProducerFactory(factory PriorityMetadataProducerFac
 	priorityMetadataProducer = factory
 }
 
-// RegisterPredicateMetadataProducerFactory registers a PredicateMetadataProducerFactory.
-func RegisterPredicateMetadataProducerFactory(factory PredicateMetadataProducerFactory) {
+// RegisterPredicateMetadataProducer registers a PredicateMetadataProducer.
+func RegisterPredicateMetadataProducer(producer predicates.PredicateMetadataProducer) {
 	schedulerFactoryMutex.Lock()
 	defer schedulerFactoryMutex.Unlock()
-	predicateMetadataProducer = factory
+	predicateMetadataProducer = producer
 }
 
 // RegisterPriorityFunction registers a priority function with the algorithm registry. Returns the name,
@@ -494,14 +494,14 @@ func getPriorityMetadataProducer(args PluginFactoryArgs) (priorities.PriorityMet
 	return priorityMetadataProducer(args), nil
 }
 
-func getPredicateMetadataProducer(args PluginFactoryArgs) (predicates.PredicateMetadataProducer, error) {
+func getPredicateMetadataProducer() (predicates.PredicateMetadataProducer, error) {
 	schedulerFactoryMutex.Lock()
 	defer schedulerFactoryMutex.Unlock()
 
 	if predicateMetadataProducer == nil {
 		return predicates.EmptyPredicateMetadataProducer, nil
 	}
-	return predicateMetadataProducer(args), nil
+	return predicateMetadataProducer, nil
 }
 
 func getPriorityFunctionConfigs(names sets.String, args PluginFactoryArgs) ([]priorities.PriorityConfig, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
`podLister` field of struct `PredicateMetadataFactory` is no longer used.  So we can remove `PredicateMetadataFactory` and get `PredicateMetadataProducer` directly.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
