### PR TITLE
Remove Quantity.s to keep the immutability of Quantity.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_proto_test.go
@@ -28,10 +28,10 @@ func TestQuantityProtoMarshal(t *testing.T) {
 		quantity string
 		expect   Quantity
 	}{
-		{"0", Quantity{i: int64Amount{value: 0, scale: 0}, s: "0", Format: DecimalSI}},
-		{"100m", Quantity{i: int64Amount{value: 100, scale: -3}, s: "100m", Format: DecimalSI}},
-		{"50m", Quantity{i: int64Amount{value: 50, scale: -3}, s: "50m", Format: DecimalSI}},
-		{"10000T", Quantity{i: int64Amount{value: 10000, scale: 12}, s: "10000T", Format: DecimalSI}},
+		{"0", Quantity{i: int64Amount{value: 0, scale: 0}, Format: DecimalSI}},
+		{"100m", Quantity{i: int64Amount{value: 100, scale: -3}, Format: DecimalSI}},
+		{"50m", Quantity{i: int64Amount{value: 50, scale: -3}, Format: DecimalSI}},
+		{"10000T", Quantity{i: int64Amount{value: 10000, scale: 12}, Format: DecimalSI}},
 	}
 	for _, testCase := range table {
 		q := MustParse(testCase.quantity)
@@ -47,9 +47,9 @@ func TestQuantityProtoMarshal(t *testing.T) {
 		dec    *inf.Dec
 		expect Quantity
 	}{
-		{dec(0, 0).Dec, Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(0, 0).Dec}, s: "0", Format: DecimalSI}},
-		{dec(10, 0).Dec, Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(10, 0).Dec}, s: "10", Format: DecimalSI}},
-		{dec(-10, 0).Dec, Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(-10, 0).Dec}, s: "-10", Format: DecimalSI}},
+		{dec(0, 0).Dec, Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(0, 0).Dec}, Format: DecimalSI}},
+		{dec(10, 0).Dec, Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(10, 0).Dec}, Format: DecimalSI}},
+		{dec(-10, 0).Dec, Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(-10, 0).Dec}, Format: DecimalSI}},
 	}
 	for _, testCase := range table2 {
 		q := Quantity{d: infDecAmount{testCase.dec}, Format: DecimalSI}
@@ -68,10 +68,10 @@ func TestQuantityProtoUnmarshal(t *testing.T) {
 		input  Quantity
 		expect string
 	}{
-		{Quantity{i: int64Amount{value: 0, scale: 0}, s: "0", Format: DecimalSI}, "0"},
-		{Quantity{i: int64Amount{value: 100, scale: -3}, s: "100m", Format: DecimalSI}, "100m"},
-		{Quantity{i: int64Amount{value: 50, scale: -3}, s: "50m", Format: DecimalSI}, "50m"},
-		{Quantity{i: int64Amount{value: 10000, scale: 12}, s: "10000T", Format: DecimalSI}, "10000T"},
+		{Quantity{i: int64Amount{value: 0, scale: 0}, Format: DecimalSI}, "0"},
+		{Quantity{i: int64Amount{value: 100, scale: -3}, Format: DecimalSI}, "100m"},
+		{Quantity{i: int64Amount{value: 50, scale: -3}, Format: DecimalSI}, "50m"},
+		{Quantity{i: int64Amount{value: 10000, scale: 12}, Format: DecimalSI}, "10000T"},
 	}
 	for _, testCase := range table {
 		var inputQ Quantity
@@ -87,9 +87,9 @@ func TestQuantityProtoUnmarshal(t *testing.T) {
 		input  Quantity
 		expect *inf.Dec
 	}{
-		{Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(0, 0).Dec}, s: "0", Format: DecimalSI}, dec(0, 0).Dec},
-		{Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(10, 0).Dec}, s: "10", Format: DecimalSI}, dec(10, 0).Dec},
-		{Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(-10, 0).Dec}, s: "-10", Format: DecimalSI}, dec(-10, 0).Dec},
+		{Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(0, 0).Dec}, Format: DecimalSI}, dec(0, 0).Dec},
+		{Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(10, 0).Dec}, Format: DecimalSI}, dec(10, 0).Dec},
+		{Quantity{i: int64Amount{value: 0, scale: 0}, d: infDecAmount{dec(-10, 0).Dec}, Format: DecimalSI}, dec(-10, 0).Dec},
 	}
 	for _, testCase := range table2 {
 		var inputQ Quantity


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind bug

**What this PR does / why we need it**:

Remove the field `Quantity.s`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82242

**Special notes for your reviewer**:

Benchmark:
Before this PR:
```
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource
BenchmarkQuantityString-4               10000000               148 ns/op
BenchmarkQuantityStringPrecalc-4        100000000               16.7 ns/op
BenchmarkQuantityStringBinarySI-4       10000000               208 ns/op
BenchmarkQuantityMarshalJSON-4          10000000               133 ns/op
BenchmarkQuantityUnmarshalJSON-4        10000000               183 ns/op
BenchmarkParseQuantity-4                20000000               110 ns/op
BenchmarkCanonicalize-4                 20000000                79.7 ns/op
BenchmarkQuantityRoundUp-4              100000000               18.4 ns/op
BenchmarkQuantityCopy-4                 100000000               17.5 ns/op
BenchmarkQuantityAdd-4                  50000000                29.0 ns/op
BenchmarkQuantityCmp-4                  100000000               21.0 ns/op
BenchmarkScaledValueSmall-4             50000000                36.4 ns/op
BenchmarkScaledValueLarge-4              3000000               422 ns/op
PASS
ok      k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource   24.054s
```

After the patch:
```
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource
BenchmarkQuantityString-4               10000000               147 ns/op
BenchmarkQuantityStringPrecalc-4        10000000               147 ns/op
BenchmarkQuantityStringBinarySI-4       10000000               205 ns/op
BenchmarkQuantityMarshalJSON-4          10000000               128 ns/op
BenchmarkQuantityUnmarshalJSON-4        10000000               178 ns/op
BenchmarkParseQuantity-4                20000000               112 ns/op
BenchmarkCanonicalize-4                 20000000                80.6 ns/op
BenchmarkQuantityRoundUp-4              100000000               17.6 ns/op
BenchmarkQuantityCopy-4                 100000000               16.4 ns/op
BenchmarkQuantityAdd-4                  50000000                27.3 ns/op
BenchmarkQuantityCmp-4                  100000000               20.2 ns/op
BenchmarkScaledValueSmall-4             50000000                36.4 ns/op
BenchmarkScaledValueLarge-4              3000000               412 ns/op
PASS
ok      k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/resource   23.496s
```

The main benchmark test is `BenchmarkQuantityStringPrecalc` (16.7 ns/op -> 147 ns/op). It takes more overhead than before but gets the immutability. This is worth it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
