### PR TITLE
Cleanup DumpAllNamespaceInfo() in e2e test

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1769,14 +1769,15 @@ func DumpAllNamespaceInfo(c clientset.Interface, namespace string) {
 	// 2. there are so many of them that working with them are mostly impossible
 	// So we dump them only if the cluster is relatively small.
 	maxNodesForDump := TestContext.MaxNodesToGather
-	if nodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{}); err == nil {
-		if len(nodes.Items) <= maxNodesForDump {
-			dumpAllNodeInfo(c)
-		} else {
-			e2elog.Logf("skipping dumping cluster info - cluster too large")
-		}
-	} else {
+	nodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{})
+	if err != nil {
 		e2elog.Logf("unable to fetch node list: %v", err)
+		return
+	}
+	if len(nodes.Items) <= maxNodesForDump {
+		dumpAllNodeInfo(c)
+	} else {
+		e2elog.Logf("skipping dumping cluster info - cluster too large")
 	}
 }
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1775,7 +1775,7 @@ func DumpAllNamespaceInfo(c clientset.Interface, namespace string) {
 		return
 	}
 	if len(nodes.Items) <= maxNodesForDump {
-		dumpAllNodeInfo(c)
+		dumpAllNodeInfo(c, nodes)
 	} else {
 		e2elog.Logf("skipping dumping cluster info - cluster too large")
 	}
@@ -1794,13 +1794,7 @@ func (o byFirstTimestamp) Less(i, j int) bool {
 	return o[i].FirstTimestamp.Before(&o[j].FirstTimestamp)
 }
 
-func dumpAllNodeInfo(c clientset.Interface) {
-	// It should be OK to list unschedulable Nodes here.
-	nodes, err := c.CoreV1().Nodes().List(metav1.ListOptions{})
-	if err != nil {
-		e2elog.Logf("unable to fetch node list: %v", err)
-		return
-	}
+func dumpAllNodeInfo(c clientset.Interface, nodes *v1.NodeList) {
 	names := make([]string, len(nodes.Items))
 	for ix := range nodes.Items {
 		names[ix] = nodes.Items[ix].Name


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

During fixing circular dependency between e2ekubelet and core framework, I need to do cleanup
DumpAllNamespaceInfo() in advance.
This PR does the following 2 things:
- Reduce redundant Nodes().List() call
- Reduce indents of DumpAllNamespaceInfo()

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
