### PR TITLE
Allow container visitor to operate on selected container types

### DIFF
--- a/pkg/api/pod/util.go
+++ b/pkg/api/pod/util.go
@@ -26,28 +26,52 @@ import (
 	"k8s.io/kubernetes/pkg/security/apparmor"
 )
 
+// ContainerType signifies container type
+type ContainerType int
+
+// DefaultContainers defines default behavior: Iterate containers based on feature gates
+const DefaultContainers ContainerType = 0
+
+const (
+	// Containers is for normal containers
+	Containers ContainerType = 1 << iota
+	// InitContainers is for init containers
+	InitContainers
+	// EphemeralContainers is for ephemeral containers
+	EphemeralContainers
+)
+
 // ContainerVisitor is called with each container spec, and returns true
 // if visiting should continue.
-type ContainerVisitor func(container *api.Container) (shouldContinue bool)
+type ContainerVisitor func(container *api.Container, containerType ContainerType) (shouldContinue bool)
 
 // VisitContainers invokes the visitor function with a pointer to the container
 // spec of every container in the given pod spec. If visitor returns false,
 // visiting is short-circuited. VisitContainers returns true if visiting completes,
 // false if visiting was short-circuited.
-func VisitContainers(podSpec *api.PodSpec, visitor ContainerVisitor) bool {
-	for i := range podSpec.InitContainers {
-		if !visitor(&podSpec.InitContainers[i]) {
-			return false
+//
+// With the default mask (zero value or DefaultContainers) VisitContainers will visit all containers
+// enabled by current feature gates. If mask is non-zero, VisitContainers will unconditionally visit
+// container types specified by mask, and no feature gate checks will be performed.
+func VisitContainers(podSpec *api.PodSpec, mask ContainerType, visitor ContainerVisitor) bool {
+	if mask == DefaultContainers || (mask&InitContainers) > 0 {
+		for i := range podSpec.InitContainers {
+			if !visitor(&podSpec.InitContainers[i], InitContainers) {
+				return false
+			}
 		}
 	}
-	for i := range podSpec.Containers {
-		if !visitor(&podSpec.Containers[i]) {
-			return false
+	if mask == DefaultContainers || (mask&Containers) > 0 {
+		for i := range podSpec.Containers {
+			if !visitor(&podSpec.Containers[i], Containers) {
+				return false
+			}
 		}
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.EphemeralContainers) {
+	if (mask == DefaultContainers && utilfeature.DefaultFeatureGate.Enabled(features.EphemeralContainers)) ||
+		(mask&EphemeralContainers) > 0 {
 		for i := range podSpec.EphemeralContainers {
-			if !visitor((*api.Container)(&podSpec.EphemeralContainers[i].EphemeralContainerCommon)) {
+			if !visitor((*api.Container)(&podSpec.EphemeralContainers[i].EphemeralContainerCommon), EphemeralContainers) {
 				return false
 			}
 		}
@@ -68,7 +92,7 @@ func VisitPodSecretNames(pod *api.Pod, visitor Visitor) bool {
 			return false
 		}
 	}
-	VisitContainers(&pod.Spec, func(c *api.Container) bool {
+	VisitContainers(&pod.Spec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		return visitContainerSecretNames(c, visitor)
 	})
 	var source *api.VolumeSource
@@ -151,7 +175,7 @@ func visitContainerSecretNames(container *api.Container, visitor Visitor) bool {
 // Transitive references (e.g. pod -> pvc -> pv -> secret) are not visited.
 // Returns true if visiting completed, false if visiting was short-circuited.
 func VisitPodConfigmapNames(pod *api.Pod, visitor Visitor) bool {
-	VisitContainers(&pod.Spec, func(c *api.Container) bool {
+	VisitContainers(&pod.Spec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		return visitContainerConfigmapNames(c, visitor)
 	})
 	var source *api.VolumeSource
@@ -362,7 +386,7 @@ func dropDisabledFields(
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.VolumeSubpath) && !subpathInUse(oldPodSpec) {
 		// drop subpath from the pod if the feature is disabled and the old spec did not specify subpaths
-		VisitContainers(podSpec, func(c *api.Container) bool {
+		VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 			for i := range c.VolumeMounts {
 				c.VolumeMounts[i].SubPath = ""
 			}
@@ -375,7 +399,7 @@ func dropDisabledFields(
 
 	if (!utilfeature.DefaultFeatureGate.Enabled(features.VolumeSubpath) || !utilfeature.DefaultFeatureGate.Enabled(features.VolumeSubpathEnvExpansion)) && !subpathExprInUse(oldPodSpec) {
 		// drop subpath env expansion from the pod if either of the subpath features is disabled and the old spec did not specify subpath env expansion
-		VisitContainers(podSpec, func(c *api.Container) bool {
+		VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 			for i := range c.VolumeMounts {
 				c.VolumeMounts[i].SubPathExpr = ""
 			}
@@ -385,7 +409,7 @@ func dropDisabledFields(
 
 	if !utilfeature.DefaultFeatureGate.Enabled(features.StartupProbe) && !startupProbeInUse(oldPodSpec) {
 		// drop startupProbe from all containers if the feature is disabled
-		VisitContainers(podSpec, func(c *api.Container) bool {
+		VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 			c.StartupProbe = nil
 			return true
 		})
@@ -433,7 +457,7 @@ func dropDisabledRunAsGroupField(podSpec, oldPodSpec *api.PodSpec) {
 		if podSpec.SecurityContext != nil {
 			podSpec.SecurityContext.RunAsGroup = nil
 		}
-		VisitContainers(podSpec, func(c *api.Container) bool {
+		VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 			if c.SecurityContext != nil {
 				c.SecurityContext.RunAsGroup = nil
 			}
@@ -512,7 +536,7 @@ func dropDisabledRunAsUserNameFieldsFromContainers(containers []api.Container) {
 func dropDisabledProcMountField(podSpec, oldPodSpec *api.PodSpec) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.ProcMountType) && !procMountInUse(oldPodSpec) {
 		defaultProcMount := api.DefaultProcMount
-		VisitContainers(podSpec, func(c *api.Container) bool {
+		VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 			if c.SecurityContext != nil && c.SecurityContext.ProcMount != nil {
 				// The ProcMount field was improperly forced to non-nil in 1.12.
 				// If the feature is disabled, and the existing object is not using any non-default values, and the ProcMount field is present in the incoming object, force to the default value.
@@ -528,7 +552,7 @@ func dropDisabledProcMountField(podSpec, oldPodSpec *api.PodSpec) {
 // This should be called from PrepareForCreate/PrepareForUpdate for all resources containing a VolumeDevice
 func dropDisabledVolumeDevicesFields(podSpec, oldPodSpec *api.PodSpec) {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.BlockVolume) && !volumeDevicesInUse(oldPodSpec) {
-		VisitContainers(podSpec, func(c *api.Container) bool {
+		VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 			c.VolumeDevices = nil
 			return true
 		})
@@ -559,7 +583,7 @@ func subpathInUse(podSpec *api.PodSpec) bool {
 	}
 
 	var inUse bool
-	VisitContainers(podSpec, func(c *api.Container) bool {
+	VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		for i := range c.VolumeMounts {
 			if len(c.VolumeMounts[i].SubPath) > 0 {
 				inUse = true
@@ -609,7 +633,7 @@ func procMountInUse(podSpec *api.PodSpec) bool {
 	}
 
 	var inUse bool
-	VisitContainers(podSpec, func(c *api.Container) bool {
+	VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		if c.SecurityContext == nil || c.SecurityContext.ProcMount == nil {
 			return true
 		}
@@ -703,7 +727,7 @@ func volumeDevicesInUse(podSpec *api.PodSpec) bool {
 	}
 
 	var inUse bool
-	VisitContainers(podSpec, func(c *api.Container) bool {
+	VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		if c.VolumeDevices != nil {
 			inUse = true
 			return false
@@ -725,7 +749,7 @@ func runAsGroupInUse(podSpec *api.PodSpec) bool {
 	}
 
 	var inUse bool
-	VisitContainers(podSpec, func(c *api.Container) bool {
+	VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		if c.SecurityContext != nil && c.SecurityContext.RunAsGroup != nil {
 			inUse = true
 			return false
@@ -814,7 +838,7 @@ func subpathExprInUse(podSpec *api.PodSpec) bool {
 	}
 
 	var inUse bool
-	VisitContainers(podSpec, func(c *api.Container) bool {
+	VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		for i := range c.VolumeMounts {
 			if len(c.VolumeMounts[i].SubPathExpr) > 0 {
 				inUse = true
@@ -834,7 +858,7 @@ func startupProbeInUse(podSpec *api.PodSpec) bool {
 	}
 
 	var inUse bool
-	VisitContainers(podSpec, func(c *api.Container) bool {
+	VisitContainers(podSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 		if c.StartupProbe != nil {
 			inUse = true
 			return false

--- a/pkg/api/pod/util_test.go
+++ b/pkg/api/pod/util_test.go
@@ -134,7 +134,7 @@ func TestVisitContainers(t *testing.T) {
 
 	for _, tc := range testCases {
 		gotNames := []string{}
-		VisitContainers(tc.haveSpec, func(c *api.Container) bool {
+		VisitContainers(tc.haveSpec, DefaultContainers, func(c *api.Container, containerType ContainerType) bool {
 			gotNames = append(gotNames, c.Name)
 			if c.SecurityContext != nil {
 				c.SecurityContext = nil

--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -387,7 +387,7 @@ func LogLocation(
 
 func podHasContainerWithName(pod *api.Pod, containerName string) bool {
 	var hasContainer bool
-	podutil.VisitContainers(&pod.Spec, func(c *api.Container) bool {
+	podutil.VisitContainers(&pod.Spec, podutil.DefaultContainers, func(c *api.Container, containerType podutil.ContainerType) bool {
 		if c.Name == containerName {
 			hasContainer = true
 			return false

--- a/pkg/security/podsecuritypolicy/provider.go
+++ b/pkg/security/podsecuritypolicy/provider.go
@@ -111,7 +111,7 @@ func (s *simpleProvider) MutatePod(pod *api.Pod) error {
 	}
 
 	var retErr error
-	podutil.VisitContainers(&pod.Spec, func(c *api.Container) bool {
+	podutil.VisitContainers(&pod.Spec, podutil.DefaultContainers, func(c *api.Container, containerType podutil.ContainerType) bool {
 		retErr = s.mutateContainer(pod, c)
 		if retErr != nil {
 			return false


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Over #79176, there was some discussion on how container visitor should be enhanced starting with this comment:
https://github.com/kubernetes/kubernetes/pull/79176#issuecomment-523670872

In this PR, we propose passing bitmask of container types to VisitContainers func so that the caller can decide which container type(s) are of interest to the caller.

The visitor would be given the container type it is visiting.

I open this PR to solicit discussion and give V2 suffix to related type / func.
When we get agreement on the approach, I will retrofit current API.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
