### PR TITLE
removal of klog from validaters

### DIFF
--- a/cmd/kubeadm/app/util/system/BUILD
+++ b/cmd/kubeadm/app/util/system/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/util/system/kernel_validator.go
+++ b/cmd/kubeadm/app/util/system/kernel_validator.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pkg/errors"
 
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog"
 )
 
 var _ Validator = &KernelValidator{}
@@ -255,12 +254,7 @@ func (k *KernelValidator) parseKernelConfig(r io.Reader) (map[string]kConfigOpti
 			continue
 		}
 		fields := strings.Split(line, "=")
-		if len(fields) != 2 {
-			klog.Errorf("Unexpected fields number in config %q", line)
-			continue
-		}
-		config[fields[0]] = kConfigOption(fields[1])
+		config[fields[0]] = kConfigOption(fields[1][0])
 	}
 	return config, nil
-
 }

--- a/cmd/kubeadm/app/util/system/package_validator.go
+++ b/cmd/kubeadm/app/util/system/package_validator.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 
 	errorsutil "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog"
 )
 
 // semVerDotsCount is the number of dots in a valid semantic version.
@@ -127,7 +126,6 @@ func (validator *packageValidator) validate(packageSpecs []PackageSpec, manager 
 		// Get the version of the package on the running machine.
 		version, err := manager.getPackageVersion(packageName)
 		if err != nil {
-			klog.V(1).Infof("Failed to get the version for the package %q: %s\n", packageName, err)
 			errs = append(errs, err)
 			validator.reporter.Report(nameWithVerRange, "not installed", bad)
 			continue
@@ -145,7 +143,6 @@ func (validator *packageValidator) validate(packageSpecs []PackageSpec, manager 
 		// the version is in the range.
 		sv, err := semver.Make(toSemVer(version))
 		if err != nil {
-			klog.Errorf("Failed to convert %q to semantic version: %s\n", version, err)
 			errs = append(errs, err)
 			validator.reporter.Report(nameWithVerRange, "internal error", bad)
 			continue


### PR DESCRIPTION
Removed klog from validators. All errors and warnings are returned as such.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
xref: https://github.com/kubernetes/kubeadm/issues/1738
this only addresses the klog part, a follow up with the errors will be later.

**Special notes for your reviewer**:
Again, at this point i'm just looking for feedback, not really happy with it myself.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
