### PR TITLE
pkg/kubelet: fix uint64 overflow when elapsed UsageCoreNanoSeconds exceeds 18446744073

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -661,7 +661,8 @@ func (p *criStatsProvider) getAndUpdateContainerUsageNanoCores(stats *runtimeapi
 		if nanoSeconds <= 0 {
 			return nil, fmt.Errorf("zero or negative interval (%v - %v)", newStats.Timestamp, cachedStats.Timestamp)
 		}
-		usageNanoCores := (newStats.UsageCoreNanoSeconds.Value - cachedStats.UsageCoreNanoSeconds.Value) * uint64(time.Second/time.Nanosecond) / uint64(nanoSeconds)
+		usageNanoCores := uint64(float64(newStats.UsageCoreNanoSeconds.Value-cachedStats.UsageCoreNanoSeconds.Value) /
+			float64(nanoSeconds) * float64(time.Second/time.Nanosecond))
 
 		// Update cache with new value.
 		usageToUpdate := usageNanoCores

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -757,6 +757,7 @@ func makeFakeLogStats(seed int) *volume.Metrics {
 func TestGetContainerUsageNanoCores(t *testing.T) {
 	var value0 uint64
 	var value1 uint64 = 10000000000
+	var value2 uint64 = 188427786383
 
 	tests := []struct {
 		desc          string
@@ -855,6 +856,31 @@ func TestGetContainerUsageNanoCores(t *testing.T) {
 				},
 			},
 			expected: &value1,
+		},
+		{
+			desc: "should return correct value if elapsed UsageCoreNanoSeconds exceeds 18446744073",
+			stats: &runtimeapi.ContainerStats{
+				Attributes: &runtimeapi.ContainerAttributes{
+					Id: "1",
+				},
+				Cpu: &runtimeapi.CpuUsage{
+					Timestamp: int64(time.Second / time.Nanosecond),
+					UsageCoreNanoSeconds: &runtimeapi.UInt64Value{
+						Value: 68172016162105,
+					},
+				},
+			},
+			cpuUsageCache: map[string]*cpuUsageRecord{
+				"1": {
+					stats: &runtimeapi.CpuUsage{
+						Timestamp: 0,
+						UsageCoreNanoSeconds: &runtimeapi.UInt64Value{
+							Value: 67983588375722,
+						},
+					},
+				},
+			},
+			expected: &value2,
 		},
 	}
 

--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -757,6 +757,8 @@ func makeFakeLogStats(seed int) *volume.Metrics {
 func TestGetContainerUsageNanoCores(t *testing.T) {
 	var value0 uint64
 	var value1 uint64 = 10000000000
+
+	// Test with a large container of 100+ CPUs
 	var value2 uint64 = 188427786383
 
 	tests := []struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a nanocore calculation overflow in the CRI stats provider when tens of CPUs are actively used by a container. The original calculation quickly exceeds MaxUint64 during the multiplication of the constant `uint64(time.Second/time.Nanosecond)` (1000000000). Moving the calculation to a float64 fixes the issue and maps to how nanocores are calculated elsewhere in kubernetes.

**Which issue(s) this PR fixes**:
Fixes #82195

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
```
