### PR TITLE
Cleanup client-go static analysis issues-phase 1

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -213,14 +213,9 @@ vendor/k8s.io/client-go/metadata/fake
 vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/restmapper
-vendor/k8s.io/client-go/testing
 vendor/k8s.io/client-go/tools/cache
-vendor/k8s.io/client-go/tools/clientcmd
 vendor/k8s.io/client-go/tools/leaderelection
-vendor/k8s.io/client-go/tools/portforward
-vendor/k8s.io/client-go/tools/watch
 vendor/k8s.io/client-go/transport
-vendor/k8s.io/client-go/util/jsonpath
 vendor/k8s.io/cloud-provider/service/helpers
 vendor/k8s.io/code-generator/cmd/client-gen/generators/fake
 vendor/k8s.io/code-generator/cmd/client-gen/generators/util

--- a/staging/src/k8s.io/client-go/testing/actions.go
+++ b/staging/src/k8s.io/client-go/testing/actions.go
@@ -439,8 +439,8 @@ func (a ActionImpl) GetSubresource() string {
 	return a.Subresource
 }
 func (a ActionImpl) Matches(verb, resource string) bool {
-	return strings.ToLower(verb) == strings.ToLower(a.Verb) &&
-		strings.ToLower(resource) == strings.ToLower(a.Resource.Resource)
+	return strings.EqualFold(verb, a.Verb) &&
+		strings.EqualFold(resource, a.Resource.Resource)
 }
 func (a ActionImpl) DeepCopy() Action {
 	ret := a

--- a/staging/src/k8s.io/client-go/testing/fixture_test.go
+++ b/staging/src/k8s.io/client-go/testing/fixture_test.go
@@ -204,7 +204,8 @@ func TestWatchCallMultipleInvocation(t *testing.T) {
 					event := <-w.ResultChan()
 					accessor, err := meta.Accessor(event.Object)
 					if err != nil {
-						t.Fatalf("unexpected error: %v", err)
+						t.Errorf("unexpected error: %v", err)
+						break
 					}
 					assert.Equal(t, c.op, event.Type, "watch event mismatched")
 					assert.Equal(t, c.name, accessor.GetName(), "watched object mismatch")

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -458,7 +458,6 @@ func TestCreateCleanDefaultCluster(t *testing.T) {
 }
 
 func TestCreateMissingContextNoDefault(t *testing.T) {
-	const expectedErrorContains = "Context was not found for specified context"
 	config := createValidTestConfig()
 	clientBuilder := NewNonInteractiveClientConfig(*config, "not-present", &ConfigOverrides{}, nil)
 

--- a/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go
@@ -24,19 +24,6 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
-type testLoader struct {
-	ClientConfigLoader
-
-	called bool
-	config *clientcmdapi.Config
-	err    error
-}
-
-func (l *testLoader) Load() (*clientcmdapi.Config, error) {
-	l.called = true
-	return l.config, l.err
-}
-
 type testClientConfig struct {
 	rawconfig          *clientcmdapi.Config
 	config             *restclient.Config

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -185,9 +185,10 @@ func validateClusterInfo(clusterName string, clusterInfo clientcmdapi.Cluster) [
 	}
 	if len(clusterInfo.CertificateAuthority) != 0 {
 		clientCertCA, err := os.Open(clusterInfo.CertificateAuthority)
-		defer clientCertCA.Close()
 		if err != nil {
 			validationErrors = append(validationErrors, fmt.Errorf("unable to read certificate-authority %v for %v due to %v", clusterInfo.CertificateAuthority, clusterName, err))
+		} else {
+			defer clientCertCA.Close()
 		}
 	}
 
@@ -223,16 +224,18 @@ func validateAuthInfo(authInfoName string, authInfo clientcmdapi.AuthInfo) []err
 
 		if len(authInfo.ClientCertificate) != 0 {
 			clientCertFile, err := os.Open(authInfo.ClientCertificate)
-			defer clientCertFile.Close()
 			if err != nil {
 				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-cert %v for %v due to %v", authInfo.ClientCertificate, authInfoName, err))
+			} else {
+				defer clientCertFile.Close()
 			}
 		}
 		if len(authInfo.ClientKey) != 0 {
 			clientKeyFile, err := os.Open(authInfo.ClientKey)
-			defer clientKeyFile.Close()
 			if err != nil {
 				validationErrors = append(validationErrors, fmt.Errorf("unable to read client-key %v for %v due to %v", authInfo.ClientKey, authInfoName, err))
+			} else {
+				defer clientKeyFile.Close()
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward_test.go
@@ -376,6 +376,9 @@ func TestGetPortsReturnsDynamicallyAssignedLocalPort(t *testing.T) {
 	<-pf.Ready
 
 	ports, err := pf.GetPorts()
+	if err != nil {
+		t.Fatalf("Failed to get ports. error: %v", err)
+	}
 
 	if len(ports) != 1 {
 		t.Fatalf("expected 1 port, got %d", len(ports))

--- a/staging/src/k8s.io/client-go/tools/watch/until_test.go
+++ b/staging/src/k8s.io/client-go/tools/watch/until_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 type fakePod struct {
-	name string
 }
 
 func (obj *fakePod) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }

--- a/staging/src/k8s.io/client-go/util/jsonpath/parser.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/parser.go
@@ -37,7 +37,6 @@ type Parser struct {
 	Name  string
 	Root  *ListNode
 	input string
-	cur   *ListNode
 	pos   int
 	start int
 	width int
@@ -186,8 +185,7 @@ func (p *Parser) parseInsideAction(cur *ListNode) error {
 func (p *Parser) parseRightDelim(cur *ListNode) error {
 	p.pos += len(rightDelim)
 	p.consumeText()
-	cur = p.Root
-	return p.parseText(cur)
+	return p.parseText(p.Root)
 }
 
 // parseIdentifier scans build-in keywords, like "range" "end"
@@ -231,7 +229,7 @@ func (p *Parser) parseRecursive(cur *ListNode) error {
 func (p *Parser) parseNumber(cur *ListNode) error {
 	r := p.peek()
 	if r == '+' || r == '-' {
-		r = p.next()
+		p.next()
 	}
 	for {
 		r = p.next()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup issues identified by staticcheck in #81189

**Which issue(s) this PR fixes**:
ref #81657

**Special notes for your reviewer**:
For easy review, list the issues here:

```
vendor/k8s.io/client-go/util/jsonpath/parser.go:40:2: field cur is unused (U1000)
vendor/k8s.io/client-go/util/jsonpath/parser.go:186:34: argument cur is overwritten before first use (SA4009)
vendor/k8s.io/client-go/util/jsonpath/parser.go:234:3: this value of r is never used (SA4006)
vendor/k8s.io/client-go/tools/watch/until_test.go:38:2: field name is unused (U1000)
vendor/k8s.io/client-go/tools/portforward/portforward_test.go:378:9: this value of err is never used (SA4006)
vendor/k8s.io/client-go/tools/clientcmd/client_config_test.go:461:8: const expectedErrorContains is unused (U1000)
vendor/k8s.io/client-go/tools/clientcmd/merged_client_builder_test.go:27:6: type testLoader is unused (U1000)
vendor/k8s.io/client-go/tools/clientcmd/validation.go:188:3: should check returned error before deferring clientCertCA.Close() (SA5001)
vendor/k8s.io/client-go/tools/clientcmd/validation.go:226:4: should check returned error before deferring clientCertFile.Close() (SA5001)
vendor/k8s.io/client-go/tools/clientcmd/validation.go:233:4: should check returned error before deferring clientKeyFile.Close() (SA5001)
vendor/k8s.io/client-go/testing/actions.go:442:9: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (SA6005)
vendor/k8s.io/client-go/testing/actions.go:443:3: should use strings.EqualFold(a, b) instead of strings.ToLower(a) == strings.ToLower(b) (SA6005)
vendor/k8s.io/client-go/testing/fixture_test.go:199:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
```


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

