### PR TITLE
storage: fix CSIInlineVolume round-trip test

### DIFF
--- a/pkg/apis/storage/fuzzer/fuzzer.go
+++ b/pkg/apis/storage/fuzzer/fuzzer.go
@@ -78,7 +78,7 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				obj.Spec.PodInfoOnMount = new(bool)
 				*(obj.Spec.PodInfoOnMount) = false
 			}
-			if obj.Spec.VolumeLifecycleModes == nil {
+			if len(obj.Spec.VolumeLifecycleModes) == 0 {
 				obj.Spec.VolumeLifecycleModes = []storage.VolumeLifecycleMode{
 					storage.VolumeLifecyclePersistent,
 				}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

When adding CSIDriver.Spec.VolumeLifecycleModes in https://github.com/kubernetes/kubernetes/pull/80568, the defaulting in
pkg/apis/storage/fuzzer/fuzzer.go did not quite match the one from
pkg/apis/storage/v1beta1/defaults.go, causing a test failure when the
corresponding feature gate is enabled.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```