### PR TITLE
 Refactor the nodeName data structure, the only entry change on kubelet startup

### DIFF
--- a/pkg/kubemark/hollow_kubelet.go
+++ b/pkg/kubemark/hollow_kubelet.go
@@ -91,7 +91,7 @@ func (hk *HollowKubelet) Run() {
 	if err := kubeletapp.RunKubelet(&options.KubeletServer{
 		KubeletFlags:         *hk.KubeletFlags,
 		KubeletConfiguration: *hk.KubeletConfiguration,
-	}, hk.KubeletDeps, false); err != nil {
+	}, hk.KubeletDeps, false, nil); err != nil {
 		klog.Fatalf("Failed to run HollowKubelet: %v. Exiting.", err)
 	}
 	select {}

--- a/staging/src/k8s.io/apimachinery/pkg/types/nodename.go
+++ b/staging/src/k8s.io/apimachinery/pkg/types/nodename.go
@@ -40,4 +40,12 @@ package types
 //   For AWS, the InstanceID is not yet suitable for use as a Node.Name, so we actually use the
 //   PrivateDnsName for the Node.Name.  And this is _not_ always the same as the hostname: if
 //   we are using a custom DHCP domain it won't be.
+// * HostnameOverride is the hostname used to identify the kubelet instead of the actual hostname.
+
 type NodeName string
+
+type NodeNameDetail struct {
+	NodeName NodeName
+	HostName      string
+	HostnameOverride string
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
>
/kind cleanup
/kind design

**What this PR does / why we need it**:

Remove duplicated variables `nodeName` on `Runkubelet` function, because it already been calculated by parent function on [L538](https://github.com/kubernetes/kubernetes/blob/master/cmd/kubelet/app/server.go#L538)

![image](https://user-images.githubusercontent.com/7907809/64074376-f8c45a80-ccdc-11e9-80e8-ffac7ac6e326.png)


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
 