### PR TITLE
Use framework functions under test/e2e/common/

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -67,7 +67,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		framework.ExpectNoError(err)
 		isReady, err := testutils.PodRunningReady(p)
 		framework.ExpectNoError(err)
-		gomega.Expect(isReady).To(gomega.BeTrue(), "pod should be ready")
+		framework.ExpectEqual(isReady, true, "pod should be ready")
 
 		// We assume the pod became ready when the container became ready. This
 		// is true for a single container pod.
@@ -83,7 +83,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		}
 
 		restartCount := getRestartCount(p)
-		gomega.Expect(restartCount == 0).To(gomega.BeTrue(), "pod should have a restart count of 0 but got %v", restartCount)
+		framework.ExpectEqual(restartCount, 0, "pod should have a restart count of 0 but got %v", restartCount)
 	})
 
 	/*
@@ -106,10 +106,10 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		framework.ExpectNoError(err)
 
 		isReady, err := testutils.PodRunningReady(p)
-		gomega.Expect(isReady).NotTo(gomega.BeTrue(), "pod should be not ready")
+		framework.ExpectNotEqual(isReady, true, "pod should be not ready")
 
 		restartCount := getRestartCount(p)
-		gomega.Expect(restartCount == 0).To(gomega.BeTrue(), "pod should have a restart count of 0 but got %v", restartCount)
+		framework.ExpectEqual(restartCount, 0, "pod should have a restart count of 0 but got %v", restartCount)
 	})
 
 	/*
@@ -407,7 +407,7 @@ func (b webserverProbeBuilder) build() *v1.Probe {
 func runLivenessTest(f *framework.Framework, pod *v1.Pod, expectNumRestarts int, timeout time.Duration) {
 	podClient := f.PodClient()
 	ns := f.Namespace.Name
-	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
+	framework.ExpectNotEqual(pod.Spec.Containers, "")
 	containerName := pod.Spec.Containers[0].Name
 	// At the end of the test, clean up by removing the pod.
 	defer func() {

--- a/test/e2e/common/init_container.go
+++ b/test/e2e/common/init_container.go
@@ -35,7 +35,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
@@ -96,19 +95,19 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), framework.PodStartTimeout)
 		defer cancel()
 		event, err := watchtools.UntilWithoutRetry(ctx, wr, conditions.PodCompleted)
-		gomega.Expect(err).To(gomega.BeNil())
+		framework.ExpectNoError(err)
 		framework.CheckInvariants(wr.Events(), framework.ContainerInitInvariant)
 		endPod := event.Object.(*v1.Pod)
 		framework.ExpectEqual(endPod.Status.Phase, v1.PodSucceeded)
 		_, init := podutil.GetPodCondition(&endPod.Status, v1.PodInitialized)
-		gomega.Expect(init).NotTo(gomega.BeNil())
+		framework.ExpectNotEqual(init, nil)
 		framework.ExpectEqual(init.Status, v1.ConditionTrue)
 
 		framework.ExpectEqual(len(endPod.Status.InitContainerStatuses), 2)
 		for _, status := range endPod.Status.InitContainerStatuses {
-			gomega.Expect(status.Ready).To(gomega.BeTrue())
-			gomega.Expect(status.State.Terminated).NotTo(gomega.BeNil())
-			gomega.Expect(status.State.Terminated.ExitCode).To(gomega.BeZero())
+			framework.ExpectEqual(status.Ready, true)
+			framework.ExpectNotEqual(status.State.Terminated, nil)
+			framework.ExpectEqual(status.State.Terminated.ExitCode, 0)
 		}
 	})
 
@@ -167,19 +166,19 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 		ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), framework.PodStartTimeout)
 		defer cancel()
 		event, err := watchtools.UntilWithoutRetry(ctx, wr, conditions.PodRunning)
-		gomega.Expect(err).To(gomega.BeNil())
+		framework.ExpectNoError(err)
 		framework.CheckInvariants(wr.Events(), framework.ContainerInitInvariant)
 		endPod := event.Object.(*v1.Pod)
 		framework.ExpectEqual(endPod.Status.Phase, v1.PodRunning)
 		_, init := podutil.GetPodCondition(&endPod.Status, v1.PodInitialized)
-		gomega.Expect(init).NotTo(gomega.BeNil())
+		framework.ExpectNotEqual(init, nil)
 		framework.ExpectEqual(init.Status, v1.ConditionTrue)
 
 		framework.ExpectEqual(len(endPod.Status.InitContainerStatuses), 2)
 		for _, status := range endPod.Status.InitContainerStatuses {
-			gomega.Expect(status.Ready).To(gomega.BeTrue())
-			gomega.Expect(status.State.Terminated).NotTo(gomega.BeNil())
-			gomega.Expect(status.State.Terminated.ExitCode).To(gomega.BeZero())
+			framework.ExpectEqual(status.Ready, true)
+			framework.ExpectNotEqual(status.State.Terminated, nil)
+			framework.ExpectEqual(status.State.Terminated.ExitCode, 0)
 		}
 	})
 
@@ -289,12 +288,12 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 				}
 			},
 		)
-		gomega.Expect(err).To(gomega.BeNil())
+		framework.ExpectNoError(err)
 		framework.CheckInvariants(wr.Events(), framework.ContainerInitInvariant)
 		endPod := event.Object.(*v1.Pod)
 		framework.ExpectEqual(endPod.Status.Phase, v1.PodPending)
 		_, init := podutil.GetPodCondition(&endPod.Status, v1.PodInitialized)
-		gomega.Expect(init).NotTo(gomega.BeNil())
+		framework.ExpectNotEqual(init, nil)
 		framework.ExpectEqual(init.Status, v1.ConditionFalse)
 		framework.ExpectEqual(init.Reason, "ContainersNotInitialized")
 		framework.ExpectEqual(init.Message, "containers with incomplete status: [init1 init2]")
@@ -398,17 +397,17 @@ var _ = framework.KubeDescribe("InitContainer [NodeConformance]", func() {
 			},
 			conditions.PodCompleted,
 		)
-		gomega.Expect(err).To(gomega.BeNil())
+		framework.ExpectNoError(err)
 		framework.CheckInvariants(wr.Events(), framework.ContainerInitInvariant)
 		endPod := event.Object.(*v1.Pod)
 
 		framework.ExpectEqual(endPod.Status.Phase, v1.PodFailed)
 		_, init := podutil.GetPodCondition(&endPod.Status, v1.PodInitialized)
-		gomega.Expect(init).NotTo(gomega.BeNil())
+		framework.ExpectNotEqual(init, nil)
 		framework.ExpectEqual(init.Status, v1.ConditionFalse)
 		framework.ExpectEqual(init.Reason, "ContainersNotInitialized")
 		framework.ExpectEqual(init.Message, "containers with incomplete status: [init2]")
 		framework.ExpectEqual(len(endPod.Status.InitContainerStatuses), 2)
-		gomega.Expect(endPod.Status.ContainerStatuses[0].State.Waiting).ToNot(gomega.BeNil())
+		framework.ExpectNotEqual(endPod.Status.ContainerStatuses[0].State.Waiting, nil)
 	})
 })

--- a/test/e2e/common/node_lease.go
+++ b/test/e2e/common/node_lease.go
@@ -42,7 +42,7 @@ var _ = framework.KubeDescribe("NodeLease", func() {
 
 	ginkgo.BeforeEach(func() {
 		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		gomega.Expect(len(nodes.Items)).NotTo(gomega.BeZero())
+		framework.ExpectNotEqual(len(nodes.Items), 0)
 		nodeName = nodes.Items[0].ObjectMeta.Name
 	})
 
@@ -62,7 +62,7 @@ var _ = framework.KubeDescribe("NodeLease", func() {
 				return nil
 			}, 5*time.Minute, 5*time.Second).Should(gomega.BeNil())
 			// check basic expectations for the lease
-			gomega.Expect(expectLease(lease, nodeName)).To(gomega.BeNil())
+			framework.ExpectEqual(expectLease(lease, nodeName), nil)
 
 			ginkgo.By("check that node lease is updated at least once within the lease duration")
 			gomega.Eventually(func() error {
@@ -100,7 +100,7 @@ var _ = framework.KubeDescribe("NodeLease", func() {
 				return nil
 			}, 5*time.Minute, 5*time.Second).Should(gomega.BeNil())
 			// check basic expectations for the lease
-			gomega.Expect(expectLease(lease, nodeName)).To(gomega.BeNil())
+			framework.ExpectEqual(expectLease(lease, nodeName), nil)
 			leaseDuration := time.Duration(*lease.Spec.LeaseDurationSeconds) * time.Second
 
 			ginkgo.By("verify NodeStatus report period is longer than lease duration")
@@ -153,7 +153,7 @@ var _ = framework.KubeDescribe("NodeLease", func() {
 			// running as cluster e2e test, because node e2e test does not create and
 			// run controller manager, i.e., no node lifecycle controller.
 			node, err := f.ClientSet.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
-			gomega.Expect(err).To(gomega.BeNil())
+			framework.ExpectNoError(err)
 			_, readyCondition := testutils.GetNodeCondition(&node.Status, v1.NodeReady)
 			framework.ExpectEqual(readyCondition.Status, v1.ConditionTrue)
 		})
@@ -162,7 +162,7 @@ var _ = framework.KubeDescribe("NodeLease", func() {
 
 func getHeartbeatTimeAndStatus(clientSet clientset.Interface, nodeName string) (time.Time, v1.NodeStatus) {
 	node, err := clientSet.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
-	gomega.Expect(err).To(gomega.BeNil())
+	framework.ExpectNoError(err)
 	_, readyCondition := testutils.GetNodeCondition(&node.Status, v1.NodeReady)
 	framework.ExpectEqual(readyCondition.Status, v1.ConditionTrue)
 	heartbeatTime := readyCondition.LastHeartbeatTime.Time

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -85,7 +85,7 @@ func testHostIP(podClient *framework.PodClient, pod *v1.Pod) {
 func startPodAndGetBackOffs(podClient *framework.PodClient, pod *v1.Pod, sleepAmount time.Duration) (time.Duration, time.Duration) {
 	podClient.CreateSync(pod)
 	time.Sleep(sleepAmount)
-	gomega.Expect(pod.Spec.Containers).NotTo(gomega.BeEmpty())
+	framework.ExpectNotEqual(pod.Spec.Containers, "")
 	podName := pod.Name
 	containerName := pod.Spec.Containers[0].Name
 
@@ -331,8 +331,8 @@ var _ = framework.KubeDescribe("Pods", func() {
 			e2elog.Failf("Failed to observe pod deletion")
 		}
 
-		gomega.Expect(lastPod.DeletionTimestamp).ToNot(gomega.BeNil())
-		gomega.Expect(lastPod.Spec.TerminationGracePeriodSeconds).ToNot(gomega.BeZero())
+		framework.ExpectNotEqual(lastPod.DeletionTimestamp, nil)
+		framework.ExpectNotEqual(lastPod.Spec.TerminationGracePeriodSeconds, 0)
 
 		selector = labels.SelectorFromSet(labels.Set(map[string]string{"time": value}))
 		options = metav1.ListOptions{LabelSelector: selector.String()}
@@ -813,14 +813,14 @@ var _ = framework.KubeDescribe("Pods", func() {
 
 		ginkgo.By("submitting the pod to kubernetes")
 		podClient.CreateSync(pod)
-		gomega.Expect(podClient.PodIsReady(podName)).To(gomega.BeFalse(), "Expect pod's Ready condition to be false initially.")
+		framework.ExpectEqual(podClient.PodIsReady(podName), false, "Expect pod's Ready condition to be false initially.")
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to true", readinessGate1))
 		_, err := podClient.Patch(podName, types.StrategicMergePatchType, []byte(fmt.Sprintf(patchStatusFmt, readinessGate1, "True")), "status")
 		framework.ExpectNoError(err)
 		// Sleep for 10 seconds.
 		time.Sleep(maxReadyStatusUpdateTolerance)
-		gomega.Expect(podClient.PodIsReady(podName)).To(gomega.BeFalse(), "Expect pod's Ready condition to be false with only one condition in readinessGates equal to True")
+		framework.ExpectEqual(podClient.PodIsReady(podName), false, "Expect pod's Ready condition to be false with only one condition in readinessGates equal to True")
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to true", readinessGate2))
 		_, err = podClient.Patch(podName, types.StrategicMergePatchType, []byte(fmt.Sprintf(patchStatusFmt, readinessGate2, "True")), "status")

--- a/test/e2e/common/security_context.go
+++ b/test/e2e/common/security_context.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/utils/pointer"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = framework.KubeDescribe("Security Context", func() {
@@ -135,7 +134,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 
 			ev, err := podClient.WaitForErrorEventOrSuccess(pod)
 			framework.ExpectNoError(err)
-			gomega.Expect(ev).NotTo(gomega.BeNil())
+			framework.ExpectNotEqual(ev, nil)
 			framework.ExpectEqual(ev.Reason, events.FailedToCreateContainer)
 		})
 		ginkgo.It("should run with an image specified user ID", func() {
@@ -153,7 +152,7 @@ var _ = framework.KubeDescribe("Security Context", func() {
 
 			ev, err := podClient.WaitForErrorEventOrSuccess(pod)
 			framework.ExpectNoError(err)
-			gomega.Expect(ev).NotTo(gomega.BeNil())
+			framework.ExpectNotEqual(ev, nil)
 			framework.ExpectEqual(ev.Reason, events.FailedToCreateContainer)
 		})
 	})

--- a/test/e2e/common/sysctl.go
+++ b/test/e2e/common/sysctl.go
@@ -82,7 +82,7 @@ var _ = framework.KubeDescribe("Sysctls [NodeFeature:Sysctls]", func() {
 		if ev != nil && ev.Reason == sysctl.UnsupportedReason {
 			framework.Skipf("No sysctl support in Docker <1.12")
 		}
-		gomega.Expect(ev).To(gomega.BeNil())
+		framework.ExpectEqual(ev, nil)
 
 		ginkgo.By("Waiting for pod completion")
 		err = f.WaitForPodNoLongerRunning(pod.Name)
@@ -125,7 +125,7 @@ var _ = framework.KubeDescribe("Sysctls [NodeFeature:Sysctls]", func() {
 		if ev != nil && ev.Reason == sysctl.UnsupportedReason {
 			framework.Skipf("No sysctl support in Docker <1.12")
 		}
-		gomega.Expect(ev).To(gomega.BeNil())
+		framework.ExpectEqual(ev, nil)
 
 		ginkgo.By("Waiting for pod completion")
 		err = f.WaitForPodNoLongerRunning(pod.Name)
@@ -172,7 +172,7 @@ var _ = framework.KubeDescribe("Sysctls [NodeFeature:Sysctls]", func() {
 		client := f.ClientSet.CoreV1().Pods(f.Namespace.Name)
 		_, err := client.Create(pod)
 
-		gomega.Expect(err).NotTo(gomega.BeNil())
+		framework.ExpectError(err)
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring(`Invalid value: "foo-"`))
 		gomega.Expect(err.Error()).To(gomega.ContainSubstring(`Invalid value: "bar.."`))
 		gomega.Expect(err.Error()).NotTo(gomega.ContainSubstring(`safe-and-unsafe`))
@@ -204,7 +204,7 @@ var _ = framework.KubeDescribe("Sysctls [NodeFeature:Sysctls]", func() {
 		}
 
 		ginkgo.By("Checking that the pod was rejected")
-		gomega.Expect(ev).ToNot(gomega.BeNil())
+		framework.ExpectNotEqual(ev, nil)
 		framework.ExpectEqual(ev.Reason, "SysctlForbidden")
 	})
 })


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There are some functions of e2e test framework and it is useful to
read the test code by using these functions.
This replaces gomega calls with these functions under test/e2e/common/

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
