### PR TITLE
Adding EndpointSlice RBAC for node-proxier/kube-proxy

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -352,17 +352,6 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			},
 		},
 		{
-			// a role to use for setting up a proxy
-			ObjectMeta: metav1.ObjectMeta{Name: "system:node-proxier"},
-			Rules: []rbacv1.PolicyRule{
-				// Used to build serviceLister
-				rbacv1helpers.NewRule("list", "watch").Groups(legacyGroup).Resources("services", "endpoints").RuleOrDie(),
-				rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
-
-				eventsRule(),
-			},
-		},
-		{
 			// a role to use for full access to the kubelet API
 			ObjectMeta: metav1.ObjectMeta{Name: "system:kubelet-api-admin"},
 			Rules: []rbacv1.PolicyRule{
@@ -471,6 +460,21 @@ func ClusterRoles() []rbacv1.ClusterRole {
 			},
 		},
 	}
+
+	// node-proxier role is used by kube-proxy.
+	nodeProxierRules := []rbacv1.PolicyRule{
+		rbacv1helpers.NewRule("list", "watch").Groups(legacyGroup).Resources("services", "endpoints").RuleOrDie(),
+		rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("nodes").RuleOrDie(),
+
+		eventsRule(),
+	}
+	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
+		nodeProxierRules = append(nodeProxierRules, rbacv1helpers.NewRule("list", "watch").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie())
+	}
+	roles = append(roles, rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "system:node-proxier"},
+		Rules:      nodeProxierRules,
+	})
 
 	kubeSchedulerRules := []rbacv1.PolicyRule{
 		eventsRule(),


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When the EndpointSlice feature gate is enabled, kube-proxy should read from EndpointSlice resources instead of Endpoints resources. That requires new RBAC permission added here.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190603-EndpointSlice-API.md)
- [Enhancement Issue](https://github.com/kubernetes/enhancements/issues/752)
