### PR TITLE
Promote VolumePVCDataSource to beta for 1.16

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -447,6 +447,7 @@ const (
 
 	// owner: @j-griffith
 	// alpha: v1.15
+	// beta: v1.16
 	//
 	// Enable support for specifying an existing PVC as a DataSource
 	VolumePVCDataSource featuregate.Feature = "VolumePVCDataSource"
@@ -542,7 +543,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceLoadBalancerFinalizer:        {Default: false, PreRelease: featuregate.Alpha},
 	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 	NonPreemptingPriority:                          {Default: false, PreRelease: featuregate.Alpha},
-	VolumePVCDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
+	VolumePVCDataSource:                            {Default: true, PreRelease: featuregate.Beta},
 	PodOverhead:                                    {Default: false, PreRelease: featuregate.Alpha},
 	IPv6DualStack:                                  {Default: false, PreRelease: featuregate.Alpha},
 	EvenPodsSpread:                                 {Default: false, PreRelease: featuregate.Alpha},

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -204,7 +204,7 @@ func (p *provisioningTestSuite) defineTests(driver TestDriver, pattern testpatte
 		}
 		l.testCase.TestDynamicProvisioning()
 	})
-	ginkgo.It("should provision storage with pvc data source [Feature:VolumePVCDataSource]", func() {
+	ginkgo.It("should provision storage with pvc data source", func() {
 		if !dInfo.Capabilities[CapPVCDataSource] {
 			framework.Skipf("Driver %q does not support cloning - skipping", dInfo.Name)
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does

Promotes the VolumePVCDataSource feature (cloning) to beta for the 1.16
release.

Since alpha release in 1.15 there have been a number of minor bug fixes
in the CSI Hospath Provisioner and the CSI provisioner sidecar.  We've
also added e2e tests using the Hostpath provisioner.
s PR does / why we need it**:


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Website docs update:  https://github.com/kubernetes/website/pull/16013
**Does this PR introduce a user-facing change?**:

```release-note
Promotes VolumePVCDataSource (Cloning) feature to beta for 1.16 release 
```

