### PR TITLE
Update Cluster Autoscaler version to 1.16.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.0-beta.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This is a followup of #82430 - just a version update (no changes since 1.16.0-beta.1)
Changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.0
CI already passed green on 1.16.0-beta.1 (https://k8s-testgrid.appspot.com/sig-autoscaling-cluster-autoscaler#gci-gce-autoscaling)

```release-note
Update Cluster Autoscaler to 1.16.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.0
```
