### PR TITLE
[PR Template] Add codeblock to capture deprecation note associated with PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,6 +43,16 @@ Enter your extended release note in the block below. If the PR requires addition
 
 ```
 
+**Should this PR be associated with a deprecation notice?**
+<!--
+Indicate whether this PR implements a change that requires users to be informed of a deprecation of behaviour.
+
+If your PR does require a deprecation note, then remove the `None` from the deprecation-note block below and add your notes.
+-->
+```deprecation-note
+None
+```
+
 **Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
 
 <!--


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds a code block to the PR Template for the **kubernetes/kubernetes** repo to capture the **deprecation note** information as requested in [Issue kubernetes/sig-release#668](https://github.com/kubernetes/sig-release/issues/668)

**Which issue(s) this PR fixes**:

Refers to Issue [kubernetes/sig-release#668](https://github.com/kubernetes/sig-release/issues/668)

**Special notes for your reviewer**:

This is a smaller focused PR that was extracted from [PR kubernetes/kubernetes #81278](https://github.com/kubernetes/kubernetes/pull/81278)

This will require an update to the [release notes tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes) for the next release cycle (1.17) to ensure that the **deprecation note** information is parsed and processed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/cc @saschagrunert @onyiny-ang
/sig release
