### PR TITLE
Remove ready file for emptydir after umount

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -422,9 +422,11 @@ func (ed *emptyDir) teardownDefault(dir string) error {
 	}
 	// Renaming the directory is not required anymore because the operation executor
 	// now handles duplicate operations on the same volume
-	err = os.RemoveAll(dir)
-	if err != nil {
+	if err := os.RemoveAll(dir); err != nil {
 		return err
+	}
+	if err := os.RemoveAll(ed.getMetaDir()); err != nil {
+		klog.Warningf("Warning: Failed to reset volume %s state", ed.volName)
 	}
 	return nil
 }
@@ -438,6 +440,9 @@ func (ed *emptyDir) teardownTmpfsOrHugetlbfs(dir string) error {
 	}
 	if err := os.RemoveAll(dir); err != nil {
 		return err
+	}
+	if err := os.RemoveAll(ed.getMetaDir()); err != nil {
+		klog.Warningf("Warning: Failed to reset volume %s state", ed.volName)
 	}
 	return nil
 }

--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -218,8 +218,13 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 	} else if !os.IsNotExist(err) {
 		t.Errorf("TearDown() failed: %v", err)
 	}
+	if _, err := os.Stat(metadataDir); err == nil {
+		t.Errorf("TearDown() failed, metadata path still exists: %s", metadataDir)
+	} else if !os.IsNotExist(err) {
+		t.Errorf("TearDown() failed: %v", err)
+	}
 
-	// Check the number of physicalMounter calls during tardown
+	// Check the number of physicalMounter calls during teardown
 	if e, a := config.expectedTeardownMounts, len(physicalMounter.Log); e != a {
 		t.Errorf("Expected %v physicalMounter calls during teardown, got %v", e, a)
 	} else if config.expectedTeardownMounts == 1 && physicalMounter.Log[0].Action != mount.FakeActionUnmount {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In my cluster , we met a problem:
when i restart kubelet, kubelet umount the pod's volumes, even the pod not deleted. 
Then kubelet won't mount the emptydit volume, b/c the ready file exists.  The volume dir will be created by runtime with permission 750, not 777
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
