### PR TITLE
kubeadm: add support for Json6902 Patches

### DIFF
--- a/cmd/kubeadm/app/util/kustomize/BUILD
+++ b/cmd/kubeadm/app/util/kustomize/BUILD
@@ -3,21 +3,25 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "json6902.go",
         "kustomize.go",
-        "unstructured.go",
+        "strategicmerge.go",
     ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/kustomize",
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/kustomize:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/sigs.k8s.io/kustomize/pkg/constants:go_default_library",
         "//vendor/sigs.k8s.io/kustomize/pkg/fs:go_default_library",
         "//vendor/sigs.k8s.io/kustomize/pkg/ifc:go_default_library",
         "//vendor/sigs.k8s.io/kustomize/pkg/loader:go_default_library",
+        "//vendor/sigs.k8s.io/kustomize/pkg/patch:go_default_library",
+        "//vendor/sigs.k8s.io/kustomize/pkg/types:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 
@@ -39,10 +43,11 @@ go_test(
     name = "go_default_test",
     srcs = [
         "kustomize_test.go",
-        "unstructured_test.go",
+        "strategicmerge_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/github.com/lithammer/dedent:go_default_library",
     ],

--- a/cmd/kubeadm/app/util/kustomize/json6902.go
+++ b/cmd/kubeadm/app/util/kustomize/json6902.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kustomize contains helpers for working with embedded kustomize commands
+package kustomize
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/kustomize/pkg/ifc"
+	"sigs.k8s.io/kustomize/pkg/patch"
+)
+
+// json6902 represents a json6902 patch
+type json6902 struct {
+	// Target refers to a Kubernetes object that the json patch will be applied to
+	*patch.Target
+
+	// Patch contain the json patch as a string
+	Patch string
+}
+
+// json6902Slice is a slice of json6902 patches.
+type json6902Slice []*json6902
+
+// newJSON6902FromFile returns a json6902 patch from a file
+func newJSON6902FromFile(f patch.Json6902, ldr ifc.Loader, file string) (*json6902, error) {
+	patch, err := ldr.Load(file)
+	if err != nil {
+		return nil, err
+	}
+
+	return &json6902{
+		Target: f.Target,
+		Patch:  string(patch),
+	}, nil
+}
+
+// filterByResource returns all the json6902 patches in the json6902Slice corresponding to a given resource
+func (s *json6902Slice) filterByResource(r *unstructured.Unstructured) json6902Slice {
+	var result json6902Slice
+	for _, p := range *s {
+		if p.Group == r.GroupVersionKind().Group &&
+			p.Version == r.GroupVersionKind().Version &&
+			p.Kind == r.GroupVersionKind().Kind &&
+			p.Namespace == r.GetNamespace() &&
+			p.Name == r.GetName() {
+			result = append(result, p)
+		}
+	}
+	return result
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR fixes limitations of the first implementation of kustomize support in kubeadm (https://github.com/kubernetes/kubernetes/pull/80905)
- support for customization stored in a git repository
- support for patchJson6902 patches

**Special notes for your reviewer**:
Now kubeadm support for kustomize can work with both when the user provides a kustomization file or not.
Support for working with a kustomization file wad not included in the initial design described in the KEP, but the implementation was simpler than expected and it enables support for patchJson6902 and many other kustomize features, so IMO this should go in the alpha release.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
``` 

/sig cluster-lifecycle
/priority important-soon
/assign @rosti @yagonobre @neolit123 @ereslibre 
