### PR TITLE
Fill s field of Quantity after parsing

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -126,6 +126,8 @@ func MustParse(str string) Quantity {
 	if err != nil {
 		panic(fmt.Errorf("cannot parse '%v': %v", str, err))
 	}
+	// fill the s field of q so that DeepEqual is idempotent across invocation of String()
+	q.String()
 	return q
 }
 
@@ -265,7 +267,9 @@ func ParseQuantity(str string) (Quantity, error) {
 		return Quantity{}, ErrFormatWrong
 	}
 	if str == "0" {
-		return Quantity{Format: DecimalSI, s: str}, nil
+		q := Quantity{Format: DecimalSI, s: str}
+		q.String()
+		return q, nil
 	}
 
 	positive, value, num, denom, suf, err := parseQuantityString(str)
@@ -318,14 +322,20 @@ func ParseQuantity(str string) (Quantity, error) {
 				switch format {
 				case BinarySI:
 					if exponent%10 == 0 && (value&0x07 != 0) {
-						return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
+						q := Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}
+						q.String()
+						return q, nil
 					}
 				default:
 					if scale%3 == 0 && !strings.HasSuffix(shifted, "000") && shifted[0] != '0' {
-						return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}, nil
+						q := Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format, s: str}
+						q.String()
+						return q, nil
 					}
 				}
-				return Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format}, nil
+				q := Quantity{i: int64Amount{value: result, scale: Scale(scale)}, Format: format}
+				q.String()
+				return q, nil
 			}
 		}
 	}
@@ -373,7 +383,9 @@ func ParseQuantity(str string) (Quantity, error) {
 		amount.Neg(amount)
 	}
 
-	return Quantity{d: infDecAmount{amount}, Format: format}, nil
+	q := Quantity{d: infDecAmount{amount}, Format: format}
+	q.String()
+	return q, nil
 }
 
 // DeepCopy returns a deep-copy of the Quantity value.  Note that the method

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -76,6 +76,13 @@ func TestQuantityParseZero(t *testing.T) {
 	}
 }
 
+func TestQuantityHasStringFieldAfterParse(t *testing.T) {
+	q := MustParse("512Mi")
+	if expected, actual := "512Mi", q.String(); expected != actual {
+		t.Errorf("Expected %v, actual %v", expected, actual)
+	}
+}
+
 // TestQuantityParseNonNumericPanic ensures that when a non-numeric string is parsed
 // it panics
 func TestQuantityParseNonNumericPanic(t *testing.T) {
@@ -703,9 +710,6 @@ func TestQuantityString(t *testing.T) {
 		if err != nil {
 			t.Errorf("%#v: unexpected error: %v", item.expect, err)
 			continue
-		}
-		if len(q.s) != 0 {
-			t.Errorf("%#v: unexpected nested string: %v", item.expect, q.s)
 		}
 		if q.String() != item.expect {
 			t.Errorf("%#v: unexpected alternate canonical: %v", item.expect, q.String())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As reported by #82242, the materialization of s field may interfere with the result of DeepEqual.

This PR materializes the s field at the end of parsing.

**Which issue(s) this PR fixes**:
Fixes #82242

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
