### PR TITLE
Move CSI volume expansion to beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -108,7 +108,7 @@ const (
 	ExpandInUsePersistentVolumes featuregate.Feature = "ExpandInUsePersistentVolumes"
 
 	// owner: @gnufied
-	// alpha: v1.14
+	// beta: v1.16
 	// Ability to expand CSI volumes
 	ExpandCSIVolumes featuregate.Feature = "ExpandCSIVolumes"
 
@@ -495,7 +495,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	QOSReserved:                         {Default: false, PreRelease: featuregate.Alpha},
 	ExpandPersistentVolumes:             {Default: true, PreRelease: featuregate.Beta},
 	ExpandInUsePersistentVolumes:        {Default: true, PreRelease: featuregate.Beta},
-	ExpandCSIVolumes:                    {Default: false, PreRelease: featuregate.Alpha},
+	ExpandCSIVolumes:                    {Default: true, PreRelease: featuregate.Beta},
 	AttachVolumeLimit:                   {Default: true, PreRelease: featuregate.Beta},
 	CPUManager:                          {Default: true, PreRelease: featuregate.Beta},
 	CPUCFSQuotaPeriod:                   {Default: false, PreRelease: featuregate.Alpha},

--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -414,7 +414,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 		})
 	})
 
-	ginkgo.Context("CSI Volume expansion [Feature:ExpandCSIVolumes]", func() {
+	ginkgo.Context("CSI Volume expansion", func() {
 		tests := []struct {
 			name                    string
 			nodeExpansionRequired   bool
@@ -525,7 +525,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			})
 		}
 	})
-	ginkgo.Context("CSI online volume expansion [Feature:ExpandCSIVolumes][Feature:ExpandInUseVolumes]", func() {
+	ginkgo.Context("CSI online volume expansion", func() {
 		tests := []struct {
 			name          string
 			disableAttach bool


### PR DESCRIPTION
Move CSI volume expansion to beta.

xref - https://github.com/kubernetes/enhancements/issues/556

fixes https://github.com/kubernetes/kubernetes/issues/81166

/sig storage

```release-note
Move CSI volume expansion to beta
```

