### PR TITLE
Cleanup staticcheck for package cache

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -213,7 +213,6 @@ vendor/k8s.io/client-go/metadata/fake
 vendor/k8s.io/client-go/rest
 vendor/k8s.io/client-go/rest/watch
 vendor/k8s.io/client-go/restmapper
-vendor/k8s.io/client-go/tools/cache
 vendor/k8s.io/client-go/tools/leaderelection
 vendor/k8s.io/client-go/transport
 vendor/k8s.io/cloud-provider/service/helpers

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -539,13 +539,6 @@ func (f *DeltaFIFO) Resync() error {
 	return nil
 }
 
-func (f *DeltaFIFO) syncKey(key string) error {
-	f.lock.Lock()
-	defer f.lock.Unlock()
-
-	return f.syncKeyLocked(key)
-}
-
 func (f *DeltaFIFO) syncKeyLocked(key string) error {
 	obj, exists, err := f.knownObjects.GetByKey(key)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/tools/cache/reflector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector.go
@@ -45,8 +45,6 @@ import (
 type Reflector struct {
 	// name identifies this reflector. By default it will be a file:line if possible.
 	name string
-	// metrics tracks basic metric information about the reflector
-	metrics *reflectorMetrics
 
 	// The type of object we expect to place in the store.
 	expectedType reflect.Type
@@ -128,9 +126,6 @@ func (r *Reflector) Run(stopCh <-chan struct{}) {
 var (
 	// nothing will ever be sent down this channel
 	neverExitWatch <-chan time.Time = make(chan time.Time)
-
-	// Used to indicate that watching stopped so that a resync could happen.
-	errorResyncRequested = errors.New("resync channel fired")
 
 	// Used to indicate that watching stopped because of a signal from the stop
 	// channel passed in from a client of the reflector.

--- a/staging/src/k8s.io/client-go/tools/cache/reflector_metrics.go
+++ b/staging/src/k8s.io/client-go/tools/cache/reflector_metrics.go
@@ -47,19 +47,6 @@ func (noopMetric) Dec()            {}
 func (noopMetric) Observe(float64) {}
 func (noopMetric) Set(float64)     {}
 
-type reflectorMetrics struct {
-	numberOfLists       CounterMetric
-	listDuration        SummaryMetric
-	numberOfItemsInList SummaryMetric
-
-	numberOfWatches      CounterMetric
-	numberOfShortWatches CounterMetric
-	watchDuration        SummaryMetric
-	numberOfItemsInWatch SummaryMetric
-
-	lastResourceVersion GaugeMetric
-}
-
 // MetricsProvider generates various metrics used by the reflector.
 type MetricsProvider interface {
 	NewListsMetric(name string) CounterMetric


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleanup issues identified by staticcheck in #81189

Errors from staticcheck:
```
vendor/k8s.io/client-go/tools/cache/delta_fifo.go:542:21: func (*DeltaFIFO).syncKey is unused (U1000)
vendor/k8s.io/client-go/tools/cache/reflector.go:49:2: field metrics is unused (U1000)
vendor/k8s.io/client-go/tools/cache/reflector.go:133:2: var errorResyncRequested is unused (U1000)
vendor/k8s.io/client-go/tools/cache/reflector_metrics.go:50:6: type reflectorMetrics is unused (U1000)
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
