### PR TITLE
Fixes static check failures in pkg/security/podsecuritypolicy/sysctl

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -56,7 +56,6 @@ pkg/scheduler/algorithm/priorities
 pkg/scheduler/api/v1
 pkg/scheduler/apis/config/v1alpha1
 pkg/scheduler/internal/queue
-pkg/security/podsecuritypolicy/sysctl
 pkg/util/coverage
 pkg/util/ebtables
 pkg/util/ipconfig

--- a/pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go
+++ b/pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go
@@ -46,8 +46,6 @@ type mustMatchPatterns struct {
 
 var (
 	_ SysctlsStrategy = &mustMatchPatterns{}
-
-	defaultSysctlsPatterns = []string{"*"}
 )
 
 // NewMustMatchPatterns creates a new mustMatchPatterns strategy that will provide validation.


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Ref: #81657 

**Special notes for your reviewer**:
Errors from the static checker:
```
pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go:50:2: var defaultSysctlsPatterns is unused (U1000)
```

**Does this PR introduce a user-facing change?**:
```release-note
None
```
