### PR TITLE
kubelet: fix removeTerminatedContainers and removeTerminatedPods

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -715,19 +715,10 @@ func removeTerminatedPods(pods []*runtimeapi.PodSandbox) []*runtimeapi.PodSandbo
 
 	result := make([]*runtimeapi.PodSandbox, 0)
 	for _, refs := range podMap {
-		if len(refs) == 1 {
-			result = append(result, refs[0])
-			continue
-		}
-		found := false
 		for i := 0; i < len(refs); i++ {
 			if refs[i].State == runtimeapi.PodSandboxState_SANDBOX_READY {
-				found = true
 				result = append(result, refs[i])
 			}
-		}
-		if !found {
-			result = append(result, refs[len(refs)-1])
 		}
 	}
 	return result
@@ -752,19 +743,10 @@ func removeTerminatedContainers(containers []*runtimeapi.Container) []*runtimeap
 
 	result := make([]*runtimeapi.Container, 0)
 	for _, refs := range containerMap {
-		if len(refs) == 1 {
-			result = append(result, refs[0])
-			continue
-		}
-		found := false
 		for i := 0; i < len(refs); i++ {
 			if refs[i].State == runtimeapi.ContainerState_CONTAINER_RUNNING {
-				found = true
 				result = append(result, refs[i])
 			}
-		}
-		if !found {
-			result = append(result, refs[len(refs)-1])
 		}
 	}
 	return result

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -231,7 +231,7 @@ func TestCRIListPodStats(t *testing.T) {
 	stats, err := provider.ListPodStats()
 	assert := assert.New(t)
 	assert.NoError(err)
-	assert.Equal(4, len(stats))
+	assert.Equal(3, len(stats))
 
 	podStatsMap := make(map[statsapi.PodReference]statsapi.PodStats)
 	for _, s := range stats {
@@ -296,17 +296,7 @@ func TestCRIListPodStats(t *testing.T) {
 	checkCRIPodCPUAndMemoryStats(assert, p2, infos[sandbox2Cgroup].Stats[0])
 
 	p3 := podStatsMap[statsapi.PodReference{Name: "sandbox3-name", UID: "sandbox3-uid", Namespace: "sandbox3-ns"}]
-	assert.Equal(sandbox3.CreatedAt, p3.StartTime.UnixNano())
-	assert.Equal(1, len(p3.Containers))
-
-	c5 := p3.Containers[0]
-	assert.Equal(cName5, c5.Name)
-	assert.Equal(container5.CreatedAt, c5.StartTime.UnixNano())
-	assert.NotNil(c5.CPU.Time)
-	assert.Zero(*c5.CPU.UsageCoreNanoSeconds)
-	assert.Zero(*c5.CPU.UsageNanoCores)
-	assert.NotNil(c5.Memory.Time)
-	assert.Zero(*c5.Memory.WorkingSetBytes)
+	assert.Equal(0, len(p3.Containers))
 
 	mockCadvisor.AssertExpectations(t)
 }
@@ -414,7 +404,7 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 	stats, err := provider.ListPodCPUAndMemoryStats()
 	assert := assert.New(t)
 	assert.NoError(err)
-	assert.Equal(4, len(stats))
+	assert.Equal(3, len(stats))
 
 	podStatsMap := make(map[statsapi.PodReference]statsapi.PodStats)
 	for _, s := range stats {
@@ -484,17 +474,7 @@ func TestCRIListPodCPUAndMemoryStats(t *testing.T) {
 	assert.Nil(c2.UserDefinedMetrics)
 
 	p3 := podStatsMap[statsapi.PodReference{Name: "sandbox3-name", UID: "sandbox3-uid", Namespace: "sandbox3-ns"}]
-	assert.Equal(sandbox3.CreatedAt, p3.StartTime.UnixNano())
-	assert.Equal(1, len(p3.Containers))
-
-	c5 := p3.Containers[0]
-	assert.Equal(cName5, c5.Name)
-	assert.Equal(container5.CreatedAt, c5.StartTime.UnixNano())
-	assert.NotNil(c5.CPU.Time)
-	assert.Zero(*c5.CPU.UsageCoreNanoSeconds)
-	assert.Zero(*c5.CPU.UsageNanoCores)
-	assert.NotNil(c5.Memory.Time)
-	assert.Zero(*c5.Memory.WorkingSetBytes)
+	assert.Equal(0, len(p3.Containers))
 
 	mockCadvisor.AssertExpectations(t)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In `removeTerminatedContainers` and `removeTerminatedPods` there is a clause to append the last ref in the list regardless of state. There is also a clause to arbitrarily inject the first ref if the length is 1. A pod with high restarts may erroneously get appended to these lists causing duplicate metrics in the Prometheus stream.

**Which issue(s) this PR fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1748073

**Special notes for your reviewer**:
Originating PR: https://github.com/kubernetes/kubernetes/pull/54606
Originating PR: https://github.com/kubernetes/kubernetes/pull/77426

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```

/cc @sjenning @kubernetes/sig-node-pr-reviews 