### PR TITLE
[WIP] Reflect projects in /etc on kubelet restart

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -112,6 +112,7 @@ go_library(
         "//pkg/volume/csi:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//pkg/volume/util/exec:go_default_library",
+        "//pkg/volume/util/fsquota:go_default_library",
         "//pkg/volume/util/hostutil:go_default_library",
         "//pkg/volume/util/subpath:go_default_library",
         "//pkg/volume/util/types:go_default_library",
@@ -152,6 +153,7 @@ go_library(
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/integer:go_default_library",
         "//vendor/k8s.io/utils/path:go_default_library",
+        "//vendor/k8s.io/utils/strings:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1457,7 +1457,11 @@ func (kl *Kubelet) Run(updates <-chan kubetypes.PodUpdate) {
 			if vol.Name != "" && vol.VolumeSource.EmptyDir != nil {
 				podVolumeDir := kl.getPodVolumeDir(pod.UID, utilstrings.EscapeQualifiedName("kubernetes.io/empty-dir"), pod.Spec.Hostname)
 				if podVolumeDir != "" {
-					fsquota.RecordProjectIDOnProjectFiles(podVolumeDir)
+					if err := fsquota.RecordProjectIDOnProjectFiles(podVolumeDir); err != nil {
+						// just log the error and continue , nothing much can be done about it
+						klog.Errorf("failed to records projects in /etc/project files on kubelet startup: %v", err)
+					}
+
 				}
 			}
 		}

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -33,7 +33,7 @@ import (
 	"time"
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -51,7 +51,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/certificate"
 	"k8s.io/client-go/util/flowcontrol"
-	"k8s.io/cloud-provider"
+	cloudprovider "k8s.io/cloud-provider"
 	internalapi "k8s.io/cri-api/pkg/apis"
 	"k8s.io/klog"
 	api "k8s.io/kubernetes/pkg/apis/core"

--- a/pkg/volume/util/fsquota/quota.go
+++ b/pkg/volume/util/fsquota/quota.go
@@ -42,6 +42,10 @@ type Interface interface {
 	// Implementations may assume that any data covered by the
 	// quota has already been removed.
 	ClearQuota(m mount.Interface, path string) error
+
+	// Records project for the given directory-path
+	// to /etc/projects and /etc/projectid
+	RecordProjectIDOnProjectFiles(podVolumeDir string) error
 }
 
 func enabledQuotasForMonitoring() bool {

--- a/pkg/volume/util/fsquota/quota_linux.go
+++ b/pkg/volume/util/fsquota/quota_linux.go
@@ -219,13 +219,6 @@ func getQuotaOnDir(m mount.Interface, path string) (common.QuotaID, error) {
 	return getApplier(path).GetQuotaOnDir(path)
 }
 
-func getQuotaIDFromDirPath(path string) (common.QuotaID, bool) {
-	if val, ok := dirQuotaMap[path]; ok {
-		return val, ok
-	}
-	return nil, false
-}
-
 func clearQuotaOnDir(m mount.Interface, path string) error {
 	// Since we may be called without path being in the map,
 	// we explicitly have to check in this case.
@@ -448,7 +441,8 @@ func ClearQuota(m mount.Interface, path string) error {
 
 // RecordProjectIDOnProjectFiles -- Records project file for the given directory-path to /etc/projects and /etc/projectid
 func RecordProjectIDOnProjectFiles(podVolumeDir string) error {
-	if id, ok := getQuotaIDFromDirPath(podVolumeDir); ok {
+	id, err := getApplier(podVolumeDir).GetQuotaOnDir(podVolumeDir)
+	if err == nil {
 		fProjects, fProjid, err := openAndLockProjectFiles()
 		if err != nil {
 			defer closeProjectFiles(fProjects, fProjid)
@@ -464,5 +458,5 @@ func RecordProjectIDOnProjectFiles(podVolumeDir string) error {
 		}
 		return err
 	}
-	return fmt.Errorf("unable to get QuotaID from directory path: %s", podVolumeDir)
+	return fmt.Errorf("unable to get QuotaID from directory path:%s: %v", podVolumeDir, err)
 }

--- a/pkg/volume/util/fsquota/quota_unsupported.go
+++ b/pkg/volume/util/fsquota/quota_unsupported.go
@@ -54,3 +54,8 @@ func GetInodes(_ string) (*resource.Quantity, error) {
 func ClearQuota(_ mount.Interface, _ string) error {
 	return errNotImplemented
 }
+
+// RecordProjectIDOnProjectFiles -- dummy implementation
+func RecordProjectIDOnProjectFiles(_ string) error {
+	return errNotImplemented
+}


### PR DESCRIPTION
As already mentioned in this issue: https://github.com/kubernetes/kubernetes/issues/79440, this change is to record projects in /etc
on kubelet restart so that we can prevent the case when other actors on the node that use project quota and rely on /etc may have collision with kubelet's project quotas

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR is a bug fix. As already mentioned in this [this issue](https://github.com/kubernetes/kubernetes/issues/79440). We would like to record  projects in /etc on kubelet restart so that other actors on the node that use project quota and rely on /etc, they may have collision with kubelet's project quotas
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/79440

**Special notes for your reviewer**:

Hey folks, I created this PR as a draft, so that we have something to start a discussion on since I am not quite sure if the changes are headed in the right direction. Would be great if you can provide some initial feedback on this.

On a side note, I think the new function that I added `RecordProjectIDOnProjectFiles` is pretty inefficient, since it writes each existing project entry one by one into the files(which is quite an expensive operation), ideally, we would like to do it in a batch after collecting all the existing projects I reckon. For doing this we might need to add a new method in `project.go` (I don't see any existing method which does that). So providing some feedback here might also be helpful. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
