### PR TITLE
startedLock is not needed for sharedIndexInformer#HasSynced

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -316,9 +316,6 @@ func (s *sharedIndexInformer) Run(stopCh <-chan struct{}) {
 }
 
 func (s *sharedIndexInformer) HasSynced() bool {
-	s.startedLock.Lock()
-	defer s.startedLock.Unlock()
-
 	if s.controller == nil {
 		return false
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In sharedIndexInformer#HasSynced, holding startedLock is not needed.
Once controller is given non-nil value, it wouldn't become nil.
Proper locking is done inside HasSynced.

This PR drops the startedLock from sharedIndexInformer#HasSynced.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
