### PR TITLE
Modified providerID to unified format

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -134,7 +134,7 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 		return
 	}
 	// Node that isn't present according to the cloud provider shouldn't have its address updated
-	exists, err := ensureNodeExistsByProviderID(instances, node, cnc.cloud)
+	exists, err := ensureNodeExistsByProviderID(instances, node)
 	if err != nil {
 		// Continue to update node address when not sure the node is not exists
 		klog.Errorf("%v", err)
@@ -343,11 +343,11 @@ func excludeCloudTaint(taints []v1.Taint) []v1.Taint {
 
 // ensureNodeExistsByProviderID checks if the instance exists by the provider id,
 // If provider id in spec is empty it calls instanceId with node name to get provider id
-func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.Node, cloud cloudprovider.Interface) (bool, error) {
+func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.Node) (bool, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		var err error
-		providerID, err := cloudprovider.GetInstanceProviderID(context.TODO(), cloud, types.NodeName(node.Name))
+		providerID, err = instances.InstanceID(context.TODO(), types.NodeName(node.Name))
 		if err != nil {
 			if err == cloudprovider.InstanceNotFound {
 				return false, nil

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -347,7 +347,7 @@ func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.No
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		var err error
-		providerID, err := cloudprovider.GetInstanceProviderID(context.TODO(), cloud, types.NodeName(node.Name))
+		providerID, err = cloudprovider.GetInstanceProviderID(context.TODO(), cloud, types.NodeName(node.Name))
 		if err != nil {
 			if err == cloudprovider.InstanceNotFound {
 				return false, nil

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -134,7 +134,7 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 		return
 	}
 	// Node that isn't present according to the cloud provider shouldn't have its address updated
-	exists, err := ensureNodeExistsByProviderID(instances, node)
+	exists, err := ensureNodeExistsByProviderID(instances, node, cnc.cloud)
 	if err != nil {
 		// Continue to update node address when not sure the node is not exists
 		klog.Errorf("%v", err)
@@ -343,11 +343,11 @@ func excludeCloudTaint(taints []v1.Taint) []v1.Taint {
 
 // ensureNodeExistsByProviderID checks if the instance exists by the provider id,
 // If provider id in spec is empty it calls instanceId with node name to get provider id
-func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.Node) (bool, error) {
+func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.Node, cloud cloudprovider.Interface) (bool, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		var err error
-		providerID, err = instances.InstanceID(context.TODO(), types.NodeName(node.Name))
+		providerID, err := cloudprovider.GetInstanceProviderID(context.TODO(), cloud, types.NodeName(node.Name))
 		if err != nil {
 			if err == cloudprovider.InstanceNotFound {
 				return false, nil

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -134,7 +134,7 @@ func (cnc *CloudNodeController) updateNodeAddress(node *v1.Node, instances cloud
 		return
 	}
 	// Node that isn't present according to the cloud provider shouldn't have its address updated
-	exists, err := ensureNodeExistsByProviderID(instances, node)
+	exists, err := ensureNodeExistsByProviderID(instances, node, cnc.cloud)
 	if err != nil {
 		// Continue to update node address when not sure the node is not exists
 		klog.Errorf("%v", err)
@@ -343,11 +343,11 @@ func excludeCloudTaint(taints []v1.Taint) []v1.Taint {
 
 // ensureNodeExistsByProviderID checks if the instance exists by the provider id,
 // If provider id in spec is empty it calls instanceId with node name to get provider id
-func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.Node) (bool, error) {
+func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.Node, cloud cloudprovider.Interface) (bool, error) {
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		var err error
-		providerID, err = instances.InstanceID(context.TODO(), types.NodeName(node.Name))
+		instanceID, err := instances.InstanceID(context.TODO(), types.NodeName(node.Name))
 		if err != nil {
 			if err == cloudprovider.InstanceNotFound {
 				return false, nil
@@ -355,10 +355,12 @@ func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.No
 			return false, err
 		}
 
-		if providerID == "" {
+		if instanceID == "" {
 			klog.Warningf("Cannot find valid providerID for node name %q, assuming non existence", node.Name)
 			return false, nil
 		}
+
+		providerID = cloudprovider.GenerateProviderID(cloud.ProviderName(), instanceID)
 	}
 
 	return instances.InstanceExistsByProviderID(context.TODO(), providerID)

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -347,7 +347,7 @@ func ensureNodeExistsByProviderID(instances cloudprovider.Instances, node *v1.No
 	providerID := node.Spec.ProviderID
 	if providerID == "" {
 		var err error
-		providerID, err = cloudprovider.GetInstanceProviderID(context.TODO(), cloud, types.NodeName(node.Name))
+		providerID, err := cloudprovider.GetInstanceProviderID(context.TODO(), cloud, types.NodeName(node.Name))
 		if err != nil {
 			if err == cloudprovider.InstanceNotFound {
 				return false, nil

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -18,6 +18,7 @@ package cloud
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -51,6 +52,7 @@ func TestEnsureNodeExistsByProviderID(t *testing.T) {
 		existsByProviderID bool
 		nodeNameErr        error
 		providerIDErr      error
+		errInstanceID      error
 	}{
 		{
 			testName:           "node exists by provider id",
@@ -104,8 +106,9 @@ func TestEnsureNodeExistsByProviderID(t *testing.T) {
 			testName:           "does not exist by no instance id",
 			existsByProviderID: true,
 			providerIDErr:      nil,
+			errInstanceID:      cloudprovider.InstanceNotFound,
 			hasInstanceID:      false,
-			nodeNameErr:        cloudprovider.InstanceNotFound,
+			nodeNameErr:        fmt.Errorf("failed to get instance ID from cloud provider: %v", cloudprovider.InstanceNotFound),
 			expectedCalls:      []string{"instance-id"},
 			expectedNodeExists: false,
 			node: &v1.Node{
@@ -137,19 +140,31 @@ func TestEnsureNodeExistsByProviderID(t *testing.T) {
 		t.Run(tc.testName, func(t *testing.T) {
 			fc := &fakecloud.Cloud{
 				ExistsByProviderID: tc.existsByProviderID,
-				Err:                tc.nodeNameErr,
 				ErrByProviderID:    tc.providerIDErr,
+				ErrInstanceID:      tc.errInstanceID,
 			}
 
 			if tc.hasInstanceID {
 				fc.ExtID = map[types.NodeName]string{
-					types.NodeName(tc.node.Name): "provider-id://a",
+					types.NodeName(tc.node.Name): "a",
 				}
 			}
 
 			instances, _ := fc.Instances()
-			exists, err := ensureNodeExistsByProviderID(instances, tc.node)
-			assert.Equal(t, err, tc.providerIDErr)
+			exists, err := ensureNodeExistsByProviderID(instances, tc.node, fc)
+
+			isInstanceExistsByProviderIDCalled := false
+			for _, called := range fc.Calls {
+				if called == "instance-exists-by-provider-id" {
+					isInstanceExistsByProviderIDCalled = true
+				}
+			}
+
+			if isInstanceExistsByProviderIDCalled {
+				assert.Equal(t, err, tc.providerIDErr)
+			} else {
+				assert.Equal(t, err, tc.nodeNameErr)
+			}
 
 			assert.EqualValues(t, tc.expectedCalls, fc.Calls,
 				"expected cloud provider methods `%v` to be called but `%v` was called ",

--- a/pkg/controller/cloud/node_lifecycle_controller.go
+++ b/pkg/controller/cloud/node_lifecycle_controller.go
@@ -166,7 +166,7 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 
 		// At this point the node has NotReady status, we need to check if the node has been removed
 		// from the cloud provider. If node cannot be found in cloudprovider, then delete the node
-		exists, err := ensureNodeExistsByProviderID(instances, node, c.cloud)
+		exists, err := ensureNodeExistsByProviderID(instances, node)
 		if err != nil {
 			klog.Errorf("error checking if node %s exists: %v", node.Name, err)
 			continue

--- a/pkg/controller/cloud/node_lifecycle_controller.go
+++ b/pkg/controller/cloud/node_lifecycle_controller.go
@@ -166,7 +166,7 @@ func (c *CloudNodeLifecycleController) MonitorNodes() {
 
 		// At this point the node has NotReady status, we need to check if the node has been removed
 		// from the cloud provider. If node cannot be found in cloudprovider, then delete the node
-		exists, err := ensureNodeExistsByProviderID(instances, node)
+		exists, err := ensureNodeExistsByProviderID(instances, node, c.cloud)
 		if err != nil {
 			klog.Errorf("error checking if node %s exists: %v", node.Name, err)
 			continue

--- a/pkg/controller/cloud/node_lifecycle_controller_test.go
+++ b/pkg/controller/cloud/node_lifecycle_controller_test.go
@@ -67,7 +67,9 @@ func Test_NodesDeleted(t *testing.T) {
 				Clientset:    fake.NewSimpleClientset(),
 			},
 			fakeCloud: &fakecloud.Cloud{
-				ExistsByProviderID: false,
+				ExistsByProviderIDFunc: func(providerID string) (bool, error) {
+					return false, nil
+				},
 			},
 			deleteNodes: []*v1.Node{
 				testutil.NewNode("node0"),
@@ -101,8 +103,9 @@ func Test_NodesDeleted(t *testing.T) {
 				Clientset:    fake.NewSimpleClientset(),
 			},
 			fakeCloud: &fakecloud.Cloud{
-				ExistsByProviderID: false,
-				ErrByProviderID:    errors.New("err!"),
+				ExistsByProviderIDFunc: func(providerID string) (bool, error) {
+					return false, errors.New("err!")
+				},
 			},
 			deleteNodes: []*v1.Node{},
 		},
@@ -134,7 +137,9 @@ func Test_NodesDeleted(t *testing.T) {
 				Clientset:    fake.NewSimpleClientset(),
 			},
 			fakeCloud: &fakecloud.Cloud{
-				ExistsByProviderID: true,
+				ExistsByProviderIDFunc: func(providerID string) (bool, error) {
+					return true, nil
+				},
 			},
 			deleteNodes: []*v1.Node{},
 		},
@@ -163,7 +168,9 @@ func Test_NodesDeleted(t *testing.T) {
 				Clientset:    fake.NewSimpleClientset(),
 			},
 			fakeCloud: &fakecloud.Cloud{
-				ExistsByProviderID: false,
+				ExistsByProviderIDFunc: func(providerID string) (bool, error) {
+					return false, nil
+				},
 			},
 			deleteNodes: []*v1.Node{
 				testutil.NewNode("node0"),
@@ -194,8 +201,10 @@ func Test_NodesDeleted(t *testing.T) {
 				Clientset:    fake.NewSimpleClientset(),
 			},
 			fakeCloud: &fakecloud.Cloud{
-				NodeShutdown:       false,
-				ExistsByProviderID: true,
+				NodeShutdown: false,
+				ExistsByProviderIDFunc: func(providerID string) (bool, error) {
+					return true, nil
+				},
 				ExtID: map[types.NodeName]string{
 					types.NodeName("node0"): "foo://12345",
 				},
@@ -230,7 +239,9 @@ func Test_NodesDeleted(t *testing.T) {
 				Clientset:    fake.NewSimpleClientset(),
 			},
 			fakeCloud: &fakecloud.Cloud{
-				ExistsByProviderID: false,
+				ExistsByProviderIDFunc: func(providerID string) (bool, error) {
+					return false, nil
+				},
 			},
 			deleteNodes: []*v1.Node{},
 		},

--- a/staging/src/k8s.io/cloud-provider/cloud.go
+++ b/staging/src/k8s.io/cloud-provider/cloud.go
@@ -100,7 +100,12 @@ func GetInstanceProviderID(ctx context.Context, cloud Interface, nodeName types.
 	if err != nil {
 		return "", fmt.Errorf("failed to get instance ID from cloud provider: %v", err)
 	}
-	return cloud.ProviderName() + "://" + instanceID, nil
+	return GenerateProviderID(cloud.ProviderName(), instanceID), nil
+}
+
+// GenerateProviderID generate a ProviderID.
+func GenerateProviderID(providerName string, instanceID string) string {
+	return providerName + "://" + instanceID
 }
 
 // LoadBalancer is an abstract, pluggable interface for load balancers.

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -63,7 +63,6 @@ type Cloud struct {
 	ErrByProviderID         error
 	NodeShutdown            bool
 	ErrShutdownByProviderID error
-	ErrInstanceID           error
 
 	Calls         []string
 	Addresses     []v1.NodeAddress
@@ -256,7 +255,7 @@ func (f *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 // InstanceID returns the cloud provider ID of the node with the specified Name.
 func (f *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	f.addCall("instance-id")
-	return f.ExtID[nodeName], f.ErrInstanceID
+	return f.ExtID[nodeName], nil
 }
 
 // InstanceType returns the type of the specified instance.

--- a/staging/src/k8s.io/cloud-provider/fake/fake.go
+++ b/staging/src/k8s.io/cloud-provider/fake/fake.go
@@ -63,6 +63,7 @@ type Cloud struct {
 	ErrByProviderID         error
 	NodeShutdown            bool
 	ErrShutdownByProviderID error
+	ErrInstanceID           error
 
 	Calls         []string
 	Addresses     []v1.NodeAddress
@@ -255,7 +256,7 @@ func (f *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string
 // InstanceID returns the cloud provider ID of the node with the specified Name.
 func (f *Cloud) InstanceID(ctx context.Context, nodeName types.NodeName) (string, error) {
 	f.addCall("instance-id")
-	return f.ExtID[nodeName], nil
+	return f.ExtID[nodeName], f.ErrInstanceID
 }
 
 // InstanceType returns the type of the specified instance.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

Modified providerID to unified format.
I think instances.InstanceExistsByProviderID's providerID is needed `<provider name>://<instance id>` format.
But currently 2 patterns exists like below:
- `<provider name>://<instance id>`
- `<instance id>`

e.g.:
- https://github.com/kubernetes/cloud-provider-gcp/blob/10327d4a8324328120bd6ca89cc892508d7c702d/vendor/k8s.io/kubernetes/pkg/cloudprovider/providers/gce/gce_util.go#L204-L213
- https://github.com/digitalocean/digitalocean-cloud-controller-manager/blob/0c5aa3ceb86362f7198872fdee710219a1a20335/cloud-controller-manager/do/droplets.go#L218-L222

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
