### PR TITLE
Included hostNetwork in GCE CSI tests.

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/controller_ss.yaml
@@ -14,6 +14,7 @@ spec:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
       serviceAccountName: csi-controller-sa
+      hostNetwork: true
       containers:
         - name: csi-provisioner
           # TODO: replace with official 1.4.0 release when ready

--- a/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
+++ b/test/e2e/testing-manifests/storage-csi/gce-pd/node_ds.yaml
@@ -11,6 +11,7 @@ spec:
       labels:
         app: gcp-compute-persistent-disk-csi-driver
     spec:
+      hostNetwork: true
       containers:
         - name: csi-driver-registrar
           image: gcr.io/gke-release/csi-node-driver-registrar:v1.1.0-gke.0


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Resolves an issue with GCE CSI tests accessing metadata services, by placing them inside the host network.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```