### PR TITLE
Cache serializations across watchers

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
@@ -44,6 +44,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/BUILD
@@ -21,6 +21,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/testing:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers.go
@@ -352,7 +352,14 @@ func (s unstructuredJSONScheme) Decode(data []byte, _ *schema.GroupVersionKind, 
 	return obj, &gvk, nil
 }
 
-func (unstructuredJSONScheme) Encode(obj runtime.Object, w io.Writer) error {
+func (s unstructuredJSONScheme) Encode(obj runtime.Object, w io.Writer) error {
+	if co, ok := obj.(runtime.CacheableObject); ok {
+		return co.CacheEncode(s.Identifier(), s.doEncode, w)
+	}
+	return s.doEncode(obj, w)
+}
+
+func (unstructuredJSONScheme) doEncode(obj runtime.Object, w io.Writer) error {
 	switch t := obj.(type) {
 	case *Unstructured:
 		return json.NewEncoder(w).Encode(t.Object)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/helpers_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 
+	runtimetesting "k8s.io/apimachinery/pkg/runtime/testing"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -158,4 +160,8 @@ func TestNestedFieldCopy(t *testing.T) {
 	assert.False(t, exists)
 	assert.Nil(t, err)
 	assert.Nil(t, res)
+}
+
+func TestCacheableObject(t *testing.T) {
+	runtimetesting.CacheableObjectTest(t, UnstructuredJSONScheme)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec_test.go
@@ -39,6 +39,7 @@ func TestCoercingMultiGroupVersioner(t *testing.T) {
 		preferredKinds []schema.GroupKind
 		kinds          []schema.GroupVersionKind
 		expectKind     schema.GroupVersionKind
+		expectedId     string
 	}{
 		{
 			name:           "matched preferred group/kind",
@@ -46,6 +47,7 @@ func TestCoercingMultiGroupVersioner(t *testing.T) {
 			preferredKinds: []schema.GroupKind{gk("mygroup", "Foo"), gk("anothergroup", "Bar")},
 			kinds:          []schema.GroupVersionKind{gvk("yetanother", "v1", "Baz"), gvk("anothergroup", "v1", "Bar")},
 			expectKind:     gvk("mygroup", "__internal", "Bar"),
+			expectedId:     "{\"accepted\":\"Foo.mygroup,Bar.anothergroup\",\"coerce\":\"true\",\"name\":\"multi\",\"target\":\"mygroup/__internal\"}",
 		},
 		{
 			name:           "matched preferred group",
@@ -53,6 +55,7 @@ func TestCoercingMultiGroupVersioner(t *testing.T) {
 			preferredKinds: []schema.GroupKind{gk("mygroup", ""), gk("anothergroup", "")},
 			kinds:          []schema.GroupVersionKind{gvk("yetanother", "v1", "Baz"), gvk("anothergroup", "v1", "Bar")},
 			expectKind:     gvk("mygroup", "__internal", "Bar"),
+			expectedId:     "{\"accepted\":\".mygroup,.anothergroup\",\"coerce\":\"true\",\"name\":\"multi\",\"target\":\"mygroup/__internal\"}",
 		},
 		{
 			name:           "no preferred group/kind match, uses first kind in list",
@@ -60,6 +63,7 @@ func TestCoercingMultiGroupVersioner(t *testing.T) {
 			preferredKinds: []schema.GroupKind{gk("mygroup", ""), gk("anothergroup", "")},
 			kinds:          []schema.GroupVersionKind{gvk("yetanother", "v1", "Baz"), gvk("yetanother", "v1", "Bar")},
 			expectKind:     gvk("mygroup", "__internal", "Baz"),
+			expectedId:     "{\"accepted\":\".mygroup,.anothergroup\",\"coerce\":\"true\",\"name\":\"multi\",\"target\":\"mygroup/__internal\"}",
 		},
 	}
 
@@ -72,6 +76,9 @@ func TestCoercingMultiGroupVersioner(t *testing.T) {
 			}
 			if kind != tc.expectKind {
 				t.Errorf("expected %#v, got %#v", tc.expectKind, kind)
+			}
+			if e, a := tc.expectedId, v.Identifier(); e != a {
+				t.Errorf("unexpected identifier: %s, expected: %s", a, e)
 			}
 		})
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/codec_test.go
@@ -14,12 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package runtime
+package runtime_test
 
 import (
+	"io"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimetesting "k8s.io/apimachinery/pkg/runtime/testing"
 )
 
 func gv(group, version string) schema.GroupVersion {
@@ -69,7 +72,7 @@ func TestCoercingMultiGroupVersioner(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			v := NewCoercingMultiGroupVersioner(tc.target, tc.preferredKinds...)
+			v := runtime.NewCoercingMultiGroupVersioner(tc.target, tc.preferredKinds...)
 			kind, ok := v.KindForGroupVersionKinds(tc.kinds)
 			if !ok {
 				t.Error("got no kind")
@@ -82,4 +85,20 @@ func TestCoercingMultiGroupVersioner(t *testing.T) {
 			}
 		})
 	}
+}
+
+type mockEncoder struct{}
+
+func (m *mockEncoder) Encode(obj runtime.Object, w io.Writer) error {
+	_, err := w.Write([]byte("mock-result"))
+	return err
+}
+
+func (m *mockEncoder) Identifier() runtime.Identifier {
+	return runtime.Identifier("mock-identifier")
+}
+
+func TestCacheableObject(t *testing.T) {
+	serializer := runtime.NewBase64Serializer(&mockEncoder{}, nil)
+	runtimetesting.CacheableObjectTest(t, serializer)
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -39,11 +39,30 @@ type GroupVersioner interface {
 	KindForGroupVersionKinds(kinds []schema.GroupVersionKind) (target schema.GroupVersionKind, ok bool)
 }
 
+// Identifier represents an identifier.
+// Identitier of two different objects should be equal if and only if for every
+// input the output they produce is exactly the same.
+type Identifier string
+
 // Encoder writes objects to a serialized form
 type Encoder interface {
 	// Encode writes an object to a stream. Implementations may return errors if the versions are
 	// incompatible, or if no conversion is defined.
 	Encode(obj Object, w io.Writer) error
+	// Identifier returns an identifier of the encoder.
+	// Identifiers of two different encoders should be equal if and only if for every input
+	// object it will be encoded to the same representation by both of them.
+	//
+	// Identifier is inteted for use with CacheableObject#CacheEncode method. In order to
+	// correctly handle CacheableObject, Encode() method should look similar to below, where
+	// doEncode() is the encoding logic of implemented encoder:
+	//   func (e *MyEncoder) Encode(obj Object, w io.Writer) error {
+	//     if co, ok := obj.(CacheableObject); ok {
+	//       return co.CacheEncode(e.Identifier(), e.doEncode, w)
+	//     }
+	//     return e.doEncode(obj, w)
+	//   }
+	Identifier() Identifier
 }
 
 // Decoder attempts to load an object from data.
@@ -254,6 +273,27 @@ type SelfLinker interface {
 type Object interface {
 	GetObjectKind() schema.ObjectKind
 	DeepCopyObject() Object
+}
+
+// CacheableObject allows an object to cache its different serializations
+// to avoid performing the same serialization multiple times.
+type CacheableObject interface {
+	// CacheEncode writes an object to a stream. The <encode> function will
+	// be used in case of cache miss. The <encode> function takes ownership
+	// of the object.
+	// If CacheableObject is a wrapper, then deep-copy of the wrapped object
+	// should be passed to <encode> function.
+	// CacheEncode assumes that for two different calls with the same <id>,
+	// <encode> function will also be the same.
+	CacheEncode(id Identifier, encode func(Object, io.Writer) error, w io.Writer) error
+	// GetObject returns a deep-copy of an object to be encoded - the caller of
+	// GetObject() is the owner of returned object. The reason for making a copy
+	// is to avoid bugs, where caller modifies the object and forgets to copy it,
+	// thus modifying the object for everyone.
+	// The object returned by GetObject should be the same as the one that is supposed
+	// to be passed to <encode> function in CacheEncode method.
+	// If CacheableObject is a wrapper, the copy of wrapped object should be returned.
+	GetObject() Object
 }
 
 // Unstructured objects store values as map[string]interface{}, with only values that can be serialized

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -37,6 +37,10 @@ type GroupVersioner interface {
 	// Scheme.New(target) and then perform a conversion between the current Go type and the destination Go type.
 	// Sophisticated implementations may use additional information about the input kinds to pick a destination kind.
 	KindForGroupVersionKinds(kinds []schema.GroupVersionKind) (target schema.GroupVersionKind, ok bool)
+	// Identifier returns string representation of the object.
+	// Identifiers of two different encoders should be equal only if for every input
+	// kinds they return the same result.
+	Identifier() string
 }
 
 // Identifier represents an identifier.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
@@ -191,6 +191,11 @@ func (gv GroupVersion) String() string {
 	return gv.Version
 }
 
+// Identifier implements runtime.GroupVersioner interface.
+func (gv GroupVersion) Identifier() string {
+	return gv.String()
+}
+
 // KindForGroupVersionKinds identifies the preferred GroupVersionKind out of a list. It returns ok false
 // if none of the options match the group. It prefers a match to group and version over just group.
 // TODO: Move GroupVersion to a package under pkg/runtime, since it's used by scheme.
@@ -245,6 +250,15 @@ func (gv GroupVersion) WithResource(resource string) GroupVersionResource {
 // TODO: Introduce an adapter type between GroupVersions and runtime.GroupVersioner, and use LegacyCodec(GroupVersion)
 //   in fewer places.
 type GroupVersions []GroupVersion
+
+// Identifier implements runtime.GroupVersioner interface.
+func (gv GroupVersions) Identifier() string {
+	groupVersions := make([]string, 0, len(gv))
+	for i := range gv {
+		groupVersions = append(groupVersions, gv[i].String())
+	}
+	return fmt.Sprintf("[%s]", strings.Join(groupVersions, ","))
+}
 
 // KindForGroupVersionKinds identifies the preferred GroupVersionKind out of a list. It returns ok false
 // if none of the options match the group.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/scheme_test.go
@@ -610,6 +610,10 @@ func (m testGroupVersioner) KindForGroupVersionKinds(kinds []schema.GroupVersion
 	return m.target, m.ok
 }
 
+func (m testGroupVersioner) Identifier() string {
+	return "testGroupVersioner"
+}
+
 func TestConvertToVersion(t *testing.T) {
 	testCases := []struct {
 		scheme *runtime.Scheme

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
@@ -16,6 +16,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/testing:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/github.com/json-iterator/go:go_default_library",
         "//vendor/github.com/modern-go/reflect2:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -304,6 +304,13 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 
 // Encode serializes the provided object to the given writer.
 func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
+	if co, ok := obj.(runtime.CacheableObject); ok {
+		return co.CacheEncode(s.Identifier(), s.doEncode, w)
+	}
+	return s.doEncode(obj, w)
+}
+
+func (s *Serializer) doEncode(obj runtime.Object, w io.Writer) error {
 	if s.options.Yaml {
 		json, err := caseSensitiveJsonIterator.Marshal(obj)
 		if err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer/recognizer"
 	"k8s.io/apimachinery/pkg/util/framer"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/klog"
 )
 
 // NewSerializer creates a JSON serializer that handles encoding versioned objects into the proper JSON form. If typer
@@ -53,11 +54,26 @@ func NewYAMLSerializer(meta MetaFactory, creater runtime.ObjectCreater, typer ru
 // and are immutable.
 func NewSerializerWithOptions(meta MetaFactory, creater runtime.ObjectCreater, typer runtime.ObjectTyper, options SerializerOptions) *Serializer {
 	return &Serializer{
-		meta:    meta,
-		creater: creater,
-		typer:   typer,
-		options: options,
+		meta:       meta,
+		creater:    creater,
+		typer:      typer,
+		options:    options,
+		identifier: identifier(options),
 	}
+}
+
+// identifier computes Identifier of Encoder based on the given options.
+func identifier(options SerializerOptions) runtime.Identifier {
+	result := map[string]string{
+		"name":   "json",
+		"yaml":   strconv.FormatBool(options.Yaml),
+		"pretty": strconv.FormatBool(options.Pretty),
+	}
+	identifier, err := json.Marshal(result)
+	if err != nil {
+		klog.Fatalf("Failed marshaling identifier for json Serializer: %v", err)
+	}
+	return runtime.Identifier(identifier)
 }
 
 // SerializerOptions holds the options which are used to configure a JSON/YAML serializer.
@@ -85,6 +101,8 @@ type Serializer struct {
 	options SerializerOptions
 	creater runtime.ObjectCreater
 	typer   runtime.ObjectTyper
+
+	identifier runtime.Identifier
 }
 
 // Serializer implements Serializer
@@ -309,6 +327,11 @@ func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	}
 	encoder := json.NewEncoder(w)
 	return encoder.Encode(obj)
+}
+
+// Identifier implements runtime.Encoder interface.
+func (s *Serializer) Identifier() runtime.Identifier {
+	return s.identifier
 }
 
 // RecognizesData implements the RecognizingDecoder interface.

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json_test.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	runtimetesting "k8s.io/apimachinery/pkg/runtime/testing"
 	"k8s.io/apimachinery/pkg/util/diff"
 )
 
@@ -454,6 +455,15 @@ func TestDecode(t *testing.T) {
 			t.Errorf("%d: unexpected object:\n%s", i, diff.ObjectGoPrintSideBySide(test.expectedObject, obj))
 		}
 	}
+}
+
+func TestCacheableObject(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "group", Version: "version", Kind: "MockCacheableObject"}
+	creater := &mockCreater{obj: &runtimetesting.MockCacheableObject{}}
+	typer := &mockTyper{gvk: &gvk}
+	serializer := json.NewSerializer(json.DefaultMetaFactory, creater, typer, false)
+
+	runtimetesting.CacheableObjectTest(t, serializer)
 }
 
 type mockCreater struct {

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/BUILD
@@ -1,9 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_library",
-)
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -34,4 +31,15 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["protobuf_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/testing:go_default_library",
+    ],
 )

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -178,6 +178,13 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 
 // Encode serializes the provided object to the given writer.
 func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
+	if co, ok := obj.(runtime.CacheableObject); ok {
+		return co.CacheEncode(s.Identifier(), s.doEncode, w)
+	}
+	return s.doEncode(obj, w)
+}
+
+func (s *Serializer) doEncode(obj runtime.Object, w io.Writer) error {
 	prefixSize := uint64(len(s.prefix))
 
 	var unk runtime.Unknown
@@ -428,6 +435,13 @@ func unmarshalToObject(typer runtime.ObjectTyper, creater runtime.ObjectCreater,
 
 // Encode serializes the provided object to the given writer. Overrides is ignored.
 func (s *RawSerializer) Encode(obj runtime.Object, w io.Writer) error {
+	if co, ok := obj.(runtime.CacheableObject); ok {
+		return co.CacheEncode(s.Identifier(), s.doEncode, w)
+	}
+	return s.doEncode(obj, w)
+}
+
+func (s *RawSerializer) doEncode(obj runtime.Object, w io.Writer) error {
 	switch t := obj.(type) {
 	case bufferedReverseMarshaller:
 		// this path performs a single allocation during write but requires the caller to implement

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf.go
@@ -86,6 +86,8 @@ type Serializer struct {
 var _ runtime.Serializer = &Serializer{}
 var _ recognizer.RecognizingDecoder = &Serializer{}
 
+const serializerIdentifier runtime.Identifier = "protobuf"
+
 // Decode attempts to convert the provided data into a protobuf message, extract the stored schema kind, apply the provided default
 // gvk, and then load that data into an object matching the desired schema kind or the provided into. If into is *runtime.Unknown,
 // the raw data will be extracted and no decoding will be performed. If into is not registered with the typer, then the object will
@@ -245,6 +247,11 @@ func (s *Serializer) Encode(obj runtime.Object, w io.Writer) error {
 	}
 }
 
+// Identifier implements runtime.Encoder interface.
+func (s *Serializer) Identifier() runtime.Identifier {
+	return serializerIdentifier
+}
+
 // RecognizesData implements the RecognizingDecoder interface.
 func (s *Serializer) RecognizesData(peek io.Reader) (bool, bool, error) {
 	prefix := make([]byte, 4)
@@ -320,6 +327,8 @@ type RawSerializer struct {
 }
 
 var _ runtime.Serializer = &RawSerializer{}
+
+const rawSerializerIdentifier runtime.Identifier = "raw-protobuf"
 
 // Decode attempts to convert the provided data into a protobuf message, extract the stored schema kind, apply the provided default
 // gvk, and then load that data into an object matching the desired schema kind or the provided into. If into is *runtime.Unknown,
@@ -458,6 +467,11 @@ func (s *RawSerializer) Encode(obj runtime.Object, w io.Writer) error {
 	default:
 		return errNotMarshalable{reflect.TypeOf(obj)}
 	}
+}
+
+// Identifier implements runtime.Encoder interface.
+func (s *RawSerializer) Identifier() runtime.Identifier {
+	return rawSerializerIdentifier
 }
 
 var LengthDelimitedFramer = lengthDelimitedFramer{}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/protobuf/protobuf_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protobuf
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	runtimetesting "k8s.io/apimachinery/pkg/runtime/testing"
+)
+
+func TestCacheableObject(t *testing.T) {
+	gvk := schema.GroupVersionKind{Group: "group", Version: "version", Kind: "MockCacheableObject"}
+	creater := &mockCreater{obj: &runtimetesting.MockCacheableObject{}}
+	typer := &mockTyper{gvk: &gvk}
+
+	encoders := []runtime.Encoder{
+		NewSerializer(creater, typer),
+		NewRawSerializer(creater, typer),
+	}
+
+	for _, encoder := range encoders {
+		runtimetesting.CacheableObjectTest(t, encoder)
+	}
+}
+
+type mockCreater struct {
+	apiVersion string
+	kind       string
+	err        error
+	obj        runtime.Object
+}
+
+func (c *mockCreater) New(kind schema.GroupVersionKind) (runtime.Object, error) {
+	c.apiVersion, c.kind = kind.GroupVersion().String(), kind.Kind
+	return c.obj, c.err
+}
+
+type mockTyper struct {
+	gvk *schema.GroupVersionKind
+	err error
+}
+
+func (t *mockTyper) ObjectKinds(obj runtime.Object) ([]schema.GroupVersionKind, bool, error) {
+	if t.gvk == nil {
+		return nil, false, t.err
+	}
+	return []schema.GroupVersionKind{*t.gvk}, false, t.err
+}
+
+func (t *mockTyper) Recognizes(_ schema.GroupVersionKind) bool {
+	return false
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/BUILD
@@ -31,6 +31,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/BUILD
@@ -17,6 +17,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/testing:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -196,6 +196,13 @@ func (c *codec) Decode(data []byte, defaultGVK *schema.GroupVersionKind, into ru
 // Encode ensures the provided object is output in the appropriate group and version, invoking
 // conversion if necessary. Unversioned objects (according to the ObjectTyper) are output as is.
 func (c *codec) Encode(obj runtime.Object, w io.Writer) error {
+	if co, ok := obj.(runtime.CacheableObject); ok {
+		return co.CacheEncode(c.Identifier(), c.doEncode, w)
+	}
+	return c.doEncode(obj, w)
+}
+
+func (c *codec) doEncode(obj runtime.Object, w io.Writer) error {
 	switch obj := obj.(type) {
 	case *runtime.Unknown:
 		return c.encoder.Encode(obj, w)

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning.go
@@ -17,12 +17,14 @@ limitations under the License.
 package versioning
 
 import (
+	"encoding/json"
 	"io"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog"
 )
 
 // NewDefaultingCodecForScheme is a convenience method for callers that are using a scheme.
@@ -62,6 +64,8 @@ func NewCodec(
 		encodeVersion: encodeVersion,
 		decodeVersion: decodeVersion,
 
+		identifier: identifier(encodeVersion, encoder),
+
 		originalSchemeName: originalSchemeName,
 	}
 	return internal
@@ -78,8 +82,28 @@ type codec struct {
 	encodeVersion runtime.GroupVersioner
 	decodeVersion runtime.GroupVersioner
 
+	identifier runtime.Identifier
+
 	// originalSchemeName is optional, but when filled in it holds the name of the scheme from which this codec originates
 	originalSchemeName string
+}
+
+// identifier computes Identifier of Encoder based on codec parameters.
+func identifier(encodeGV runtime.GroupVersioner, encoder runtime.Encoder) runtime.Identifier {
+	result := map[string]string{
+		"name": "versioning",
+	}
+	if encodeGV != nil {
+		result["encodeGV"] = encodeGV.Identifier()
+	}
+	if encoder != nil {
+		result["encoder"] = string(encoder.Identifier())
+	}
+	identifier, err := json.Marshal(result)
+	if err != nil {
+		klog.Fatalf("Failed marshaling identifier for codec: %v", err)
+	}
+	return runtime.Identifier(identifier)
 }
 
 // Decode attempts a decode of the object, then tries to convert it to the internal version. If into is provided and the decoding is
@@ -229,4 +253,9 @@ func (c *codec) Encode(obj runtime.Object, w io.Writer) error {
 
 	// Conversion is responsible for setting the proper group, version, and kind onto the outgoing object
 	return c.encoder.Encode(out, w)
+}
+
+// Identifier implements runtime.Encoder interface.
+func (c *codec) Identifier() runtime.Identifier {
+	return c.identifier
 }

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/BUILD
@@ -8,6 +8,7 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "cacheable_object.go",
         "doc.go",
         "types.go",
         "zz_generated.deepcopy.go",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/testing/cacheable_object.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/testing/cacheable_object.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// nonCacheableTestObject implements json.Marshaler and proto.Marshaler interfaces
+// for mocking purpose.
+// +k8s:deepcopy-gen=false
+type noncacheableTestObject struct {
+	gvk schema.GroupVersionKind
+}
+
+// MarshalJSON implements json.Marshaler interface.
+func (*noncacheableTestObject) MarshalJSON() ([]byte, error) {
+	return []byte("\"json-result\""), nil
+}
+
+// Marshal implements proto.Marshaler interface.
+func (*noncacheableTestObject) Marshal() ([]byte, error) {
+	return []byte("\"proto-result\""), nil
+}
+
+// DeepCopyObject implements runtime.Object interface.
+func (*noncacheableTestObject) DeepCopyObject() runtime.Object {
+	panic("DeepCopy unimplemented for noncacheableTestObject")
+}
+
+// GetObjectKind implements runtime.Object interface.
+func (o *noncacheableTestObject) GetObjectKind() schema.ObjectKind {
+	return o
+}
+
+// GroupVersionKind implements schema.ObjectKind interface.
+func (o *noncacheableTestObject) GroupVersionKind() schema.GroupVersionKind {
+	return o.gvk
+}
+
+// SetGroupVersionKind implements schema.ObjectKind interface.
+func (o *noncacheableTestObject) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	o.gvk = gvk
+}
+
+var _ runtime.CacheableObject = &MockCacheableObject{}
+
+// MochCacheableObject is used to test CacheableObject interface.
+// +k8s:deepcopy-gen=false
+type MockCacheableObject struct {
+	gvk schema.GroupVersionKind
+
+	t *testing.T
+
+	runEncode      bool
+	returnSelf     bool
+	expectedResult string
+	expectedError  error
+
+	intercepted []runtime.Identifier
+}
+
+// DeepCopyObject implements runtime.Object interface.
+func (m *MockCacheableObject) DeepCopyObject() runtime.Object {
+	panic("DeepCopy unimplemented for MockCacheableObject")
+}
+
+// GetObjectKind implements runtime.Object interface.
+func (m *MockCacheableObject) GetObjectKind() schema.ObjectKind {
+	return m
+}
+
+// GroupVersionKind implements schema.ObjectKind interface.
+func (m *MockCacheableObject) GroupVersionKind() schema.GroupVersionKind {
+	return m.gvk
+}
+
+// SetGroupVersionKind implements schema.ObjectKind interface.
+func (m *MockCacheableObject) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	m.gvk = gvk
+}
+
+// Marshal implements proto.Marshaler interface.
+// This is implemented to avoid errors from protobuf serializer.
+func (*MockCacheableObject) Marshal() ([]byte, error) {
+	return []byte("\"proto-result\""), nil
+}
+
+// CacheEncode implements runtime.CacheableObject interface.
+func (m *MockCacheableObject) CacheEncode(id runtime.Identifier, encode func(runtime.Object, io.Writer) error, w io.Writer) error {
+	m.intercepted = append(m.intercepted, id)
+	if m.runEncode {
+		return encode(m.GetObject(), w)
+	}
+	if _, err := w.Write([]byte(m.expectedResult)); err != nil {
+		m.t.Errorf("couldn't write to io.Writer: %v", err)
+	}
+	return m.expectedError
+}
+
+// GetObject implements runtime.CacheableObject interface.
+func (m *MockCacheableObject) GetObject() runtime.Object {
+	if m.returnSelf {
+		return m
+	}
+	gvk := schema.GroupVersionKind{Group: "group", Version: "version", Kind: "noncacheableTestObject"}
+	return &noncacheableTestObject{gvk: gvk}
+}
+
+func (m *MockCacheableObject) interceptedCalls() []runtime.Identifier {
+	return m.intercepted
+}
+
+type testBuffer struct {
+	writer io.Writer
+	t      *testing.T
+	object *MockCacheableObject
+}
+
+// Write implements io.Writer interface.
+func (b *testBuffer) Write(p []byte) (int, error) {
+	// Before writing any byte, check if <object> has already
+	// intercepted any CacheEncode operation.
+	if len(b.object.interceptedCalls()) == 0 {
+		b.t.Errorf("writing to buffer without handling MockCacheableObject")
+	}
+	return b.writer.Write(p)
+}
+
+// CacheableObjectTest implements a test that should be run for every
+// runtime.Encoder interface implementation.
+// It checks whether CacheableObject is properly supported by it.
+func CacheableObjectTest(t *testing.T, e runtime.Encoder) {
+	gvk1 := schema.GroupVersionKind{Group: "group", Version: "version1", Kind: "MockCacheableObject"}
+
+	testCases := []struct {
+		desc           string
+		runEncode      bool
+		returnSelf     bool
+		expectedResult string
+		expectedError  error
+	}{
+		{
+			desc:      "delegate",
+			runEncode: true,
+		},
+		{
+			desc:       "delegate return self",
+			runEncode:  true,
+			returnSelf: true,
+		},
+		{
+			desc:           "cached success",
+			runEncode:      false,
+			expectedResult: "result",
+			expectedError:  nil,
+		},
+		{
+			desc:           "cached failure",
+			runEncode:      false,
+			expectedResult: "",
+			expectedError:  fmt.Errorf("encoding error"),
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			obj := &MockCacheableObject{
+				gvk:            gvk1,
+				t:              t,
+				runEncode:      test.runEncode,
+				returnSelf:     test.returnSelf,
+				expectedResult: test.expectedResult,
+				expectedError:  test.expectedError,
+			}
+			buffer := bytes.NewBuffer(nil)
+			w := &testBuffer{
+				writer: buffer,
+				t:      t,
+				object: obj,
+			}
+
+			if err := e.Encode(obj, w); err != test.expectedError {
+				t.Errorf("unexpected error: %v, expected: %v", err, test.expectedError)
+			}
+			if !test.runEncode {
+				if result := buffer.String(); result != test.expectedResult {
+					t.Errorf("unexpected result: %s, expected: %s", result, test.expectedResult)
+				}
+			}
+			intercepted := obj.interceptedCalls()
+			if len(intercepted) != 1 {
+				t.Fatalf("unexpected number of intercepted calls: %v", intercepted)
+			}
+			if intercepted[0] != e.Identifier() {
+				t.Errorf("unexpected intercepted call: %v, expected: %v", intercepted, e.Identifier())
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/BUILD
@@ -46,6 +46,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/util.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/discovery/util.go
@@ -64,6 +64,13 @@ func identifier(e runtime.Encoder) runtime.Identifier {
 }
 
 func (c stripVersionEncoder) Encode(obj runtime.Object, w io.Writer) error {
+	if co, ok := obj.(runtime.CacheableObject); ok {
+		return co.CacheEncode(c.Identifier(), c.doEncode, w)
+	}
+	return c.doEncode(obj, w)
+}
+
+func (c stripVersionEncoder) doEncode(obj runtime.Object, w io.Writer) error {
 	buf := bytes.NewBuffer([]byte{})
 	err := c.encoder.Encode(obj, buf)
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "create_test.go",
         "namer_test.go",
+        "response_test.go",
         "rest_test.go",
     ],
     embed = [":go_default_library"],
@@ -21,6 +22,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/testapigroup/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
@@ -33,6 +35,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/example/v1:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/response_test.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	examplev1 "k8s.io/apiserver/pkg/apis/example/v1"
+	"k8s.io/apiserver/pkg/endpoints/handlers/negotiation"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+)
+
+var _ runtime.CacheableObject = &mockCacheableObject{}
+
+type mockCacheableObject struct {
+	gvk schema.GroupVersionKind
+	obj runtime.Object
+}
+
+// DeepCopyObject implements runtime.Object interface.
+func (m *mockCacheableObject) DeepCopyObject() runtime.Object {
+	panic("DeepCopy unimplemented for mockCacheableObject")
+}
+
+// GetObjectKind implements runtime.Object interface.
+func (m *mockCacheableObject) GetObjectKind() schema.ObjectKind {
+	return m
+}
+
+// GroupVersionKind implements schema.ObjectKind interface.
+func (m *mockCacheableObject) GroupVersionKind() schema.GroupVersionKind {
+	return m.gvk
+}
+
+// SetGroupVersionKind implements schema.ObjectKind interface.
+func (m *mockCacheableObject) SetGroupVersionKind(gvk schema.GroupVersionKind) {
+	m.gvk = gvk
+}
+
+// CacheEncode implements runtime.CacheableObject interface.
+func (m *mockCacheableObject) CacheEncode(id runtime.Identifier, encode func(runtime.Object, io.Writer) error, w io.Writer) error {
+	return fmt.Errorf("unimplemented")
+}
+
+// GetObject implements runtime.CacheableObject interface.
+func (m *mockCacheableObject) GetObject() runtime.Object {
+	return m.obj
+}
+
+type mockNamer struct{}
+
+func (*mockNamer) Namespace(_ *http.Request) (string, error)           { return "", nil }
+func (*mockNamer) Name(_ *http.Request) (string, string, error)        { return "", "", nil }
+func (*mockNamer) ObjectName(_ runtime.Object) (string, string, error) { return "", "", nil }
+func (*mockNamer) SetSelfLink(_ runtime.Object, _ string) error        { return nil }
+func (*mockNamer) GenerateLink(_ *request.RequestInfo, _ runtime.Object) (string, error) {
+	return "", nil
+}
+func (*mockNamer) GenerateListLink(_ *http.Request) (string, error) { return "", nil }
+
+func TestCacheableObject(t *testing.T) {
+	pomGVK := metav1.SchemeGroupVersion.WithKind("PartialObjectMetadata")
+	tableGVK := metav1.SchemeGroupVersion.WithKind("Table")
+
+	status := &metav1.Status{Status: "status"}
+	pod := &examplev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+	}
+	podMeta := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "name",
+			Namespace: "namespace",
+		},
+	}
+	podMeta.GetObjectKind().SetGroupVersionKind(pomGVK)
+	podTable := &metav1.Table{
+		Rows: []metav1.TableRow{
+			{
+				Cells: []interface{}{pod.Name, pod.CreationTimestamp.Time.UTC().Format(time.RFC3339)},
+			},
+		},
+	}
+
+	tableConvertor := rest.NewDefaultTableConvertor(examplev1.Resource("Pod"))
+
+	testCases := []struct {
+		desc      string
+		object    runtime.Object
+		opts      *metav1beta1.TableOptions
+		mediaType negotiation.MediaTypeOptions
+
+		expectedUnwrap bool
+		expectedObj    runtime.Object
+		expectedErr    error
+	}{
+		{
+			desc:        "metav1.Status",
+			object:      status,
+			expectedObj: status,
+			expectedErr: nil,
+		},
+		{
+			desc:        "cacheableObject nil convert",
+			object:      &mockCacheableObject{obj: pod},
+			mediaType:   negotiation.MediaTypeOptions{},
+			expectedObj: &mockCacheableObject{obj: pod},
+			expectedErr: nil,
+		},
+		{
+			desc:        "cacheableObject as PartialObjectMeta",
+			object:      &mockCacheableObject{obj: pod},
+			mediaType:   negotiation.MediaTypeOptions{Convert: &pomGVK},
+			expectedObj: podMeta,
+			expectedErr: nil,
+		},
+		{
+			desc:        "cacheableObject as Table",
+			object:      &mockCacheableObject{obj: pod},
+			opts:        &metav1beta1.TableOptions{NoHeaders: true, IncludeObject: metav1.IncludeNone},
+			mediaType:   negotiation.MediaTypeOptions{Convert: &tableGVK},
+			expectedObj: podTable,
+			expectedErr: nil,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.desc, func(t *testing.T) {
+			result, err := transformObject(
+				request.WithRequestInfo(context.TODO(), &request.RequestInfo{}),
+				test.object, test.opts, test.mediaType,
+				&RequestScope{
+					Namer:          &mockNamer{},
+					TableConvertor: tableConvertor,
+				},
+				nil)
+
+			if err != test.expectedErr {
+				t.Errorf("unexpected error: %v, expected: %v", err, test.expectedErr)
+			}
+			if a, e := result, test.expectedObj; !reflect.DeepEqual(a, e) {
+				t.Errorf("unexpected result: %v, expected: %v", a, e)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/writers_test.go
@@ -287,6 +287,10 @@ func (e *fakeEncoder) Encode(obj runtime.Object, w io.Writer) error {
 	return err
 }
 
+func (e *fakeEncoder) Identifier() runtime.Identifier {
+	return runtime.Identifier("fake")
+}
+
 func gzipContent(data []byte, level int) []byte {
 	buf := &bytes.Buffer{}
 	gw, err := gzip.NewWriterLevel(buf, level)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "cacher.go",
+        "caching_object.go",
         "time_budget.go",
         "util.go",
         "watch_cache.go",
@@ -19,6 +20,8 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
@@ -38,6 +41,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "cacher_whitebox_test.go",
+        "caching_object_test.go",
         "time_budget_test.go",
         "util_test.go",
         "watch_cache_test.go",

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -20,12 +20,14 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	goruntime "runtime"
 	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -265,7 +267,7 @@ func newTestCacher(s storage.Interface, cap int) (*Cacher, storage.Versioner, er
 		Versioner:      testVersioner{},
 		ResourcePrefix: prefix,
 		KeyFunc:        func(obj runtime.Object) (string, error) { return storage.NamespaceKeyFunc(prefix, obj) },
-		GetAttrsFunc:   func(obj runtime.Object) (labels.Set, fields.Set, error) { return nil, nil, nil },
+		GetAttrsFunc:   storage.DefaultNamespaceScopedAttr,
 		NewFunc:        func() runtime.Object { return &example.Pod{} },
 		NewListFunc:    func() runtime.Object { return &example.PodList{} },
 		Codec:          codecs.LegacyCodec(examplev1.SchemeGroupVersion),
@@ -452,7 +454,7 @@ func TestWatcherNotGoingBackInTime(t *testing.T) {
 				shouldContinue = false
 				break
 			}
-			rv, err := testVersioner{}.ParseResourceVersion(event.Object.(*examplev1.Pod).ResourceVersion)
+			rv, err := testVersioner{}.ParseResourceVersion(event.Object.(metaRuntimeInterface).GetResourceVersion())
 			if err != nil {
 				t.Errorf("unexpected parsing error: %v", err)
 			} else {
@@ -905,4 +907,108 @@ func TestDispatchEventWillNotBeBlockedByTimedOutWatcher(t *testing.T) {
 	if eventsCount != totalPods {
 		t.Errorf("watcher is blocked by slower one (count: %d)", eventsCount)
 	}
+}
+
+func verifyEvents(t *testing.T, w watch.Interface, events []watch.Event) {
+	_, _, line, _ := goruntime.Caller(1)
+	for _, expectedEvent := range events {
+		select {
+		case event := <-w.ResultChan():
+			if e, a := expectedEvent.Type, event.Type; e != a {
+				t.Logf("(called from line %d)", line)
+				t.Errorf("Expected: %s, got: %s", e, a)
+			}
+			object := event.Object
+			if co, ok := object.(runtime.CacheableObject); ok {
+				object = co.GetObject()
+			}
+			if e, a := expectedEvent.Object, object; !apiequality.Semantic.DeepEqual(e, a) {
+				t.Logf("(called from line %d)", line)
+				t.Errorf("Expected: %#v, got: %#v", e, a)
+			}
+		case <-time.After(wait.ForeverTestTimeout):
+			t.Logf("(called from line %d)", line)
+			t.Errorf("Timed out waiting for an event")
+		}
+	}
+}
+
+func TestCachingDeleteEvents(t *testing.T) {
+	backingStorage := &dummyStorage{}
+	cacher, _, err := newTestCacher(backingStorage, 1000)
+	if err != nil {
+		t.Fatalf("Couldn't create cacher: %v", err)
+	}
+	defer cacher.Stop()
+
+	// Wait until cacher is initialized.
+	cacher.ready.wait()
+
+	fooPredicate := storage.SelectionPredicate{
+		Label: labels.SelectorFromSet(map[string]string{"foo": "true"}),
+		Field: fields.Everything(),
+	}
+	barPredicate := storage.SelectionPredicate{
+		Label: labels.SelectorFromSet(map[string]string{"bar": "true"}),
+		Field: fields.Everything(),
+	}
+
+	createWatch := func(pred storage.SelectionPredicate) watch.Interface {
+		w, err := cacher.Watch(context.TODO(), "pods/ns", "999", pred)
+		if err != nil {
+			t.Fatalf("Failed to create watch: %v", err)
+		}
+		return w
+	}
+
+	allEventsWatcher := createWatch(storage.Everything)
+	defer allEventsWatcher.Stop()
+	fooEventsWatcher := createWatch(fooPredicate)
+	defer fooEventsWatcher.Stop()
+	barEventsWatcher := createWatch(barPredicate)
+	defer barEventsWatcher.Stop()
+
+	makePod := func(labels map[string]string, rv string) *examplev1.Pod {
+		return &examplev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "pod",
+				Namespace:       "ns",
+				Labels:          labels,
+				ResourceVersion: rv,
+			},
+		}
+	}
+	pod1 := makePod(map[string]string{"foo": "true", "bar": "true"}, "1001")
+	pod2 := makePod(map[string]string{"foo": "true"}, "1002")
+	pod3 := makePod(map[string]string{}, "1003")
+	pod4 := makePod(map[string]string{}, "1004")
+	pod1DeletedAt2 := pod1.DeepCopyObject().(*examplev1.Pod)
+	pod1DeletedAt2.ResourceVersion = "1002"
+	pod2DeletedAt3 := pod2.DeepCopyObject().(*examplev1.Pod)
+	pod2DeletedAt3.ResourceVersion = "1003"
+
+	allEvents := []watch.Event{
+		{Type: watch.Added, Object: pod1.DeepCopy()},
+		{Type: watch.Modified, Object: pod2.DeepCopy()},
+		{Type: watch.Modified, Object: pod3.DeepCopy()},
+		{Type: watch.Deleted, Object: pod4.DeepCopy()},
+	}
+	fooEvents := []watch.Event{
+		{Type: watch.Added, Object: pod1.DeepCopy()},
+		{Type: watch.Modified, Object: pod2.DeepCopy()},
+		{Type: watch.Deleted, Object: pod2DeletedAt3.DeepCopy()},
+	}
+	barEvents := []watch.Event{
+		{Type: watch.Added, Object: pod1.DeepCopy()},
+		{Type: watch.Deleted, Object: pod1DeletedAt2.DeepCopy()},
+	}
+
+	cacher.watchCache.Add(pod1)
+	cacher.watchCache.Update(pod2)
+	cacher.watchCache.Update(pod3)
+	cacher.watchCache.Delete(pod4)
+
+	verifyEvents(t, allEventsWatcher, allEvents)
+	verifyEvents(t, fooEventsWatcher, fooEvents)
+	verifyEvents(t, barEventsWatcher, barEvents)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -703,7 +703,7 @@ func testCacherSendBookmarkEvents(t *testing.T, watchCacheEnabled, allowWatchBoo
 			}
 			rv, err := cacher.versioner.ObjectResourceVersion(event.Object)
 			if err != nil {
-				t.Errorf("failed to parse resource version from %#v", event.Object)
+				t.Errorf("failed to parse resource version from %#v: %v", event.Object, err)
 			}
 			if event.Type == watch.Bookmark {
 				if !expectedBookmarks {

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object.go
@@ -1,0 +1,397 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"runtime/debug"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
+)
+
+var _ runtime.CacheableObject = &cachingObject{}
+
+// metaRuntimeInterface implements runtime.Object and
+// metav1.Object interfaces.
+type metaRuntimeInterface interface {
+	runtime.Object
+	metav1.Object
+}
+
+// serializationResult captures a result of serialization.
+type serializationResult struct {
+	// once should be used to ensure serialization is computed once.
+	once sync.Once
+
+	// raw is serialized object.
+	raw []byte
+	// err is error from serialization.
+	err error
+}
+
+// serializationsCache is a type for caching serialization results.
+type serializationsCache map[runtime.Identifier]*serializationResult
+
+// cachingObject is an object that is able to cache its serializations
+// so that each of those is computed exactly once.
+//
+// cachingObject implements the metav1.Object interface (accessors for
+// all metadata fields). However, setters for all fields except from
+// SelfLink (which is set lately in the path) are ignored.
+type cachingObject struct {
+	lock sync.RWMutex
+
+	// Object for which serializations are cached.
+	object metaRuntimeInterface
+
+	// serializations is a cache containing object`s serializations.
+	// The value stored in atomic.Value is of type serializationsCache.
+	// The atomic.Value type is used to allow fast-path.
+	serializations atomic.Value
+}
+
+// newCachingObject performs a deep copy of the given object and wraps it
+// into a cachingObject.
+// An error is returned if it's not possible to cast the object to
+// metav1.Object type.
+func newCachingObject(object runtime.Object) (*cachingObject, error) {
+	if obj, ok := object.(metaRuntimeInterface); ok {
+		result := &cachingObject{object: obj.DeepCopyObject().(metaRuntimeInterface)}
+		result.serializations.Store(make(serializationsCache))
+		return result, nil
+	}
+	return nil, fmt.Errorf("can't cast object to metav1.Object: %#v", object)
+}
+
+func (o *cachingObject) getSerializationResult(id runtime.Identifier) *serializationResult {
+	// Fast-path for getting from cache.
+	serializations := o.serializations.Load().(serializationsCache)
+	if result, exists := serializations[id]; exists {
+		return result
+	}
+
+	// Slow-path (that may require insert).
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	serializations = o.serializations.Load().(serializationsCache)
+	// Check if in the meantime it wasn't inserted.
+	if result, exists := serializations[id]; exists {
+		return result
+	}
+
+	// Insert an entry for <id>. This requires copy of existing map.
+	newSerializations := make(serializationsCache)
+	for k, v := range serializations {
+		newSerializations[k] = v
+	}
+	result := &serializationResult{}
+	newSerializations[id] = result
+	o.serializations.Store(newSerializations)
+	return result
+}
+
+// CacheEncode implements runtime.CacheableObject interface.
+// It serializes the object and writes the result to given io.Writer trying
+// to first use the already cached result and falls back to a given encode
+// function in case of cache miss.
+// It assumes that for a given identifier, the encode function always encodes
+// each input object into the same output format.
+func (o *cachingObject) CacheEncode(id runtime.Identifier, encode func(runtime.Object, io.Writer) error, w io.Writer) error {
+	result := o.getSerializationResult(id)
+	result.once.Do(func() {
+		buffer := bytes.NewBuffer(nil)
+		result.err = encode(o.GetObject(), buffer)
+		result.raw = buffer.Bytes()
+	})
+	// Once invoked, fields of serialization will not change.
+	if result.err != nil {
+		return result.err
+	}
+	_, err := w.Write(result.raw)
+	return err
+}
+
+// GetObject implements runtime.CacheableObject interface.
+// It returns deep-copy of the wrapped object to return ownership of it
+// to the called according to the contract of the interface.
+func (o *cachingObject) GetObject() runtime.Object {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.DeepCopyObject().(metaRuntimeInterface)
+}
+
+// GetObjectKind implements runtime.Object interface.
+func (o *cachingObject) GetObjectKind() schema.ObjectKind {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetObjectKind()
+}
+
+// DeepCopyObject implements runtime.Object interface.
+func (o *cachingObject) DeepCopyObject() runtime.Object {
+	// DeepCopyObject on cachingObject is not expected to be called anywhere.
+	// However, to be on the safe-side, we implement it, though given the
+	// cache is only an optimization we ignore copying it.
+	result := &cachingObject{}
+	result.serializations.Store(make(serializationsCache))
+
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	result.object = o.object.DeepCopyObject().(metaRuntimeInterface)
+	return result
+}
+
+var (
+	invalidationCacheTimestampLock sync.Mutex
+	invalidationCacheTimestamp     time.Time
+)
+
+// shouldLogCacheInvalidation allows for logging cache-invalidation
+// at most once per second (to avoid spamming logs in case of issues).
+func shouldLogCacheInvalidation(now time.Time) bool {
+	invalidationCacheTimestampLock.Lock()
+	defer invalidationCacheTimestampLock.Unlock()
+	if invalidationCacheTimestamp.Add(time.Second).Before(now) {
+		invalidationCacheTimestamp = now
+		return true
+	}
+	return false
+}
+
+func (o *cachingObject) invalidateCacheLocked() {
+	if cache, ok := o.serializations.Load().(serializationsCache); ok && len(cache) == 0 {
+		return
+	}
+	// We don't expect cache invalidation to happen - so we want
+	// to log the stacktrace to allow debugging if that will happen.
+	// OTOH, we don't want to spam logs with it.
+	// So we try to log it at most once per second.
+	if shouldLogCacheInvalidation(time.Now()) {
+		klog.Warningf("Unexpected cache invalidation for %#v\n%s", o.object, string(debug.Stack()))
+	}
+	o.serializations.Store(make(serializationsCache))
+}
+
+// The following functions implement metav1.Object interface:
+// - getters simply delegate for the underlying object
+// - setters check if operations isn't noop and if so,
+//   invalidate the cache and delegate for the underlying object
+
+func (o *cachingObject) conditionalSet(isNoop func() bool, set func()) {
+	if fastPath := func() bool {
+		o.lock.RLock()
+		defer o.lock.RUnlock()
+		return isNoop()
+	}(); fastPath {
+		return
+	}
+	o.lock.Lock()
+	defer o.lock.Unlock()
+	if isNoop() {
+		return
+	}
+	o.invalidateCacheLocked()
+	set()
+}
+
+func (o *cachingObject) GetNamespace() string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetNamespace()
+}
+func (o *cachingObject) SetNamespace(namespace string) {
+	o.conditionalSet(
+		func() bool { return o.object.GetNamespace() == namespace },
+		func() { o.object.SetNamespace(namespace) },
+	)
+}
+func (o *cachingObject) GetName() string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetName()
+}
+func (o *cachingObject) SetName(name string) {
+	o.conditionalSet(
+		func() bool { return o.object.GetName() == name },
+		func() { o.object.SetName(name) },
+	)
+}
+func (o *cachingObject) GetGenerateName() string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetGenerateName()
+}
+func (o *cachingObject) SetGenerateName(name string) {
+	o.conditionalSet(
+		func() bool { return o.object.GetGenerateName() == name },
+		func() { o.object.SetGenerateName(name) },
+	)
+}
+func (o *cachingObject) GetUID() types.UID {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetUID()
+}
+func (o *cachingObject) SetUID(uid types.UID) {
+	o.conditionalSet(
+		func() bool { return o.object.GetUID() == uid },
+		func() { o.object.SetUID(uid) },
+	)
+}
+func (o *cachingObject) GetResourceVersion() string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetResourceVersion()
+}
+func (o *cachingObject) SetResourceVersion(version string) {
+	o.conditionalSet(
+		func() bool { return o.object.GetResourceVersion() == version },
+		func() { o.object.SetResourceVersion(version) },
+	)
+}
+func (o *cachingObject) GetGeneration() int64 {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetGeneration()
+}
+func (o *cachingObject) SetGeneration(generation int64) {
+	o.conditionalSet(
+		func() bool { return o.object.GetGeneration() == generation },
+		func() { o.object.SetGeneration(generation) },
+	)
+}
+func (o *cachingObject) GetSelfLink() string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetSelfLink()
+}
+func (o *cachingObject) SetSelfLink(selfLink string) {
+	o.conditionalSet(
+		func() bool { return o.object.GetSelfLink() == selfLink },
+		func() { o.object.SetSelfLink(selfLink) },
+	)
+}
+func (o *cachingObject) GetCreationTimestamp() metav1.Time {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetCreationTimestamp()
+}
+func (o *cachingObject) SetCreationTimestamp(timestamp metav1.Time) {
+	o.conditionalSet(
+		func() bool { return o.object.GetCreationTimestamp() == timestamp },
+		func() { o.object.SetCreationTimestamp(timestamp) },
+	)
+}
+func (o *cachingObject) GetDeletionTimestamp() *metav1.Time {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetDeletionTimestamp()
+}
+func (o *cachingObject) SetDeletionTimestamp(timestamp *metav1.Time) {
+	o.conditionalSet(
+		func() bool { return o.object.GetDeletionTimestamp() == timestamp },
+		func() { o.object.SetDeletionTimestamp(timestamp) },
+	)
+}
+func (o *cachingObject) GetDeletionGracePeriodSeconds() *int64 {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetDeletionGracePeriodSeconds()
+}
+func (o *cachingObject) SetDeletionGracePeriodSeconds(gracePeriodSeconds *int64) {
+	o.conditionalSet(
+		func() bool { return o.object.GetDeletionGracePeriodSeconds() == gracePeriodSeconds },
+		func() { o.object.SetDeletionGracePeriodSeconds(gracePeriodSeconds) },
+	)
+}
+func (o *cachingObject) GetLabels() map[string]string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetLabels()
+}
+func (o *cachingObject) SetLabels(labels map[string]string) {
+	o.conditionalSet(
+		func() bool { return reflect.DeepEqual(o.object.GetLabels(), labels) },
+		func() { o.object.SetLabels(labels) },
+	)
+}
+func (o *cachingObject) GetAnnotations() map[string]string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetAnnotations()
+}
+func (o *cachingObject) SetAnnotations(annotations map[string]string) {
+	o.conditionalSet(
+		func() bool { return reflect.DeepEqual(o.object.GetAnnotations(), annotations) },
+		func() { o.object.SetAnnotations(annotations) },
+	)
+}
+func (o *cachingObject) GetFinalizers() []string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetFinalizers()
+}
+func (o *cachingObject) SetFinalizers(finalizers []string) {
+	o.conditionalSet(
+		func() bool { return reflect.DeepEqual(o.object.GetFinalizers(), finalizers) },
+		func() { o.object.SetFinalizers(finalizers) },
+	)
+}
+func (o *cachingObject) GetOwnerReferences() []metav1.OwnerReference {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetOwnerReferences()
+}
+func (o *cachingObject) SetOwnerReferences(references []metav1.OwnerReference) {
+	o.conditionalSet(
+		func() bool { return reflect.DeepEqual(o.object.GetOwnerReferences(), references) },
+		func() { o.object.SetOwnerReferences(references) },
+	)
+}
+func (o *cachingObject) GetClusterName() string {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetClusterName()
+}
+func (o *cachingObject) SetClusterName(clusterName string) {
+	o.conditionalSet(
+		func() bool { return o.object.GetClusterName() == clusterName },
+		func() { o.object.SetClusterName(clusterName) },
+	)
+}
+func (o *cachingObject) GetManagedFields() []metav1.ManagedFieldsEntry {
+	o.lock.RLock()
+	defer o.lock.RUnlock()
+	return o.object.GetManagedFields()
+}
+func (o *cachingObject) SetManagedFields(managedFields []metav1.ManagedFieldsEntry) {
+	o.conditionalSet(
+		func() bool { return reflect.DeepEqual(o.object.GetManagedFields(), managedFields) },
+		func() { o.object.SetManagedFields(managedFields) },
+	)
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/caching_object_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cacher
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type mockEncoder struct {
+	identifier     runtime.Identifier
+	expectedResult string
+	expectedError  error
+
+	callsNumber int32
+}
+
+func newMockEncoder(id, result string, err error) *mockEncoder {
+	return &mockEncoder{
+		identifier:     runtime.Identifier(id),
+		expectedResult: result,
+		expectedError:  err,
+	}
+}
+
+func (e *mockEncoder) encode(_ runtime.Object, w io.Writer) error {
+	atomic.AddInt32(&e.callsNumber, 1)
+	if e.expectedError != nil {
+		return e.expectedError
+	}
+	_, err := w.Write([]byte(e.expectedResult))
+	return err
+}
+
+func TestCachingObject(t *testing.T) {
+	object, err := newCachingObject(&v1.Pod{})
+	if err != nil {
+		t.Fatalf("couldn't create cachingObject: %v", err)
+	}
+
+	encoders := []*mockEncoder{
+		newMockEncoder("1", "result1", nil),
+		newMockEncoder("2", "", fmt.Errorf("mock error")),
+		newMockEncoder("3", "result3", nil),
+	}
+
+	for _, encoder := range encoders {
+		buffer := bytes.NewBuffer(nil)
+		err := object.CacheEncode(encoder.identifier, encoder.encode, buffer)
+		if a, e := err, encoder.expectedError; e != a {
+			t.Errorf("%s: unexpected error: %v, expected: %v", encoder.identifier, a, e)
+		}
+		if a, e := buffer.String(), encoder.expectedResult; e != a {
+			t.Errorf("%s: unexpected result: %s, expected: %s", encoder.identifier, a, e)
+		}
+	}
+	for _, encoder := range encoders {
+		if encoder.callsNumber != 1 {
+			t.Errorf("%s: unexpected number of encode() calls: %d", encoder.identifier, encoder.callsNumber)
+		}
+	}
+}
+
+func TestSelfLink(t *testing.T) {
+	object, err := newCachingObject(&v1.Pod{})
+	if err != nil {
+		t.Fatalf("couldn't create cachingObject: %v", err)
+	}
+	selfLink := "selfLink"
+	object.SetSelfLink(selfLink)
+
+	encodeSelfLink := func(obj runtime.Object, w io.Writer) error {
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			t.Fatalf("failed to get accessor for %#v: %v", obj, err)
+		}
+		_, err = w.Write([]byte(accessor.GetSelfLink()))
+		return err
+	}
+	buffer := bytes.NewBuffer(nil)
+	if err := object.CacheEncode("", encodeSelfLink, buffer); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if a, e := buffer.String(), selfLink; a != e {
+		t.Errorf("unexpected serialization: %s, expected: %s", a, e)
+	}
+
+	// GetObject should also set selfLink.
+	buffer.Reset()
+	if err := encodeSelfLink(object.GetObject(), buffer); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if a, e := buffer.String(), selfLink; a != e {
+		t.Errorf("unexpected serialization: %s, expected: %s", a, e)
+	}
+}
+
+func TestCachingObjectRaces(t *testing.T) {
+	object, err := newCachingObject(&v1.Pod{})
+	if err != nil {
+		t.Fatalf("couldn't create cachingObject: %v", err)
+	}
+
+	encoders := []*mockEncoder{}
+	for i := 0; i < 10; i++ {
+		encoder := newMockEncoder(fmt.Sprintf("%d", i), "result", nil)
+		encoders = append(encoders, encoder)
+	}
+
+	numWorkers := 1000
+	wg := &sync.WaitGroup{}
+	wg.Add(numWorkers)
+
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			defer wg.Done()
+			object.SetSelfLink("selfLink")
+			buffer := bytes.NewBuffer(nil)
+			for _, encoder := range encoders {
+				buffer.Reset()
+				if err := object.CacheEncode(encoder.identifier, encoder.encode, buffer); err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if callsNumber := atomic.LoadInt32(&encoder.callsNumber); callsNumber != 1 {
+					t.Errorf("unexpected number of serializations: %d", callsNumber)
+				}
+			}
+			accessor, err := meta.Accessor(object.GetObject())
+			if err != nil {
+				t.Fatalf("failed to get accessor: %v", err)
+			}
+			if selfLink := accessor.GetSelfLink(); selfLink != "selfLink" {
+				t.Errorf("unexpected selfLink: %s", selfLink)
+			}
+		}()
+	}
+	wg.Wait()
+}

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -206,6 +206,37 @@ func (w *watchCache) objectToVersionedRuntimeObject(obj interface{}) (runtime.Ob
 	return object, resourceVersion, nil
 }
 
+func setCachingObjects(event *watchCacheEvent, versioner storage.Versioner) {
+	switch event.Type {
+	case watch.Added, watch.Modified:
+		if object, err := newCachingObject(event.Object); err == nil {
+			event.Object = object
+		} else {
+			klog.Errorf("couldn't create cachingObject from: %#v", event.Object)
+		}
+		// Don't wrap PrevObject for update event (for create events it is nil).
+		// We only encode those to deliver DELETE watch events, so if
+		// event.Object is not nil it can be used only for watchers for which
+		// selector was satisfied for its previous version and is no longer
+		// satisfied for the current version.
+		// This is rare enough that it doesn't justify making deep-copy of the
+		// object (done by newCachingObject) every time.
+	case watch.Deleted:
+		// Don't wrap Object for delete events - these are not to deliver any
+		// events. Only wrap PrevObject.
+		if object, err := newCachingObject(event.PrevObject); err == nil {
+			// Update resource version of the underlying object.
+			// event.PrevObject is used to deliver DELETE watch events and
+			// for them, we set resourceVersion to <current> instead of
+			// the resourceVersion of the last modification of the object.
+			updateResourceVersionIfNeeded(object.object, versioner, event.ResourceVersion)
+			event.PrevObject = object
+		} else {
+			klog.Errorf("couldn't create cachingObject from: %#v", event.Object)
+		}
+	}
+}
+
 // processEvent is safe as long as there is at most one call to it in flight
 // at any point in time.
 func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, updateFunc func(*storeElement) error) error {
@@ -219,7 +250,7 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		return err
 	}
 
-	watchCacheEvent := &watchCacheEvent{
+	wcEvent := &watchCacheEvent{
 		Type:            event.Type,
 		Object:          elem.Object,
 		ObjLabels:       elem.Labels,
@@ -242,12 +273,12 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 		}
 		if exists {
 			previousElem := previous.(*storeElement)
-			watchCacheEvent.PrevObject = previousElem.Object
-			watchCacheEvent.PrevObjLabels = previousElem.Labels
-			watchCacheEvent.PrevObjFields = previousElem.Fields
+			wcEvent.PrevObject = previousElem.Object
+			wcEvent.PrevObjLabels = previousElem.Labels
+			wcEvent.PrevObjFields = previousElem.Fields
 		}
 
-		w.updateCache(watchCacheEvent)
+		w.updateCache(wcEvent)
 		w.resourceVersion = resourceVersion
 		defer w.cond.Broadcast()
 
@@ -260,7 +291,18 @@ func (w *watchCache) processEvent(event watch.Event, resourceVersion uint64, upd
 	// This is safe as long as there is at most one call to processEvent in flight
 	// at any point in time.
 	if w.eventHandler != nil {
-		w.eventHandler(watchCacheEvent)
+		// Set up caching of object serializations only for dispatching this event.
+		//
+		// Storing serializations in memory would result in increased memory usage,
+		// but it would help for caching encodings for watches started from old
+		// versions. However, we still don't have a convincing data that the gain
+		// from it justifies increased memory usage, so for now we drop the cached
+		// serializations after dispatching this event.
+
+		// Make a shallow copy to allow overwriting Object and PrevObject.
+		wce := *wcEvent
+		setCachingObjects(&wce, w.versioner)
+		w.eventHandler(&wce)
 	}
 	return nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache_test.go
@@ -18,6 +18,7 @@ package cacher
 
 import (
 	"fmt"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -431,4 +432,54 @@ func TestReflectorForWatchCache(t *testing.T) {
 			t.Errorf("unexpected resource version: %d", version)
 		}
 	}
+}
+
+func TestCachingObjects(t *testing.T) {
+	store := newTestWatchCache(5)
+
+	index := 0
+	store.eventHandler = func(event *watchCacheEvent) {
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			if _, ok := event.Object.(runtime.CacheableObject); !ok {
+				t.Fatalf("Object in %s event should support caching: %#v", event.Type, event.Object)
+			}
+			if _, ok := event.PrevObject.(runtime.CacheableObject); ok {
+				t.Fatalf("PrevObject in %s event should not support caching: %#v", event.Type, event.Object)
+			}
+		case watch.Deleted:
+			if _, ok := event.Object.(runtime.CacheableObject); ok {
+				t.Fatalf("Object in %s event should not support caching: %#v", event.Type, event.Object)
+			}
+			if _, ok := event.PrevObject.(runtime.CacheableObject); !ok {
+				t.Fatalf("PrevObject in %s event should support caching: %#v", event.Type, event.Object)
+			}
+		}
+
+		// Verify that delivered event is the same as cached one modulo Object/PrevObject.
+		switch event.Type {
+		case watch.Added, watch.Modified:
+			event.Object = event.Object.(runtime.CacheableObject).GetObject()
+		case watch.Deleted:
+			event.PrevObject = event.PrevObject.(runtime.CacheableObject).GetObject()
+			// In events store in watchcache, we also don't update ResourceVersion.
+			// So we need to ensure that we don't fail on it.
+			resourceVersion, err := store.versioner.ObjectResourceVersion(store.cache[index].PrevObject)
+			if err != nil {
+				t.Fatalf("Failed to parse resource version: %v", err)
+			}
+			updateResourceVersionIfNeeded(event.PrevObject, store.versioner, resourceVersion)
+		}
+		if a, e := event, store.cache[index]; !reflect.DeepEqual(a, e) {
+			t.Errorf("watchCacheEvent messed up: %#v, expected: %#v", a, e)
+		}
+		index++
+	}
+
+	pod1 := makeTestPod("pod", 1)
+	pod2 := makeTestPod("pod", 2)
+	pod3 := makeTestPod("pod", 3)
+	store.Add(pod1)
+	store.Update(pod2)
+	store.Delete(pod3)
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/tests/cacher_test.go
@@ -357,7 +357,11 @@ func verifyWatchEvent(t *testing.T, w watch.Interface, eventType watch.EventType
 			t.Logf("(called from line %d)", line)
 			t.Errorf("Expected: %s, got: %s", eventType, event.Type)
 		}
-		if e, a := eventObject, event.Object; !apiequality.Semantic.DeepDerivative(e, a) {
+		object := event.Object
+		if co, ok := object.(runtime.CacheableObject); ok {
+			object = co.GetObject()
+		}
+		if e, a := eventObject, object; !apiequality.Semantic.DeepDerivative(e, a) {
 			t.Logf("(called from line %d)", line)
 			t.Errorf("Expected (%s): %#v, got: %#v", eventType, e, a)
 		}
@@ -606,7 +610,11 @@ func TestStartingResourceVersion(t *testing.T) {
 
 	select {
 	case e := <-watcher.ResultChan():
-		pod := e.Object.(*example.Pod)
+		object := e.Object
+		if co, ok := object.(runtime.CacheableObject); ok {
+			object = co.GetObject()
+		}
+		pod := object.(*example.Pod)
 		podRV, err := v.ParseResourceVersion(pod.ResourceVersion)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -725,7 +733,11 @@ func TestRandomWatchDeliver(t *testing.T) {
 		if !ok {
 			break
 		}
-		if a, e := event.Object.(*example.Pod).Name, fmt.Sprintf("foo-%d", watched); e != a {
+		object := event.Object
+		if co, ok := object.(runtime.CacheableObject); ok {
+			object = co.GetObject()
+		}
+		if a, e := object.(*example.Pod).Name, fmt.Sprintf("foo-%d", watched); e != a {
 			t.Errorf("Unexpected object watched: %s, expected %s", a, e)
 		}
 		watched++
@@ -911,7 +923,7 @@ func TestWatchBookmarksWithCorrectResourceVersion(t *testing.T) {
 				pod := fmt.Sprintf("foo-%d", i)
 				err := createPod(etcdStorage, makeTestPod(pod))
 				if err != nil {
-					t.Fatalf("failed to create pod %v", pod)
+					t.Fatalf("failed to create pod %v: %v", pod, err)
 				}
 				time.Sleep(time.Second / 100)
 			}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/scheme.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/scheme.go
@@ -58,6 +58,11 @@ func (dynamicCodec) Encode(obj runtime.Object, w io.Writer) error {
 	return unstructured.UnstructuredJSONScheme.Encode(obj, w)
 }
 
+// Identifier implements runtime.Encoder interface.
+func (dynamicCodec) Identifier() runtime.Identifier {
+	return unstructured.UnstructuredJSONScheme.Identifier()
+}
+
 // UnstructuredPlusDefaultContentConfig returns a rest.ContentConfig for dynamic types.  It includes enough codecs to act as a "normal"
 // serializer for the rest.client with options, status and the like.
 func UnstructuredPlusDefaultContentConfig() rest.ContentConfig {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/scheme.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/scheme.go
@@ -55,6 +55,8 @@ func (dynamicCodec) Decode(data []byte, gvk *schema.GroupVersionKind, obj runtim
 }
 
 func (dynamicCodec) Encode(obj runtime.Object, w io.Writer) error {
+	// There is no need to handle runtime.CacheableObject, as we only
+	// fallback to other encoders here.
 	return unstructured.UnstructuredJSONScheme.Encode(obj, w)
 }
 

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -190,6 +190,10 @@ func (c *fakeCodec) Encode(obj runtime.Object, stream io.Writer) error {
 	return nil
 }
 
+func (c *fakeCodec) Identifier() runtime.Identifier {
+	return runtime.Identifier("fake")
+}
+
 type fakeRoundTripper struct{}
 
 func (r *fakeRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {


### PR DESCRIPTION
Reuse serialization result across watchers - before this change, we were serializing objects independently for every single watcher. With this PR, when dispatching an event in watchcache:
- wrap the object into one that is caching its encodings
- reuse them if multiple watchers expect the same serialization format

This is significant performance improvement:
- in 5k tests, we save ~15% of memory allocations
- in 5k tests, we save ~5% of CPU
This is also addressing https://github.com/kubernetes/kubernetes/issues/75294

Ref https://github.com/kubernetes/enhancements/issues/1152