### PR TITLE
Return default randomAllocator when port range is absent

### DIFF
--- a/pkg/proxy/userspace/port_allocator.go
+++ b/pkg/proxy/userspace/port_allocator.go
@@ -76,7 +76,7 @@ type rangeAllocator struct {
 
 func newPortRangeAllocator(r net.PortRange, autoFill bool) PortAllocator {
 	if r.Base == 0 || r.Size == 0 {
-		panic("illegal argument: may not specify an empty port range")
+		return &randomAllocator{}
 	}
 	ra := &rangeAllocator{
 		PortRange: r,

--- a/pkg/proxy/userspace/port_allocator_test.go
+++ b/pkg/proxy/userspace/port_allocator_test.go
@@ -23,17 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/net"
 )
 
-func TestRangeAllocatorEmpty(t *testing.T) {
-	r := &net.PortRange{}
-	r.Set("0-0")
-	defer func() {
-		if rv := recover(); rv == nil {
-			t.Fatalf("expected panic because of empty port range: %#v", r)
-		}
-	}()
-	_ = newPortRangeAllocator(*r, true)
-}
-
 func TestRangeAllocatorFullyAllocated(t *testing.T) {
 	r := &net.PortRange{}
 	r.Set("1-1")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently for newPortRangeAllocator, when Base is 0, default randomAllocator is returned.
However, newPortRangeAllocator checks whether Base is 0 and panics if that is the case.

This PR fixes the inconsistency by returning default allocator.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
