### PR TITLE
The correct PluginConfig.Args is not passed to the corresponding PluginFactory in kube-scheduler when multiple PluginConfig items are defined

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -582,7 +582,9 @@ func (f *framework) GetWaitingPod(uid types.UID) WaitingPod {
 
 func pluginNameToConfig(args []config.PluginConfig) map[string]*runtime.Unknown {
 	pc := make(map[string]*runtime.Unknown, 0)
-	for _, p := range args {
+	for i := range args {
+		// This is needed because the type of PluginConfig.Args is not pointer type.
+		p := args[i]
 		pc[p.Name] = &p.Args
 	}
 	return pc


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

/sig scheduling

`PluginConfig.Args` is not passed as expected if `PluginConfig` has multiple items.  It is because the type of `PluginConfig.Args` is not pointer type.

**Which issue(s) this PR fixes**:

It fixes the above issue so that `NewFramework` correctly initialize `PluginConfig.Args` as expected.

**Special notes for your reviewer**:

the PR did not change api(`KubeSchedulerConfiguration`) at all but fixes inside of kube-scheduler (just allocating new variable to capture the correct `PluginConfig.Args`)

**Does this PR introduce a user-facing change?**:

```release-note
fixed an issue that the correct PluginConfig.Args is not passed to the corresponding PluginFactory in kube-scheduler when multiple PluginConfig items are defined.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
