### PR TITLE
Compute webhook selectors and client once per webhookconfig revision

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/BUILD
@@ -9,6 +9,9 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/accessors.go
@@ -17,8 +17,14 @@ limitations under the License.
 package webhook
 
 import (
+	"sync"
+	"fmt"
+
 	"k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	webhookutil "k8s.io/apiserver/pkg/util/webhook"
+	"k8s.io/client-go/rest"
 )
 
 // WebhookAccessor provides a common interface to both mutating and validating webhook types.
@@ -28,6 +34,13 @@ type WebhookAccessor interface {
 
 	// GetConfigurationName gets the name of the webhook configuration that owns this webhook.
 	GetConfigurationName() string
+
+	// GetRESTClient gets the webhook client
+	GetRESTClient(clientManager *webhookutil.ClientManager) (*rest.RESTClient, error)
+	// GetParsedNamespaceSelector gets the webhook NamespaceSelector field.
+	GetParsedNamespaceSelector() (labels.Selector, error)
+	// GetParsedObjectSelector gets the webhook ObjectSelector field.
+	GetParsedObjectSelector() (labels.Selector, error)
 
 	// GetName gets the webhook Name field. Note that the name is scoped to the webhook
 	// configuration and does not provide a globally unique identity, if a unique identity is
@@ -60,134 +73,200 @@ type WebhookAccessor interface {
 
 // NewMutatingWebhookAccessor creates an accessor for a MutatingWebhook.
 func NewMutatingWebhookAccessor(uid, configurationName string, h *v1beta1.MutatingWebhook) WebhookAccessor {
-	return mutatingWebhookAccessor{uid: uid, configurationName: configurationName, MutatingWebhook: h}
+	return &mutatingWebhookAccessor{uid: uid, configurationName: configurationName, MutatingWebhook: h}
 }
 
 type mutatingWebhookAccessor struct {
 	*v1beta1.MutatingWebhook
 	uid               string
 	configurationName string
+
+	initObjectSelector sync.Once
+	objectSelector     labels.Selector
+	objectSelectorErr  error
+
+	initNamespaceSelector sync.Once
+	namespaceSelector     labels.Selector
+	namespaceSelectorErr  error
+
+	initClient sync.Once
+	client     *rest.RESTClient
+	clientErr  error
 }
 
-func (m mutatingWebhookAccessor) GetUID() string {
+func (m *mutatingWebhookAccessor) GetUID() string {
 	return m.uid
 }
 
-func (m mutatingWebhookAccessor) GetConfigurationName() string {
+func (m *mutatingWebhookAccessor) GetConfigurationName() string {
 	return m.configurationName
 }
 
-func (m mutatingWebhookAccessor) GetName() string {
+func (m *mutatingWebhookAccessor) GetRESTClient(clientManager *webhookutil.ClientManager) (*rest.RESTClient, error) {
+	m.initClient.Do(func() {
+		m.client, m.clientErr = nil, fmt.Errorf("unimplemented")
+	})
+	return m.client, m.clientErr
+}
+
+func (m *mutatingWebhookAccessor) GetParsedNamespaceSelector() (labels.Selector, error) {
+	m.initNamespaceSelector.Do(func() {
+		m.namespaceSelector, m.namespaceSelectorErr = metav1.LabelSelectorAsSelector(m.NamespaceSelector)
+	})
+	return m.namespaceSelector, m.namespaceSelectorErr
+}
+
+func (m *mutatingWebhookAccessor) GetParsedObjectSelector() (labels.Selector, error) {
+	m.initObjectSelector.Do(func() {
+		m.objectSelector, m.objectSelectorErr = metav1.LabelSelectorAsSelector(m.ObjectSelector)
+	})
+	return m.objectSelector, m.objectSelectorErr
+}
+
+func (m *mutatingWebhookAccessor) GetName() string {
 	return m.Name
 }
 
-func (m mutatingWebhookAccessor) GetClientConfig() v1beta1.WebhookClientConfig {
+func (m *mutatingWebhookAccessor) GetClientConfig() v1beta1.WebhookClientConfig {
 	return m.ClientConfig
 }
 
-func (m mutatingWebhookAccessor) GetRules() []v1beta1.RuleWithOperations {
+func (m *mutatingWebhookAccessor) GetRules() []v1beta1.RuleWithOperations {
 	return m.Rules
 }
 
-func (m mutatingWebhookAccessor) GetFailurePolicy() *v1beta1.FailurePolicyType {
+func (m *mutatingWebhookAccessor) GetFailurePolicy() *v1beta1.FailurePolicyType {
 	return m.FailurePolicy
 }
 
-func (m mutatingWebhookAccessor) GetMatchPolicy() *v1beta1.MatchPolicyType {
+func (m *mutatingWebhookAccessor) GetMatchPolicy() *v1beta1.MatchPolicyType {
 	return m.MatchPolicy
 }
 
-func (m mutatingWebhookAccessor) GetNamespaceSelector() *metav1.LabelSelector {
+func (m *mutatingWebhookAccessor) GetNamespaceSelector() *metav1.LabelSelector {
 	return m.NamespaceSelector
 }
 
-func (m mutatingWebhookAccessor) GetObjectSelector() *metav1.LabelSelector {
+func (m *mutatingWebhookAccessor) GetObjectSelector() *metav1.LabelSelector {
 	return m.ObjectSelector
 }
 
-func (m mutatingWebhookAccessor) GetSideEffects() *v1beta1.SideEffectClass {
+func (m *mutatingWebhookAccessor) GetSideEffects() *v1beta1.SideEffectClass {
 	return m.SideEffects
 }
 
-func (m mutatingWebhookAccessor) GetTimeoutSeconds() *int32 {
+func (m *mutatingWebhookAccessor) GetTimeoutSeconds() *int32 {
 	return m.TimeoutSeconds
 }
 
-func (m mutatingWebhookAccessor) GetAdmissionReviewVersions() []string {
+func (m *mutatingWebhookAccessor) GetAdmissionReviewVersions() []string {
 	return m.AdmissionReviewVersions
 }
 
-func (m mutatingWebhookAccessor) GetMutatingWebhook() (*v1beta1.MutatingWebhook, bool) {
+func (m *mutatingWebhookAccessor) GetMutatingWebhook() (*v1beta1.MutatingWebhook, bool) {
 	return m.MutatingWebhook, true
 }
 
-func (m mutatingWebhookAccessor) GetValidatingWebhook() (*v1beta1.ValidatingWebhook, bool) {
+func (m *mutatingWebhookAccessor) GetValidatingWebhook() (*v1beta1.ValidatingWebhook, bool) {
 	return nil, false
 }
 
 // NewValidatingWebhookAccessor creates an accessor for a ValidatingWebhook.
 func NewValidatingWebhookAccessor(uid, configurationName string, h *v1beta1.ValidatingWebhook) WebhookAccessor {
-	return validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
+	return &validatingWebhookAccessor{uid: uid, configurationName: configurationName, ValidatingWebhook: h}
 }
 
 type validatingWebhookAccessor struct {
 	*v1beta1.ValidatingWebhook
 	uid               string
 	configurationName string
+
+	initObjectSelector sync.Once
+	objectSelector     labels.Selector
+	objectSelectorErr  error
+
+	initNamespaceSelector sync.Once
+	namespaceSelector     labels.Selector
+	namespaceSelectorErr  error
+
+	initClient sync.Once
+	client     *rest.RESTClient
+	clientErr  error
 }
 
-func (v validatingWebhookAccessor) GetUID() string {
+func (v *validatingWebhookAccessor) GetUID() string {
 	return v.uid
 }
 
-func (v validatingWebhookAccessor) GetConfigurationName() string {
+func (v *validatingWebhookAccessor) GetConfigurationName() string {
 	return v.configurationName
 }
 
-func (v validatingWebhookAccessor) GetName() string {
+func (v *validatingWebhookAccessor) GetRESTClient(clientManager *webhookutil.ClientManager) (*rest.RESTClient, error) {
+	v.initClient.Do(func() {
+		v.client, v.clientErr = nil, fmt.Errorf("unimplemented")
+	})
+	return v.client, v.clientErr
+}
+
+func (v *validatingWebhookAccessor) GetParsedNamespaceSelector() (labels.Selector, error) {
+	v.initNamespaceSelector.Do(func() {
+		v.namespaceSelector, v.namespaceSelectorErr = metav1.LabelSelectorAsSelector(v.NamespaceSelector)
+	})
+	return v.namespaceSelector, v.namespaceSelectorErr
+}
+
+func (v *validatingWebhookAccessor) GetParsedObjectSelector() (labels.Selector, error) {
+	v.initObjectSelector.Do(func() {
+		v.objectSelector, v.objectSelectorErr = metav1.LabelSelectorAsSelector(v.ObjectSelector)
+	})
+	return v.objectSelector, v.objectSelectorErr
+}
+
+func (v *validatingWebhookAccessor) GetName() string {
 	return v.Name
 }
 
-func (v validatingWebhookAccessor) GetClientConfig() v1beta1.WebhookClientConfig {
+func (v *validatingWebhookAccessor) GetClientConfig() v1beta1.WebhookClientConfig {
 	return v.ClientConfig
 }
 
-func (v validatingWebhookAccessor) GetRules() []v1beta1.RuleWithOperations {
+func (v *validatingWebhookAccessor) GetRules() []v1beta1.RuleWithOperations {
 	return v.Rules
 }
 
-func (v validatingWebhookAccessor) GetFailurePolicy() *v1beta1.FailurePolicyType {
+func (v *validatingWebhookAccessor) GetFailurePolicy() *v1beta1.FailurePolicyType {
 	return v.FailurePolicy
 }
 
-func (v validatingWebhookAccessor) GetMatchPolicy() *v1beta1.MatchPolicyType {
+func (v *validatingWebhookAccessor) GetMatchPolicy() *v1beta1.MatchPolicyType {
 	return v.MatchPolicy
 }
 
-func (v validatingWebhookAccessor) GetNamespaceSelector() *metav1.LabelSelector {
+func (v *validatingWebhookAccessor) GetNamespaceSelector() *metav1.LabelSelector {
 	return v.NamespaceSelector
 }
 
-func (v validatingWebhookAccessor) GetObjectSelector() *metav1.LabelSelector {
+func (v *validatingWebhookAccessor) GetObjectSelector() *metav1.LabelSelector {
 	return v.ObjectSelector
 }
 
-func (v validatingWebhookAccessor) GetSideEffects() *v1beta1.SideEffectClass {
+func (v *validatingWebhookAccessor) GetSideEffects() *v1beta1.SideEffectClass {
 	return v.SideEffects
 }
 
-func (v validatingWebhookAccessor) GetTimeoutSeconds() *int32 {
+func (v *validatingWebhookAccessor) GetTimeoutSeconds() *int32 {
 	return v.TimeoutSeconds
 }
 
-func (v validatingWebhookAccessor) GetAdmissionReviewVersions() []string {
+func (v *validatingWebhookAccessor) GetAdmissionReviewVersions() []string {
 	return v.AdmissionReviewVersions
 }
 
-func (v validatingWebhookAccessor) GetMutatingWebhook() (*v1beta1.MutatingWebhook, bool) {
+func (v *validatingWebhookAccessor) GetMutatingWebhook() (*v1beta1.MutatingWebhook, bool) {
 	return nil, false
 }
 
-func (v validatingWebhookAccessor) GetValidatingWebhook() (*v1beta1.ValidatingWebhook, bool) {
+func (v *validatingWebhookAccessor) GetValidatingWebhook() (*v1beta1.ValidatingWebhook, bool) {
 	return v.ValidatingWebhook, true
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/BUILD
@@ -28,7 +28,6 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/util:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -40,7 +40,6 @@ import (
 	webhookerrors "k8s.io/apiserver/pkg/admission/plugin/webhook/errors"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 	webhookrequest "k8s.io/apiserver/pkg/admission/plugin/webhook/request"
-	"k8s.io/apiserver/pkg/admission/plugin/webhook/util"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	utiltrace "k8s.io/utils/trace"
@@ -197,7 +196,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *v1beta
 		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	// Make the webhook request
-	client, err := a.cm.HookClient(util.HookClientConfigForWebhook(invocation.Webhook))
+	client, err := invocation.Webhook.GetRESTClient(a.cm)
 	if err != nil {
 		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/namespace/matcher.go
@@ -95,8 +95,7 @@ func (m *Matcher) MatchNamespaceSelector(h webhook.WebhookAccessor, attr admissi
 		// Also update the comment in types.go
 		return true, nil
 	}
-	// TODO: adding an LRU cache to cache the translation
-	selector, err := metav1.LabelSelectorAsSelector(h.GetNamespaceSelector())
+	selector, err := h.GetParsedNamespaceSelector()
 	if err != nil {
 		return false, apierrors.NewInternalError(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/BUILD
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/object/matcher.go
@@ -19,7 +19,6 @@ package object
 import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
@@ -47,8 +46,7 @@ func matchObject(obj runtime.Object, selector labels.Selector) bool {
 // MatchObjectSelector decideds whether the request matches the ObjectSelector
 // of the webhook. Only when they match, the webhook is called.
 func (m *Matcher) MatchObjectSelector(h webhook.WebhookAccessor, attr admission.Attributes) (bool, *apierrors.StatusError) {
-	// TODO: adding an LRU cache to cache the translation
-	selector, err := metav1.LabelSelectorAsSelector(h.GetObjectSelector())
+	selector, err := h.GetParsedObjectSelector()
 	if err != nil {
 		return false, apierrors.NewInternalError(err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/BUILD
@@ -40,7 +40,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main",
+    importpath = "k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main",
+    visibility = ["//visibility:private"],
+    deps = ["//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing:go_default_library"],
+)
+
+go_binary(
+    name = "main",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main/main.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main/main.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	webhooktesting "k8s.io/apiserver/pkg/admission/plugin/webhook/testing"
+)
+
+func main() {
+	server := webhooktesting.NewTestServer(nil)
+	server.StartTLS()
+	fmt.Println("serving on", server.URL)
+	select {}
+}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/testcase.go
@@ -217,6 +217,7 @@ type ValidatingTest struct {
 	IsCRD                  bool
 	IsDryRun               bool
 	AdditionalLabels       map[string]string
+	SkipBenchmark          bool
 	ExpectLabels           map[string]string
 	ExpectAllow            bool
 	ErrorContains          string
@@ -233,6 +234,7 @@ type MutatingTest struct {
 	IsCRD                  bool
 	IsDryRun               bool
 	AdditionalLabels       map[string]string
+	SkipBenchmark          bool
 	ExpectLabels           map[string]string
 	ExpectAllow            bool
 	ErrorContains          string
@@ -262,7 +264,7 @@ func ConvertToMutatingTestCases(tests []ValidatingTest, configurationName string
 				break
 			}
 		}
-		r[i] = MutatingTest{t.Name, ConvertToMutatingWebhooks(t.Webhooks), t.Path, t.IsCRD, t.IsDryRun, t.AdditionalLabels, t.ExpectLabels, t.ExpectAllow, t.ErrorContains, t.ExpectAnnotations, t.ExpectStatusCode, t.ExpectReinvokeWebhooks}
+		r[i] = MutatingTest{t.Name, ConvertToMutatingWebhooks(t.Webhooks), t.Path, t.IsCRD, t.IsDryRun, t.AdditionalLabels, t.SkipBenchmark, t.ExpectLabels, t.ExpectAllow, t.ErrorContains, t.ExpectAnnotations, t.ExpectStatusCode, t.ExpectReinvokeWebhooks}
 	}
 	return r
 }
@@ -404,7 +406,8 @@ func NewNonMutatingTestCases(url *url.URL) []ValidatingTest {
 				AdmissionReviewVersions: []string{"v1beta1"},
 			}},
 
-			ExpectAllow: true,
+			SkipBenchmark: true,
+			ExpectAllow:   true,
 		},
 		{
 			Name: "match & fail (but disallow because fail close on nil FailurePolicy)",
@@ -499,7 +502,8 @@ func NewNonMutatingTestCases(url *url.URL) []ValidatingTest {
 				ObjectSelector:          &metav1.LabelSelector{},
 				AdmissionReviewVersions: []string{"v1beta1"},
 			}},
-			ExpectAllow: true,
+			SkipBenchmark: true,
+			ExpectAllow:   true,
 		},
 		{
 			Name: "absent response and fail closed",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/webhook_server.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/webhook_server.go
@@ -20,7 +20,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,11 +30,12 @@ import (
 )
 
 // NewTestServer returns a webhook test HTTPS server with fixed webhook test certs.
-func NewTestServer(t *testing.T) *httptest.Server {
+func NewTestServer(t testing.TB) *httptest.Server {
 	// Create the test webhook server
 	sCert, err := tls.X509KeyPair(testcerts.ServerCert, testcerts.ServerKey)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+		t.FailNow()
 	}
 	rootCAs := x509.NewCertPool()
 	rootCAs.AppendCertsFromPEM(testcerts.CACert)
@@ -49,7 +49,7 @@ func NewTestServer(t *testing.T) *httptest.Server {
 }
 
 func webhookHandler(w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("got req: %v\n", r.URL.Path)
+	// fmt.Printf("got req: %v\n", r.URL.Path)
 	switch r.URL.Path {
 	case "/internalErr":
 		http.Error(w, "webhook internal server error", http.StatusInternalServerError)

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/util/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/util/BUILD
@@ -6,10 +6,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/util",
     importpath = "k8s.io/apiserver/pkg/admission/plugin/webhook/util",
     visibility = ["//visibility:public"],
-    deps = [
-        "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
-    ],
+    deps = ["//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook:go_default_library"],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/util/client_config.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/util/client_config.go
@@ -18,34 +18,7 @@ package util
 
 import (
 	"k8s.io/apiserver/pkg/admission/plugin/webhook"
-	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 )
-
-// HookClientConfigForWebhook construct a webhookutil.ClientConfig using a WebhookAccessor to access
-// v1beta1.MutatingWebhook and v1beta1.ValidatingWebhook API objects.  webhookutil.ClientConfig is used
-// to create a HookClient and the purpose of the config struct is to share that with other packages
-// that need to create a HookClient.
-func HookClientConfigForWebhook(w webhook.WebhookAccessor) webhookutil.ClientConfig {
-	ret := webhookutil.ClientConfig{Name: w.GetName(), CABundle: w.GetClientConfig().CABundle}
-	if w.GetClientConfig().URL != nil {
-		ret.URL = *w.GetClientConfig().URL
-	}
-	if w.GetClientConfig().Service != nil {
-		ret.Service = &webhookutil.ClientConfigService{
-			Name:      w.GetClientConfig().Service.Name,
-			Namespace: w.GetClientConfig().Service.Namespace,
-		}
-		if w.GetClientConfig().Service.Port != nil {
-			ret.Service.Port = *w.GetClientConfig().Service.Port
-		} else {
-			ret.Service.Port = 443
-		}
-		if w.GetClientConfig().Service.Path != nil {
-			ret.Service.Path = *w.GetClientConfig().Service.Path
-		}
-	}
-	return ret
-}
 
 // HasAdmissionReviewVersion check whether a version is accepted by a given webhook.
 func HasAdmissionReviewVersion(a string, w webhook.WebhookAccessor) bool {

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/BUILD
@@ -22,7 +22,6 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/util:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/webhook:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -32,7 +32,6 @@ import (
 	webhookerrors "k8s.io/apiserver/pkg/admission/plugin/webhook/errors"
 	"k8s.io/apiserver/pkg/admission/plugin/webhook/generic"
 	webhookrequest "k8s.io/apiserver/pkg/admission/plugin/webhook/request"
-	"k8s.io/apiserver/pkg/admission/plugin/webhook/util"
 	webhookutil "k8s.io/apiserver/pkg/util/webhook"
 	"k8s.io/klog"
 	utiltrace "k8s.io/utils/trace"
@@ -158,7 +157,7 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1beta1.Validati
 		return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	// Make the webhook request
-	client, err := d.cm.HookClient(util.HookClientConfigForWebhook(invocation.Webhook))
+	client, err := invocation.Webhook.GetRESTClient(d.cm)
 	if err != nil {
 		return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/plugin_test.go
@@ -19,6 +19,7 @@ package validating
 import (
 	"context"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,6 +29,68 @@ import (
 	webhooktesting "k8s.io/apiserver/pkg/admission/plugin/webhook/testing"
 	auditinternal "k8s.io/apiserver/pkg/apis/audit"
 )
+
+// BenchmarkValidate tests that ValidatingWebhook#Validate works as expected
+func BenchmarkValidate(b *testing.B) {
+	testServerURL := os.Getenv("WEBHOOK_TEST_SERVER_URL")
+	if len(testServerURL) == 0 {
+		b.Log("warning, WEBHOOK_TEST_SERVER_URL not set, starting in-process server, benchmarks will include webhook cost.")
+		b.Log("to run a standalone server, run:")
+		b.Log("go run ./vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main/main.go")
+		testServer := webhooktesting.NewTestServer(b)
+		testServer.StartTLS()
+		defer testServer.Close()
+		testServerURL = testServer.URL
+	}
+
+	objectInterfaces := webhooktesting.NewObjectInterfacesForTest()
+
+	serverURL, err := url.ParseRequestURI(testServerURL)
+	if err != nil {
+		b.Fatalf("this should never happen? %v", err)
+	}
+
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+
+	for _, tt := range webhooktesting.NewNonMutatingTestCases(serverURL) {
+		// For now, skip failure cases or tests that explicitly skip benchmarking
+		if !tt.ExpectAllow || tt.SkipBenchmark {
+			continue
+		}
+
+		b.Run(tt.Name, func(b *testing.B) {
+			wh, err := NewValidatingAdmissionWebhook(nil)
+			if err != nil {
+				b.Errorf("%s: failed to create validating webhook: %v", tt.Name, err)
+				return
+			}
+
+			ns := "webhook-test"
+			client, informer := webhooktesting.NewFakeValidatingDataSource(ns, tt.Webhooks, stopCh)
+
+			wh.SetAuthenticationInfoResolverWrapper(webhooktesting.Wrapper(webhooktesting.NewAuthenticationInfoResolver(new(int32))))
+			wh.SetServiceResolver(webhooktesting.NewServiceResolver(*serverURL))
+			wh.SetExternalKubeClientSet(client)
+			wh.SetExternalKubeInformerFactory(informer)
+
+			informer.Start(stopCh)
+			informer.WaitForCacheSync(stopCh)
+
+			if err = wh.ValidateInitialization(); err != nil {
+				b.Errorf("%s: failed to validate initialization: %v", tt.Name, err)
+				return
+			}
+
+			attr := webhooktesting.NewAttribute(ns, nil, tt.IsDryRun)
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				wh.Validate(context.TODO(), attr, objectInterfaces)
+			}
+		})
+	}
+}
 
 // TestValidate tests that ValidatingWebhook#Validate works as expected
 func TestValidate(t *testing.T) {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1260,7 +1260,6 @@ k8s.io/apiserver/pkg/admission/plugin/webhook/namespace
 k8s.io/apiserver/pkg/admission/plugin/webhook/object
 k8s.io/apiserver/pkg/admission/plugin/webhook/request
 k8s.io/apiserver/pkg/admission/plugin/webhook/rules
-k8s.io/apiserver/pkg/admission/plugin/webhook/util
 k8s.io/apiserver/pkg/admission/plugin/webhook/validating
 k8s.io/apiserver/pkg/admission/testing
 k8s.io/apiserver/pkg/apis/apiserver


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Avoids recomputing the object and namespace selector, and the client config cache key for webhooks on every request.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Benchmark setup:
```
# check out commit with benchmarks and test server
git checkout 13e599ab5701242aeb85e3017660cc1c1219f4bc

go run ./vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/testing/main/main.go
serving on https://127.0.0.1:56558

WEBHOOK_TEST_SERVER_URL=https://127.0.0.1:56558 go test ./vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating -bench . -benchmem -run=NONE > old-mutating.txt 
WEBHOOK_TEST_SERVER_URL=https://127.0.0.1:56558 go test ./vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/validating -bench . -benchmem -run=NONE > old-validating.txt 

# check out the commit that switches to use cached selectors/clients
git checkout 633927b877dbe0e3fbd4ebeaca6189b86951cb39
WEBHOOK_TEST_SERVER_URL=https://127.0.0.1:56558 go test ./vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating -bench . -benchmem -run=NONE > new-mutating.txt 
WEBHOOK_TEST_SERVER_URL=https://127.0.0.1:56558 go test ./vendor/k8s.io/apiserver/pkg/admission/plugin/webhook/validating -bench . -benchmem -run=NONE > new-validating.txt 

go get golang.org/x/tools/cmd/benchcmp
benchcmp old-validating.txt new-validating.txt 
benchcmp old-mutating.txt new-mutating.txt 
```

results:
```
benchmark                                                                                         old ns/op     new ns/op     delta
BenchmarkValidate/no_match-8                                                                      1075          1111          +3.35%
BenchmarkValidate/match_&_allow-8                                                                 264106        261397        -1.03%
BenchmarkValidate/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns-8        2727          1400          -48.66%
BenchmarkValidate/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns_ii-8     2323          1350          -41.89%
BenchmarkValidate/match_&_allow_(url)-8                                                           260119        263347        +1.24%
BenchmarkValidate/no_match_dry_run-8                                                              1017          1000          -1.67%
BenchmarkValidate/match_dry_run_side_effects_None-8                                               279578        254158        -9.09%
BenchmarkValidate/match_dry_run_side_effects_NoneOnDryRun-8                                       279564        255092        -8.75%
BenchmarkValidate/illegal_annotation_format-8                                                     284790        278731        -2.13%
BenchmarkValidate/skip_webhook_whose_objectSelector_does_not_match-8                              286823        253339        -11.67%
BenchmarkValidate/skip_webhook_whose_objectSelector_does_not_match_CRD's_labels-8                 264151        248464        -5.94%
```

```
benchmark                                                                                         old allocs     new allocs     delta
BenchmarkValidate/no_match-8                                                                      6              6              +0.00%
BenchmarkValidate/match_&_allow-8                                                                 632            624            -1.27%
BenchmarkValidate/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns-8        15             8              -46.67%
BenchmarkValidate/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns_ii-8     15             8              -46.67%
BenchmarkValidate/match_&_allow_(url)-8                                                           631            624            -1.11%
BenchmarkValidate/no_match_dry_run-8                                                              6              6              +0.00%
BenchmarkValidate/match_dry_run_side_effects_None-8                                               632            624            -1.27%
BenchmarkValidate/match_dry_run_side_effects_NoneOnDryRun-8                                       632            624            -1.27%
BenchmarkValidate/illegal_annotation_format-8                                                     659            652            -1.06%
BenchmarkValidate/skip_webhook_whose_objectSelector_does_not_match-8                              642            626            -2.49%
BenchmarkValidate/skip_webhook_whose_objectSelector_does_not_match_CRD's_labels-8                 642            626            -2.49%
```
```
benchmark                                                                                         old bytes     new bytes     delta
BenchmarkValidate/no_match-8                                                                      638           639           +0.16%
BenchmarkValidate/match_&_allow-8                                                                 27341         22390         -18.11%
BenchmarkValidate/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns-8        1091          790           -27.59%
BenchmarkValidate/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns_ii-8     1057          793           -24.98%
BenchmarkValidate/match_&_allow_(url)-8                                                           27228         22305         -18.08%
BenchmarkValidate/no_match_dry_run-8                                                              617           614           -0.49%
BenchmarkValidate/match_dry_run_side_effects_None-8                                               27290         22344         -18.12%
BenchmarkValidate/match_dry_run_side_effects_NoneOnDryRun-8                                       27288         22337         -18.14%
BenchmarkValidate/illegal_annotation_format-8                                                     32086         27208         -15.20%
BenchmarkValidate/skip_webhook_whose_objectSelector_does_not_match-8                              27930         22528         -19.34%
BenchmarkValidate/skip_webhook_whose_objectSelector_does_not_match_CRD's_labels-8                 28094         22680         -19.27%
```

```
benchmark                                                                                      old ns/op     new ns/op     delta
BenchmarkAdmit/match_&_remove_label-8                                                          354432        299584        -15.47%
BenchmarkAdmit/match_&_add_label-8                                                             468388        411575        -12.13%
BenchmarkAdmit/match_CRD_&_add_label-8                                                         301069        270244        -10.24%
BenchmarkAdmit/match_CRD_&_remove_label-8                                                      259746        230004        -11.45%
BenchmarkAdmit/first_webhook_remove_labels,_second_webhook_shouldn't_be_called-8               4993          2662          -46.69%
BenchmarkAdmit/first_webhook_remove_labels_from_CRD,_second_webhook_shouldn't_be_called-8      6015          3472          -42.28%
BenchmarkAdmit/match_&_reinvoke_if_needed_policy-8                                             689181        577692        -16.18%
BenchmarkAdmit/match_&_never_reinvoke_policy-8                                                 428772        399701        -6.78%
BenchmarkAdmit/match_&_never_reinvoke_policy_(by_default)-8                                    443057        401451        -9.39%
BenchmarkAdmit/match_&_no_reinvoke-8                                                           261543        236949        -9.40%
BenchmarkAdmit/no_match-8                                                                      2049          2065          +0.78%
BenchmarkAdmit/match_&_allow-8                                                                 256604        243131        -5.25%
BenchmarkAdmit/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns-8        3550          2517          -29.10%
BenchmarkAdmit/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns_ii-8     3585          2243          -37.43%
BenchmarkAdmit/match_&_allow_(url)-8                                                           271428        248382        -8.49%
BenchmarkAdmit/no_match_dry_run-8                                                              2143          2151          +0.37%
BenchmarkAdmit/match_dry_run_side_effects_None-8                                               277550        298720        +7.63%
BenchmarkAdmit/match_dry_run_side_effects_NoneOnDryRun-8                                       267333        249574        -6.64%
BenchmarkAdmit/illegal_annotation_format-8                                                     274315        263585        -3.91%
BenchmarkAdmit/skip_webhook_whose_objectSelector_does_not_match-8                              252154        261920        +3.87%
BenchmarkAdmit/skip_webhook_whose_objectSelector_does_not_match_CRD's_labels-8                 196856        187236        -4.89%
```
```
benchmark                                                                                      old allocs     new allocs     delta
BenchmarkAdmit/match_&_remove_label-8                                                          786            777            -1.15%
BenchmarkAdmit/match_&_add_label-8                                                             1442           1433           -0.62%
BenchmarkAdmit/match_CRD_&_add_label-8                                                         585            577            -1.37%
BenchmarkAdmit/match_CRD_&_remove_label-8                                                      407            399            -1.97%
BenchmarkAdmit/first_webhook_remove_labels,_second_webhook_shouldn't_be_called-8               28             12             -57.14%
BenchmarkAdmit/first_webhook_remove_labels_from_CRD,_second_webhook_shouldn't_be_called-8      36             20             -44.44%
BenchmarkAdmit/match_&_reinvoke_if_needed_policy-8                                             1343           1327           -1.19%
BenchmarkAdmit/match_&_never_reinvoke_policy-8                                                 1440           1432           -0.56%
BenchmarkAdmit/match_&_never_reinvoke_policy_(by_default)-8                                    1440           1432           -0.56%
BenchmarkAdmit/match_&_no_reinvoke-8                                                           626            618            -1.28%
BenchmarkAdmit/no_match-8                                                                      8              8              +0.00%
BenchmarkAdmit/match_&_allow-8                                                                 637            629            -1.26%
BenchmarkAdmit/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns-8        17             10             -41.18%
BenchmarkAdmit/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns_ii-8     17             10             -41.18%
BenchmarkAdmit/match_&_allow_(url)-8                                                           636            629            -1.10%
BenchmarkAdmit/no_match_dry_run-8                                                              8              8              +0.00%
BenchmarkAdmit/match_dry_run_side_effects_None-8                                               637            629            -1.26%
BenchmarkAdmit/match_dry_run_side_effects_NoneOnDryRun-8                                       637            629            -1.26%
BenchmarkAdmit/illegal_annotation_format-8                                                     664            657            -1.05%
BenchmarkAdmit/skip_webhook_whose_objectSelector_does_not_match-8                              647            631            -2.47%
BenchmarkAdmit/skip_webhook_whose_objectSelector_does_not_match_CRD's_labels-8                 260            244            -6.15%
```
```
benchmark                                                                                      old bytes     new bytes     delta
BenchmarkAdmit/match_&_remove_label-8                                                          40137         33707         -16.02%
BenchmarkAdmit/match_&_add_label-8                                                             56842         50592         -11.00%
BenchmarkAdmit/match_CRD_&_add_label-8                                                         42223         36407         -13.77%
BenchmarkAdmit/match_CRD_&_remove_label-8                                                      32912         27490         -16.47%
BenchmarkAdmit/first_webhook_remove_labels,_second_webhook_shouldn't_be_called-8               2916          2270          -22.15%
BenchmarkAdmit/first_webhook_remove_labels_from_CRD,_second_webhook_shouldn't_be_called-8      3232          2599          -19.59%
BenchmarkAdmit/match_&_reinvoke_if_needed_policy-8                                             74961         64850         -13.49%
BenchmarkAdmit/match_&_never_reinvoke_policy-8                                                 52454         47398         -9.64%
BenchmarkAdmit/match_&_never_reinvoke_policy_(by_default)-8                                    52492         47432         -9.64%
BenchmarkAdmit/match_&_no_reinvoke-8                                                           28033         23018         -17.89%
BenchmarkAdmit/no_match-8                                                                      1919          1915          -0.21%
BenchmarkAdmit/match_&_allow-8                                                                 28487         23529         -17.40%
BenchmarkAdmit/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns-8        2414          2083          -13.71%
BenchmarkAdmit/match_&_disallow_&_but_allowed_because_namespaceSelector_exempt_the_ns_ii-8     2400          2108          -12.17%
BenchmarkAdmit/match_&_allow_(url)-8                                                           28355         23470         -17.23%
BenchmarkAdmit/no_match_dry_run-8                                                              1917          1911          -0.31%
BenchmarkAdmit/match_dry_run_side_effects_None-8                                               28462         23527         -17.34%
BenchmarkAdmit/match_dry_run_side_effects_NoneOnDryRun-8                                       28473         23504         -17.45%
BenchmarkAdmit/illegal_annotation_format-8                                                     33254         28370         -14.69%
BenchmarkAdmit/skip_webhook_whose_objectSelector_does_not_match-8                              28961         23695         -18.18%
BenchmarkAdmit/skip_webhook_whose_objectSelector_does_not_match_CRD's_labels-8                 24262         18931         -21.97%
```

/sig api-machinery
/cc @jpbetz @sttts @roycaihw 