### PR TITLE
Fixing bugs related to Endpoint Slices

### DIFF
--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -112,6 +112,7 @@ go_library(
         "//pkg/volume/util:go_default_library",
         "//pkg/volume/vsphere_volume:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/api/discovery/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -23,12 +23,14 @@ package app
 import (
 	"net/http"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
+	discoveryv1alpha1 "k8s.io/api/discovery/v1alpha1"
+	"k8s.io/klog"
 	endpointslicecontroller "k8s.io/kubernetes/pkg/controller/endpointslice"
 )
 
 func startEndpointSliceController(ctx ControllerContext) (http.Handler, bool, error) {
-	if !ctx.AvailableResources[schema.GroupVersionResource{Group: "discovery", Version: "v1alpha1", Resource: "endpointslices"}] {
+	if !ctx.AvailableResources[discoveryv1alpha1.SchemeGroupVersion.WithResource("endpointslices")] {
+		klog.Warningf("Not starting endpointslice-controller, discovery.k8s.io/v1alpha1 resources are not available")
 		return nil, false, nil
 	}
 

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -36,10 +36,14 @@ var (
 	maxEndpoints           = 1000
 )
 
+// ValidateEndpointSliceName can be used to check whether the given endpoint
+// slice name is valid. Prefix indicates this name will be used as part of
+// generation, in which case trailing dashes are allowed.
+var ValidateEndpointSliceName = apimachineryvalidation.NameIsDNSSubdomain
+
 // ValidateEndpointSlice validates an EndpointSlice.
 func ValidateEndpointSlice(endpointSlice *discovery.EndpointSlice) field.ErrorList {
-	validateEndpointSliceName := apimachineryvalidation.NameIsDNSSubdomain
-	allErrs := apivalidation.ValidateObjectMeta(&endpointSlice.ObjectMeta, true, validateEndpointSliceName, field.NewPath("metadata"))
+	allErrs := apivalidation.ValidateObjectMeta(&endpointSlice.ObjectMeta, true, ValidateEndpointSliceName, field.NewPath("metadata"))
 
 	addrType := discovery.AddressType("")
 	if endpointSlice.AddressType == nil {

--- a/pkg/controller/.import-restrictions
+++ b/pkg/controller/.import-restrictions
@@ -188,6 +188,8 @@
         "k8s.io/kubernetes/pkg/apis/core/v1",
         "k8s.io/kubernetes/pkg/apis/core/v1/helper",
         "k8s.io/kubernetes/pkg/apis/core/validation",
+        "k8s.io/kubernetes/pkg/apis/discovery",
+        "k8s.io/kubernetes/pkg/apis/discovery/validation",
         "k8s.io/kubernetes/pkg/cloudprovider",
         "k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
         "k8s.io/kubernetes/pkg/controller",

--- a/pkg/controller/endpointslice/BUILD
+++ b/pkg/controller/endpointslice/BUILD
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/apis/discovery/validation:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/util/endpoint:go_default_library",
         "//pkg/util/hash:go_default_library",

--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -42,10 +43,6 @@ import (
 )
 
 const (
-	// serviceNameLabel is used to indicate the name of a Kubernetes service
-	// associated with an EndpointSlice.
-	serviceNameLabel = "kubernetes.io/service-name"
-
 	// maxRetries is the number of times a service will be retried before it is
 	// dropped out of the queue. Any sync error, such as a failure to create or
 	// update an EndpointSlice could trigger a retry. With the current
@@ -276,7 +273,7 @@ func (c *Controller) syncService(key string) error {
 		return err
 	}
 
-	esLabelSelector := labels.Set(map[string]string{serviceNameLabel: service.Name}).AsSelectorPreValidated()
+	esLabelSelector := labels.Set(map[string]string{discovery.LabelServiceName: service.Name}).AsSelectorPreValidated()
 	endpointSlices, err := c.endpointSliceLister.EndpointSlices(service.Namespace).List(esLabelSelector)
 
 	if err != nil {

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -108,7 +108,7 @@ func TestSyncServiceWithSelector(t *testing.T) {
 	assert.Len(t, sliceList.Items, 1, "Expected 1 endpoint slices")
 	slice := sliceList.Items[0]
 	assert.Regexp(t, "^"+serviceName, slice.Name)
-	assert.Equal(t, serviceName, slice.Labels[serviceNameLabel])
+	assert.Equal(t, serviceName, slice.Labels[discovery.LabelServiceName])
 	assert.EqualValues(t, []discovery.EndpointPort{}, slice.Ports)
 	assert.EqualValues(t, []discovery.Endpoint{}, slice.Endpoints)
 	assert.NotEmpty(t, slice.Annotations["endpoints.kubernetes.io/last-change-trigger-time"])
@@ -189,11 +189,11 @@ func TestSyncServiceEndpointSliceSelection(t *testing.T) {
 
 	// 3 slices, 2 with matching labels for our service
 	endpointSlices := []*discovery.EndpointSlice{{
-		ObjectMeta: metav1.ObjectMeta{Name: "matching-1", Namespace: ns, Labels: map[string]string{serviceNameLabel: serviceName}},
+		ObjectMeta: metav1.ObjectMeta{Name: "matching-1", Namespace: ns, Labels: map[string]string{discovery.LabelServiceName: serviceName}},
 	}, {
-		ObjectMeta: metav1.ObjectMeta{Name: "matching-2", Namespace: ns, Labels: map[string]string{serviceNameLabel: serviceName}},
+		ObjectMeta: metav1.ObjectMeta{Name: "matching-2", Namespace: ns, Labels: map[string]string{discovery.LabelServiceName: serviceName}},
 	}, {
-		ObjectMeta: metav1.ObjectMeta{Name: "not-matching-1", Namespace: ns, Labels: map[string]string{serviceNameLabel: "something-else"}},
+		ObjectMeta: metav1.ObjectMeta{Name: "not-matching-1", Namespace: ns, Labels: map[string]string{discovery.LabelServiceName: "something-else"}},
 	}}
 
 	// need to add them to both store and fake clientset

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,8 +57,8 @@ func TestNewEndpointSlice(t *testing.T) {
 
 	expectedSlice := discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:          map[string]string{serviceNameLabel: service.Name},
-			GenerateName:    fmt.Sprintf("%s.", service.Name),
+			Labels:          map[string]string{discovery.LabelServiceName: service.Name},
+			GenerateName:    fmt.Sprintf("%s-", service.Name),
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Namespace:       service.Namespace,
 		},
@@ -81,7 +80,7 @@ func TestPodToEndpoint(t *testing.T) {
 
 	multiIPPod.Status.PodIPs = []v1.PodIP{{IP: "1.2.3.4"}, {IP: "1234::5678:0000:0000:9abc:def0"}}
 
-	node1 := &corev1.Node{
+	node1 := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: readyPod.Spec.NodeName,
 			Labels: map[string]string{
@@ -288,14 +287,14 @@ func newClientset() *fake.Clientset {
 	return client
 }
 
-func newServiceAndendpointMeta(name, namespace string) (corev1.Service, endpointMeta) {
+func newServiceAndendpointMeta(name, namespace string) (v1.Service, endpointMeta) {
 	portNum := int32(80)
 	portNameIntStr := intstr.IntOrString{
 		Type:   intstr.Int,
 		IntVal: portNum,
 	}
 
-	svc := corev1.Service{
+	svc := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
@@ -317,7 +316,7 @@ func newServiceAndendpointMeta(name, namespace string) (corev1.Service, endpoint
 	return svc, endpointMeta
 }
 
-func newEmptyEndpointSlice(n int, namespace string, endpointMeta endpointMeta, svc corev1.Service) *discovery.EndpointSlice {
+func newEmptyEndpointSlice(n int, namespace string, endpointMeta endpointMeta, svc v1.Service) *discovery.EndpointSlice {
 	return &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.%d", svc.Name, n),

--- a/pkg/master/reconcilers/endpointsadapter.go
+++ b/pkg/master/reconcilers/endpointsadapter.go
@@ -25,12 +25,6 @@ import (
 	discoveryclient "k8s.io/client-go/kubernetes/typed/discovery/v1alpha1"
 )
 
-const (
-	// serviceNameLabel is used to indicate the name of a Kubernetes service
-	// associated with an EndpointSlice.
-	serviceNameLabel = "kubernetes.io/service-name"
-)
-
 // EndpointsAdapter provides a simple interface for reading and writing both
 // Endpoints and Endpoint Slices.
 // NOTE: This is an incomplete adapter implementation that is only suitable for
@@ -103,8 +97,7 @@ func (adapter *EndpointsAdapter) ensureEndpointSliceFromEndpoints(namespace stri
 func endpointSliceFromEndpoints(endpoints *corev1.Endpoints) *discovery.EndpointSlice {
 	endpointSlice := &discovery.EndpointSlice{}
 	endpointSlice.Name = endpoints.Name
-	endpointSlice.Labels = map[string]string{serviceNameLabel: endpoints.Name}
-	endpointSlice.OwnerReferences = []metav1.OwnerReference{{Kind: "Service", Name: endpoints.Name}}
+	endpointSlice.Labels = map[string]string{discovery.LabelServiceName: endpoints.Name}
 
 	ipAddressType := discovery.AddressTypeIP
 	endpointSlice.AddressType = &ipAddressType

--- a/pkg/master/reconcilers/endpointsadapter_test.go
+++ b/pkg/master/reconcilers/endpointsadapter_test.go
@@ -294,8 +294,7 @@ func generateEndpointsAndSlice(name, namespace string, ports []int, addresses []
 	addressTypeIP := discovery.AddressTypeIP
 
 	epSlice := &discovery.EndpointSlice{ObjectMeta: objectMeta, AddressType: &addressTypeIP}
-	epSlice.Labels = map[string]string{serviceNameLabel: name}
-	epSlice.OwnerReferences = []metav1.OwnerReference{{Kind: "Service", Name: name}}
+	epSlice.Labels = map[string]string{discovery.LabelServiceName: name}
 	subset := corev1.EndpointSubset{}
 
 	for i, port := range ports {

--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -179,7 +179,11 @@ func (ect *EndpointChangeTracker) EndpointSliceUpdate(endpointSlice *discovery.E
 		return false
 	}
 
-	namespacedName, _ := endpointSliceCacheKeys(endpointSlice)
+	namespacedName, _, err := endpointSliceCacheKeys(endpointSlice)
+	if err != nil {
+		klog.Warningf("Error getting endpoint slice cache keys: %v", err)
+		return false
+	}
 
 	metrics.EndpointChangesTotal.Inc()
 

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -17,6 +17,7 @@ limitations under the License.
 package proxy
 
 import (
+	"fmt"
 	"sort"
 
 	"k8s.io/api/core/v1"
@@ -79,12 +80,12 @@ func standardEndpointInfo(ep *BaseEndpointInfo) Endpoint {
 
 // Update a slice in the cache.
 func (cache *EndpointSliceCache) Update(endpointSlice *discovery.EndpointSlice) {
-	serviceKey, sliceKey := endpointSliceCacheKeys(endpointSlice)
-	// This should never actually happen
-	if serviceKey.Name == "" || serviceKey.Namespace == "" || sliceKey == "" {
-		klog.Errorf("Invalid endpoint slice, name and owner reference required %v", endpointSlice)
+	serviceKey, sliceKey, err := endpointSliceCacheKeys(endpointSlice)
+	if err != nil {
+		klog.Warningf("Error getting endpoint slice cache keys: %v", err)
 		return
 	}
+
 	esInfo := &endpointSliceInfo{
 		Ports:     endpointSlice.Ports,
 		Endpoints: []*endpointInfo{},
@@ -105,7 +106,11 @@ func (cache *EndpointSliceCache) Update(endpointSlice *discovery.EndpointSlice) 
 
 // Delete a slice from the cache.
 func (cache *EndpointSliceCache) Delete(endpointSlice *discovery.EndpointSlice) {
-	serviceKey, sliceKey := endpointSliceCacheKeys(endpointSlice)
+	serviceKey, sliceKey, err := endpointSliceCacheKeys(endpointSlice)
+	if err != nil {
+		klog.Warningf("Error getting endpoint slice cache keys: %v", err)
+		return
+	}
 	delete(cache.sliceByServiceMap[serviceKey], sliceKey)
 }
 
@@ -214,16 +219,15 @@ func formatEndpointsList(endpoints []Endpoint) []string {
 }
 
 // endpointSliceCacheKeys returns cache keys used for a given EndpointSlice.
-func endpointSliceCacheKeys(endpointSlice *discovery.EndpointSlice) (types.NamespacedName, string) {
-	if len(endpointSlice.OwnerReferences) == 0 {
-		klog.Errorf("No owner reference set on endpoint slice: %s", endpointSlice.Name)
-		return types.NamespacedName{}, endpointSlice.Name
+func endpointSliceCacheKeys(endpointSlice *discovery.EndpointSlice) (types.NamespacedName, string, error) {
+	var err error
+	serviceName, ok := endpointSlice.Labels[discovery.LabelServiceName]
+	if !ok || serviceName == "" {
+		err = fmt.Errorf("No %s label set on endpoint slice: %s", discovery.LabelServiceName, endpointSlice.Name)
+	} else if endpointSlice.Namespace == "" || endpointSlice.Name == "" {
+		err = fmt.Errorf("Expected EndpointSlice name and namespace to be set: %v", endpointSlice)
 	}
-	if len(endpointSlice.OwnerReferences) > 1 {
-		klog.Errorf("More than 1 owner reference set on endpoint slice: %s", endpointSlice.Name)
-	}
-	ownerRef := endpointSlice.OwnerReferences[0]
-	return types.NamespacedName{Namespace: endpointSlice.Namespace, Name: ownerRef.Name}, endpointSlice.Name
+	return types.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}, endpointSlice.Name, err
 }
 
 // byIP helps sort endpoints by IP

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -200,9 +200,9 @@ func generateEndpointSliceWithOffset(serviceName, namespace string, sliceNum, of
 	ipAddressType := discovery.AddressTypeIP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-%d", serviceName, sliceNum),
-			Namespace:       namespace,
-			OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: serviceName}},
+			Name:      fmt.Sprintf("%s-%d", serviceName, sliceNum),
+			Namespace: namespace,
+			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports:       []discovery.EndpointPort{},
 		AddressType: &ipAddressType,

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -390,6 +390,7 @@ func NewFakeProxier(ipt utiliptables.Interface, endpointSlicesEnabled bool) *Pro
 		nodePortAddresses:        make([]string, 0),
 		networkInterfacer:        utilproxytest.NewFakeNetwork(),
 	}
+	p.setInitialized(true)
 	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
 	return p
 }
@@ -2335,9 +2336,9 @@ COMMIT
 	ipAddressType := discovery.AddressTypeIP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-1", serviceName),
-			Namespace:       namespaceName,
-			OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: serviceName}},
+			Name:      fmt.Sprintf("%s-1", serviceName),
+			Namespace: namespaceName,
+			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
 			Name: utilpointer.StringPtr(""),

--- a/pkg/proxy/ipvs/BUILD
+++ b/pkg/proxy/ipvs/BUILD
@@ -19,6 +19,7 @@ go_test(
         "//pkg/proxy/ipvs/testing:go_default_library",
         "//pkg/proxy/util:go_default_library",
         "//pkg/proxy/util/testing:go_default_library",
+        "//pkg/util/async:go_default_library",
         "//pkg/util/ipset:go_default_library",
         "//pkg/util/ipset/testing:go_default_library",
         "//pkg/util/iptables:go_default_library",

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -819,7 +819,11 @@ func (proxier *Proxier) OnServiceDelete(service *v1.Service) {
 func (proxier *Proxier) OnServiceSynced() {
 	proxier.mu.Lock()
 	proxier.servicesSynced = true
-	proxier.setInitialized(proxier.endpointsSynced || proxier.endpointSlicesSynced)
+	if utilfeature.DefaultFeatureGate.Enabled(features.EndpointSlice) {
+		proxier.setInitialized(proxier.endpointSlicesSynced)
+	} else {
+		proxier.setInitialized(proxier.endpointsSynced)
+	}
 	proxier.mu.Unlock()
 
 	// Sync unconditionally - this is called once per lifetime.
@@ -847,7 +851,7 @@ func (proxier *Proxier) OnEndpointsDelete(endpoints *v1.Endpoints) {
 func (proxier *Proxier) OnEndpointsSynced() {
 	proxier.mu.Lock()
 	proxier.endpointsSynced = true
-	proxier.setInitialized(proxier.servicesSynced && proxier.endpointsSynced)
+	proxier.setInitialized(proxier.servicesSynced)
 	proxier.mu.Unlock()
 
 	// Sync unconditionally - this is called once per lifetime.
@@ -883,7 +887,7 @@ func (proxier *Proxier) OnEndpointSliceDelete(endpointSlice *discovery.EndpointS
 func (proxier *Proxier) OnEndpointSlicesSynced() {
 	proxier.mu.Lock()
 	proxier.endpointSlicesSynced = true
-	proxier.setInitialized(proxier.servicesSynced && proxier.endpointSlicesSynced)
+	proxier.setInitialized(proxier.servicesSynced)
 	proxier.mu.Unlock()
 
 	// Sync unconditionally - this is called once per lifetime.
@@ -900,7 +904,7 @@ func (proxier *Proxier) syncProxyRules() {
 	defer proxier.mu.Unlock()
 
 	// don't sync rules till we've received services and endpoints
-	if !proxier.endpointsSynced || !proxier.servicesSynced {
+	if !proxier.isInitialized() {
 		klog.V(2).Info("Not syncing ipvs rules until Services and Endpoints have been received from master")
 		return
 	}

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
@@ -36,6 +37,7 @@ import (
 	netlinktest "k8s.io/kubernetes/pkg/proxy/ipvs/testing"
 	utilproxy "k8s.io/kubernetes/pkg/proxy/util"
 	proxyutiltest "k8s.io/kubernetes/pkg/proxy/util/testing"
+	"k8s.io/kubernetes/pkg/util/async"
 	utilipset "k8s.io/kubernetes/pkg/util/ipset"
 	ipsettest "k8s.io/kubernetes/pkg/util/ipset/testing"
 	utiliptables "k8s.io/kubernetes/pkg/util/iptables"
@@ -134,7 +136,7 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 	for _, is := range ipsetInfo {
 		ipsetList[is.name] = NewIPSet(ipset, is.name, is.setType, false, is.comment)
 	}
-	return &Proxier{
+	p := &Proxier{
 		exec:                  fexec,
 		serviceMap:            make(proxy.ServiceMap),
 		serviceChanges:        proxy.NewServiceChangeTracker(newServiceInfo, nil, nil),
@@ -164,6 +166,9 @@ func NewFakeProxier(ipt utiliptables.Interface, ipvs utilipvs.Interface, ipset u
 		networkInterfacer:     proxyutiltest.NewFakeNetwork(),
 		gracefuldeleteManager: NewGracefulTerminationManager(ipvs),
 	}
+	p.setInitialized(true)
+	p.syncRunner = async.NewBoundedFrequencyRunner("test-sync-runner", p.syncProxyRules, 0, time.Minute, 1)
+	return p
 }
 
 func makeNSN(namespace, name string) types.NamespacedName {
@@ -3660,9 +3665,9 @@ func TestEndpointSliceE2E(t *testing.T) {
 	ipAddressType := discovery.AddressTypeIP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-1", serviceName),
-			Namespace:       namespaceName,
-			OwnerReferences: []metav1.OwnerReference{{Kind: "Service", Name: serviceName}},
+			Name:      fmt.Sprintf("%s-1", serviceName),
+			Namespace: namespaceName,
+			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
 			Name: utilpointer.StringPtr(""),

--- a/staging/src/k8s.io/api/discovery/v1alpha1/BUILD
+++ b/staging/src/k8s.io/api/discovery/v1alpha1/BUILD
@@ -8,6 +8,7 @@ go_library(
         "register.go",
         "types.go",
         "types_swagger_doc_generated.go",
+        "well_known_labels.go",
         "zz_generated.deepcopy.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/api/discovery/v1alpha1",

--- a/staging/src/k8s.io/api/discovery/v1alpha1/well_known_labels.go
+++ b/staging/src/k8s.io/api/discovery/v1alpha1/well_known_labels.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+const (
+	// LabelServiceName is used to indicate the name of a Kubernetes service.
+	LabelServiceName = "kubernetes.io/service-name"
+)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This should fix a bug that could break masters when the EndpointSlice feature gate was enabled. This was all tied to how the apiserver creates and manages it's own services and endpoints (or in this case endpoint slices). Consumers of endpoint slices also need to know about the corresponding service. Previously we were trying to set an owner reference here for this purpose, but that came with potential downsides and increased complexity. This PR changes behavior of the apiserver endpointslice integration to set the service name label instead of owner references, and simplifies consumer logic to reference that (both are set by the EndpointSlice controller).

**Which issue(s) this PR fixes**:
Should help with https://github.com/kubernetes/kubernetes/issues/82174.

**Special notes for your reviewer**:
This PR includes a bit of cleanup as well. Where both `corev1` and `v1` were accidentally used as imports, the code has been cleaned up to use whichever one required less changes. Additionally, serviceNameLabel had been set as a const in a couple packages. This change meant it would be required in yet another package, so an equivalent has been added to `core/v1/well_known_labels`.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190603-EndpointSlice-API.md)
- [Enhancement Issue](https://github.com/kubernetes/enhancements/issues/752)

/cc @freehan 