### PR TITLE
Add wrapper for prometheus buckets functionality 

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -21,6 +21,19 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// DefBuckets is a wrapper for prometheus.DefBuckets
+var DefBuckets = prometheus.DefBuckets
+
+// LinearBuckets is a wrapper for prometheus.LinearBuckets.
+func LinearBuckets(start, width float64, count int) []float64 {
+	return prometheus.LinearBuckets(start, width, count)
+}
+
+// ExponentialBuckets is a wrapper for prometheus.ExponentialBuckets.
+func ExponentialBuckets(start, factor float64, count int) []float64 {
+	return prometheus.ExponentialBuckets(start, factor, count)
+}
+
 // Histogram is our internal representation for our wrapping struct around prometheus
 // histograms. Summary implements both kubeCollector and ObserverMetric
 type Histogram struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When migrating metrics to stability framework, I hope to import `k8s.io/component-base/metrics` is enough, especially for a `Histogram` type.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


/assign @logicalhan 
/cc @brancz 