### PR TITLE
Ensure the KUBE-MARK-DROP chain in kube-proxy mode=ipvs

### DIFF
--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -111,6 +111,7 @@ var iptablesChains = []struct {
 	{utiliptables.TableNAT, KubeNodePortChain},
 	{utiliptables.TableNAT, KubeLoadBalancerChain},
 	{utiliptables.TableNAT, KubeMarkMasqChain},
+	{utiliptables.TableNAT, KubeMarkDropChain},
 	{utiliptables.TableFilter, KubeForwardChain},
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig network
/area ipvs

**What this PR does / why we need it**:

The `kube-proxy` expects the `KUBE-MARK-DROP` to exist. This chain is created by `kubelet`, it works but creates an unnecessary race. Ensuring the chain in both `kube-proxy` and `kubelet` removes the race without affecting the function.

Also in dual-stack the  `KUBE-MARK-DROP` is only created for the "cluster default" family by `kubelet` so dual-stack operation fails for `kube-proxy` unless the chain is created by other means, e.g with;
```
ip6tables -t nat -N KUBE-MARK-DROP
```

**Which issue(s) this PR fixes**:

Fixes #80462

**Special notes for your reviewer**:

Nobody seem to remember why the `KUBE-MARK-DROP` is created by `kubelet`.

**Does this PR introduce a user-facing change?**:

```release-note
Ensure the KUBE-MARK-DROP chain in kube-proxy mode=ipvs. The chain is ensured for both ipv4 and ipv6 in dual-stack operation.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

