### PR TITLE
e2e log: fix time stamp normalization in unit test

### DIFF
--- a/test/e2e/framework/log/logger_test.go
+++ b/test/e2e/framework/log/logger_test.go
@@ -138,7 +138,7 @@ func normalizeReport(report reporters.FakeReporter) suiteResults {
 }
 
 // timePrefix matches "Jul 17 08:08:25.950: " at the beginning of each line.
-var timePrefix = regexp.MustCompile(`(?m)^[[:alpha:]]{3} [[:digit:]]{1,2} [[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]{3}: `)
+var timePrefix = regexp.MustCompile(`(?m)^[[:alpha:]]{3} +[[:digit:]]{1,2} +[[:digit:]]{2}:[[:digit:]]{2}:[[:digit:]]{2}.[[:digit:]]{3}: `)
 
 func stripTimes(in string) string {
 	return timePrefix.ReplaceAllString(in, "")


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

The date/time regex did not cover that "Sep 1 09:32:17.938" uses " 1"
instead of "1" for the day and thus the test started failing in
September.

**Special notes for your reviewer**:

The CI seems to cache the unit test results, so CI isn't failing (yet). The problem can be seen in the https://github.com/kubernetes/kubernetes/pull/82249 test PR (which forced the test to run anew) or when running `go test -count=1 -v ./test/e2e/framework/log` locally.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig testing