### PR TITLE
e2e logging: disable brittle output test

### DIFF
--- a/test/e2e/framework/log/BUILD
+++ b/test/e2e/framework/log/BUILD
@@ -30,7 +30,6 @@ go_test(
     srcs = ["logger_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//test/e2e/framework:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/ginkgo/config:go_default_library",
         "//vendor/github.com/onsi/ginkgo/reporters:go_default_library",

--- a/test/e2e/framework/log/logger_test.go
+++ b/test/e2e/framework/log/logger_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package log_test
 
 import (
-	"errors"
+	// "errors"
 	"regexp"
 	"sort"
 	"strings"
@@ -28,7 +28,7 @@ import (
 	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 
-	"k8s.io/kubernetes/test/e2e/framework"
+	// "k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/log"
 )
 
@@ -44,10 +44,10 @@ var _ = ginkgo.Describe("log", func() {
 	ginkgo.It("asserts", func() {
 		gomega.Expect(false).To(gomega.Equal(true), "false is never true")
 	})
-	ginkgo.It("error", func() {
-		err := errors.New("an error with a long, useless description")
-		framework.ExpectNoError(err, "hard-coded error")
-	})
+	// ginkgo.It("error", func() { // TODO(pohly): enable again, see comment below.
+	// 	err := errors.New("an error with a long, useless description")
+	// 	framework.ExpectNoError(err, "hard-coded error")
+	// })
 	ginkgo.AfterEach(func() {
 		log.Logf("after")
 		gomega.Expect(true).To(gomega.Equal(false), "true is never false either")
@@ -79,13 +79,16 @@ func TestFailureOutput(t *testing.T) {
 			// TODO: should start with k8s.io/kubernetes/test/e2e/framework/log_test.glob..func1.3()
 			stack: "\tassertion.go:75\nk8s.io/kubernetes/vendor/github.com/onsi/gomega/internal/assertion.(*Assertion).To()\n\tassertion.go:38\nk8s.io/kubernetes/test/e2e/framework/log_test.glob..func1.3()\n\tlogger_test.go:45\nk8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()\n\tlogger_test.go:65\n",
 		},
-		testResult{
-			name:    "[Top Level] log error",
-			output:  "INFO: before\nFAIL: hard-coded error\nUnexpected error:\n    <*errors.errorString>: {\n        s: \"an error with a long, useless description\",\n    }\n    an error with a long, useless description\noccurred\nINFO: after\nFAIL: true is never false either\nExpected\n    <bool>: true\nto equal\n    <bool>: false\n",
-			failure: "hard-coded error\nUnexpected error:\n    <*errors.errorString>: {\n        s: \"an error with a long, useless description\",\n    }\n    an error with a long, useless description\noccurred",
-			// TODO: should start with k8s.io/kubernetes/test/e2e/framework/log_test.glob..func1.4()
-			stack: "\tutil.go:1368\nk8s.io/kubernetes/test/e2e/framework.ExpectNoError()\n\tutil.go:1362\nk8s.io/kubernetes/test/e2e/framework/log_test.glob..func1.4()\n\tlogger_test.go:49\nk8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()\n\tlogger_test.go:65\n",
-		},
+		// That util.go appears in the output is a bug (https://github.com/kubernetes/kubernetes/issues/82013).
+		// Because it currently appears, this test case is brittle and breaks when someome makes unrelated
+		// changes in util.go which change the line number. Therefore it is commented out.
+		// testResult{
+		// 	name:    "[Top Level] log error",
+		// 	output:  "INFO: before\nFAIL: hard-coded error\nUnexpected error:\n    <*errors.errorString>: {\n        s: \"an error with a long, useless description\",\n    }\n    an error with a long, useless description\noccurred\nINFO: after\nFAIL: true is never false either\nExpected\n    <bool>: true\nto equal\n    <bool>: false\n",
+		// 	failure: "hard-coded error\nUnexpected error:\n    <*errors.errorString>: {\n        s: \"an error with a long, useless description\",\n    }\n    an error with a long, useless description\noccurred",
+		// 	// TODO: should start with k8s.io/kubernetes/test/e2e/framework/log_test.glob..func1.4()
+		// 	stack: "\tutil.go:1362\nk8s.io/kubernetes/test/e2e/framework.ExpectNoError()\n\tutil.go:1356\nk8s.io/kubernetes/test/e2e/framework/log_test.glob..func1.4()\n\tlogger_test.go:49\nk8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync()\n\tlogger_test.go:65\n",
+		// },
 		testResult{
 			name:    "[Top Level] log fails",
 			output:  "INFO: before\nFAIL: I'm failing.\nINFO: after\nFAIL: true is never false either\nExpected\n    <bool>: true\nto equal\n    <bool>: false\n",


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

Because unrelated changes to util.go change the test output, it is
better to exclude the test case where util.go (incorrectly!) is
included.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
