### PR TITLE
Bump gonvml module and remove CGO dependency.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -88,7 +88,7 @@ require (
 	github.com/mattn/go-shellwords v1.0.5 // indirect
 	github.com/mesos/mesos-go v0.0.9 // indirect
 	github.com/miekg/dns v1.1.4
-	github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2 // indirect
+	github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 // indirect
 	github.com/mistifyio/go-zfs v2.1.1+incompatible // indirect
 	github.com/mohae/deepcopy v0.0.0-20170603005431-491d3605edfb // indirect
 	github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c // indirect
@@ -344,7 +344,7 @@ replace (
 	github.com/mesos/mesos-go => github.com/mesos/mesos-go v0.0.9
 	github.com/mholt/certmagic => github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2
 	github.com/miekg/dns => github.com/miekg/dns v1.1.4
-	github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2
+	github.com/mindprince/gonvml => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
 	github.com/mistifyio/go-zfs => github.com/mistifyio/go-zfs v2.1.1+incompatible
 	github.com/mitchellh/go-homedir => github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/go-wordwrap => github.com/mitchellh/go-wordwrap v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -306,8 +306,8 @@ github.com/mesos/mesos-go v0.0.9/go.mod h1:kPYCMQ9gsOXVAle1OsoY4I1+9kPu8GHkf88aV
 github.com/mholt/certmagic v0.6.2-0.20190624175158-6a42ef9fe8c2/go.mod h1:g4cOPxcjV0oFq3qwpjSA30LReKD8AoIfwAY9VvG35NY=
 github.com/miekg/dns v1.1.4 h1:rCMZsU2ScVSYcAsOXgmC6+AKOK+6pmQTOcw03nfwYV0=
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2 h1:v3dy+FJr7gS7nLgYG7YjX/pmUWuFdudcpnoRNHt2heo=
-github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
+github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 h1:PS1dLCGtD8bb9RPKJrc8bS7qHL6JnW1CZvwzH9dPoUs=
+github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v2.1.1+incompatible h1:gAMO1HM9xBRONLHHYnu5iFsOJUiJdNZo6oqSENd4eW8=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/pkg/kubelet/cadvisor/cadvisor_linux.go
+++ b/pkg/kubelet/cadvisor/cadvisor_linux.go
@@ -1,4 +1,4 @@
-// +build cgo,linux
+// +build linux
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/kubelet/cadvisor/cadvisor_unsupported.go
+++ b/pkg/kubelet/cadvisor/cadvisor_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux,!windows linux,!cgo
+// +build !linux,!windows
 
 /*
 Copyright 2015 The Kubernetes Authors.

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -1,4 +1,4 @@
-// +build cgo,linux
+// +build linux
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/pkg/kubelet/cadvisor/helpers_unsupported.go
+++ b/pkg/kubelet/cadvisor/helpers_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux linux,!cgo
+// +build !linux
 
 /*
 Copyright 2017 The Kubernetes Authors.

--- a/vendor/github.com/mindprince/gonvml/.travis.gofmt.sh
+++ b/vendor/github.com/mindprince/gonvml/.travis.gofmt.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ -n "$(gofmt -s -l .)" ]; then
+  echo "Go code is not properly formatted:"
+  gofmt -s -d -e .
+  exit 1
+fi

--- a/vendor/github.com/mindprince/gonvml/.travis.yml
+++ b/vendor/github.com/mindprince/gonvml/.travis.yml
@@ -1,0 +1,9 @@
+language: go
+
+go:
+  - "1.8"
+  - "1.9"
+  - "1.10"
+
+script:
+  - make presubmit

--- a/vendor/github.com/mindprince/gonvml/BUILD
+++ b/vendor/github.com/mindprince/gonvml/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bindings.go",
+        "bindings_nocgo.go",
         "nvml.h",
     ],
     cgo = True,

--- a/vendor/github.com/mindprince/gonvml/Makefile
+++ b/vendor/github.com/mindprince/gonvml/Makefile
@@ -18,3 +18,6 @@ PKG=github.com/mindprince/gonvml
 build:
 	docker run -v $(shell pwd):/go/src/$(PKG) --workdir=/go/src/$(PKG) golang:1.8 go build cmd/example/example.go
 
+.PHONY: presubmit
+presubmit:
+	./.travis.gofmt.sh

--- a/vendor/github.com/mindprince/gonvml/bindings.go
+++ b/vendor/github.com/mindprince/gonvml/bindings.go
@@ -111,6 +111,38 @@ nvmlReturn_t nvmlDeviceGetPowerUsage(nvmlDevice_t device, unsigned int *power) {
   return nvmlDeviceGetPowerUsageFunc(device, power);
 }
 
+nvmlReturn_t (*nvmlDeviceGetTemperatureFunc)(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp);
+nvmlReturn_t nvmlDeviceGetTemperature(nvmlDevice_t device, nvmlTemperatureSensors_t sensorType, unsigned int *temp) {
+  if (nvmlDeviceGetTemperatureFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  return nvmlDeviceGetTemperatureFunc(device, sensorType, temp);
+}
+
+nvmlReturn_t (*nvmlDeviceGetFanSpeedFunc)(nvmlDevice_t device, unsigned int *speed);
+nvmlReturn_t nvmlDeviceGetFanSpeed(nvmlDevice_t device, unsigned int *speed) {
+  if (nvmlDeviceGetFanSpeedFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  return nvmlDeviceGetFanSpeedFunc(device, speed);
+}
+
+nvmlReturn_t (*nvmlDeviceGetEncoderUtilizationFunc)(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs);
+nvmlReturn_t nvmlDeviceGetEncoderUtilization(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs) {
+  if (nvmlDeviceGetEncoderUtilizationFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  return nvmlDeviceGetEncoderUtilizationFunc(device, utilization, samplingPeriodUs);
+}
+
+nvmlReturn_t (*nvmlDeviceGetDecoderUtilizationFunc)(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs);
+nvmlReturn_t nvmlDeviceGetDecoderUtilization(nvmlDevice_t device, unsigned int* utilization, unsigned int* samplingPeriodUs) {
+  if (nvmlDeviceGetDecoderUtilizationFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  return nvmlDeviceGetDecoderUtilizationFunc(device, utilization, samplingPeriodUs);
+}
+
 nvmlReturn_t (*nvmlDeviceGetSamplesFunc)(nvmlDevice_t device, nvmlSamplingType_t type, unsigned long long lastSeenTimeStamp, nvmlValueType_t *sampleValType, unsigned int *sampleCount, nvmlSample_t *samples);
 
 // Loads the "libnvidia-ml.so.1" shared library.
@@ -169,8 +201,24 @@ nvmlReturn_t nvmlInit_dl(void) {
   if (nvmlDeviceGetPowerUsageFunc == NULL) {
     return NVML_ERROR_FUNCTION_NOT_FOUND;
   }
+  nvmlDeviceGetTemperatureFunc = dlsym(nvmlHandle, "nvmlDeviceGetTemperature");
+  if (nvmlDeviceGetTemperatureFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  nvmlDeviceGetFanSpeedFunc = dlsym(nvmlHandle, "nvmlDeviceGetFanSpeed");
+  if (nvmlDeviceGetFanSpeedFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
   nvmlDeviceGetSamplesFunc = dlsym(nvmlHandle, "nvmlDeviceGetSamples");
   if (nvmlDeviceGetSamplesFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  nvmlDeviceGetEncoderUtilizationFunc = dlsym(nvmlHandle, "nvmlDeviceGetEncoderUtilization");
+  if (nvmlDeviceGetEncoderUtilizationFunc == NULL) {
+    return NVML_ERROR_FUNCTION_NOT_FOUND;
+  }
+  nvmlDeviceGetDecoderUtilizationFunc = dlsym(nvmlHandle, "nvmlDeviceGetDecoderUtilization");
+  if (nvmlDeviceGetDecoderUtilizationFunc == NULL) {
     return NVML_ERROR_FUNCTION_NOT_FOUND;
   }
   nvmlReturn_t result = nvmlInitFunc();
@@ -384,7 +432,7 @@ func (d Device) MemoryInfo() (uint64, uint64, error) {
 
 // UtilizationRates returns the percent of time over the past sample period during which:
 // utilization.gpu: one or more kernels were executing on the GPU.
-// utilizatoin.memory: global (device) memory was being read or written.
+// utilization.memory: global (device) memory was being read or written.
 func (d Device) UtilizationRates() (uint, uint, error) {
 	if C.nvmlHandle == nil {
 		return 0, 0, errLibraryNotLoaded
@@ -428,4 +476,49 @@ func (d Device) AverageGPUUtilization(since time.Duration) (uint, error) {
 	var n C.uint
 	r := C.nvmlDeviceGetAverageUsage(d.dev, C.NVML_GPU_UTILIZATION_SAMPLES, lastTs, &n)
 	return uint(n), errorString(r)
+}
+
+// Temperature returns the temperature for this GPU in Celsius.
+func (d Device) Temperature() (uint, error) {
+	if C.nvmlHandle == nil {
+		return 0, errLibraryNotLoaded
+	}
+	var n C.uint
+	r := C.nvmlDeviceGetTemperature(d.dev, C.NVML_TEMPERATURE_GPU, &n)
+	return uint(n), errorString(r)
+}
+
+// FanSpeed returns the temperature for this GPU in the percentage of its full
+// speed, with 100 being the maximum.
+func (d Device) FanSpeed() (uint, error) {
+	if C.nvmlHandle == nil {
+		return 0, errLibraryNotLoaded
+	}
+	var n C.uint
+	r := C.nvmlDeviceGetFanSpeed(d.dev, &n)
+	return uint(n), errorString(r)
+}
+
+// EncoderUtilization returns the percent of time over the last sample period during which the GPU video encoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
+func (d Device) EncoderUtilization() (uint, uint, error) {
+	if C.nvmlHandle == nil {
+		return 0, 0, errLibraryNotLoaded
+	}
+	var n C.uint
+	var sp C.uint
+	r := C.nvmlDeviceGetEncoderUtilization(d.dev, &n, &sp)
+	return uint(n), uint(sp), errorString(r)
+}
+
+// DecoderUtilization returns the percent of time over the last sample period during which the GPU video decoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
+func (d Device) DecoderUtilization() (uint, uint, error) {
+	if C.nvmlHandle == nil {
+		return 0, 0, errLibraryNotLoaded
+	}
+	var n C.uint
+	var sp C.uint
+	r := C.nvmlDeviceGetDecoderUtilization(d.dev, &n, &sp)
+	return uint(n), uint(sp), errorString(r)
 }

--- a/vendor/github.com/mindprince/gonvml/bindings_nocgo.go
+++ b/vendor/github.com/mindprince/gonvml/bindings_nocgo.go
@@ -1,0 +1,115 @@
+// +build !cgo
+
+package gonvml
+
+import (
+	"errors"
+	"time"
+)
+
+var errNoCgo = errors.New("this binary is built without CGO, NVML is disabled")
+
+// Initialize initializes NVML.
+// Call this before calling any other methods.
+func Initialize() error {
+	return errNoCgo
+}
+
+// Shutdown shuts down NVML.
+// Call this once NVML is no longer being used.
+func Shutdown() error {
+	return errNoCgo
+}
+
+// SystemDriverVersion returns the the driver version on the system.
+func SystemDriverVersion() (string, error) {
+	return "", errNoCgo
+}
+
+// DeviceCount returns the number of nvidia devices on the system.
+func DeviceCount() (uint, error) {
+	return 0, errNoCgo
+}
+
+// Device is the handle for the device.
+// This handle is obtained by calling DeviceHandleByIndex().
+type Device struct {
+}
+
+// DeviceHandleByIndex returns the device handle for a particular index.
+// The indices range from 0 to DeviceCount()-1. The order in which NVML
+// enumerates devices has no guarantees of consistency between reboots.
+func DeviceHandleByIndex(idx uint) (Device, error) {
+	return Device{}, errNoCgo
+}
+
+// MinorNumber returns the minor number for the device.
+// The minor number for the device is such that the Nvidia device node
+// file for each GPU will have the form /dev/nvidia[minor number].
+func (d Device) MinorNumber() (uint, error) {
+	return 0, errNoCgo
+}
+
+// UUID returns the globally unique immutable UUID associated with this device.
+func (d Device) UUID() (string, error) {
+	return "", errNoCgo
+}
+
+// Name returns the product name of the device.
+func (d Device) Name() (string, error) {
+	return "", errNoCgo
+}
+
+// MemoryInfo returns the total and used memory (in bytes) of the device.
+func (d Device) MemoryInfo() (uint64, uint64, error) {
+	return 0, 0, errNoCgo
+}
+
+// UtilizationRates returns the percent of time over the past sample period during which:
+// utilization.gpu: one or more kernels were executing on the GPU.
+// utilizatoin.memory: global (device) memory was being read or written.
+func (d Device) UtilizationRates() (uint, uint, error) {
+	return 0, 0, errNoCgo
+}
+
+// PowerUsage returns the power usage for this GPU and its associated circuitry
+// in milliwatts. The reading is accurate to within +/- 5% of current power draw.
+func (d Device) PowerUsage() (uint, error) {
+	return 0, errNoCgo
+}
+
+// AveragePowerUsage returns the power usage for this GPU and its associated circuitry
+// in milliwatts averaged over the samples collected in the last `since` duration.
+func (d Device) AveragePowerUsage(since time.Duration) (uint, error) {
+	return 0, errNoCgo
+}
+
+// AverageGPUUtilization returns the utilization.gpu metric (percent of time
+// one of more kernels were executing on the GPU) averaged over the samples
+// collected in the last `since` duration.
+func (d Device) AverageGPUUtilization(since time.Duration) (uint, error) {
+	return 0, errNoCgo
+}
+
+// Temperature returns the temperature for this GPU in Celsius.
+func (d Device) Temperature() (uint, error) {
+	return 0, errNoCgo
+}
+
+// FanSpeed returns the temperature for this GPU in the percentage of its full
+// speed, with 100 being the maximum.
+func (d Device) FanSpeed() (uint, error) {
+	return 0, errNoCgo
+}
+
+// EncoderUtilization returns the percent of time over the last sample period during which the GPU video encoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
+func (d Device) EncoderUtilization() (uint, uint, error) {
+	return 0, 0, errNoCgo
+}
+
+// DecoderUtilization returns the percent of time over the last sample period during which the GPU video decoder was being used.
+// The sampling period is variable and is returned in the second return argument in microseconds.
+func (d Device) DecoderUtilization() (uint, uint, error) {
+	return 0, 0, errNoCgo
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -610,7 +610,7 @@ github.com/mattn/go-shellwords
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/miekg/dns v1.1.4 => github.com/miekg/dns v1.1.4
 github.com/miekg/dns
-# github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2 => github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2
+# github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989 => github.com/mindprince/gonvml v0.0.0-20190828220739-9ebdce4bb989
 github.com/mindprince/gonvml
 # github.com/mistifyio/go-zfs v2.1.1+incompatible => github.com/mistifyio/go-zfs v2.1.1+incompatible
 github.com/mistifyio/go-zfs


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

Remove CGO dependency created by gonvml module. The module has been bumped with stubs for nocgo allowing K8s and cAdvisor to be built with full features without CGO dependency (except the Nvidia GPU cAdvisor features from this module).

This is the first PR to support Risc-V architecture, additional module bumps to follow.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

Signed-off-by: Carlos de Paula <me@carlosedp.com>