### PR TITLE
remove slice dependency from service_controller

### DIFF
--- a/pkg/controller/service/BUILD
+++ b/pkg/controller/service/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/features:go_default_library",
         "//pkg/util/metrics:go_default_library",
-        "//pkg/util/slice:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/controller/service/service_controller.go
+++ b/pkg/controller/service/service_controller.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/util/metrics"
-	"k8s.io/kubernetes/pkg/util/slice"
 )
 
 const (
@@ -818,11 +817,23 @@ func (s *ServiceController) removeFinalizer(service *v1.Service) error {
 
 	// Make a copy so we don't mutate the shared informer cache.
 	updated := service.DeepCopy()
-	updated.ObjectMeta.Finalizers = slice.RemoveString(updated.ObjectMeta.Finalizers, servicehelper.LoadBalancerCleanupFinalizer, nil)
+	updated.ObjectMeta.Finalizers = removeString(updated.ObjectMeta.Finalizers, servicehelper.LoadBalancerCleanupFinalizer)
 
 	klog.V(2).Infof("Removing finalizer from service %s/%s", updated.Namespace, updated.Name)
 	_, err := patch(s.kubeClient.CoreV1(), service, updated)
 	return err
+}
+
+// removeString returns a newly created []string that contains all items from slice that
+// are not equal to s.
+func removeString(slice []string, s string) []string {
+	var newSlice []string
+	for _, item := range slice {
+		if item != s {
+			newSlice = append(newSlice, item)
+		}
+	}
+	return newSlice
 }
 
 // patchStatus patches the service with the given LoadBalancerStatus.


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>

**What type of PR is this?**

/kind cleanup
/priority important-soon

**What this PR does / why we need it**: removes the slice dependency by copying the removeString function and simplifying it 

**Which issue(s) this PR fixes**: part of #81172

**Special notes for your reviewer**:

see https://github.com/kubernetes/utils/pull/110#pullrequestreview-278624064 and https://github.com/kubernetes/kubernetes/pull/81605#issuecomment-524037893

/assign @liggitt @andrewsykim 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
