### PR TITLE
Allow private key reuse from certificate managers for server certs

### DIFF
--- a/pkg/kubelet/certificate/kubelet.go
+++ b/pkg/kubelet/certificate/kubelet.go
@@ -25,7 +25,7 @@ import (
 	"sort"
 
 	certificates "k8s.io/api/certificates/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
 	certificatesclient "k8s.io/client-go/kubernetes/typed/certificates/v1beta1"
@@ -80,6 +80,9 @@ func NewKubeletServerCertificateManager(kubeClient clientset.Interface, kubeCfg 
 	}
 
 	m, err := certificate.NewManager(&certificate.Config{
+		// Allow reuse of the private key so that approvers can more easily
+		// renew server certs
+		AllowPrivateKeyReuse: true,
 		ClientFn: func(current *tls.Certificate) (certificatesclient.CertificateSigningRequestInterface, error) {
 			return certSigningRequestClient, nil
 		},


### PR DESCRIPTION
Server certificates need to be renewed in cert rotation, but it is
difficult for callers to renew server certificates if the private
key is continually changing. Instead, set server certificate renewal
to reuse the private key if possible. There should be no security
impact from this (node compromise exposes the private key already)
but it does mean private keys are changed less frequently.

/kind bug

```release-note
Server certificate renewal from the Kubelet now attempts to reuse the existing private key, if any.
```

```docs
```