### PR TITLE
IndexFunc should return set of strings

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -229,16 +229,16 @@ func NewDaemonSetsController(
 	return dsc, nil
 }
 
-func indexByPodNodeName(obj interface{}) ([]string, error) {
+func indexByPodNodeName(obj interface{}) (sets.String, error) {
 	pod, ok := obj.(*v1.Pod)
 	if !ok {
-		return []string{}, nil
+		return sets.String{}, nil
 	}
 	// We are only interested in active pods with nodeName set
 	if len(pod.Spec.NodeName) == 0 || pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
-		return []string{}, nil
+		return sets.String{}, nil
 	}
-	return []string{pod.Spec.NodeName}, nil
+	return sets.NewString(pod.Spec.NodeName), nil
 }
 
 func (dsc *DaemonSetsController) deleteDaemonset(obj interface{}) {

--- a/pkg/controller/nodelifecycle/BUILD
+++ b/pkg/controller/nodelifecycle/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers/apps/v1:go_default_library",

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	appsv1informers "k8s.io/client-go/informers/apps/v1"
@@ -366,15 +367,15 @@ func NewNodeLifecycleController(
 	})
 	nc.podInformerSynced = podInformer.Informer().HasSynced
 	podInformer.Informer().AddIndexers(cache.Indexers{
-		nodeNameKeyIndex: func(obj interface{}) ([]string, error) {
+		nodeNameKeyIndex: func(obj interface{}) (sets.String, error) {
 			pod, ok := obj.(*v1.Pod)
 			if !ok {
-				return []string{}, nil
+				return sets.String{}, nil
 			}
 			if len(pod.Spec.NodeName) == 0 {
-				return []string{}, nil
+				return sets.String{}, nil
 			}
-			return []string{pod.Spec.NodeName}, nil
+			return sets.NewString(pod.Spec.NodeName), nil
 		},
 	})
 

--- a/pkg/controller/volume/attachdetach/BUILD
+++ b/pkg/controller/volume/attachdetach/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",

--- a/pkg/controller/volume/persistentvolume/index.go
+++ b/pkg/controller/volume/persistentvolume/index.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	pvutil "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/util"
@@ -39,12 +40,12 @@ func newPersistentVolumeOrderedIndex() persistentVolumeOrderedIndex {
 
 // accessModesIndexFunc is an indexing function that returns a persistent
 // volume's AccessModes as a string
-func accessModesIndexFunc(obj interface{}) ([]string, error) {
+func accessModesIndexFunc(obj interface{}) (sets.String, error) {
 	if pv, ok := obj.(*v1.PersistentVolume); ok {
 		modes := v1helper.GetAccessModesAsString(pv.Spec.AccessModes)
-		return []string{modes}, nil
+		return sets.NewString(modes), nil
 	}
-	return []string{""}, fmt.Errorf("object is not a persistent volume: %v", obj)
+	return sets.NewString(""), fmt.Errorf("object is not a persistent volume: %v", obj)
 }
 
 // listByAccessModes returns all volumes with the given set of

--- a/pkg/controller/volume/scheduling/BUILD
+++ b/pkg/controller/volume/scheduling/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/etcd3:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",

--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -119,10 +120,10 @@ func objInfoKeyFunc(obj interface{}) (string, error) {
 	return objInfo.name, nil
 }
 
-func (c *assumeCache) objInfoIndexFunc(obj interface{}) ([]string, error) {
+func (c *assumeCache) objInfoIndexFunc(obj interface{}) (sets.String, error) {
 	objInfo, ok := obj.(*objInfo)
 	if !ok {
-		return []string{""}, &errWrongType{"objInfo", obj}
+		return sets.NewString(""), &errWrongType{"objInfo", obj}
 	}
 	return c.indexFunc(objInfo.latestObj)
 }
@@ -348,11 +349,11 @@ type pvAssumeCache struct {
 	AssumeCache
 }
 
-func pvStorageClassIndexFunc(obj interface{}) ([]string, error) {
+func pvStorageClassIndexFunc(obj interface{}) (sets.String, error) {
 	if pv, ok := obj.(*v1.PersistentVolume); ok {
-		return []string{pv.Spec.StorageClassName}, nil
+		return sets.NewString(pv.Spec.StorageClassName), nil
 	}
-	return []string{""}, fmt.Errorf("object is not a v1.PersistentVolume: %v", obj)
+	return sets.NewString(""), fmt.Errorf("object is not a v1.PersistentVolume: %v", obj)
 }
 
 // NewPVAssumeCache creates a PV assume cache.

--- a/staging/src/k8s.io/client-go/tools/cache/index.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index.go
@@ -53,7 +53,7 @@ type Indexer interface {
 }
 
 // IndexFunc knows how to compute the set of indexed values for an object.
-type IndexFunc func(obj interface{}) ([]string, error)
+type IndexFunc func(obj interface{}) (sets.String, error)
 
 // IndexFuncToKeyFuncAdapter adapts an indexFunc to a keyFunc.  This is only useful if your index function returns
 // unique values for every object.  This is conversion can create errors when more than one key is found.  You
@@ -70,7 +70,10 @@ func IndexFuncToKeyFuncAdapter(indexFunc IndexFunc) KeyFunc {
 		if len(indexKeys) == 0 {
 			return "", fmt.Errorf("unexpected empty indexKeys")
 		}
-		return indexKeys[0], nil
+		for k := range indexKeys {
+			return k, nil
+		}
+		return "", err
 	}
 }
 
@@ -80,12 +83,12 @@ const (
 )
 
 // MetaNamespaceIndexFunc is a default index function that indexes based on an object's namespace
-func MetaNamespaceIndexFunc(obj interface{}) ([]string, error) {
+func MetaNamespaceIndexFunc(obj interface{}) (sets.String, error) {
 	meta, err := meta.Accessor(obj)
 	if err != nil {
-		return []string{""}, fmt.Errorf("object has no meta: %v", err)
+		return sets.String{}, fmt.Errorf("object has no meta: %v", err)
 	}
-	return []string{meta.GetNamespace()}, nil
+	return sets.NewString(meta.GetNamespace()), nil
 }
 
 // Index maps the indexed value to a set of keys in the store that match on that value

--- a/staging/src/k8s.io/client-go/tools/cache/index_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/index_test.go
@@ -25,9 +25,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func testIndexFunc(obj interface{}) ([]string, error) {
+func testIndexFunc(obj interface{}) (sets.String, error) {
 	pod := obj.(*v1.Pod)
-	return []string{pod.Labels["foo"]}, nil
+	return sets.NewString(pod.Labels["foo"]), nil
 }
 
 func TestGetIndexFuncValues(t *testing.T) {
@@ -53,11 +53,16 @@ func TestGetIndexFuncValues(t *testing.T) {
 	}
 }
 
-func testUsersIndexFunc(obj interface{}) ([]string, error) {
+func testUsersIndexFunc(obj interface{}) (sets.String, error) {
 	pod := obj.(*v1.Pod)
 	usersString := pod.Annotations["users"]
 
-	return strings.Split(usersString, ","), nil
+	users := strings.Split(usersString, ",")
+	userSet := sets.String{}
+	for _, user := range users {
+		userSet.Insert(user)
+	}
+	return userSet, nil
 }
 
 func TestMultiIndexKeys(t *testing.T) {

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -160,12 +160,8 @@ func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, er
 				klog.V(4).Infof("Unable to calculate an index entry for mutation cache entry %s: %v", key, err)
 				continue
 			}
-			for _, inIndex := range elements {
-				if inIndex != indexKey {
-					continue
-				}
+			if elements.Has(indexKey) {
 				items = append(items, updated)
-				break
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/store_test.go
@@ -123,8 +123,8 @@ func testStoreKeyFunc(obj interface{}) (string, error) {
 	return obj.(testStoreObject).id, nil
 }
 
-func testStoreIndexFunc(obj interface{}) ([]string, error) {
-	return []string{obj.(testStoreObject).val}, nil
+func testStoreIndexFunc(obj interface{}) (sets.String, error) {
+	return sets.NewString(obj.(testStoreObject).val), nil
 }
 
 func testStoreIndexers() Indexers {

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
@@ -152,12 +152,15 @@ func (c *threadSafeMap) Index(indexName string, obj interface{}) ([]interface{},
 	if len(indexKeys) == 1 {
 		// In majority of cases, there is exactly one value matching.
 		// Optimize the most common path - deduping is not needed here.
-		returnKeySet = index[indexKeys[0]]
+		for k := range indexKeys {
+			returnKeySet = index[k]
+			break
+		}
 	} else {
 		// Need to de-dupe the return list.
 		// Since multiple keys are allowed, this can happen.
 		returnKeySet = sets.String{}
-		for _, indexKey := range indexKeys {
+		for indexKey := range indexKeys {
 			for key := range index[indexKey] {
 				returnKeySet.Insert(key)
 			}
@@ -264,7 +267,7 @@ func (c *threadSafeMap) updateIndices(oldObj interface{}, newObj interface{}, ke
 			c.indices[name] = index
 		}
 
-		for _, indexValue := range indexValues {
+		for indexValue := range indexValues {
 			set := index[indexValue]
 			if set == nil {
 				set = sets.String{}
@@ -288,7 +291,7 @@ func (c *threadSafeMap) deleteFromIndices(obj interface{}, key string) {
 		if index == nil {
 			continue
 		}
-		for _, indexValue := range indexValues {
+		for indexValue := range indexValues {
 			set := index[indexValue]
 			if set != nil {
 				set.Delete(key)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
```
// IndexFunc knows how to compute the set of indexed values for an object.
```
Returning set of indexed values allows mutationCache#ByIndex to perform O(1) lookup.
Currently the lookup is done using a 3rd loop.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
