### PR TITLE
Use DeepCopy to obtain copy of event

### DIFF
--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -171,9 +171,8 @@ func (eventBroadcaster *eventBroadcasterImpl) StartRecordingToSink(sink EventSin
 
 func recordToSink(sink EventSink, event *v1.Event, eventCorrelator *EventCorrelator, sleepDuration time.Duration) {
 	// Make a copy before modification, because there could be multiple listeners.
-	// Events are safe to copy like this.
-	eventCopy := *event
-	event = &eventCopy
+	eventCopy := event.DeepCopy()
+	event = eventCopy
 	result, err := eventCorrelator.EventCorrelate(event)
 	if err != nil {
 		utilruntime.HandleError(err)

--- a/staging/src/k8s.io/client-go/tools/record/event_test.go
+++ b/staging/src/k8s.io/client-go/tools/record/event_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -460,6 +461,10 @@ func TestUpdateExpiredEvent(t *testing.T) {
 	ev.ResourceVersion = "updated-resource-version"
 	ev.Count = 2
 	recordToSink(sink, ev, eventCorrelator, 0)
+	ev.ResourceVersion = ""
+	if !reflect.DeepEqual(ev, createdEvent) {
+		t.Error("event passed to recordToSink was not deep copied")
+	}
 
 	if createdEvent == nil {
 		t.Error("Event did not get created after patch failed")


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In recordToSink, we should use DeepCopy to obtain copy of event.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
