### PR TITLE
Remove Client#ClusterAvailable from interface

### DIFF
--- a/cmd/kubeadm/app/phases/etcd/local.go
+++ b/cmd/kubeadm/app/phases/etcd/local.go
@@ -82,7 +82,7 @@ func CheckLocalEtcdClusterStatus(client clientset.Interface, cfg *kubeadmapi.Clu
 	}
 
 	// Checking health state
-	_, err = etcdClient.GetClusterStatus()
+	err = etcdClient.CheckClusterHealth()
 	if err != nil {
 		return errors.Wrap(err, "etcd cluster is not healthy")
 	}

--- a/cmd/kubeadm/app/phases/upgrade/BUILD
+++ b/cmd/kubeadm/app/phases/upgrade/BUILD
@@ -97,7 +97,6 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
-        "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
         "//vendor/github.com/coreos/etcd/pkg/transport:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
     ],

--- a/cmd/kubeadm/app/phases/upgrade/compute_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/compute_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
 	"github.com/pkg/errors"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -76,14 +75,12 @@ type fakeEtcdClient struct {
 	mismatchedVersions bool
 }
 
-func (f fakeEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
-
 func (f fakeEtcdClient) WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error) {
 	return true, nil
 }
 
-func (f fakeEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
-	return make(map[string]*clientv3.StatusResponse), nil
+func (f fakeEtcdClient) CheckClusterHealth() error {
+	return nil
 }
 
 func (f fakeEtcdClient) GetVersion() (string, error) {

--- a/cmd/kubeadm/app/phases/upgrade/staticpods.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods.go
@@ -269,7 +269,7 @@ func performEtcdStaticPodUpgrade(certsRenewMgr *renewal.Manager, client clientse
 	}
 
 	// Checking health state of etcd before proceeding with the upgrade
-	_, err := oldEtcdClient.GetClusterStatus()
+	err := oldEtcdClient.CheckClusterHealth()
 	if err != nil {
 		return true, errors.Wrap(err, "etcd cluster is not healthy")
 	}

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -28,7 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/coreos/etcd/clientv3"
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/pkg/errors"
 
@@ -241,17 +240,12 @@ func (spm *fakeStaticPodPathManager) CleanupDirs() error {
 
 type fakeTLSEtcdClient struct{ TLS bool }
 
-func (c fakeTLSEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
-
 func (c fakeTLSEtcdClient) WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error) {
 	return true, nil
 }
 
-func (c fakeTLSEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
-	return map[string]*clientv3.StatusResponse{
-		"https://1.2.3.4:2379": {
-			Version: "3.1.12",
-		}}, nil
+func (c fakeTLSEtcdClient) CheckClusterHealth() error {
+	return nil
 }
 
 func (c fakeTLSEtcdClient) GetClusterVersions() (map[string]string, error) {
@@ -280,13 +274,11 @@ func (c fakeTLSEtcdClient) RemoveMember(id uint64) ([]etcdutil.Member, error) {
 
 type fakePodManifestEtcdClient struct{ ManifestDir, CertificatesDir string }
 
-func (c fakePodManifestEtcdClient) ClusterAvailable() (bool, error) { return true, nil }
-
 func (c fakePodManifestEtcdClient) WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error) {
 	return true, nil
 }
 
-func (c fakePodManifestEtcdClient) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
+func (c fakePodManifestEtcdClient) CheckClusterHealth() error {
 	// Make sure the certificates generated from the upgrade are readable from disk
 	tlsInfo := transport.TLSInfo{
 		CertFile:      filepath.Join(c.CertificatesDir, constants.EtcdCACertName),
@@ -294,13 +286,7 @@ func (c fakePodManifestEtcdClient) GetClusterStatus() (map[string]*clientv3.Stat
 		TrustedCAFile: filepath.Join(c.CertificatesDir, constants.EtcdHealthcheckClientKeyName),
 	}
 	_, err := tlsInfo.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	return map[string]*clientv3.StatusResponse{
-		"https://1.2.3.4:2379": {Version: "3.1.12"},
-	}, nil
+	return err
 }
 
 func (c fakePodManifestEtcdClient) GetClusterVersions() (map[string]string, error) {

--- a/cmd/kubeadm/app/util/etcd/etcd.go
+++ b/cmd/kubeadm/app/util/etcd/etcd.go
@@ -48,8 +48,7 @@ var addRemoveBackoff = wait.Backoff{
 
 // ClusterInterrogator is an interface to get etcd cluster related information
 type ClusterInterrogator interface {
-	ClusterAvailable() (bool, error)
-	GetClusterStatus() (map[string]*clientv3.StatusResponse, error)
+	CheckClusterHealth() error
 	GetClusterVersions() (map[string]string, error)
 	GetVersion() (string, error)
 	WaitForClusterAvailable(retries int, retryInterval time.Duration) (bool, error)
@@ -296,7 +295,7 @@ func (c *Client) GetVersion() (string, error) {
 // GetClusterVersions returns a map of the endpoints and their associated versions
 func (c *Client) GetClusterVersions() (map[string]string, error) {
 	versions := make(map[string]string)
-	statuses, err := c.GetClusterStatus()
+	statuses, err := c.getClusterStatus()
 	if err != nil {
 		return versions, err
 	}
@@ -307,17 +306,14 @@ func (c *Client) GetClusterVersions() (map[string]string, error) {
 	return versions, nil
 }
 
-// ClusterAvailable returns true if the cluster status indicates the cluster is available.
-func (c *Client) ClusterAvailable() (bool, error) {
-	_, err := c.GetClusterStatus()
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+// CheckClusterHealth returns nil for status Up or error for status Down
+func (c *Client) CheckClusterHealth() error {
+	_, err := c.getClusterStatus()
+	return err
 }
 
-// GetClusterStatus returns nil for status Up or error for status Down
-func (c *Client) GetClusterStatus() (map[string]*clientv3.StatusResponse, error) {
+// getClusterStatus returns nil for status Up (along with endpoint status response map) or error for status Down
+func (c *Client) getClusterStatus() (map[string]*clientv3.StatusResponse, error) {
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:   c.Endpoints,
 		DialTimeout: 5 * time.Second,
@@ -349,7 +345,7 @@ func (c *Client) WaitForClusterAvailable(retries int, retryInterval time.Duratio
 			time.Sleep(retryInterval)
 		}
 		klog.V(2).Infof("[etcd] attempting to see if all cluster endpoints (%s) are available %d/%d", c.Endpoints, i+1, retries)
-		resp, err := c.ClusterAvailable()
+		_, err := c.getClusterStatus()
 		if err != nil {
 			switch err {
 			case context.DeadlineExceeded:
@@ -359,7 +355,7 @@ func (c *Client) WaitForClusterAvailable(retries int, retryInterval time.Duratio
 			}
 			continue
 		}
-		return resp, nil
+		return true, nil
 	}
 	return false, errors.New("timeout waiting for etcd cluster to be available")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For Client#ClusterAvailable, since we don't care about the map for StatusResponse, we can return upon going through every endpoint.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
