### PR TITLE
crd-e2e: test functionality change in preparation for conformance promotion

### DIFF
--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -99,6 +100,18 @@ var _ = SIGDescribe("CustomResourceDefinition Watch", func() {
 			expectEvent(watchB, watch.Added, testCrB)
 			expectNoEvent(watchA, watch.Added, testCrB)
 
+			ginkgo.By("Modifying first CR")
+			err = patchCustomResource(noxuResourceClient, watchCRNameA)
+			framework.ExpectNoError(err, "failed to patch custom resource: %s", watchCRNameA)
+			expectEvent(watchA, watch.Modified, nil)
+			expectNoEvent(watchB, watch.Modified, nil)
+
+			ginkgo.By("Modifying second CR")
+			err = patchCustomResource(noxuResourceClient, watchCRNameB)
+			framework.ExpectNoError(err, "failed to patch custom resource: %s", watchCRNameB)
+			expectEvent(watchB, watch.Modified, nil)
+			expectNoEvent(watchA, watch.Modified, nil)
+
 			ginkgo.By("Deleting first CR")
 			err = deleteCustomResource(noxuResourceClient, watchCRNameA)
 			framework.ExpectNoError(err, "failed to delete custom resource: %s", watchCRNameA)
@@ -150,6 +163,15 @@ func instantiateCustomResource(instanceToCreate *unstructured.Unstructured, clie
 		return nil, fmt.Errorf("expected %v, got %v", e, a)
 	}
 	return createdInstance, nil
+}
+
+func patchCustomResource(client dynamic.ResourceInterface, name string) error {
+	_, err := client.Patch(
+		name,
+		types.JSONPatchType,
+		[]byte(`[{ "op": "add", "path": "/dummy", "value": "test" }]`),
+		metav1.PatchOptions{})
+	return err
 }
 
 func deleteCustomResource(client dynamic.ResourceInterface, name string) error {

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -37,7 +37,7 @@ import (
 
 var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 
-	f := framework.NewDefaultFramework("custom-resource-definition")
+	framework.NewDefaultFramework("custom-resource-definition")
 
 	ginkgo.Context("Simple CustomResourceDefinition", func() {
 		/*
@@ -55,7 +55,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 			randomDefinition := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
 
 			// Create CRD and waits for the resource to be recognized and available.
-			randomDefinition, err = fixtures.CreateNewV1CustomResourceDefinition(randomDefinition, apiExtensionClient, f.DynamicClient)
+			randomDefinition, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(randomDefinition, apiExtensionClient)
 			framework.ExpectNoError(err, "creating CustomResourceDefinition")
 
 			defer func() {
@@ -84,14 +84,14 @@ var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 			for i := 0; i < testListSize; i++ {
 				crd := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
 				crd.Labels = map[string]string{"e2e-list-test-uuid": testUUID}
-				crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, f.DynamicClient)
+				crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
 				framework.ExpectNoError(err, "creating CustomResourceDefinition")
 				crds[i] = crd
 			}
 
 			// Create a crd w/o the label to ensure the label selector matching works correctly
 			crd := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
-			crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, f.DynamicClient)
+			crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
 			framework.ExpectNoError(err, "creating CustomResourceDefinition")
 			defer func() {
 				err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)
@@ -140,7 +140,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources", func() {
 
 			// Create CRD and waits for the resource to be recognized and available.
 			crd := fixtures.NewRandomNameV1CustomResourceDefinition(v1.ClusterScoped)
-			crd, err = fixtures.CreateNewV1CustomResourceDefinition(crd, apiExtensionClient, f.DynamicClient)
+			crd, err = fixtures.CreateNewV1CustomResourceDefinitionWatchUnsafe(crd, apiExtensionClient)
 			framework.ExpectNoError(err, "creating CustomResourceDefinition")
 			defer func() {
 				err = fixtures.DeleteV1CustomResourceDefinition(crd, apiExtensionClient)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
squash the test functionality change from https://github.com/kubernetes/kubernetes/pull/81864/commits:
- check watch observes CR modified events
- use WatchUnsafe creation method to create CRD when the test doesn't exercise CR API

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/cc @liggitt 