### PR TITLE
fix staticcheck failures in "cluster/images/etcd-version-monitor"

### DIFF
--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -250,7 +250,6 @@ func getVersionPeriodically(stopCh <-chan struct{}) {
 		}
 		select {
 		case <-stopCh:
-			break
 		case <-time.After(scrapeTimeout):
 		}
 	}

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,4 +1,3 @@
-cluster/images/etcd-version-monitor
 cluster/images/etcd/migrate
 cmd/controller-manager/app
 cmd/kube-controller-manager/app


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind cleanup

**What this PR does / why we need it**:

```
Errors from staticcheck:
cluster/images/etcd-version-monitor/etcd-version-monitor.go:253:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
```

**Which issue(s) this PR fixes**:

Ref: #81657

**Special notes for your reviewer**:

```
NONE
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
