### PR TITLE
Deprecate func's which may panic in thread_safe_store

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache.go
@@ -153,8 +153,7 @@ func (c *ExpirationCache) Add(obj interface{}) error {
 	c.expirationLock.Lock()
 	defer c.expirationLock.Unlock()
 
-	c.cacheStorage.Add(key, &TimestampedEntry{obj, c.clock.Now(), key})
-	return nil
+	return c.cacheStorage.Add(key, &TimestampedEntry{obj, c.clock.Now(), key})
 }
 
 // Update has not been implemented yet for lack of a use case, so this method
@@ -171,8 +170,7 @@ func (c *ExpirationCache) Delete(obj interface{}) error {
 	}
 	c.expirationLock.Lock()
 	defer c.expirationLock.Unlock()
-	c.cacheStorage.Delete(key)
-	return nil
+	return c.cacheStorage.Delete(key)
 }
 
 // Replace will convert all items in the given list to TimestampedEntries
@@ -190,8 +188,7 @@ func (c *ExpirationCache) Replace(list []interface{}, resourceVersion string) er
 	}
 	c.expirationLock.Lock()
 	defer c.expirationLock.Unlock()
-	c.cacheStorage.Replace(items, resourceVersion)
-	return nil
+	return c.cacheStorage.Replace(items, resourceVersion)
 }
 
 // Resync will touch all objects to put them into the processing queue

--- a/staging/src/k8s.io/client-go/tools/cache/expiration_cache_fakes.go
+++ b/staging/src/k8s.io/client-go/tools/cache/expiration_cache_fakes.go
@@ -26,11 +26,13 @@ type fakeThreadSafeMap struct {
 	deletedKeys chan<- string
 }
 
-func (c *fakeThreadSafeMap) Delete(key string) {
+func (c *fakeThreadSafeMap) Delete(key string) error {
 	if c.deletedKeys != nil {
-		c.ThreadSafeStore.Delete(key)
+		err := c.ThreadSafeStore.Delete(key)
 		c.deletedKeys <- key
+		return err
 	}
+	return nil
 }
 
 // FakeExpirationPolicy keeps the list for keys which never expires.

--- a/staging/src/k8s.io/client-go/tools/cache/store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store.go
@@ -125,8 +125,7 @@ func (c *cache) Add(obj interface{}) error {
 	if err != nil {
 		return KeyError{obj, err}
 	}
-	c.cacheStorage.Add(key, obj)
-	return nil
+	return c.cacheStorage.Add(key, obj)
 }
 
 // Update sets an item in the cache to its updated state.
@@ -135,8 +134,7 @@ func (c *cache) Update(obj interface{}) error {
 	if err != nil {
 		return KeyError{obj, err}
 	}
-	c.cacheStorage.Update(key, obj)
-	return nil
+	return c.cacheStorage.Update(key, obj)
 }
 
 // Delete removes an item from the cache.
@@ -145,8 +143,7 @@ func (c *cache) Delete(obj interface{}) error {
 	if err != nil {
 		return KeyError{obj, err}
 	}
-	c.cacheStorage.Delete(key)
-	return nil
+	return c.cacheStorage.Delete(key)
 }
 
 // List returns a list of all the items.
@@ -218,8 +215,7 @@ func (c *cache) Replace(list []interface{}, resourceVersion string) error {
 		}
 		items[key] = item
 	}
-	c.cacheStorage.Replace(items, resourceVersion)
-	return nil
+	return c.cacheStorage.Replace(items, resourceVersion)
 }
 
 // Resync touches all items in the store to force processing


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There are two places in thread_safe_store where we panic on error.

This PR removes the panic and returns the error to caller(s).

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
