### PR TITLE
Use log functions of core framework on p*

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -33,7 +33,6 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/sysctl"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
 	"github.com/onsi/ginkgo"
@@ -151,11 +150,11 @@ func (c *PodClient) Update(name string, updateFn func(pod *v1.Pod)) {
 		updateFn(pod)
 		_, err = c.PodInterface.Update(pod)
 		if err == nil {
-			e2elog.Logf("Successfully updated pod %q", name)
+			Logf("Successfully updated pod %q", name)
 			return true, nil
 		}
 		if errors.IsConflict(err) {
-			e2elog.Logf("Conflicting update to pod %q, re-get and re-update: %v", name, err)
+			Logf("Conflicting update to pod %q, re-get and re-update: %v", name, err)
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to update pod %q: %v", name, err)
@@ -173,7 +172,7 @@ func (c *PodClient) DeleteSync(name string, options *metav1.DeleteOptions, timeo
 func (c *PodClient) DeleteSyncInNamespace(name string, namespace string, options *metav1.DeleteOptions, timeout time.Duration) {
 	err := c.Delete(name, options)
 	if err != nil && !errors.IsNotFound(err) {
-		e2elog.Failf("Failed to delete pod %q: %v", name, err)
+		Failf("Failed to delete pod %q: %v", name, err)
 	}
 	gomega.Expect(e2epod.WaitForPodToDisappear(c.f.ClientSet, namespace, name, labels.Everything(),
 		2*time.Second, timeout)).To(gomega.Succeed(), "wait for pod %q to disappear", name)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This makes sub packages of e2e test framework to use log functions
of core framework instead for avoiding circular dependencies.

Ref: https://github.com/kubernetes/kubernetes/pull/81802

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
