### PR TITLE
New extended resources kublet flag

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -248,9 +248,9 @@ func ValidateKubeletFlags(f *KubeletFlags) error {
 	}
 
 	for k, v := range f.NodeExtendedResources {
-		// This is possibly a little more restrictive then necessary, but all pure integers are valid Quantities
+		// This is possibly a little more restrictive than necessary, but all pure integers are valid Quantities
 		if i, err := strconv.ParseInt(v, 10, 64); err != nil || i < 0 {
-			return fmt.Errorf("node extended resources must be whole 64-bit signed (but non-negative) integers. Instead we saw %s=%s", k, v)
+			return fmt.Errorf("node extended resources must be 64bit signed (but non-negative) integers; saw %s=%s", k, v)
 		}
 	}
 

--- a/cmd/kubelet/app/options/options_test.go
+++ b/cmd/kubelet/app/options/options_test.go
@@ -146,7 +146,7 @@ func asArgs(fn, defaultFn func(*pflag.FlagSet)) []string {
 	return args
 }
 
-func TestValidateKubeletFlags(t *testing.T) {
+func TestValidateKubeletLabelFlags(t *testing.T) {
 	tests := []struct {
 		name   string
 		error  bool
@@ -185,6 +185,58 @@ func TestValidateKubeletFlags(t *testing.T) {
 
 			if !tt.error && err != nil {
 				t.Errorf("ValidateKubeletFlags should not have failed with labels: %+v", tt.labels)
+			}
+		})
+	}
+
+}
+
+func TestValidateKubeletResourceFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		error     bool
+		resources map[string]string
+	}{
+		{
+			name:  "Invalid resource (not integer)",
+			error: true,
+			resources: map[string]string{
+				"example.com/dongle": "4.5",
+			},
+		},
+		{
+			name:  "Invalid resource (negative)",
+			error: true,
+			resources: map[string]string{
+				"example.com/dongle": "-4",
+			},
+		},
+		{
+			name:  "Valid resource",
+			error: false,
+			resources: map[string]string{
+				"example.com/dongle": "4",
+			},
+		},
+		{
+			name:      "Empty resource list",
+			error:     false,
+			resources: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateKubeletFlags(&KubeletFlags{
+				NodeExtendedResources: tt.resources,
+			})
+
+			if tt.error && err == nil {
+				t.Errorf("ValidateKubeletFlags should have failed with resources: %+v", tt.resources)
+			}
+
+			if !tt.error && err != nil {
+				t.Errorf("ValidateKubeletFlags should not have failed with resources: %+v", tt.resources)
 			}
 		})
 	}

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1164,7 +1164,8 @@ func createAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32) (k kubelet.Bootstrap, err error) {
+	nodeStatusMaxImages int32,
+	nodeExtendedResources map[string]string) (k kubelet.Bootstrap, err error) {
 	// TODO: block until all sources have delivered at least one update to the channel, or break the sync loop
 	// up into "per source" synchronizations
 
@@ -1198,7 +1199,8 @@ func createAndInitKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		nodeLabels,
 		seccompProfileRoot,
 		bootstrapCheckpointPath,
-		nodeStatusMaxImages)
+		nodeStatusMaxImages,
+		nodeExtendedResources)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -361,7 +361,8 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	nodeLabels map[string]string,
 	seccompProfileRoot string,
 	bootstrapCheckpointPath string,
-	nodeStatusMaxImages int32) (*Kubelet, error) {
+	nodeStatusMaxImages int32,
+	nodeExtendedResources map[string]string) (*Kubelet, error) {
 	if rootDirectory == "" {
 		return nil, fmt.Errorf("invalid root directory %q", rootDirectory)
 	}
@@ -543,6 +544,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		experimentalHostUserNamespaceDefaulting: utilfeature.DefaultFeatureGate.Enabled(features.ExperimentalHostUserNamespaceDefaultingGate),
 		keepTerminatedPodVolumes:                keepTerminatedPodVolumes,
 		nodeStatusMaxImages:                     nodeStatusMaxImages,
+		nodeExtendedResources:                   nodeExtendedResources,
 	}
 
 	if klet.cloud != nil {
@@ -1221,6 +1223,9 @@ type Kubelet struct {
 
 	// This flag sets a maximum number of images to report in the node status.
 	nodeStatusMaxImages int32
+
+	// This flag sets static extended resources to report in the node status
+	nodeExtendedResources map[string]string
 
 	// Handles RuntimeClass objects for the Kubelet.
 	runtimeClassManager *runtimeclass.Manager

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -548,6 +548,7 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(*v1.Node) error {
 	var setters []func(n *v1.Node) error
 	setters = append(setters,
 		nodestatus.NodeAddress(kl.nodeIP, kl.nodeIPValidator, kl.hostname, kl.hostnameOverridden, kl.externalCloudProvider, kl.cloud, nodeAddressesFunc),
+		nodestatus.MachineExtendedResources(kl.nodeExtendedResources),
 		nodestatus.MachineInfo(string(kl.nodeName), kl.maxPods, kl.podsPerCore, kl.GetCachedMachineInfo, kl.containerManager.GetCapacity,
 			kl.containerManager.GetDevicePluginResourceCapacity, kl.containerManager.GetNodeAllocatableReservation, kl.recordEvent),
 		nodestatus.VersionInfo(kl.cadvisor.VersionInfo, kl.containerRuntime.Type, kl.containerRuntime.Version),

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -184,6 +184,11 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 			defer testKubelet.Cleanup()
 			kubelet := testKubelet.kubelet
 			kubelet.nodeStatusMaxImages = tc.nodeStatusMaxImages
+			kubelet.nodeExtendedResources = map[string]string{
+				"example.com/dongle": "4",
+				// Assert that we clobber whatever "extended" resources with the built-in ones
+				string(v1.ResourceCPU): "7777",
+			}
 			kubelet.kubeClient = nil // ensure only the heartbeat client is used
 			kubelet.containerManager = &localCM{
 				ContainerManager: cm.NewStubContainerManager(),
@@ -265,16 +270,18 @@ func TestUpdateNewNodeStatus(t *testing.T) {
 						KubeProxyVersion:        version.Get().String(),
 					},
 					Capacity: v1.ResourceList{
-						v1.ResourceCPU:              *resource.NewMilliQuantity(2000, resource.DecimalSI),
-						v1.ResourceMemory:           *resource.NewQuantity(10e9, resource.BinarySI),
-						v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
-						v1.ResourceEphemeralStorage: *resource.NewQuantity(5000, resource.BinarySI),
+						v1.ResourceCPU:                        *resource.NewMilliQuantity(2000, resource.DecimalSI),
+						v1.ResourceMemory:                     *resource.NewQuantity(10e9, resource.BinarySI),
+						v1.ResourcePods:                       *resource.NewQuantity(0, resource.DecimalSI),
+						v1.ResourceEphemeralStorage:           *resource.NewQuantity(5000, resource.BinarySI),
+						v1.ResourceName("example.com/dongle"): *resource.NewQuantity(4, resource.DecimalSI),
 					},
 					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:              *resource.NewMilliQuantity(1800, resource.DecimalSI),
-						v1.ResourceMemory:           *resource.NewQuantity(9900e6, resource.BinarySI),
-						v1.ResourcePods:             *resource.NewQuantity(0, resource.DecimalSI),
-						v1.ResourceEphemeralStorage: *resource.NewQuantity(3000, resource.BinarySI),
+						v1.ResourceCPU:                        *resource.NewMilliQuantity(1800, resource.DecimalSI),
+						v1.ResourceMemory:                     *resource.NewQuantity(9900e6, resource.BinarySI),
+						v1.ResourcePods:                       *resource.NewQuantity(0, resource.DecimalSI),
+						v1.ResourceEphemeralStorage:           *resource.NewQuantity(3000, resource.BinarySI),
+						v1.ResourceName("example.com/dongle"): *resource.NewQuantity(4, resource.DecimalSI),
 					},
 					Addresses: []v1.NodeAddress{
 						{Type: v1.NodeInternalIP, Address: "127.0.0.1"},

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -227,6 +227,22 @@ func hasAddressValue(addresses []v1.NodeAddress, addressValue string) bool {
 	return false
 }
 
+func MachineExtendedResources(nodeExtendedResources map[string]string) Setter {
+	return func(node *v1.Node) error {
+		if node.Status.Capacity == nil {
+			node.Status.Capacity = v1.ResourceList{}
+		}
+		for k, v := range nodeExtendedResources {
+			q, err := resource.ParseQuantity(v)
+			if err != nil {
+				return err
+			}
+			node.Status.Capacity[v1.ResourceName(k)] = q
+		}
+		return nil
+	}
+}
+
 // MachineInfo returns a Setter that updates machine-related information on the node.
 func MachineInfo(nodeName string,
 	maxPods int,

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -355,6 +355,37 @@ func TestNodeAddress(t *testing.T) {
 	}
 }
 
+func TestMachineExtendedResources(t *testing.T) {
+	existingNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, Annotations: make(map[string]string)},
+		Spec:       v1.NodeSpec{},
+		Status: v1.NodeStatus{
+			Capacity: v1.ResourceList{
+				"pre-existing": resource.MustParse("0"),
+			},
+		},
+	}
+
+	// construct setter
+	setter := MachineExtendedResources(map[string]string{
+		"com.example/dongle": "4",
+	})
+
+	// call setter on existing node
+	err := setter(existingNode)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expected := v1.ResourceList{
+		"pre-existing":       resource.MustParse("0"),
+		"com.example/dongle": resource.MustParse("4"),
+	}
+
+	assert.True(t, apiequality.Semantic.DeepEqual(expected, existingNode.Status.Capacity),
+		"Diff: %s", diff.ObjectDiff(expected, existingNode.Status.Capacity))
+}
+
 func TestMachineInfo(t *testing.T) {
 	const nodeName = "test-node"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Enables kubeadm configured nodes to start up advertising a specific set
of extended resources, instead of needing to wait for the node to
register in the API and send a specific PATCH to the node's status.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None that I could find, but both myself and one other person have raised the question in the sig-node slack channel.

**Special notes for your reviewer**:

I ignored the very good advice to not implement new kubelet flags because it's not clear to me how to define which subset of nodes get which KubeletConfiguration(s).

That said, I'm happy to learn more about component configs if you would help guide me in moving this config there and attaching it to the right nodes via `kubeadm`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Adds a --node-extended-resources flag to instruct the kubelet to register the node with statically defined extended resoures
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
