### PR TITLE
Use etcd image version suffixes in kubeadm

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -262,6 +262,10 @@ const (
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
 	DefaultEtcdVersion = "3.3.15"
 
+	// DefaultEtcdImageVersion indicates the etcd image version that kubeadm uses.
+	// For example, the image version of "k8s.gcr.io/etcd:3.3.15-0" is "0".
+	DefaultEtcdImageVersion = "0"
+
 	// PauseVersion indicates the default pause image version for kubeadm
 	PauseVersion = "3.1"
 
@@ -424,8 +428,8 @@ var (
 		13: "3.2.24",
 		14: "3.3.10",
 		15: "3.3.10",
-		16: "3.3.15",
-		17: "3.3.15",
+		16: "3.3.15-0",
+		17: "3.3.15-0",
 	}
 
 	// KubeadmCertsClusterRoleName sets the name for the ClusterRole that allows

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -260,11 +260,7 @@ const (
 	MinExternalEtcdVersion = "3.2.18"
 
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
-	DefaultEtcdVersion = "3.3.15"
-
-	// DefaultEtcdImageVersion indicates the etcd image version that kubeadm uses.
-	// For example, the image version of "k8s.gcr.io/etcd:3.3.15-0" is "0".
-	DefaultEtcdImageVersion = "0"
+	DefaultEtcdVersion = "3.3.15-0"
 
 	// PauseVersion indicates the default pause image version for kubeadm
 	PauseVersion = "3.1"

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -68,7 +68,7 @@ func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration) string {
 		etcdImageRepository = cfg.Etcd.Local.ImageRepository
 	}
 	// Etcd uses an imageTag that corresponds to the etcd version matching the Kubernetes version
-	etcdImageTag := fmt.Sprintf("%s-%s", constants.DefaultEtcdVersion, constants.DefaultEtcdImageVersion)
+	etcdImageTag := constants.DefaultEtcdVersion
 	etcdVersion, err := constants.EtcdSupportedVersion(cfg.KubernetesVersion)
 	if err == nil {
 		etcdImageTag = etcdVersion.String()

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -68,7 +68,7 @@ func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration) string {
 		etcdImageRepository = cfg.Etcd.Local.ImageRepository
 	}
 	// Etcd uses an imageTag that corresponds to the etcd version matching the Kubernetes version
-	etcdImageTag := constants.DefaultEtcdVersion
+	etcdImageTag := fmt.Sprintf("%s-%s", constants.DefaultEtcdVersion, constants.DefaultEtcdImageVersion)
 	etcdVersion, err := constants.EtcdSupportedVersion(cfg.KubernetesVersion)
 	if err == nil {
 		etcdImageTag = etcdVersion.String()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

etcd images published in gcr.io now include an image version suffix. For example the image version of  `k8s.gcr.io/etcd:3.3.15-0` is `0`.

All in-tree kubernetes code uses these image versions except kubeadm and we'd like to update kubeadm to use them as well so that if we ever need to update an etcd image with a new base image or a fix to the scripts contained in the image we can do it via immutable docker tags.

One kubeadm is updated we will stop publishing the unversioned tags, e.g.  `k8s.gcr.io/etcd:3.3.15`.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/milestone 1.17
/area etcd
/sig api-machinery
/priority important-longterm
/cc @dims 