### PR TITLE
fix: adding padding the encoded docker auth field

### DIFF
--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -282,7 +282,20 @@ func (ident DockerConfigEntry) MarshalJSON() ([]byte, error) {
 // decodeDockerConfigFieldAuth deserializes the "auth" field from dockercfg into a
 // username and a password. The format of the auth field is base64(<username>:<password>).
 func decodeDockerConfigFieldAuth(field string) (username, password string, err error) {
-	decoded, err := base64.StdEncoding.DecodeString(field)
+
+	var decoded []byte
+
+	// StdEncoding can only decode padded string
+	// RawStdEncoding can only decode unpadded string
+	// a string is correctly padded if and only if its length is a multiple of 4
+	if (len(field) % 4) == 0 {
+		// decode padded data
+		decoded, err = base64.StdEncoding.DecodeString(field)
+	} else {
+		// decode unpadded data
+		decoded, err = base64.RawStdEncoding.DecodeString(field)
+	}
+
 	if err != nil {
 		return
 	}

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package credentialprovider
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"io/ioutil"
 	"os"
@@ -204,6 +205,34 @@ func TestDecodeDockerConfigFieldAuth(t *testing.T) {
 		// auth field decodes to username & password
 		{
 			input:    "Zm9vOmJhcg==",
+			username: "foo",
+			password: "bar",
+		},
+
+		// some test as before but with field not well padded
+		{
+			input:    "Zm9vOmJhcg",
+			username: "foo",
+			password: "bar",
+		},
+
+		// standard encoding (with padding)
+		{
+			input:    base64.StdEncoding.EncodeToString([]byte("foo:bar")),
+			username: "foo",
+			password: "bar",
+		},
+
+		// raw encoding (without padding)
+		{
+			input:    base64.RawStdEncoding.EncodeToString([]byte("foo:bar")),
+			username: "foo",
+			password: "bar",
+		},
+
+		// the input is encoded with encodeDockerConfigFieldAuth (standard encoding)
+		{
+			input:    encodeDockerConfigFieldAuth("foo", "bar"),
 			username: "foo",
 			password: "bar",
 		},


### PR DESCRIPTION
The docker-credential-desk does not pad anymore the auth field.
it is then possible to have a not padded field.

this fix is to padded the field before encoding it.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

It fixes a little bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82147
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No user-facing change
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
k8s dockerconfigjson secrets are now compatible with docker config desktop authentication credentials files
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
