### PR TITLE
openstack: Don't Delete LB in Case of Security Group Reconciliation Errors

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go
@@ -999,9 +999,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 	if lbaas.opts.ManageSecurityGroups {
 		err := lbaas.ensureSecurityGroup(clusterName, apiService, nodes, loadbalancer)
 		if err != nil {
-			// cleanup what was created so far
-			_ = lbaas.EnsureLoadBalancerDeleted(ctx, clusterName, apiService)
-			return status, err
+			return status, fmt.Errorf("Error reconciling security groups for LB service %v/%v: %v", apiService.Namespace, apiService.Name, err)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This fixes the legacy Openstack cloud provider's lbaas control loop so the EnsureLoadBalancer() function no longer deletes the LB if something went wrong when reconciling the LB's security groups. With the current master, if you have an LB service and associated LB already up and running and working fine, and then during a reconcile loop (which shouldn't change anything) e.g. the OpenStack API is down temporarily at the wrong moment (i.e. if it's still up during the LB and listener reconciliation, but then down during the SG reconciliation), then the whole LB will be deleted. We saw this exact thing happen in a real world customer application, which went offline because of if (the LB is recreated shortly after, but likely with a different floating IP).

Deleting the LB in case of errors in a "reconcile" (rather than "create") function seems just wrong, and all the other parts of EnsureLoadBalancer() don't do it either: E.g. if a transient error occurs when creating a listener, we just return it and leave the LB in a half-created state (https://github.com/kubernetes/kubernetes/blob/c7c89f8c6140e0639dc8ba2d8dcdd6fdbd5409ae/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go#L785-L788), and the service controller will catch that error and re-queue the work item (https://github.com/kubernetes/kubernetes/blob/3fe7a570001ae0a6773da34a2eee7246ef416094/pkg/controller/service/service_controller.go#L255-L256) so the LB creation will go through eventually.

This PR just fixes the SG reconciliation to follow the same pattern. It seems to me that the current "delete LB in case an an error" approach was originally not part of a "reconcile" function but of a "create" function, where it would've made more sense.

The same bug is present in the new out-of-tree openstack cloud provider; I've submitted a corresponding PR there (https://github.com/kubernetes/cloud-provider-openstack/pull/743). We'd still like to fix this error in-tree as well and also have the fix backported to 1.15 and 1.14 (please?) because our migration to cloud controller manager is still in the early planning stages and will take more time.

**Which issue(s) this PR fixes**:

Fixes #35056

**Release note**:

```release-note
Openstack: Do not delete managed LB in case of security group reconciliation errors
```
