### PR TITLE
cluster: test: get-kube print if call will use token

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -165,10 +165,12 @@ function download_tarball() {
   url="${DOWNLOAD_URL_PREFIX}/${file}"
   mkdir -p "${download_path}"
   if [[ $(which curl) ]]; then
+    echo "Using culr to get files"
     # if the url belongs to GCS API we should use oauth2_token in the headers
     local curl_headers=""
     if { [[ "${KUBERNETES_PROVIDER:-gce}" == "gce" ]] || [[ "${KUBERNETES_PROVIDER}" == "gke" ]] ; } &&
        [[ "$url" =~ ^https://storage.googleapis.com.* ]] && valid-storage-scope ; then
+       echo "curl call will include authorization bearer token"
       curl_headers="Authorization: Bearer $(get-credentials)"
     fi
     curl ${curl_headers:+-H "${curl_headers}"} -fL --retry 3 --keepalive-time 2 "${url}" -o "${download_path}/${file}"


### PR DESCRIPTION
modified get-kube-binaries.sh to print if the curl call will use a header token.
I suspect some tests are failing because we are not including the token to fetch the files from the buckets.

**What type of PR is this?**
/kind failing-test


**Special notes for your reviewer**:
I tried the PR e2e test, but seems the script might be "pre-configured" in the VM where the tests is running.
from the "pull-kubernetes-e2e-gce" logs:
Downloading kubernetes release v1.17.0-alpha.0.1141+cce475c3e3ddc4
...
Extracting ...
...
2019/09/05 18:48:03 process.go:155: Step '/workspace/get-kube.sh' finished in 17.23715354s

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
