### PR TITLE
Return error when connection attempt encounters too many FDs

### DIFF
--- a/pkg/proxy/userspace/proxysocket.go
+++ b/pkg/proxy/userspace/proxysocket.go
@@ -104,7 +104,7 @@ func TryConnectEndpoints(service proxy.ServicePortName, srcAddr net.Addr, protoc
 		outConn, err := net.DialTimeout(protocol, endpoint, dialTimeout)
 		if err != nil {
 			if isTooManyFDsError(err) {
-				panic("Dial failed: " + err.Error())
+				return nil, fmt.Errorf("Dial failed: %v", err.Error())
 			}
 			klog.Errorf("Dial failed: %v", err)
 			sessionAffinityReset = true


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For TryConnectEndpoints, this PR removes the panic. Instead, we return the error to caller.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
