### PR TITLE
FindContainerStatusByName should find non-exited container

### DIFF
--- a/pkg/kubelet/container/helpers_test.go
+++ b/pkg/kubelet/container/helpers_test.go
@@ -415,6 +415,11 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 		Namespace: pod.Namespace,
 		ContainerStatuses: []*ContainerStatus{
 			{
+				Name:     "alive",
+				State:    ContainerStateExited,
+				ExitCode: 2,
+			},
+			{
 				Name:  "alive",
 				State: ContainerStateRunning,
 			},
@@ -427,11 +432,6 @@ func TestShouldContainerBeRestarted(t *testing.T) {
 				Name:     "failed",
 				State:    ContainerStateExited,
 				ExitCode: 1,
-			},
-			{
-				Name:     "alive",
-				State:    ContainerStateExited,
-				ExitCode: 2,
 			},
 			{
 				Name:  "unknown",

--- a/pkg/kubelet/container/runtime.go
+++ b/pkg/kubelet/container/runtime.go
@@ -317,12 +317,15 @@ type ContainerStatus struct {
 // FindContainerStatusByName returns container status in the pod status with the given name.
 // When there are multiple containers' statuses with the same name, the first match will be returned.
 func (podStatus *PodStatus) FindContainerStatusByName(containerName string) *ContainerStatus {
+	var containerStatRet *ContainerStatus
 	for _, containerStatus := range podStatus.ContainerStatuses {
 		if containerStatus.Name == containerName {
-			return containerStatus
+			if containerStatRet == nil || containerStatus.State != ContainerStateExited {
+				containerStatRet = containerStatus
+			}
 		}
 	}
-	return nil
+	return containerStatRet
 }
 
 // Get container status of all the running containers in a pod


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #82512 reported, when there are multiple ContainerStatus'es with same container name, FindContainerStatusByName should find non-exited container status.

This is option #1 from potential solutions.

**Which issue(s) this PR fixes**:
Fixes #82512

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
