### PR TITLE
reverseproxy: recover from stdlib panic

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -23,12 +23,10 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -232,20 +230,11 @@ func (h *UpgradeAwareHandler) ServeHTTP(w http.ResponseWriter, req *http.Request
 	proxy := httputil.NewSingleHostReverseProxy(&url.URL{Scheme: h.Location.Scheme, Host: h.Location.Host})
 	proxy.Transport = h.Transport
 	proxy.FlushInterval = h.FlushInterval
-	proxy.ErrorLog = log.New(noSuppressPanicError{}, "", log.LstdFlags)
+
+	defer func() {
+		recover() // ignore panics inside of the reverse proxy on unclean disconnects
+	}()
 	proxy.ServeHTTP(w, newReq)
-}
-
-type noSuppressPanicError struct{}
-
-func (noSuppressPanicError) Write(p []byte) (n int, err error) {
-	// skip "suppressing panic for copyResponse error in test; copy error" error message
-	// that ends up in CI tests on each kube-apiserver termination as noise and
-	// everybody thinks this is fatal.
-	if strings.Contains(string(p), "suppressing panic") {
-		return len(p), nil
-	}
-	return os.Stderr.Write(p)
 }
 
 // tryUpgrade returns true if the request was handled.


### PR DESCRIPTION
The Golang stdlib reverse proxy panics for request contexts coming from an HTTP server. It prints warnings otherwise. Compare https://github.com/golang/go/blob/master/src/net/http/httputil/reverseproxy.go#L295. 

In https://github.com/kubernetes/kubernetes/pull/82146 we switched to the request context, leading to the change panic behaviour.

/kind bug

```release-note
Avoid panic in the kube-apiserver aggregator when long-running proxied connections are closed.
```