### PR TITLE
WIP kube-proxy: do not record NetworkProgrammingLatency after syncing cache.

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -250,7 +250,7 @@ func TestCleanupLeftovers(t *testing.T) {
 		}),
 	)
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// test cleanup left over
 	if CleanupLeftovers(ipvs, ipt, ipset, true) {
@@ -708,7 +708,7 @@ func TestNodePort(t *testing.T) {
 			makeServiceMap(fp, test.services...)
 			makeEndpointsMap(fp, test.endpoints...)
 
-			fp.syncProxyRules()
+			fp.syncProxyRules(true)
 
 			if !reflect.DeepEqual(ipvs, test.expectedIPVS) {
 				t.Logf("actual ipvs state: %v", ipvs)
@@ -874,7 +874,7 @@ func TestClusterIP(t *testing.T) {
 			makeServiceMap(fp, test.services...)
 			makeEndpointsMap(fp, test.endpoints...)
 
-			fp.syncProxyRules()
+			fp.syncProxyRules(true)
 
 			if !reflect.DeepEqual(ipvs, test.expectedIPVS) {
 				t.Logf("actual ipvs state: %v", ipvs)
@@ -914,7 +914,7 @@ func TestExternalIPsNoEndpoint(t *testing.T) {
 
 	makeEndpointsMap(fp)
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// check ipvs service and destinations
 	services, err := ipvs.GetVirtualServers()
@@ -982,7 +982,7 @@ func TestExternalIPs(t *testing.T) {
 		}),
 	)
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// check ipvs service and destinations
 	services, err := ipvs.GetVirtualServers()
@@ -1052,7 +1052,7 @@ func TestLoadBalancer(t *testing.T) {
 		}),
 	)
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// Expect 2 services and 1 destination
 	epVS := &netlinktest.ExpectedVirtualServer{
@@ -1149,7 +1149,7 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 	fp.networkInterfacer.(*proxyutiltest.FakeNetwork).AddInterfaceAddr(&itf1, addrs1)
 	fp.nodePortAddresses = []string{"100.101.102.0/24", "2001:db8::0/64"}
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// Expect 3 services and 1 destination
 	epVS := &netlinktest.ExpectedVirtualServer{
@@ -1229,7 +1229,7 @@ func TestLoadBalanceSourceRanges(t *testing.T) {
 		}),
 	)
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// Check ipvs service and destinations
 	epVS := &netlinktest.ExpectedVirtualServer{
@@ -1334,7 +1334,7 @@ func TestAcceptIPVSTraffic(t *testing.T) {
 			}),
 		)
 	}
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// Check iptables chain and rules
 	epIpt := netlinktest.ExpectedIptablesChain{
@@ -1406,7 +1406,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 		}),
 	)
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// Expect 2 services and 1 destination
 	epVS := &netlinktest.ExpectedVirtualServer{
@@ -1755,7 +1755,7 @@ func TestSessionAffinity(t *testing.T) {
 	)
 	makeEndpointsMap(fp)
 
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 
 	// check ipvs service and destinations
 	services, err := ipvs.GetVirtualServers()
@@ -3320,7 +3320,7 @@ func TestMultiPortServiceBindAddr(t *testing.T) {
 
 	// first, add multi-port service1
 	fp.OnServiceAdd(service1)
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 	remainingAddrs, _ := fp.netlinkHandle.ListBindAddress(DefaultDummyDevice)
 	// should only remain address "172.16.55.4"
 	if len(remainingAddrs) != 1 {
@@ -3332,7 +3332,7 @@ func TestMultiPortServiceBindAddr(t *testing.T) {
 
 	// update multi-port service1 to single-port service2
 	fp.OnServiceUpdate(service1, service2)
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 	remainingAddrs, _ = fp.netlinkHandle.ListBindAddress(DefaultDummyDevice)
 	// should still only remain address "172.16.55.4"
 	if len(remainingAddrs) != 1 {
@@ -3343,7 +3343,7 @@ func TestMultiPortServiceBindAddr(t *testing.T) {
 
 	// update single-port service2 to multi-port service3
 	fp.OnServiceUpdate(service2, service3)
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 	remainingAddrs, _ = fp.netlinkHandle.ListBindAddress(DefaultDummyDevice)
 	// should still only remain address "172.16.55.4"
 	if len(remainingAddrs) != 1 {
@@ -3354,7 +3354,7 @@ func TestMultiPortServiceBindAddr(t *testing.T) {
 
 	// delete multi-port service3
 	fp.OnServiceDelete(service3)
-	fp.syncProxyRules()
+	fp.syncProxyRules(true)
 	remainingAddrs, _ = fp.netlinkHandle.ListBindAddress(DefaultDummyDevice)
 	// all addresses should be unbound
 	if len(remainingAddrs) != 0 {

--- a/pkg/proxy/metrics/BUILD
+++ b/pkg/proxy/metrics/BUILD
@@ -5,7 +5,11 @@ go_library(
     srcs = ["metrics.go"],
     importpath = "k8s.io/kubernetes/pkg/proxy/metrics",
     visibility = ["//visibility:public"],
-    deps = ["//vendor/github.com/prometheus/client_golang/prometheus:go_default_library"],
+    deps = [
+        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
 )
 
 filegroup(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Recording NetworkProgrammingLatency on sync events produces incorrect results. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/perf-tests/issues/640

**Special notes for your reviewer**:
n/a 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
n/a 
```
