### PR TITLE
Enable setting status code for kubectl errors in diff sub-command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -82,6 +82,7 @@ type DiffOptions struct {
 	EnforceNamespace bool
 	Builder          *resource.Builder
 	Diff             *DiffProgram
+	ExitCode         int
 }
 
 func validateArgs(cmd *cobra.Command, args []string) error {
@@ -109,6 +110,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 		Long:                  diffLong,
 		Example:               diffExample,
 		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.ErrorExitCode(options.ExitCode)
 			cmdutil.CheckErr(options.Complete(f, cmd))
 			cmdutil.CheckErr(validateArgs(cmd, args))
 			cmdutil.CheckErr(options.Run())
@@ -118,6 +120,7 @@ func NewCmdDiff(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	usage := "contains the configuration to diff"
 	cmdutil.AddFilenameOptionFlags(cmd, &options.FilenameOptions, usage)
 	cmdutil.AddServerSideApplyFlags(cmd)
+	cmd.Flags().IntVar(&options.ExitCode, "exit-code", 1, "Exit status code for kubectl errors. Can be used to distinguish between diff statuses and problems communicating with the server.")
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -275,6 +275,23 @@ func TestCheckExitError(t *testing.T) {
 	})
 }
 
+func TestSetErrorExitCode(t *testing.T) {
+	ErrorExitCode(42)
+	defer ResetErrorExitCode()
+	testCheckError(t, []checkErrTestCase{
+		{
+			errors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Invalid1").GroupKind(), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field"), "single", "details")}),
+			"The Invalid1 \"invalidation\" is invalid: field: Invalid value: \"single\": details\n",
+			42,
+		},
+		{
+			exec.CodeExitError{Err: fmt.Errorf("pod foo/bar terminated"), Code: 24},
+			"pod foo/bar terminated",
+			24,
+		},
+	})
+}
+
 func testCheckError(t *testing.T, tests []checkErrTestCase) {
 	var errReturned string
 	var codeReturned int


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Currently kubectl diff does not provide a way to differentiate between errors in kubectl and non-zero status codes from the external diff utility. This forces the use of the sub-command in scripts to either ignore the problem or perform string parsing of the output to attempt to identify what has happened.

This PR addresses this by adding a new `--exit-code` flag to `kubectl diff` to provide the user with a way to setup a sentinel exit code to distinguish between statuses propagated from the diff tool and any errors encountered by kubectl itself.

To ensure compatibility with any existing scripts which might be relying on the current behavior the new flag defaults to the current exit code `1`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/707

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Introduced new `--exit-code` option for `kubectl diff` to enable specifying a distinct exit status for kubectl errors.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area kubectl
/sig cli