### PR TITLE
Improving GCE cluster up logic for EndpointSlice Controller

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -247,6 +247,10 @@ RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 
 if [[ "${KUBE_FEATURE_GATES:-}" == "AllAlpha=true" ]]; then
   RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-api/all=true}"
+fi
+
+# If feature gates includes AllAlpha or EndpointSlice, and EndpointSlice has not been disabled, add EndpointSlice controller to list of controllers to run.
+if [[ (( "${KUBE_FEATURE_GATES:-}" == *"AllAlpha=true"* ) || ( "${KUBE_FEATURE_GATES:-}" == *"EndpointSlice=true"* )) && "${KUBE_FEATURE_GATES:-}" != *"EndpointSlice=false"* ]]; then
   RUN_CONTROLLERS="${RUN_CONTROLLERS:-*,endpointslice}"
 fi
 

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -136,6 +136,10 @@ RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-}"
 
 if [[ "${KUBE_FEATURE_GATES:-}" == "AllAlpha=true" ]]; then
   RUNTIME_CONFIG="${KUBE_RUNTIME_CONFIG:-api/all=true}"
+fi
+
+# If feature gates includes AllAlpha or EndpointSlice, and EndpointSlice has not been disabled, add EndpointSlice controller to list of controllers to run.
+if [[ (( "${KUBE_FEATURE_GATES:-}" == *"AllAlpha=true"* ) || ( "${KUBE_FEATURE_GATES:-}" == *"EndpointSlice=true"* )) && "${KUBE_FEATURE_GATES:-}" != *"EndpointSlice=false"* ]]; then
   RUN_CONTROLLERS="${RUN_CONTROLLERS:-*,endpointslice}"
 fi
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
In the original PR I'd missed that the e2e alpha tests actually set `KUBE_FEATURE_GATES=AllAlpha=true,CSIMigration=false` not just `KUBE_FEATURE_GATES=AllAlpha=true` like that was checking for. This replaces the initial check with something more thorough.

**Which issue(s) this PR fixes**:
Should help with https://github.com/kubernetes/kubernetes/issues/82174.

**Special notes for your reviewer**:
Adding tests specifically for this seemed like overkill, but here are some examples of this logic in action:
<img width="1156" alt="Screen Shot 2019-09-05 at 7 25 12 PM" src="https://user-images.githubusercontent.com/419322/64396654-28dc6800-d013-11e9-93d4-bf6b110e963b.png">

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/milestone 1.16
/cc @bowei @lachie83 