### PR TITLE
Allow kubectl cp to an existing directory

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -304,7 +304,7 @@ func (o *CopyOptions) copyFromPod(src, dest fileSpec) error {
 		cmdutil.CheckErr(err)
 	}()
 	prefix := getPrefix(src.File)
-	prefix = path.Clean(prefix)
+	prefix = path.Dir(path.Clean(prefix))
 	// remove extraneous path shortcuts - these could occur if a path contained extra "../"
 	// and attempted to navigate beyond "/" in a remote filesystem
 	prefix = stripPathShortcuts(prefix)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently invoking `kubectl cp mydc-1-7k2q7:/etc/hosts local/` will fail with `error: open local: is a directory` when `local/` is a pre-existing directory.

**Special notes for your reviewer**:
/assign @liggitt

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubectl cp command to allow copying to an existing directory
```