### PR TITLE
dockershim/network: fix panic for cni plugins in IPv4/IPv6 dual-stack mode

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni_others.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_others.go
@@ -74,6 +74,10 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 		return nil, err
 	}
 
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("cannot find pod IPs in the network namespace, skipping pod network status for container %q", id)
+	}
+
 	return &network.PodNetworkStatus{
 		IP:  ips[0],
 		IPs: ips,

--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -271,18 +271,20 @@ func GetPodIPs(execer utilexec.Interface, nsenterPath, netnsPath, interfaceName 
 		return []net.IP{ip}, nil
 	}
 
-	list := make([]net.IP, 0)
-	var err4, err6 error
-	if ipv4, err4 := getOnePodIP(execer, nsenterPath, netnsPath, interfaceName, "-4"); err4 != nil {
-		list = append(list, ipv4)
-	}
-
-	if ipv6, err6 := getOnePodIP(execer, nsenterPath, netnsPath, interfaceName, "-6"); err6 != nil {
-		list = append(list, ipv6)
+	var (
+		list []net.IP
+		errs []error
+	)
+	for _, addrType := range []string{"-4", "-6"} {
+		if ip, err := getOnePodIP(execer, nsenterPath, netnsPath, interfaceName, addrType); err == nil {
+			list = append(list, ip)
+		} else {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(list) == 0 {
-		return nil, utilerrors.NewAggregate([]error{err4, err6})
+		return nil, utilerrors.NewAggregate(errs)
 	}
 	return list, nil
 


### PR DESCRIPTION

```
 k8s.io/kubernetes/pkg/kubelet/dockershim/network/cni.(*cniNetworkPlugin).GetPodNetworkStatus(0xc000a04370, 0xc000b89a62, 0xb, 0xc000b89a49, 0x18, 0x42edffb, 0x6, 0xc000cfa340, 0x40, 0xc000ced7d0, ...)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockershim/network/cni/cni_others.go:78 +0x420
 k8s.io/kubernetes/pkg/kubelet/dockershim/network.(*PluginManager).GetPodNetworkStatus(0xc000a51880, 0xc000b89a62, 0xb, 0xc000b89a49, 0x18, 0x42edffb, 0x6, 0xc000cfa340, 0x40, 0x0, ...)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockershim/network/plugins.go:391 +0x1f9
 k8s.io/kubernetes/pkg/kubelet/dockershim.(*dockerService).getIPsFromPlugin(0xc00029b600, 0xc000c25cb0, 0x40, 0x78c0000, 0x7982100, 0x0, 0x0)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox.go:335 +0x1c3
 k8s.io/kubernetes/pkg/kubelet/dockershim.(*dockerService).getIPs(0xc00029b600, 0xc000b66cc0, 0x40, 0xc000c25cb0, 0x30bd171a, 0xed508364b, 0x0)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox.go:373 +0xe3
 k8s.io/kubernetes/pkg/kubelet/dockershim.(*dockerService).PodSandboxStatus(0xc00029b600, 0x4ad8b20, 0xc000c25c80, 0xc000cde1c0, 0xc00029b600, 0xc000c25c80, 0xc0005f5bd0)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/pkg/kubelet/dockershim/docker_sandbox.go:439 +0x133
 k8s.io/kubernetes/vendor/k8s.io/cri-api/pkg/apis/runtime/v1alpha2._RuntimeService_PodSandboxStatus_Handler(0x42c4e00, 0xc00029b600, 0x4ad8b20, 0xc000c25c80, 0xc000c126c0, 0x0, 0x4ad8b20, 0xc000c25c80, 0xc000cb2d20, 0x42)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/cri-api/pkg/apis/runtime/v1alpha2/api.pb.go:7663 +0x23e
 k8s.io/kubernetes/vendor/google.golang.org/grpc.(*Server).processUnaryRPC(0xc000a4f760, 0x4b45280, 0xc000b02d80, 0xc000847c00, 0xc000a61b00, 0x78c97c0, 0x0, 0x0, 0x0)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/google.golang.org/grpc/server.go:995 +0x466
 k8s.io/kubernetes/vendor/google.golang.org/grpc.(*Server).handleStream(0xc000a4f760, 0x4b45280, 0xc000b02d80, 0xc000847c00, 0x0)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/google.golang.org/grpc/server.go:1275 +0xda6
 k8s.io/kubernetes/vendor/google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000a8e9c0, 0xc000a4f760, 0x4b45280, 0xc000b02d80, 0xc000847c00)
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/google.golang.org/grpc/server.go:710 +0x9f
 created by k8s.io/kubernetes/vendor/google.golang.org/grpc.(*Server).serveStreams.func1
         /workspace/anago-v1.16.0-beta.1.787+48ca054daba9e6/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/google.golang.org/grpc/server.go:708 +0xa1
```

Fixes: dba434c4ba0b ("kubenet for ipv6 dualstack")
Signed-off-by: André Martins <aanm90@gmail.com>

**What type of PR is this?**
/kind bug
/sig network
/area kubelet

**Special notes for your reviewer**:

Although this is in alpha, should this be considered a blocker for k8s 1.16.0? Can, or will this be backported for k8s 1.16.1?

**Does this PR introduce a user-facing change?**:
```release-note
Fix panic in kubelet when running IPv4/IPv6 dual-stack mode with a CNI plugin
```

cc @khenidak 