### PR TITLE
update cAdvisor godeps to v0.34.0 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.3.1
-	github.com/google/cadvisor v0.33.2-0.20190719172907-9fa3b1429966
+	github.com/google/cadvisor v0.34.0
 	github.com/google/certificate-transparency-go v1.0.21 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/gofuzz v1.0.0
@@ -282,7 +282,7 @@ replace (
 	github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
 	github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
 	github.com/google/btree => github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c
-	github.com/google/cadvisor => github.com/google/cadvisor v0.33.2-0.20190719172907-9fa3b1429966
+	github.com/google/cadvisor => github.com/google/cadvisor v0.34.0
 	github.com/google/certificate-transparency-go => github.com/google/certificate-transparency-go v1.0.21
 	github.com/google/go-cmp => github.com/google/go-cmp v0.3.0
 	github.com/google/gofuzz => github.com/google/gofuzz v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e h1:KhcknUwkWHKZ
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/cadvisor v0.33.2-0.20190719172907-9fa3b1429966 h1:8PpCh6R0YjmmztPXOq9aKhiUqLGUrp6Fly3vWk7l2Fg=
-github.com/google/cadvisor v0.33.2-0.20190719172907-9fa3b1429966/go.mod h1:1nql6U13uTHaLYB8rLS5x9IJc2qT6Xd/Tr1sTX6NE48=
+github.com/google/cadvisor v0.34.0 h1:No7G6U/TasplR9uNqyc5Jj0Bet5VSYsK5xLygOf4pUw=
+github.com/google/cadvisor v0.34.0/go.mod h1:1nql6U13uTHaLYB8rLS5x9IJc2qT6Xd/Tr1sTX6NE48=
 github.com/google/certificate-transparency-go v1.0.21 h1:Yf1aXowfZ2nuboBsg7iYGLmwsOARdV86pfH3g95wXmE=
 github.com/google/certificate-transparency-go v1.0.21/go.mod h1:QeJfpSbVSfYc7RgB3gJFj9cbuQMMchQxrWXz8Ruopmg=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=

--- a/vendor/github.com/google/cadvisor/container/raw/factory.go
+++ b/vendor/github.com/google/cadvisor/container/raw/factory.go
@@ -30,6 +30,7 @@ import (
 )
 
 var dockerOnly = flag.Bool("docker_only", false, "Only report docker containers in addition to root stats")
+var disableRootCgroupStats = flag.Bool("disable_root_cgroup_stats", false, "Disable collecting root Cgroup stats")
 
 type rawFactory struct {
 	// Factory for machine information.

--- a/vendor/github.com/google/cadvisor/container/raw/handler.go
+++ b/vendor/github.com/google/cadvisor/container/raw/handler.go
@@ -227,6 +227,9 @@ func (self *rawContainerHandler) getFsStats(stats *info.ContainerStats) error {
 }
 
 func (self *rawContainerHandler) GetStats() (*info.ContainerStats, error) {
+	if *disableRootCgroupStats && isRootCgroup(self.name) {
+		return nil, nil
+	}
 	stats, err := self.libcontainerHandler.GetStats()
 	if err != nil {
 		return stats, err

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -435,7 +435,7 @@ github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c => github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c
 github.com/google/btree
-# github.com/google/cadvisor v0.33.2-0.20190719172907-9fa3b1429966 => github.com/google/cadvisor v0.33.2-0.20190719172907-9fa3b1429966
+# github.com/google/cadvisor v0.34.0 => github.com/google/cadvisor v0.34.0
 github.com/google/cadvisor/accelerators
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
Since this version bump contains at least one bugfix.

**What this PR does / why we need it**:
cAdvisor cuts a release for each kubernetes release.  This is the cAdvisor release update for kubernetes 1.16.

**Which issue(s) this PR fixes**:
Fixes #81228

**Does this PR introduce a user-facing change?**:
```release-note
- Fix disk stats in LXD using ZFS storage pool
- Fix CRI-O missing network metris bug
- Add `container_sockets`, `container_threads`, and `container_threads_max` metrics
```

/assign @dchen1107 