### PR TITLE
Skip deleted keys in strategicpatch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1329,10 +1329,12 @@ func mergeMap(original, patch map[string]interface{}, schema LookupPatchMeta, me
 			}
 		}
 
-		_, ok := original[k]
-		if !ok {
-			// If it's not in the original document, just take the patch value.
-			original[k] = patchV
+		val, ok := original[k]
+		if !ok || val == nil {
+			if !isDeleteList {
+				// If it's not in the original document, just take the patch value.
+				original[k] = patchV
+			}
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:


/kind bug

**What this PR does / why we need it**:

When I delete a finalizer from an empty or null array,  strategicpatch will add it to the array.

Code:
```go
func main() {
	out, err := strategicpatch.StrategicMergePatch(origin, patch, &v1.Pod{})
	if err != nil {
		log.Fatal(err)
	}
	fmt.Printf("%s", out)
}

var origin = []byte(`{
    "metadata": {
	  "finalizers": null
    }
}`)

var patch = []byte(`{
    "metadata": {
        "$deleteFromPrimitiveList/finalizers": [
            "finalizer.k8s.alipay.com/myfinalizer"
        ]
    }
}`)
```
Output:
```
{"metadata":{"finalizers":["finalizer.k8s.alipay.com/myfinalizer"]}}
```

`"metadata": {}` generates the same result.


This is caused by removing finalizers in parallel.

The procedure: I assumes that there are two controllers have added finalizers. When I delete the object:
```
A receives the event.
B receives the event.
A generates a patch to remove A's finalizer.
B generates a patch to remove B's finalizer.
// To simplify the interpretation, I assume A is prior to B and the object is not deleted because of other finalizers.
B receives an update event (caused by A)
B regenerates a patch to remove B's finalizer.
B Got 422 from apiserver:
  Forbidden: no new finalizers can be added if the object is being deleted, found new finalizers []string{\"finalizer_of_B\"}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Skip deleted keys in strategicpatch
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
