### PR TITLE
Move updatePod to statefulset_test

### DIFF
--- a/test/integration/statefulset/BUILD
+++ b/test/integration/statefulset/BUILD
@@ -38,6 +38,8 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//test/integration/framework:go_default_library",
     ],
 )

--- a/test/integration/statefulset/util.go
+++ b/test/integration/statefulset/util.go
@@ -231,22 +231,6 @@ func waitSTSStable(t *testing.T, clientSet clientset.Interface, sts *appsv1.Stat
 	}
 }
 
-func updatePod(t *testing.T, podClient typedv1.PodInterface, podName string, updateFunc func(*v1.Pod)) *v1.Pod {
-	var pod *v1.Pod
-	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		newPod, err := podClient.Get(podName, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		updateFunc(newPod)
-		pod, err = podClient.Update(newPod)
-		return err
-	}); err != nil {
-		t.Fatalf("failed to update pod %s: %v", podName, err)
-	}
-	return pod
-}
-
 func updatePodStatus(t *testing.T, podClient typedv1.PodInterface, podName string, updateStatusFunc func(*v1.Pod)) *v1.Pod {
 	var pod *v1.Pod
 	if err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Noticed the following from https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/81907/pull-kubernetes-verify/1165682891863101440 

test/integration/statefulset/util.go:234:6: func updatePod is unused (U1000)

This PR moves the func to the test where it is used.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
