### PR TITLE
iptables: ugly hack to quickly fix kubernetes on RHEL 7

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -581,6 +581,8 @@ func getIPTablesWaitFlag(version *utilversion.Version) []string {
 func getIPTablesRestoreWaitFlag(version *utilversion.Version) []string {
 	if version.AtLeast(WaitRestoreMinVersion) {
 		return []string{WaitString, WaitSecondsValue}
+	} else if version.String() == "1.4.21" { // HACK for 1.16.0; see https://github.com/kubernetes/kubernetes/issues/82587
+		return []string{WaitString}
 	} else {
 		return nil
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I broke kubernetes on RHEL 7. This is not the right fix, but it's the most minimal fix.

**Which issue(s) this PR fixes**:
Addresses #82587 but is not the final fix

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
(Or do we release-note differences between pre-release versions?)

/sig network
/priority critical-urgent