### PR TITLE
Allow typha-chpa to get apps/deployments

### DIFF
--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
@@ -10,6 +10,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-  - apiGroups: ["extensions"]
+  - apiGroups: ["apps", "extensions"]
     resources: ["deployments/scale"]
     verbs: ["get", "update"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
It allows typha-chpa to get apps/deployments in addition to extension/deployments

Without this typha-chpa fails after deployments were switched from extensions to apps with
```
E0902 11:25:51.197420       1 reflector.go:283] github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient/k8sclient.go:96: Failed to watch *v1.Node: unknown (get nodes)
E0902 11:25:53.118490       1 reflector.go:283] github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient/k8sclient.go:96: Failed to watch *v1.Node: unknown (get nodes)
E0902 11:25:54.997493       1 reflector.go:283] github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient/k8sclient.go:96: Failed to watch *v1.Node: unknown (get nodes)
E0902 11:25:57.097423       1 reflector.go:283] github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient/k8sclient.go:96: Failed to watch *v1.Node: unknown (get nodes)
E0902 11:25:59.097417       1 reflector.go:283] github.com/kubernetes-incubator/cluster-proportional-autoscaler/pkg/autoscaler/k8sclient/k8sclient.go:96: Failed to watch *v1.Node: unknown (get nodes)
I0902 11:25:59.697325       1 k8sclient.go:221] Falling back to extensions/v1beta1, error using apps/v1: deployments.apps "calico-typha" is forbidden: User "system:serviceaccount:kube-system:typha-cpha" cannot get resource "deployments/scale" in API group "apps" in the namespace "kube-system"
E0902 11:25:59.699833       1 autoscaler_server.go:120] Update failure: the server could not find the requested resource
```

Ref. https://github.com/kubernetes/test-infra/pull/13709

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```


