### PR TITLE
Update cluster autoscaler image to 1.16.0-beta.1

### DIFF
--- a/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
+++ b/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
@@ -40,7 +40,7 @@ rules:
     resources: ["poddisruptionbudgets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["storageclasses"]
+    resources: ["storageclasses", "csinodes"]
     verbs: ["get", "list", "watch"]
   # misc access
   - apiGroups: [""]

--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.15.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.0-beta.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",
@@ -27,13 +27,15 @@
                     "periodSeconds": 60
                 },
                 "command": [
-                    "./run.sh",
+                    "/cluster-autoscaler",
                     "--kubernetes=https://127.0.0.1:443",
                     "--v=4",
-                    "--logtostderr=true",
+                    "--logtostderr=false",
+                    "--log-file=/var/log/cluster-autoscaler.log",
+                    "--log-file-max-size=0",
                     "--write-status-configmap=true",
                     "--balance-similar-node-groups=true",
-		    "--expendable-pods-priority-cutoff=-10",
+                    "--expendable-pods-priority-cutoff=-10",
                     {{params}}
                 ],
                 "env": [


### PR DESCRIPTION
This PR updates CA version in gce manifests to 1.16.0-beta.1

We need to merge it during freeze because, Cluster Autoscaler imports large amount of k8s code to simulate scheduler behavior, yet it lives in separate repository. Therefore
we need to build final release candidate just at the end of k8s release cycle.

We verified image manually yet the manifest in `cluster/gce/manifests/cluster-autoscaler.manifest` needs to be updated to trigger e2e tests run. If those prove that thera are no issues with new release, we will send out yet another PR which updates the image to non-beta version. The release notes will be provided in that followup PR.

/kind bug
/priority critical-urgent
/sig autoscaling
/assign @mwielgus

```release-note
NONE
```
