### PR TITLE
kubelet: create container in parallel

### DIFF
--- a/pkg/kubelet/container/sync_result.go
+++ b/pkg/kubelet/container/sync_result.go
@@ -109,7 +109,7 @@ func (p *PodSyncResult) AddSyncResult(result ...*SyncResult) {
 func (p *PodSyncResult) AddPodSyncResult(result PodSyncResult) {
 	p.mutex.Lock()
 	defer p.mutex.Unlock()
-	p.AddSyncResult(result.SyncResults...)
+	p.SyncResults = append(p.SyncResults, result.SyncResults...)
 	p.SyncError = result.SyncError
 }
 

--- a/pkg/kubelet/kuberuntime/BUILD
+++ b/pkg/kubelet/kuberuntime/BUILD
@@ -64,6 +64,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/tools/reference:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
+        "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",
         "//vendor/github.com/armon/circbuf:go_default_library",

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -494,6 +494,13 @@ func TestSyncPod(t *testing.T) {
 			Name:            "foo1",
 			Image:           "busybox",
 			ImagePullPolicy: v1.PullIfNotPresent,
+			Lifecycle:       &v1.Lifecycle{
+				PostStart: &v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
+					},
+				},
+			},
 		},
 		{
 			Name:            "foo2",
@@ -579,6 +586,13 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 			Name:            "foo1",
 			Image:           "busybox",
 			ImagePullPolicy: v1.PullIfNotPresent,
+			Lifecycle:       &v1.Lifecycle{
+				PostStart: &v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
+					},
+				},
+			},
 		},
 		{
 			Name:            "foo2",
@@ -617,7 +631,7 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	assert.NoError(t, result.Error())
 	verifyContainerStatuses(t, fakeRuntime, expected, "init container still running; do nothing")
 
-	// 3. should create all app containers because init container finished.
+	// 3. should create all app containers in parallel because init container finished.
 	// Stop init container instance 0.
 	sandboxIDs, err := m.getSandboxIDByPodUID(pod.UID, nil)
 	require.NoError(t, err)

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -494,7 +494,7 @@ func TestSyncPod(t *testing.T) {
 			Name:            "foo1",
 			Image:           "busybox",
 			ImagePullPolicy: v1.PullIfNotPresent,
-			Lifecycle:       &v1.Lifecycle{
+			Lifecycle: &v1.Lifecycle{
 				PostStart: &v1.Handler{
 					Exec: &v1.ExecAction{
 						Command: []string{"sh", "-c", "while true; do sleep 3600; done"},
@@ -586,7 +586,7 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 			Name:            "foo1",
 			Image:           "busybox",
 			ImagePullPolicy: v1.PullIfNotPresent,
-			Lifecycle:       &v1.Lifecycle{
+			Lifecycle: &v1.Lifecycle{
 				PostStart: &v1.Handler{
 					Exec: &v1.ExecAction{
 						Command: []string{"sh", "-c", "while true; do sleep 3600; done"},

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"strconv"
+	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -35,6 +36,7 @@ import (
 
 const (
 	maxRespBodyLength = 10 * 1 << 10 // 10KB
+	defaultTimeoutOfRunInContainer = time.Second * 60
 )
 
 type HandlerRunner struct {
@@ -60,7 +62,7 @@ func (hr *HandlerRunner) Run(containerID kubecontainer.ContainerID, pod *v1.Pod,
 	case handler.Exec != nil:
 		var msg string
 		// TODO(tallclair): Pass a proper timeout value.
-		output, err := hr.commandRunner.RunInContainer(containerID, handler.Exec.Command, 0)
+		output, err := hr.commandRunner.RunInContainer(containerID, handler.Exec.Command, defaultTimeoutOfRunInContainer)
 		if err != nil {
 			msg = fmt.Sprintf("Exec lifecycle hook (%v) for Container %q in Pod %q failed - error: %v, message: %q", handler.Exec.Command, container.Name, format.Pod(pod), err, string(output))
 			klog.V(1).Infof(msg)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Now, kubelet create container one by one, the creation of the previous container may block the next creation of container for a long time(pulling image, running container, and executing postStart). In special cases, it may lock the startup of the container. See #81450

I think we should better create container in parallel by goroutine.
**Which issue(s) this PR fixes**:
Fixes #81450

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```