### PR TITLE
Fill s field of Quantity after parsing

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -126,6 +126,8 @@ func MustParse(str string) Quantity {
 	if err != nil {
 		panic(fmt.Errorf("cannot parse '%v': %v", str, err))
 	}
+	// fill the s field of q so that DeepEqual is idempotent across invocation of String()
+	q.String()
 	return q
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -76,6 +76,13 @@ func TestQuantityParseZero(t *testing.T) {
 	}
 }
 
+func TestQuantityHasStringFieldAfterParse(t *testing.T) {
+	q := MustParse("512Mi")
+	if expected, actual := "512Mi", q.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
 // TestQuantityParseNonNumericPanic ensures that when a non-numeric string is parsed
 // it panics
 func TestQuantityParseNonNumericPanic(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As reported by #82242, the materialization of s field may interfere with the result of DeepEqual.

This PR materializes the s field at the end of parsing.

**Which issue(s) this PR fixes**:
Fixes #82242

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
