### PR TITLE
Fix staticcheck failures in `test/utils/...`

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -124,7 +124,6 @@ test/integration/serviceaccount
 test/integration/serving
 test/integration/ttlcontroller
 test/integration/volume
-test/utils
 vendor/k8s.io/apimachinery/pkg/api/meta
 vendor/k8s.io/apimachinery/pkg/api/resource
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured

--- a/test/utils/audit.go
+++ b/test/utils/audit.go
@@ -137,7 +137,6 @@ func CheckForDuplicates(el auditinternal.EventList) (auditinternal.EventList, er
 	// existingEvents holds a slice of audit events that have been seen
 	existingEvents := []AuditEvent{}
 	duplicates := auditinternal.EventList{}
-	var err error
 	for _, e := range el.Items {
 		event, err := testEventFromInternal(&e)
 		if err != nil {
@@ -147,12 +146,17 @@ func CheckForDuplicates(el auditinternal.EventList) (auditinternal.EventList, er
 		for _, existing := range existingEvents {
 			if reflect.DeepEqual(existing, event) {
 				duplicates.Items = append(duplicates.Items, e)
-				err = fmt.Errorf("failed duplicate check")
 				continue
 			}
 		}
 		existingEvents = append(existingEvents, event)
 	}
+
+	var err error
+	if len(duplicates.Items) > 0 {
+		err = fmt.Errorf("failed duplicate check")
+	}
+
 	return duplicates, err
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The `err` return value was being overwritten in an unintended way, which
means the function may not return the proper error value. This diff
ensures it does.

**Which issue(s) this PR fixes**:
ref #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
