### PR TITLE
Use log functions of core framework on sub [j-l]

### DIFF
--- a/test/e2e/framework/job/BUILD
+++ b/test/e2e/framework/job/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/job/rest.go
+++ b/test/e2e/framework/job/rest.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 // GetJob uses c to get the Job in namespace ns named name. If the returned error is nil, the returned Job is valid.
@@ -64,7 +63,7 @@ func UpdateJobWithRetries(c clientset.Interface, namespace, name string, applyUp
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(job)
 		if job, err = jobs.Update(job); err == nil {
-			e2elog.Logf("Updating job %s", name)
+			framework.Logf("Updating job %s", name)
 			return true, nil
 		}
 		updateErr = err

--- a/test/e2e/framework/lifecycle/BUILD
+++ b/test/e2e/framework/lifecycle/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/lifecycle/upgrade.go
+++ b/test/e2e/framework/lifecycle/upgrade.go
@@ -27,40 +27,39 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 // RealVersion turns a version constants into a version string deployable on
 // GKE.  See hack/get-build.sh for more information.
 func RealVersion(s string) (string, error) {
-	e2elog.Logf("Getting real version for %q", s)
+	framework.Logf("Getting real version for %q", s)
 	v, _, err := framework.RunCmd(path.Join(framework.TestContext.RepoRoot, "hack/get-build.sh"), "-v", s)
 	if err != nil {
 		return v, fmt.Errorf("error getting real version for %q: %v", s, err)
 	}
-	e2elog.Logf("Version for %q is %q", s, v)
+	framework.Logf("Version for %q is %q", s, v)
 	return strings.TrimPrefix(strings.TrimSpace(v), "v"), nil
 }
 
 func traceRouteToMaster() {
 	traceroute, err := exec.LookPath("traceroute")
 	if err != nil {
-		e2elog.Logf("Could not find traceroute program")
+		framework.Logf("Could not find traceroute program")
 		return
 	}
 	cmd := exec.Command(traceroute, "-I", framework.GetMasterHost())
 	out, err := cmd.Output()
 	if len(out) != 0 {
-		e2elog.Logf(string(out))
+		framework.Logf(string(out))
 	}
 	if exiterr, ok := err.(*exec.ExitError); err != nil && ok {
-		e2elog.Logf("Error while running traceroute: %s", exiterr.Stderr)
+		framework.Logf("Error while running traceroute: %s", exiterr.Stderr)
 	}
 }
 
 // CheckMasterVersion validates the master version
 func CheckMasterVersion(c clientset.Interface, want string) error {
-	e2elog.Logf("Checking master version")
+	framework.Logf("Checking master version")
 	var err error
 	var v *version.Info
 	waitErr := wait.PollImmediate(5*time.Second, 2*time.Minute, func() (bool, error) {
@@ -81,7 +80,7 @@ func CheckMasterVersion(c clientset.Interface, want string) error {
 	if !strings.HasPrefix(got, want) {
 		return fmt.Errorf("master had kube-apiserver version %s which does not start with %s", got, want)
 	}
-	e2elog.Logf("Master is at version %s", want)
+	framework.Logf("Master is at version %s", want)
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This makes sub packages of e2e test framework to use log functions
of core framework instead for avoiding circular dependencies.

Ref: https://github.com/kubernetes/kubernetes/issues/81427

NOTE: test/e2e/framework/kubelet, test/e2e/framework/metrics and
test/e2e/framework/node will make circular dependencies if
updating them. It is necessary to solve them in advance before
this work.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
