### PR TITLE
aggregator/apiextensions: logs & metrics why OpenAPI spec is regenerated

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["controller.go"],
+    srcs = [
+        "controller.go",
+        "metrics.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/controller/openapi",
     importpath = "k8s.io/apiextensions-apiserver/pkg/controller/openapi",
     visibility = ["//visibility:public"],
@@ -17,6 +20,8 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/handler:go_default_library",

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -169,11 +169,12 @@ func (c *Controller) sync(name string) error {
 		}
 		delete(c.crdSpecs, name)
 		klog.V(2).Infof("Updating CRD OpenAPI spec because %s was removed", name)
+		regenerationCounter.With(map[string]string{"crd": name, "reason": "remove"})
 		return c.updateSpecLocked()
 	}
 
 	// compute CRD spec and see whether it changed
-	oldSpecs := c.crdSpecs[crd.Name]
+	oldSpecs, updated := c.crdSpecs[crd.Name]
 	newSpecs, changed, err := buildVersionSpecs(crd, oldSpecs)
 	if err != nil {
 		return err
@@ -185,6 +186,11 @@ func (c *Controller) sync(name string) error {
 	// update specs of this CRD
 	c.crdSpecs[crd.Name] = newSpecs
 	klog.V(2).Infof("Updating CRD OpenAPI spec because %s changed", name)
+	reason := "add"
+	if updated {
+		reason = "update"
+	}
+	regenerationCounter.With(map[string]string{"crd": name, "reason": reason})
 	return c.updateSpecLocked()
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/controller.go
@@ -168,6 +168,7 @@ func (c *Controller) sync(name string) error {
 			return nil
 		}
 		delete(c.crdSpecs, name)
+		klog.V(2).Infof("Updating CRD OpenAPI spec because %s was removed", name)
 		return c.updateSpecLocked()
 	}
 
@@ -183,6 +184,7 @@ func (c *Controller) sync(name string) error {
 
 	// update specs of this CRD
 	c.crdSpecs[crd.Name] = newSpecs
+	klog.V(2).Infof("Updating CRD OpenAPI spec because %s changed", name)
 	return c.updateSpecLocked()
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/metrics.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/metrics.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openapi
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	regenerationCounter = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "apiextensions_openapi_v2_regeneration_count",
+			Help:           "Counter of OpenAPI v2 spec regeneration count broken down by causing CRD name and reason.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"crd", "reason"},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(regenerationCounter)
+}

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "aggregator.go",
         "downloader.go",
+        "metrics.go",
         "priority.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator",
@@ -14,6 +15,8 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/BUILD
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/aggregator:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/builder:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/common:go_default_library",

--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/metrics.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator/metrics.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+var (
+	regenerationCounter = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Name:           "aggregator_openapi_v2_regeneration_count",
+			Help:           "Counter of OpenAPI v2 spec regeneration count broken down by causing APIService name and reason.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"apiservice", "reason"},
+	)
+	regenerationDurationGauge = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Name:           "aggregator_openapi_v2_regeneration_duration",
+			Help:           "Gauge of OpenAPI v2 spec regeneration duration in seconds.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"reason"},
+	)
+)
+
+func init() {
+	legacyregistry.MustRegister(regenerationCounter)
+	legacyregistry.MustRegister(regenerationDurationGauge)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1637,6 +1637,7 @@ k8s.io/component-base/featuregate
 k8s.io/component-base/featuregate/testing
 k8s.io/component-base/logs
 k8s.io/component-base/metrics
+k8s.io/component-base/metrics/legacyregistry
 k8s.io/component-base/version
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api
 k8s.io/cri-api/pkg/apis


### PR DESCRIPTION
Every OpenAPI spec regeneration is heavy on the CPU, a multi-second one-core operation. In a normal cluster this should happen not so often. If it does, the admin has to know. This PR will add the log output to make the situation actionable.

/kind feature


```release-note
Log when kube-apiserver regenerates the OpenAPI spec and why. OpenAPI spec generation is a very CPU-heavy process that is sensitive to continuous updates of CRDs and APIServices.

Added metrics aggregator_openapi_v2_regeneration_count, aggregator_openapi_v2_regeneration_gauge and apiextension_openapi_v2_regeneration_count metrics counting the triggering APIService and CRDs and the reason (add, update, delete).
```