### PR TITLE
kubeadm: Fetching kube-proxy's config map is now optional

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/BUILD
+++ b/cmd/kubeadm/app/componentconfigs/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//pkg/proxy/apis/config:go_default_library",
         "//pkg/proxy/apis/config/v1alpha1:go_default_library",
         "//pkg/proxy/apis/config/validation:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/cmd/kubeadm/app/componentconfigs/config_test.go
+++ b/cmd/kubeadm/app/componentconfigs/config_test.go
@@ -47,6 +47,7 @@ func TestGetFromConfigMap(t *testing.T) {
 		component     RegistrationKind
 		configMap     *fakeConfigMap
 		expectedError bool
+		expectedNil   bool
 	}{
 		{
 			name:      "valid kube-proxy",
@@ -59,10 +60,10 @@ func TestGetFromConfigMap(t *testing.T) {
 			},
 		},
 		{
-			name:          "invalid kube-proxy - missing ConfigMap",
-			component:     KubeProxyConfigurationKind,
-			configMap:     nil,
-			expectedError: true,
+			name:        "valid kube-proxy - missing ConfigMap",
+			component:   KubeProxyConfigurationKind,
+			configMap:   nil,
+			expectedNil: true,
 		},
 		{
 			name:      "invalid kube-proxy - missing key",
@@ -123,8 +124,8 @@ func TestGetFromConfigMap(t *testing.T) {
 				return
 			}
 
-			if obj == nil {
-				t.Error("unexpected nil return value")
+			if rt.expectedNil != (obj == nil) {
+				t.Error("unexpected return value")
 			}
 		})
 	}

--- a/cmd/kubeadm/app/util/config/cluster.go
+++ b/cmd/kubeadm/app/util/config/cluster.go
@@ -203,6 +203,11 @@ func getComponentConfigs(client clientset.Interface, clusterConfiguration *kubea
 			return err
 		}
 
+		// Some components may not be installed or managed by kubeadm, hence GetFromConfigMap won't return an error or an object
+		if obj == nil {
+			continue
+		}
+
 		if ok := registration.SetToInternalConfig(obj, clusterConfiguration); !ok {
 			return errors.Errorf("couldn't save componentconfig value for kind %q", string(kind))
 		}

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -449,7 +449,6 @@ func TestGetComponentConfigs(t *testing.T) {
 					},
 				},
 			},
-			expectedError: true,
 		},
 	}
 
@@ -482,9 +481,6 @@ func TestGetComponentConfigs(t *testing.T) {
 			// Test expected values in InitConfiguration
 			if cfg.ComponentConfigs.Kubelet == nil {
 				t.Errorf("invalid cfg.ComponentConfigs.Kubelet")
-			}
-			if cfg.ComponentConfigs.KubeProxy == nil {
-				t.Errorf("invalid cfg.ComponentConfigs.KubeProxy")
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind design

**What this PR does / why we need it**:

Whenever kubeadm needs to fetch its configuration from the cluster, it gets
the component configuration of all supported components (currently only kubelet
and kube-proxy). However, kube-proxy is deemed an optional component and its
installation may be skipped (by skipping the addon/kube-proxy phase on init).
When kube-proxy's installation is skipped, its config map is not created and
all kubeadm operations, that fetch the config from the cluster, are bound to
fail with "not found" or "forbidden" (because of missing RBAC rules) errors.

To fix this issue, we have to ignore the 403 and 404 errors, returned on an
attempt to fetch kube-proxy's component config from the cluster.
The `GetFromKubeProxyConfigMap` function now supports returning nil for both
error and object to indicate just such a case.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#1733

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/priority important-longterm
/assign @neolit123
/assign @fabriziopandini

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: Allow users to skip the kube-proxy init addon phase during init and still be able to join a cluster and perform some other minor operations (but not upgrade).
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
