### PR TITLE
hack/e2e.go: Download kubetest as recommended

### DIFF
--- a/hack/e2e.go
+++ b/hack/e2e.go
@@ -90,6 +90,7 @@ func wait(cmd string, args ...string) error {
 	c := exec.Command(cmd, args...)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
+	c.Env = append(os.Environ(), "GO111MODULE=on")
 	if err := c.Start(); err != nil {
 		return err
 	}
@@ -156,7 +157,10 @@ func (t tester) getKubetest(get bool, old time.Duration) (string, error) {
 		return "", fmt.Errorf("cannot install kubetest until $GOPATH is set")
 	}
 	log.Print("Updating kubetest binary...")
-	cmd := []string{"go", "get", "-u", "k8s.io/test-infra/kubetest"}
+	// per: https://github.com/kubernetes/test-infra/pull/14094#issuecomment-526717609
+	// it is recommended to download kubetest with 1.11 modules and no -u
+	// GO111MODULE=on is set in Env Command in wait()
+	cmd := []string{"go", "get", "k8s.io/test-infra/kubetest"}
 	if err = t.wait(cmd[0], cmd[1:]...); err != nil {
 		return "", fmt.Errorf("%s: %v", strings.Join(cmd, " "), err) // Could not upgrade
 	}

--- a/hack/e2e_test.go
+++ b/hack/e2e_test.go
@@ -200,7 +200,7 @@ func TestGetKubetest(t *testing.T) {
 	p := "PATH"
 	pk := filepath.Join(p, "kubetest")
 	eu := errors.New("upgrade failed")
-	euVerbose := fmt.Errorf("go get -u k8s.io/test-infra/kubetest: %v", eu)
+	euVerbose := fmt.Errorf("go get k8s.io/test-infra/kubetest: %v", eu)
 	et := errors.New("touch failed")
 	cases := []struct {
 		name string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, kubetest fails to download, as it is not being downloaded as recommended here: https://github.com/kubernetes/test-infra/pull/14094#issuecomment-526717609
fix this in hack/e2e.go
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Continuation of a fix for https://github.com/kubernetes/test-infra/issues/14070
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
