### PR TITLE
Check cache is synced first before sleeping

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -209,7 +209,7 @@ func WaitForNamedCacheSync(controllerName string, stopCh <-chan struct{}, cacheS
 // if the controller should shutdown
 // callers should prefer WaitForNamedCacheSync()
 func WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
-	err := wait.PollUntil(syncedPollPeriod,
+	err := wait.PollImmediateUntil(syncedPollPeriod,
 		func() (bool, error) {
 			for _, syncFunc := range cacheSyncs {
 				if !syncFunc() {


### PR DESCRIPTION
If a cache was already synced, cache.WaitForCacheSync would
always take 100ms to complete because the PollUntil method will
sleep first before checking the condition.  Switching to
PollImmediateUntil will ensure already synced caches will return
immediately.  For code that has, for example, 20 informers, the time
to check the cache was in sync would take at least 2 seconds, but with
this change it can be as fast as you can actually load the data.

Signed-off-by: Darren Shepherd <darren@rancher.com>

```release-note
NONE
``` 