### PR TITLE
kubeadm: fix upgrade checks

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/policy.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy.go
@@ -71,7 +71,7 @@ func EnforceVersionPolicies(versionGetter VersionGetter, newK8sVersionStr string
 	}
 
 	// Make sure the new version is a supported version (higher than the minimum one supported)
-	if constants.MinimumControlPlaneVersion.AtLeast(newK8sVersion) {
+	if !newK8sVersion.AtLeast(constants.MinimumControlPlaneVersion) {
 		// This must not happen, kubeadm always supports a minimum version; and we can't go below that
 		skewErrors.Mandatory = append(skewErrors.Mandatory, errors.Errorf("Specified version to upgrade to %q is equal to or lower than the minimum supported version %q. Please specify a higher version to upgrade to", newK8sVersionStr, clusterVersionStr))
 	}

--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -191,6 +191,15 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			newK8sVersion:         constants.MinimumControlPlaneVersion.WithPatch(6).String(),
 			expectedSkippableErrs: 1, // can't upgrade old k8s with newer kubeadm
 		},
+		{
+			name: "build release supported at MinimumControlPlaneVersion",
+			vg: &fakeVersionGetter{
+				clusterVersion: constants.MinimumControlPlaneVersion.String(),
+				kubeletVersion: constants.MinimumControlPlaneVersion.String(),
+				kubeadmVersion: constants.MinimumControlPlaneVersion.WithBuildeMetadata("build").String(),
+			},
+			newK8sVersion: constants.MinimumControlPlaneVersion.WithBuildeMetadata("build").String(),
+		},
 	}
 
 	for _, rt := range tests {

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -183,6 +183,14 @@ func (v *Version) WithPreRelease(preRelease string) *Version {
 	return &result
 }
 
+// WithBuildeMetadata returns copy of the version object with requested buildMetadata
+func (v *Version) WithBuildeMetadata(buildMetadata string) *Version {
+	result := *v
+	result.components = []uint{v.Major(), v.Minor(), v.Patch()}
+	result.buildMetadata = buildMetadata
+	return &result
+}
+
 // String converts a Version back to a string; note that for versions parsed with
 // ParseGeneric, this will not include the trailing uninterpreted portion of the version
 // number.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kubeadm upgrade executes a set of checks before doing upgrades, including also a check for ensuring the target version is >= than the minimum supported version.

However, this check currently fails when we are upgrading to the minimum supported version+buildmetadata, which instead should be acceptable.
This PR fixes this problem

**Which issue(s) this PR fixes**:
Fixes #https://github.com/kubernetes/kubeadm/issues/1749

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```