### PR TITLE
fix: add nodeName back to the nodeUpdateQueue.

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -510,14 +510,14 @@ func (nc *Controller) doNodeProcessingPassWorker() {
 		if nc.taintNodeByCondition {
 			if err := nc.doNoScheduleTaintingPass(nodeName); err != nil {
 				klog.Errorf("Failed to taint NoSchedule on node <%s>, requeue it: %v", nodeName, err)
-				// TODO(k82cn): Add nodeName back to the queue
+				nc.nodeUpdateQueue.Add(nodeName)
 			}
 		}
 		// TODO: re-evaluate whether there are any labels that need to be
 		// reconcile in 1.19. Remove this function if it's no longer necessary.
 		if err := nc.reconcileNodeLabels(nodeName); err != nil {
 			klog.Errorf("Failed to reconcile labels for node <%s>, requeue it: %v", nodeName, err)
-			// TODO(yujuhong): Add nodeName back to the queue
+			nc.nodeUpdateQueue.Add(nodeName)
 		}
 		nc.nodeUpdateQueue.Done(nodeName)
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Add the node back to nodeUpdateQueue when error occurs, for retry after.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/sig node