### PR TITLE
Write the Stackdriver config separately from the installation.

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -111,7 +111,10 @@ try {
   Set-EnvironmentVars
   Create-Directories
   Download-HelperScripts
-  InstallAndStart-LoggingAgent
+
+  Install-LoggingAgent
+  Configure-LoggingAgent
+  Restart-LoggingAgent
 
   Create-DockerRegistryKey
   Configure-Dockerd


### PR DESCRIPTION
This will let us preinstall the Stackdriver logging agent on our Windows node images while still configuring the agent correctly when bringing up those nodes.

This change is a noop for the current Windows-K8s-on-GCE tests/clusters. The hostname in the config file looks the same before-and-after:
```
"logging.googleapis.com/local_resource_id" ${"k8s_node.e2e-test-peterhornyack-windows-node-group-6tw6"}
"logging.googleapis.com/local_resource_id" ${"k8s_node.e2e-test-peterhornyack-windows-node-group-mf5r"}
```

/kind cleanup

```release-note
NONE
```