### PR TITLE
Update default etcd server to 3.3.15 for kubernetes 1.16

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: "etcd"
-    version: 3.3.10
+    version: 3.3.15
     refPaths:
     - path: cluster/gce/manifests/etcd.manifest
       match: etcd_docker_tag|etcd_version

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -35,11 +35,11 @@ _CRI_TARBALL_ARCH_SHA256 = {
     "s390x": "8b7b5749cba88ef337997ae90aa04380e3cab2c040b44b505b2fcd691c4935e4",
 }
 
-ETCD_VERSION = "3.3.10"
+ETCD_VERSION = "3.3.15"
 _ETCD_TARBALL_ARCH_SHA256 = {
-    "amd64": "1620a59150ec0a0124a65540e23891243feb2d9a628092fb1edcc23974724a45",
-    "arm64": "5ec97b0b872adce275b8130d19db314f7f2b803aeb24c4aae17a19e2d66853c4",
-    "ppc64le": "148fe96f0ec1813c5db9916199e96a913174304546bc8447a2d2f9fee4b8f6c2",
+    "amd64": "87e30dc472a48b775a9e764cb742a5df0a2844e7b82d12917d7ea489febbc8c8",
+    "arm64": "0cdacf1a5f8095322ee77b62ac5e79c3326a5166deb69f558214b110b312b4c0",
+    "ppc64le": "dcaa8d0ec1a117f6456778f3b9c7e685d4609c2a3c448afda1aa7a4232d0c481",
 }
 
 # Dependencies needed for a Kubernetes "release", e.g. building docker images,

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -187,7 +187,7 @@ ENABLE_METADATA_AGENT="${KUBE_ENABLE_METADATA_AGENT:-none}"
 # Useful for scheduling heapster in large clusters with nodes of small size.
 HEAPSTER_MACHINE_TYPE="${HEAPSTER_MACHINE_TYPE:-}"
 
-# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. 3.3.10-1) if you need
+# Set etcd image (e.g. k8s.gcr.io/etcd) and version (e.g. 3.3.15-0) if you need
 # non-default version.
 ETCD_IMAGE="${TEST_ETCD_IMAGE:-}"
 ETCD_DOCKER_REPOSITORY="${TEST_ETCD_DOCKER_REPOSITORY:-}"

--- a/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
+++ b/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
@@ -13,4 +13,4 @@ spec:
   dnsPolicy: Default
   containers:
   - name: etcd-empty-dir-cleanup
-    image: k8s.gcr.io/etcd-empty-dir-cleanup:3.3.10.1
+    image: k8s.gcr.io/etcd-empty-dir-cleanup:3.3.15.0

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -14,7 +14,7 @@
 "containers":[
     {
     "name": "etcd-container",
-    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.3.10-1') }}",
+    "image": "{{ pillar.get('etcd_docker_repository', 'k8s.gcr.io/etcd') }}:{{ pillar.get('etcd_docker_tag', '3.3.15-0') }}",
     "resources": {
       "requests": {
         "cpu": {{ cpulimit }}
@@ -30,7 +30,7 @@
         "value": "{{ pillar.get('storage_backend', 'etcd3') }}"
       },
       { "name": "TARGET_VERSION",
-        "value": "{{ pillar.get('etcd_version', '3.3.10') }}"
+        "value": "{{ pillar.get('etcd_version', '3.3.15') }}"
       },
       { "name": "DATA_DIRECTORY",
         "value": "/var/etcd/data{{ suffix }}"

--- a/cluster/gce/upgrade-aliases.sh
+++ b/cluster/gce/upgrade-aliases.sh
@@ -170,8 +170,8 @@ export KUBE_GCE_ENABLE_IP_ALIASES=true
 export SECONDARY_RANGE_NAME="pods-default"
 export STORAGE_BACKEND="etcd3"
 export STORAGE_MEDIA_TYPE="application/vnd.kubernetes.protobuf"
-export ETCD_IMAGE=3.3.10-1
-export ETCD_VERSION=3.3.10
+export ETCD_IMAGE=3.3.15-0
+export ETCD_VERSION=3.3.15
 
 # Upgrade master with updated kube envs
 "${KUBE_ROOT}/cluster/gce/upgrade.sh" -M -l

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -14,13 +14,13 @@
 
 .PHONY:	build push
 
-ETCD_VERSION = 3.3.10
+ETCD_VERSION = 3.3.15
 # Image should be pulled from k8s.gcr.io, which will auto-detect
 # region (us, eu, asia, ...) and pull from the closest.
 REGISTRY = k8s.gcr.io
 # Images should be pushed to staging-k8s.gcr.io.
 PUSH_REGISTRY = staging-k8s.gcr.io
-TAG = 3.3.10.0
+TAG = 3.3.15.0
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -15,7 +15,7 @@
 # Build the etcd image
 #
 # Usage:
-# 	[BUNDLED_ETCD_VERSIONS=3.0.17 3.1.12 3.2.24 3.3.10] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
+# 	[BUNDLED_ETCD_VERSIONS=3.0.17 3.1.12 3.2.24 3.3.15] [REGISTRY=k8s.gcr.io] [ARCH=amd64] [BASEIMAGE=busybox] make (build|push)
 #
 # The image contains different etcd versions to simplify
 # upgrades. Thus be careful when removing any versions from here.
@@ -26,15 +26,15 @@
 # Except from etcd-$(version) and etcdctl-$(version) binaries, we also
 # need etcd and etcdctl binaries for backward compatibility reasons.
 # That binary will be set to the last version from $(BUNDLED_ETCD_VERSIONS).
-BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.12 3.2.24 3.3.10
+BUNDLED_ETCD_VERSIONS?=3.0.17 3.1.12 3.2.24 3.3.15
 
 # LATEST_ETCD_VERSION identifies the most recent etcd version available.
-LATEST_ETCD_VERSION?=3.3.10
+LATEST_ETCD_VERSION?=3.3.15
 
 # REVISION provides a version number fo this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
 # for each revision of this image at that etcd version.
-REVISION?=2
+REVISION?=0
 
 # IMAGE_TAG Uniquely identifies k8s.gcr.io/etcd docker image with a tag of the form "<etcd-version>-<revision>".
 IMAGE_TAG=$(LATEST_ETCD_VERSION)-$(REVISION)
@@ -62,7 +62,7 @@ endif
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled
 # golang version should match the golang version from https://github.com/coreos/etcd/releases for the current ETCD_VERSION.
-GOLANG_VERSION?=1.10.4
+GOLANG_VERSION?=1.12.9
 GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 

--- a/cluster/images/etcd/README.md
+++ b/cluster/images/etcd/README.md
@@ -26,7 +26,7 @@ server.
 
 `migrate` writes a `version.txt` file to track the "current" version
 of etcd that was used to persist data to disk. A "target" version may also be provided
-by the `TARGET_STORAGE` (e.g. "etcd3") and `TARGET_VERSION` (e.g. "3.3.10" )
+by the `TARGET_STORAGE` (e.g. "etcd3") and `TARGET_VERSION` (e.g. "3.3.15" )
 environment variables. If the persisted version differs from the target version,
 `migrate-if-needed.sh` will migrate the data from the current to the target
 version.

--- a/cluster/images/etcd/migrate-if-needed.sh
+++ b/cluster/images/etcd/migrate-if-needed.sh
@@ -18,7 +18,7 @@
 # This script performs etcd upgrade based on the following environmental
 # variables:
 # TARGET_STORAGE - API of etcd to be used (supported: 'etcd3')
-# TARGET_VERSION - etcd release to be used (supported: '3.0.17', '3.1.12', '3.2.24', "3.3.10")
+# TARGET_VERSION - etcd release to be used (supported: '3.0.17', '3.1.12', '3.2.24', "3.3.15")
 # DATA_DIRECTORY - directory with etcd data
 #
 # The current etcd version and storage format is detected based on the
@@ -28,7 +28,7 @@
 # The update workflow support the following upgrade steps:
 # - 3.0.17/etcd3 -> 3.1.12/etcd3
 # - 3.1.12/etcd3 -> 3.2.24/etcd3
-# - 3.2.24/etcd3 -> 3.3.10/etcd3
+# - 3.2.24/etcd3 -> 3.3.15/etcd3
 #
 # NOTE: The releases supported in this script has to match release binaries
 # present in the etcd image (to make this script work correctly).
@@ -41,7 +41,7 @@ set -o nounset
 
 # NOTE: BUNDLED_VERSION has to match release binaries present in the
 # etcd image (to make this script work correctly).
-BUNDLED_VERSIONS="3.0.17, 3.1.12, 3.2.24, 3.3.10"
+BUNDLED_VERSIONS="3.0.17, 3.1.12, 3.2.24, 3.3.15"
 
 ETCD_NAME="${ETCD_NAME:-etcd-$(hostname)}"
 if [ -z "${DATA_DIRECTORY:-}" ]; then

--- a/cluster/images/etcd/migrate/integration_test.go
+++ b/cluster/images/etcd/migrate/integration_test.go
@@ -25,6 +25,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"math/big"
@@ -37,6 +38,7 @@ import (
 	"time"
 
 	"github.com/blang/semver"
+	"k8s.io/klog"
 )
 
 var (
@@ -44,6 +46,13 @@ var (
 	testVersionPrevious   = &EtcdVersion{semver.MustParse("3.0.17")}
 	testVersionLatest     = &EtcdVersion{semver.MustParse("3.1.12")}
 )
+
+func init() {
+	// Enable klog which is used in dependencies
+	klog.InitFlags(nil)
+	flag.Set("logtostderr", "true")
+	flag.Set("v", "9")
+}
 
 func TestMigrate(t *testing.T) {
 	migrations := []struct {

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -260,7 +260,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.3.10"
+	DefaultEtcdVersion = "3.3.15"
 
 	// PauseVersion indicates the default pause image version for kubeadm
 	PauseVersion = "3.1"
@@ -424,8 +424,8 @@ var (
 		13: "3.2.24",
 		14: "3.3.10",
 		15: "3.3.10",
-		16: "3.3.10",
-		17: "3.3.10",
+		16: "3.3.15",
+		17: "3.3.15",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -16,7 +16,7 @@
 
 # A set of helpers for starting/running etcd for tests
 
-ETCD_VERSION=${ETCD_VERSION:-3.3.10}
+ETCD_VERSION=${ETCD_VERSION:-3.3.15}
 ETCD_HOST=${ETCD_HOST:-127.0.0.1}
 ETCD_PORT=${ETCD_PORT:-2379}
 export KUBE_INTEGRATION_ETCD_URL="http://${ETCD_HOST}:${ETCD_PORT}"

--- a/staging/src/k8s.io/sample-apiserver/artifacts/example/rc.yaml
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/example/rc.yaml
@@ -25,4 +25,4 @@ spec:
         imagePullPolicy: Never
         args: [ "--etcd-servers=http://localhost:2379" ]
       - name: etcd
-        image: quay.io/coreos/etcd:v3.3.10
+        image: quay.io/coreos/etcd:v3.3.15

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -32,7 +32,7 @@ import (
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 )
 
-const etcdImage = "3.3.10-1"
+const etcdImage = "3.3.15-0"
 
 // EtcdUpgrade upgrades etcd on GCE.
 func EtcdUpgrade(targetStorage, targetVersion string) error {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -217,7 +217,7 @@ func initImageConfigs() map[int]Config {
 	configs[Dnsutils] = Config{e2eRegistry, "dnsutils", "1.1"}
 	configs[DebianBase] = Config{googleContainerRegistry, "debian-base", "0.4.1"}
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
-	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.10"}
+	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.15"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
 	configs[Httpd] = Config{dockerLibraryRegistry, "httpd", "2.4.38-alpine"}
 	configs[HttpdNew] = Config{dockerLibraryRegistry, "httpd", "2.4.39-alpine"}


### PR DESCRIPTION
We already bumped etcd client to 3.3.15 before code freeze but we neglected to bump the server itself. Also see additional information in https://github.com/kubernetes/kubeadm/issues/1726

Change-Id: I68f1a5e5339d83077a1a9f312c4e6e33848886c5

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Updated default etcd service used by kubernetes to 3.3.15
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
