### PR TITLE
Propagate error when creating LRUExpireCache

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -193,7 +193,11 @@ func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, er
 		tokenAuth := tokenunion.New(tokenAuthenticators...)
 		// Optionally cache authentication results
 		if config.TokenSuccessCacheTTL > 0 || config.TokenFailureCacheTTL > 0 {
-			tokenAuth = tokencache.New(tokenAuth, true, config.TokenSuccessCacheTTL, config.TokenFailureCacheTTL)
+			var err error
+			tokenAuth, err = tokencache.New(tokenAuth, true, config.TokenSuccessCacheTTL, config.TokenFailureCacheTTL)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 		authenticators = append(authenticators, bearertoken.New(tokenAuth), websocket.NewProtocolAuthenticator(tokenAuth))
 		securityDefinitions["BearerToken"] = &spec.SecurityScheme{
@@ -326,5 +330,5 @@ func newWebhookTokenAuthenticator(webhookConfigFile string, ttl time.Duration, i
 		return nil, err
 	}
 
-	return tokencache.New(webhookTokenAuthenticator, false, ttl, ttl), nil
+	return tokencache.New(webhookTokenAuthenticator, false, ttl, ttl)
 }

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -266,10 +266,14 @@ func NewImagePolicyWebhook(configFile io.Reader) (*Plugin, error) {
 	if err != nil {
 		return nil, err
 	}
+	var lruCache *cache.LRUExpireCache
+	if lruCache, err = cache.NewLRUExpireCache(1024); err != nil {
+		return nil, err
+	}
 	return &Plugin{
 		Handler:       admission.NewHandler(admission.Create, admission.Update),
 		webhook:       gw,
-		responseCache: cache.NewLRUExpireCache(1024),
+		responseCache: lruCache,
 		allowTTL:      whConfig.AllowTTL,
 		denyTTL:       whConfig.DenyTTL,
 		defaultAllow:  whConfig.DefaultAllow,

--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/lruexpirecache.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/lruexpirecache.go
@@ -44,18 +44,18 @@ type LRUExpireCache struct {
 }
 
 // NewLRUExpireCache creates an expiring cache with the given size
-func NewLRUExpireCache(maxSize int) *LRUExpireCache {
+func NewLRUExpireCache(maxSize int) (*LRUExpireCache, error) {
 	return NewLRUExpireCacheWithClock(maxSize, realClock{})
 }
 
 // NewLRUExpireCacheWithClock creates an expiring cache with the given size, using the specified clock to obtain the current time.
-func NewLRUExpireCacheWithClock(maxSize int, clock Clock) *LRUExpireCache {
+func NewLRUExpireCacheWithClock(maxSize int, clock Clock) (*LRUExpireCache, error) {
 	cache, err := lru.New(maxSize)
 	if err != nil {
 		// if called with an invalid size
-		panic(err)
+		return nil, err
 	}
-	return &LRUExpireCache{clock: clock, cache: cache}
+	return &LRUExpireCache{clock: clock, cache: cache}, nil
 }
 
 type cacheEntry struct {

--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/lruexpirecache_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/lruexpirecache_test.go
@@ -39,30 +39,39 @@ func expectNotEntry(t *testing.T, c *LRUExpireCache, key lru.Key) {
 }
 
 func TestSimpleGet(t *testing.T) {
-	c := NewLRUExpireCache(10)
-	c.Add("long-lived", "12345", 10*time.Hour)
-	expectEntry(t, c, "long-lived", "12345")
+	if c, err := NewLRUExpireCache(10); err != nil {
+		t.Errorf("cache creation error: %v", err)
+	} else {
+		c.Add("long-lived", "12345", 10*time.Hour)
+		expectEntry(t, c, "long-lived", "12345")
+	}
 }
 
 func TestExpiredGet(t *testing.T) {
 	fakeClock := clock.NewFakeClock(time.Now())
-	c := NewLRUExpireCacheWithClock(10, fakeClock)
-	c.Add("short-lived", "12345", 1*time.Millisecond)
-	// ensure the entry expired
-	fakeClock.Step(2 * time.Millisecond)
-	expectNotEntry(t, c, "short-lived")
+	if c, err := NewLRUExpireCacheWithClock(10, fakeClock); err != nil {
+		t.Errorf("cache creation error: %v", err)
+	} else {
+		c.Add("short-lived", "12345", 1*time.Millisecond)
+		// ensure the entry expired
+		fakeClock.Step(2 * time.Millisecond)
+		expectNotEntry(t, c, "short-lived")
+	}
 }
 
 func TestLRUOverflow(t *testing.T) {
-	c := NewLRUExpireCache(4)
-	c.Add("elem1", "1", 10*time.Hour)
-	c.Add("elem2", "2", 10*time.Hour)
-	c.Add("elem3", "3", 10*time.Hour)
-	c.Add("elem4", "4", 10*time.Hour)
-	c.Add("elem5", "5", 10*time.Hour)
-	expectNotEntry(t, c, "elem1")
-	expectEntry(t, c, "elem2", "2")
-	expectEntry(t, c, "elem3", "3")
-	expectEntry(t, c, "elem4", "4")
-	expectEntry(t, c, "elem5", "5")
+	if c, err := NewLRUExpireCache(4); err != nil {
+		t.Errorf("cache creation error: %v", err)
+	} else {
+		c.Add("elem1", "1", 10*time.Hour)
+		c.Add("elem2", "2", 10*time.Hour)
+		c.Add("elem3", "3", 10*time.Hour)
+		c.Add("elem4", "4", 10*time.Hour)
+		c.Add("elem5", "5", 10*time.Hour)
+		expectNotEntry(t, c, "elem1")
+		expectEntry(t, c, "elem2", "2")
+		expectEntry(t, c, "elem3", "3")
+		expectEntry(t, c, "elem4", "4")
+		expectEntry(t, c, "elem5", "5")
+	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -183,7 +183,11 @@ func NewLifecycle(immortalNamespaces sets.String) (*Lifecycle, error) {
 }
 
 func newLifecycleWithClock(immortalNamespaces sets.String, clock utilcache.Clock) (*Lifecycle, error) {
-	forceLiveLookupCache := utilcache.NewLRUExpireCacheWithClock(100, clock)
+	var forceLiveLookupCache *utilcache.LRUExpireCache
+	var err error
+	if forceLiveLookupCache, err = utilcache.NewLRUExpireCacheWithClock(100, clock); err != nil {
+		return nil, err
+	}
 	return &Lifecycle{
 		Handler:              admission.NewHandler(admission.Create, admission.Update, admission.Delete),
 		immortalNamespaces:   immortalNamespaces,

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
@@ -92,7 +92,10 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 		if err != nil {
 			return nil, nil, err
 		}
-		cachingTokenAuth := cache.New(tokenAuth, false, c.CacheTTL, c.CacheTTL)
+		var cachingTokenAuth authenticator.Token
+		if cachingTokenAuth, err = cache.New(tokenAuth, false, c.CacheTTL, c.CacheTTL); err != nil {
+			return nil, nil, err
+		}
 		authenticators = append(authenticators, bearertoken.New(cachingTokenAuth), websocket.NewProtocolAuthenticator(cachingTokenAuth))
 
 		securityDefinitions["BearerToken"] = &spec.SecurityScheme{

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_simple.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_simple.go
@@ -27,8 +27,13 @@ type simpleCache struct {
 	lru *lrucache.LRUExpireCache
 }
 
-func newSimpleCache(size int, clock clock.Clock) cache {
-	return &simpleCache{lru: lrucache.NewLRUExpireCacheWithClock(size, clock)}
+func newSimpleCache(size int, clock clock.Clock) (cache, error) {
+	var lruExpireCache *lrucache.LRUExpireCache
+	var err error
+	if lruExpireCache, err = lrucache.NewLRUExpireCacheWithClock(size, clock); err != nil {
+		return nil, err
+	}
+	return &simpleCache{lru: lruExpireCache}, nil
 }
 
 func (c *simpleCache) get(key string) (*cacheRecord, bool) {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
@@ -29,19 +29,39 @@ import (
 )
 
 func TestSimpleCache(t *testing.T) {
-	testCache(newSimpleCache(4096, clock.RealClock{}), t)
+	var simpleCache cache
+	var err error
+	if simpleCache, err = newSimpleCache(4096, clock.RealClock{}); err != nil {
+		t.Errorf("cache creation error: %v", err)
+	}
+	testCache(simpleCache, t)
 }
 
 func BenchmarkSimpleCache(b *testing.B) {
-	benchmarkCache(newSimpleCache(4096, clock.RealClock{}), b)
+	var simpleCache cache
+	var err error
+	if simpleCache, err = newSimpleCache(4096, clock.RealClock{}); err != nil {
+		b.Errorf("cache creation error: %v", err)
+	}
+	benchmarkCache(simpleCache, b)
 }
 
 func TestStripedCache(t *testing.T) {
-	testCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(128, clock.RealClock{}) }), t)
+	var simpleCache cache
+	var err error
+	if simpleCache, err = newSimpleCache(128, clock.RealClock{}); err != nil {
+		t.Errorf("cache creation error: %v", err)
+	}
+	testCache(newStripedCache(32, fnvHashFunc, func() cache { return simpleCache }), t)
 }
 
 func BenchmarkStripedCache(b *testing.B) {
-	benchmarkCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(128, clock.RealClock{}) }), b)
+	var simpleCache cache
+	var err error
+	if simpleCache, err = newSimpleCache(128, clock.RealClock{}); err != nil {
+		b.Errorf("cache creation error: %v", err)
+	}
+	benchmarkCache(newStripedCache(32, fnvHashFunc, func() cache { return simpleCache }), b)
 }
 
 func benchmarkCache(cache cache, b *testing.B) {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
@@ -41,7 +41,11 @@ func TestCachedTokenAuthenticator(t *testing.T) {
 	})
 	fakeClock := utilclock.NewFakeClock(time.Now())
 
-	a := newWithClock(fakeAuth, true, time.Minute, 0, fakeClock)
+	var a authenticator.Token
+	var err error
+	if a, err = newWithClock(fakeAuth, true, time.Minute, 0, fakeClock); err != nil {
+		t.Errorf("token creation err: %v", err)
+	}
 
 	calledWithToken, resultUsers, resultOk, resultErr = []string{}, nil, false, nil
 	a.AuthenticateToken(context.Background(), "bad1")
@@ -113,7 +117,11 @@ func TestCachedTokenAuthenticatorWithAudiences(t *testing.T) {
 	})
 	fakeClock := utilclock.NewFakeClock(time.Now())
 
-	a := newWithClock(fakeAuth, true, time.Minute, 0, fakeClock)
+	var a authenticator.Token
+	var err error
+	if a, err = newWithClock(fakeAuth, true, time.Minute, 0, fakeClock); err != nil {
+		t.Errorf("token creation error: %v", err)
+	}
 
 	resultUsers["audAusertoken1"] = &user.DefaultInfo{Name: "user1"}
 	resultUsers["audBusertoken1"] = &user.DefaultInfo{Name: "user1-different"}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_test.go
@@ -205,7 +205,7 @@ func newTokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, c
 		return nil, err
 	}
 
-	return cache.New(authn, false, cacheTime, cacheTime), nil
+	return cache.New(authn, false, cacheTime, cacheTime)
 }
 
 func TestTLSConfig(t *testing.T) {

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -92,9 +92,14 @@ func New(kubeConfigFile string, authorizedTTL, unauthorizedTTL time.Duration) (*
 
 // newWithBackoff allows tests to skip the sleep.
 func newWithBackoff(subjectAccessReview authorizationclient.SubjectAccessReviewInterface, authorizedTTL, unauthorizedTTL, initialBackoff time.Duration) (*WebhookAuthorizer, error) {
+	var cache_ *cache.LRUExpireCache
+	var err error
+	if cache_, err = cache.NewLRUExpireCache(1024); err != nil {
+		return nil, err
+	}
 	return &WebhookAuthorizer{
 		subjectAccessReview: subjectAccessReview,
-		responseCache:       cache.NewLRUExpireCache(1024),
+		responseCache:       cache_,
 		authorizedTTL:       authorizedTTL,
 		unauthorizedTTL:     unauthorizedTTL,
 		initialBackoff:      initialBackoff,

--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -61,10 +61,11 @@ type ResourceVersionComparator interface {
 // in the underlying store. This is only safe if your use of the cache can handle mutation entries
 // remaining in the cache for up to ttl when mutations and deletes occur very closely in time.
 func NewIntegerResourceVersionMutationCache(backingCache Store, indexer Indexer, ttl time.Duration, includeAdds bool) MutationCache {
+	lruCache, _ := utilcache.NewLRUExpireCache(100)
 	return &mutationCache{
 		backingCache:  backingCache,
 		indexer:       indexer,
-		mutationCache: utilcache.NewLRUExpireCache(100),
+		mutationCache: lruCache,
 		comparator:    etcdObjectVersioner{},
 		ttl:           ttl,
 		includeAdds:   includeAdds,

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -89,7 +89,12 @@ func getTestWebhookTokenAuth(serverURL string) (authenticator.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	return bearertoken.New(cache.New(webhookTokenAuth, false, 2*time.Minute, 2*time.Minute)), nil
+	var token authenticator.Token
+	token, err = cache.New(webhookTokenAuth, false, 2*time.Minute, 2*time.Minute)
+	if err != nil {
+		return nil, err
+	}
+	return bearertoken.New(token), nil
 }
 
 func path(resource, namespace, name string) string {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently NewLRUExpireCacheWithClock panics when invalid size is passed.

This PR propagate the error when creating LRUExpireCache.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
