### PR TITLE
Rewrite tests for tableprinter.go

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -53,7 +53,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
     ],
 )


### PR DESCRIPTION
* Adds significant tests for `tableprinter.go` in preparation for moving this file out of Kubernetes core.
* Improves unit test coverage for `tableprinter.go` from `17.2%` to `82.4%`.
* Concentrates on validating the exported `PrintObj()` function which transforms (mostly) `Tables` to strings.
* Also focuses on how `PrintOptions` affects printing output.
* Removes previous test which exercised non-exported function

/kind cleanup
/sig cli
/area kubectl
/area code-organization
/priority important-soon

```release-note
NONE
```