### PR TITLE
Fix wrong command in e2e agnhost utility function

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -475,9 +475,9 @@ func ProxyMode(f *Framework) (string, error) {
 			HostNetwork: true,
 			Containers: []v1.Container{
 				{
-					Name:    "detector",
-					Image:   AgnHostImage,
-					Command: []string{"pause"},
+					Name:  "detector",
+					Image: AgnHostImage,
+					Args:  []string{"pause"},
 				},
 			},
 		},


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

The `Command` will cause the container process not starting correctly,
so we now use the `Args` to end up running `/agnhost pause` as intended.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

**Special notes for your reviewer**:

Fixes the failing e2e test in CRI-O: https://openshift-gce-devel.appspot.com/build/origin-federated-results/pr-logs/pull/cri-o_cri-o/2759/test_pull_request_crio_e2e_fedora/6861/#kubernetes-e2e-suite-sig-network-services-should-preserve-source-pod-ip-for-traffic-thru-service-cluster-ip-linuxonly

If you wonder why it does not fail on docker, that's because the test does not report the error correctly but fails the same way.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
