### PR TITLE
Correct comment in CertOrKeyExist

### DIFF
--- a/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
+++ b/cmd/kubeadm/app/util/pkiutil/pki_helpers.go
@@ -198,7 +198,7 @@ func CertOrKeyExist(pkiPath, name string) bool {
 	_, certErr := os.Stat(certificatePath)
 	_, keyErr := os.Stat(privateKeyPath)
 	if os.IsNotExist(certErr) && os.IsNotExist(keyErr) {
-		// The cert or the key did not exist
+		// The cert and the key do not exist
 		return false
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The comment in CertOrKeyExist mentioned cert or the key not existent.
However this is inconsistent with the condition above the comment.

This PR corrects the comment.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
