### PR TITLE
Make sure loadbalancer service is deleted before exiting the test

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1565,14 +1565,9 @@ var _ = SIGDescribe("Services", func() {
 			svc.Spec.LoadBalancerSourceRanges = []string{acceptPod.Status.PodIP + "/32"}
 		})
 
-		// Clean up loadbalancer service
 		defer func() {
-			jig.UpdateServiceOrFail(svc.Namespace, svc.Name, func(svc *v1.Service) {
-				svc.Spec.Type = v1.ServiceTypeNodePort
-				svc.Spec.LoadBalancerSourceRanges = nil
-			})
-			err := cs.CoreV1().Services(svc.Namespace).Delete(svc.Name, nil)
-			framework.ExpectNoError(err)
+			ginkgo.By("Clean up loadbalancer service")
+			e2eservice.WaitForServiceDeletedWithFinalizer(cs, svc.Namespace, svc.Name)
 		}()
 
 		svc = jig.WaitForLoadBalancerOrFail(namespace, serviceName, loadBalancerCreateTimeout)
@@ -1641,6 +1636,12 @@ var _ = SIGDescribe("Services", func() {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			enableILB(svc)
 		})
+
+		defer func() {
+			ginkgo.By("Clean up loadbalancer service")
+			e2eservice.WaitForServiceDeletedWithFinalizer(cs, svc.Namespace, svc.Name)
+		}()
+
 		svc = jig.WaitForLoadBalancerOrFail(namespace, serviceName, createTimeout)
 		jig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
 		lbIngress := &svc.Status.LoadBalancer.Ingress[0]
@@ -1723,9 +1724,6 @@ var _ = SIGDescribe("Services", func() {
 			jig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
 			framework.ExpectEqual(e2eservice.GetIngressPoint(lbIngress), internalStaticIP)
 		}
-
-		ginkgo.By("switching to ClusterIP type to destroy loadbalancer")
-		jig.ChangeServiceType(svc.Namespace, svc.Name, v1.ServiceTypeClusterIP, createTimeout)
 	})
 
 	// This test creates a load balancer, make sure its health check interval
@@ -1757,13 +1755,9 @@ var _ = SIGDescribe("Services", func() {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		})
 
-		// Clean up loadbalancer service
 		defer func() {
-			jig.UpdateServiceOrFail(svc.Namespace, svc.Name, func(svc *v1.Service) {
-				svc.Spec.Type = v1.ServiceTypeNodePort
-			})
-			err = cs.CoreV1().Services(svc.Namespace).Delete(svc.Name, nil)
-			framework.ExpectNoError(err)
+			ginkgo.By("Clean up loadbalancer service")
+			e2eservice.WaitForServiceDeletedWithFinalizer(cs, svc.Namespace, svc.Name)
 		}()
 
 		svc = jig.WaitForLoadBalancerOrFail(namespace, serviceName, e2eservice.LoadBalancerCreateTimeoutDefault)


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Ref https://github.com/kubernetes/kubernetes/issues/82186#issuecomment-527674286, I originally planed to bump the namespace deletion timeout on large cluster, but later realized it makes more sense to make sure the loadbalancer service is cleaned up before exiting the test, so we don't simply lay the burden to the test framework.

This PR applies the same fix to other relevant LB tests as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82186 

**Special notes for your reviewer**:
cc @oxddr @lachie83 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
