### PR TITLE
Add const CNITimeoutSec as part of resolving #65743

### DIFF
--- a/pkg/kubelet/dockershim/network/network.go
+++ b/pkg/kubelet/dockershim/network/network.go
@@ -22,3 +22,7 @@ const DefaultInterfaceName = "eth0"
 // UseDefaultMTU is a marker value that indicates the plugin should determine its own MTU
 // It is the zero value, so a non-initialized value will mean "UseDefault"
 const UseDefaultMTU = 0
+
+// CNITimeoutSec is set to be slightly less than 240sec/4mins, which is the default remote runtime request timeout.
+// Implemented as part of resolving Issue #65743
+const CNITimeoutSec = 220


### PR DESCRIPTION
/kind cleanup
/sig network 
/priority important-soon
/milestone v1.16

moving the new 220sec variable to a constant as requested here
https://github.com/kubernetes/kubernetes/pull/71653#issuecomment-518342055

pushing this as Code Freeze is tomorrow
