### PR TITLE
Tolerate ending slash when running staticcheck

### DIFF
--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -25,6 +25,7 @@ source "${KUBE_ROOT}/hack/lib/util.sh"
 kube::golang::verify_go_version
 
 FOCUS="${1:-}"
+FOCUS="${FOCUS%/}" # Remove the ending "/"
 
 # See https://staticcheck.io/docs/checks
 CHECKS=(


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Tolerate the ending slash (`/`) when running staticcheck script.

Without the PR:

```console
⇒  hack/verify-staticcheck.sh pkg/scheduler/internal/queue/
installing staticcheck from vendor
!!! Error in hack/verify-staticcheck.sh:71
  Error in hack/verify-staticcheck.sh:71. 'grep -vE "$ignore_pattern"' exited with status 0
1
1
1
Call stack:
  1: hack/verify-staticcheck.sh:71 main(...)
Exiting with status 1
Errors from staticcheck:
-: no Go files in /Users/wei.huang1/gospace/src/k8s.io/kubernetes (compile)

Please review the above warnings. You can test via:
  staticcheck -checks "all,-S1*,-ST1*"
If the above warnings do not make sense, you can exempt the line or file. See:
  https://staticcheck.io/docs/#ignoring-problems
```

With this PR, `hack/verify-staticcheck.sh pkg/scheduler/internal/queue/` and `hack/verify-staticcheck.sh pkg/scheduler/internal/queue` both work.

```console
⇒  hack/verify-staticcheck.sh pkg/scheduler/internal/queue/
installing staticcheck from vendor
Errors from staticcheck:
pkg/scheduler/internal/queue/scheduling_queue_test.go:38:5: var negPriority is unused (U1000)
pkg/scheduler/internal/queue/scheduling_queue_test.go:38:58: var veryHighPriority is unused (U1000)

Please review the above warnings. You can test via:
  staticcheck -checks "all,-S1*,-ST1*"
If the above warnings do not make sense, you can exempt the line or file. See:
  https://staticcheck.io/docs/#ignoring-problems
```

**Special notes for your reviewer**:

1. This error only occurs when the package with ending slash is the most childish one. (i.e. without the PR, `hack/verify-staticcheck.sh pkg/scheduler/` also works b/c some children packages match "pkg/scheduler/")

1. We can additionally tolerate the `grep -vE` error by appending `|| true` so that the script only outputs "no Go files" error:

```bash
all_packages=()
while IFS='' read -r line; do
  all_packages+=("./$line")
done < <( hack/make-rules/helpers/cache_go_dirs.sh "${KUBE_ROOT}/_tmp/all_go_dirs" |
            grep "^${FOCUS:-.}" |
            grep -vE "(third_party|generated|clientset_generated|/_)" |
            grep -vE "$ignore_pattern" || true )
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/assign @tallclair @fejta 
