### PR TITLE
feat(scheduler): expose kubernetes client in the framework handle

### DIFF
--- a/pkg/scheduler/factory/factory.go
+++ b/pkg/scheduler/factory/factory.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -403,7 +403,12 @@ func (c *Configurator) CreateFromKeys(predicateKeys, priorityKeys sets.String, e
 	pluginConfig = append(pluginConfig, pluginConfigForPriorities...)
 	pluginConfig = append(pluginConfig, c.pluginConfig...)
 
-	framework, err := framework.NewFramework(c.registry, &plugins, pluginConfig)
+	framework, err := framework.NewFramework(
+		c.registry,
+		&plugins,
+		pluginConfig,
+		framework.WithClientSet(c.client),
+	)
 	if err != nil {
 		klog.Fatalf("error initializing the scheduling framework: %v", err)
 	}

--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -56,6 +57,8 @@ type framework struct {
 	postBindPlugins       []PostBindPlugin
 	unreservePlugins      []UnreservePlugin
 	permitPlugins         []PermitPlugin
+
+	clientSet clientset.Interface
 }
 
 // extensionPoint encapsulates desired and applied set of plugins at a specific extension
@@ -85,15 +88,37 @@ func (f *framework) getExtensionPoints(plugins *config.Plugins) []extensionPoint
 	}
 }
 
+type frameworkOptions struct {
+	clientSet clientset.Interface
+}
+
+// Option for the framework.
+type Option func(*frameworkOptions)
+
+// WithClientSet sets clientSet for the scheduling framework.
+func WithClientSet(clientSet clientset.Interface) Option {
+	return func(o *frameworkOptions) {
+		o.clientSet = clientSet
+	}
+}
+
+var defaultFrameworkOptions = frameworkOptions{}
+
 var _ = Framework(&framework{})
 
 // NewFramework initializes plugins given the configuration and the registry.
-func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfig) (Framework, error) {
+func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfig, opts ...Option) (Framework, error) {
+	options := defaultFrameworkOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
 	f := &framework{
 		registry:              r,
 		nodeInfoSnapshot:      schedulernodeinfo.NewSnapshot(),
 		pluginNameToWeightMap: make(map[string]int),
 		waitingPods:           newWaitingPodsMap(),
+		clientSet:             options.clientSet,
 	}
 	if plugins == nil {
 		return f, nil
@@ -550,6 +575,11 @@ func (f *framework) ListPlugins() map[string][]string {
 		return m
 	}
 	return nil
+}
+
+// ClientSet returns a kubernetes clientset.
+func (f *framework) ClientSet() clientset.Interface {
+	return f.clientSet
 }
 
 func (f *framework) pluginsNeeded(plugins *config.Plugins) map[string]config.Plugin {

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -25,6 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	clientset "k8s.io/client-go/kubernetes"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
@@ -429,4 +430,7 @@ type FrameworkHandle interface {
 
 	// GetWaitingPod returns a waiting pod given its UID.
 	GetWaitingPod(uid types.UID) WaitingPod
+
+	// ClientSet returns a kubernetes clientSet.
+	ClientSet() clientset.Interface
 }

--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -42,6 +42,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],
 )

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/clock"
+	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
@@ -218,6 +219,10 @@ func (*fakeFramework) RunPermitPlugins(state *framework.CycleState, pod *v1.Pod,
 func (*fakeFramework) IterateOverWaitingPods(callback func(framework.WaitingPod)) {}
 
 func (*fakeFramework) GetWaitingPod(uid types.UID) framework.WaitingPod {
+	return nil
+}
+
+func (*fakeFramework) ClientSet() clientset.Interface {
 	return nil
 }
 


### PR DESCRIPTION
/kind feature
/sig scheduling
/priority important-soon

**What this PR does / why we need it**:

The default bind plugin requires access to the kubernetes client, in order to update the binding field of the pods, https://github.com/kubernetes/kubernetes/pull/81593/files#diff-4de324639a7ba31f0577f95e417a4b24R52

https://github.com/kubernetes/kubernetes/blob/8aca2c148018770e4ad0f4b21d98a81ff714f731/plugin/pkg/scheduling/defaultbinder/plugin.go#L43-L56


ref: https://github.com/kubernetes/kubernetes/pull/82432

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Expose kubernetes client in the scheduling framework handle.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
