### PR TITLE
feat: update scheduling framework interface with camelcase

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -195,9 +195,9 @@ func (g *genericScheduler) Schedule(pod *v1.Pod, pluginContext *framework.Plugin
 	}
 
 	// Run "prefilter" plugins.
-	prefilterStatus := g.framework.RunPrefilterPlugins(pluginContext, pod)
-	if !prefilterStatus.IsSuccess() {
-		return result, prefilterStatus.AsError()
+	preFilterStatus := g.framework.RunPreFilterPlugins(pluginContext, pod)
+	if !preFilterStatus.IsSuccess() {
+		return result, preFilterStatus.AsError()
 	}
 
 	numNodes := g.cache.NodeTree().NumNodes()

--- a/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
+++ b/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
@@ -17,7 +17,7 @@ limitations under the License.
 package multipoint
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
@@ -27,7 +27,7 @@ import (
 type CommunicatingPlugin struct{}
 
 var _ = framework.ReservePlugin(CommunicatingPlugin{})
-var _ = framework.PrebindPlugin(CommunicatingPlugin{})
+var _ = framework.PreBindPlugin(CommunicatingPlugin{})
 
 // Name is the name of the plug used in Registry and configurations.
 const Name = "multipoint-communicating-plugin"
@@ -50,8 +50,8 @@ func (mc CommunicatingPlugin) Reserve(pc *framework.PluginContext, pod *v1.Pod, 
 	return nil
 }
 
-// Prebind is the functions invoked by the framework at "prebind" extension point.
-func (mc CommunicatingPlugin) Prebind(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+// PreBind is the functions invoked by the framework at "prebind" extension point.
+func (mc CommunicatingPlugin) PreBind(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
 	if pod == nil {
 		return framework.NewStatus(framework.Error, "pod cannot be nil")
 	}

--- a/pkg/scheduler/framework/plugins/examples/prebind/prebind.go
+++ b/pkg/scheduler/framework/plugins/examples/prebind/prebind.go
@@ -19,27 +19,27 @@ package prebind
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
-// StatelessPrebindExample is an example of a simple plugin that has no state
+// StatelessPreBindExample is an example of a simple plugin that has no state
 // and implements only one hook for prebind.
-type StatelessPrebindExample struct{}
+type StatelessPreBindExample struct{}
 
-var _ = framework.PrebindPlugin(StatelessPrebindExample{})
+var _ = framework.PreBindPlugin(StatelessPreBindExample{})
 
 // Name is the name of the plugin used in Registry and configurations.
 const Name = "stateless-prebind-plugin-example"
 
 // Name returns name of the plugin. It is used in logs, etc.
-func (sr StatelessPrebindExample) Name() string {
+func (sr StatelessPreBindExample) Name() string {
 	return Name
 }
 
-// Prebind is the functions invoked by the framework at "prebind" extension point.
-func (sr StatelessPrebindExample) Prebind(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+// PreBind is the functions invoked by the framework at "prebind" extension point.
+func (sr StatelessPreBindExample) PreBind(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
 	if pod == nil {
 		return framework.NewStatus(framework.Error, fmt.Sprintf("pod cannot be nil"))
 	}
@@ -51,5 +51,5 @@ func (sr StatelessPrebindExample) Prebind(pc *framework.PluginContext, pod *v1.P
 
 // New initializes a new plugin and returns it.
 func New(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
-	return &StatelessPrebindExample{}, nil
+	return &StatelessPreBindExample{}, nil
 }

--- a/pkg/scheduler/framework/plugins/examples/stateful/stateful.go
+++ b/pkg/scheduler/framework/plugins/examples/stateful/stateful.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
@@ -36,7 +36,7 @@ type MultipointExample struct {
 }
 
 var _ = framework.ReservePlugin(&MultipointExample{})
-var _ = framework.PrebindPlugin(&MultipointExample{})
+var _ = framework.PreBindPlugin(&MultipointExample{})
 
 // Name is the name of the plug used in Registry and configurations.
 const Name = "multipoint-plugin-example"
@@ -53,9 +53,9 @@ func (mp *MultipointExample) Reserve(pc *framework.PluginContext, pod *v1.Pod, n
 	return nil
 }
 
-// Prebind is the functions invoked by the framework at "prebind" extension point.
-func (mp *MultipointExample) Prebind(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
-	// Prebind could be called concurrently for different pods.
+// PreBind is the functions invoked by the framework at "prebind" extension point.
+func (mp *MultipointExample) PreBind(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+	// PreBind could be called concurrently for different pods.
 	mp.mu.Lock()
 	defer mp.mu.Unlock()
 	mp.numRuns++

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -45,7 +45,7 @@ type framework struct {
 	scorePlugins              []ScorePlugin
 	scoreWithNormalizePlugins []ScoreWithNormalizePlugin
 	reservePlugins            []ReservePlugin
-	prebindPlugins            []PrebindPlugin
+	preBindPlugins            []PreBindPlugin
 	bindPlugins               []BindPlugin
 	postBindPlugins           []PostBindPlugin
 	unreservePlugins          []UnreservePlugin
@@ -186,11 +186,11 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 	if plugins.PreBind != nil {
 		for _, pb := range plugins.PreBind.Enabled {
 			if pg, ok := pluginsMap[pb.Name]; ok {
-				p, ok := pg.(PrebindPlugin)
+				p, ok := pg.(PreBindPlugin)
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend prebind plugin", pb.Name)
 				}
-				f.prebindPlugins = append(f.prebindPlugins, p)
+				f.preBindPlugins = append(f.preBindPlugins, p)
 			} else {
 				return nil, fmt.Errorf("prebind plugin %q does not exist", pb.Name)
 			}
@@ -425,13 +425,13 @@ func (f *framework) RunScorePlugins(pc *PluginContext, pod *v1.Pod, nodes []*v1.
 	return pluginToNodeScores, nil
 }
 
-// RunPrebindPlugins runs the set of configured prebind plugins. It returns a
+// RunPreBindPlugins runs the set of configured prebind plugins. It returns a
 // failure (bool) if any of the plugins returns an error. It also returns an
 // error containing the rejection message or the error occurred in the plugin.
-func (f *framework) RunPrebindPlugins(
+func (f *framework) RunPreBindPlugins(
 	pc *PluginContext, pod *v1.Pod, nodeName string) *Status {
-	for _, pl := range f.prebindPlugins {
-		status := pl.Prebind(pc, pod, nodeName)
+	for _, pl := range f.preBindPlugins {
+		status := pl.PreBind(pc, pod, nodeName)
 		if !status.IsSuccess() {
 			if status.Code() == Unschedulable {
 				msg := fmt.Sprintf("rejected by %q at prebind: %v", pl.Name(), status.Message())

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -47,7 +47,7 @@ type framework struct {
 	reservePlugins            []ReservePlugin
 	prebindPlugins            []PrebindPlugin
 	bindPlugins               []BindPlugin
-	postbindPlugins           []PostbindPlugin
+	postBindPlugins           []PostBindPlugin
 	unreservePlugins          []UnreservePlugin
 	permitPlugins             []PermitPlugin
 }
@@ -214,11 +214,11 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 	if plugins.PostBind != nil {
 		for _, pb := range plugins.PostBind.Enabled {
 			if pg, ok := pluginsMap[pb.Name]; ok {
-				p, ok := pg.(PostbindPlugin)
+				p, ok := pg.(PostBindPlugin)
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend postbind plugin", pb.Name)
 				}
-				f.postbindPlugins = append(f.postbindPlugins, p)
+				f.postBindPlugins = append(f.postBindPlugins, p)
 			} else {
 				return nil, fmt.Errorf("postbind plugin %q does not exist", pb.Name)
 			}
@@ -467,11 +467,11 @@ func (f *framework) RunBindPlugins(pc *PluginContext, pod *v1.Pod, nodeName stri
 	return status
 }
 
-// RunPostbindPlugins runs the set of configured postbind plugins.
-func (f *framework) RunPostbindPlugins(
+// RunPostBindPlugins runs the set of configured postbind plugins.
+func (f *framework) RunPostBindPlugins(
 	pc *PluginContext, pod *v1.Pod, nodeName string) {
-	for _, pl := range f.postbindPlugins {
-		pl.Postbind(pc, pod, nodeName)
+	for _, pl := range f.postBindPlugins {
+		pl.PostBind(pc, pod, nodeName)
 	}
 }
 

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -152,13 +152,13 @@ type QueueSortPlugin interface {
 	Less(*PodInfo, *PodInfo) bool
 }
 
-// PrefilterPlugin is an interface that must be implemented by "prefilter" plugins.
+// PreFilterPlugin is an interface that must be implemented by "prefilter" plugins.
 // These plugins are called at the beginning of the scheduling cycle.
-type PrefilterPlugin interface {
+type PreFilterPlugin interface {
 	Plugin
-	// Prefilter is called at the beginning of the scheduling cycle. All prefilter
+	// PreFilter is called at the beginning of the scheduling cycle. All PreFilter
 	// plugins must return success or the pod will be rejected.
-	Prefilter(pc *PluginContext, p *v1.Pod) *Status
+	PreFilter(pc *PluginContext, p *v1.Pod) *Status
 }
 
 // FilterPlugin is an interface for Filter plugins. These plugins are called at the
@@ -289,11 +289,11 @@ type Framework interface {
 	// QueueSortFunc returns the function to sort pods in scheduling queue
 	QueueSortFunc() LessFunc
 
-	// RunPrefilterPlugins runs the set of configured prefilter plugins. It returns
+	// RunPreFilterPlugins runs the set of configured prefilter plugins. It returns
 	// *Status and its code is set to non-success if any of the plugins returns
 	// anything but Success. If a non-success status is returned, then the scheduling
 	// cycle is aborted.
-	RunPrefilterPlugins(pc *PluginContext, pod *v1.Pod) *Status
+	RunPreFilterPlugins(pc *PluginContext, pod *v1.Pod) *Status
 
 	// RunFilterPlugins runs the set of configured filter plugins for pod on the
 	// given host. If any of these plugins returns any status other than "Success",

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -225,13 +225,13 @@ type ReservePlugin interface {
 	Reserve(pc *PluginContext, p *v1.Pod, nodeName string) *Status
 }
 
-// PrebindPlugin is an interface that must be implemented by "prebind" plugins.
+// PreBindPlugin is an interface that must be implemented by "prebind" plugins.
 // These plugins are called before a pod being scheduled.
-type PrebindPlugin interface {
+type PreBindPlugin interface {
 	Plugin
-	// Prebind is called before binding a pod. All prebind plugins must return
+	// PreBind is called before binding a pod. All prebind plugins must return
 	// success or the pod will be rejected and won't be sent for binding.
-	Prebind(pc *PluginContext, p *v1.Pod, nodeName string) *Status
+	PreBind(pc *PluginContext, p *v1.Pod, nodeName string) *Status
 }
 
 // PostBindPlugin is an interface that must be implemented by "postbind" plugins.
@@ -311,12 +311,12 @@ type Framework interface {
 	// a non-success status.
 	RunScorePlugins(pc *PluginContext, pod *v1.Pod, nodes []*v1.Node) (PluginToNodeScores, *Status)
 
-	// RunPrebindPlugins runs the set of configured prebind plugins. It returns
+	// RunPreBindPlugins runs the set of configured prebind plugins. It returns
 	// *Status and its code is set to non-success if any of the plugins returns
 	// anything but Success. If the Status code is "Unschedulable", it is
 	// considered as a scheduling check failure, otherwise, it is considered as an
 	// internal error. In either case the pod is not going to be bound.
-	RunPrebindPlugins(pc *PluginContext, pod *v1.Pod, nodeName string) *Status
+	RunPreBindPlugins(pc *PluginContext, pod *v1.Pod, nodeName string) *Status
 
 	// RunPostBindPlugins runs the set of configured postbind plugins.
 	RunPostBindPlugins(pc *PluginContext, pod *v1.Pod, nodeName string)

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -234,15 +234,15 @@ type PrebindPlugin interface {
 	Prebind(pc *PluginContext, p *v1.Pod, nodeName string) *Status
 }
 
-// PostbindPlugin is an interface that must be implemented by "postbind" plugins.
+// PostBindPlugin is an interface that must be implemented by "postbind" plugins.
 // These plugins are called after a pod is successfully bound to a node.
-type PostbindPlugin interface {
+type PostBindPlugin interface {
 	Plugin
-	// Postbind is called after a pod is successfully bound. These plugins are
+	// PostBind is called after a pod is successfully bound. These plugins are
 	// informational. A common application of this extension point is for cleaning
 	// up. If a plugin needs to clean-up its state after a pod is scheduled and
-	// bound, Postbind is the extension point that it should register.
-	Postbind(pc *PluginContext, p *v1.Pod, nodeName string)
+	// bound, PostBind is the extension point that it should register.
+	PostBind(pc *PluginContext, p *v1.Pod, nodeName string)
 }
 
 // UnreservePlugin is an interface for Unreserve plugins. This is an informational
@@ -318,8 +318,8 @@ type Framework interface {
 	// internal error. In either case the pod is not going to be bound.
 	RunPrebindPlugins(pc *PluginContext, pod *v1.Pod, nodeName string) *Status
 
-	// RunPostbindPlugins runs the set of configured postbind plugins.
-	RunPostbindPlugins(pc *PluginContext, pod *v1.Pod, nodeName string)
+	// RunPostBindPlugins runs the set of configured postbind plugins.
+	RunPostBindPlugins(pc *PluginContext, pod *v1.Pod, nodeName string)
 
 	// RunReservePlugins runs the set of configured reserve plugins. If any of these
 	// plugins returns an error, it does not continue running the remaining ones and

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -179,7 +179,7 @@ func (*fakeFramework) RunScorePlugins(pc *framework.PluginContext, pod *v1.Pod, 
 	return nil, nil
 }
 
-func (*fakeFramework) RunPrebindPlugins(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+func (*fakeFramework) RunPreBindPlugins(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
 	return nil
 }
 

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -187,7 +187,7 @@ func (*fakeFramework) RunBindPlugins(pc *framework.PluginContext, pod *v1.Pod, n
 	return nil
 }
 
-func (*fakeFramework) RunPostbindPlugins(pc *framework.PluginContext, pod *v1.Pod, nodeName string) {}
+func (*fakeFramework) RunPostBindPlugins(pc *framework.PluginContext, pod *v1.Pod, nodeName string) {}
 
 func (*fakeFramework) RunPostFilterPlugins(pc *framework.PluginContext, pod *v1.Pod, nodes []*v1.Node, filteredNodesStatuses framework.NodeToStatusMap) *framework.Status {
 	return nil

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -167,7 +167,7 @@ func (*fakeFramework) NodeInfoSnapshot() *internalcache.NodeInfoSnapshot {
 	return nil
 }
 
-func (*fakeFramework) RunPrefilterPlugins(pc *framework.PluginContext, pod *v1.Pod) *framework.Status {
+func (*fakeFramework) RunPreFilterPlugins(pc *framework.PluginContext, pod *v1.Pod) *framework.Status {
 	return nil
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -670,7 +670,7 @@ func (sched *Scheduler) scheduleOne() {
 			metrics.PodScheduleSuccesses.Inc()
 
 			// Run "postbind" plugins.
-			fwk.RunPostbindPlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost)
+			fwk.RunPostBindPlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost)
 		}
 	}()
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -632,10 +632,10 @@ func (sched *Scheduler) scheduleOne() {
 		}
 
 		// Run "prebind" plugins.
-		prebindStatus := fwk.RunPrebindPlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost)
-		if !prebindStatus.IsSuccess() {
+		preBindStatus := fwk.RunPreBindPlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost)
+		if !preBindStatus.IsSuccess() {
 			var reason string
-			if prebindStatus.Code() == framework.Unschedulable {
+			if preBindStatus.Code() == framework.Unschedulable {
 				metrics.PodScheduleFailures.Inc()
 				reason = v1.PodReasonUnschedulable
 			} else {
@@ -647,7 +647,7 @@ func (sched *Scheduler) scheduleOne() {
 			}
 			// trigger un-reserve plugins to clean up state associated with the reserved Pod
 			fwk.RunUnreservePlugins(pluginContext, assumedPod, scheduleResult.SuggestedHost)
-			sched.recordSchedulingFailure(assumedPod, prebindStatus.AsError(), reason, prebindStatus.Message())
+			sched.recordSchedulingFailure(assumedPod, preBindStatus.AsError(), reason, preBindStatus.Message())
 			return
 		}
 

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -31,10 +31,10 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
-type PrefilterPlugin struct {
-	numPrefilterCalled int
-	failPrefilter      bool
-	rejectPrefilter    bool
+type PreFilterPlugin struct {
+	numPreFilterCalled int
+	failPreFilter      bool
+	rejectPreFilter    bool
 }
 
 type ScorePlugin struct {
@@ -113,7 +113,7 @@ const (
 	permitPluginName             = "permit-plugin"
 )
 
-var _ = framework.PrefilterPlugin(&PrefilterPlugin{})
+var _ = framework.PreFilterPlugin(&PreFilterPlugin{})
 var _ = framework.ScorePlugin(&ScorePlugin{})
 var _ = framework.FilterPlugin(&FilterPlugin{})
 var _ = framework.ScorePlugin(&ScorePlugin{})
@@ -321,27 +321,27 @@ func (pp *PostbindPlugin) reset() {
 }
 
 // Name returns name of the plugin.
-func (pp *PrefilterPlugin) Name() string {
+func (pp *PreFilterPlugin) Name() string {
 	return prefilterPluginName
 }
 
-// Prefilter is a test function that returns (true, nil) or errors for testing.
-func (pp *PrefilterPlugin) Prefilter(pc *framework.PluginContext, pod *v1.Pod) *framework.Status {
-	pp.numPrefilterCalled++
-	if pp.failPrefilter {
+// PreFilter is a test function that returns (true, nil) or errors for testing.
+func (pp *PreFilterPlugin) PreFilter(pc *framework.PluginContext, pod *v1.Pod) *framework.Status {
+	pp.numPreFilterCalled++
+	if pp.failPreFilter {
 		return framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))
 	}
-	if pp.rejectPrefilter {
+	if pp.rejectPreFilter {
 		return framework.NewStatus(framework.Unschedulable, fmt.Sprintf("reject pod %v", pod.Name))
 	}
 	return nil
 }
 
 // reset used to reset prefilter plugin.
-func (pp *PrefilterPlugin) reset() {
-	pp.numPrefilterCalled = 0
-	pp.failPrefilter = false
-	pp.rejectPrefilter = false
+func (pp *PreFilterPlugin) reset() {
+	pp.numPreFilterCalled = 0
+	pp.failPreFilter = false
+	pp.rejectPreFilter = false
 }
 
 // Name returns name of the plugin.
@@ -426,11 +426,11 @@ func newPermitPlugin(permitPlugin *PermitPlugin) framework.PluginFactory {
 	}
 }
 
-// TestPrefilterPlugin tests invocation of prefilter plugins.
-func TestPrefilterPlugin(t *testing.T) {
+// TestPreFilterPlugin tests invocation of prefilter plugins.
+func TestPreFilterPlugin(t *testing.T) {
 	// Create a plugin registry for testing. Register only a pre-filter plugin.
-	prefilterPlugin := &PrefilterPlugin{}
-	registry := framework.Registry{prefilterPluginName: newPlugin(prefilterPlugin)}
+	preFilterPlugin := &PreFilterPlugin{}
+	registry := framework.Registry{prefilterPluginName: newPlugin(preFilterPlugin)}
 
 	// Setup initial prefilter plugin for testing.
 	plugins := &schedulerconfig.Plugins{
@@ -478,8 +478,8 @@ func TestPrefilterPlugin(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		prefilterPlugin.failPrefilter = test.fail
-		prefilterPlugin.rejectPrefilter = test.reject
+		preFilterPlugin.failPreFilter = test.fail
+		preFilterPlugin.rejectPreFilter = test.reject
 		// Create a best effort pod.
 		pod, err := createPausePod(cs,
 			initPausePod(cs, &pausePodConfig{Name: "test-pod", Namespace: context.ns.Name}))
@@ -497,11 +497,11 @@ func TestPrefilterPlugin(t *testing.T) {
 			}
 		}
 
-		if prefilterPlugin.numPrefilterCalled == 0 {
+		if preFilterPlugin.numPreFilterCalled == 0 {
 			t.Errorf("Expected the prefilter plugin to be called.")
 		}
 
-		prefilterPlugin.reset()
+		preFilterPlugin.reset()
 		cleanupPods(cs, t, []*v1.Pod{pod})
 	}
 }


### PR DESCRIPTION
/kind cleanup
/sig scheduling
/priority important-soon
/assign @bsalamat @ahg-g @Huang-Wei 


**What this PR does / why we need it**:

Currently, the scheduler config API uses camelcase for `PreFilter`, `PostFilter`, `PreBind` and `PostBind` plugins.

```go
type Plugins struct {
	// PreFilter is a list of plugins that should be invoked at "PreFilter" extension point of the scheduling framework.
	PreFilter *PluginSet

	// PostFilter is a list of plugins that are invoked after filtering out infeasible nodes.
	PostFilter *PluginSet

	// PreBind is a list of plugins that should be invoked before a pod is bound.
	PreBind *PluginSet

	// PostBind is a list of plugins that should be invoked after a pod is successfully bound.
	PostBind *PluginSet
}
```

But in the scheduling framework API, we use the `PostFilter` (with capitalize F), `Prefilter`, `Prebind` and `Postbind` as the interface, we should make it consistent with the scheduler config API that we already agreed on and listed in the [KEP](https://github.com/draveness/enhancements/blob/5ff5d20c848547d535911f5362c5326b68bbf623/keps/sig-scheduling/20180409-scheduling-framework.md#configuring-plugins). 

This PR updates the following APIs in the scheduling framework:

+ Prebind -> PreBind
+ Postbind -> PostBind
+ Prefilter -> PreFilter

It would be great if we make the change before 1.16 code freeze.

**Does this PR introduce a user-facing change?**:

```release-note
Use PostFilter instead of Postfilter in the scheduling framework
Use PreFilter instead of Prefilter in the scheduling framework
Use PreBind instead of Prebind in the scheduling framework
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```