### PR TITLE
omit redundant type bool from variable declarations

### DIFF
--- a/pkg/security/apparmor/validate.go
+++ b/pkg/security/apparmor/validate.go
@@ -102,7 +102,7 @@ func validateHost(runtime string) error {
 
 	// Check build support.
 	if isDisabledBuild {
-		return errors.New("Binary not compiled for linux")
+		return errors.New("binary not compiled for linux")
 	}
 
 	// Check kernel support.
@@ -112,7 +112,7 @@ func validateHost(runtime string) error {
 
 	// Check runtime support. Currently only Docker is supported.
 	if runtime != kubetypes.DockerContainerRuntime && runtime != kubetypes.RemoteContainerRuntime {
-		return fmt.Errorf("AppArmor is only enabled for 'docker' and 'remote' runtimes. Found: %q.", runtime)
+		return fmt.Errorf("AppArmor is only enabled for 'docker' and 'remote' runtimes. Found: %q", runtime)
 	}
 
 	return nil

--- a/pkg/security/podsecuritypolicy/provider_test.go
+++ b/pkg/security/podsecuritypolicy/provider_test.go
@@ -556,7 +556,7 @@ func TestValidateContainerFailures(t *testing.T) {
 	}
 
 	failPrivPod := defaultPod()
-	var priv bool = true
+	var priv = true
 	failPrivPod.Spec.Containers[0].SecurityContext.Privileged = &priv
 
 	failProcMountPod := defaultPod()
@@ -1043,7 +1043,7 @@ func TestValidateContainerSuccess(t *testing.T) {
 	privPSP := defaultPSP()
 	privPSP.Spec.Privileged = true
 	privPod := defaultPod()
-	var priv bool = true
+	var priv = true
 	privPod.Spec.Containers[0].SecurityContext.Privileged = &priv
 
 	capsPSP := defaultPSP()
@@ -1275,7 +1275,7 @@ func defaultNamedPSP(name string) *policy.PodSecurityPolicy {
 }
 
 func defaultPod() *api.Pod {
-	var notPriv bool = false
+	var notPriv = false
 	return &api.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},
@@ -1299,7 +1299,7 @@ func defaultPod() *api.Pod {
 }
 
 func defaultV1Pod() *v1.Pod {
-	var notPriv bool = false
+	var notPriv = false
 	return &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**

Omit redundant type bool from variable declarations, referring to golint's recommendations.
Following file involved:
/kubernetes/pkg/security/podsecuritypolicy/provider_test.go

**Which issue(s) this PR fixes:**

Fixes #

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**
```release-note
NONE
```