### PR TITLE
migrate from framework.GetReadySchedulableNodesOrDie to e2enode.GetReadySchedulableNodes

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/auth:go_default_library",
         "//test/e2e/framework/log:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/providers/aws:go_default_library",
         "//test/e2e/framework/providers/azure:go_default_library",

--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -84,6 +84,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/deployment:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/ssh:go_default_library",
         "//test/utils:go_default_library",

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -39,6 +39,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/onsi/ginkgo"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -48,8 +49,11 @@ import (
 // with some wiggle room, to prevent pods being unable to schedule due
 // to max pod constraints.
 func estimateMaximumPods(c clientset.Interface, min, max int32) int32 {
+	nodes, err := e2enode.GetReadySchedulableNodes(c)
+	framework.ExpectNoError(err)
+
 	availablePods := int32(0)
-	for _, node := range framework.GetReadySchedulableNodesOrDie(c).Items {
+	for _, node := range nodes.Items {
 		if q, ok := node.Status.Allocatable["pods"]; ok {
 			if num, ok := q.AsInt64(); ok {
 				availablePods += int32(num)

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/kubernetes/pkg/controller/daemon"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -381,13 +382,14 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 	  rollback of updates to a DaemonSet.
 	*/
 	framework.ConformanceIt("should rollback without unnecessary restarts", func() {
-		schedulableNodes := framework.GetReadySchedulableNodesOrDie(c)
+		schedulableNodes, err := e2enode.GetReadySchedulableNodes(c)
+		framework.ExpectNoError(err)
 		gomega.Expect(len(schedulableNodes.Items)).To(gomega.BeNumerically(">", 1), "Conformance test suite needs a cluster with at least 2 nodes.")
 		framework.Logf("Create a RollingUpdate DaemonSet")
 		label := map[string]string{daemonsetNameLabel: dsName}
 		ds := newDaemonSet(dsName, image, label)
 		ds.Spec.UpdateStrategy = appsv1.DaemonSetUpdateStrategy{Type: appsv1.RollingUpdateDaemonSetStrategyType}
-		ds, err := c.AppsV1().DaemonSets(ns).Create(ds)
+		ds, err = c.AppsV1().DaemonSets(ns).Create(ds)
 		framework.ExpectNoError(err)
 
 		framework.Logf("Check that daemon pods launch on every node of the cluster")
@@ -420,7 +422,8 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 				framework.Failf("unexpected pod found, image = %s", image)
 			}
 		}
-		schedulableNodes = framework.GetReadySchedulableNodesOrDie(c)
+		schedulableNodes, err = e2enode.GetReadySchedulableNodes(c)
+		framework.ExpectNoError(err)
 		if len(schedulableNodes.Items) < 2 {
 			framework.ExpectEqual(len(existingPods), 0)
 		} else {
@@ -505,7 +508,10 @@ func separateDaemonSetNodeLabels(labels map[string]string) (map[string]string, m
 }
 
 func clearDaemonSetNodeLabels(c clientset.Interface) error {
-	nodeList := framework.GetReadySchedulableNodesOrDie(c)
+	nodeList, err := e2enode.GetReadySchedulableNodes(c)
+	if err != nil {
+		return err
+	}
 	for _, node := range nodeList.Items {
 		_, err := setDaemonSetNodeLabels(c, node.Name, map[string]string{})
 		if err != nil {

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -160,9 +160,9 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 		framework.ExpectNoError(err, "error waiting for daemon pods to be running on no nodes")
 
 		ginkgo.By("Change node label to blue, check that daemon pod is launched.")
-		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">", 0))
-		newNode, err := setDaemonSetNodeLabels(c, nodeList.Items[0].Name, nodeSelector)
+		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		framework.ExpectNoError(err)
+		newNode, err := setDaemonSetNodeLabels(c, node.Name, nodeSelector)
 		framework.ExpectNoError(err, "error setting labels on node")
 		daemonSetLabels, _ := separateDaemonSetNodeLabels(newNode.Labels)
 		framework.ExpectEqual(len(daemonSetLabels), 1)
@@ -173,7 +173,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 
 		ginkgo.By("Update the node label to green, and wait for daemons to be unscheduled")
 		nodeSelector[daemonsetColorLabel] = "green"
-		greenNode, err := setDaemonSetNodeLabels(c, nodeList.Items[0].Name, nodeSelector)
+		greenNode, err := setDaemonSetNodeLabels(c, node.Name, nodeSelector)
 		framework.ExpectNoError(err, "error removing labels on node")
 		err = wait.PollImmediate(dsRetryPeriod, dsRetryTimeout, checkRunningOnNoNodes(f, ds))
 		framework.ExpectNoError(err, "error waiting for daemon pod to not be running on nodes")
@@ -223,9 +223,9 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 		framework.ExpectNoError(err, "error waiting for daemon pods to be running on no nodes")
 
 		ginkgo.By("Change node label to blue, check that daemon pod is launched.")
-		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		gomega.Expect(len(nodeList.Items)).To(gomega.BeNumerically(">", 0))
-		newNode, err := setDaemonSetNodeLabels(c, nodeList.Items[0].Name, nodeSelector)
+		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		framework.ExpectNoError(err)
+		newNode, err := setDaemonSetNodeLabels(c, node.Name, nodeSelector)
 		framework.ExpectNoError(err, "error setting labels on node")
 		daemonSetLabels, _ := separateDaemonSetNodeLabels(newNode.Labels)
 		framework.ExpectEqual(len(daemonSetLabels), 1)
@@ -235,7 +235,7 @@ var _ = SIGDescribe("Daemon set [Serial]", func() {
 		framework.ExpectNoError(err)
 
 		ginkgo.By("Remove the node label and wait for daemons to be unscheduled")
-		_, err = setDaemonSetNodeLabels(c, nodeList.Items[0].Name, map[string]string{})
+		_, err = setDaemonSetNodeLabels(c, node.Name, map[string]string{})
 		framework.ExpectNoError(err, "error removing labels on node")
 		err = wait.PollImmediate(dsRetryPeriod, dsRetryTimeout, checkRunningOnNoNodes(f, ds))
 		framework.ExpectNoError(err, "error waiting for daemon pod to not be running on nodes")

--- a/test/e2e/apps/network_partition.go
+++ b/test/e2e/apps/network_partition.go
@@ -492,7 +492,8 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 				framework.SkipUnlessSSHKeyPresent()
 				ginkgo.By("choose a node - we will block all network traffic on this node")
 				var podOpts metav1.ListOptions
-				nodes := framework.GetReadySchedulableNodesOrDie(c)
+				nodes, err := e2enode.GetReadySchedulableNodes(c)
+				framework.ExpectNoError(err)
 				e2enode.Filter(nodes, func(node v1.Node) bool {
 					if !e2enode.IsConditionSetAsExpected(&node, v1.NodeReady, true) {
 						return false

--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -34,6 +34,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	watchtools "k8s.io/client-go/tools/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
@@ -679,8 +680,8 @@ var _ = SIGDescribe("StatefulSet", func() {
 			podName := "test-pod"
 			statefulPodName := ssName + "-0"
 			ginkgo.By("Looking for a node to schedule stateful set and pod")
-			nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-			node := nodes.Items[0]
+			node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+			framework.ExpectNoError(err)
 
 			ginkgo.By("Creating pod with conflicting port in namespace " + f.Namespace.Name)
 			conflictingPort := v1.ContainerPort{HostPort: 21017, ContainerPort: 21017, Name: "conflict"}
@@ -699,7 +700,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 					NodeName: node.Name,
 				},
 			}
-			pod, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
+			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
 			framework.ExpectNoError(err)
 
 			ginkgo.By("Creating statefulset with conflicting port in namespace " + f.Namespace.Name)

--- a/test/e2e/autoscaling/autoscaling_timer.go
+++ b/test/e2e/autoscaling/autoscaling_timer.go
@@ -62,7 +62,8 @@ var _ = SIGDescribe("[Feature:ClusterSizeAutoscalingScaleUp] [Slow] Autoscaling"
 				}
 
 				// Make sure all nodes are schedulable, otherwise we are in some kind of a problem state.
-				nodes = framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+				nodes, err = e2enode.GetReadySchedulableNodes(f.ClientSet)
+				framework.ExpectNoError(err)
 				schedulableCount := len(nodes.Items)
 				framework.ExpectEqual(schedulableCount, nodeGroupSize, "not all nodes are schedulable")
 			})

--- a/test/e2e/autoscaling/cluster_autoscaler_scalability.go
+++ b/test/e2e/autoscaling/cluster_autoscaler_scalability.go
@@ -36,7 +36,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -90,9 +89,9 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 
 		framework.ExpectNoError(e2enode.WaitForReadyNodes(c, sum, scaleUpTimeout))
 
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err)
 		nodeCount = len(nodes.Items)
-		gomega.Expect(nodeCount).NotTo(gomega.BeZero())
 		cpu := nodes.Items[0].Status.Capacity[v1.ResourceCPU]
 		mem := nodes.Items[0].Status.Capacity[v1.ResourceMemory]
 		coresPerNode = int((&cpu).MilliValue() / 1000)
@@ -324,7 +323,8 @@ var _ = framework.KubeDescribe("Cluster size autoscaler scalability [Slow]", fun
 		time.Sleep(scaleDownTimeout)
 
 		ginkgo.By("Checking if the number of nodes is as expected")
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err)
 		klog.Infof("Nodes: %v, expected: %v", len(nodes.Items), totalNodes)
 		framework.ExpectEqual(len(nodes.Items), totalNodes)
 	})

--- a/test/e2e/cloud/nodes.go
+++ b/test/e2e/cloud/nodes.go
@@ -43,8 +43,8 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 	ginkgo.It("should be deleted on API server if it doesn't exist in the cloud provider", func() {
 		ginkgo.By("deleting a node on the cloud provider")
 
-		nodeDeleteCandidates := framework.GetReadySchedulableNodesOrDie(c)
-		nodeToDelete := nodeDeleteCandidates.Items[0]
+		nodeToDelete, err := e2enode.GetRandomReadySchedulableNode(c)
+		framework.ExpectNoError(err)
 
 		origNodes, err := e2enode.GetReadyNodesIncludingTainted(c)
 		if err != nil {
@@ -55,7 +55,7 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 
 		framework.Logf("Original number of ready nodes: %d", len(origNodes.Items))
 
-		err = framework.DeleteNodeOnCloudProvider(&nodeToDelete)
+		err = framework.DeleteNodeOnCloudProvider(nodeToDelete)
 		if err != nil {
 			framework.Failf("failed to delete node %q, err: %q", nodeToDelete.Name, err)
 		}

--- a/test/e2e/common/node_lease.go
+++ b/test/e2e/common/node_lease.go
@@ -41,9 +41,9 @@ var _ = framework.KubeDescribe("NodeLease", func() {
 	f := framework.NewDefaultFramework("node-lease-test")
 
 	ginkgo.BeforeEach(func() {
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		gomega.Expect(len(nodes.Items)).NotTo(gomega.BeZero())
-		nodeName = nodes.Items[0].ObjectMeta.Name
+		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		framework.ExpectNoError(err)
+		nodeName = node.Name
 	})
 
 	ginkgo.Context("when the NodeLease feature is enabled", func() {

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -50,7 +50,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",

--- a/test/e2e/framework/lifecycle/BUILD
+++ b/test/e2e/framework/lifecycle/BUILD
@@ -10,6 +10,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/lifecycle/upgrade.go
+++ b/test/e2e/framework/lifecycle/upgrade.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
 
 // RealVersion turns a version constants into a version string deployable on
@@ -86,7 +87,10 @@ func CheckMasterVersion(c clientset.Interface, want string) error {
 
 // CheckNodesVersions validates the nodes versions
 func CheckNodesVersions(cs clientset.Interface, want string) error {
-	l := framework.GetReadySchedulableNodesOrDie(cs)
+	l, err := e2enode.GetReadySchedulableNodes(cs)
+	if err != nil {
+		return err
+	}
 	for _, n := range l.Items {
 		// We do prefix trimming and then matching because:
 		// want   looks like:  0.19.3-815-g50e67d4

--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -32,7 +32,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -621,28 +620,11 @@ func (config *NetworkingTestConfig) setup(selector map[string]string) {
 	}
 }
 
-// shuffleNodes copies nodes from the specified slice into a copy in random
-// order. It returns a new slice.
-func shuffleNodes(nodes []v1.Node) []v1.Node {
-	shuffled := make([]v1.Node, len(nodes))
-	perm := rand.Perm(len(nodes))
-	for i, j := range perm {
-		shuffled[j] = nodes[i]
-	}
-	return shuffled
-}
-
 func (config *NetworkingTestConfig) createNetProxyPods(podName string, selector map[string]string) []*v1.Pod {
 	ExpectNoError(WaitForAllNodesSchedulable(config.f.ClientSet, 10*time.Minute))
-	nodeList := GetReadySchedulableNodesOrDie(config.f.ClientSet)
-
-	// To make this test work reasonably fast in large clusters,
-	// we limit the number of NetProxyPods to no more than
-	// maxNetProxyPodsCount on random nodes.
-	nodes := shuffleNodes(nodeList.Items)
-	if len(nodes) > maxNetProxyPodsCount {
-		nodes = nodes[:maxNetProxyPodsCount]
-	}
+	nodeList, err := e2enode.GetBoundedReadySchedulableNodes(config.f.ClientSet, maxNetProxyPodsCount)
+	ExpectNoError(err)
+	nodes := nodeList.Items
 
 	// create pods, one for each node
 	createdPods := make([]*v1.Pod, 0, len(nodes))

--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -591,7 +591,8 @@ func (config *NetworkingTestConfig) setup(selector map[string]string) {
 
 	ginkgo.By("Getting node addresses")
 	ExpectNoError(WaitForAllNodesSchedulable(config.f.ClientSet, 10*time.Minute))
-	nodeList := GetReadySchedulableNodesOrDie(config.f.ClientSet)
+	nodeList, err := e2enode.GetReadySchedulableNodes(config.f.ClientSet)
+	ExpectNoError(err)
 	config.ExternalAddrs = e2enode.FirstAddress(nodeList, v1.NodeExternalIP)
 
 	SkipUnlessNodeCountIsAtLeast(2)

--- a/test/e2e/framework/node/BUILD
+++ b/test/e2e/framework/node/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -371,6 +371,16 @@ func GetBoundedReadySchedulableNodes(c clientset.Interface, maxNodes int) (nodes
 	return nodes, nil
 }
 
+// GetRandomReadySchedulableNode gets a single randomly-selected node which is available for
+// running pods on. If there are no available nodes it will return an error.
+func GetRandomReadySchedulableNode(c clientset.Interface) (*v1.Node, error) {
+	nodes, err := GetReadySchedulableNodes(c)
+	if err != nil {
+		return nil, err
+	}
+	return &nodes.Items[rand.Intn(len(nodes.Items))], nil
+}
+
 // GetReadyNodesIncludingTainted returns all ready nodes, even those which are tainted.
 // There are cases when we care about tainted nodes
 // E.g. in tests related to nodes with gpu we care about nodes despite

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -338,7 +338,8 @@ func (k *NodeKiller) Run(stopCh <-chan struct{}) {
 }
 
 func (k *NodeKiller) pickNodes() []v1.Node {
-	nodes := GetReadySchedulableNodesOrDie(k.client)
+	nodes, err := e2enode.GetReadySchedulableNodes(k.client)
+	ExpectNoError(err)
 	numNodes := int(k.config.FailureRatio * float64(len(nodes.Items)))
 	shuffledNodes := shuffleNodes(nodes.Items)
 	if len(shuffledNodes) > numNodes {

--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -341,11 +341,10 @@ func (k *NodeKiller) pickNodes() []v1.Node {
 	nodes, err := e2enode.GetReadySchedulableNodes(k.client)
 	ExpectNoError(err)
 	numNodes := int(k.config.FailureRatio * float64(len(nodes.Items)))
-	shuffledNodes := shuffleNodes(nodes.Items)
-	if len(shuffledNodes) > numNodes {
-		return shuffledNodes[:numNodes]
-	}
-	return shuffledNodes
+
+	nodes, err = e2enode.GetBoundedReadySchedulableNodes(k.client, numNodes)
+	ExpectNoError(err)
+	return nodes.Items
 }
 
 func (k *NodeKiller) kill(nodes []v1.Node) {

--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -353,16 +353,6 @@ func SetInstanceTags(cloudConfig framework.CloudConfig, instanceName, zone strin
 	return resTags.Items
 }
 
-// GetNodeTags gets k8s node tag from one of the nodes
-func GetNodeTags(c clientset.Interface, cloudConfig framework.CloudConfig) []string {
-	nodes := framework.GetReadySchedulableNodesOrDie(c)
-	if len(nodes.Items) == 0 {
-		framework.Logf("GetNodeTags: Found 0 node.")
-		return []string{}
-	}
-	return GetInstanceTags(cloudConfig, nodes.Items[0].Name).Items
-}
-
 // IsGoogleAPIHTTPErrorCode returns true if the error is a google api
 // error matching the corresponding HTTP error code.
 func IsGoogleAPIHTTPErrorCode(err error, code int) bool {

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -264,7 +264,8 @@ func (j *TestJig) CreateLoadBalancerService(namespace, serviceName string, timeo
 // GetEndpointNodes returns a map of nodenames:external-ip on which the
 // endpoints of the given Service are running.
 func (j *TestJig) GetEndpointNodes(svc *v1.Service) map[string][]string {
-	nodes := j.GetNodes(MaxNodesForEndpointsTests)
+	nodes, err := e2enode.GetBoundedReadySchedulableNodes(j.Client, MaxNodesForEndpointsTests)
+	framework.ExpectNoError(err)
 	endpoints, err := j.Client.CoreV1().Endpoints(svc.Namespace).Get(svc.Name, metav1.GetOptions{})
 	if err != nil {
 		framework.Failf("Get endpoints for service %s/%s failed (%s)", svc.Namespace, svc.Name, err)
@@ -287,27 +288,6 @@ func (j *TestJig) GetEndpointNodes(svc *v1.Service) map[string][]string {
 		}
 	}
 	return nodeMap
-}
-
-// GetNodes returns the first maxNodesForTest nodes. Useful in large clusters
-// where we don't eg: want to create an endpoint per node.
-func (j *TestJig) GetNodes(maxNodesForTest int) (nodes *v1.NodeList) {
-	nodes = framework.GetReadySchedulableNodesOrDie(j.Client)
-	if len(nodes.Items) <= maxNodesForTest {
-		maxNodesForTest = len(nodes.Items)
-	}
-	nodes.Items = nodes.Items[:maxNodesForTest]
-	return nodes
-}
-
-// GetNodesNames returns a list of names of the first maxNodesForTest nodes
-func (j *TestJig) GetNodesNames(maxNodesForTest int) []string {
-	nodes := j.GetNodes(maxNodesForTest)
-	nodesNames := []string{}
-	for _, node := range nodes.Items {
-		nodesNames = append(nodesNames, node.Name)
-	}
-	return nodesNames
 }
 
 // WaitForEndpointOnNode waits for a service endpoint on the given node.
@@ -840,7 +820,8 @@ func (j *TestJig) checkNodePortServiceReachability(namespace string, svc *v1.Ser
 	servicePorts := svc.Spec.Ports
 
 	// Consider only 2 nodes for testing
-	nodes := j.GetNodes(2)
+	nodes, err := e2enode.GetBoundedReadySchedulableNodes(j.Client, 2)
+	framework.ExpectNoError(err)
 
 	j.WaitForAvailableEndpoint(namespace, svc.Name, ServiceEndpointsTimeout)
 

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -26,6 +26,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
 
 // GetServicesProxyRequest returns a request for a service proxy.
@@ -110,7 +111,9 @@ func DescribeSvc(ns string) {
 
 // GetServiceLoadBalancerCreationTimeout returns a timeout value for creating a load balancer of a service.
 func GetServiceLoadBalancerCreationTimeout(cs clientset.Interface) time.Duration {
-	if nodes := framework.GetReadySchedulableNodesOrDie(cs); len(nodes.Items) > LargeClusterMinNodesNumber {
+	nodes, err := e2enode.GetReadySchedulableNodes(cs)
+	framework.ExpectNoError(err)
+	if len(nodes.Items) > LargeClusterMinNodesNumber {
 		return LoadBalancerCreateTimeoutLarge
 	}
 	return LoadBalancerCreateTimeoutDefault

--- a/test/e2e/framework/suites.go
+++ b/test/e2e/framework/suites.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/component-base/version"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
@@ -80,7 +81,9 @@ func SetupSuite() {
 
 	// If NumNodes is not specified then auto-detect how many are scheduleable and not tainted
 	if TestContext.CloudConfig.NumNodes == DefaultNumNodes {
-		TestContext.CloudConfig.NumNodes = len(GetReadySchedulableNodesOrDie(c).Items)
+		nodes, err := e2enode.GetReadySchedulableNodes(c)
+		ExpectNoError(err)
+		TestContext.CloudConfig.NumNodes = len(nodes.Items)
 	}
 
 	// Ensure all pods are running and ready before starting tests (otherwise,

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2897,7 +2897,10 @@ func NewE2ETestNodePreparer(client clientset.Interface, countToStrategy []testut
 
 // PrepareNodes prepares nodes in the cluster.
 func (p *E2ETestNodePreparer) PrepareNodes() error {
-	nodes := GetReadySchedulableNodesOrDie(p.client)
+	nodes, err := e2enode.GetReadySchedulableNodes(p.client)
+	if err != nil {
+		return err
+	}
 	numTemplates := 0
 	for _, v := range p.countToStrategy {
 		numTemplates += v.Count
@@ -2923,9 +2926,11 @@ func (p *E2ETestNodePreparer) PrepareNodes() error {
 // CleanupNodes cleanups nodes in the cluster.
 func (p *E2ETestNodePreparer) CleanupNodes() error {
 	var encounteredError error
-	nodes := GetReadySchedulableNodesOrDie(p.client)
+	nodes, err := e2enode.GetReadySchedulableNodes(p.client)
+	if err != nil {
+		return err
+	}
 	for i := range nodes.Items {
-		var err error
 		name := nodes.Items[i].Name
 		strategy, found := p.nodeToAppliedStrategy[name]
 		if found {

--- a/test/e2e/gke_node_pools.go
+++ b/test/e2e/gke_node_pools.go
@@ -21,6 +21,7 @@ import (
 	"os/exec"
 
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/onsi/ginkgo"
 )
@@ -98,7 +99,8 @@ func testCreateDeleteNodePool(f *framework.Framework, poolName string) {
 // label with the given node pool name.
 func nodesWithPoolLabel(f *framework.Framework, poolName string) int {
 	nodeCount := 0
-	nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+	nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+	framework.ExpectNoError(err)
 	for _, node := range nodeList.Items {
 		if poolLabel := node.Labels["cloud.google.com/gke-nodepool"]; poolLabel == poolName {
 			nodeCount++

--- a/test/e2e/instrumentation/logging/BUILD
+++ b/test/e2e/instrumentation/logging/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/config:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/e2e/instrumentation/common:go_default_library",
         "//test/e2e/instrumentation/logging/elasticsearch:go_default_library",
         "//test/e2e/instrumentation/logging/stackdriver:go_default_library",

--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	instrumentation "k8s.io/kubernetes/test/e2e/instrumentation/common"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -76,7 +77,8 @@ var _ = instrumentation.SIGDescribe("Logging soak [Performance] [Slow] [Disrupti
 // was produced in each and every pod at least once.  The final arg is the timeout for the test to verify all the pods got logs.
 func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname string, timeout time.Duration) {
 
-	nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+	nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+	framework.ExpectNoError(err)
 	totalPods := len(nodes.Items)
 	framework.ExpectNotEqual(totalPods, 0)
 

--- a/test/e2e/instrumentation/logging/stackdriver/BUILD
+++ b/test/e2e/instrumentation/logging/stackdriver/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/e2e/instrumentation/common:go_default_library",
         "//test/e2e/instrumentation/logging/utils:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/test/e2e/instrumentation/logging/stackdriver/soak.go
+++ b/test/e2e/instrumentation/logging/stackdriver/soak.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	instrumentation "k8s.io/kubernetes/test/e2e/instrumentation/common"
 	"k8s.io/kubernetes/test/e2e/instrumentation/logging/utils"
 
@@ -45,7 +46,8 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 
 	ginkgo.It("should ingest logs from applications running for a prolonged amount of time", func() {
 		withLogProviderForScope(f, podsScope, func(p *sdLogProvider) {
-			nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet).Items
+			nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+			framework.ExpectNoError(err)
 			maxPodCount := 10
 			jobDuration := 30 * time.Minute
 			linesPerPodPerSecond := 100
@@ -68,7 +70,7 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 			podsByRun := [][]utils.FiniteLoggingPod{}
 			for runIdx := 0; runIdx < podRunCount; runIdx++ {
 				podsInRun := []utils.FiniteLoggingPod{}
-				for nodeIdx, node := range nodes {
+				for nodeIdx, node := range nodes.Items {
 					podName := fmt.Sprintf("job-logs-generator-%d-%d-%d-%d", maxPodCount, linesPerPod, runIdx, nodeIdx)
 					pod := utils.NewLoadLoggingPod(podName, node.Name, linesPerPod, jobDuration)
 					pods = append(pods, pod)
@@ -93,7 +95,7 @@ var _ = instrumentation.SIGDescribe("Cluster level logging implemented by Stackd
 			}()
 
 			checker := utils.NewFullIngestionPodLogChecker(p, maxAllowedLostFraction, pods...)
-			err := utils.WaitForLogs(checker, ingestionInterval, ingestionTimeout)
+			err = utils.WaitForLogs(checker, ingestionInterval, ingestionTimeout)
 			framework.ExpectNoError(err)
 
 			utils.EnsureLoggingAgentRestartsCount(f, p.LoggingAgentName(), allowedRestarts)

--- a/test/e2e/instrumentation/logging/utils/BUILD
+++ b/test/e2e/instrumentation/logging/utils/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/k8s.io/utils/integer:go_default_library",

--- a/test/e2e/instrumentation/logging/utils/logging_agent.go
+++ b/test/e2e/instrumentation/logging/utils/logging_agent.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/utils/integer"
 )
 
@@ -40,7 +41,10 @@ func EnsureLoggingAgentDeployment(f *framework.Framework, appName string) error 
 		agentPerNode[pod.Spec.NodeName]++
 	}
 
-	nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+	nodeList, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+	if err != nil {
+		return fmt.Errorf("failed to get nodes: %v", err)
+	}
 	for _, node := range nodeList.Items {
 		agentPodsCount, ok := agentPerNode[node.Name]
 

--- a/test/e2e/instrumentation/logging/utils/misc.go
+++ b/test/e2e/instrumentation/logging/utils/misc.go
@@ -19,11 +19,13 @@ package utils
 import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 )
 
 // GetNodeIds returns the list of node names and panics in case of failure.
 func GetNodeIds(cs clientset.Interface) []string {
-	nodes := framework.GetReadySchedulableNodesOrDie(cs)
+	nodes, err := e2enode.GetReadySchedulableNodes(cs)
+	framework.ExpectNoError(err)
 	nodeIds := []string{}
 	for _, n := range nodes.Items {
 		nodeIds = append(nodeIds, n.Name)

--- a/test/e2e/instrumentation/monitoring/BUILD
+++ b/test/e2e/instrumentation/monitoring/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//test/e2e/framework/config:go_default_library",
         "//test/e2e/framework/gpu:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/instrumentation/common:go_default_library",
         "//test/e2e/scheduling:go_default_library",

--- a/test/e2e/instrumentation/monitoring/metrics_grabber.go
+++ b/test/e2e/instrumentation/monitoring/metrics_grabber.go
@@ -23,6 +23,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/metrics"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	instrumentation "k8s.io/kubernetes/test/e2e/instrumentation/common"
 
 	gin "github.com/onsi/ginkgo"
@@ -51,9 +52,9 @@ var _ = instrumentation.SIGDescribe("MetricsGrabber", func() {
 
 	gin.It("should grab all metrics from a Kubelet.", func() {
 		gin.By("Proxying to Node through the API server")
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		gom.Expect(nodes.Items).NotTo(gom.BeEmpty())
-		response, err := grabber.GrabFromKubelet(nodes.Items[0].Name)
+		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		framework.ExpectNoError(err)
+		response, err := grabber.GrabFromKubelet(node.Name)
 		framework.ExpectNoError(err)
 		gom.Expect(response).NotTo(gom.BeEmpty())
 	})

--- a/test/e2e/lifecycle/kubelet_security.go
+++ b/test/e2e/lifecycle/kubelet_security.go
@@ -39,9 +39,9 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 	var nodeName string
 
 	ginkgo.BeforeEach(func() {
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		gomega.Expect(len(nodes.Items)).NotTo(gomega.BeZero())
-		node = &nodes.Items[0]
+		var err error
+		node, err = e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		framework.ExpectNoError(err)
 		nodeName = node.Name
 	})
 

--- a/test/e2e/lifecycle/node_lease.go
+++ b/test/e2e/lifecycle/node_lease.go
@@ -103,7 +103,8 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 
 			ginkgo.By("verify node lease exists for every nodes")
-			originalNodes := framework.GetReadySchedulableNodesOrDie(c)
+			originalNodes, err := e2enode.GetReadySchedulableNodes(c)
+			framework.ExpectNoError(err)
 			framework.ExpectEqual(len(originalNodes.Items), framework.TestContext.CloudConfig.NumNodes)
 
 			gomega.Eventually(func() error {
@@ -128,7 +129,8 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 			gomega.Expect(err).To(gomega.BeNil())
 			err = e2enode.WaitForReadyNodes(c, framework.TestContext.CloudConfig.NumNodes-1, 10*time.Minute)
 			gomega.Expect(err).To(gomega.BeNil())
-			targetNodes := framework.GetReadySchedulableNodesOrDie(c)
+			targetNodes, err := e2enode.GetReadySchedulableNodes(c)
+			framework.ExpectNoError(err)
 			framework.ExpectEqual(len(targetNodes.Items), int(targetNumNodes))
 
 			ginkgo.By("verify node lease is deleted for the deleted node")

--- a/test/e2e/lifecycle/reboot.go
+++ b/test/e2e/lifecycle/reboot.go
@@ -134,7 +134,8 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 
 func testReboot(c clientset.Interface, rebootCmd string, hook terminationHook) {
 	// Get all nodes, and kick off the test on each.
-	nodelist := framework.GetReadySchedulableNodesOrDie(c)
+	nodelist, err := e2enode.GetReadySchedulableNodes(c)
+	framework.ExpectNoError(err, "failed to list nodes")
 	if hook != nil {
 		defer func() {
 			framework.Logf("Executing termination hook on nodes")

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -47,7 +47,8 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 
 	ginkgo.It("should have ipv4 and ipv6 internal node ip", func() {
 		// TODO (aramase) can switch to new function to get all nodes
-		nodeList := framework.GetReadySchedulableNodesOrDie(cs)
+		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
 
 		for _, node := range nodeList.Items {
 			// get all internal ips for node
@@ -61,7 +62,8 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 
 	ginkgo.It("should have ipv4 and ipv6 node podCIDRs", func() {
 		// TODO (aramase) can switch to new function to get all nodes
-		nodeList := framework.GetReadySchedulableNodesOrDie(cs)
+		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
 
 		for _, node := range nodeList.Items {
 			framework.ExpectEqual(len(node.Spec.PodCIDRs), 2)
@@ -121,12 +123,8 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 
 		// get all schedulable nodes to determine the number of replicas for pods
 		// this is to ensure connectivity from all nodes on cluster
-		nodeList := framework.GetReadySchedulableNodesOrDie(cs)
-		gomega.Expect(nodeList).NotTo(gomega.BeNil())
-
-		if len(nodeList.Items) < 1 {
-			framework.Failf("Expect at least 1 node, got %v", len(nodeList.Items))
-		}
+		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
 
 		replicas := int32(len(nodeList.Items))
 

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -123,6 +123,8 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 
 		// get all schedulable nodes to determine the number of replicas for pods
 		// this is to ensure connectivity from all nodes on cluster
+		// FIXME: tests may be run in large clusters. This test is O(n^2) in the
+		// number of nodes used. It should use GetBoundedReadySchedulableNodes().
 		nodeList, err := e2enode.GetReadySchedulableNodes(cs)
 		framework.ExpectNoError(err)
 

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -188,10 +188,8 @@ var _ = SIGDescribe("Firewall rule", func() {
 	})
 
 	ginkgo.It("should have correct firewall rules for e2e cluster", func() {
-		nodes := framework.GetReadySchedulableNodesOrDie(cs)
-		if len(nodes.Items) <= 0 {
-			framework.Failf("Expect at least 1 node, got: %v", len(nodes.Items))
-		}
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("Checking if e2e firewall rules are correct")
 		for _, expFw := range gce.GetE2eFirewalls(cloudConfig.MasterName, cloudConfig.MasterTag, cloudConfig.NodeTag, cloudConfig.Network, cloudConfig.ClusterIPRange) {

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -32,7 +32,6 @@ import (
 	gcecloud "k8s.io/legacy-cloud-providers/gce"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -73,11 +72,12 @@ var _ = SIGDescribe("Firewall rule", func() {
 		framework.Logf("Got cluster ID: %v", clusterID)
 
 		jig := e2eservice.NewTestJig(cs, serviceName)
-		nodeList := jig.GetNodes(e2eservice.MaxNodesForEndpointsTests)
-		gomega.Expect(nodeList).NotTo(gomega.BeNil())
-		nodesNames := jig.GetNodesNames(e2eservice.MaxNodesForEndpointsTests)
-		if len(nodesNames) <= 0 {
-			framework.Failf("Expect at least 1 node, got: %v", nodesNames)
+		nodeList, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
+		framework.ExpectNoError(err)
+
+		nodesNames := []string{}
+		for _, node := range nodeList.Items {
+			nodesNames = append(nodesNames, node.Name)
 		}
 		nodesSet := sets.NewString(nodesNames...)
 

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -51,14 +51,15 @@ var _ = SIGDescribe("Network", func() {
 	fr := framework.NewDefaultFramework("network")
 
 	ginkgo.It("should set TCP CLOSE_WAIT timeout", func() {
-		nodes := framework.GetReadySchedulableNodesOrDie(fr.ClientSet)
-		ips := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
-
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(fr.ClientSet, 2)
+		framework.ExpectNoError(err)
 		if len(nodes.Items) < 2 {
 			framework.Skipf(
 				"Test requires >= 2 Ready nodes, but there are only %v nodes",
 				len(nodes.Items))
 		}
+
+		ips := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
 
 		type NodeInfo struct {
 			node   *v1.Node
@@ -81,7 +82,7 @@ var _ = SIGDescribe("Network", func() {
 		zero := int64(0)
 
 		// Some distributions (Ubuntu 16.04 etc.) don't support the proc file.
-		_, err := e2essh.IssueSSHCommandWithResult(
+		_, err = e2essh.IssueSSHCommandWithResult(
 			"ls /proc/net/nf_conntrack",
 			framework.TestContext.Provider,
 			clientNodeInfo.node)

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/net"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -287,23 +288,16 @@ func truncate(b []byte, maxLen int) []byte {
 	return b2
 }
 
-func pickNode(cs clientset.Interface) (string, error) {
-	// TODO: investigate why it doesn't work on master Node.
-	nodes := framework.GetReadySchedulableNodesOrDie(cs)
-	if len(nodes.Items) == 0 {
-		return "", fmt.Errorf("no nodes exist, can't test node proxy")
-	}
-	return nodes.Items[0].Name, nil
-}
-
 func nodeProxyTest(f *framework.Framework, prefix, nodeDest string) {
-	node, err := pickNode(f.ClientSet)
+	// TODO: investigate why it doesn't work on master Node.
+	node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
 	framework.ExpectNoError(err)
+
 	// TODO: Change it to test whether all requests succeeded when requests
 	// not reaching Kubelet issue is debugged.
 	serviceUnavailableErrors := 0
 	for i := 0; i < proxyAttempts; i++ {
-		_, status, d, err := doProxy(f, prefix+node+nodeDest, i)
+		_, status, d, err := doProxy(f, prefix+node.Name+nodeDest, i)
 		if status == http.StatusServiceUnavailable {
 			framework.Logf("ginkgo.Failed proxying node logs due to service unavailable: %v", err)
 			time.Sleep(time.Second)

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -566,7 +566,9 @@ var _ = SIGDescribe("Services", func() {
 			loadBalancerLagTimeout = e2eservice.LoadBalancerLagTimeoutAWS
 		}
 		loadBalancerCreateTimeout := e2eservice.LoadBalancerCreateTimeoutDefault
-		if nodes := framework.GetReadySchedulableNodesOrDie(cs); len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
 			loadBalancerCreateTimeout = e2eservice.LoadBalancerCreateTimeoutLarge
 		}
 
@@ -1522,7 +1524,9 @@ var _ = SIGDescribe("Services", func() {
 			loadBalancerLagTimeout = e2eservice.LoadBalancerLagTimeoutAWS
 		}
 		loadBalancerCreateTimeout := e2eservice.LoadBalancerCreateTimeoutDefault
-		if nodes := framework.GetReadySchedulableNodesOrDie(cs); len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
 			loadBalancerCreateTimeout = e2eservice.LoadBalancerCreateTimeoutLarge
 		}
 
@@ -1540,7 +1544,6 @@ var _ = SIGDescribe("Services", func() {
 		// This container is an nginx container listening on port 80
 		// See kubernetes/contrib/ingress/echoheaders/nginx.conf for content of response
 		jig.RunOrFail(namespace, nil)
-		var err error
 		// Make sure acceptPod is running. There are certain chances that pod might be teminated due to unexpected reasons.
 		acceptPod, err = cs.CoreV1().Pods(namespace).Get(acceptPod.Name, metav1.GetOptions{})
 		framework.ExpectNoError(err, "Unable to get pod %s", acceptPod.Name)
@@ -1598,7 +1601,9 @@ var _ = SIGDescribe("Services", func() {
 		framework.SkipUnlessProviderIs("azure", "gke", "gce")
 
 		createTimeout := e2eservice.LoadBalancerCreateTimeoutDefault
-		if nodes := framework.GetReadySchedulableNodesOrDie(cs); len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
 			createTimeout = e2eservice.LoadBalancerCreateTimeoutLarge
 		}
 
@@ -2076,7 +2081,9 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 		framework.SkipUnlessProviderIs("gce", "gke")
 
 		cs = f.ClientSet
-		if nodes := framework.GetReadySchedulableNodesOrDie(cs); len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
+		if len(nodes.Items) > e2eservice.LargeClusterMinNodesNumber {
 			loadBalancerCreateTimeout = e2eservice.LoadBalancerCreateTimeoutLarge
 		}
 	})
@@ -2450,7 +2457,8 @@ func execAffinityTestForNonLBServiceWithOptionalTransition(f *framework.Framewor
 	framework.ExpectNoError(err, "failed to fetch service: %s in namespace: %s", serviceName, ns)
 	var svcIP string
 	if serviceType == v1.ServiceTypeNodePort {
-		nodes := framework.GetReadySchedulableNodesOrDie(cs)
+		nodes, err := e2enode.GetReadySchedulableNodes(cs)
+		framework.ExpectNoError(err)
 		addrs := e2enode.CollectAddresses(nodes, v1.NodeInternalIP)
 		gomega.Expect(len(addrs)).To(gomega.BeNumerically(">", 0), "ginkgo.Failed to get Node internal IP")
 		svcIP = addrs[0]

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -295,7 +295,8 @@ var _ = SIGDescribe("Services", func() {
 		framework.Logf("sourceip-test cluster ip: %s", serviceIP)
 
 		ginkgo.By("Picking 2 Nodes to test whether source IP is preserved or not")
-		nodes := jig.GetNodes(2)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, 2)
+		framework.ExpectNoError(err)
 		nodeCounts := len(nodes.Items)
 		if nodeCounts < 2 {
 			framework.Skipf("The test requires at least two ready nodes on %s, but found %v", framework.TestContext.Provider, nodeCounts)
@@ -305,7 +306,7 @@ var _ = SIGDescribe("Services", func() {
 		serverPodName := "echo-sourceip"
 		pod := f.NewAgnhostPod(serverPodName, "netexec", "--http-port", strconv.Itoa(servicePort))
 		pod.Labels = jig.Labels
-		_, err := cs.CoreV1().Pods(ns).Create(pod)
+		_, err = cs.CoreV1().Pods(ns).Create(pod)
 		framework.ExpectNoError(err)
 		framework.ExpectNoError(f.WaitForPodRunning(pod.Name))
 		defer func() {
@@ -1986,7 +1987,8 @@ var _ = SIGDescribe("Services", func() {
 		namespace := f.Namespace.Name
 		serviceName := "no-pods"
 		jig := e2eservice.NewTestJig(cs, serviceName)
-		nodes := jig.GetNodes(e2eservice.MaxNodesForEndpointsTests)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
+		framework.ExpectNoError(err)
 		labels := map[string]string{
 			"nopods": "nopods",
 		}
@@ -1997,7 +1999,7 @@ var _ = SIGDescribe("Services", func() {
 		}}
 
 		ginkgo.By("creating a service with no endpoints")
-		_, err := jig.CreateServiceWithServicePort(labels, namespace, ports)
+		_, err = jig.CreateServiceWithServicePort(labels, namespace, ports)
 		if err != nil {
 			framework.Failf("ginkgo.Failed to create service: %v", err)
 		}
@@ -2169,7 +2171,8 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 		namespace := f.Namespace.Name
 		serviceName := "external-local-nodes"
 		jig := e2eservice.NewTestJig(cs, serviceName)
-		nodes := jig.GetNodes(e2eservice.MaxNodesForEndpointsTests)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
+		framework.ExpectNoError(err)
 
 		svc := jig.CreateOnlyLocalLoadBalancerService(namespace, serviceName, loadBalancerCreateTimeout, false,
 			func(svc *v1.Service) {
@@ -2292,7 +2295,8 @@ var _ = SIGDescribe("ESIPP [Slow] [DisabledForLargeClusters]", func() {
 		serviceName := "external-local-update"
 		jig := e2eservice.NewTestJig(cs, serviceName)
 
-		nodes := jig.GetNodes(e2eservice.MaxNodesForEndpointsTests)
+		nodes, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
+		framework.ExpectNoError(err)
 		if len(nodes.Items) < 2 {
 			framework.Failf("Need at least 2 nodes to verify source ip from a node without endpoint")
 		}

--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -30,6 +30,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	"k8s.io/kubernetes/test/e2e/framework/volume"
@@ -270,18 +271,10 @@ var _ = SIGDescribe("kubelet", func() {
 			// nodes we observe initially.
 			nodeLabels = make(map[string]string)
 			nodeLabels["kubelet_cleanup"] = "true"
-			nodes := framework.GetReadySchedulableNodesOrDie(c)
-			numNodes = len(nodes.Items)
-			framework.ExpectNotEqual(numNodes, 0)
+			nodes, err := e2enode.GetBoundedReadySchedulableNodes(c, maxNodesToCheck)
+			framework.ExpectNoError(err)
 			nodeNames = sets.NewString()
-			// If there are a lot of nodes, we don't want to use all of them
-			// (if there are 1000 nodes in the cluster, starting 10 pods/node
-			// will take ~10 minutes today). And there is also deletion phase.
-			// Instead, we choose at most 10 nodes.
-			if numNodes > maxNodesToCheck {
-				numNodes = maxNodesToCheck
-			}
-			for i := 0; i < numNodes; i++ {
+			for i := 0; i < len(nodes.Items); i++ {
 				nodeNames.Insert(nodes.Items[i].Name)
 			}
 			for nodeName := range nodeNames {

--- a/test/e2e/node/kubelet_perf.go
+++ b/test/e2e/node/kubelet_perf.go
@@ -27,6 +27,7 @@ import (
 	kubeletstatsv1alpha1 "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2eperf "k8s.io/kubernetes/test/e2e/framework/perf"
 	"k8s.io/kubernetes/test/e2e/perftype"
 	testutils "k8s.io/kubernetes/test/utils"
@@ -200,7 +201,8 @@ var _ = SIGDescribe("Kubelet [Serial] [Slow]", func() {
 	var rm *e2ekubelet.ResourceMonitor
 
 	ginkgo.BeforeEach(func() {
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
+		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err)
 		nodeNames = sets.NewString()
 		for _, node := range nodes.Items {
 			nodeNames.Insert(node.Name)

--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -85,9 +86,8 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// propagated to the right places.
 
 		// Pick a node where all pods will run.
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		framework.ExpectNotEqual(len(nodes.Items), 0, "No available nodes for scheduling")
-		node := &nodes.Items[0]
+		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
+		framework.ExpectNoError(err)
 
 		// Fail the test if the namespace is not set. We expect that the
 		// namespace is unique and we might delete user data if it's not.
@@ -139,7 +139,7 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// The host mounts one tmpfs to testdir/host and puts a file there so we
 		// can check mount propagation from the host to pods.
 		cmd := fmt.Sprintf("sudo mkdir %[1]q/host; sudo mount -t tmpfs e2e-mount-propagation-host %[1]q/host; echo host > %[1]q/host/file", hostDir)
-		err := e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+		err = e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
 		framework.ExpectNoError(err)
 
 		defer func() {

--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -58,8 +58,8 @@ var _ = SIGDescribe("NodeProblemDetector [DisabledForLargeClusters]", func() {
 		framework.SkipUnlessSSHKeyPresent()
 
 		ginkgo.By("Getting all nodes and their SSH-able IP addresses")
-		nodes := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		framework.ExpectNotEqual(len(nodes.Items), 0)
+		nodes, err := e2enode.GetReadySchedulableNodes(f.ClientSet)
+		framework.ExpectNoError(err)
 		hosts := []string{}
 		for _, node := range nodes.Items {
 			for _, addr := range node.Status.Addresses {

--- a/test/e2e/scalability/load.go
+++ b/test/e2e/scalability/load.go
@@ -59,6 +59,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/extensions"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	"k8s.io/kubernetes/test/e2e/framework/timer"
 	testutils "k8s.io/kubernetes/test/utils"
 
@@ -158,14 +159,14 @@ var _ = SIGDescribe("Load capacity", func() {
 		clientset = f.ClientSet
 
 		ns = f.Namespace.Name
-		nodes := framework.GetReadySchedulableNodesOrDie(clientset)
-		nodeCount = len(nodes.Items)
-		gomega.Expect(nodeCount).NotTo(gomega.BeZero())
+
+		_, err := e2enode.GetRandomReadySchedulableNode(clientset)
+		framework.ExpectNoError(err)
 
 		// Terminating a namespace (deleting the remaining objects from it - which
 		// generally means events) can affect the current run. Thus we wait for all
 		// terminating namespace to be finally deleted before starting this test.
-		err := framework.CheckTestingNSDeletedExcept(clientset, ns)
+		err = framework.CheckTestingNSDeletedExcept(clientset, ns)
 		framework.ExpectNoError(err)
 
 		framework.ExpectNoError(e2emetrics.ResetMetrics(clientset))

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -95,7 +95,7 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		if err != nil {
 			framework.Logf("Unexpected error occurred: %v", err)
 		}
-		nodeList, err = e2enode.GetReadySchedulableNodesOrDie(cs)
+		nodeList, err = e2enode.GetReadySchedulableNodes(cs)
 		if err != nil {
 			framework.Logf("Unexpected error occurred: %v", err)
 		}

--- a/test/e2e/upgrades/BUILD
+++ b/test/e2e/upgrades/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/job:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/service:go_default_library",
         "//test/e2e/framework/statefulset:go_default_library",
         "//test/e2e/framework/testfiles:go_default_library",

--- a/test/e2e/upgrades/kube_proxy_migration.go
+++ b/test/e2e/upgrades/kube_proxy_migration.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/onsi/ginkgo"
 )
@@ -118,7 +119,13 @@ func waitForKubeProxyStaticPodsRunning(c clientset.Interface) error {
 			return false, nil
 		}
 
-		numberSchedulableNodes := len(framework.GetReadySchedulableNodesOrDie(c).Items)
+		nodes, err := e2enode.GetReadySchedulableNodes(c)
+		if err != nil {
+			framework.Logf("Failed to get nodes: %v", err)
+			return false, nil
+		}
+
+		numberSchedulableNodes := len(nodes.Items)
 		numberkubeProxyPods := 0
 		for _, pod := range pods.Items {
 			if pod.Status.Phase == v1.PodRunning {
@@ -176,7 +183,13 @@ func waitForKubeProxyDaemonSetRunning(c clientset.Interface) error {
 			return false, nil
 		}
 
-		numberSchedulableNodes := len(framework.GetReadySchedulableNodesOrDie(c).Items)
+		nodes, err := e2enode.GetReadySchedulableNodes(c)
+		if err != nil {
+			framework.Logf("Failed to get nodes: %v", err)
+			return false, nil
+		}
+
+		numberSchedulableNodes := len(nodes.Items)
 		numberkubeProxyPods := int(daemonSets.Items[0].Status.NumberAvailable)
 		if numberkubeProxyPods != numberSchedulableNodes {
 			framework.Logf("Expect %v kube-proxy DaemonSet pods running, got %v", numberSchedulableNodes, numberkubeProxyPods)

--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/gpu:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/coreos/go-systemd/util:go_default_library",

--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -179,8 +180,9 @@ func disableCPUManagerInKubelet(f *framework.Framework) (oldCfg *kubeletconfig.K
 
 	// Wait for the Kubelet to be ready.
 	gomega.Eventually(func() bool {
-		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		return len(nodeList.Items) == 1
+		nodes, err := e2enode.TotalReady(f.ClientSet)
+		framework.ExpectNoError(err)
+		return nodes == 1
 	}, time.Minute, time.Second).Should(gomega.BeTrue())
 
 	return oldCfg
@@ -231,8 +233,9 @@ func enableCPUManagerInKubelet(f *framework.Framework, cleanStateFile bool) (old
 
 	// Wait for the Kubelet to be ready.
 	gomega.Eventually(func() bool {
-		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		return len(nodeList.Items) == 1
+		nodes, err := e2enode.TotalReady(f.ClientSet)
+		framework.ExpectNoError(err)
+		return nodes == 1
 	}, time.Minute, time.Second).Should(gomega.BeTrue())
 
 	return oldCfg

--- a/test/e2e_node/node_perf_test.go
+++ b/test/e2e_node/node_perf_test.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	"k8s.io/kubernetes/test/e2e_node/perf/workloads"
 
@@ -48,8 +49,9 @@ func setKubeletConfig(f *framework.Framework, cfg *kubeletconfig.KubeletConfigur
 
 	// Wait for the Kubelet to be ready.
 	gomega.Eventually(func() bool {
-		nodeList := framework.GetReadySchedulableNodesOrDie(f.ClientSet)
-		return len(nodeList.Items) == 1
+		nodes, err := e2enode.TotalReady(f.ClientSet)
+		framework.ExpectNoError(err)
+		return nodes == 1
 	}, time.Minute, time.Second).Should(gomega.BeTrue())
 }
 

--- a/test/integration/framework/BUILD
+++ b/test/integration/framework/BUILD
@@ -67,7 +67,7 @@ go_library(
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
-        "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/node:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",

--- a/test/integration/framework/perf_utils.go
+++ b/test/integration/framework/perf_utils.go
@@ -21,7 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	e2eframework "k8s.io/kubernetes/test/e2e/framework"
+	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	testutils "k8s.io/kubernetes/test/utils"
 
 	"k8s.io/klog"
@@ -84,7 +84,10 @@ func (p *IntegrationTestNodePreparer) PrepareNodes() error {
 		}
 	}
 
-	nodes := e2eframework.GetReadySchedulableNodesOrDie(p.client)
+	nodes, err := e2enode.GetReadySchedulableNodes(p.client)
+	if err != nil {
+		klog.Fatalf("Error listing nodes: %v", err)
+	}
 	index := 0
 	sum := 0
 	for _, v := range p.countToStrategy {
@@ -101,7 +104,10 @@ func (p *IntegrationTestNodePreparer) PrepareNodes() error {
 
 // CleanupNodes deletes existing test nodes.
 func (p *IntegrationTestNodePreparer) CleanupNodes() error {
-	nodes := e2eframework.GetReadySchedulableNodesOrDie(p.client)
+	nodes, err := e2enode.GetReadySchedulableNodes(p.client)
+	if err != nil {
+		klog.Fatalf("Error listing nodes: %v", err)
+	}
 	for i := range nodes.Items {
 		if err := p.client.CoreV1().Nodes().Delete(nodes.Items[i].Name, &metav1.DeleteOptions{}); err != nil {
 			klog.Errorf("Error while deleting Node: %v", err)


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrates tests from `framework.GetReadySchedulableNodesOrDie` to `e2enode.GetReadySchedulableNodes` and then gets rid of `framework.GetReadySchedulableNodesOrDie` (and `e2eservice.TestJig.GetNodes`).

In doing this, I found four common special cases:
1. Many tests just want to assert that at least one ready, schedulable node exists.
2. Many tests want a single ready schedulable node. (Many of these tests currently always use "`nodes.Items[0]`". Others pick a random one.)
3. Many tests want *at most N* randomly-selected ready schedulable nodes
4. Many tests want to know the *number* of ready, schedulable nodes, but don't care about any of the details.

For 2 (gimme a random node), I added `GetRandomReadySchedulableNode`. It mostly doesn't really make the code much shorter, but it seems a little more self-documenting. Likewise I used that in the cases that are doing 1 (assert at least one node exists) because the naming seems sufficiently self-documenting that I could get rid of comments in some cases.

For 3, I added a `max` parameter to `GetReadySchedulableNodes`, and had it return a random subset of nodes if `max != -1` and the total number is larger than `max`. In the original version of this PR I added a separate `GetBoundedReadySchedulableNodes` method for that case, but it seemed to me like maybe it would be good to add the `max` arg to the main function, so that every caller is forced to think about whether they really should be operating on *all* of the nodes or not. (I'm not convinced this was the right decision.)

I ended up not doing anything about 4 (counting nodes) because it's not that hard to just get the list and call `len()` on it.

I also changed `GetReadySchedulableNodes` to return an error if there are no ready, schedulable nodes, rather than just returning an empty list. Many tests already had an assertion about this, and in basically all other cases the test would not actually be useful if there were no nodes to work with. There was one function (`test/e2e/framework/providers/gce/gce.go:GetNodeTags()`) that explicitly considered 0 nodes to be not an error, but nothing calls that function anyway...

(EDIT: I missed `test/e2e_node/`. It turns out there are tests there that would want to distinguish between "can't list nodes" and "there are 0 nodes". I changed them to use `e2enode.TotalReady`.)

I ported over every existing user of the old function just to test out whether my API changes seemed right or not, but I could move some of that into separate PRs if you want this smaller. The `GetRandomReadySchedulableNode` change is also an independent commit and could be split into a separate PR.

```release-note
NONE
```

/kind cleanup
/assign timothysc