### PR TITLE
Implement semantic DeepEqual for ResourceList and EmptyDirVolumeSource

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/equality/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/api/equality/BUILD
@@ -11,6 +11,7 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/api/equality",
     importpath = "k8s.io/apimachinery/pkg/api/equality",
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",

--- a/staging/src/k8s.io/apimachinery/pkg/api/equality/semantic.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/equality/semantic.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // Semantic can do semantic deep equality checks for api objects.
@@ -45,5 +46,35 @@ var Semantic = conversion.EqualitiesOrDie(
 	},
 	func(a, b fields.Selector) bool {
 		return a.String() == b.String()
+	},
+	func(a, b corev1.ResourceList) bool {
+		if len(a) != len(b) {
+			return false
+		}
+		if len(a) == 0 {
+			return true
+		}
+		for k, v := range a {
+			bVal, ok := b[k]
+			if !ok || bVal.Cmp(v) != 0 {
+				return false
+			}
+		}
+		return true
+	},
+	func(a, b corev1.EmptyDirVolumeSource) bool {
+		if a.Medium != b.Medium {
+			return false
+		}
+		if a.SizeLimit == nil {
+			if b.SizeLimit != nil {
+				return false
+			}
+			return true
+		}
+		if b.SizeLimit == nil {
+			return false
+		}
+		return a.SizeLimit.Cmp(*(b.SizeLimit)) == 0
 	},
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #82242 mentioned, ResourceList and EmptyDirVolumeSource involve Quantity field, hence their semantic DeepEqual should use Cmp between Quantity fields.

This PR adds ResourceList and EmptyDirVolumeSource to semantic.go

**Which issue(s) this PR fixes**:
Fixes #82242

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
