### PR TITLE
Add ready plugin to dns tests

### DIFF
--- a/test/e2e/network/dns_configmap.go
+++ b/test/e2e/network/dns_configmap.go
@@ -68,6 +68,7 @@ func (t *dnsFederationsConfigMapTest) run() {
 		valid1 := map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
+        ready
         kubernetes %v in-addr.arpa ip6.arpa {
             pods insecure
             upstream
@@ -84,6 +85,7 @@ func (t *dnsFederationsConfigMapTest) run() {
 		valid2 := map[string]string{
 			"Corefile": fmt.Sprintf(`:53 {
         health
+        ready
         kubernetes %v in-addr.arpa ip6.arpa {
             pods insecure
             upstream
@@ -234,6 +236,7 @@ func (t *dnsNameserverTest) run(isIPv6 bool) {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
+        ready
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream
@@ -333,6 +336,7 @@ func (t *dnsPtrFwdTest) run(isIPv6 bool) {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
+        ready
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream
@@ -444,6 +448,7 @@ func (t *dnsExternalNameTest) run(isIPv6 bool) {
 		t.setConfigMap(&v1.ConfigMap{Data: map[string]string{
 			"Corefile": fmt.Sprintf(`.:53 {
         health
+        ready
         kubernetes %v in-addr.arpa ip6.arpa {
            pods insecure
            upstream


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Add the `ready` plugin which is required to report the `readiness` of CoreDNS pods.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Fixes the tests failing in https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-serial

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/priority critical-urgent