### PR TITLE
Enable the RuntimeClass admission controller on GCE & CI

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -356,7 +356,7 @@ fi
 CUSTOM_INGRESS_YAML="${CUSTOM_INGRESS_YAML:-}"
 
 # Admission Controllers to invoke prior to persisting objects in cluster
-ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,PersistentVolumeClaimResize,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection
+ADMISSION_CONTROL=NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,DefaultStorageClass,PersistentVolumeClaimResize,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,RuntimeClass
 
 if [[ "${ENABLE_POD_SECURITY_POLICY:-}" == "true" ]]; then
   ADMISSION_CONTROL="${ADMISSION_CONTROL},PodSecurityPolicy"

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -387,7 +387,7 @@ fi
 CUSTOM_INGRESS_YAML="${CUSTOM_INGRESS_YAML:-}"
 
 if [[ -z "${KUBE_ADMISSION_CONTROL:-}" ]]; then
-  ADMISSION_CONTROL="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,PodPreset,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,PersistentVolumeClaimResize"
+  ADMISSION_CONTROL="NamespaceLifecycle,LimitRanger,ServiceAccount,PersistentVolumeLabel,PodPreset,DefaultStorageClass,DefaultTolerationSeconds,NodeRestriction,Priority,StorageObjectInUseProtection,PersistentVolumeClaimResize,RuntimeClass"
   if [[ "${ENABLE_POD_SECURITY_POLICY:-}" == "true" ]]; then
     ADMISSION_CONTROL="${ADMISSION_CONTROL},PodSecurityPolicy"
   fi

--- a/test/e2e/common/runtimeclass.go
+++ b/test/e2e/common/runtimeclass.go
@@ -22,6 +22,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -33,6 +34,7 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
 )
 
 const (
@@ -49,14 +51,13 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 
 	ginkgo.It("should reject a Pod requesting a non-existent RuntimeClass", func() {
 		rcName := f.Namespace.Name + "-nonexistent"
-		pod := createRuntimeClassPod(f, rcName)
-		expectSandboxFailureEvent(f, pod, fmt.Sprintf("\"%s\" not found", rcName))
+		expectPodRejection(f, newRuntimeClassPod(rcName))
 	})
 
 	ginkgo.It("should reject a Pod requesting a RuntimeClass with an unconfigured handler", func() {
 		handler := f.Namespace.Name + "-handler"
 		rcName := createRuntimeClass(f, "unconfigured-handler", handler)
-		pod := createRuntimeClassPod(f, rcName)
+		pod := f.PodClient().Create(newRuntimeClassPod(rcName))
 		expectSandboxFailureEvent(f, pod, handler)
 	})
 
@@ -69,7 +70,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 		}
 
 		rcName := createRuntimeClass(f, "preconfigured-handler", handler)
-		pod := createRuntimeClassPod(f, rcName)
+		pod := f.PodClient().Create(newRuntimeClassPod(rcName))
 		expectPodSuccess(f, pod)
 	})
 
@@ -94,8 +95,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 			}))
 		})
 
-		pod := createRuntimeClassPod(f, rcName)
-		expectSandboxFailureEvent(f, pod, fmt.Sprintf("\"%s\" not found", rcName))
+		expectPodRejection(f, newRuntimeClassPod(rcName))
 	})
 })
 
@@ -109,9 +109,9 @@ func createRuntimeClass(f *framework.Framework, name, handler string) string {
 	return rc.GetName()
 }
 
-// createRuntimeClass creates a test pod with the given runtimeClassName.
-func createRuntimeClassPod(f *framework.Framework, runtimeClassName string) *v1.Pod {
-	pod := &v1.Pod{
+// newRuntimeClassPod generates a test pod with the given runtimeClassName.
+func newRuntimeClassPod(runtimeClassName string) *v1.Pod {
+	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("test-runtimeclass-%s-", runtimeClassName),
 		},
@@ -126,7 +126,19 @@ func createRuntimeClassPod(f *framework.Framework, runtimeClassName string) *v1.
 			AutomountServiceAccountToken: utilpointer.BoolPtr(false),
 		},
 	}
-	return f.PodClient().Create(pod)
+}
+
+func expectPodRejection(f *framework.Framework, pod *v1.Pod) {
+	// The Node E2E doesn't run the RuntimeClass admission controller, so we expect the rejection to
+	// happen by the Kubelet.
+	if framework.TestContext.NodeE2E {
+		pod = f.PodClient().Create(pod)
+		expectSandboxFailureEvent(f, pod, fmt.Sprintf("\"%s\" not found", *pod.Spec.RuntimeClassName))
+	} else {
+		_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
+		framework.ExpectError(err, "should be forbidden")
+		gomega.Expect(apierrs.IsForbidden(err)).To(gomega.BeTrue(), "should be forbidden error")
+	}
 }
 
 // expectPodSuccess waits for the given pod to terminate successfully.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Follow up to https://github.com/kubernetes/kubernetes/pull/81862, I didn't realize we were overriding the admission controllers in the default GCE / CI environment.

**Which issue(s) this PR fixes**:
Unblocks https://github.com/kubernetes/kubernetes/pull/81915

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/sig node
/priority important-soon
/milestone v1.16