### PR TITLE
Fix `test/integration/kubelet` staticcheck failures

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -115,7 +115,6 @@ test/integration/etcd
 test/integration/examples
 test/integration/framework
 test/integration/garbagecollector
-test/integration/kubelet
 test/integration/master
 test/integration/replicationcontroller
 test/integration/scale

--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -61,6 +61,7 @@ func TestWatchBasedManager(t *testing.T) {
 	// create 1000 secrets in parallel
 	t.Log(time.Now(), "creating 1000 secrets")
 	wg := sync.WaitGroup{}
+	errCh := make(chan error, 1)
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
@@ -68,17 +69,27 @@ func TestWatchBasedManager(t *testing.T) {
 			for j := 0; j < 100; j++ {
 				name := fmt.Sprintf("s%d", i*100+j)
 				if _, err := client.CoreV1().Secrets(testNamespace).Create(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name}}); err != nil {
-					t.Fatal(err)
+					select {
+					case errCh <- err:
+					default:
+					}
 				}
 			}
 			fmt.Print(".")
 		}(i)
 	}
+
 	wg.Wait()
+	select {
+	case err := <-errCh:
+		t.Fatal(err)
+	default:
+	}
 	t.Log(time.Now(), "finished creating 1000 secrets")
 
 	// fetch all secrets
 	wg = sync.WaitGroup{}
+	errCh = make(chan error, 1)
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(i int) {
@@ -99,7 +110,10 @@ func TestWatchBasedManager(t *testing.T) {
 					return true, nil
 				})
 				if err != nil {
-					t.Fatalf("failed on %s: %v", name, err)
+					select {
+					case errCh <- fmt.Errorf("failed on :%s: %v", name, err):
+					default:
+					}
 				}
 				if d := time.Since(start); d > time.Second {
 					t.Logf("%s took %v", name, d)
@@ -107,5 +121,11 @@ func TestWatchBasedManager(t *testing.T) {
 			}
 		}(i)
 	}
+
 	wg.Wait()
+	select {
+	case err = <-errCh:
+		t.Fatal(err)
+	default:
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`test/integration/kubelet` was failing staticcheck because it was
calling `t.Fatal` from the non-main Go routine. Address this by sending
errors causing t.Fatal back to a channel. The main thread can then
iterate through this channel, and call t.Fatal if there are any errors
in the channel.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
