### PR TITLE
Poll block device size on live storage resize

### DIFF
--- a/pkg/util/resizefs/BUILD
+++ b/pkg/util/resizefs/BUILD
@@ -11,37 +11,50 @@ go_library(
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
+            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+            "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/klog:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:nacl": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/util/mount:go_default_library",
+            "//pkg/volume:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/util/resizefs/resizefs_linux.go
+++ b/pkg/util/resizefs/resizefs_linux.go
@@ -112,8 +112,7 @@ func findBlockDeviceRescanPath(path string) (string, error) {
 	// return just the last part
 	parts := strings.Split(devicePath, "/")
 	if len(parts) == 3 && strings.HasPrefix(parts[1], "dev") {
-		blockPath := "/sys/block" + "/" + parts[2] + "/device/rescan"
-		return filepath.EvalSymlinks(blockPath)
+		return filepath.EvalSymlinks(filepath.Join("/sys/block", parts[2], "device", "rescan"))
 	}
 	return "", fmt.Errorf("Illegal path for device " + devicePath)
 }

--- a/pkg/util/resizefs/resizefs_unsupported.go
+++ b/pkg/util/resizefs/resizefs_unsupported.go
@@ -35,6 +35,6 @@ func NewResizeFs(mounter *mount.SafeFormatAndMount) *ResizeFs {
 }
 
 // Resize perform resize of file system
-func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string) (bool, error) {
+func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string, rescanDevice bool) (bool, error) {
 	return false, fmt.Errorf("Resize is not supported for this build")
 }

--- a/pkg/util/resizefs/resizefs_unsupported.go
+++ b/pkg/util/resizefs/resizefs_unsupported.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"k8s.io/kubernetes/pkg/util/mount"
+	"k8s.io/kubernetes/pkg/volume"
 )
 
 // ResizeFs Provides support for resizing file systems
@@ -35,6 +36,6 @@ func NewResizeFs(mounter *mount.SafeFormatAndMount) *ResizeFs {
 }
 
 // Resize perform resize of file system
-func (resizefs *ResizeFs) Resize(devicePath string, deviceMountPath string, rescanDevice bool) (bool, error) {
+func (resizefs *ResizeFs) Resize(resizeOptions volume.NodeResizeOptions, rescanDevice bool) (bool, error) {
 	return false, fmt.Errorf("Resize is not supported for this build")
 }

--- a/pkg/volume/awsebs/aws_ebs.go
+++ b/pkg/volume/awsebs/aws_ebs.go
@@ -334,7 +334,7 @@ func (plugin *awsElasticBlockStorePlugin) NodeExpand(resizeOptions volume.NodeRe
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/awsebs/aws_ebs.go
+++ b/pkg/volume/awsebs/aws_ebs.go
@@ -334,7 +334,7 @@ func (plugin *awsElasticBlockStorePlugin) NodeExpand(resizeOptions volume.NodeRe
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -308,7 +308,7 @@ func (plugin *azureDataDiskPlugin) NodeExpand(resizeOptions volume.NodeResizeOpt
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/azure_dd/azure_dd.go
+++ b/pkg/volume/azure_dd/azure_dd.go
@@ -308,7 +308,7 @@ func (plugin *azureDataDiskPlugin) NodeExpand(resizeOptions volume.NodeResizeOpt
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -322,7 +322,7 @@ func (plugin *cinderPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (
 		return true, nil
 	}
 
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, true)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -322,7 +322,7 @@ func (plugin *cinderPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (
 		return true, nil
 	}
 
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, true)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions, true)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/flexvolume/expander-defaults.go
+++ b/pkg/volume/flexvolume/expander-defaults.go
@@ -51,7 +51,7 @@ func (e *expanderDefaults) NodeExpand(rsOpt volume.NodeResizeOptions) (bool, err
 		return true, nil
 	}
 
-	_, err = util.GenericResizeFS(e.plugin.host, e.plugin.GetPluginName(), rsOpt.DevicePath, rsOpt.DeviceMountPath)
+	_, err = util.GenericResizeFS(e.plugin.host, e.plugin.GetPluginName(), rsOpt.DevicePath, rsOpt.DeviceMountPath, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/flexvolume/expander-defaults.go
+++ b/pkg/volume/flexvolume/expander-defaults.go
@@ -51,7 +51,7 @@ func (e *expanderDefaults) NodeExpand(rsOpt volume.NodeResizeOptions) (bool, err
 		return true, nil
 	}
 
-	_, err = util.GenericResizeFS(e.plugin.host, e.plugin.GetPluginName(), rsOpt.DevicePath, rsOpt.DeviceMountPath, false)
+	_, err = util.GenericResizeFS(e.plugin.host, e.plugin.GetPluginName(), rsOpt, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -290,7 +290,7 @@ func (plugin *gcePersistentDiskPlugin) NodeExpand(resizeOptions volume.NodeResiz
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/gcepd/gce_pd.go
+++ b/pkg/volume/gcepd/gce_pd.go
@@ -290,7 +290,7 @@ func (plugin *gcePersistentDiskPlugin) NodeExpand(resizeOptions volume.NodeResiz
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
+	_, err = util.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -211,7 +211,7 @@ func (plugin *rbdPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (boo
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = volutil.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath)
+	_, err = volutil.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -211,7 +211,7 @@ func (plugin *rbdPlugin) NodeExpand(resizeOptions volume.NodeResizeOptions) (boo
 	if !fsVolume {
 		return true, nil
 	}
-	_, err = volutil.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions.DevicePath, resizeOptions.DeviceMountPath, false)
+	_, err = volutil.GenericResizeFS(plugin.host, plugin.GetPluginName(), resizeOptions, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -263,12 +263,12 @@ func MergeResizeConditionOnPVC(
 }
 
 // GenericResizeFS : call generic filesystem resizer for plugins that don't have any special filesystem resize requirements
-func GenericResizeFS(host volume.VolumeHost, pluginName, devicePath, deviceMountPath string) (bool, error) {
+func GenericResizeFS(host volume.VolumeHost, pluginName, devicePath, deviceMountPath string, rescanDevice bool) (bool, error) {
 	mounter := host.GetMounter(pluginName)
 	diskFormatter := &mount.SafeFormatAndMount{
 		Interface: mounter,
 		Exec:      host.GetExec(pluginName),
 	}
 	resizer := resizefs.NewResizeFs(diskFormatter)
-	return resizer.Resize(devicePath, deviceMountPath)
+	return resizer.Resize(devicePath, deviceMountPath, rescanDevice)
 }

--- a/pkg/volume/util/resize_util.go
+++ b/pkg/volume/util/resize_util.go
@@ -263,12 +263,12 @@ func MergeResizeConditionOnPVC(
 }
 
 // GenericResizeFS : call generic filesystem resizer for plugins that don't have any special filesystem resize requirements
-func GenericResizeFS(host volume.VolumeHost, pluginName, devicePath, deviceMountPath string, rescanDevice bool) (bool, error) {
+func GenericResizeFS(host volume.VolumeHost, pluginName string, resizeOptions volume.NodeResizeOptions, rescanDevice bool) (bool, error) {
 	mounter := host.GetMounter(pluginName)
 	diskFormatter := &mount.SafeFormatAndMount{
 		Interface: mounter,
 		Exec:      host.GetExec(pluginName),
 	}
 	resizer := resizefs.NewResizeFs(diskFormatter)
-	return resizer.Resize(devicePath, deviceMountPath, rescanDevice)
+	return resizer.Resize(resizeOptions, rescanDevice)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR allows kubelet to poll the new size of the attached block device, when it has been resized in a live (in-use) mode.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82281

**Special notes for your reviewer**:

Can be used with OpenStack Cinder CSI plugin as well as built-in cinder plugin (PR: https://github.com/kubernetes/cloud-provider-openstack/issues/748)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Poll block device size on live storage resize
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
