### PR TITLE
Fix staticcheck failures for test/images

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -65,14 +65,6 @@ test/e2e/apps
 test/e2e/autoscaling
 test/e2e/instrumentation/logging/stackdriver
 test/e2e/instrumentation/monitoring
-test/images/agnhost/dns
-test/images/agnhost/inclusterclient
-test/images/agnhost/net/nat
-test/images/agnhost/netexec
-test/images/agnhost/pause
-test/images/agnhost/serve-hostname
-test/images/agnhost/webhook
-test/images/pets/peer-finder
 test/integration/auth
 test/integration/client
 test/integration/deployment

--- a/test/images/agnhost/dns/common.go
+++ b/test/images/agnhost/dns/common.go
@@ -17,10 +17,8 @@ limitations under the License.
 package dns
 
 import (
-	"bytes"
 	"fmt"
 	"io/ioutil"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -74,17 +72,4 @@ func readFile(fileName string) string {
 	}
 
 	return string(fileData)
-}
-
-func runCommand(name string, arg ...string) string {
-	var out bytes.Buffer
-	cmd := exec.Command(name, arg...)
-	cmd.Stdout = &out
-
-	err := cmd.Run()
-	if err != nil {
-		panic(err)
-	}
-
-	return strings.TrimSpace(out.String())
 }

--- a/test/images/agnhost/dns/dns_windows.go
+++ b/test/images/agnhost/dns/dns_windows.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dns
 
 import (
+	"bytes"
+	"os/exec"
 	"strings"
 )
 
@@ -38,4 +40,17 @@ func getDNSServerList() []string {
 	}
 
 	panic("Could not find DNS Server list!")
+}
+
+func runCommand(name string, arg ...string) string {
+	var out bytes.Buffer
+	cmd := exec.Command(name, arg...)
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	return strings.TrimSpace(out.String())
 }

--- a/test/images/agnhost/inclusterclient/main.go
+++ b/test/images/agnhost/inclusterclient/main.go
@@ -72,6 +72,7 @@ func main(cmd *cobra.Command, args []string) {
 
 	c := kubernetes.NewForConfigOrDie(cfg).RESTClient()
 
+	//lint:ignore SA1015 noisy positive, `time.Tick` is used in a main function which is fine
 	t := time.Tick(time.Duration(pollInterval) * time.Second)
 	for {
 		<-t

--- a/test/images/agnhost/net/nat/closewait.go
+++ b/test/images/agnhost/net/nat/closewait.go
@@ -38,6 +38,7 @@ import (
 
 // leakedConnection is a global variable that should leak the active
 // connection assigned here.
+//lint:ignore U1000 intentional unused variable
 var leakedConnection *net.TCPConn
 
 // CloseWaitServerOptions holds server JSON options.

--- a/test/images/agnhost/netexec/netexec.go
+++ b/test/images/agnhost/netexec/netexec.go
@@ -154,7 +154,7 @@ func exitHandler(w http.ResponseWriter, r *http.Request) {
 
 func hostnameHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("GET /hostname")
-	fmt.Fprintf(w, getHostName())
+	fmt.Fprint(w, getHostName())
 }
 
 // healthHandler response with a 200 if the UDP server is ready. It also serves
@@ -247,7 +247,7 @@ func dialHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	bytes, err := json.Marshal(output)
 	if err == nil {
-		fmt.Fprintf(w, string(bytes))
+		fmt.Fprint(w, string(bytes))
 	} else {
 		http.Error(w, fmt.Sprintf("response could not be serialized. %v", err), http.StatusExpectationFailed)
 	}
@@ -314,7 +314,7 @@ func shellHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("Output: %s", output)
 	bytes, err := json.Marshal(output)
 	if err == nil {
-		fmt.Fprintf(w, string(bytes))
+		fmt.Fprint(w, string(bytes))
 	} else {
 		http.Error(w, fmt.Sprintf("response could not be serialized. %v", err), http.StatusExpectationFailed)
 	}
@@ -328,7 +328,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		result["error"] = "Unable to upload file."
 		bytes, err := json.Marshal(result)
 		if err == nil {
-			fmt.Fprintf(w, string(bytes))
+			fmt.Fprint(w, string(bytes))
 		} else {
 			http.Error(w, fmt.Sprintf("%s. Also unable to serialize output. %v", result["error"], err), http.StatusInternalServerError)
 		}
@@ -342,7 +342,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		result["error"] = "Unable to open file for write"
 		bytes, err := json.Marshal(result)
 		if err == nil {
-			fmt.Fprintf(w, string(bytes))
+			fmt.Fprint(w, string(bytes))
 		} else {
 			http.Error(w, fmt.Sprintf("%s. Also unable to serialize output. %v", result["error"], err), http.StatusInternalServerError)
 		}
@@ -354,7 +354,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		result["error"] = "Unable to write file."
 		bytes, err := json.Marshal(result)
 		if err == nil {
-			fmt.Fprintf(w, string(bytes))
+			fmt.Fprint(w, string(bytes))
 		} else {
 			http.Error(w, fmt.Sprintf("%s. Also unable to serialize output. %v", result["error"], err), http.StatusInternalServerError)
 		}
@@ -367,7 +367,7 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 		result["error"] = "Unable to chmod file."
 		bytes, err := json.Marshal(result)
 		if err == nil {
-			fmt.Fprintf(w, string(bytes))
+			fmt.Fprint(w, string(bytes))
 		} else {
 			http.Error(w, fmt.Sprintf("%s. Also unable to serialize output. %v", result["error"], err), http.StatusInternalServerError)
 		}
@@ -378,12 +378,16 @@ func uploadHandler(w http.ResponseWriter, r *http.Request) {
 	result["output"] = UploadFile
 	w.WriteHeader(http.StatusCreated)
 	bytes, err := json.Marshal(result)
-	fmt.Fprintf(w, string(bytes))
+	if err != nil {
+		http.Error(w, fmt.Sprintf("%s. Also unable to serialize output. %v", result["error"], err), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprint(w, string(bytes))
 }
 
 func hostNameHandler(w http.ResponseWriter, r *http.Request) {
 	log.Printf("GET /hostName")
-	fmt.Fprintf(w, getHostName())
+	fmt.Fprint(w, getHostName())
 }
 
 // udp server supports the hostName, echo and clientIP commands.

--- a/test/images/agnhost/pause/pause.go
+++ b/test/images/agnhost/pause/pause.go
@@ -40,7 +40,6 @@ func pause(cmd *cobra.Command, args []string) {
 	done := make(chan int, 1)
 	signal.Notify(sigCh, syscall.SIGINT)
 	signal.Notify(sigCh, syscall.SIGTERM)
-	signal.Notify(sigCh, syscall.SIGKILL)
 	go func() {
 		sig := <-sigCh
 		switch sig {
@@ -50,9 +49,6 @@ func pause(cmd *cobra.Command, args []string) {
 		case syscall.SIGTERM:
 			done <- 2
 			os.Exit(2)
-		case syscall.SIGKILL:
-			done <- 0
-			os.Exit(0)
 		}
 	}()
 	result := <-done

--- a/test/images/agnhost/serve-hostname/serve_hostname.go
+++ b/test/images/agnhost/serve-hostname/serve_hostname.go
@@ -121,7 +121,7 @@ func main(cmd *cobra.Command, args []string) {
 		}()
 	}
 	log.Printf("Serving on port %d.\n", port)
-	signals := make(chan os.Signal)
+	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, syscall.SIGTERM)
 	sig := <-signals
 	log.Printf("Shutting down after receiving signal: %s.\n", sig)

--- a/test/images/agnhost/webhook/patch_test.go
+++ b/test/images/agnhost/webhook/patch_test.go
@@ -129,6 +129,9 @@ func TestJSONPatchForUnstructured(t *testing.T) {
 		t.Fatal(err)
 	}
 	patchedJS, err := patchObj.Apply(crJS)
+	if err != nil {
+		t.Fatal(err)
+	}
 	patchedObj := unstructured.Unstructured{}
 	err = json.Unmarshal(patchedJS, &patchedObj)
 	if err != nil {

--- a/test/images/pets/peer-finder/peer-finder.go
+++ b/test/images/pets/peer-finder/peer-finder.go
@@ -152,8 +152,8 @@ func main() {
 		script = *onChange
 		log.Printf("No on-start supplied, on-change %v will be applied on start.", script)
 	}
-	for newPeers, peers := sets.NewString(), sets.NewString(); script != ""; time.Sleep(pollPeriod) {
-		newPeers, err = lookup(*svc)
+	for peers := sets.NewString(); script != ""; time.Sleep(pollPeriod) {
+		newPeers, err := lookup(*svc)
 		if err != nil {
 			log.Printf("%v", err)
 			continue


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/priority important-longterm
/sig testing

**What this PR does / why we need it**:

Cleanup the `test/images` issues identified by staticcheck in #81189:
```
Errors from staticcheck:
test/images/agnhost/dns/common.go:79:6: func runCommand is unused (U1000)
test/images/agnhost/inclusterclient/main.go:75:16: using time.Tick leaks the underlying ticker, consider using it only in endless functions, tests and the main package, and use time.NewTicker here (SA1015)
test/images/agnhost/net/nat/closewait.go:41:5: var leakedConnection is unused (U1000)
test/images/agnhost/netexec/netexec.go:157:17: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:250:18: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:317:18: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:331:19: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:345:19: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:357:19: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:370:19: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:380:9: this value of err is never used (SA4006)
test/images/agnhost/netexec/netexec.go:381:17: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/netexec/netexec.go:386:17: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)
test/images/agnhost/pause/pause.go:43:23: syscall.SIGKILL cannot be trapped (did you mean syscall.SIGTERM?) (SA1016)
test/images/agnhost/serve-hostname/serve_hostname.go:125:15: the channel used with signal.Notify should be buffered (SA1017)
test/images/agnhost/webhook/patch_test.go:131:13: this value of err is never used (SA4006)
test/images/pets/peer-finder/peer-finder.go:155:6: this value of newPeers is never used (SA4006)
```

**Which issue(s) this PR fixes**:

#36858, #81657

**Special notes for your reviewer**:

None.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```