### PR TITLE
Adding a nil check in endpointslicecache

### DIFF
--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -163,7 +163,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 		namespacedName types.NamespacedName
 		endpointSlices []*discovery.EndpointSlice
 		hostname       string
-		expectedMap    map[ServicePortName]map[string]Endpoint
+		expectedMap    spToEndpointMap
 	}{
 		"simple use case with 3 endpoints": {
 			namespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"},
@@ -171,7 +171,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 			endpointSlices: []*discovery.EndpointSlice{
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(80)}),
 			},
-			expectedMap: map[ServicePortName]map[string]Endpoint{
+			expectedMap: spToEndpointMap{
 				{NamespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"}, Port: "port-0"}: {
 					"10.0.1.1": &BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: false},
 					"10.0.1.2": &BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
@@ -190,7 +190,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 
 		got := esCache.endpointInfoByServicePort(tc.namespacedName)
 		if !reflect.DeepEqual(got, tc.expectedMap) {
-			t.Errorf("[%s] endpointInfoByServicePort does not match. Want: %v, Got: %v", name, tc.expectedMap, got)
+			t.Errorf("[%s] endpointInfoByServicePort does not match. Want: %+v, Got: %+v", name, tc.expectedMap, got)
 		}
 
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The only way I've been able to cause this to be nil here is with a test where I unintentionally wasn't initializing endpointslicecache properly, but this seemed like a place that would be better and safer with a nil check, so here it is.

**Which issue(s) this PR fixes**:
There's a tiny chance this could help with https://github.com/kubernetes/kubernetes/issues/82174, though all my e2e testing today suggests that will already be fixed when https://github.com/kubernetes/kubernetes/pull/82380 gets in.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/20190603-EndpointSlice-API.md)
- [Enhancement Issue](https://github.com/kubernetes/enhancements/issues/752)

/milestone 1.16
/cc @bowei @lachie83