### PR TITLE
keep the status error from envelope service

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope.go
@@ -94,13 +94,17 @@ func (t *envelopeTransformer) TransformFromStorage(data []byte, context value.Co
 		value.RecordCacheMiss()
 		key, err := t.envelopeService.Decrypt(encKey)
 		if err != nil {
-			return nil, false, fmt.Errorf("error while decrypting key: %q", err)
+			// Do NOT wrap this err using fmt.Errorf() or similar functions
+			// because this gRPC status error has useful error code when
+			// record the metric.
+			return nil, false, err
 		}
 		transformer, err = t.addTransformer(encKey, key)
 		if err != nil {
 			return nil, false, err
 		}
 	}
+
 	return transformer.TransformFromStorage(encData, context)
 }
 
@@ -113,6 +117,9 @@ func (t *envelopeTransformer) TransformToStorage(data []byte, context value.Cont
 
 	encKey, err := t.envelopeService.Encrypt(newKey)
 	if err != nil {
+		// Do NOT wrap this err using fmt.Errorf() or similar functions
+		// because this gRPC status error has useful error code when
+		// record the metric.
 		return nil, err
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,63 +29,97 @@ import (
 )
 
 func TestTotals(t *testing.T) {
+	nonStatusErr := errors.New("test error")
+	failedPreconditionErr := status.Error(codes.FailedPrecondition, "test error")
+	internalErr := status.Error(codes.Internal, "test error")
+	nonStatusErrTransformer := PrefixTransformer{Prefix: []byte("k8s:enc:kms:v1:"), Transformer: &testTransformer{err: nonStatusErr}}
+	failedPreconditionErrTransformer := PrefixTransformer{Prefix: []byte("k8s:enc:kms:v1:"), Transformer: &testTransformer{err: failedPreconditionErr}}
+	internalErrTransformer := PrefixTransformer{Prefix: []byte("k8s:enc:kms:v1:"), Transformer: &testTransformer{err: internalErr}}
+	okTransformer := PrefixTransformer{Prefix: []byte("k8s:enc:kms:v1:"), Transformer: &testTransformer{from: []byte("value")}}
+
 	testCases := []struct {
 		desc    string
+		prefix  Transformer
 		metrics []string
-		error   error
 		want    string
 	}{
 		{
-			desc: "non-status error",
+			desc:   "non-status error",
+			prefix: NewPrefixTransformers(nil, nonStatusErrTransformer),
 			metrics: []string{
 				"apiserver_storage_transformation_operations_total",
 				"apiserver_storage_transformation_failures_total",
 			},
-			error: errors.New("foo"),
 			want: `
-  # HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
-  # TYPE apiserver_storage_transformation_failures_total counter
-  apiserver_storage_transformation_failures_total{transformation_type="encrypt"} 1
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
-  # TYPE apiserver_storage_transformation_operations_total counter
-  apiserver_storage_transformation_operations_total{status="Unknown",transformation_type="encrypt",transformer_prefix="k8s:enc:kms:v1:"} 1
+# HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
+# TYPE apiserver_storage_transformation_failures_total counter
+apiserver_storage_transformation_failures_total{transformation_type="from_storage"} 1
+apiserver_storage_transformation_failures_total{transformation_type="to_storage"} 1
+# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+# TYPE apiserver_storage_transformation_operations_total counter
+apiserver_storage_transformation_operations_total{status="Unknown",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+apiserver_storage_transformation_operations_total{status="Unknown",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 `,
 		},
 		{
-			desc: "error is nil",
+			desc:   "ok",
+			prefix: NewPrefixTransformers(nil, okTransformer),
 			metrics: []string{
 				"apiserver_storage_transformation_operations_total",
 				"apiserver_storage_transformation_failures_total",
 			},
 			want: `
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
-  # TYPE apiserver_storage_transformation_operations_total counter
-  apiserver_storage_transformation_operations_total{status="OK",transformation_type="encrypt",transformer_prefix="k8s:enc:kms:v1:"} 1
+# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+# TYPE apiserver_storage_transformation_operations_total counter
+apiserver_storage_transformation_operations_total{status="OK",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+apiserver_storage_transformation_operations_total{status="OK",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 `,
 		},
 		{
-			desc: "status error from kms-plugin",
+			desc:   "failed precondition",
+			prefix: NewPrefixTransformers(nil, failedPreconditionErrTransformer),
 			metrics: []string{
 				"apiserver_storage_transformation_operations_total",
 				"apiserver_storage_transformation_failures_total",
 			},
-			error: status.Error(codes.FailedPrecondition, "foo"),
 			want: `
-  # HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
-  # TYPE apiserver_storage_transformation_failures_total counter
-  apiserver_storage_transformation_failures_total{transformation_type="encrypt"} 1
-	# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
-  # TYPE apiserver_storage_transformation_operations_total counter
-  apiserver_storage_transformation_operations_total{status="FailedPrecondition",transformation_type="encrypt",transformer_prefix="k8s:enc:kms:v1:"} 1
+# HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
+# TYPE apiserver_storage_transformation_failures_total counter
+apiserver_storage_transformation_failures_total{transformation_type="from_storage"} 1
+apiserver_storage_transformation_failures_total{transformation_type="to_storage"} 1
+# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+# TYPE apiserver_storage_transformation_operations_total counter
+apiserver_storage_transformation_operations_total{status="FailedPrecondition",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+apiserver_storage_transformation_operations_total{status="FailedPrecondition",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+`,
+		},
+		{
+			desc:   "internal",
+			prefix: NewPrefixTransformers(nil, internalErrTransformer),
+			metrics: []string{
+				"apiserver_storage_transformation_operations_total",
+				"apiserver_storage_transformation_failures_total",
+			},
+			want: `
+# HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
+# TYPE apiserver_storage_transformation_failures_total counter
+apiserver_storage_transformation_failures_total{transformation_type="from_storage"} 1
+apiserver_storage_transformation_failures_total{transformation_type="to_storage"} 1
+# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+# TYPE apiserver_storage_transformation_operations_total counter
+apiserver_storage_transformation_operations_total{status="Internal",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+apiserver_storage_transformation_operations_total{status="Internal",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
 `,
 		},
 	}
 
 	RegisterMetrics()
+	transformerOperationsTotal.Reset()
 
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
-			RecordTransformation("encrypt", "k8s:enc:kms:v1:", time.Now(), tt.error)
+			tt.prefix.TransformToStorage([]byte("value"), nil)
+			tt.prefix.TransformFromStorage([]byte("k8s:enc:kms:v1:value"), nil)
 			defer transformerOperationsTotal.Reset()
 			defer deprecatedTransformerFailuresTotal.Reset()
 			if err := testutil.GatherAndCompare(prometheus.DefaultGatherer, strings.NewReader(tt.want), tt.metrics...); err != nil {


### PR DESCRIPTION
Change-Id: I8263c4673d5f57617acf315c7af6ebe5aacd9c7c

this PR will propagate the status error from envelope provider to metrics so that can record the useful error code for better monitoring.

i would like to treat this as a bug, because it blinds us from differentiating errors we got from envelope provider. if envelope provider returns FailedPrecondition, right now will classify it as Unknown.

**What type of PR is this?**
/kind bug

```release-note
none
```