### PR TITLE
feat: add etcd-prefix into --etcd-servers-overrides option.

### DIFF
--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -116,6 +116,10 @@ func (c *completedStorageFactoryConfig) New() (*serverstorage.DefaultStorageFact
 	storageFactory.AddCohabitatingResources(networking.Resource("ingresses"), extensions.Resource("ingresses"))
 
 	for _, override := range c.EtcdServersOverrides {
+		// Currently, the string override can include three options:
+		//   [0] group/resource (must): the group and resource type info for target resource.
+		//   [1] servers (must): the etcd servers to be replaced with.
+		//   [2] etcd-prefix (optional): the base location for a GroupResource.
 		tokens := strings.Split(override, "#")
 		apiresource := strings.Split(tokens[0], "/")
 
@@ -125,6 +129,11 @@ func (c *completedStorageFactoryConfig) New() (*serverstorage.DefaultStorageFact
 
 		servers := strings.Split(tokens[1], ";")
 		storageFactory.SetEtcdLocation(groupResource, servers)
+
+		if len(tokens) > 2 {
+			prefix := tokens[2]
+			storageFactory.SetEtcdPrefix(groupResource, prefix)
+		}
 	}
 	if len(c.EncryptionProviderConfigFilepath) != 0 {
 		transformerOverrides, err := encryptionconfig.GetTransformerOverrides(c.EncryptionProviderConfigFilepath)

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd_test.go
@@ -103,7 +103,7 @@ func TestEtcdOptionsValidate(t *testing.T) {
 				DefaultWatchCacheSize:   100,
 				EtcdServersOverrides:    []string{"/events/http://127.0.0.1:4002"},
 			},
-			expectErr: "--etcd-servers-overrides invalid, must be of format: group/resource#servers, where servers are URLs, semicolon separated",
+			expectErr: "--etcd-servers-overrides invalid, must be of format: group/resource#servers#/etcd-prefix, where servers are URLs, semicolon separated, and #/etcd-prefix is optional",
 		},
 		{
 			name: "test when EtcdOptions is valid",
@@ -127,6 +127,53 @@ func TestEtcdOptionsValidate(t *testing.T) {
 				DefaultWatchCacheSize:   100,
 				EtcdServersOverrides:    []string{"/events#http://127.0.0.1:4002"},
 			},
+		},
+		{
+			name: "test when EtcdOptions with etcd-prefix is valid",
+			testOptions: &EtcdOptions{
+				StorageConfig: storagebackend.Config{
+					Type:   "etcd3",
+					Prefix: "/registry",
+					Transport: storagebackend.TransportConfig{
+						ServerList: []string{"http://127.0.0.1"},
+						KeyFile:    "/var/run/kubernetes/etcd.key",
+						CAFile:     "/var/run/kubernetes/etcdca.crt",
+						CertFile:   "/var/run/kubernetes/etcdce.crt",
+					},
+					CompactionInterval:    storagebackend.DefaultCompactInterval,
+					CountMetricPollPeriod: time.Minute,
+				},
+				DefaultStorageMediaType: "application/vnd.kubernetes.protobuf",
+				DeleteCollectionWorkers: 1,
+				EnableGarbageCollection: true,
+				EnableWatchCache:        true,
+				DefaultWatchCacheSize:   100,
+				EtcdServersOverrides:    []string{"/events#http://127.0.0.1:4002#/overrided-registry"},
+			},
+		},
+		{
+			name: "test when EtcdOptions with etcd-prefix is invalid",
+			testOptions: &EtcdOptions{
+				StorageConfig: storagebackend.Config{
+					Type:   "etcd3",
+					Prefix: "/registry",
+					Transport: storagebackend.TransportConfig{
+						ServerList: []string{"http://127.0.0.1"},
+						KeyFile:    "/var/run/kubernetes/etcd.key",
+						CAFile:     "/var/run/kubernetes/etcdca.crt",
+						CertFile:   "/var/run/kubernetes/etcdce.crt",
+					},
+					CompactionInterval:    storagebackend.DefaultCompactInterval,
+					CountMetricPollPeriod: time.Minute,
+				},
+				DefaultStorageMediaType: "application/vnd.kubernetes.protobuf",
+				DeleteCollectionWorkers: 1,
+				EnableGarbageCollection: true,
+				EnableWatchCache:        true,
+				DefaultWatchCacheSize:   100,
+				EtcdServersOverrides:    []string{"/events#http://127.0.0.1:4002#overrided-registry"},
+			},
+			expectErr: "--etcd-servers-overrides invalid, must be of format: group/resource#servers#/etcd-prefix, where servers are URLs, semicolon separated, and #/etcd-prefix is optional",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add ability to override the `etcd-prefix` via `--etcd-servers-overrides` when moving some resource to other etcd servers.

There is a scenario to explain why we need this ability.

Users have many large scale (5000+) kubernetes clusters, and they want to extract some kinds of resources, events for example, to erase the burden on etcd. They prefer to use one etcd cluster against several kubernetes clusters for storing events purpose, since the cloud VMs with SSDs are not quite cheap. And it would be better to use different prefixes for different clusters, but they prefer to use defaults `--etcd-prefix` for the etcd cluster that storing other resources.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
action required: Users who have been customizing option --etcd-servers-overrides should modify their setting values by adding # (at least) at the end of each item in list.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/sig api-machinery
/area apiserver