### PR TITLE
Fix racy lazyEcrProvider updates

### DIFF
--- a/pkg/credentialprovider/aws/aws_credentials_test.go
+++ b/pkg/credentialprovider/aws/aws_credentials_test.go
@@ -161,3 +161,17 @@ func TestChinaEcrProvide(t *testing.T) {
 		}
 	}
 }
+
+// TestConcurrentEcrLazyProvide tests that LazyProvide is thread-safe, because it may be called from two places during
+// kubelet startup: PullImage to pull a particular pod's container image and RunPodSandbox to pull the sandbox image
+func TestConcurrentEcrLazyProvide(t *testing.T) {
+	region := "us-west-2"
+	provider := &lazyEcrProvider{
+		region:    region,
+		regionURL: registryURL(region),
+	}
+
+	for i := 0; i < 10; i++ {
+		go provider.LazyProvide()
+	}
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: There is a race in the ECR credentials provider kubernetes 1.11-1.13 and probably earlier that causes kubelet to immediately panic. It's not in 1.14.?+ because the ECR credentials provider was refactored and the patch for that was backported to 1.14 (https://github.com/kubernetes/kubernetes/issues/78164).

The problem is that LazyProvide is not thread-safe. The variable ecrProvider.getter is written to in 2 places & read from 1: 

Write 1: https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/credentialprovider/aws/aws_credentials.go#L127 (write getter to nil)
Write 2: https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/credentialprovider/aws/aws_credentials.go#L176 (write getter to value)
Read: https://github.com/kubernetes/kubernetes/blob/release-1.13/pkg/credentialprovider/aws/aws_credentials.go#L192 (read getter)

If between Write 2 and Read in Thread 1, Thread 2 executes Write 1, then Thread 1 will get a nil panic when it does the Read.

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/78164

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
