### PR TITLE
Add ConnorDoyle to /pkg/kubelet approvers

### DIFF
--- a/pkg/kubelet/OWNERS
+++ b/pkg/kubelet/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - tallclair
 - vishh
 - yujuhong
+- ConnorDoyle
 reviewers:
 - sig-node-reviewers
 labels:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Add self to /pkg/kubelet approvers in OWNERS file. Some kubelet approvers are overloaded, and some are inactive. I have experience so far as an approver in the container manager, a sub-component of the kubelet.

```release-note
NONE
```

/assign @derekwaynecarr @dchen1107 