### PR TITLE
fix staticcheck faulures in 'cmd' pkg

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -597,6 +597,7 @@ func (s *ProxyServer) Run() error {
 			w.Header().Set("X-Content-Type-Options", "nosniff")
 			fmt.Fprintf(w, "%s", s.ProxyMode)
 		})
+		//lint:ignore SA1019 See the Metrics Stability Migration KEP
 		proxyMux.Handle("/metrics", legacyregistry.Handler())
 		if s.EnableProfiling {
 			routes.Profiling{}.Install(proxyMux)

--- a/cmd/linkcheck/links.go
+++ b/cmd/linkcheck/links.go
@@ -72,7 +72,7 @@ var (
 )
 
 func newWalkFunc(invalidLink *bool, client *http.Client) filepath.WalkFunc {
-	return func(filePath string, info os.FileInfo, err error) error {
+	return func(filePath string, info os.FileInfo, initErr error) error {
 		hasSuffix := false
 		for _, suffix := range *fileSuffix {
 			hasSuffix = hasSuffix || strings.HasSuffix(info.Name(), suffix)

--- a/cmd/preferredimports/preferredimports.go
+++ b/cmd/preferredimports/preferredimports.go
@@ -27,7 +27,6 @@ import (
 	"go/format"
 	"go/parser"
 	"go/token"
-	"golang.org/x/crypto/ssh/terminal"
 	"io/ioutil"
 	"log"
 	"os"
@@ -35,6 +34,8 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 var (

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,7 +1,5 @@
 cluster/images/etcd-version-monitor
 cluster/images/etcd/migrate
-cmd/kube-proxy/app
-cmd/linkcheck
 pkg/controller/daemon
 pkg/controller/deployment
 pkg/controller/disruption


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

```
Errors from staticcheck:

cmd/kube-controller-manager/app/controllermanager.go:422:22: discoveryClient.ServerResources is deprecated: use ServerGroupsAndResources instead.  (SA1019)

cmd/kube-proxy/app/server.go:556:31: legacyregistry.Handler is deprecated: Please note the issues described in the doc comment of InstrumentHandler. You might want to consider using promhttp.Handler instead.  (SA1019)

cmd/linkcheck/links.go:75:49: argument err is overwritten before first use (SA4009)

cmd/preferredimports/preferredimports.go:54:2: field errors is unused (U1000)
```

**Which issue(s) this PR fixes**:

Ref: #81657

**Special notes for your reviewer**:

```
NONE
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```