### PR TITLE
Kubectl: take pod overhead into account for node info

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/resource/resource.go
@@ -28,7 +28,9 @@ import (
 )
 
 // PodRequestsAndLimits returns a dictionary of all defined resources summed up for all
-// containers of the pod.
+// containers of the pod. If pod overhead is non-nil, the pod overhead is added to the
+// total container resource requests and to the total container limits which have a
+// non-zero quantity.
 func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
 	reqs, limits = corev1.ResourceList{}, corev1.ResourceList{}
 	for _, container := range pod.Spec.Containers {
@@ -39,6 +41,18 @@ func PodRequestsAndLimits(pod *corev1.Pod) (reqs, limits corev1.ResourceList) {
 	for _, container := range pod.Spec.InitContainers {
 		maxResourceList(reqs, container.Resources.Requests)
 		maxResourceList(limits, container.Resources.Limits)
+	}
+
+	// Add overhead for running a pod to the sum of requests and to non-zero limits:
+	if pod.Spec.Overhead != nil {
+		addResourceList(reqs, pod.Spec.Overhead)
+
+		for name, quantity := range pod.Spec.Overhead {
+			if value, ok := limits[name]; ok && !value.IsZero() {
+				value.Add(quantity)
+				limits[name] = value
+			}
+		}
 	}
 	return
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:

kubectl doesn't take Pod Overhead into account. 

**Special notes for your reviewer**:

Unfortunately, I do not see any examples of 'feature gates' with CLI tools.  Because of this, I am not sure, but think it would be appropriate to include Pod.Spec.Overhead if it is defined in the Pod.Spec (which should only be the case if the feature is enabled, or if someone is manually adding without the admission controller).  
 
```release-note
Add PodOverhead awareness to kubectl
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

See https://github.com/kubernetes/enhancements/tree/master/keps/sig-node