### PR TITLE
Modified to unified providerID format

### DIFF
--- a/pkg/cloudprovider/providers/fake/fake.go
+++ b/pkg/cloudprovider/providers/fake/fake.go
@@ -55,6 +55,7 @@ type FakeCloud struct {
 	ErrByProviderID         error
 	NodeShutdown            bool
 	ErrShutdownByProviderID error
+	ErrInstanceID           error
 
 	Calls         []string
 	Addresses     []v1.NodeAddress
@@ -234,7 +235,7 @@ func (f *FakeCloud) NodeAddressesByProviderID(ctx context.Context, providerID st
 // InstanceID returns the cloud provider ID of the node with the specified Name.
 func (f *FakeCloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	f.addCall("instance-id")
-	return f.ExtID[nodeName], nil
+	return f.ExtID[nodeName], f.ErrInstanceID
 }
 
 // InstanceType returns the type of the specified instance.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Modified to unified providerID format.
I think instances.InstanceExistsByProviderID's providerID is needed `<provider name>://<instance id>` format.
But currently 2 patterns exists like below:
- `<provider name>://<instance id>`
- `<instance id>`


**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
