### PR TITLE
Starting EndpointSlice Controller when all Alpha gates are enabled in cluster up

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -247,6 +247,7 @@ RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 
 if [[ "${KUBE_FEATURE_GATES:-}" == "AllAlpha=true" ]]; then
   RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-api/all=true}"
+  RUN_CONTROLLERS="${RUN_CONTROLLERS:-*,endpointslice}"
 fi
 
 # Optional: set feature gates

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -136,6 +136,7 @@ RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 
 if [[ "${KUBE_FEATURE_GATES:-}" == "AllAlpha=true" ]]; then
   RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-api/all=true}"
+  RUN_CONTROLLERS="${RUN_CONTROLLERS:-*,endpointslice}"
 fi
 
 # Optional: set feature gates

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -1285,6 +1285,11 @@ EOF
 FEATURE_GATES: $(yaml-quote ${FEATURE_GATES})
 EOF
   fi
+  if [ -n "${RUN_CONTROLLERS:-}" ]; then
+    cat >>$file <<EOF
+RUN_CONTROLLERS: $(yaml-quote ${RUN_CONTROLLERS})
+EOF
+  fi
   if [ -n "${PROVIDER_VARS:-}" ]; then
     local var_name
     local var_value


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Tests enabling all alpha feature gates for the 1.16 release are currently failing due to the EndpointSlice controller not being enabled.

**Which issue(s) this PR fixes**:
Should help with https://github.com/kubernetes/kubernetes/issues/82174.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190603-EndpointSlice-API.md)
- [Enhancement Issue](https://github.com/kubernetes/enhancements/issues/752)

/milestone 1.16
/cc @freehan @lachie83 