### PR TITLE
Add dns capability to GCE window cluster

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -805,6 +805,10 @@ function construct-linux-kubelet-flags {
 }
 
 # Sets KUBELET_ARGS with the kubelet flags for Windows nodes.
+# Note that to configure flags with explicit empty string values, we can't escape
+# double-quotes, because they still break sc.exe after expansion in the
+# binPath parameter, and single-quotes get parsed as characters instead of
+# string delimiters.
 function construct-windows-kubelet-flags {
   local flags="$(construct-common-kubelet-flags)"
 
@@ -868,11 +872,8 @@ function construct-windows-kubelet-flags {
   # actually log to the file
   flags+=" --logtostderr=false"
 
-  # Configure flags with explicit empty string values. We can't escape
-  # double-quotes, because they still break sc.exe after expansion in the
-  # binPath parameter, and single-quotes get parsed as characters instead of
-  # string delimiters.
-  flags+=" --resolv-conf="
+  # Configure the file path for host dns configuration
+  flags+=" --resolv-conf=${WINDOWS_CNI_CONFIG_DIR}\hostdns.conf"
 
   # Both --cgroups-per-qos and --enforce-node-allocatable should be disabled on
   # windows; the latter requires the former to be enabled to work.

--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -126,6 +126,7 @@ try {
   Set-PodCidr
   Configure-HostNetworkingService
   Configure-CniNetworking
+  Configure-HostDnsConf
   Configure-GcePdTools
   Configure-Kubelet
 

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -857,7 +857,8 @@ function Configure-CniNetworking {
   "name":  "l2bridge",
   "type":  "win-bridge",
   "capabilities":  {
-    "portMappings":  true
+    "portMappings":  true,
+    "dns": true
   },
   "ipam":  {
     "type": "host-local",
@@ -911,6 +912,28 @@ function Configure-CniNetworking {
   replace('MGMT_SUBNET', ${mgmt_subnet})
 
   Log-Output "CNI config:`n$(Get-Content -Raw ${l2bridge_conf})"
+}
+
+# Obtain the host dns conf and save it to a file so that kubelet/CNI
+# can use it to configure dns suffix search list for pods.
+# The value of DNS server is ignored right now because the pod will
+# always only use cluster DNS service, but for consistency, we still
+# parsed them here in the same format as Linux resolv.conf.
+# This function must be called after Configure-HostNetworkingService.
+function Configure-HostDnsConf {
+  $net_adapter = Get_MgmtNetAdapter
+  $server_ips = (Get-DnsClientServerAddress `
+          -InterfaceAlias ${net_adapter}.Name).ServerAddresses
+  $search_list = (Get-DnsClient).ConnectionSpecificSuffixSearchList
+  $conf = ""
+  ForEach ($ip in $server_ips)  {
+	$conf = $conf + "nameserver $ip`r`n"
+  }
+  $conf = $conf + "search $search_list"
+  $hostdns_conf = "${env:CNI_CONFIG_DIR}\hostdns.conf"
+  New-Item -Force -ItemType file ${hostdns_conf} | Out-Null
+  Set-Content ${hostdns_conf} $conf
+  Log-Output "HOST dns conf:`n$(Get-Content -Raw ${hostdns_conf})"
 }
 
 # Fetches the kubelet config from the instance metadata and puts it at


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Add dns capability to GCE/GKE window clusters so that dns suffix search list will be programmed for windows pods.

**Which issue(s) this PR fixes**:
User cannot do dns lookup without full FQDN, such as service name, from their windows pods.

**Does this PR introduce a user-facing change?**:
None

```release-note
Fix the dns suffix search list for GCE window clusters.
```

