### PR TITLE
kubelet e2e: defer the close to after the error check

### DIFF
--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -168,10 +168,10 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 
 			gomega.Eventually(func() error {
 				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream()
-				defer rc.Close()
 				if err != nil {
 					return err
 				}
+				defer rc.Close()
 				buf := new(bytes.Buffer)
 				buf.ReadFrom(rc)
 				hostsFileContent := buf.String()


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fixes a crash in the e2e kubelet test

**Which issue(s) this PR fixes**:
https://bugzilla.redhat.com/show_bug.cgi?id=1744422

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
