### PR TITLE
Add the ability to migrate CoreDNS configmap in kube-up

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -63,7 +63,7 @@ dependencies:
 
 
   - name: "coredns-kube-up"
-    version: 1.3.1
+    version: 1.5.0
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: k8s.gcr.io/coredns

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -63,7 +63,7 @@ dependencies:
 
 
   - name: "coredns-kube-up"
-    version: 1.5.0
+    version: 1.6.2
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: k8s.gcr.io/coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -64,9 +64,9 @@ data:
     .:53 {
         errors
         health
+        ready
         kubernetes __PILLAR__DNS__DOMAIN__ in-addr.arpa ip6.arpa {
             pods insecure
-            upstream
             fallthrough in-addr.arpa ip6.arpa
             ttl 30
         }
@@ -116,7 +116,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -150,8 +150,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /health
-            port: 8080
+            path: /ready
+            port: 8181
             scheme: HTTP
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -116,7 +116,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.5.0
+        image: k8s.gcr.io/coredns:1.6.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -64,9 +64,9 @@ data:
     .:53 {
         errors
         health
+        ready
         kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {
             pods insecure
-            upstream
             fallthrough in-addr.arpa ip6.arpa
             ttl 30
         }
@@ -116,7 +116,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -150,8 +150,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /health
-            port: 8080
+            path: /ready
+            port: 8181
             scheme: HTTP
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -116,7 +116,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.5.0
+        image: k8s.gcr.io/coredns:1.6.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -64,9 +64,9 @@ data:
     .:53 {
         errors
         health
+        ready
         kubernetes $DNS_DOMAIN in-addr.arpa ip6.arpa {
             pods insecure
-            upstream
             fallthrough in-addr.arpa ip6.arpa
             ttl 30
         }
@@ -116,7 +116,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.3.1
+        image: k8s.gcr.io/coredns:1.5.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:
@@ -150,8 +150,8 @@ spec:
           failureThreshold: 5
         readinessProbe:
           httpGet:
-            path: /health
-            port: 8080
+            path: /ready
+            port: 8181
             scheme: HTTP
         securityContext:
           allowPrivilegeEscalation: false

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -116,7 +116,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.5.0
+        image: k8s.gcr.io/coredns:1.6.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
This is a re-created PR of #78302 since the branch of that PR has been lost.

/kind bug

**What this PR does / why we need it**:
Following CoreDNS ConfigMap changes in #78030, it is required that the ConfigMap gets updated during an `upgrade`. 
If I understand correctly, `EnsureExists` doesn't update the ConfigMap during an upgrade and requires `Reconcile` for the ConfigMap to upgrade.

This is evident from the logs:

Logs from `ci-kubernetes-e2e-gce-new-master-upgrade-cluster`:
```
event for coredns-5cd44cdc5d-lzbmv: {kubelet bootstrap-e2e-minion-group-b8n6} Unhealthy: Readiness probe failed: Get http://10.64.2.20:8181/ready: dial tcp 10.64.2.20:8181: connect: connection refused
```
Logs from `ci-kubernetes-e2e-gce-master-new-downgrade-cluster`:
```
/etc/coredns/Corefile:4 - Error during parsing: Unknown directive 'ready'
```
In both cases, the CoreDNS deployment is updated but not the ConfigMap.
This PR aims to add the ability to migrate the CoreDNS ConfigMap in kube-up in the event of an upgrade/downgrade.

It also bumps the version of CoreDNS to 1.6.2

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78123 

**Special notes for your reviewer**:

This is a re-created PR of #78302 since the branch of that PR has been lost.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/priority critical-urgent
/cc @chrisohaver @mrhohn
/assign @bowei @BenTheElder 