### PR TITLE
Modify the log of kube-proxy

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -326,7 +326,7 @@ func getProxyMode(proxyMode string, khandle ipvs.KernelHandler, ipsetver ipvs.IP
 	case proxyModeIPVS:
 		return tryIPVSProxy(khandle, ipsetver, kcompat)
 	}
-	klog.Warningf("Flag proxy-mode=%q unknown, assuming iptables proxy", proxyMode)
+	klog.Warningf("Unknown proxy mode %q, assuming iptables proxy", proxyMode)
 	return tryIPTablesProxy(kcompat)
 }
 


### PR DESCRIPTION
Modify the warning log of kube-proxy when we run kube-proxy server
with --proxy-mode, but in the config file, we omit it, like 'kube-proxy --config config.conf  --proxy-mode ipvs'
Then it logs like ""{"log":"W0905 09:14:40.321571       1 server_others.go:249] Flag proxy-mode=\"\" unknown, assuming iptables proxy\n","stream":"stderr", "time":"2019-09-05T09:14:40.321858964Z"} 
This may lead to confusion. I think it should me modefied.

