### PR TITLE
Automated cherry pick of #81453: Apply will fail with managed fields + tests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -179,6 +179,8 @@ func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, fieldManager 
 	accessor, err := meta.Accessor(liveObj)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get accessor: %v", err)
+	} else if objMeta.GetManagedFields() != nil && len(objMeta.GetManagedFields()) != 0 {
+		return nil, fmt.Errorf("apply is not allowed with managed fields set but was: %v", objMeta.GetManagedFields())
 	}
 	missingManagedFields := (len(accessor.GetManagedFields()) == 0)
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -179,8 +179,6 @@ func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, fieldManager 
 	accessor, err := meta.Accessor(liveObj)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't get accessor: %v", err)
-	} else if objMeta.GetManagedFields() != nil && len(objMeta.GetManagedFields()) != 0 {
-		return nil, fmt.Errorf("apply is not allowed with managed fields set but was: %v", objMeta.GetManagedFields())
 	}
 	missingManagedFields := (len(accessor.GetManagedFields()) == 0)
 
@@ -194,6 +192,11 @@ func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, fieldManager 
 	if err := yaml.Unmarshal(patch, &patchObj.Object); err != nil {
 		return nil, fmt.Errorf("error decoding YAML: %v", err)
 	}
+
+	if patchObj.GetManagedFields() != nil {
+		return nil, fmt.Errorf("managed fields must be nil but was %v", patchObj.GetManagedFields())
+	}
+
 	if patchObj.GetAPIVersion() != f.groupVersion.String() {
 		return nil,
 			errors.NewBadRequest(

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -25,7 +25,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -472,23 +471,15 @@ func BenchmarkRepeatedUpdate(b *testing.B) {
 func TestApplyFailsWithManagedFields(t *testing.T) {
 	f := NewTestFieldManager()
 
-	obj := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			ManagedFields: []metav1.ManagedFieldsEntry{
-				{
-					Manager: "test",
-				},
-			},
-		},
-	}
-
-	_, err := f.Apply(obj, []byte(`{
+	_, err := f.Apply(&corev1.Pod{}, []byte(`{
 		"apiVersion": "apps/v1",
 		"kind": "Pod",
 		"metadata": {
-			"labels": {
-				"a": "b"
-			},
+			"managedFields": [
+				{
+				  "manager": "test",
+				}
+			]
 		}
 	}`), "fieldmanager_test", false)
 
@@ -497,36 +488,10 @@ func TestApplyFailsWithManagedFields(t *testing.T) {
 	}
 }
 
-func TestApplySuccessWithEmptyManagedFields(t *testing.T) {
+func TestApplySuccessWithNoManagedFields(t *testing.T) {
 	f := NewTestFieldManager()
 
-	obj := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			ManagedFields: []metav1.ManagedFieldsEntry{},
-		},
-	}
-
-	_, err := f.Apply(obj, []byte(`{
-		"apiVersion": "apps/v1",
-		"kind": "Pod",
-		"metadata": {
-			"labels": {
-				"a": "b"
-			},
-		}
-	}`), "fieldmanager_test", false)
-
-	if err != nil {
-		t.Fatalf("failed to apply object: %v", err)
-	}
-}
-
-func TestApplySuccessWithNilManagedFields(t *testing.T) {
-	f := NewTestFieldManager()
-
-	obj := &corev1.Pod{}
-
-	_, err := f.Apply(obj, []byte(`{
+	_, err := f.Apply(&corev1.Pod{}, []byte(`{
 		"apiVersion": "apps/v1",
 		"kind": "Pod",
 		"metadata": {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -22,9 +22,12 @@ import (
 	"net/http"
 	"testing"
 
+	"time"
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -103,37 +106,36 @@ func TestApplyStripsFields(t *testing.T) {
 	obj := &corev1.Pod{}
 	obj.ObjectMeta.ManagedFields = []metav1.ManagedFieldsEntry{{}}
 
-	newObj, err := f.Apply(obj, []byte(`{
-		"apiVersion": "apps/v1",
-		"kind": "Deployment",
-		"metadata": {
-			"name": "b",
-			"namespace": "b",
-			"creationTimestamp": "2016-05-19T09:59:00Z",
-			"selfLink": "b",
-			"uid": "b",
-			"clusterName": "b",
-			"generation": 0,
-			"managedFields": [{
-					"manager": "apply",
-					"operation": "Apply",
-					"apiVersion": "apps/v1",
-					"fields": {
-						"f:metadata": {
-							"f:labels": {
-								"f:test-label": {}
-							}
-						}
-					}
-				}],
-			"resourceVersion": "b"
-		}
-	}`), "fieldmanager_test", false)
+	newObj := &corev1.Pod{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "b",
+			Namespace:         "b",
+			CreationTimestamp: metav1.NewTime(time.Now()),
+			SelfLink:          "b",
+			UID:               "b",
+			ClusterName:       "b",
+			Generation:        0,
+			ManagedFields: []metav1.ManagedFieldsEntry{
+				{
+					Manager:    "update",
+					Operation:  metav1.ManagedFieldsOperationApply,
+					APIVersion: "apps/v1",
+				},
+			},
+			ResourceVersion: "b",
+		},
+	}
+
+	updatedObj, err := f.Update(obj, newObj, "fieldmanager_test")
 	if err != nil {
 		t.Fatalf("failed to apply object: %v", err)
 	}
 
-	accessor, err := meta.Accessor(newObj)
+	accessor, err := meta.Accessor(updatedObj)
 	if err != nil {
 		t.Fatalf("couldn't get accessor: %v", err)
 	}


### PR DESCRIPTION
Cherry pick of #81453 on release-1.16.

#81453: Apply will fail with managed fields + tests

```release-note
NONE
```