### PR TITLE
Add NonRoot image to whitelist in e2e test

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -63,6 +63,7 @@ var CommonImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.TestWebserver),
 	imageutils.GetE2EImage(imageutils.VolumeNFSServer),
 	imageutils.GetE2EImage(imageutils.VolumeGlusterServer),
+	imageutils.GetE2EImage(imageutils.NonRoot),
 )
 
 type testImagesStruct struct {


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:
When test/e2e/common/security_context.go use NonRoot image,
it would trigger an error as following
    should not run with an explicit root user ID [It]
    /go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/
	kubernetes/test/e2e/common/security_context.go:131

    Image "gcr.io/kubernetes-e2e-test-images/nonroot:1.0"
	is not in the white list, consider adding it to
	CommonImageWhiteList in test/e2e/common/util.go or
	NodeImageWhiteList in test/e2e_node/image_list.go
    Expected
        <bool>: false
    to be true

This test is not about test whitelist function but if k8s
can create pod with non root user successfully.
Also checked other tests that use NonRoot image, they
are not affected by add NonRoot image into whilelist.

**Which issue(s) this PR fixes**:
Fixes #82419

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
None

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


```docs
None
```
