### PR TITLE
Remove unused func NewBroadcasterWithCorrelatorOptions

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -144,14 +144,6 @@ func NewBroadcasterForTests(sleepDuration time.Duration) EventBroadcaster {
 	}
 }
 
-func NewBroadcasterWithCorrelatorOptions(options CorrelatorOptions) EventBroadcaster {
-	return &eventBroadcasterImpl{
-		Broadcaster:   watch.NewBroadcaster(maxQueuedEvents, watch.DropIfChannelFull),
-		sleepDuration: defaultSleepDuration,
-		options:       options,
-	}
-}
-
 type eventBroadcasterImpl struct {
 	*watch.Broadcaster
 	sleepDuration time.Duration


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
NewBroadcasterWithCorrelatorOptions is not used anywhere in the code base.

This PR removes it.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
