### PR TITLE
Use pod + nsenter instead of SSH in mount propagation tests

### DIFF
--- a/test/e2e/node/BUILD
+++ b/test/e2e/node/BUILD
@@ -49,6 +49,7 @@ go_library(
         "//test/e2e/framework/volume:go_default_library",
         "//test/e2e/perftype:go_default_library",
         "//test/e2e/scheduling:go_default_library",
+        "//test/e2e/storage/utils:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/test/e2e/node/mount_propagation.go
+++ b/test/e2e/node/mount_propagation.go
@@ -24,7 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
-	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
+	"k8s.io/kubernetes/test/e2e/storage/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
@@ -85,6 +85,9 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// tmpfs to a subdirectory there. We check that these mounts are
 		// propagated to the right places.
 
+		hostExec := utils.NewHostExec(f)
+		defer hostExec.Cleanup()
+
 		// Pick a node where all pods will run.
 		node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
 		framework.ExpectNoError(err)
@@ -101,8 +104,8 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// running in parallel.
 		hostDir := "/var/lib/kubelet/" + f.Namespace.Name
 		defer func() {
-			cleanCmd := fmt.Sprintf("sudo rm -rf %q", hostDir)
-			e2essh.IssueSSHCommand(cleanCmd, framework.TestContext.Provider, node)
+			cleanCmd := fmt.Sprintf("rm -rf %q", hostDir)
+			hostExec.IssueCommand(cleanCmd, node)
 		}()
 
 		podClient := f.PodClient()
@@ -138,13 +141,13 @@ var _ = SIGDescribe("Mount propagation", func() {
 
 		// The host mounts one tmpfs to testdir/host and puts a file there so we
 		// can check mount propagation from the host to pods.
-		cmd := fmt.Sprintf("sudo mkdir %[1]q/host; sudo mount -t tmpfs e2e-mount-propagation-host %[1]q/host; echo host > %[1]q/host/file", hostDir)
-		err = e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+		cmd := fmt.Sprintf("mkdir %[1]q/host; mount -t tmpfs e2e-mount-propagation-host %[1]q/host; echo host > %[1]q/host/file", hostDir)
+		err = hostExec.IssueCommand(cmd, node)
 		framework.ExpectNoError(err)
 
 		defer func() {
-			cmd := fmt.Sprintf("sudo umount %q/host", hostDir)
-			e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+			cmd := fmt.Sprintf("umount %q/host", hostDir)
+			hostExec.IssueCommand(cmd, node)
 		}()
 
 		// Now check that mounts are propagated to the right containers.
@@ -180,12 +183,12 @@ var _ = SIGDescribe("Mount propagation", func() {
 		// Check that the mounts are/are not propagated to the host.
 		// Host can see mount from master
 		cmd = fmt.Sprintf("test `cat %q/master/file` = master", hostDir)
-		err = e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+		err = hostExec.IssueCommand(cmd, node)
 		framework.ExpectNoError(err, "host should see mount from master")
 
 		// Host can't see mount from slave
 		cmd = fmt.Sprintf("test ! -e %q/slave/file", hostDir)
-		err = e2essh.IssueSSHCommand(cmd, framework.TestContext.Provider, node)
+		err = hostExec.IssueCommand(cmd, node)
 		framework.ExpectNoError(err, "host shouldn't see mount from slave")
 	})
 })


### PR DESCRIPTION
Not all Kubernetes clusters allow ssh to nodes during test.

**What type of PR is this?**
/kind cleanup

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/sig node

cc @msau42 @derekwaynecarr, PTAL