### PR TITLE
Use log functions of core framework on sub [p-s]

### DIFF
--- a/test/e2e/framework/profile_gatherer.go
+++ b/test/e2e/framework/profile_gatherer.go
@@ -26,7 +26,6 @@ import (
 	"sync"
 	"time"
 
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 )
 
@@ -182,7 +181,7 @@ func GatherCPUProfileForSeconds(componentName string, profileBaseName string, se
 		defer wg.Done()
 	}
 	if err := gatherProfile(componentName, profileBaseName, fmt.Sprintf("profile?seconds=%v", seconds)); err != nil {
-		e2elog.Logf("Failed to gather %v CPU profile: %v", componentName, err)
+		Logf("Failed to gather %v CPU profile: %v", componentName, err)
 	}
 }
 
@@ -192,7 +191,7 @@ func GatherMemoryProfile(componentName string, profileBaseName string, wg *sync.
 		defer wg.Done()
 	}
 	if err := gatherProfile(componentName, profileBaseName, "heap"); err != nil {
-		e2elog.Logf("Failed to gather %v memory profile: %v", componentName, err)
+		Logf("Failed to gather %v memory profile: %v", componentName, err)
 	}
 }
 

--- a/test/e2e/framework/replicaset/BUILD
+++ b/test/e2e/framework/replicaset/BUILD
@@ -18,7 +18,6 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/typed/apps/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],

--- a/test/e2e/framework/replicaset/rest.go
+++ b/test/e2e/framework/replicaset/rest.go
@@ -24,13 +24,12 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	testutils "k8s.io/kubernetes/test/utils"
 )
 
 // UpdateReplicaSetWithRetries updates replicaset template with retries.
 func UpdateReplicaSetWithRetries(c clientset.Interface, namespace, name string, applyUpdate testutils.UpdateReplicaSetFunc) (*appsv1.ReplicaSet, error) {
-	return testutils.UpdateReplicaSetWithRetries(c, namespace, name, applyUpdate, e2elog.Logf, framework.Poll, framework.PollShortTimeout)
+	return testutils.UpdateReplicaSetWithRetries(c, namespace, name, applyUpdate, framework.Logf, framework.Poll, framework.PollShortTimeout)
 }
 
 // CheckNewRSAnnotations check if the new RS's annotation is as expected

--- a/test/e2e/framework/service/BUILD
+++ b/test/e2e/framework/service/BUILD
@@ -36,7 +36,6 @@ go_library(
         "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//staging/src/k8s.io/cloud-provider/service/helpers:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/ssh:go_default_library",

--- a/test/e2e/framework/service/affinity_checker.go
+++ b/test/e2e/framework/service/affinity_checker.go
@@ -17,7 +17,7 @@ limitations under the License.
 package service
 
 import (
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 // affinityTracker tracks the destination of a request for the affinity tests.
@@ -28,7 +28,7 @@ type affinityTracker struct {
 // Record the response going to a given host.
 func (at *affinityTracker) recordHost(host string) {
 	at.hostTrace = append(at.hostTrace, host)
-	e2elog.Logf("Received response from host: %s", host)
+	framework.Logf("Received response from host: %s", host)
 }
 
 // Check that we got a constant count requests going to the same host.
@@ -51,6 +51,6 @@ func (at *affinityTracker) checkHostTrace(count int) (fulfilled, affinityHolds b
 }
 
 func checkAffinityFailed(tracker affinityTracker, err string) {
-	e2elog.Logf("%v", tracker.hostTrace)
-	e2elog.Failf(err)
+	framework.Logf("%v", tracker.hostTrace)
+	framework.Failf(err)
 }

--- a/test/e2e/framework/service/hostname.go
+++ b/test/e2e/framework/service/hostname.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -118,22 +117,22 @@ func VerifyServeHostnameServiceUp(c clientset.Interface, ns, host string, expect
 		// verify service from node
 		func() string {
 			cmd := "set -e; " + buildCommand("wget -q --timeout=0.2 --tries=1 -O -")
-			e2elog.Logf("Executing cmd %q on host %v", cmd, host)
+			framework.Logf("Executing cmd %q on host %v", cmd, host)
 			result, err := e2essh.SSH(cmd, host, framework.TestContext.Provider)
 			if err != nil || result.Code != 0 {
 				e2essh.LogResult(result)
-				e2elog.Logf("error while SSH-ing to node: %v", err)
+				framework.Logf("error while SSH-ing to node: %v", err)
 			}
 			return result.Stdout
 		},
 		// verify service from pod
 		func() string {
 			cmd := buildCommand("wget -q -T 1 -O -")
-			e2elog.Logf("Executing cmd %q in pod %v/%v", cmd, ns, execPod.Name)
+			framework.Logf("Executing cmd %q in pod %v/%v", cmd, ns, execPod.Name)
 			// TODO: Use exec-over-http via the netexec pod instead of kubectl exec.
 			output, err := framework.RunHostCmd(ns, execPod.Name, cmd)
 			if err != nil {
-				e2elog.Logf("error while kubectl execing %q in pod %v/%v: %v\nOutput: %v", cmd, ns, execPod.Name, err, output)
+				framework.Logf("error while kubectl execing %q in pod %v/%v: %v\nOutput: %v", cmd, ns, execPod.Name, err, output)
 			}
 			return output
 		},
@@ -159,12 +158,12 @@ func VerifyServeHostnameServiceUp(c clientset.Interface, ns, host string, expect
 			// and we need a better way to track how often it occurs.
 			if gotEndpoints.IsSuperset(expectedEndpoints) {
 				if !gotEndpoints.Equal(expectedEndpoints) {
-					e2elog.Logf("Ignoring unexpected output wgetting endpoints of service %s: %v", serviceIP, gotEndpoints.Difference(expectedEndpoints))
+					framework.Logf("Ignoring unexpected output wgetting endpoints of service %s: %v", serviceIP, gotEndpoints.Difference(expectedEndpoints))
 				}
 				passed = true
 				break
 			}
-			e2elog.Logf("Unable to reach the following endpoints of service %s: %v", serviceIP, expectedEndpoints.Difference(gotEndpoints))
+			framework.Logf("Unable to reach the following endpoints of service %s: %v", serviceIP, expectedEndpoints.Difference(gotEndpoints))
 		}
 		if !passed {
 			// Sort the lists so they're easier to visually diff.
@@ -191,12 +190,12 @@ func VerifyServeHostnameServiceDown(c clientset.Interface, host string, serviceI
 		result, err := e2essh.SSH(command, host, framework.TestContext.Provider)
 		if err != nil {
 			e2essh.LogResult(result)
-			e2elog.Logf("error while SSH-ing to node: %v", err)
+			framework.Logf("error while SSH-ing to node: %v", err)
 		}
 		if result.Code != 99 {
 			return nil
 		}
-		e2elog.Logf("service still alive - still waiting")
+		framework.Logf("service still alive - still waiting")
 	}
 	return fmt.Errorf("waiting for service to be down timed out")
 }

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -26,7 +26,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 )
 
 // GetServicesProxyRequest returns a request for a service proxy.
@@ -103,10 +102,10 @@ func EnableAndDisableInternalLB() (enable func(svc *v1.Service), disable func(sv
 
 // DescribeSvc logs the output of kubectl describe svc for the given namespace
 func DescribeSvc(ns string) {
-	e2elog.Logf("\nOutput of kubectl describe svc:\n")
+	framework.Logf("\nOutput of kubectl describe svc:\n")
 	desc, _ := framework.RunKubectl(
 		"describe", "svc", fmt.Sprintf("--namespace=%v", ns))
-	e2elog.Logf(desc)
+	framework.Logf(desc)
 }
 
 // GetServiceLoadBalancerCreationTimeout returns a timeout value for creating a load balancer of a service.

--- a/test/e2e/framework/service/wait.go
+++ b/test/e2e/framework/service/wait.go
@@ -26,7 +26,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	servicehelper "k8s.io/cloud-provider/service/helpers"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 
 	"github.com/onsi/ginkgo"
 )
@@ -38,7 +37,7 @@ func WaitForServiceResponding(c clientset.Interface, ns, name string) error {
 	return wait.PollImmediate(framework.Poll, RespondingTimeout, func() (done bool, err error) {
 		proxyRequest, errProxy := GetServicesProxyRequest(c, c.CoreV1().RESTClient().Get())
 		if errProxy != nil {
-			e2elog.Logf("Failed to get services proxy request: %v:", errProxy)
+			framework.Logf("Failed to get services proxy request: %v:", errProxy)
 			return false, nil
 		}
 
@@ -52,18 +51,18 @@ func WaitForServiceResponding(c clientset.Interface, ns, name string) error {
 			Raw()
 		if err != nil {
 			if ctx.Err() != nil {
-				e2elog.Failf("Failed to GET from service %s: %v", name, err)
+				framework.Failf("Failed to GET from service %s: %v", name, err)
 				return true, err
 			}
-			e2elog.Logf("Failed to GET from service %s: %v:", name, err)
+			framework.Logf("Failed to GET from service %s: %v:", name, err)
 			return false, nil
 		}
 		got := string(body)
 		if len(got) == 0 {
-			e2elog.Logf("Service %s: expected non-empty response", name)
+			framework.Logf("Service %s: expected non-empty response", name)
 			return false, err // stop polling
 		}
-		e2elog.Logf("Service %s: found nonempty answer: %s", name, got)
+		framework.Logf("Service %s: found nonempty answer: %s", name, got)
 		return true, nil
 	})
 }
@@ -72,7 +71,7 @@ func WaitForServiceResponding(c clientset.Interface, ns, name string) error {
 func WaitForServiceDeletedWithFinalizer(cs clientset.Interface, namespace, name string) {
 	ginkgo.By("Delete service with finalizer")
 	if err := cs.CoreV1().Services(namespace).Delete(name, nil); err != nil {
-		e2elog.Failf("Failed to delete service %s/%s", namespace, name)
+		framework.Failf("Failed to delete service %s/%s", namespace, name)
 	}
 
 	ginkgo.By("Wait for service to disappear")
@@ -80,15 +79,15 @@ func WaitForServiceDeletedWithFinalizer(cs clientset.Interface, namespace, name 
 		svc, err := cs.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				e2elog.Logf("Service %s/%s is gone.", namespace, name)
+				framework.Logf("Service %s/%s is gone.", namespace, name)
 				return true, nil
 			}
 			return false, err
 		}
-		e2elog.Logf("Service %s/%s still exists with finalizers: %v", namespace, name, svc.Finalizers)
+		framework.Logf("Service %s/%s still exists with finalizers: %v", namespace, name, svc.Finalizers)
 		return false, nil
 	}); pollErr != nil {
-		e2elog.Failf("Failed to wait for service to disappear: %v", pollErr)
+		framework.Failf("Failed to wait for service to disappear: %v", pollErr)
 	}
 }
 
@@ -108,11 +107,11 @@ func WaitForServiceUpdatedWithFinalizer(cs clientset.Interface, namespace, name 
 			}
 		}
 		if foundFinalizer != hasFinalizer {
-			e2elog.Logf("Service %s/%s hasFinalizer=%t, want %t", namespace, name, foundFinalizer, hasFinalizer)
+			framework.Logf("Service %s/%s hasFinalizer=%t, want %t", namespace, name, foundFinalizer, hasFinalizer)
 			return false, nil
 		}
 		return true, nil
 	}); pollErr != nil {
-		e2elog.Failf("Failed to wait for service to hasFinalizer=%t: %v", hasFinalizer, pollErr)
+		framework.Failf("Failed to wait for service to hasFinalizer=%t: %v", hasFinalizer, pollErr)
 	}
 }

--- a/test/e2e/framework/statefulset/BUILD
+++ b/test/e2e/framework/statefulset/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/manifest:go_default_library",
         "//test/utils/image:go_default_library",
     ],

--- a/test/e2e/framework/statefulset/fixtures.go
+++ b/test/e2e/framework/statefulset/fixtures.go
@@ -31,7 +31,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	e2efwk "k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -157,7 +156,7 @@ func BreakPodHTTPProbe(ss *appsv1.StatefulSet, pod *v1.Pod) error {
 	// Ignore 'mv' errors to make this idempotent.
 	cmd := fmt.Sprintf("mv -v /usr/local/apache2/htdocs%v /tmp/ || true", path)
 	stdout, err := e2efwk.RunHostCmdWithRetries(pod.Namespace, pod.Name, cmd, StatefulSetPoll, StatefulPodTimeout)
-	e2elog.Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
+	e2efwk.Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
 	return err
 }
 
@@ -181,7 +180,7 @@ func RestorePodHTTPProbe(ss *appsv1.StatefulSet, pod *v1.Pod) error {
 	// Ignore 'mv' errors to make this idempotent.
 	cmd := fmt.Sprintf("mv -v /tmp%v /usr/local/apache2/htdocs/ || true", path)
 	stdout, err := e2efwk.RunHostCmdWithRetries(pod.Namespace, pod.Name, cmd, StatefulSetPoll, StatefulPodTimeout)
-	e2elog.Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
+	e2efwk.Logf("stdout of %v on %v: %v", cmd, pod.Name, stdout)
 	return err
 }
 
@@ -243,17 +242,17 @@ func ResumeNextPod(c clientset.Interface, ss *appsv1.StatefulSet) {
 	resumedPod := ""
 	for _, pod := range podList.Items {
 		if pod.Status.Phase != v1.PodRunning {
-			e2elog.Failf("Found pod in phase %q, cannot resume", pod.Status.Phase)
+			e2efwk.Failf("Found pod in phase %q, cannot resume", pod.Status.Phase)
 		}
 		if podutil.IsPodReady(&pod) || !hasPauseProbe(&pod) {
 			continue
 		}
 		if resumedPod != "" {
-			e2elog.Failf("Found multiple paused stateful pods: %v and %v", pod.Name, resumedPod)
+			e2efwk.Failf("Found multiple paused stateful pods: %v and %v", pod.Name, resumedPod)
 		}
 		_, err := e2efwk.RunHostCmdWithRetries(pod.Namespace, pod.Name, "dd if=/dev/zero of=/data/statefulset-continue bs=1 count=1 conv=fsync", StatefulSetPoll, StatefulPodTimeout)
 		e2efwk.ExpectNoError(err)
-		e2elog.Logf("Resumed pod %v", pod.Name)
+		e2efwk.Logf("Resumed pod %v", pod.Name)
 		resumedPod = pod.Name
 	}
 }

--- a/test/e2e/framework/statefulset/rest.go
+++ b/test/e2e/framework/statefulset/rest.go
@@ -32,7 +32,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	e2efwk "k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	"k8s.io/kubernetes/test/e2e/manifest"
 )
 
@@ -42,18 +41,18 @@ func CreateStatefulSet(c clientset.Interface, manifestPath, ns string) *appsv1.S
 		return filepath.Join(manifestPath, file)
 	}
 
-	e2elog.Logf("Parsing statefulset from %v", mkpath("statefulset.yaml"))
+	e2efwk.Logf("Parsing statefulset from %v", mkpath("statefulset.yaml"))
 	ss, err := manifest.StatefulSetFromManifest(mkpath("statefulset.yaml"), ns)
 	e2efwk.ExpectNoError(err)
-	e2elog.Logf("Parsing service from %v", mkpath("service.yaml"))
+	e2efwk.Logf("Parsing service from %v", mkpath("service.yaml"))
 	svc, err := manifest.SvcFromManifest(mkpath("service.yaml"))
 	e2efwk.ExpectNoError(err)
 
-	e2elog.Logf(fmt.Sprintf("creating " + ss.Name + " service"))
+	e2efwk.Logf(fmt.Sprintf("creating " + ss.Name + " service"))
 	_, err = c.CoreV1().Services(ns).Create(svc)
 	e2efwk.ExpectNoError(err)
 
-	e2elog.Logf(fmt.Sprintf("creating statefulset %v/%v with %d replicas and selector %+v", ss.Namespace, ss.Name, *(ss.Spec.Replicas), ss.Spec.Selector))
+	e2efwk.Logf(fmt.Sprintf("creating statefulset %v/%v with %d replicas and selector %+v", ss.Namespace, ss.Name, *(ss.Spec.Replicas), ss.Spec.Selector))
 	_, err = c.AppsV1().StatefulSets(ns).Create(ss)
 	e2efwk.ExpectNoError(err)
 	WaitForRunningAndReady(c, *ss.Spec.Replicas, ss)
@@ -74,7 +73,7 @@ func DeleteStatefulPodAtIndex(c clientset.Interface, index int, ss *appsv1.State
 	name := getStatefulSetPodNameAtIndex(index, ss)
 	noGrace := int64(0)
 	if err := c.CoreV1().Pods(ss.Namespace).Delete(name, &metav1.DeleteOptions{GracePeriodSeconds: &noGrace}); err != nil {
-		e2elog.Failf("Failed to delete stateful pod %v for StatefulSet %v/%v: %v", name, ss.Namespace, ss.Name, err)
+		e2efwk.Failf("Failed to delete stateful pod %v for StatefulSet %v/%v: %v", name, ss.Namespace, ss.Name, err)
 	}
 }
 
@@ -93,7 +92,7 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 			errList = append(errList, fmt.Sprintf("%v", err))
 		}
 		WaitForStatusReplicas(c, ss, 0)
-		e2elog.Logf("Deleting statefulset %v", ss.Name)
+		e2efwk.Logf("Deleting statefulset %v", ss.Name)
 		// Use OrphanDependents=false so it's deleted synchronously.
 		// We already made sure the Pods are gone inside Scale().
 		if err := c.AppsV1().StatefulSets(ss.Namespace).Delete(ss.Name, &metav1.DeleteOptions{OrphanDependents: new(bool)}); err != nil {
@@ -107,13 +106,13 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 	pvcPollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
 		pvcList, err := c.CoreV1().PersistentVolumeClaims(ns).List(metav1.ListOptions{LabelSelector: labels.Everything().String()})
 		if err != nil {
-			e2elog.Logf("WARNING: Failed to list pvcs, retrying %v", err)
+			e2efwk.Logf("WARNING: Failed to list pvcs, retrying %v", err)
 			return false, nil
 		}
 		for _, pvc := range pvcList.Items {
 			pvNames.Insert(pvc.Spec.VolumeName)
 			// TODO: Double check that there are no pods referencing the pvc
-			e2elog.Logf("Deleting pvc: %v with volume %v", pvc.Name, pvc.Spec.VolumeName)
+			e2efwk.Logf("Deleting pvc: %v with volume %v", pvc.Name, pvc.Spec.VolumeName)
 			if err := c.CoreV1().PersistentVolumeClaims(ns).Delete(pvc.Name, nil); err != nil {
 				return false, nil
 			}
@@ -127,7 +126,7 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 	pollErr := wait.PollImmediate(StatefulSetPoll, StatefulSetTimeout, func() (bool, error) {
 		pvList, err := c.CoreV1().PersistentVolumes().List(metav1.ListOptions{LabelSelector: labels.Everything().String()})
 		if err != nil {
-			e2elog.Logf("WARNING: Failed to list pvs, retrying %v", err)
+			e2efwk.Logf("WARNING: Failed to list pvs, retrying %v", err)
 			return false, nil
 		}
 		waitingFor := []string{}
@@ -139,7 +138,7 @@ func DeleteAllStatefulSets(c clientset.Interface, ns string) {
 		if len(waitingFor) == 0 {
 			return true, nil
 		}
-		e2elog.Logf("Still waiting for pvs of statefulset to disappear:\n%v", strings.Join(waitingFor, "\n"))
+		e2efwk.Logf("Still waiting for pvs of statefulset to disappear:\n%v", strings.Join(waitingFor, "\n"))
 		return false, nil
 	})
 	if pollErr != nil {
@@ -161,7 +160,7 @@ func UpdateStatefulSetWithRetries(c clientset.Interface, namespace, name string,
 		// Apply the update, then attempt to push it to the apiserver.
 		applyUpdate(statefulSet)
 		if statefulSet, err = statefulSets.Update(statefulSet); err == nil {
-			e2elog.Logf("Updating stateful set %s", name)
+			e2efwk.Logf("Updating stateful set %s", name)
 			return true, nil
 		}
 		updateErr = err
@@ -178,7 +177,7 @@ func Scale(c clientset.Interface, ss *appsv1.StatefulSet, count int32) (*appsv1.
 	name := ss.Name
 	ns := ss.Namespace
 
-	e2elog.Logf("Scaling statefulset %s to %d", name, count)
+	e2efwk.Logf("Scaling statefulset %s to %d", name, count)
 	ss = update(c, ns, name, func(ss *appsv1.StatefulSet) { *(ss.Spec.Replicas) = count })
 
 	var statefulPodList *v1.PodList
@@ -223,7 +222,7 @@ func Restart(c clientset.Interface, ss *appsv1.StatefulSet) {
 func GetStatefulSet(c clientset.Interface, namespace, name string) *appsv1.StatefulSet {
 	ss, err := c.AppsV1().StatefulSets(namespace).Get(name, metav1.GetOptions{})
 	if err != nil {
-		e2elog.Failf("Failed to get StatefulSet %s/%s: %v", namespace, name, err)
+		e2efwk.Failf("Failed to get StatefulSet %s/%s: %v", namespace, name, err)
 	}
 	return ss
 }
@@ -263,7 +262,7 @@ func CheckMount(c clientset.Interface, ss *appsv1.StatefulSet, mountPath string)
 
 // CheckServiceName asserts that the ServiceName for ss is equivalent to expectedServiceName.
 func CheckServiceName(ss *appsv1.StatefulSet, expectedServiceName string) error {
-	e2elog.Logf("Checking if statefulset spec.serviceName is %s", expectedServiceName)
+	e2efwk.Logf("Checking if statefulset spec.serviceName is %s", expectedServiceName)
 
 	if expectedServiceName != ss.Spec.ServiceName {
 		return fmt.Errorf("wrong service name governing statefulset. Expected %s got %s",
@@ -278,7 +277,7 @@ func ExecInStatefulPods(c clientset.Interface, ss *appsv1.StatefulSet, cmd strin
 	podList := GetPodList(c, ss)
 	for _, statefulPod := range podList.Items {
 		stdout, err := e2efwk.RunHostCmdWithRetries(statefulPod.Namespace, statefulPod.Name, cmd, StatefulSetPoll, StatefulPodTimeout)
-		e2elog.Logf("stdout of %v on %v: %v", cmd, statefulPod.Name, stdout)
+		e2efwk.Logf("stdout of %v on %v: %v", cmd, statefulPod.Name, stdout)
 		if err != nil {
 			return err
 		}
@@ -304,7 +303,7 @@ func update(c clientset.Interface, ns, name string, update func(ss *appsv1.State
 	for i := 0; i < 3; i++ {
 		ss, err := c.AppsV1().StatefulSets(ns).Get(name, metav1.GetOptions{})
 		if err != nil {
-			e2elog.Failf("failed to get statefulset %q: %v", name, err)
+			e2efwk.Failf("failed to get statefulset %q: %v", name, err)
 		}
 		update(ss)
 		ss, err = c.AppsV1().StatefulSets(ns).Update(ss)
@@ -312,10 +311,10 @@ func update(c clientset.Interface, ns, name string, update func(ss *appsv1.State
 			return ss
 		}
 		if !apierrs.IsConflict(err) && !apierrs.IsServerTimeout(err) {
-			e2elog.Failf("failed to update statefulset %q: %v", name, err)
+			e2efwk.Failf("failed to update statefulset %q: %v", name, err)
 		}
 	}
-	e2elog.Failf("too many retries draining statefulset %q", name)
+	e2efwk.Failf("too many retries draining statefulset %q", name)
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This makes sub packages of e2e test framework to use log functions
of core framework instead for avoiding circular dependencies.

Ref: https://github.com/kubernetes/kubernetes/issues/81427

**Special notes for your reviewer**:

test/e2e/framework/ssh will make circular dependencies if
updating it. It is necessary to solve the issue in advance
before this work.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
