### PR TITLE
delete lo network when TearDownPod to avoid CNI cache leak

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -328,6 +328,14 @@ func (plugin *cniNetworkPlugin) TearDownPod(namespace string, name string, id ku
 		klog.Warningf("CNI failed to retrieve network namespace path: %v", err)
 	}
 
+	// Windows doesn't have loNetwork. It comes only with Linux
+	if plugin.loNetwork != nil {
+		// Loopback network deletion failure should not be fatal on teardown
+		if err := plugin.deleteFromNetwork(plugin.loNetwork, name, namespace, id, netnsPath, nil); err != nil {
+			klog.Warningf("CNI failed to delete loopback network: %v", err)
+		}
+	}
+
 	return plugin.deleteFromNetwork(plugin.getDefaultNetwork(), name, namespace, id, netnsPath, nil)
 }
 

--- a/pkg/kubelet/dockershim/network/cni/cni_test.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_test.go
@@ -226,6 +226,7 @@ func TestCNIPlugin(t *testing.T) {
 	cniPlugin.loNetwork.CNIConfig = mockLoCNI
 
 	mockLoCNI.On("AddNetworkList", context.TODO(), cniPlugin.loNetwork.NetworkConfig, mock.AnythingOfType("*libcni.RuntimeConf")).Return(&types020.Result{IP4: &types020.IPConfig{IP: net.IPNet{IP: []byte{127, 0, 0, 1}}}}, nil)
+	mockLoCNI.On("DelNetworkList", context.TODO(), cniPlugin.loNetwork.NetworkConfig, mock.AnythingOfType("*libcni.RuntimeConf")).Return(nil)
 
 	// Check that status returns an error
 	if err := cniPlugin.Status(); err == nil {

--- a/pkg/kubelet/dockershim/network/kubenet/BUILD
+++ b/pkg/kubelet/dockershim/network/kubenet/BUILD
@@ -109,6 +109,8 @@ go_test(
             "//pkg/util/iptables/testing:go_default_library",
             "//pkg/util/sysctl/testing:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+            "//vendor/github.com/containernetworking/cni/libcni:go_default_library",
+            "//vendor/github.com/containernetworking/cni/pkg/types:go_default_library",
             "//vendor/github.com/stretchr/testify/assert:go_default_library",
             "//vendor/github.com/stretchr/testify/mock:go_default_library",
             "//vendor/k8s.io/utils/exec:go_default_library",

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
@@ -499,6 +499,11 @@ func (plugin *kubenetNetworkPlugin) SetUpPod(namespace string, name string, id k
 func (plugin *kubenetNetworkPlugin) teardown(namespace string, name string, id kubecontainer.ContainerID) error {
 	errList := []error{}
 
+	// Loopback network deletion failure should not be fatal on teardown
+	if err := plugin.delContainerFromNetwork(plugin.loConfig, "lo", namespace, name, id); err != nil {
+		klog.Warningf("Failed to delete loopback network: %v", err)
+	}
+
 	// no ip dependent actions
 	if err := plugin.delContainerFromNetwork(plugin.netConfig, network.DefaultInterfaceName, namespace, name, id); err != nil {
 		errList = append(errList, err)

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux_test.go
@@ -18,11 +18,13 @@ package kubenet
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/containernetworking/cni/libcni"
+	"github.com/containernetworking/cni/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	"strings"
-
-	"testing"
 
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
@@ -159,6 +161,12 @@ func TestTeardownCallsShaper(t *testing.T) {
 	mockcni := &mock_cni.MockCNI{}
 	ips := make(map[kubecontainer.ContainerID]utilsets.String)
 	kubenet := newFakeKubenetPlugin(ips, fexec, fhost)
+	kubenet.loConfig = &libcni.NetworkConfig{
+		Network: &types.NetConf{
+			Name: "loopback-fake",
+			Type: "loopback",
+		},
+	}
 	kubenet.cniConfig = mockcni
 	kubenet.iptables = ipttest.NewFake()
 	kubenet.bandwidthShaper = fshaper
@@ -255,6 +263,12 @@ func TestTearDownWithoutRuntime(t *testing.T) {
 
 		ips := make(map[kubecontainer.ContainerID]utilsets.String)
 		kubenet := newFakeKubenetPlugin(ips, fexec, fhost)
+		kubenet.loConfig = &libcni.NetworkConfig{
+			Network: &types.NetConf{
+				Name: "loopback-fake",
+				Type: "loopback",
+			},
+		}
 		kubenet.cniConfig = mockcni
 		kubenet.iptables = ipttest.NewFake()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Libcni in vendor has been updated to v0.7.1, it will [cache some results](https://github.com/kubernetes/kubernetes/blob/f1453953b703a0cb8cb47dbdfde4c9be846f8350/vendor/github.com/containernetworking/cni/libcni/api.go#L263) on disk during adding CNI network, if we don't delete CNI network, the cache files will be left on disk forever which will cause leak problem, such as running out of iNode.

Maybe in the future, libcni will do some improvements on this, but we need to delete lo network when TearDownPod to avoid CNI cache leak now.

**Special notes for your reviewer**:
[libcni release v0.7.0](https://github.com/containernetworking/cni/releases/tag/v0.7.0)

```release-note
NONE
```
