### PR TITLE
fix(scheduler): remove the defer function cost

### DIFF
--- a/test/integration/scheduler_perf/scheduler_bench_test.go
+++ b/test/integration/scheduler_perf/scheduler_bench_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -409,6 +409,9 @@ func benchmarkScheduling(numNodes, numExistingPods, minPods int,
 		// Since the total amount of time is relatively large, it might not be a concern.
 		time.Sleep(100 * time.Millisecond)
 	}
+
+	// Note: without this line we're taking the overhead of defer() into account.
+	b.StopTimer()
 }
 
 // makeBasePodWithSecrets creates a Pod object to be used as a template.


### PR DESCRIPTION
/kind bug
/sig scheduling
/priority important-longterm

**What this PR does / why we need it**:

Remove the cost of the defer function in the scheduler perf test.

#### Without StopTimer

```go
package main

import "testing"
import "time"

func test() {
	 // ...
}

func BenchmarkWithoutStopTimer(b *testing.B) {
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
		test()
	}

	defer time.Sleep(1 * time.Second)
}

$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/golang
BenchmarkLocality-8   	       1	1001293479 ns/op
PASS
ok  	github.com/golang	1.010s
(base)
```

#### With StopTimer


```go
package main

import "testing"
import "time"

func test() {
	 // ...
}

func BenchmarkLocality(b *testing.B) {
	b.ResetTimer()

	for i := 0; i < b.N; i++ {
	    test()
	}

	defer time.Sleep(1 * time.Second)
	b.StopTimer()
}

$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/golang
BenchmarkLocality-8   	   30000	     45513 ns/op
PASS
ok  	github.com/golang	5.866s
(base)
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref: #81719

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
