### PR TITLE
Clarify retry.RetryOnConflict docs

### DIFF
--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -65,18 +65,37 @@ func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) 
 	return err
 }
 
-// RetryOnConflict executes the function function repeatedly, retrying if the server returns a conflicting
-// write. Callers should preserve previous executions if they wish to retry changes. It performs an
-// exponential backoff.
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
 //
-//     var pod *api.Pod
-//     err := RetryOnConflict(DefaultBackoff, func() (err error) {
-//       pod, err = c.Pods("mynamespace").UpdateStatus(podStatus)
-//       return
+//     err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//         // Fetch the resource here; you need to refetch it on every try, since
+//         // if you got a conflict on the last update attempt then you need to get
+//         // the current version before making your own changes.
+//         pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//         if err ! nil {
+//             return err
+//         }
+//
+//         // Make whatever updates to the resource are needed
+//         pod.Status.Phase = v1.PodFailed
+//
+//         // Try to update
+//         _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//         // You have to return err itself here (not wrapped inside another error)
+//         // so that RetryOnConflict can identify it correctly.
+//         return err
 //     })
 //     if err != nil {
-//       // may be conflict if max retries were hit
-//       return err
+//         // May be conflict if max retries were hit, or may be something unrelated
+//         // like permissions or a network error
+//         return err
 //     }
 //     ...
 //


### PR DESCRIPTION
**What this PR does / why we need it**:
The documentation for `retry.RetryOnConflict` is both incomplete and misleading. Especially, the example code is not even using the function correctly, and is equivalent to not using `RetryOnConflict` at all (in that, if it does not succeed on the first try, it will not succeed on any of the retries either).

Also, #80402 moved most of the `RetryOnConflict` documentation to the new `OnError` function, but I think it makes sense to thoroughly document `RetryOnConflict` itself, since it is the more commonly-used function, and because many of the details of how it needs to be used are specific to conflict errors.

```release-note
NONE
```

/kind documentation
/priority important-soon