### PR TITLE
fix some missing errors return statements

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -226,12 +226,10 @@ vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1/helper
 vendor/k8s.io/kube-aggregator/pkg/controllers/autoregister
 vendor/k8s.io/kube-aggregator/pkg/controllers/openapi/aggregator
 vendor/k8s.io/kubectl/pkg/cmd/annotate
-vendor/k8s.io/kubectl/pkg/cmd/apply
 vendor/k8s.io/kubectl/pkg/cmd/certificates
 vendor/k8s.io/kubectl/pkg/cmd/config
 vendor/k8s.io/kubectl/pkg/cmd/edit
 vendor/k8s.io/kubectl/pkg/cmd/exec
-vendor/k8s.io/kubectl/pkg/cmd/label
 vendor/k8s.io/kubectl/pkg/cmd/proxy
 vendor/k8s.io/kubectl/pkg/cmd/rollingupdate
 vendor/k8s.io/kubectl/pkg/cmd/scale

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go
@@ -90,6 +90,9 @@ func (s *DryRunnableStorage) GuaranteedUpdate(
 			return err
 		}
 		rev, err := s.Versioner().ObjectResourceVersion(ptrToType)
+		if err != nil {
+			return err
+		}
 		out, _, err := tryUpdate(ptrToType, storage.ResponseMeta{ResourceVersion: rev})
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -251,6 +251,9 @@ func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 
 	o.OpenAPISchema, _ = f.OpenAPISchema()
 	o.Validator, err = f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
+	if err != nil {
+		return err
+	}
 	o.Builder = f.NewBuilder()
 	o.Mapper, err = f.ToRESTMapper()
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -182,6 +182,9 @@ func (o *LabelOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 	}
 	o.resources = resources
 	o.newLabels, o.removeLabels, err = parseLabels(labelArgs)
+	if err != nil {
+		return err
+	}
 
 	if o.list && len(o.outputFormat) > 0 {
 		return fmt.Errorf("--list and --output may not be specified together")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

some functions missed the errors return statements as below, it will lead to a wrong error returned:
[staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go#L92](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/dryrun.go#L92)
[staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go#L253](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go#L253)
[staging/src/k8s.io/kubectl/pkg/cmd/label/label.go#L184](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go#L184)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

Signed-off-by: haoshuwei <haoshuwei24@gmail.com>