### PR TITLE
Construct NamespacedName only when there is no error in endpointSliceCacheKeys

### DIFF
--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -221,13 +221,16 @@ func formatEndpointsList(endpoints []Endpoint) []string {
 // endpointSliceCacheKeys returns cache keys used for a given EndpointSlice.
 func endpointSliceCacheKeys(endpointSlice *discovery.EndpointSlice) (types.NamespacedName, string, error) {
 	var err error
+	var namespacedName types.NamespacedName
 	serviceName, ok := endpointSlice.Labels[discovery.LabelServiceName]
 	if !ok || serviceName == "" {
 		err = fmt.Errorf("No %s label set on endpoint slice: %s", discovery.LabelServiceName, endpointSlice.Name)
 	} else if endpointSlice.Namespace == "" || endpointSlice.Name == "" {
 		err = fmt.Errorf("Expected EndpointSlice name and namespace to be set: %v", endpointSlice)
+	} else {
+		namespacedName = types.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}
 	}
-	return types.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}, endpointSlice.Name, err
+	return namespacedName, endpointSlice.Name, err
 }
 
 // byIP helps sort endpoints by IP


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In endpointSliceCacheKeys, when the Namespace or Name of the slice is unspecified, there is no need to construct NamespacedName.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
