### PR TITLE
e2e: fix pause command in ProxyMode func

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -469,9 +469,9 @@ func ProxyMode(f *Framework) (string, error) {
 			HostNetwork: true,
 			Containers: []v1.Container{
 				{
-					Name:    "detector",
-					Image:   AgnHostImage,
-					Command: []string{"pause"},
+					Name:  "detector",
+					Image: AgnHostImage,
+					Args:  []string{"pause"},
 				},
 			},
 		},


### PR DESCRIPTION
The agn image has no pause command, only a pause subcommand of the agn command.

/kind bug

```release-note
NONE
```