### PR TITLE
[FEATURE BRANCH] use shuffle sharding validation in flowcontrol

### DIFF
--- a/pkg/apis/flowcontrol/validation/BUILD
+++ b/pkg/apis/flowcontrol/validation/BUILD
@@ -11,6 +11,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/shufflesharding:go_default_library",
     ],
 )
 

--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -416,6 +416,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 				field.Invalid(field.NewPath("spec").Child("assuredConcurrencyShares"), int32(0), "must be positive"),
 				field.Invalid(field.NewPath("spec").Child("queueLengthLimit"), int32(0), "must be positive"),
 				field.Invalid(field.NewPath("spec").Child("queues"), int32(0), "must be positive"),
+				field.Invalid(field.NewPath("spec").Child("handSize"), int32(0), "handSize is not positive; deckSize is not positive"),
 			},
 		},
 		{
@@ -432,7 +433,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 				},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("handSize"), int32(8), "falling factorial of handSize (8) and queues (512) exceeds 60 bits"),
+				field.Invalid(field.NewPath("spec").Child("handSize"), int32(8), "more than 60 bits of entropy required"),
 			},
 		},
 		{
@@ -449,7 +450,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 				},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("handSize"), int32(10), "falling factorial of handSize (10) and queues (128) exceeds 60 bits"),
+				field.Invalid(field.NewPath("spec").Child("handSize"), int32(10), "more than 60 bits of entropy required"),
 			},
 		},
 		{
@@ -466,7 +467,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 				},
 			},
 			expectedErrors: field.ErrorList{
-				field.Invalid(field.NewPath("spec").Child("handSize"), int32(3), "falling factorial of handSize (3) and queues (2147483647) exceeds 60 bits"),
+				field.Invalid(field.NewPath("spec").Child("handSize"), int32(3), "more than 60 bits of entropy required"),
 			},
 		},
 		{
@@ -499,6 +500,7 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 			},
 			expectedErrors: field.ErrorList{
 				field.Invalid(field.NewPath("spec").Child("handSize"), int32(8), "should not be greater than queues (7)"),
+				field.Invalid(field.NewPath("spec").Child("handSize"), int32(8), "handSize is greater than deckSize"),
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Make flowcontrol use validation in shuffle sharding to avoid duplication of validation functions, easier to maintain.


```release-note
None
```