### PR TITLE
Cleanup aws staticcheck issue(U1000).

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -249,7 +249,6 @@ vendor/k8s.io/kubectl/pkg/cmd/util/editor
 vendor/k8s.io/kubectl/pkg/cmd/wait
 vendor/k8s.io/kubectl/pkg/describe/versioned
 vendor/k8s.io/kubectl/pkg/scale
-vendor/k8s.io/legacy-cloud-providers/aws
 vendor/k8s.io/legacy-cloud-providers/azure
 vendor/k8s.io/legacy-cloud-providers/vsphere
 vendor/k8s.io/metrics/pkg/client/custom_metrics

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -475,6 +475,7 @@ func (elb *FakeELB) ModifyLoadBalancerAttributes(*elb.ModifyLoadBalancerAttribut
 
 // expectDescribeLoadBalancers is not implemented but is required for interface
 // conformance
+//lint:ignore U1000 required for interface conformance
 func (elb *FakeELB) expectDescribeLoadBalancers(loadBalancerName string) {
 	panic("Not implemented")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup the legacy-cloud-providers/aws issues identified by staticcheck in #81189

**Which issue(s) this PR fixes**:
ref #81657

**Special notes for your reviewer**:
Errors from staticcheck:
```
vendor/k8s.io/legacy-cloud-providers/aws/aws_fakes.go:478:21: func (*FakeELB).expectDescribeLoadBalancers is unused (U1000)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

