### PR TITLE
fix staticcheck failures in 'pkg/client pkg/credentialprovider pkg/ku…

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -6,7 +6,6 @@ pkg/controller/podautoscaler
 pkg/controller/replicaset
 pkg/controller/resourcequota
 pkg/controller/statefulset
-pkg/probe/http
 pkg/registry/autoscaling/horizontalpodautoscaler/storage
 pkg/registry/core/namespace/storage
 pkg/registry/core/persistentvolumeclaim/storage
@@ -81,7 +80,6 @@ vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc
 vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook
-vendor/k8s.io/cli-runtime/pkg/printers
 vendor/k8s.io/client-go/discovery/cached/memory
 vendor/k8s.io/client-go/dynamic/fake
 vendor/k8s.io/client-go/metadata/fake

--- a/pkg/credentialprovider/azure/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure/azure_acr_helper.go
@@ -67,7 +67,6 @@ type acrAuthResponse struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
-// 5 minutes buffer time to allow timeshift between local machine and AAD
 const userAgentHeader = "User-Agent"
 const userAgent = "kubernetes-credentialprovider-acr"
 

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -73,7 +73,7 @@ func TestHTTPProbeProxy(t *testing.T) {
 
 	go func() {
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, res)
+			fmt.Fprint(w, res)
 		})
 		err := http.ListenAndServe(":9098", nil)
 		if err != nil {

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/tableprinter.go
@@ -94,9 +94,8 @@ func printHeader(columnNames []string, w io.Writer) error {
 // PrintObj prints the obj in a human-friendly format according to the type of the obj.
 func (h *HumanReadablePrinter) PrintObj(obj runtime.Object, output io.Writer) error {
 
-	w, found := output.(*tabwriter.Writer)
-	if !found {
-		w = GetNewTabWriter(output)
+	if _, found := output.(*tabwriter.Writer); !found {
+		w := GetNewTabWriter(output)
 		output = w
 		defer w.Flush()
 	}


### PR DESCRIPTION
…beapiserver pkg/kubectl pkg/master pkg/printers pkg/probe'

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

```
Errors from staticcheck:

-: could not analyze dependency k8s.io/kubernetes/pkg/client/tests [k8s.io/kubernetes/pkg/client/tests.test] of k8s.io/kubernetes/pkg/client/tests.test (compile)
pkg/client/tests/portfoward_test.go:176:11: no new variables on left side of := (compile)

pkg/credentialprovider/aws/aws_credentials_test.go:199:3: this value of creds is never used (SA4006)
pkg/credentialprovider/aws/aws_credentials_test.go:296:3: this value of creds is never used (SA4006)
pkg/credentialprovider/azure/azure_acr_helper.go:71:7: const timeShiftBuffer is unused (U1000)
pkg/credentialprovider/config_test.go:42:2: this value of preferredPaths is never used (SA4006)
pkg/credentialprovider/config_test.go:42:25: this result of append is never used, except maybe in other appends (SA4010)

pkg/kubeapiserver/admission/initializer.go:47:2: field authorizer is unused (U1000)
pkg/kubeapiserver/admission/initializer.go:51:2: field serviceResolver is unused (U1000)
pkg/kubeapiserver/admission/initializer.go:52:2: field authenticationInfoResolverWrapper is unused (U1000)

pkg/kubectl/cmd/get/customcolumn.go:166:5: this value of w is never used (SA4006)

pkg/printers/internalversion/printers_test.go:2117:10: this value of err is never used (SA4006)
pkg/printers/tablegenerator.go:49:2: field args is unused (U1000)
pkg/printers/tableprinter.go:93:2: this value of w is never used (SA4006)

pkg/probe/http/http_test.go:75:19: printf-style function with dynamic format string and no further arguments should use print-style function instead (SA1006)

pkg/master/master_test.go:257:2: this value of nodes is never used (SA4006)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

Ref: #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
