### PR TITLE
Correctly use defer on response

### DIFF
--- a/pkg/cloudprovider/providers/openstack/metadata.go
+++ b/pkg/cloudprovider/providers/openstack/metadata.go
@@ -153,10 +153,12 @@ func getMetadataFromMetadataService(metadataVersion string) (*Metadata, error) {
 	metadataURL := getMetadataURL(metadataVersion)
 	klog.V(4).Infof("Attempting to fetch metadata from %s", metadataURL)
 	resp, err := http.Get(metadataURL)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, fmt.Errorf("error fetching %s: %v", metadataURL, err)
 	}
-	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		err = fmt.Errorf("unexpected status code when reading metadata from %s: %s", metadataURL, resp.Status)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Normally when there is an error, the response will be nil and an error will be returned. But, when we get a redirection error, response will not be nil but there’ll be an error.

This PR calls the defer in correct order to ensure we’re closing the response body.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
