### PR TITLE
Skip PriorityConfigFactory registration if the factory pointer is nil

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -334,7 +334,9 @@ func (c *Configurator) CreateFromConfig(policy schedulerapi.Policy) (*Config, er
 	} else {
 		for _, priority := range policy.Priorities {
 			klog.V(2).Infof("Registering priority: %s", priority.Name)
-			priorityKeys.Insert(RegisterCustomPriorityFunction(priority))
+			if key := RegisterCustomPriorityFunction(priority); len(key) > 0 {
+				priorityKeys.Insert(key)
+			}
 		}
 	}
 

--- a/pkg/scheduler/factory/plugins.go
+++ b/pkg/scheduler/factory/plugins.go
@@ -409,6 +409,7 @@ func RegisterCustomPriorityFunction(policy schedulerapi.PriorityPolicy) string {
 
 	if pcf == nil {
 		klog.Fatalf("Invalid configuration: Priority type not found for %s", policy.Name)
+		return ""
 	}
 
 	return RegisterPriorityConfigFactory(policy.Name, *pcf)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When PriorityConfigFactory pointer is nil, we should skip registering the factory, avoiding nil pointer reference.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
