### PR TITLE
NodeInfoManager should use informer to cache CSINodeInfo objects

### DIFF
--- a/pkg/volume/csi/nodeinfomanager/BUILD
+++ b/pkg/volume/csi/nodeinfomanager/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/storage/v1beta1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
+++ b/pkg/volume/csi/nodeinfomanager/nodeinfomanager_test.go
@@ -1074,7 +1074,7 @@ func TestInstallCSIDriverExistingAnnotation(t *testing.T) {
 			nil,
 		)
 
-		nim := NewNodeInfoManager(types.NodeName(nodeName), host, nil)
+		nim := NewNodeInfoManager(types.NodeName(nodeName), host, nil, nil)
 
 		// Act
 		_, err = nim.CreateCSINode()
@@ -1135,7 +1135,7 @@ func test(t *testing.T, addNodeInfo bool, csiNodeInfoEnabled bool, testcases []t
 			nodeName,
 			nil,
 		)
-		nim := NewNodeInfoManager(types.NodeName(nodeName), host, nil)
+		nim := NewNodeInfoManager(types.NodeName(nodeName), host, nil, nil)
 
 		//// Act
 		nim.CreateCSINode()

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -340,6 +340,8 @@ type KubeletVolumeHost interface {
 	CSIDriverLister() storagelisters.CSIDriverLister
 	// CSIDriverSynced returns the informer synced for the CSIDriver API Object
 	CSIDriversSynced() cache.InformerSynced
+	// CSINodeLister returns the informer lister for the CSINode API Object
+	CSINodeLister() storagelisters.CSINodeLister
 	// WaitForCacheSync is a helper function that waits for cache sync for CSIDriverLister
 	WaitForCacheSync() error
 	// Returns hostutil.HostUtils

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -1510,7 +1510,11 @@ func (f *fakeVolumeHost) CSIDriversSynced() cache.InformerSynced {
 }
 
 func (f *fakeVolumeHost) CSINodeLister() storagelisters.CSINodeLister {
-	// not needed for testing
+	csiNodeInformer := f.informerFactory.Storage().V1beta1().CSINodes()
+	if csiNodeInformer != nil {
+		csiNodeLister := csiNodeInformer.Lister()
+		return csiNodeLister
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #70773

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
