### PR TITLE
CVE-2019-11251: Remove symlink support from kubectl cp

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -26,7 +26,6 @@ pkg/credentialprovider
 pkg/credentialprovider/aws
 pkg/credentialprovider/azure
 pkg/kubeapiserver/admission
-pkg/kubectl/cmd/cp
 pkg/kubectl/cmd/get
 pkg/kubelet/apis/podresources
 pkg/kubelet/cm/devicemanager


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Based on the recent discussion in SIG-CLI we've decided to drop support when copying data from pods.

**Special notes for your reviewer**:
/assign @liggitt @tallclair 
Only the second commit matters, the first is coming from https://github.com/kubernetes/kubernetes/pull/82087

Fixes #87773

**Does this PR introduce a user-facing change?**:
```release-note
`kubectl cp` no longer supports copying symbolic links from containers; to support this use case, see `kubectl exec --help` for examples using `tar` directly
```
