### PR TITLE
fix error strings end with punctuation or a newline

### DIFF
--- a/pkg/kubectl/cmd/get/customcolumn.go
+++ b/pkg/kubectl/cmd/get/customcolumn.go
@@ -108,12 +108,12 @@ func splitOnWhitespace(line string) []string {
 func NewCustomColumnsPrinterFromTemplate(templateReader io.Reader, decoder runtime.Decoder) (*CustomColumnsPrinter, error) {
 	scanner := bufio.NewScanner(templateReader)
 	if !scanner.Scan() {
-		return nil, fmt.Errorf("invalid template, missing header line. Expected format is one line of space separated headers, one line of space separated column specs.")
+		return nil, fmt.Errorf("invalid template, missing header line. Expected format is one line of space separated headers, one line of space separated column specs")
 	}
 	headers := splitOnWhitespace(scanner.Text())
 
 	if !scanner.Scan() {
-		return nil, fmt.Errorf("invalid template, missing spec line. Expected format is one line of space separated headers, one line of space separated column specs.")
+		return nil, fmt.Errorf("invalid template, missing spec line. Expected format is one line of space separated headers, one line of space separated column specs")
 	}
 	specs := splitOnWhitespace(scanner.Text())
 

--- a/pkg/kubectl/cmd/get/customcolumn_flags.go
+++ b/pkg/kubectl/cmd/get/customcolumn_flags.go
@@ -86,7 +86,7 @@ func (f *CustomColumnsPrintFlags) ToPrinter(templateFormat string) (printers.Res
 	if templateFormat == "custom-columns-file" {
 		file, err := os.Open(templateValue)
 		if err != nil {
-			return nil, fmt.Errorf("error reading template %s, %v\n", templateValue, err)
+			return nil, fmt.Errorf("error reading template %s, %v", templateValue, err)
 		}
 		defer file.Close()
 		p, err := NewCustomColumnsPrinterFromTemplate(file, decoder)


### PR DESCRIPTION
/kind cleanup

fix error strings end with punctuation or a newline in pkg/kubectl/cmd/get