### PR TITLE
Cleanup staticcheck issues for apiextension

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -137,16 +137,6 @@ test/integration/ttlcontroller
 test/integration/volume
 test/integration/volumescheduling
 test/utils
-vendor/k8s.io/apiextensions-apiserver/pkg/apiserver
-vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion
-vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema
-vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta
-vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning
-vendor/k8s.io/apiextensions-apiserver/pkg/controller/finalizer
-vendor/k8s.io/apiextensions-apiserver/pkg/registry/customresource
-vendor/k8s.io/apiextensions-apiserver/test/integration
-vendor/k8s.io/apiextensions-apiserver/test/integration/conversion
-vendor/k8s.io/apiextensions-apiserver/test/integration/fixtures
 vendor/k8s.io/apimachinery/pkg/api/meta
 vendor/k8s.io/apimachinery/pkg/api/resource
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter.go
@@ -112,16 +112,6 @@ func (f *webhookConverterFactory) NewWebhookConverter(crd *internal.CustomResour
 	}, nil
 }
 
-// hasConversionReviewVersion check whether a version is accepted by a given webhook.
-func (c *webhookConverter) hasConversionReviewVersion(v string) bool {
-	for _, b := range c.conversionReviewVersions {
-		if b == v {
-			return true
-		}
-	}
-	return false
-}
-
 // getObjectsToConvert returns a list of objects requiring conversion.
 // if obj is a list, getObjectsToConvert returns a (potentially empty) list of the items that are not already in the desired version.
 // if obj is not a list, and is already in the desired version, getObjectsToConvert returns an empty list.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -96,6 +96,9 @@ func TestConvertFieldLabel(t *testing.T) {
 				t.Fatal(err)
 			}
 			_, c, err := f.NewConverter(&crd)
+			if err != nil {
+				t.Fatalf("Failed to create CR converter. error: %v", err)
+			}
 
 			label, value, err := c.ConvertFieldLabel(schema.GroupVersionKind{}, test.label, "value")
 			if e, a := test.expectError, err != nil; e != a {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/goopenapi_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/goopenapi_test.go
@@ -19,7 +19,6 @@ package schema
 import (
 	"math/rand"
 	"reflect"
-	"regexp"
 	"testing"
 	"time"
 
@@ -30,8 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/json"
 )
-
-var nullTypeRE = regexp.MustCompile(`"type":\["([^"]*)","null"]`)
 
 func TestStructuralRoundtrip(t *testing.T) {
 	f := fuzz.New()

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation_test.go
@@ -225,18 +225,6 @@ func required(path ...string) validationMatch {
 func invalid(path ...string) validationMatch {
 	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeInvalid}
 }
-func invalidIndex(index int, path ...string) validationMatch {
-	return validationMatch{path: field.NewPath(path[0], path[1:]...).Index(index), errorType: field.ErrorTypeInvalid}
-}
-func unsupported(path ...string) validationMatch {
-	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeNotSupported}
-}
-func immutable(path ...string) validationMatch {
-	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeInvalid}
-}
-func forbidden(path ...string) validationMatch {
-	return validationMatch{path: field.NewPath(path[0], path[1:]...), errorType: field.ErrorTypeForbidden}
-}
 
 func (v validationMatch) matches(err *field.Error) bool {
 	return err.Type == v.errorType && err.Field == v.path.String()

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go
@@ -636,6 +636,7 @@ func BenchmarkDeepCopy(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
+		//lint:ignore SA4010 the result of append is never used, it's acceptable since in benchmark testing.
 		instances = append(instances, runtime.DeepCopyJSON(obj))
 	}
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -149,8 +149,7 @@ func (c *CRDFinalizer) sync(key string) error {
 		cond, deleteErr := c.deleteInstances(crd)
 		apiextensions.SetCRDCondition(crd, cond)
 		if deleteErr != nil {
-			crd, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
-			if err != nil {
+			if _, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd); err != nil {
 				utilruntime.HandleError(err)
 			}
 			return deleteErr

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -164,7 +164,7 @@ func (c *CRDFinalizer) sync(key string) error {
 	}
 
 	apiextensions.CRDRemoveFinalizer(crd, apiextensions.CustomResourceCleanupFinalizer)
-	crd, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
+	_, err = c.crdClient.CustomResourceDefinitions().UpdateStatus(crd)
 	if apierrors.IsNotFound(err) || apierrors.IsConflict(err) {
 		// deleted or changed in the meantime, we'll get called again
 		return nil

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -342,7 +342,7 @@ func scaleFromCustomResource(cr *unstructured.Unstructured, specReplicasPath, st
 	var labelSelector string
 	if len(labelSelectorPath) > 0 {
 		labelSelectorPath = strings.TrimPrefix(labelSelectorPath, ".") // ignore leading period
-		labelSelector, found, err = unstructured.NestedString(cr.UnstructuredContent(), strings.Split(labelSelectorPath, ".")...)
+		labelSelector, _, err = unstructured.NestedString(cr.UnstructuredContent(), strings.Split(labelSelectorPath, ".")...)
 		if err != nil {
 			return nil, false, err
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -524,8 +524,7 @@ func TestDiscovery(t *testing.T) {
 
 	scope := apiextensionsv1beta1.NamespaceScoped
 	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(scope)
-	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
-	if err != nil {
+	if _, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient); err != nil {
 		t.Fatal(err)
 	}
 
@@ -828,12 +827,18 @@ func TestCrossNamespaceListWatch(t *testing.T) {
 	noxuNamespacedResourceClient1 := newNamespacedCustomResourceClient(ns1, dynamicClient, noxuDefinition)
 	instances[ns1] = createInstanceWithNamespaceHelper(t, ns1, "foo1", noxuNamespacedResourceClient1, noxuDefinition)
 	noxuNamespacesWatch1, err := noxuNamespacedResourceClient1.Watch(metav1.ListOptions{ResourceVersion: initialListListMeta.GetResourceVersion()})
+	if err != nil {
+		t.Fatalf("Failed to watch namespace: %s, error: %v", ns1, err)
+	}
 	defer noxuNamespacesWatch1.Stop()
 
 	ns2 := "namespace-2"
 	noxuNamespacedResourceClient2 := newNamespacedCustomResourceClient(ns2, dynamicClient, noxuDefinition)
 	instances[ns2] = createInstanceWithNamespaceHelper(t, ns2, "foo2", noxuNamespacedResourceClient2, noxuDefinition)
 	noxuNamespacesWatch2, err := noxuNamespacedResourceClient2.Watch(metav1.ListOptions{ResourceVersion: initialListListMeta.GetResourceVersion()})
+	if err != nil {
+		t.Fatalf("Failed to watch namespace: %s, error: %v", ns2, err)
+	}
 	defer noxuNamespacesWatch2.Stop()
 
 	createdList, err := noxuResourceClient.List(metav1.ListOptions{})

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -45,7 +45,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	"k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
 	serveroptions "k8s.io/apiextensions-apiserver/pkg/cmd/server/options"
 	apiextensionsfeatures "k8s.io/apiextensions-apiserver/pkg/features"
 	"k8s.io/apiextensions-apiserver/test/integration/fixtures"
@@ -271,8 +270,7 @@ func validateStorageVersion(t *testing.T, ctc *conversionTestContext) {
 			}
 			ctc.setAndWaitStorageVersion(t, "v1beta2")
 
-			obj, err = client.Get(obj.GetName(), metav1.GetOptions{})
-			if err != nil {
+			if _, err = client.Get(obj.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -942,7 +940,6 @@ type conversionTestContext struct {
 	namespace           string
 	apiExtensionsClient clientset.Interface
 	dynamicClient       dynamic.Interface
-	options             *options.CustomResourceDefinitionsServerOptions
 	crd                 *apiextensionsv1beta1.CustomResourceDefinition
 	etcdObjectReader    *storage.EtcdObjectReader
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/server.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/server.go
@@ -34,6 +34,9 @@ import (
 func StartDefaultServer(t servertesting.Logger, flags ...string) (func(), *rest.Config, *options.CustomResourceDefinitionsServerOptions, error) {
 	// create kubeconfig which will not actually be used. But authz/authn needs it to startup.
 	fakeKubeConfig, err := ioutil.TempFile("", "kubeconfig")
+	if err != nil {
+		return nil, nil, nil, err
+	}
 	fakeKubeConfig.WriteString(`
 apiVersion: v1
 kind: Config

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -536,7 +536,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error setting .status.num: %v", err)
 			}
-			createdNoxuInstance, err = noxuResourceClient.UpdateStatus(createdNoxuInstance, metav1.UpdateOptions{})
+			_, err = noxuResourceClient.UpdateStatus(createdNoxuInstance, metav1.UpdateOptions{})
 			if err == nil {
 				t.Fatal("expected error, but got none")
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -582,8 +582,7 @@ spec:
 
 	// create CRDs
 	t.Logf("Creating CRD %s", crd.Name)
-	crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd)
-	if err != nil {
+	if _, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Create(crd); err != nil {
 		t.Fatalf("unexpected create error: %v", err)
 	}
 
@@ -613,8 +612,7 @@ spec:
 			t.Fatalf("unexpected get error: %v", err)
 		}
 		crd.Spec.Validation = nil
-		crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd)
-		if apierrors.IsConflict(err) {
+		if _, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd); apierrors.IsConflict(err) {
 			continue
 		}
 		if err != nil {
@@ -647,8 +645,7 @@ spec:
 			t.Fatalf("unexpected get error: %v", err)
 		}
 		crd.Spec.Validation = &apiextensionsv1beta1.CustomResourceValidation{OpenAPIV3Schema: origSchema}
-		crd, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd)
-		if apierrors.IsConflict(err) {
+		if _, err = apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd); apierrors.IsConflict(err) {
 			continue
 		}
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup issues identified by staticcheck in #81189

**Which issue(s) this PR fixes**:
ref #81657

**Special notes for your reviewer**:

In order to review more convenient, split with check types.
For more details about check description, please refer to http://staticcheck.io/docs/checks.

Commit: Dealing with unused functions/variables/types. (staticcheck U1000)
```
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter.go:116:28: func (*webhookConverter).hasConversionReviewVersion is unused (U1000)
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/goopenapi_test.go:34:5: var nullTypeRE is unused (U1000)
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation_test.go:228:6: func invalidIndex is unused (U1000)
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation_test.go:231:6: func unsupported is unused (U1000)
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation_test.go:234:6: func immutable is unused (U1000)
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta/validation_test.go:237:6: func forbidden is unused (U1000)
vendor/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go:945:2: field options is unused (U1000)
```

Commit: Dealing with value never used issue. (staticcheck SA4006)
```
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go:98:10: this value of err is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go:133:4: this value of crd is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go:345:18: this value of found is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/basic_test.go:527:2: this value of noxuDefinition is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/basic_test.go:830:24: this value of err is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/basic_test.go:836:24: this value of err is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go:274:4: this value of obj is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/fixtures/server.go:36:18: this value of err is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go:539:4: this value of createdNoxuInstance is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/validation_test.go:585:2: this value of crd is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/validation_test.go:616:3: this value of crd is never used (SA4006)
vendor/k8s.io/apiextensions-apiserver/test/integration/validation_test.go:650:3: this value of crd is never used (SA4006)
```

Commit: Dealing with concurrency issue. (staticcheck SA2002 SA4010)
```
vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning/algorithm_test.go:639:21: this result of append is never used, except maybe in other appends (SA4010)
vendor/k8s.io/apiextensions-apiserver/test/integration/change_test.go:67:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiextensions-apiserver/test/integration/change_test.go:99:3: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
vendor/k8s.io/apiextensions-apiserver/test/integration/change_test.go:119:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

