### PR TITLE
kubectl cluster-info dump: use file extension according to output format

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -33,7 +33,7 @@ func TestSetupOutputWriterNoOp(t *testing.T) {
 		f := cmdtesting.NewTestFactory()
 		defer f.Cleanup()
 
-		writer := setupOutputWriter(test, buf, "/some/file/that/should/be/ignored")
+		writer := setupOutputWriter(test, buf, "/some/file/that/should/be/ignored", "")
 		if writer != buf {
 			t.Errorf("expected: %v, saw: %v", buf, writer)
 		}
@@ -41,19 +41,20 @@ func TestSetupOutputWriterNoOp(t *testing.T) {
 }
 
 func TestSetupOutputWriterFile(t *testing.T) {
-	file := "output.json"
+	file := "output"
+	extension := ".json"
 	dir, err := ioutil.TempDir(os.TempDir(), "out")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	fullPath := path.Join(dir, file)
+	fullPath := path.Join(dir, file) + extension
 	defer os.RemoveAll(dir)
 
 	_, _, buf, _ := genericclioptions.NewTestIOStreams()
 	f := cmdtesting.NewTestFactory()
 	defer f.Cleanup()
 
-	writer := setupOutputWriter(dir, buf, file)
+	writer := setupOutputWriter(dir, buf, file, extension)
 	if writer == buf {
 		t.Errorf("expected: %v, saw: %v", buf, writer)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Currently, `kubectl cluster-info dump --output-directory=... -o ...` creates a bunch of `.json` files, no matter the output format is. For example, with `-o yaml`, it generates YAML files with extension `.json`, which leads to a wrong formatting by text editors.

**Which issue(s) this PR fixes**:

Fixes #82011

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
kubectl cluster-info dump --output-directory=xxx now generates files with an extension depending on the output format.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
