### PR TITLE
Store new state in lb.services

### DIFF
--- a/pkg/proxy/userspace/roundrobin.go
+++ b/pkg/proxy/userspace/roundrobin.go
@@ -244,6 +244,7 @@ func (lb *LoadBalancerRR) OnEndpointsAdd(endpoints *v1.Endpoints) {
 
 			// Reset the round-robin index.
 			state.index = 0
+			lb.services[svcPort] = state
 		}
 	}
 }
@@ -278,6 +279,7 @@ func (lb *LoadBalancerRR) OnEndpointsUpdate(oldEndpoints, endpoints *v1.Endpoint
 
 			// Reset the round-robin index.
 			state.index = 0
+			lb.services[svcPort] = state
 		}
 		registeredEndpoints[svcPort] = true
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In LoadBalancerRR#OnEndpointsAdd, after new balancerState is created, it is not stored in lb.services (and forgot).

This PR stores the new balancerState in the lb.services map.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
