### PR TITLE
Split defaultPrintHandler from handlerEntry in table printing

### DIFF
--- a/pkg/printers/tableprinter_test.go
+++ b/pkg/printers/tableprinter_test.go
@@ -41,7 +41,7 @@ func testPrintNamespace(obj *corev1.Namespace, options PrintOptions) ([]metav1be
 	row := metav1beta1.TableRow{
 		Object: runtime.RawExtension{Object: obj},
 	}
-	row.Cells = append(row.Cells, obj.Name, obj.Status.Phase, "<unknow>")
+	row.Cells = append(row.Cells, obj.Name, obj.Status.Phase, "<unknown>")
 	return []metav1beta1.TableRow{row}, nil
 }
 
@@ -50,7 +50,7 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 
 	testCase := []struct {
 		name          string
-		h             *handlerEntry
+		h             *printHandler
 		opt           PrintOptions
 		eventType     string
 		obj           runtime.Object
@@ -60,7 +60,7 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 	}{
 		{
 			name: "no tablecolumndefinition and includeheader flase",
-			h: &handlerEntry{
+			h: &printHandler{
 				columnDefinitions: []metav1beta1.TableColumnDefinition{},
 				printFunc:         printFunc,
 			},
@@ -69,11 +69,11 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: false,
-			expectOut:     "test\t\t<unknow>\n",
+			expectOut:     "test\t\t<unknown>\n",
 		},
 		{
 			name: "no tablecolumndefinition and includeheader true",
-			h: &handlerEntry{
+			h: &printHandler{
 				columnDefinitions: []metav1beta1.TableColumnDefinition{},
 				printFunc:         printFunc,
 			},
@@ -82,11 +82,11 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: true,
-			expectOut:     "\ntest\t\t<unknow>\n",
+			expectOut:     "\ntest\t\t<unknown>\n",
 		},
 		{
 			name: "have tablecolumndefinition and includeheader true",
-			h: &handlerEntry{
+			h: &printHandler{
 				columnDefinitions: testNamespaceColumnDefinitions,
 				printFunc:         printFunc,
 			},
@@ -95,11 +95,11 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: true,
-			expectOut:     "NAME\tSTATUS\tAGE\ntest\t\t<unknow>\n",
+			expectOut:     "NAME\tSTATUS\tAGE\ntest\t\t<unknown>\n",
 		},
 		{
 			name: "with event type",
-			h: &handlerEntry{
+			h: &printHandler{
 				columnDefinitions: testNamespaceColumnDefinitions,
 				printFunc:         printFunc,
 			},
@@ -109,11 +109,11 @@ func TestPrintRowsForHandlerEntry(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 			},
 			includeHeader: true,
-			expectOut:     "EVENT\tNAME\tSTATUS\tAGE\nADDED   \ttest\t\t<unknow>\n",
+			expectOut:     "EVENT\tNAME\tSTATUS\tAGE\nADDED   \ttest\t\t<unknown>\n",
 		},
 		{
 			name: "print namespace and withnamespace true, should not print header",
-			h: &handlerEntry{
+			h: &printHandler{
 				columnDefinitions: testNamespaceColumnDefinitions,
 				printFunc:         printFunc,
 			},


### PR DESCRIPTION
* Continues kubectl printing refactor by splitting `printHandler` from `handlerEntry` in table printing. This is necessary to eventually move table printing out of kubernetes core.
* Fixes typo in table printing test.

/kind cleanup
/sig cli
/area kubectl
/area code-organization
/priority important-soon

```release-note
NONE
```