### PR TITLE
fix static check failures in staging  pkg

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -207,7 +207,6 @@ vendor/k8s.io/apiserver/pkg/util/wsstream
 vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc
 vendor/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook
 vendor/k8s.io/apiserver/plugin/pkg/authorizer/webhook
-vendor/k8s.io/cli-runtime/pkg/resource
 vendor/k8s.io/client-go/discovery/cached/memory
 vendor/k8s.io/client-go/dynamic/fake
 vendor/k8s.io/client-go/metadata/fake
@@ -217,7 +216,6 @@ vendor/k8s.io/client-go/restmapper
 vendor/k8s.io/client-go/tools/cache
 vendor/k8s.io/client-go/tools/leaderelection
 vendor/k8s.io/client-go/transport
-vendor/k8s.io/cloud-provider/service/helpers
 vendor/k8s.io/code-generator/cmd/client-gen/generators/fake
 vendor/k8s.io/code-generator/cmd/client-gen/generators/util
 vendor/k8s.io/code-generator/cmd/go-to-protobuf/protobuf
@@ -246,4 +244,3 @@ vendor/k8s.io/kubectl/pkg/scale
 vendor/k8s.io/legacy-cloud-providers/aws
 vendor/k8s.io/legacy-cloud-providers/azure
 vendor/k8s.io/metrics/pkg/client/custom_metrics
-vendor/k8s.io/sample-controller

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -54,9 +54,8 @@ import (
 )
 
 var (
-	corev1GV     = schema.GroupVersion{Version: "v1"}
-	corev1Codec  = scheme.Codecs.CodecForVersions(scheme.Codecs.LegacyCodec(corev1GV), scheme.Codecs.UniversalDecoder(corev1GV), corev1GV, corev1GV)
-	metaAccessor = meta.NewAccessor()
+	corev1GV    = schema.GroupVersion{Version: "v1"}
+	corev1Codec = scheme.Codecs.CodecForVersions(scheme.Codecs.LegacyCodec(corev1GV), scheme.Codecs.UniversalDecoder(corev1GV), corev1GV, corev1GV)
 )
 
 func stringBody(body string) io.ReadCloser {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -44,8 +44,8 @@ import (
 )
 
 const (
-	constSTDINstr       string = "STDIN"
-	stopValidateMessage        = "if you choose to ignore these errors, turn validation off with --validate=false"
+	constSTDINstr       = "STDIN"
+	stopValidateMessage = "if you choose to ignore these errors, turn validation off with --validate=false"
 )
 
 // Watchable describes a resource that can be watched for changes that occur on the server,

--- a/staging/src/k8s.io/cloud-provider/service/helpers/helper_test.go
+++ b/staging/src/k8s.io/cloud-provider/service/helpers/helper_test.go
@@ -59,13 +59,13 @@ func TestGetLoadBalancerSourceRanges(t *testing.T) {
 		annotations[v1.AnnotationLoadBalancerSourceRangesKey] = v
 		svc := v1.Service{}
 		svc.Annotations = annotations
-		cidrs, err := GetLoadBalancerSourceRanges(&svc)
+		_, err := GetLoadBalancerSourceRanges(&svc)
 		if err != nil {
 			t.Errorf("Unexpected error parsing: %q", v)
 		}
 		svc = v1.Service{}
 		svc.Spec.LoadBalancerSourceRanges = strings.Split(v, ",")
-		cidrs, err = GetLoadBalancerSourceRanges(&svc)
+		cidrs, err := GetLoadBalancerSourceRanges(&svc)
 		if err != nil {
 			t.Errorf("Unexpected error parsing: %q", v)
 		}

--- a/staging/src/k8s.io/sample-controller/controller_test.go
+++ b/staging/src/k8s.io/sample-controller/controller_test.go
@@ -175,8 +175,8 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 	}
 
 	switch a := actual.(type) {
-	case core.CreateAction:
-		e, _ := expected.(core.CreateAction)
+	case core.CreateActionImpl:
+		e, _ := expected.(core.CreateActionImpl)
 		expObject := e.GetObject()
 		object := a.GetObject()
 
@@ -184,8 +184,8 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
 				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
 		}
-	case core.UpdateAction:
-		e, _ := expected.(core.UpdateAction)
+	case core.UpdateActionImpl:
+		e, _ := expected.(core.UpdateActionImpl)
 		expObject := e.GetObject()
 		object := a.GetObject()
 
@@ -193,8 +193,8 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 			t.Errorf("Action %s %s has wrong object\nDiff:\n %s",
 				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expObject, object))
 		}
-	case core.PatchAction:
-		e, _ := expected.(core.PatchAction)
+	case core.PatchActionImpl:
+		e, _ := expected.(core.PatchActionImpl)
 		expPatch := e.GetPatch()
 		patch := a.GetPatch()
 
@@ -202,6 +202,9 @@ func checkAction(expected, actual core.Action, t *testing.T) {
 			t.Errorf("Action %s %s has wrong patch\nDiff:\n %s",
 				a.GetVerb(), a.GetResource().Resource, diff.ObjectGoPrintSideBySide(expPatch, patch))
 		}
+	default:
+		t.Errorf("Uncaptured Action %s %s, you should explicitly add a case to capture it",
+			actual.GetVerb(), actual.GetResource().Resource)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

```
Errors from staticcheck:

vendor/k8s.io/cloud-provider/service/helpers/helper_test.go:62:3: this value of cidrs is never used (SA4006)

vendor/k8s.io/sample-controller/controller_test.go:179:2: unreachable case clause: k8s.io/kubernetes/vendor/k8s.io/client-go/testing.CreateAction will always match before k8s.io/kubernetes/vendor/k8s.io/client-go/testing.UpdateAction (SA4020)

vendor/k8s.io/cli-runtime/pkg/resource/builder_test.go:59:2: var metaAccessor is unused (U1000)
vendor/k8s.io/cli-runtime/pkg/resource/visitor.go:47:2: only the first constant in this group has an explicit type (SA9004)
```
**Which issue(s) this PR fixes**:

Ref: #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```