### PR TITLE
register cloud controller manager when necessary

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -367,6 +367,8 @@ func CreateKubeAPIServerConfig(
 			ServiceAccountMaxExpiration: s.ServiceAccountTokenMaxExpiration,
 
 			VersionedInformers: versionedInformers,
+
+			CloudProvider: s.ServerRunOptions.CloudProvider,
 		},
 	}
 

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -187,6 +187,8 @@ type ExtraConfig struct {
 	ServiceAccountMaxExpiration time.Duration
 
 	VersionedInformers informers.SharedInformerFactory
+
+	CloudProvider *kubeoptions.CloudProviderOptions
 }
 
 type Config struct {
@@ -354,6 +356,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 			ServiceAccountIssuer:        c.ExtraConfig.ServiceAccountIssuer,
 			ServiceAccountMaxExpiration: c.ExtraConfig.ServiceAccountMaxExpiration,
 			APIAudiences:                c.GenericConfig.Authentication.APIAudiences,
+			CloudProvider:               c.ExtraConfig.CloudProvider,
 		}
 		if err := m.InstallLegacyAPI(&c, c.GenericConfig.RESTOptionsGetter, legacyRESTStorageProvider); err != nil {
 			return nil, err

--- a/pkg/master/master_test.go
+++ b/pkg/master/master_test.go
@@ -153,6 +153,7 @@ func TestLegacyRestStorageStrategies(t *testing.T) {
 		ServiceIPRange:       masterCfg.ExtraConfig.ServiceIPRange,
 		ServiceNodePortRange: masterCfg.ExtraConfig.ServiceNodePortRange,
 		LoopbackClientConfig: masterCfg.GenericConfig.LoopbackClientConfig,
+		CloudProvider:        masterCfg.ExtraConfig.CloudProvider,
 	}
 
 	_, apiGroupInfo, err := storageProvider.NewLegacyRESTStorage(masterCfg.GenericConfig.RESTOptionsGetter)

--- a/pkg/registry/core/rest/BUILD
+++ b/pkg/registry/core/rest/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = ["storage_core_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/kubeapiserver/options:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
@@ -25,6 +26,7 @@ go_library(
         "//pkg/api/legacyscheme:go_default_library",
         "//pkg/apis/core:go_default_library",
         "//pkg/features:go_default_library",
+        "//pkg/kubeapiserver/options:go_default_library",
         "//pkg/kubelet/client:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/registry/core/componentstatus:go_default_library",

--- a/pkg/registry/core/rest/storage_core_test.go
+++ b/pkg/registry/core/rest/storage_core_test.go
@@ -22,10 +22,14 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
+	kubeoptions "k8s.io/kubernetes/pkg/kubeapiserver/options"
 )
 
 func TestGetServersToValidate(t *testing.T) {
-	servers := componentStatusStorage{fakeStorageFactory{}}.serversToValidate()
+	servers := componentStatusStorage{
+		fakeStorageFactory{},
+		&kubeoptions.CloudProviderOptions{},
+	}.serversToValidate()
 
 	if e, a := 3, len(servers); e != a {
 		t.Errorf("expected %v, got %v", e, a)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Users can obtain cloud controller status via `kubectl get cs` when the cluster is deployed by a cloud provider.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74643

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Users can obtain cloud controller status via `kubectl get cs` when the cluster is deployed by a cloud provider, just like `controller-manager`
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```