### PR TITLE
Break out of the loop when active endpoint is found

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/status/available_controller.go
@@ -210,6 +210,7 @@ func (c *AvailableConditionController) sync(key string) error {
 			if port.Port == *servicePort {
 				foundPort = true
 				portName = port.Name
+				break
 			}
 		}
 		if !foundPort {
@@ -238,6 +239,7 @@ func (c *AvailableConditionController) sync(key string) error {
 			return err
 		}
 		hasActiveEndpoints := false
+	outer:
 		for _, subset := range endpoints.Subsets {
 			if len(subset.Addresses) == 0 {
 				continue
@@ -245,6 +247,7 @@ func (c *AvailableConditionController) sync(key string) error {
 			for _, endpointPort := range subset.Ports {
 				if endpointPort.Name == portName {
 					hasActiveEndpoints = true
+					break outer
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For AvailableConditionController#sync, when we have found the endpoint in the loop over endpoints.Subsets, we can come out of the loop early.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
