### PR TITLE
Check the error return from AddPlugin

### DIFF
--- a/pkg/kubelet/pluginmanager/operationexecutor/BUILD
+++ b/pkg/kubelet/pluginmanager/operationexecutor/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -23,6 +23,7 @@ package operationexecutor
 import (
 	"context"
 	"fmt"
+	"k8s.io/klog"
 	"net"
 	"time"
 
@@ -112,11 +113,14 @@ func (og *operationGenerator) GenerateRegisterPluginFunc(
 		}
 		// We add the plugin to the actual state of world cache before calling a plugin consumer's Register handle
 		// so that if we receive a delete event during Register Plugin, we can process it as a DeRegister call.
-		actualStateOfWorldUpdater.AddPlugin(cache.PluginInfo{
+		err = actualStateOfWorldUpdater.AddPlugin(cache.PluginInfo{
 			SocketPath:           socketPath,
 			FoundInDeprecatedDir: foundInDeprecatedDir,
 			Timestamp:            timestamp,
 		})
+		if err != nil {
+			klog.Errorf("RegisterPlugin error -- failed to add plugin at socket %s, err: %v", socketPath, err)
+		}
 		if err := handler.RegisterPlugin(infoResp.Name, infoResp.Endpoint, infoResp.SupportedVersions); err != nil {
 			return og.notifyPlugin(client, false, fmt.Sprintf("RegisterPlugin error -- plugin registration failed with err: %v", err))
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently the error return from actualStateOfWorldUpdater.AddPlugin is ignored.

This PR adds the check of the error return.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
