### PR TITLE
Use log functions of core framework on test/e2e/apps

### DIFF
--- a/test/e2e/apps/BUILD
+++ b/test/e2e/apps/BUILD
@@ -64,7 +64,6 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/deployment:go_default_library",
         "//test/e2e/framework/job:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/replicaset:go_default_library",

--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -35,7 +35,6 @@ import (
 	"k8s.io/kubernetes/pkg/controller/job"
 	"k8s.io/kubernetes/test/e2e/framework"
 	jobutil "k8s.io/kubernetes/test/e2e/framework/job"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -451,7 +450,7 @@ func waitForJobReplaced(c clientset.Interface, ns, previousJobName string) error
 		if len(aliveJobs) > 1 {
 			return false, fmt.Errorf("More than one job is running %+v", jobs.Items)
 		} else if len(aliveJobs) == 0 {
-			e2elog.Logf("Warning: Found 0 jobs in namespace %v", ns)
+			framework.Logf("Warning: Found 0 jobs in namespace %v", ns)
 			return false, nil
 		}
 		return aliveJobs[0].Name != previousJobName, nil

--- a/test/e2e/apps/daemon_restart.go
+++ b/test/e2e/apps/daemon_restart.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -74,7 +73,7 @@ type RestartDaemonConfig struct {
 // NewRestartConfig creates a RestartDaemonConfig for the given node and daemon.
 func NewRestartConfig(nodeName, daemonName string, healthzPort int, pollInterval, pollTimeout time.Duration) *RestartDaemonConfig {
 	if !framework.ProviderIs("gce") {
-		e2elog.Logf("WARNING: SSH through the restart config might not work on %s", framework.TestContext.Provider)
+		framework.Logf("WARNING: SSH through the restart config might not work on %s", framework.TestContext.Provider)
 	}
 	return &RestartDaemonConfig{
 		nodeName:     nodeName,
@@ -91,7 +90,7 @@ func (r *RestartDaemonConfig) String() string {
 
 // waitUp polls healthz of the daemon till it returns "ok" or the polling hits the pollTimeout
 func (r *RestartDaemonConfig) waitUp() {
-	e2elog.Logf("Checking if %v is up by polling for a 200 on its /healthz endpoint", r)
+	framework.Logf("Checking if %v is up by polling for a 200 on its /healthz endpoint", r)
 	healthzCheck := fmt.Sprintf(
 		"curl -s -o /dev/null -I -w \"%%{http_code}\" http://localhost:%v/healthz", r.healthzPort)
 
@@ -101,12 +100,12 @@ func (r *RestartDaemonConfig) waitUp() {
 		if result.Code == 0 {
 			httpCode, err := strconv.Atoi(result.Stdout)
 			if err != nil {
-				e2elog.Logf("Unable to parse healthz http return code: %v", err)
+				framework.Logf("Unable to parse healthz http return code: %v", err)
 			} else if httpCode == 200 {
 				return true, nil
 			}
 		}
-		e2elog.Logf("node %v exec command, '%v' failed with exitcode %v: \n\tstdout: %v\n\tstderr: %v",
+		framework.Logf("node %v exec command, '%v' failed with exitcode %v: \n\tstdout: %v\n\tstderr: %v",
 			r.nodeName, healthzCheck, result.Code, result.Stdout, result.Stderr)
 		return false, nil
 	})
@@ -115,7 +114,7 @@ func (r *RestartDaemonConfig) waitUp() {
 
 // kill sends a SIGTERM to the daemon
 func (r *RestartDaemonConfig) kill() {
-	e2elog.Logf("Killing %v", r)
+	framework.Logf("Killing %v", r)
 	_, err := e2essh.NodeExec(r.nodeName, fmt.Sprintf("pgrep %v | xargs -I {} sudo kill {}", r.daemonName), framework.TestContext.Provider)
 	framework.ExpectNoError(err)
 }
@@ -275,7 +274,7 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 		}
 		if len(newKeys.List()) != len(existingKeys.List()) ||
 			!newKeys.IsSuperset(existingKeys) {
-			e2elog.Failf("RcManager created/deleted pods after restart \n\n %+v", tracker)
+			framework.Failf("RcManager created/deleted pods after restart \n\n %+v", tracker)
 		}
 	})
 
@@ -300,13 +299,13 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 	ginkgo.It("Kubelet should not restart containers across restart", func() {
 		nodeIPs, err := e2enode.GetPublicIps(f.ClientSet)
 		if err != nil {
-			e2elog.Logf("Unexpected error occurred: %v", err)
+			framework.Logf("Unexpected error occurred: %v", err)
 		}
 		// TODO: write a wrapper for ExpectNoErrorWithOffset()
 		framework.ExpectNoErrorWithOffset(0, err)
 		preRestarts, badNodes := getContainerRestarts(f.ClientSet, ns, labelSelector)
 		if preRestarts != 0 {
-			e2elog.Logf("WARNING: Non-zero container restart count: %d across nodes %v", preRestarts, badNodes)
+			framework.Logf("WARNING: Non-zero container restart count: %d across nodes %v", preRestarts, badNodes)
 		}
 		for _, ip := range nodeIPs {
 			restarter := NewRestartConfig(
@@ -315,8 +314,8 @@ var _ = SIGDescribe("DaemonRestart [Disruptive]", func() {
 		}
 		postRestarts, badNodes := getContainerRestarts(f.ClientSet, ns, labelSelector)
 		if postRestarts != preRestarts {
-			framework.DumpNodeDebugInfo(f.ClientSet, badNodes, e2elog.Logf)
-			e2elog.Failf("Net container restart count went from %v -> %v after kubelet restart on nodes %v \n\n %+v", preRestarts, postRestarts, badNodes, tracker)
+			framework.DumpNodeDebugInfo(f.ClientSet, badNodes, framework.Logf)
+			framework.Failf("Net container restart count went from %v -> %v after kubelet restart on nodes %v \n\n %+v", preRestarts, postRestarts, badNodes, tracker)
 		}
 	})
 })

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -311,7 +310,7 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 			return false, fmt.Errorf("pods is nil")
 		}
 		if len(pods.Items) < n {
-			e2elog.Logf("pods: %v < %v", len(pods.Items), n)
+			framework.Logf("pods: %v < %v", len(pods.Items), n)
 			return false, nil
 		}
 		ready := 0
@@ -321,7 +320,7 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 			}
 		}
 		if ready < n {
-			e2elog.Logf("running pods: %v < %v", ready, n)
+			framework.Logf("running pods: %v < %v", ready, n)
 			return false, nil
 		}
 		return true, nil

--- a/test/e2e/apps/job.go
+++ b/test/e2e/apps/job.go
@@ -26,7 +26,6 @@ import (
 	batchinternal "k8s.io/kubernetes/pkg/apis/batch"
 	"k8s.io/kubernetes/test/e2e/framework"
 	jobutil "k8s.io/kubernetes/test/e2e/framework/job"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 
 	"github.com/onsi/ginkgo"
@@ -243,7 +242,7 @@ var _ = SIGDescribe("Job", func() {
 		// updates we need to allow more than backoff+1
 		// TODO revert this back to above when https://github.com/kubernetes/kubernetes/issues/64787 gets fixed
 		if len(pods.Items) < backoff+1 {
-			e2elog.Failf("Not enough pod created expected at least %d, got %#v", backoff+1, pods.Items)
+			framework.Failf("Not enough pod created expected at least %d, got %#v", backoff+1, pods.Items)
 		}
 		for _, pod := range pods.Items {
 			framework.ExpectEqual(pod.Status.Phase, v1.PodFailed)

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/controller/replication"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -136,7 +135,7 @@ func TestReplicationControllerServeImageOrFail(f *framework.Framework, test stri
 
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
-	e2elog.Logf("Ensuring all pods for ReplicationController %q are running", name)
+	framework.Logf("Ensuring all pods for ReplicationController %q are running", name)
 	running := int32(0)
 	for _, pod := range pods.Items {
 		if pod.DeletionTimestamp != nil {
@@ -152,7 +151,7 @@ func TestReplicationControllerServeImageOrFail(f *framework.Framework, test stri
 			}
 		}
 		framework.ExpectNoError(err)
-		e2elog.Logf("Pod %q is running (conditions: %+v)", pod.Name, pod.Status.Conditions)
+		framework.Logf("Pod %q is running (conditions: %+v)", pod.Name, pod.Status.Conditions)
 		running++
 	}
 
@@ -162,13 +161,13 @@ func TestReplicationControllerServeImageOrFail(f *framework.Framework, test stri
 	}
 
 	// Verify that something is listening.
-	e2elog.Logf("Trying to dial the pod")
+	framework.Logf("Trying to dial the pod")
 	retryTimeout := 2 * time.Minute
 	retryInterval := 5 * time.Second
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 	err = wait.Poll(retryInterval, retryTimeout, e2epod.NewProxyResponseChecker(f.ClientSet, f.Namespace.Name, label, name, true, pods).CheckAllResponses)
 	if err != nil {
-		e2elog.Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
+		framework.Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
 	}
 }
 
@@ -181,7 +180,7 @@ func testReplicationControllerConditionCheck(f *framework.Framework) {
 	namespace := f.Namespace.Name
 	name := "condition-test"
 
-	e2elog.Logf("Creating quota %q that allows only two pods to run in the current namespace", name)
+	framework.Logf("Creating quota %q that allows only two pods to run in the current namespace", name)
 	quota := newPodQuota(name, "2")
 	_, err := c.CoreV1().ResourceQuotas(namespace).Create(quota)
 	framework.ExpectNoError(err)

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/controller/replicaset"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	replicasetutil "k8s.io/kubernetes/test/e2e/framework/replicaset"
 
@@ -125,7 +124,7 @@ func testReplicaSetServeImageOrFail(f *framework.Framework, test string, image s
 	// Create a ReplicaSet for a service that serves its hostname.
 	// The source for the Docker containter kubernetes/serve_hostname is
 	// in contrib/for-demos/serve_hostname
-	e2elog.Logf("Creating ReplicaSet %s", name)
+	framework.Logf("Creating ReplicaSet %s", name)
 	newRS := newRS(name, replicas, map[string]string{"name": name}, name, image, []string{"serve-hostname"})
 	newRS.Spec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{{ContainerPort: 9376}}
 	_, err := f.ClientSet.AppsV1().ReplicaSets(f.Namespace.Name).Create(newRS)
@@ -138,7 +137,7 @@ func testReplicaSetServeImageOrFail(f *framework.Framework, test string, image s
 
 	// Wait for the pods to enter the running state. Waiting loops until the pods
 	// are running so non-running pods cause a timeout for this test.
-	e2elog.Logf("Ensuring a pod for ReplicaSet %q is running", name)
+	framework.Logf("Ensuring a pod for ReplicaSet %q is running", name)
 	running := int32(0)
 	for _, pod := range pods.Items {
 		if pod.DeletionTimestamp != nil {
@@ -154,7 +153,7 @@ func testReplicaSetServeImageOrFail(f *framework.Framework, test string, image s
 			}
 		}
 		framework.ExpectNoError(err)
-		e2elog.Logf("Pod %q is running (conditions: %+v)", pod.Name, pod.Status.Conditions)
+		framework.Logf("Pod %q is running (conditions: %+v)", pod.Name, pod.Status.Conditions)
 		running++
 	}
 
@@ -164,13 +163,13 @@ func testReplicaSetServeImageOrFail(f *framework.Framework, test string, image s
 	}
 
 	// Verify that something is listening.
-	e2elog.Logf("Trying to dial the pod")
+	framework.Logf("Trying to dial the pod")
 	retryTimeout := 2 * time.Minute
 	retryInterval := 5 * time.Second
 	label := labels.SelectorFromSet(labels.Set(map[string]string{"name": name}))
 	err = wait.Poll(retryInterval, retryTimeout, e2epod.NewProxyResponseChecker(f.ClientSet, f.Namespace.Name, label, name, true, pods).CheckAllResponses)
 	if err != nil {
-		e2elog.Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
+		framework.Failf("Did not get expected responses within the timeout period of %.2f seconds.", retryTimeout.Seconds())
 	}
 }
 

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -34,7 +34,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	e2esset "k8s.io/kubernetes/test/e2e/framework/statefulset"
@@ -90,7 +89,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
 				framework.DumpDebugInfo(c, ns)
 			}
-			e2elog.Logf("Deleting all statefulset in ns %v", ns)
+			framework.Logf("Deleting all statefulset in ns %v", ns)
 			e2esset.DeleteAllStatefulSets(c, ns)
 		})
 
@@ -712,7 +711,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 			ginkgo.By("Waiting until pod " + podName + " will start running in namespace " + f.Namespace.Name)
 			if err := f.WaitForPodRunning(podName); err != nil {
-				e2elog.Failf("Pod %v did not start running: %v", podName, err)
+				framework.Failf("Pod %v did not start running: %v", podName, err)
 			}
 
 			var initialStatefulPodUID types.UID
@@ -726,19 +725,19 @@ var _ = SIGDescribe("StatefulSet", func() {
 				pod := event.Object.(*v1.Pod)
 				switch event.Type {
 				case watch.Deleted:
-					e2elog.Logf("Observed delete event for stateful pod %v in namespace %v", pod.Name, pod.Namespace)
+					framework.Logf("Observed delete event for stateful pod %v in namespace %v", pod.Name, pod.Namespace)
 					if initialStatefulPodUID == "" {
 						return false, nil
 					}
 					return true, nil
 				}
-				e2elog.Logf("Observed stateful pod in namespace: %v, name: %v, uid: %v, status phase: %v. Waiting for statefulset controller to delete.",
+				framework.Logf("Observed stateful pod in namespace: %v, name: %v, uid: %v, status phase: %v. Waiting for statefulset controller to delete.",
 					pod.Namespace, pod.Name, pod.UID, pod.Status.Phase)
 				initialStatefulPodUID = pod.UID
 				return false, nil
 			})
 			if err != nil {
-				e2elog.Failf("Pod %v expected to be re-created at least once", statefulPodName)
+				framework.Failf("Pod %v expected to be re-created at least once", statefulPodName)
 			}
 
 			ginkgo.By("Removing pod with conflicting port in namespace " + f.Namespace.Name)
@@ -780,7 +779,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			ginkgo.By("getting scale subresource")
 			scale, err := c.AppsV1().StatefulSets(ns).GetScale(ssName, metav1.GetOptions{})
 			if err != nil {
-				e2elog.Failf("Failed to get scale subresource: %v", err)
+				framework.Failf("Failed to get scale subresource: %v", err)
 			}
 			framework.ExpectEqual(scale.Spec.Replicas, int32(1))
 			framework.ExpectEqual(scale.Status.Replicas, int32(1))
@@ -789,14 +788,14 @@ var _ = SIGDescribe("StatefulSet", func() {
 			scale.Spec.Replicas = 2
 			scaleResult, err := c.AppsV1().StatefulSets(ns).UpdateScale(ssName, scale)
 			if err != nil {
-				e2elog.Failf("Failed to put scale subresource: %v", err)
+				framework.Failf("Failed to put scale subresource: %v", err)
 			}
 			framework.ExpectEqual(scaleResult.Spec.Replicas, int32(2))
 
 			ginkgo.By("verifying the statefulset Spec.Replicas was modified")
 			ss, err = c.AppsV1().StatefulSets(ns).Get(ssName, metav1.GetOptions{})
 			if err != nil {
-				e2elog.Failf("Failed to get statefulset resource: %v", err)
+				framework.Failf("Failed to get statefulset resource: %v", err)
 			}
 			framework.ExpectEqual(*(ss.Spec.Replicas), int32(2))
 		})
@@ -813,7 +812,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
 				framework.DumpDebugInfo(c, ns)
 			}
-			e2elog.Logf("Deleting all statefulset in ns %v", ns)
+			framework.Logf("Deleting all statefulset in ns %v", ns)
 			e2esset.DeleteAllStatefulSets(c, ns)
 		})
 
@@ -853,9 +852,9 @@ func kubectlExecWithRetries(args ...string) (out string) {
 		if out, err = framework.RunKubectl(args...); err == nil {
 			return
 		}
-		e2elog.Logf("Retrying %v:\nerror %v\nstdout %v", args, err, out)
+		framework.Logf("Retrying %v:\nerror %v\nstdout %v", args, err, out)
 	}
-	e2elog.Failf("Failed to execute \"%v\" with retries: %v", args, err)
+	framework.Failf("Failed to execute \"%v\" with retries: %v", args, err)
 	return
 }
 
@@ -892,7 +891,7 @@ func (c *clusterAppTester) run() {
 
 	ginkgo.By("Reading value under foo from member with index 2")
 	if err := pollReadWithTimeout(c.statefulPod, 2, "foo", "bar"); err != nil {
-		e2elog.Failf("%v", err)
+		framework.Failf("%v", err)
 	}
 }
 
@@ -915,7 +914,7 @@ func (z *zookeeperTester) write(statefulPodIndex int, kv map[string]string) {
 	ns := fmt.Sprintf("--namespace=%v", z.ss.Namespace)
 	for k, v := range kv {
 		cmd := fmt.Sprintf("/opt/zookeeper/bin/zkCli.sh create /%v %v", k, v)
-		e2elog.Logf(framework.RunKubectlOrDie("exec", ns, name, "--", "/bin/sh", "-c", cmd))
+		framework.Logf(framework.RunKubectlOrDie("exec", ns, name, "--", "/bin/sh", "-c", cmd))
 	}
 }
 
@@ -946,12 +945,12 @@ func (m *mysqlGaleraTester) mysqlExec(cmd, ns, podName string) string {
 func (m *mysqlGaleraTester) deploy(ns string) *appsv1.StatefulSet {
 	m.ss = e2esset.CreateStatefulSet(m.client, mysqlGaleraManifestPath, ns)
 
-	e2elog.Logf("Deployed statefulset %v, initializing database", m.ss.Name)
+	framework.Logf("Deployed statefulset %v, initializing database", m.ss.Name)
 	for _, cmd := range []string{
 		"create database statefulset;",
 		"use statefulset; create table foo (k varchar(20), v varchar(20));",
 	} {
-		e2elog.Logf(m.mysqlExec(cmd, ns, fmt.Sprintf("%v-0", m.ss.Name)))
+		framework.Logf(m.mysqlExec(cmd, ns, fmt.Sprintf("%v-0", m.ss.Name)))
 	}
 	return m.ss
 }
@@ -960,7 +959,7 @@ func (m *mysqlGaleraTester) write(statefulPodIndex int, kv map[string]string) {
 	name := fmt.Sprintf("%v-%d", m.ss.Name, statefulPodIndex)
 	for k, v := range kv {
 		cmd := fmt.Sprintf("use statefulset; insert into foo (k, v) values (\"%v\", \"%v\");", k, v)
-		e2elog.Logf(m.mysqlExec(cmd, m.ss.Namespace, name))
+		framework.Logf(m.mysqlExec(cmd, m.ss.Namespace, name))
 	}
 }
 
@@ -991,7 +990,7 @@ func (m *redisTester) deploy(ns string) *appsv1.StatefulSet {
 func (m *redisTester) write(statefulPodIndex int, kv map[string]string) {
 	name := fmt.Sprintf("%v-%d", m.ss.Name, statefulPodIndex)
 	for k, v := range kv {
-		e2elog.Logf(m.redisExec(fmt.Sprintf("SET %v %v", k, v), m.ss.Namespace, name))
+		framework.Logf(m.redisExec(fmt.Sprintf("SET %v %v", k, v), m.ss.Namespace, name))
 	}
 }
 
@@ -1016,12 +1015,12 @@ func (c *cockroachDBTester) cockroachDBExec(cmd, ns, podName string) string {
 
 func (c *cockroachDBTester) deploy(ns string) *appsv1.StatefulSet {
 	c.ss = e2esset.CreateStatefulSet(c.client, cockroachDBManifestPath, ns)
-	e2elog.Logf("Deployed statefulset %v, initializing database", c.ss.Name)
+	framework.Logf("Deployed statefulset %v, initializing database", c.ss.Name)
 	for _, cmd := range []string{
 		"CREATE DATABASE IF NOT EXISTS foo;",
 		"CREATE TABLE IF NOT EXISTS foo.bar (k STRING PRIMARY KEY, v STRING);",
 	} {
-		e2elog.Logf(c.cockroachDBExec(cmd, ns, fmt.Sprintf("%v-0", c.ss.Name)))
+		framework.Logf(c.cockroachDBExec(cmd, ns, fmt.Sprintf("%v-0", c.ss.Name)))
 	}
 	return c.ss
 }
@@ -1030,7 +1029,7 @@ func (c *cockroachDBTester) write(statefulPodIndex int, kv map[string]string) {
 	name := fmt.Sprintf("%v-%d", c.ss.Name, statefulPodIndex)
 	for k, v := range kv {
 		cmd := fmt.Sprintf("UPSERT INTO foo.bar VALUES ('%v', '%v');", k, v)
-		e2elog.Logf(c.cockroachDBExec(cmd, c.ss.Namespace, name))
+		framework.Logf(c.cockroachDBExec(cmd, c.ss.Namespace, name))
 	}
 }
 func (c *cockroachDBTester) read(statefulPodIndex int, key string) string {
@@ -1175,14 +1174,14 @@ func confirmStatefulPodCount(c clientset.Interface, count int, ss *appsv1.Statef
 		if statefulPodCount != count {
 			e2epod.LogPodStates(podList.Items)
 			if hard {
-				e2elog.Failf("StatefulSet %v scaled unexpectedly scaled to %d -> %d replicas", ss.Name, count, len(podList.Items))
+				framework.Failf("StatefulSet %v scaled unexpectedly scaled to %d -> %d replicas", ss.Name, count, len(podList.Items))
 			} else {
-				e2elog.Logf("StatefulSet %v has not reached scale %d, at %d", ss.Name, count, statefulPodCount)
+				framework.Logf("StatefulSet %v has not reached scale %d, at %d", ss.Name, count, statefulPodCount)
 			}
 			time.Sleep(1 * time.Second)
 			continue
 		}
-		e2elog.Logf("Verifying statefulset %v doesn't scale past %d for another %+v", ss.Name, count, deadline.Sub(t))
+		framework.Logf("Verifying statefulset %v doesn't scale past %d for another %+v", ss.Name, count, deadline.Sub(t))
 		time.Sleep(1 * time.Second)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR makes `test/e2e/apps/*` to use log functions of core framework.

**Which issue(s) this PR fixes**:
Ref #81427

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```