### PR TITLE
[PR Template] Add codeblock to capture primary sig associated with PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,21 @@ https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-k
 6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
 -->
 
+**Which is the sponsoring or primary SIG associated with this PR?**
+<!--
+Label the sponsoring or primary SIG associated with this PR.
+
+For reference on available SIGs, you can find more details at:
+https://github.com/kubernetes/test-infra/blob/master/label_sync/labels.md#labels-that-apply-to-all-repos-for-both-issues-and-prs
+
+Add only ONE sig here, by adding the sig name in the primary-sig block below.
+
+Examples: cloud-provider or api-machinery
+-->
+```primary-sig
+
+```
+
 **What type of PR is this?**
 > Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
 >


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds a code block to the PR Template for the **kubernetes/kubernetes** repo to capture the **primary sig** information as requested in [Issue kubernetes/sig-release#668](https://github.com/kubernetes/sig-release/issues/668)

**Which issue(s) this PR fixes**:

Refers to Issue [kubernetes/sig-release#668](https://github.com/kubernetes/sig-release/issues/668)

**Special notes for your reviewer**:

This is a smaller focused PR that was extracted from [PR kubernetes/kubernetes #81278](https://github.com/kubernetes/kubernetes/pull/81278)

This will require an update to the [release notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) for the next release cycle (1.17) to ensure that the **primary sig** information is parsed and processed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/cc @saschagrunert @onyiny-ang
/sig release
