### PR TITLE
Fix kubectl normalizers to stop injecting extra whitespace

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/templates/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -33,4 +33,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["normalizers_test.go"],
+    embed = [":go_default_library"],
 )

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
@@ -47,7 +47,14 @@ func (r *ASCIIRenderer) NormalText(out *bytes.Buffer, text []byte) {
 	for _, line := range lines {
 		trimmed := strings.Trim(line, " \n\t")
 		if len(trimmed) > 0 && trimmed[0] != '_' {
-			out.WriteString(" ")
+			b := out.Bytes()
+			if len(b) == 0 {
+				// Don't lead with a space
+			} else if c := b[len(b)-1]; c == ' ' || c == '\n' {
+				// Don't insert an extra space next to a space
+			} else {
+				out.WriteString(" ")
+			}
 		}
 		out.WriteString(trimmed)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package templates
+
+import "testing"
+
+func TestLongDesc(t *testing.T) {
+	grid := []struct {
+		In       string
+		Expected string
+	}{
+		{
+			In:       `Single line.`,
+			Expected: `Single line.`,
+		},
+		{
+			In: `
+Multiple lines.
+
+Line 2.
+Line 3.
+`,
+			Expected: `Multiple lines.
+
+ Line 2. Line 3.`,
+		},
+		{
+			In: `
+   Whitespace trimming  preserves   inline    spaces.
+
+  Line 2.
+    Line 3.
+`,
+			Expected: `Whitespace trimming  preserves   inline    spaces.
+
+ Line 2. Line 3.`,
+		},
+		{
+			In:       `TEXT_WITH_UNDERSCORE`,
+			Expected: `TEXT_WITH_UNDERSCORE`,
+		},
+	}
+
+	for _, g := range grid {
+		actual := LongDesc(g.In)
+		if actual == g.Expected {
+			continue
+		}
+
+		t.Errorf("LongDesc(%q) produced unexpected output.  Actual=%q, Expected=%q", g.In, actual, g.Expected)
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/normalizers_test.go
@@ -36,7 +36,7 @@ Line 3.
 `,
 			Expected: `Multiple lines.
 
- Line 2. Line 3.`,
+Line 2. Line 3.`,
 		},
 		{
 			In: `
@@ -47,7 +47,7 @@ Line 3.
 `,
 			Expected: `Whitespace trimming  preserves   inline    spaces.
 
- Line 2. Line 3.`,
+Line 2. Line 3.`,
 		},
 		{
 			In:       `TEXT_WITH_UNDERSCORE`,


### PR DESCRIPTION
demonstrate the problem and fixes it.

/kind bug


```docs
NONE
```