### PR TITLE
Break out of loop when finalizer is found

### DIFF
--- a/test/e2e/framework/service/wait.go
+++ b/test/e2e/framework/service/wait.go
@@ -105,6 +105,7 @@ func WaitForServiceUpdatedWithFinalizer(cs clientset.Interface, namespace, name 
 		for _, finalizer := range svc.Finalizers {
 			if finalizer == servicehelper.LoadBalancerCleanupFinalizer {
 				foundFinalizer = true
+				break
 			}
 		}
 		if foundFinalizer != hasFinalizer {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In WaitForServiceUpdatedWithFinalizer, when the LoadBalancerCleanupFinalizer is found, we can come out of the loop.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
