### PR TITLE
promote crd discovery e2e to conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -14,6 +14,7 @@ test/e2e/apimachinery/crd_watch.go: "watch on custom resource definition objects
 test/e2e/apimachinery/custom_resource_definition.go: "creating/deleting custom resource definition objects works"
 test/e2e/apimachinery/custom_resource_definition.go: "listing custom resource definition objects works"
 test/e2e/apimachinery/custom_resource_definition.go: "getting/updating/patching custom resource definition status sub-resource works"
+test/e2e/apimachinery/custom_resource_definition.go: "should include custom resource definition resources in discovery documents"
 test/e2e/apimachinery/garbage_collector.go: "should delete pods created by rc when not orphaning"
 test/e2e/apimachinery/garbage_collector.go: "should orphan pods created by rc if delete options say so"
 test/e2e/apimachinery/garbage_collector.go: "should delete RS created by deployment when not orphaning"

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -188,7 +188,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		Description: Fetch /apis, /apis/apiextensions.k8s.io, and /apis/apiextensions.k8s.io/v1 discovery documents,
 		and ensure they indicate CustomResourceDefinition apiextensions.k8s.io/v1 resources are available.
 	*/
-	ginkgo.It("should include custom resource definition resources in discovery documents", func() {
+	framework.ConformanceIt("should include custom resource definition resources in discovery documents", func() {
 		{
 			ginkgo.By("fetching the /apis discovery document")
 			apiGroupList := &metav1.APIGroupList{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promote the CRD discovery doc e2e test (which merged in https://github.com/kubernetes/kubernetes/pull/82036) to the conformance suite, to cover all endpoints for conformance. This is the one remaining bit-flipping mentioned in https://github.com/kubernetes/kubernetes/pull/81864#issuecomment-526361962

[Run history of that test](https://k8s-testgrid.appspot.com/sig-release-master-blocking#gce-cos-master-default&width=5&sort-by-flakiness=&include-filter-by-regex=&include-filter-by-regex=CustomResource.*discovery)

/area conformance

@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-api-machinery-pr-reviews @kubernetes/cncf-conformance-wg

/cc @johnbelamaric @liggitt 
/assign @smarterclayton 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
