### PR TITLE
Set 0 sync period in scheduler integration test

### DIFF
--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -1173,7 +1173,7 @@ func TestBindPlugin(t *testing.T) {
 	}
 
 	// Create the scheduler with the test plugin set.
-	testCtx := testutils.InitTestSchedulerWithOptions(t, testContext, nil, time.Second,
+	testCtx := testutils.InitTestSchedulerWithOptions(t, testContext, nil,
 		scheduler.WithProfiles(prof),
 		scheduler.WithFrameworkOutOfTreeRegistry(registry))
 	testutils.SyncInformerFactory(testCtx)
@@ -1895,7 +1895,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 }
 
 func initTestSchedulerForFrameworkTest(t *testing.T, testCtx *testutils.TestContext, nodeCount int, opts ...scheduler.Option) *testutils.TestContext {
-	testCtx = testutils.InitTestSchedulerWithOptions(t, testCtx, nil, time.Second, opts...)
+	testCtx = testutils.InitTestSchedulerWithOptions(t, testCtx, nil, opts...)
 	testutils.SyncInformerFactory(testCtx)
 	go testCtx.Scheduler.Run(testCtx.Ctx)
 

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1217,7 +1218,7 @@ func TestBindPlugin(t *testing.T) {
 		{
 			name:               "bind plugin fails to bind the pod",
 			bindPluginStatuses: []*framework.Status{framework.NewStatus(framework.Error, "failed to bind"), framework.NewStatus(framework.Success, "")},
-			expectInvokeEvents: []pluginInvokeEvent{{pluginName: bindPlugin1.Name(), val: 1}, {pluginName: reservePlugin.Name(), val: 1}, {pluginName: bindPlugin1.Name(), val: 2}, {pluginName: reservePlugin.Name(), val: 2}},
+			expectInvokeEvents: []pluginInvokeEvent{{pluginName: bindPlugin1.Name(), val: 1}, {pluginName: reservePlugin.Name(), val: 1}},
 		},
 	}
 
@@ -1878,11 +1879,16 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 		t.Errorf("Error while creating the preemptor pod: %v", err)
 	}
 
-	if err = testutils.WaitForPodToSchedule(testCtx.ClientSet, preemptorPod); err != nil {
-		t.Errorf("Expected the preemptor pod to be scheduled. error: %v", err)
-	}
+	// TODO(#96478): uncomment below once we find a way to trigger MoveAllToActiveOrBackoffQueue()
+	// upon deletion event of unassigned waiting pods.
+	// if err = testutils.WaitForPodToSchedule(testCtx.ClientSet, preemptorPod); err != nil {
+	// 	t.Errorf("Expected the preemptor pod to be scheduled. error: %v", err)
+	// }
 
-	if _, err := getPod(testCtx.ClientSet, waitingPod.Name, waitingPod.Namespace); err == nil {
+	if err := wait.Poll(200*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
+		_, err := getPod(testCtx.ClientSet, waitingPod.Name, waitingPod.Namespace)
+		return apierrors.IsNotFound(err), nil
+	}); err != nil {
 		t.Error("Expected the waiting pod to get preempted and deleted")
 	}
 

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -149,7 +149,7 @@ func TestPreemption(t *testing.T) {
 	}
 	testCtx := testutils.InitTestSchedulerWithOptions(t,
 		testutils.InitTestMaster(t, "preemption", nil),
-		nil, time.Second,
+		nil,
 		scheduler.WithProfiles(prof),
 		scheduler.WithFrameworkOutOfTreeRegistry(registry))
 	testutils.SyncInformerFactory(testCtx)

--- a/test/integration/scheduler/priorities_test.go
+++ b/test/integration/scheduler/priorities_test.go
@@ -57,7 +57,6 @@ func initTestSchedulerForPriorityTest(t *testing.T, scorePluginName string) *tes
 		t,
 		testutils.InitTestMaster(t, strings.ToLower(scorePluginName), nil),
 		nil,
-		0,
 		scheduler.WithProfiles(prof),
 	)
 	testutils.SyncInformerFactory(testCtx)

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -561,7 +561,7 @@ func TestMultipleSchedulers(t *testing.T) {
 
 	// 5. create and start a scheduler with name "foo-scheduler"
 	fooProf := kubeschedulerconfig.KubeSchedulerProfile{SchedulerName: fooScheduler}
-	testCtx = testutils.InitTestSchedulerWithOptions(t, testCtx, nil, time.Second, scheduler.WithProfiles(fooProf))
+	testCtx = testutils.InitTestSchedulerWithOptions(t, testCtx, nil, scheduler.WithProfiles(fooProf))
 	testutils.SyncInformerFactory(testCtx)
 	go testCtx.Scheduler.Run(testCtx.Ctx)
 

--- a/test/integration/scheduler/taint_test.go
+++ b/test/integration/scheduler/taint_test.go
@@ -70,7 +70,7 @@ func TestTaintNodeByCondition(t *testing.T) {
 		QPS:           -1,
 		Host:          testCtx.HTTPServer.URL,
 		ContentConfig: restclient.ContentConfig{GroupVersion: &schema.GroupVersion{Group: "", Version: "v1"}}})
-	externalInformers := informers.NewSharedInformerFactory(externalClientset, time.Second)
+	externalInformers := informers.NewSharedInformerFactory(externalClientset, 0)
 
 	admission.SetExternalKubeClientSet(externalClientset)
 	admission.SetExternalKubeInformerFactory(externalInformers)

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -80,7 +80,7 @@ func initDisruptionController(t *testing.T, testCtx *testutils.TestContext) *dis
 // initTest initializes a test environment and creates master and scheduler with default
 // configuration.
 func initTest(t *testing.T, nsPrefix string, opts ...scheduler.Option) *testutils.TestContext {
-	testCtx := testutils.InitTestSchedulerWithOptions(t, testutils.InitTestMaster(t, nsPrefix, nil), nil, time.Second, opts...)
+	testCtx := testutils.InitTestSchedulerWithOptions(t, testutils.InitTestMaster(t, nsPrefix, nil), nil, opts...)
 	testutils.SyncInformerFactory(testCtx)
 	go testCtx.Scheduler.Run(testCtx.Ctx)
 	return testCtx
@@ -101,7 +101,7 @@ func initTestDisablePreemption(t *testing.T, nsPrefix string) *testutils.TestCon
 	}
 	testCtx := testutils.InitTestSchedulerWithOptions(
 		t, testutils.InitTestMaster(t, nsPrefix, nil), nil,
-		time.Second, scheduler.WithProfiles(prof))
+		scheduler.WithProfiles(prof))
 	testutils.SyncInformerFactory(testCtx)
 	go testCtx.Scheduler.Run(testCtx.Ctx)
 	return testCtx

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -373,7 +373,7 @@ func InitTestScheduler(
 	policy *schedulerapi.Policy,
 ) *TestContext {
 	// Pod preemption is enabled by default scheduler configuration.
-	return InitTestSchedulerWithOptions(t, testCtx, policy, time.Second)
+	return InitTestSchedulerWithOptions(t, testCtx, policy)
 }
 
 // InitTestSchedulerWithOptions initializes a test environment and creates a scheduler with default
@@ -382,11 +382,10 @@ func InitTestSchedulerWithOptions(
 	t *testing.T,
 	testCtx *TestContext,
 	policy *schedulerapi.Policy,
-	resyncPeriod time.Duration,
 	opts ...scheduler.Option,
 ) *TestContext {
 	// 1. Create scheduler
-	testCtx.InformerFactory = scheduler.NewInformerFactory(testCtx.ClientSet, resyncPeriod)
+	testCtx.InformerFactory = scheduler.NewInformerFactory(testCtx.ClientSet, 0)
 
 	var err error
 	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The resync period reconciles between the in-memory cache and the business logic. It's a misunderstanding that it's used to sync with apiserver. A common pattern is set it to 0 and widely used across the codebase.

This PR sets the resync period to 0.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig scheduling
/priority important-longterm
