### PR TITLE
Add debug info to kubectl e2e

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -1322,16 +1322,19 @@ metadata:
 
 			ginkgo.By("limiting log lines")
 			out := framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--tail=1")
+			e2elog.Logf("got output %q", out)
 			gomega.Expect(len(out)).NotTo(gomega.BeZero())
 			framework.ExpectEqual(len(lines(out)), 1)
 
 			ginkgo.By("limiting log bytes")
 			out = framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--limit-bytes=1")
+			e2elog.Logf("got output %q", out)
 			framework.ExpectEqual(len(lines(out)), 1)
 			framework.ExpectEqual(len(out), 1)
 
 			ginkgo.By("exposing timestamps")
 			out = framework.RunKubectlOrDie("logs", podName, containerName, nsFlag, "--tail=1", "--timestamps")
+			e2elog.Logf("got output %q", out)
 			l := lines(out)
 			framework.ExpectEqual(len(l), 1)
 			words := strings.Split(l[0], " ")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:
Adds info about what output was received from the pod log

**Special notes for your reviewer**:
Intended to help track down https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-gce-conformance-latest/1166754091573972992

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @BenTheElder 
/sig cli testing