### PR TITLE
Cleanup vsphere staticcheck issue

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -251,6 +251,5 @@ vendor/k8s.io/kubectl/pkg/describe/versioned
 vendor/k8s.io/kubectl/pkg/scale
 vendor/k8s.io/legacy-cloud-providers/aws
 vendor/k8s.io/legacy-cloud-providers/azure
-vendor/k8s.io/legacy-cloud-providers/vsphere
 vendor/k8s.io/metrics/pkg/client/custom_metrics
 vendor/k8s.io/sample-controller

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -657,7 +657,7 @@ func (vs *VSphere) NodeAddresses(ctx context.Context, nodeName k8stypes.NodeName
 	// Below logic can be executed only on master as VC details are present.
 	addrs := []v1.NodeAddress{}
 	// Create context
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	vsi, err := vs.getVSphereInstance(nodeName)
 	if err != nil {
@@ -1640,6 +1640,10 @@ func (vs *VSphere) GetVolumeLabels(volumePath string) (map[string]string, error)
 		return nil, err
 	}
 	dsZones, err = vs.collapseZonesInRegion(ctx, dsZones)
+	if err != nil {
+		klog.Errorf("Failed to collapse zones. %v", err)
+		return nil, err
+	}
 	// FIXME: For now, pick the first zone of datastore as the zone of volume
 	labels := make(map[string]string)
 	if len(dsZones) > 0 {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup the legacy-cloud-providers/vsphere issues identified by staticcheck in #81189

**Which issue(s) this PR fixes**:
ref #81657

**Special notes for your reviewer**:
Errors from staticcheck:
```
vendor/k8s.io/legacy-cloud-providers/vsphere/nodemanager.go:187:5: defers in this range loop won't run unless the channel gets closed (SA9001)
vendor/k8s.io/legacy-cloud-providers/vsphere/vsphere.go:641:34: argument ctx is overwritten before first use (SA4009)
vendor/k8s.io/legacy-cloud-providers/vsphere/vsphere.go:1642:11: this value of err is never used (SA4006)
```


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

