### PR TITLE
fix static check failures

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -4,7 +4,6 @@ cmd/kube-controller-manager/app
 cmd/kube-proxy/app
 cmd/linkcheck
 cmd/preferredimports
-hack/make-rules/helpers/go2make/testdata/dir-with-gofiles
 pkg/client/tests
 pkg/controller/daemon
 pkg/controller/deployment
@@ -75,8 +74,6 @@ pkg/volume/util/fsquota/common
 pkg/volume/util/operationexecutor
 pkg/volume/util/subpath
 pkg/volume/vsphere_volume
-plugin/pkg/admission/imagepolicy
-plugin/pkg/admission/podnodeselector
 test/e2e/apimachinery
 test/e2e/apps
 test/e2e/auth

--- a/hack/make-rules/helpers/go2make/testdata/dir-with-gofiles/bar.go
+++ b/hack/make-rules/helpers/go2make/testdata/dir-with-gofiles/bar.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package gofiles
 
-func bar() {
+func Bar() {
 }

--- a/hack/make-rules/helpers/go2make/testdata/dir-with-gofiles/foo.go
+++ b/hack/make-rules/helpers/go2make/testdata/dir-with-gofiles/foo.go
@@ -16,5 +16,5 @@ limitations under the License.
 
 package gofiles
 
-func foo() {
+func Foo() {
 }

--- a/pkg/apis/scheduling/v1alpha1/defaults.go
+++ b/pkg/apis/scheduling/v1alpha1/defaults.go
@@ -19,9 +19,14 @@ package v1alpha1
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/scheduling/v1alpha1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
 )
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}
 
 // SetDefaults_PriorityClass sets additional defaults compared to its counterpart
 // in extensions.

--- a/pkg/apis/scheduling/v1alpha1/register.go
+++ b/pkg/apis/scheduling/v1alpha1/register.go
@@ -42,5 +42,5 @@ func init() {
 	// We only register manually written functions here. The registration of the
 	// generated functions takes place in the generated files. The separation
 	// makes the code compile even when the generated files are missing.
-	localSchemeBuilder.Register(RegisterDefaults)
+	localSchemeBuilder.Register(addDefaultingFuncs)
 }

--- a/pkg/apis/scheduling/v1beta1/defaults.go
+++ b/pkg/apis/scheduling/v1beta1/defaults.go
@@ -19,9 +19,14 @@ package v1beta1
 import (
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/api/scheduling/v1beta1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
 )
+
+func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	return RegisterDefaults(scheme)
+}
 
 // SetDefaults_PriorityClass sets additional defaults compared to its counterpart
 // in extensions.

--- a/pkg/apis/scheduling/v1beta1/register.go
+++ b/pkg/apis/scheduling/v1beta1/register.go
@@ -42,5 +42,5 @@ func init() {
 	// We only register manually written functions here. The registration of the
 	// generated functions takes place in the generated files. The separation
 	// makes the code compile even when the generated files are missing.
-	localSchemeBuilder.Register(RegisterDefaults)
+	localSchemeBuilder.Register(addDefaultingFuncs)
 }

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -84,7 +84,6 @@ type Plugin struct {
 	responseCache *cache.LRUExpireCache
 	allowTTL      time.Duration
 	denyTTL       time.Duration
-	retryBackoff  time.Duration
 	defaultAllow  bool
 }
 

--- a/plugin/pkg/admission/imagepolicy/admission_test.go
+++ b/plugin/pkg/admission/imagepolicy/admission_test.go
@@ -984,6 +984,7 @@ func TestReturnedAnnotationAdd(t *testing.T) {
 		pod                 *api.Pod
 		verifierAnnotations map[string]string
 		expectedAnnotations map[string]string
+		wantErr             bool
 	}{
 		{
 			test: "Add valid response annotations",
@@ -1029,6 +1030,7 @@ func TestReturnedAnnotationAdd(t *testing.T) {
 			expectedAnnotations: map[string]string{
 				"imagepolicywebhook.image-policy.k8s.io/foo-test": "false",
 			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -1058,6 +1060,14 @@ func TestReturnedAnnotationAdd(t *testing.T) {
 			attr = &fakeAttributes{attr, annotations}
 
 			err = wh.Validate(context.TODO(), attr, nil)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("%s: expected error making admission request: %v", tt.test, err)
+				}
+			} else if err != nil {
+				t.Errorf("%s: failed to admit: %v", tt.test, err)
+			}
+
 			if !reflect.DeepEqual(annotations, tt.expectedAnnotations) {
 				t.Errorf("got audit annotations: %v; want: %v", annotations, tt.expectedAnnotations)
 			}

--- a/plugin/pkg/admission/imagepolicy/certs_test.go
+++ b/plugin/pkg/admission/imagepolicy/certs_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 // This file was generated using openssl by the gencerts.sh script
 // and holds raw certificates for the imagepolicy webhook tests.
 
+//lint:file-ignore U1000 Ignore all unused code, it's generated
+
 package imagepolicy
 
 var caKey = []byte(`-----BEGIN RSA PRIVATE KEY-----

--- a/plugin/pkg/admission/imagepolicy/gencerts.sh
+++ b/plugin/pkg/admission/imagepolicy/gencerts.sh
@@ -86,6 +86,8 @@ limitations under the License.
 // This file was generated using openssl by the gencerts.sh script
 // and holds raw certificates for the imagepolicy webhook tests.
 
+//lint:file-ignore U1000 Ignore all unused code, it's generated
+
 package imagepolicy
 EOF
 

--- a/plugin/pkg/admission/podnodeselector/admission.go
+++ b/plugin/pkg/admission/podnodeselector/admission.go
@@ -232,13 +232,12 @@ func (p *Plugin) defaultGetNamespace(name string) (*corev1.Namespace, error) {
 
 func (p *Plugin) getNodeSelectorMap(namespace *corev1.Namespace) (labels.Set, error) {
 	selector := labels.Set{}
-	labelsMap := labels.Set{}
 	var err error
 	found := false
 	if len(namespace.ObjectMeta.Annotations) > 0 {
 		for _, annotation := range NamespaceNodeSelectors {
 			if ns, ok := namespace.ObjectMeta.Annotations[annotation]; ok {
-				labelsMap, err = labels.ConvertSelectorToLabelsMap(ns)
+				labelsMap, err := labels.ConvertSelectorToLabelsMap(ns)
 				if err != nil {
 					return labels.Set{}, err
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind cleanup


**What this PR does / why we need it**:

```
Errors from staticcheck:

plugin/pkg/admission/imagepolicy/admission.go:87:2: field retryBackoff is unused (U1000)
plugin/pkg/admission/imagepolicy/admission_test.go:1060:4: this value of err is never used (SA4006)
plugin/pkg/admission/imagepolicy/certs_test.go:22:5: var caKey is unused (U1000)
plugin/pkg/admission/imagepolicy/certs_test.go:70:5: var badCAKey is unused (U1000)

plugin/pkg/admission/podnodeselector/admission.go:235:2: this value of labelsMap is never used (SA4006)

hack/make-rules/helpers/go2make/testdata/dir-with-gofiles/bar.go:19:6: func bar is unused (U1000)
hack/make-rules/helpers/go2make/testdata/dir-with-gofiles/foo.go:19:6: func foo is unused (U1000)

pkg/apis/scheduling/v1alpha1/defaults.go:27:6: func addDefaultingFuncs is unused (U1000)

pkg/apis/scheduling/v1beta1/defaults.go:27:6: func addDefaultingFuncs is unused (U1000)
```

**Which issue(s) this PR fixes**:

Ref: #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```