### PR TITLE
FlattenListVisitor now continues traversal on errors and returns an aggregate error

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -375,7 +375,6 @@ func (v ContinueOnErrorVisitor) Visit(fn VisitorFunc) error {
 // that interface - into multiple Infos. Returns nil in the case of no errors.
 // When an error is hit on sub items (for instance, if a List contains an object that does
 // not have a registered client or resource), returns an aggregate error.
-
 type FlattenListVisitor struct {
 	visitor Visitor
 	typer   runtime.ObjectTyper
@@ -428,7 +427,6 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 		errs := []error{}
 		for i := range items {
 			item, err := v.mapper.infoForObject(items[i], v.typer, preferredGVKs)
-
 			if err != nil {
 				errs = append(errs, err)
 				continue

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -372,10 +372,10 @@ func (v ContinueOnErrorVisitor) Visit(fn VisitorFunc) error {
 
 // FlattenListVisitor flattens any objects that runtime.ExtractList recognizes as a list
 // - has an "Items" public field that is a slice of runtime.Objects or objects satisfying
-// that interface - into multiple Infos. An error on any sub item (for instance, if a List
-// contains an object that does not have a registered client or resource) will terminate
-// the visit.
-// TODO: allow errors to be aggregated?
+// that interface - into multiple Infos. Returns nil in the case of no errors.
+// When an error is hit on sub items (for instance, if a List contains an object that does
+// not have a registered client or resource), returns an aggregate error.
+
 type FlattenListVisitor struct {
 	visitor Visitor
 	typer   runtime.ObjectTyper
@@ -425,20 +425,23 @@ func (v FlattenListVisitor) Visit(fn VisitorFunc) error {
 		if info.Mapping != nil && !info.Mapping.GroupVersionKind.Empty() {
 			preferredGVKs = append(preferredGVKs, info.Mapping.GroupVersionKind)
 		}
-
+		errs := []error{}
 		for i := range items {
 			item, err := v.mapper.infoForObject(items[i], v.typer, preferredGVKs)
+
 			if err != nil {
-				return err
+				errs = append(errs, err)
+				continue
 			}
 			if len(info.ResourceVersion) != 0 {
 				item.ResourceVersion = info.ResourceVersion
 			}
 			if err := fn(item, nil); err != nil {
-				return err
+				errs = append(errs, err)
 			}
 		}
-		return nil
+		return utilerrors.NewAggregate(errs)
+
 	})
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor_test.go
@@ -18,9 +18,11 @@ package resource
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
@@ -174,6 +176,21 @@ func TestFlattenListVisitor(t *testing.T) {
 
 	err := b.Do().Visit(test.Handle)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if len(test.Infos) != 6 {
+		t.Fatal(spew.Sdump(test.Infos))
+	}
+}
+
+func TestFlattenListVisitorWithVisitorError(t *testing.T) {
+	b := newDefaultBuilder().
+		FilenameParam(false, &FilenameOptions{Recursive: false, Filenames: []string{"../../artifacts/deeply-nested.yaml"}}).
+		Flatten()
+
+	test := &testVisitor{InjectErr: errors.New("visitor error")}
+	err := b.Do().Visit(test.Handle)
+	if err == nil || !strings.Contains(err.Error(), "visitor error") {
 		t.Fatal(err)
 	}
 	if len(test.Infos) != 6 {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority important-longterm
/sig cli

When running a kubectl get and a list of items needs to be flattened in the traversal, traversal is halted when we run into an error on a single item. This behaviour is inconsistent with what happens if we pass this same input in a format that doesn't involve a list being flattened. An example is detailed in the issue link where we have inconsistent behaviour between passing arguments in a yaml file vs directly on the command line.

This PR ensures consistency between these two behaviours by collecting errors and returning them as an aggregate as opposed to failing the command.  

**Which issue(s) this PR fixes**:
Fixes #80541 
Replaces #81452

**Special notes for your reviewer**:
/assign @damemi @mfojtik 
cc @kharunsamuel1 

**Does this PR introduce a user-facing change?**:

```release-note
Make kubectl get --ignore-not-found continue processing when encountering error. 
```
