### PR TITLE
Fallback to schemaless apply behavior for custom resources with unhandled schemas

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -644,27 +644,10 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 		structuralSchemas[v.Name] = s
 	}
 
-	var openAPIModels proto.Models
-	if utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) && r.staticOpenAPISpec != nil {
-		specs := []*spec.Swagger{}
-		for _, v := range crd.Spec.Versions {
-			s, err := builder.BuildSwagger(crd, v.Name, builder.Options{V2: false, StripDefaults: true, StripValueValidation: true})
-			if err != nil {
-				utilruntime.HandleError(err)
-				return nil, fmt.Errorf("the server could not properly serve the CR schema")
-			}
-			specs = append(specs, s)
-		}
-		mergedOpenAPI, err := builder.MergeSpecs(r.staticOpenAPISpec, specs...)
-		if err != nil {
-			utilruntime.HandleError(err)
-			return nil, fmt.Errorf("the server could not properly merge the CR schema")
-		}
-		openAPIModels, err = utilopenapi.ToProtoModels(mergedOpenAPI)
-		if err != nil {
-			utilruntime.HandleError(err)
-			return nil, fmt.Errorf("the server could not properly serve the CR schema")
-		}
+	openAPIModels, err := buildOpenAPIModelsForApply(r.staticOpenAPISpec, crd)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("error building openapi models for %s: %v", crd.Name, err))
+		openAPIModels = nil
 	}
 
 	for _, v := range crd.Spec.Versions {
@@ -1238,4 +1221,36 @@ func serverStartingError() error {
 		err.ErrStatus.Details.RetryAfterSeconds = int32(10)
 	}
 	return err
+}
+
+// buildOpenAPIModelsForApply constructs openapi models from any validation schemas specified in the custom resource,
+// and merges it with the models defined in the static OpenAPI spec.
+// Returns nil models if the ServerSideApply feature is disabled, or the static spec is nil, or an error is encountered.
+func buildOpenAPIModelsForApply(staticOpenAPISpec *spec.Swagger, crd *apiextensions.CustomResourceDefinition) (proto.Models, error) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.ServerSideApply) {
+		return nil, nil
+	}
+	if staticOpenAPISpec == nil {
+		return nil, nil
+	}
+
+	specs := []*spec.Swagger{}
+	for _, v := range crd.Spec.Versions {
+		s, err := builder.BuildSwagger(crd, v.Name, builder.Options{V2: false, StripDefaults: true, StripValueValidation: true})
+		if err != nil {
+			return nil, err
+		}
+		specs = append(specs, s)
+	}
+
+	mergedOpenAPI, err := builder.MergeSpecs(staticOpenAPISpec, specs...)
+	if err != nil {
+		return nil, err
+	}
+
+	models, err := utilopenapi.ToProtoModels(mergedOpenAPI)
+	if err != nil {
+		return nil, err
+	}
+	return models, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Falls back to schema-less behavior for server-side-apply for custom resources defined with schemas that are not handled by kube-openapi.

An inability to construct the schema for server-side-apply to use should not block serving of existing CRDs

**Which issue(s) this PR fixes**:
Fixes #82436

**Does this PR introduce a user-facing change?**:
```release-note
Resolved regression serving custom resources with unhandled validation schemas with the ServerSideApply feature enabled
```

/sig api-machinery
/cc @apelisse @jennybuckley @sttts 
/milestone v1.16
/priority critical-urgent