### PR TITLE
Correct func name WithBuildMetadata

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/policy_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/policy_test.go
@@ -196,9 +196,9 @@ func TestEnforceVersionPolicies(t *testing.T) {
 			vg: &fakeVersionGetter{
 				clusterVersion: constants.MinimumControlPlaneVersion.String(),
 				kubeletVersion: constants.MinimumControlPlaneVersion.String(),
-				kubeadmVersion: constants.MinimumControlPlaneVersion.WithBuildeMetadata("build").String(),
+				kubeadmVersion: constants.MinimumControlPlaneVersion.WithBuildMetadata("build").String(),
 			},
-			newK8sVersion: constants.MinimumControlPlaneVersion.WithBuildeMetadata("build").String(),
+			newK8sVersion: constants.MinimumControlPlaneVersion.WithBuildMetadata("build").String(),
 		},
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -183,8 +183,8 @@ func (v *Version) WithPreRelease(preRelease string) *Version {
 	return &result
 }
 
-// WithBuildeMetadata returns copy of the version object with requested buildMetadata
-func (v *Version) WithBuildeMetadata(buildMetadata string) *Version {
+// WithBuildMetadata returns copy of the version object with requested buildMetadata
+func (v *Version) WithBuildMetadata(buildMetadata string) *Version {
 	result := *v
 	result.components = []uint{v.Major(), v.Minor(), v.Patch()}
 	result.buildMetadata = buildMetadata


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is follow up to #81836 where WithBuildMetadata was spelled incorrectly.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
