### PR TITLE
Fixed issue with duplicate containerPorts in different address families

### DIFF
--- a/pkg/kubelet/container/BUILD
+++ b/pkg/kubelet/container/BUILD
@@ -39,6 +39,7 @@ go_library(
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",
         "//third_party/forked/golang/expansion:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -558,13 +558,19 @@ func TestMakePortMappings(t *testing.T) {
 					// Duplicated, should be ignored.
 					port("foo", v1.ProtocolUDP, 888, 8888, ""),
 					// Duplicated, should be ignored.
-					port("", v1.ProtocolTCP, 80, 8888, ""),
+					port("", v1.ProtocolTCP, 80, 8888, "127.0.0.1"),
+					// Duplicated with different address family, shouldn't be ignored
+					port("", v1.ProtocolTCP, 80, 8080, "::"),
+					// No address family specified
+					port("", v1.ProtocolTCP, 1234, 5678, ""),
 				},
 			},
 			[]PortMapping{
-				portMapping("fooContainer-TCP:80", v1.ProtocolTCP, 80, 8080, "127.0.0.1"),
-				portMapping("fooContainer-TCP:443", v1.ProtocolTCP, 443, 4343, "192.168.0.1"),
+				portMapping("fooContainer-v4-TCP:80", v1.ProtocolTCP, 80, 8080, "127.0.0.1"),
+				portMapping("fooContainer-v4-TCP:443", v1.ProtocolTCP, 443, 4343, "192.168.0.1"),
 				portMapping("fooContainer-foo", v1.ProtocolUDP, 555, 5555, ""),
+				portMapping("fooContainer-v6-TCP:80", v1.ProtocolTCP, 80, 8080, "::"),
+				portMapping("fooContainer-any-TCP:1234", v1.ProtocolTCP, 1234, 5678, ""),
 			},
 		},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Allows duplicate containerPorts when hostIPs of different address families are supplied.

**Which issue(s) this PR fixes**:
Fixes #82373

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
NONE

/sig network
