### PR TITLE
Cleanup cluster/images/conformance/go-runner test data after test done

### DIFF
--- a/cluster/images/conformance/go-runner/tar_test.go
+++ b/cluster/images/conformance/go-runner/tar_test.go
@@ -58,6 +58,10 @@ func TestTar(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			err := tarDir(tc.dir, tc.outpath)
+			if err == nil {
+				defer os.Remove(tc.outpath)
+			}
+
 			switch {
 			case err != nil && len(tc.expectErr) == 0:
 				t.Fatalf("Expected nil error but got %q", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
After UT (cluster/images/conformance/go-runner) run, the test data `tartest/out.tar.gz` should be removed. 

Reproduce:
```shell
[root@ecs-d8b6 kubernetes]# go test ./cluster/images/conformance/go-runner -run=TestTar        
ok  k8s.io/kubernetes/cluster/images/conformance/go-runner0.004s
[root@ecs-d8b6 kubernetes]# git status
# On branch master
# Untracked files:
#   (use "git add <file>..." to include in what will be committed)
#
#cluster/images/conformance/go-runner/testdata/tartest/out.tar.gz
nothing added to commit but untracked files present (use "git add" to track)
```
It is the residues `cluster/images/conformance/go-runner/testdata/tartest/out.tar.gz`.


After cleanup, it looks like: 
```shell
[root@ecs-d8b6 kubernetes]# go test ./cluster/images/conformance/go-runner -run=TestTar
ok  k8s.io/kubernetes/cluster/images/conformance/go-runner0.005s
[root@ecs-d8b6 kubernetes]# git status
# On branch pr_cleanup_testtar_testdata
nothing to commit, working directory clean
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
```release-note
NONE
```
[edit]: add release-note, none.

**Does this PR introduce a user-facing change?**:

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
