### PR TITLE
Harden kube-dns to run with less privileges.

### DIFF
--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -105,7 +105,7 @@ spec:
       labels:
         k8s-app: kube-dns
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -105,7 +105,7 @@ spec:
       labels:
         k8s-app: kube-dns
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -105,7 +105,7 @@ spec:
       labels:
         k8s-app: kube-dns
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -196,7 +196,6 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
         securityContext:
-          allowPrivilegeEscalation: false
           capabilities:
             drop:
               - all

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -154,7 +154,7 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsUser: 1001
-          runAsGroup: 2001
+          runAsGroup: 1001
       - name: dnsmasq
         image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
@@ -231,6 +231,6 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsUser: 1001
-          runAsGroup: 2001
+          runAsGroup: 1001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -88,6 +88,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
+        runAsNonRoot: true
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       tolerations:
@@ -150,6 +151,11 @@ spec:
         volumeMounts:
         - name: kube-dns-config
           mountPath: /kube-dns-config
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
       - name: dnsmasq
         image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
@@ -190,6 +196,16 @@ spec:
         volumeMounts:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
+          capabilities:
+            drop:
+              - all
+            add:
+              - NET_BIND_SERVICE
+              - SETGID
       - name: sidecar
         image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
         livenessProbe:
@@ -214,5 +230,10 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -230,10 +230,10 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1001
-            runAsGroup: 2001
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.base
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.base
@@ -82,13 +82,12 @@ spec:
       labels:
         k8s-app: kube-dns
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
         prometheus.io/port: "10054"
         prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsNonRoot: true
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       tolerations:
@@ -198,8 +197,6 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
-          runAsNonRoot: false
           capabilities:
             drop:
               - all

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -196,7 +196,6 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
         securityContext:
-          allowPrivilegeEscalation: false
           capabilities:
             drop:
               - all

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -154,7 +154,7 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsUser: 1001
-          runAsGroup: 2001
+          runAsGroup: 1001
       - name: dnsmasq
         image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
@@ -231,6 +231,6 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsUser: 1001
-          runAsGroup: 2001
+          runAsGroup: 1001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -88,6 +88,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
+        runAsNonRoot: true
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       tolerations:
@@ -150,6 +151,11 @@ spec:
         volumeMounts:
         - name: kube-dns-config
           mountPath: /kube-dns-config
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
       - name: dnsmasq
         image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
@@ -190,6 +196,16 @@ spec:
         volumeMounts:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
+          capabilities:
+            drop:
+              - all
+            add:
+              - NET_BIND_SERVICE
+              - SETGID
       - name: sidecar
         image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
         livenessProbe:
@@ -214,5 +230,10 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -230,10 +230,10 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1001
-            runAsGroup: 2001
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.in
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.in
@@ -82,13 +82,12 @@ spec:
       labels:
         k8s-app: kube-dns
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
         prometheus.io/port: "10054"
         prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsNonRoot: true
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       tolerations:
@@ -198,8 +197,6 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
-          runAsNonRoot: false
           capabilities:
             drop:
               - all

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -196,7 +196,6 @@ spec:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
         securityContext:
-          allowPrivilegeEscalation: false
           capabilities:
             drop:
               - all

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -154,7 +154,7 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsUser: 1001
-          runAsGroup: 2001
+          runAsGroup: 1001
       - name: dnsmasq
         image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
@@ -231,6 +231,6 @@ spec:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
           runAsUser: 1001
-          runAsGroup: 2001
+          runAsGroup: 1001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -88,6 +88,7 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
+        runAsNonRoot: true
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       tolerations:
@@ -150,6 +151,11 @@ spec:
         volumeMounts:
         - name: kube-dns-config
           mountPath: /kube-dns-config
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
       - name: dnsmasq
         image: k8s.gcr.io/k8s-dns-dnsmasq-nanny:1.14.13
         livenessProbe:
@@ -190,6 +196,16 @@ spec:
         volumeMounts:
         - name: kube-dns-config
           mountPath: /etc/k8s/dns/dnsmasq-nanny
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false
+          runAsNonRoot: false
+          capabilities:
+            drop:
+              - all
+            add:
+              - NET_BIND_SERVICE
+              - SETGID
       - name: sidecar
         image: k8s.gcr.io/k8s-dns-sidecar:1.14.13
         livenessProbe:
@@ -214,5 +230,10 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 1001
+            runAsGroup: 2001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -230,10 +230,10 @@ spec:
           requests:
             memory: 20Mi
             cpu: 10m
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsUser: 1001
-            runAsGroup: 2001
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 1001
+          runAsGroup: 2001
       dnsPolicy: Default  # Don't use cluster DNS.
       serviceAccountName: kube-dns

--- a/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
+++ b/cluster/addons/dns/kube-dns/kube-dns.yaml.sed
@@ -82,13 +82,12 @@ spec:
       labels:
         k8s-app: kube-dns
       annotations:
-        seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
+        seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
         prometheus.io/port: "10054"
         prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-cluster-critical
       securityContext:
-        runAsNonRoot: true
         supplementalGroups: [ 65534 ]
         fsGroup: 65534
       tolerations:
@@ -198,8 +197,6 @@ spec:
           mountPath: /etc/k8s/dns/dnsmasq-nanny
         securityContext:
           allowPrivilegeEscalation: false
-          readOnlyRootFilesystem: false
-          runAsNonRoot: false
           capabilities:
             drop:
               - all


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Hardens the kube-dns add-on by implementing some security best practices, such as:
- Run as non-root (& disallow privilege escalation)
- ReadOnlyRootFilesystem
- Drop unneeded capabilities


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82623

**Special notes for your reviewer**:
No major changes were made, only removed privileges not used by the containers. 
The dnsmasq cannot run as non-root at this point, so will leave it for the time being as it will require deeper changes.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kube-dns add-on: 
- All containers are now being executed under more restrictive privileges. 
- Most of the containers now run as non-root user and has the root filesystem set as read-only. 
- The remaining container running as root only has the minimum Linux capabilities it requires to run. 
- Privilege escalation has been disabled for all containers.

```
