### PR TITLE
Adding TooMany error type

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/field/errors.go
@@ -116,6 +116,10 @@ const (
 	// This is similar to ErrorTypeInvalid, but the error will not include the
 	// too-long value.  See TooLong().
 	ErrorTypeTooLong ErrorType = "FieldValueTooLong"
+	// ErrorTypeTooMany is used to report "too many". This is used to
+	// report that a given list has too many items. This is similar to FieldValueTooLong,
+	// but the error indicates quantity instead of length.
+	ErrorTypeTooMany ErrorType = "FieldValueTooMany"
 	// ErrorTypeInternal is used to report other errors that are not related
 	// to user input.  See InternalError().
 	ErrorTypeInternal ErrorType = "InternalError"
@@ -138,6 +142,8 @@ func (t ErrorType) String() string {
 		return "Forbidden"
 	case ErrorTypeTooLong:
 		return "Too long"
+	case ErrorTypeTooMany:
+		return "Too many"
 	case ErrorTypeInternal:
 		return "Internal error"
 	default:
@@ -199,6 +205,13 @@ func Forbidden(field *Path, detail string) *Error {
 // value.
 func TooLong(field *Path, value interface{}, maxLength int) *Error {
 	return &Error{ErrorTypeTooLong, field.String(), value, fmt.Sprintf("must have at most %d characters", maxLength)}
+}
+
+// TooMany returns a *Error indicating "too many". This is used to
+// report that a given list has too many items. This is similar to TooLong,
+// but the returned error indicates quantity instead of length.
+func TooMany(field *Path, actualQuantity, maxQuantity int) *Error {
+	return &Error{ErrorTypeTooMany, field.String(), actualQuantity, fmt.Sprintf("must have at most %d items", maxQuantity)}
 }
 
 // InternalError returns a *Error indicating "internal error".  This is used


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds a TooMany error type, as used by https://github.com/kubernetes/kubernetes/pull/80766 and [suggested](https://github.com/kubernetes/kubernetes/pull/72046#discussion_r316897974) for https://github.com/kubernetes/kubernetes/pull/72046.

**Special notes for your reviewer**:
Pulled out of #80766 for ease of use in #72046.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @thockin 