### PR TITLE
Add an optional flag to kubelet for vols outside of kublet control

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -189,6 +189,10 @@ type KubeletFlags struct {
 	KeepTerminatedPodVolumes bool
 	// EnableCAdvisorJSONEndpoints enables some cAdvisor endpoints that will be removed in future versions
 	EnableCAdvisorJSONEndpoints bool
+	// Number of volumes which exist outside of kubelet's control. Allows
+	// kubelet to account for volumes explicitly mounted to the node for purposes
+	// such as container storage.
+	NumNonKubeVolumes int64
 }
 
 // NewKubeletFlags will create a new KubeletFlags with default values
@@ -220,6 +224,7 @@ func NewKubeletFlags() *KubeletFlags {
 		// prior to the introduction of this flag, there was a hardcoded cap of 50 images
 		NodeStatusMaxImages:         50,
 		EnableCAdvisorJSONEndpoints: true,
+		NumNonKubeVolumes:           0,
 	}
 }
 
@@ -381,6 +386,7 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 	fs.BoolVar(&f.RegisterNode, "register-node", f.RegisterNode, "Register the node with the apiserver. If --kubeconfig is not provided, this flag is irrelevant, as the Kubelet won't have an apiserver to register with.")
 	fs.Var(utiltaints.NewTaintsVar(&f.RegisterWithTaints), "register-with-taints", "Register the node with the given list of taints (comma separated \"<key>=<value>:<effect>\"). No-op if register-node is false.")
+	fs.Int64Var(&f.NumNonKubeVolumes, "num-non-kube-volumes", f.NumNonKubeVolumes, "Number of non root volumes which exist outside of kubelet's control. If set, kubelet will reduce the number of volumes which can be mounted to the node by the quantity specified. Default: 0")
 
 	// EXPERIMENTAL FLAGS
 	fs.StringVar(&f.ExperimentalMounterPath, "experimental-mounter-path", f.ExperimentalMounterPath, "[Experimental] Path of mounter binary. Leave empty to use the default mount.")

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1039,7 +1039,8 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 		kubeServer.NodeLabels,
 		kubeServer.SeccompProfileRoot,
 		kubeServer.BootstrapCheckpointPath,
-		kubeServer.NodeStatusMaxImages)
+		kubeServer.NodeStatusMaxImages,
+		kubeServer.NumNonKubeVolumes)
 	if err != nil {
 		return fmt.Errorf("failed to create kubelet: %v", err)
 	}
@@ -1115,7 +1116,8 @@ func createAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32) (k kubelet.Bootstrap, err error) {
+	nodeStatusMaxImages int32,
+	numNonKubeVolumes int64) (k kubelet.Bootstrap, err error) {
 	// TODO: block until all sources have delivered at least one update to the channel, or break the sync loop
 	// up into "per source" synchronizations
 
@@ -1149,7 +1151,8 @@ func createAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeLabels,
 		seccompProfileRoot,
 		bootstrapCheckpointPath,
-		nodeStatusMaxImages)
+		nodeStatusMaxImages,
+		numNonKubeVolumes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -235,7 +235,8 @@ type Builder func(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32) (Bootstrap, error)
+	nodeStatusMaxImages int32,
+	numNonKubeVolumes int64) (Bootstrap, error)
 
 // Dependencies is a bin for things we might consider "injected dependencies" -- objects constructed
 // at runtime that are necessary for running the Kubelet. This is a temporary solution for grouping
@@ -361,7 +362,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32) (*Kubelet, error) {
+	nodeStatusMaxImages int32,
+	numNonKubeVolumes int64) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
 	}
@@ -543,6 +545,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		experimentalHostUserNamespaceDefaulting: utilfeature.DefaultFeatureGate.Enabled(features.ExperimentalHostUserNamespaceDefaultingGate),
 		keepTerminatedPodVolumes:                keepTerminatedPodVolumes,
 		nodeStatusMaxImages:                     nodeStatusMaxImages,
+		numNonKubeVolumes:                       numNonKubeVolumes,
 	}
 
 	if klet.cloud != nil {
@@ -1223,6 +1226,8 @@ type Kubelet struct {
 
 	// Handles RuntimeClass objects for the Kubelet.
 	runtimeClassManager *runtimeclass.Manager
+	// Number of non kubernetes controlled volumes which exist on the node.
+	numNonKubeVolumes int64
 }
 
 // setupDataDirs creates:

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -542,7 +542,7 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(*v1.Node) error {
 		nodestatus.GoRuntime(),
 	)
 	if utilfeature.DefaultFeatureGate.Enabled(features.AttachVolumeLimit) {
-		setters = append(setters, nodestatus.VolumeLimits(kl.volumePluginMgr.ListVolumePluginWithLimits))
+		setters = append(setters, nodestatus.VolumeLimits(kl.volumePluginMgr.ListVolumePluginWithLimits, kl.numNonKubeVolumes))
 	}
 	setters = append(setters,
 		nodestatus.MemoryPressureCondition(kl.clock.Now, kl.evictionManager.IsUnderMemoryPressure, kl.recordNodeStatusEvent),

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -729,6 +729,7 @@ func VolumesInUse(syncedFunc func() bool, // typically Kubelet.volumeManager.Rec
 
 // VolumeLimits returns a Setter that updates the volume limits on the node.
 func VolumeLimits(volumePluginListFunc func() []volume.VolumePluginWithAttachLimits, // typically Kubelet.volumePluginMgr.ListVolumePluginWithLimits
+	numNonKubeVolumes int64,
 ) Setter {
 	return func(node *v1.Node) error {
 		if node.Status.Capacity == nil {
@@ -746,8 +747,8 @@ func VolumeLimits(volumePluginListFunc func() []volume.VolumePluginWithAttachLim
 				continue
 			}
 			for limitKey, value := range attachLimits {
-				node.Status.Capacity[v1.ResourceName(limitKey)] = *resource.NewQuantity(value, resource.DecimalSI)
-				node.Status.Allocatable[v1.ResourceName(limitKey)] = *resource.NewQuantity(value, resource.DecimalSI)
+				node.Status.Capacity[v1.ResourceName(limitKey)] = *resource.NewQuantity(value-numNonKubeVolumes, resource.DecimalSI)
+				node.Status.Allocatable[v1.ResourceName(limitKey)] = *resource.NewQuantity(value-numNonKubeVolumes, resource.DecimalSI)
 			}
 		}
 		return nil


### PR DESCRIPTION
Allows kubelet to account for volumes, other than root, which
exist on the node when reporting number of allowable volume mounts.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Allows a cluster operator to inform kubelet about how many volumes exist on nodes other than the root volume. This covers use cases such as creating separate volumes for container storage. Without this information, kubelet will report too many volume mounts as being possible since it assumes the only volume in use is root.

**Which issue(s) this PR fixes**:
Fixes #81533

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Add optional kubelet flag --num-non-kube-volumes. This allows one to specify the number of volumes, other than root, which are mounted to the node outside of kubelet's control. This information allows kubelet to accurately report the number of available volume mounts.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
