### PR TITLE
fix failing test in k8s.io/legacy-cloud-providers/gce

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_fake.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_fake.go
@@ -20,9 +20,12 @@ package gce
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
 	compute "google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -60,9 +63,19 @@ func fakeClusterID(clusterID string) ClusterID {
 	}
 }
 
+type fakeRoundTripper struct{}
+
+func (*fakeRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("err: test used fake http client")
+}
+
 // NewFakeGCECloud constructs a fake GCE Cloud from the cluster values.
 func NewFakeGCECloud(vals TestClusterValues) *Cloud {
-	service, _ := compute.NewService(context.Background())
+	client := &http.Client{Transport: &fakeRoundTripper{}}
+	service, err := compute.NewService(context.Background(), option.WithHTTPClient(client))
+	if err != nil {
+
+	}
 	gce := &Cloud{
 		region:           vals.Region,
 		service:          service,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
I found while the gce api upgrade, the fake httpclient is deleted, i added back or the entire test will fail in 
`k8s.io/legacy-cloud-providers/gce`, it just panic like this: 
```
+++ [0902 13:33:24] Running tests without code coverage
=== RUN   TestAddressManagerNoRequestedIP
--- FAIL: TestAddressManagerNoRequestedIP (0.02s)
    gce_address_manager_test.go:38: {test-project us-central1 us-central1-b us-central1-c test-cluster-id Test Cluster Name}
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1bc303a]

goroutine 29 [running]:
testing.tRunner.func1(0xc0002bc300)
	/usr/local/go/src/testing/testing.go:830 +0x392
panic(0x1ee6240, 0x3971b60)
	/usr/local/go/src/runtime/panic.go:522 +0x1b5
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/gce.(*Cloud).getRegionLink(...)
	/home/matrix/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/gce/gce_zones.go:89
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/gce.fakeGCECloud(0x229e9c9, 0xc, 0x229d9be, 0xb, 0x229fd0e, 0xd, 0x229fd1b, 0xd, 0x22a223a, 0xf, ...)
	/home/matrix/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/gce/gce_util.go:72 +0x40a
k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/gce.TestAddressManagerNoRequestedIP(0xc0002bc300)
	/home/matrix/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/gce/gce_address_manager_test.go:39 +0xc4
testing.tRunner(0xc0002bc300, 0x2363c50)
	/usr/local/go/src/testing/testing.go:865 +0xc0
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:916 +0x35a
FAIL	k8s.io/kubernetes/vendor/k8s.io/legacy-cloud-providers/gce	0.038s
Makefile:185: recipe for target 'test' failed
make: *** [test] Error 1

```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
