### PR TITLE
publishing: add missing deps for 1.16 branch

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -130,6 +130,10 @@ rules:
     dependencies:
     - repository: apimachinery
       branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
 - destination: apiserver
   library: true
   branches:
@@ -568,6 +572,10 @@ rules:
       branch: release-1.16
     - repository: component-base
       branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
 - destination: kubelet
   library: true
   branches:
@@ -636,6 +644,10 @@ rules:
       branch: release-1.16
     - repository: component-base
       branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
 - destination: kube-controller-manager
   library: true
   branches:
@@ -672,6 +684,10 @@ rules:
       branch: release-1.16
     - repository: component-base
       branch: release-1.16
+    - repository: api
+      branch: release-1.16
+    - repository: client-go
+      branch: release-13.0
 - destination: cluster-bootstrap
   library: true
   branches:


### PR DESCRIPTION
https://github.com/kubernetes/kubernetes/pull/81173 introduced new dependencies in the master branch in https://github.com/kubernetes/kubernetes/commit/94b612fbd6bee1d88a3193763249d4244070dbee but since we fast forward the `release-1.16` branch today, the new deps need to be added to the 1.16 rules as well.

This will fix the currently broken publishing bot: https://github.com/kubernetes/kubernetes/issues/56876

/assign @sttts @dims 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

