### PR TITLE
DO NOT MERGE - Experiment on filtering cluster resources by scope

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -532,6 +532,7 @@ func BuildAuthenticator(s *options.ServerRunOptions, extclient clientgoclientset
 			versionedInformer.Core().V1().Secrets().Lister(),
 			versionedInformer.Core().V1().ServiceAccounts().Lister(),
 			versionedInformer.Core().V1().Pods().Lister(),
+			versionedInformer.Core().V1().Namespaces().Lister(),
 		)
 	}
 	authenticatorConfig.BootstrapTokenAuthenticator = bootstrap.NewTokenAuthenticator(

--- a/pkg/auth/authorizer/abac/example_policy_file.jsonl
+++ b/pkg/auth/authorizer/abac/example_policy_file.jsonl
@@ -1,6 +1,7 @@
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group":"system:authenticated",  "nonResourcePath": "*", "readonly": true}}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group":"system:unauthenticated", "nonResourcePath": "*", "readonly": true}}
-{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"admin",     "namespace": "*",              "resource": "*",         "apiGroup": "*"                   }}
+{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group":"system:authenticated",     "namespace": "*",              "resource": "*",         "apiGroup": "*"                   }}
+{"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"group":"system:unauthenticated",     "namespace": "*",              "resource": "*",         "apiGroup": "*"                   }}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"scheduler", "namespace": "*",              "resource": "pods",                       "readonly": true }}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"scheduler", "namespace": "*",              "resource": "bindings"                                     }}
 {"apiVersion": "abac.authorization.kubernetes.io/v1beta1", "kind": "Policy", "spec": {"user":"kubelet",   "namespace": "*",              "resource": "pods",                       "readonly": true }}

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -587,15 +587,16 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:
-	genericfeatures.StreamingProxyRedirects: {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.ValidateProxyRedirects:  {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.AdvancedAuditing:        {Default: true, PreRelease: featuregate.GA},
-	genericfeatures.DynamicAuditing:         {Default: false, PreRelease: featuregate.Alpha},
-	genericfeatures.APIResponseCompression:  {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.APIListChunking:         {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.DryRun:                  {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.ServerSideApply:         {Default: true, PreRelease: featuregate.Beta},
-	genericfeatures.RequestManagement:       {Default: false, PreRelease: featuregate.Alpha},
+	genericfeatures.ClusterResourceRestriction: {Default: true, PreRelease: featuregate.Alpha},
+	genericfeatures.StreamingProxyRedirects:    {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.ValidateProxyRedirects:     {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.AdvancedAuditing:           {Default: true, PreRelease: featuregate.GA},
+	genericfeatures.DynamicAuditing:            {Default: false, PreRelease: featuregate.Alpha},
+	genericfeatures.APIResponseCompression:     {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.APIListChunking:            {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.DryRun:                     {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.ServerSideApply:            {Default: true, PreRelease: featuregate.Beta},
+	genericfeatures.RequestManagement:          {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from apiextensions-apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/serviceaccount/jwt.go
+++ b/pkg/serviceaccount/jwt.go
@@ -41,6 +41,7 @@ type ServiceAccountTokenGetter interface {
 	GetServiceAccount(namespace, name string) (*v1.ServiceAccount, error)
 	GetPod(namespace, name string) (*v1.Pod, error)
 	GetSecret(namespace, name string) (*v1.Secret, error)
+	GetNamespace(name string) (*v1.Namespace, error)
 }
 
 type TokenGenerator interface {

--- a/pkg/serviceaccount/util.go
+++ b/pkg/serviceaccount/util.go
@@ -17,7 +17,7 @@ limitations under the License.
 package serviceaccount
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiserverserviceaccount "k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 )
@@ -43,6 +43,8 @@ func UserInfo(namespace, name, uid string) user.Info {
 type ServiceAccountInfo struct {
 	Name, Namespace, UID string
 	PodName, PodUID      string
+	RestrictionFilter    string
+	RestrictionDefault   string
 }
 
 func (sa *ServiceAccountInfo) UserInfo() user.Info {
@@ -56,6 +58,13 @@ func (sa *ServiceAccountInfo) UserInfo() user.Info {
 			PodNameKey: {sa.PodName},
 			PodUIDKey:  {sa.PodUID},
 		}
+	}
+	if len(sa.RestrictionFilter) > 0 {
+		if info.Extra == nil {
+			info.Extra = make(map[string][]string)
+		}
+		info.Extra["restrict.auth.k8s.io/filter"] = []string{sa.RestrictionFilter}
+		info.Extra["restrict.auth.k8s.io/default"] = []string{sa.RestrictionDefault}
 	}
 	return info
 }

--- a/plugin/pkg/admission/resourcerestriction/admission.go
+++ b/plugin/pkg/admission/resourcerestriction/admission.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcerestriction
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	"k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corev1listers "k8s.io/client-go/listers/core/v1"
+	"k8s.io/klog"
+)
+
+// PluginName indicates name of admission plugin.
+const PluginName = "ResourceRestriction"
+
+// Register registers a plugin
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return NewResourceRestriction(), nil
+	})
+}
+
+// ResourceRestriction is an implementation of admission.Interface.
+// It looks at creation or update actions on cluster scoped resources and ensures
+// labels are appropriately mapped based on the authorizer.
+type ResourceRestriction struct {
+	*admission.Handler
+	client          kubernetes.Interface
+	namespaceLister corev1listers.NamespaceLister
+}
+
+var _ admission.MutationInterface = &ResourceRestriction{}
+var _ = genericadmissioninitializer.WantsExternalKubeInformerFactory(&ResourceRestriction{})
+var _ = genericadmissioninitializer.WantsExternalKubeClientSet(&ResourceRestriction{})
+
+// Admit makes an admission decision based on the request attributes
+func (p *ResourceRestriction) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	// Don't modify if the request is for a dry-run.
+	if a.IsDryRun() {
+		return nil
+	}
+
+	// load user and find restrictions
+	user, ok := request.UserFrom(ctx)
+	if !ok {
+		return nil
+	}
+	if len(user.GetExtra()["restrict.auth.k8s.io/default"]) == 0 && len(user.GetExtra()["restrict.auth.k8s.io/filter"]) == 0 {
+		return nil
+	}
+
+	var defaultRestriction map[string]string
+	switch extraPartDefaults := user.GetExtra()["restrict.auth.k8s.io/default"]; {
+	case len(extraPartDefaults) > 1:
+		return fmt.Errorf("ResourceRestriction requires zero or one default labels")
+	case len(extraPartDefaults) == 1:
+		reqs, err := labels.ParseToRequirements(extraPartDefaults[0])
+		if err != nil {
+			return fmt.Errorf("ResourceRestriction is unable to handle filters: %v", err)
+		}
+		for _, req := range reqs {
+			if req.Operator() != selection.Equals {
+				continue
+			}
+			if req.Values().Len() != 1 {
+				continue
+			}
+			if defaultRestriction == nil {
+				defaultRestriction = make(map[string]string)
+			}
+			defaultRestriction[req.Key()] = req.Values().List()[0]
+		}
+	}
+
+	var filterRestriction labels.Selector = labels.Everything()
+	switch extraPartRestrictions := user.GetExtra()["restrict.auth.k8s.io/filter"]; {
+	case len(extraPartRestrictions) > 1:
+		return fmt.Errorf("ResourceRestriction requires zero or one filters")
+	case len(extraPartRestrictions) == 1:
+		selector, err := labels.Parse(extraPartRestrictions[0])
+		if err != nil {
+			return fmt.Errorf("ResourceRestriction is unable to handle filters: %v", err)
+		}
+		filterRestriction = selector
+	}
+
+	if len(a.GetNamespace()) > 0 {
+		// we need to wait for our caches to warm
+		if !p.WaitForReady() {
+			return admission.NewForbidden(a, fmt.Errorf("not yet ready to handle request"))
+		}
+
+		ns, err := p.namespaceLister.Get(a.GetNamespace())
+		if err == nil {
+			return nil
+		}
+		if !errors.IsNotFound(err) {
+			return admission.NewForbidden(a, err)
+		}
+		if !filterRestriction.Matches(labels.Set(ns.Labels)) {
+			return admission.NewForbidden(a, fmt.Errorf("operations on this resource are forbidden"))
+		}
+
+		// TODO: limit setting filter labels here?
+
+		return nil
+	}
+
+	if len(a.GetSubresource()) != 0 {
+		// TODO: probably not safe, needs more thought, or possibly to be implemented in storage
+		return nil
+	}
+
+	meta, ok := a.GetObject().(metav1.Object)
+	if !ok {
+		// ignore non-object resources
+		klog.Infof("DEBUG: unexpected admission object for create: %T", a.GetObject())
+		return nil
+	}
+	objLabels := labels.Set(meta.GetLabels())
+
+	switch a.GetOperation() {
+	case admission.Create:
+		for k, v := range defaultRestriction {
+			if _, ok := objLabels[k]; ok {
+				continue
+			}
+			if objLabels == nil {
+				objLabels = make(labels.Set)
+				meta.SetLabels(objLabels)
+			}
+			objLabels[k] = v
+		}
+	}
+
+	if !filterRestriction.Matches(objLabels) {
+		return admission.NewForbidden(a, fmt.Errorf("operations on this resource are forbidden"))
+	}
+
+	return nil
+}
+
+// NewResourceRestriction creates a new namespace provision admission control handler
+func NewResourceRestriction() *ResourceRestriction {
+	return &ResourceRestriction{
+		Handler: admission.NewHandler(admission.Create, admission.Update, admission.Delete, admission.Connect),
+	}
+}
+
+// SetExternalKubeClientSet implements the WantsExternalKubeClientSet interface.
+func (p *ResourceRestriction) SetExternalKubeClientSet(client kubernetes.Interface) {
+	p.client = client
+}
+
+// SetExternalKubeInformerFactory implements the WantsExternalKubeInformerFactory interface.
+func (p *ResourceRestriction) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
+	namespaceInformer := f.Core().V1().Namespaces()
+	p.namespaceLister = namespaceInformer.Lister()
+	p.SetReadyFunc(namespaceInformer.Informer().HasSynced)
+}
+
+// ValidateInitialization implements the InitializationValidator interface.
+func (p *ResourceRestriction) ValidateInitialization() error {
+	if p.namespaceLister == nil {
+		return fmt.Errorf("missing namespaceLister")
+	}
+	if p.client == nil {
+		return fmt.Errorf("missing client")
+	}
+	return nil
+}

--- a/plugin/pkg/admission/resourcerestriction/admission_test.go
+++ b/plugin/pkg/admission/resourcerestriction/admission_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcerestriction
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/admission"
+	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
+	admissiontesting "k8s.io/apiserver/pkg/admission/testing"
+	"k8s.io/client-go/informers"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+// newHandlerForTest returns the admission controller configured for testing.
+func newHandlerForTest(c clientset.Interface) (admission.MutationInterface, informers.SharedInformerFactory, error) {
+	f := informers.NewSharedInformerFactory(c, 5*time.Minute)
+	handler := NewResourceRestriction()
+	pluginInitializer := genericadmissioninitializer.New(c, f, nil)
+	pluginInitializer.Initialize(handler)
+	err := admission.ValidateInitialization(handler)
+	return handler, f, err
+}
+
+// newMockClientForTest creates a mock client that returns a client configured for the specified list of namespaces.
+func newMockClientForTest(namespaces []string) *fake.Clientset {
+	mockClient := &fake.Clientset{}
+	mockClient.AddReactor("list", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
+		namespaceList := &corev1.NamespaceList{
+			ListMeta: metav1.ListMeta{
+				ResourceVersion: fmt.Sprintf("%d", len(namespaces)),
+			},
+		}
+		for i, ns := range namespaces {
+			namespaceList.Items = append(namespaceList.Items, corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            ns,
+					ResourceVersion: fmt.Sprintf("%d", i),
+				},
+			})
+		}
+		return true, namespaceList, nil
+	})
+	return mockClient
+}
+
+// newPod returns a new pod for the specified namespace
+func newPod(namespace string) api.Pod {
+	return api.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "123", Namespace: namespace},
+		Spec: api.PodSpec{
+			Volumes:    []api.Volume{{Name: "vol"}},
+			Containers: []api.Container{{Name: "ctr", Image: "image"}},
+		},
+	}
+}
+
+// hasCreateNamespaceAction returns true if it has the create namespace action
+func hasCreateNamespaceAction(mockClient *fake.Clientset) bool {
+	for _, action := range mockClient.Actions() {
+		if action.GetVerb() == "create" && action.GetResource().Resource == "namespaces" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAdmission verifies a namespace is created on create requests for namespace managed resources
+func TestAdmission(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest([]string{})
+	handler, informerFactory, err := newHandlerForTest(mockClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+
+	pod := newPod(namespace)
+	err = admissiontesting.WithReinvocationTesting(t, handler).Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+	if err != nil {
+		t.Errorf("unexpected error returned from admission handler")
+	}
+	if !hasCreateNamespaceAction(mockClient) {
+		t.Errorf("expected create namespace action")
+	}
+}
+
+// TestAdmissionNamespaceExists verifies that no client call is made when a namespace already exists
+func TestAdmissionNamespaceExists(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest([]string{namespace})
+	handler, informerFactory, err := newHandlerForTest(mockClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+
+	pod := newPod(namespace)
+	err = admissiontesting.WithReinvocationTesting(t, handler).Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+	if err != nil {
+		t.Errorf("unexpected error returned from admission handler")
+	}
+	if hasCreateNamespaceAction(mockClient) {
+		t.Errorf("unexpected create namespace action")
+	}
+}
+
+// TestAdmissionDryRun verifies that no client call is made on a dry run request
+func TestAdmissionDryRun(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest([]string{})
+	handler, informerFactory, err := newHandlerForTest(mockClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+
+	pod := newPod(namespace)
+	err = admissiontesting.WithReinvocationTesting(t, handler).Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, true, nil), nil)
+	if err != nil {
+		t.Errorf("unexpected error returned from admission handler")
+	}
+	if hasCreateNamespaceAction(mockClient) {
+		t.Errorf("unexpected create namespace action")
+	}
+}
+
+// TestIgnoreAdmission validates that a request is ignored if its not a create
+func TestIgnoreAdmission(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest([]string{})
+	handler, informerFactory, err := newHandlerForTest(mockClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+	chainHandler := admissiontesting.WithReinvocationTesting(t, admission.NewChainHandler(handler))
+
+	pod := newPod(namespace)
+	err = admissiontesting.WithReinvocationTesting(t, chainHandler).Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil), nil)
+	if err != nil {
+		t.Errorf("unexpected error returned from admission handler")
+	}
+	if hasCreateNamespaceAction(mockClient) {
+		t.Errorf("unexpected create namespace action")
+	}
+}
+
+func TestAdmissionWithLatentCache(t *testing.T) {
+	namespace := "test"
+	mockClient := newMockClientForTest([]string{})
+	mockClient.AddReactor("create", "namespaces", func(action core.Action) (bool, runtime.Object, error) {
+		return true, nil, errors.NewAlreadyExists(api.Resource("namespaces"), namespace)
+	})
+	handler, informerFactory, err := newHandlerForTest(mockClient)
+	if err != nil {
+		t.Errorf("unexpected error initializing handler: %v", err)
+	}
+	informerFactory.Start(wait.NeverStop)
+
+	pod := newPod(namespace)
+	err = admissiontesting.WithReinvocationTesting(t, handler).Admit(context.TODO(), admission.NewAttributesRecord(&pod, nil, api.Kind("Pod").WithVersion("version"), pod.Namespace, pod.Name, api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil), nil)
+	if err != nil {
+		t.Errorf("unexpected error returned from admission handler")
+	}
+
+	if !hasCreateNamespaceAction(mockClient) {
+		t.Errorf("expected create namespace action")
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -1839,6 +1839,13 @@ func schema_pkg_apis_meta_v1_ListOptions(ref common.ReferenceCallback) common.Op
 							Format:      "",
 						},
 					},
+					"namespaceLabelSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A selector to restrict the set of namespaces that objects are returned from by the namespace label. Using this field with a resource that is not namespace scoped will return a bad request error. The default is to select all namespaces.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"watch": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/types.go
@@ -33,6 +33,12 @@ type ListOptions struct {
 	LabelSelector labels.Selector
 	// A selector based on fields
 	FieldSelector fields.Selector
+	// A selector to restrict the set of namespaces that objects are returned from
+	// by the namespace label. Using this field with a resource that is not namespace
+	// scoped will return a bad request error. The default is to select all namespaces.
+	// +optional
+	NamespaceLabelSelector labels.Selector
+
 	// If true, watch for changes to this list
 	Watch bool
 	// allowWatchBookmarks requests watch events with type "BOOKMARK".

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/zz_generated.conversion.go
@@ -107,6 +107,9 @@ func autoConvert_internalversion_ListOptions_To_v1_ListOptions(in *ListOptions, 
 	if err := v1.Convert_fields_Selector_To_string(&in.FieldSelector, &out.FieldSelector, s); err != nil {
 		return err
 	}
+	if err := v1.Convert_labels_Selector_To_string(&in.NamespaceLabelSelector, &out.NamespaceLabelSelector, s); err != nil {
+		return err
+	}
 	out.Watch = in.Watch
 	out.AllowWatchBookmarks = in.AllowWatchBookmarks
 	out.ResourceVersion = in.ResourceVersion
@@ -126,6 +129,9 @@ func autoConvert_v1_ListOptions_To_internalversion_ListOptions(in *v1.ListOption
 		return err
 	}
 	if err := v1.Convert_string_To_fields_Selector(&in.FieldSelector, &out.FieldSelector, s); err != nil {
+		return err
+	}
+	if err := v1.Convert_string_To_labels_Selector(&in.NamespaceLabelSelector, &out.NamespaceLabelSelector, s); err != nil {
 		return err
 	}
 	out.Watch = in.Watch

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/zz_generated.deepcopy.go
@@ -69,6 +69,9 @@ func (in *ListOptions) DeepCopyInto(out *ListOptions) {
 	if in.FieldSelector != nil {
 		out.FieldSelector = in.FieldSelector.DeepCopySelector()
 	}
+	if in.NamespaceLabelSelector != nil {
+		out.NamespaceLabelSelector = in.NamespaceLabelSelector.DeepCopySelector()
+	}
 	if in.TimeoutSeconds != nil {
 		in, out := &in.TimeoutSeconds, &out.TimeoutSeconds
 		*out = new(int64)

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -330,6 +330,12 @@ type ListOptions struct {
 	// +optional
 	FieldSelector string `json:"fieldSelector,omitempty" protobuf:"bytes,2,opt,name=fieldSelector"`
 
+	// A selector to restrict the set of namespaces that objects are returned from
+	// by the namespace label. Using this field with a resource that is not namespace
+	// scoped will return a bad request error. The default is to select all namespaces.
+	// +optional
+	NamespaceLabelSelector string `json:"namespaceLabelSelector,omitempty"`
+
 	// +k8s:deprecated=includeUninitialized,protobuf=6
 
 	// Watch for changes to the described resources and return them as a stream of

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
@@ -36,6 +36,7 @@ func NewAuthenticator() authenticator.Request {
 			User: &user.DefaultInfo{
 				Name:   anonymousUser,
 				Groups: []string{unauthenticatedGroup},
+				Extra:  map[string][]string{"filter.k8s.io/query": []string{"org.k8s.io/infrastructure"}},
 			},
 			Audiences: auds,
 		}, true, nil

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -225,6 +225,12 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope *RequestScope, forceWatc
 			return
 		}
 
+		if opts.NamespaceLabelSelector != nil && !opts.NamespaceLabelSelector.Empty() && !scope.NamespaceScoped {
+			err = errors.NewBadRequest("namespace label selection is only valid on namespace scoped resources")
+			scope.err(err, w, req)
+			return
+		}
+
 		// transform fields
 		// TODO: DecodeParametersInto should do this.
 		if opts.FieldSelector != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go
@@ -69,9 +69,10 @@ type RequestScope struct {
 	TableConvertor rest.TableConvertor
 	FieldManager   *fieldmanager.FieldManager
 
-	Resource    schema.GroupVersionResource
-	Kind        schema.GroupVersionKind
-	Subresource string
+	Resource        schema.GroupVersionResource
+	Kind            schema.GroupVersionKind
+	Subresource     string
+	NamespaceScoped bool
 
 	MetaGroupVersion schema.GroupVersion
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/installer.go
@@ -539,6 +539,8 @@ func (a *APIInstaller) registerResourceHandlers(path string, storage rest.Storag
 		Resource:    a.group.GroupVersion.WithResource(resource),
 		Subresource: subresource,
 		Kind:        fqKindToRegister,
+		
+		NamespaceScoped: namespaceScoped,
 
 		HubGroupVersion: schema.GroupVersion{Group: fqKindToRegister.Group, Version: runtime.APIVersionInternal},
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -77,6 +77,14 @@ const (
 	// all at once.
 	APIListChunking featuregate.Feature = "APIListChunking"
 
+	// owner: @smarterclayton
+	// alpha: v1.17
+	//
+	// Allow cluster-scoped resources to be restricted based on characteristics
+	// of the user for better subdivision of critical security resources within a
+	// single cluster.
+	ClusterResourceRestriction featuregate.Feature = "ClusterResourceRestriction"
+
 	// owner: @apelisse
 	// alpha: v1.12
 	// beta: v1.13
@@ -149,6 +157,8 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	ClusterResourceRestriction: {Default: true, PreRelease: featuregate.Alpha},
+
 	StreamingProxyRedirects: {Default: true, PreRelease: featuregate.Beta},
 	ValidateProxyRedirects:  {Default: true, PreRelease: featuregate.Beta},
 	AdvancedAuditing:        {Default: true, PreRelease: featuregate.GA},

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/options.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/options.go
@@ -19,6 +19,7 @@ package generic
 import (
 	"time"
 
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -33,6 +34,8 @@ type RESTOptions struct {
 	DeleteCollectionWorkers int
 	ResourcePrefix          string
 	CountMetricPollPeriod   time.Duration
+
+	NamespaceLabelsAccessor func(ns string) (labels.Labels, error)
 }
 
 // Implement RESTOptionsGetter so that RESTOptions can directly be used when available (i.e. tests)

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -997,7 +997,15 @@ func filterWithAttrsFunction(key string, p storage.SelectionPredicate) filterWit
 		if !hasPathPrefix(objKey, key) {
 			return false
 		}
-		return p.MatchesObjectAttributes(label, field)
+		if !p.MatchesObjectAttributes(label, field) {
+			return false
+		}
+		if p.NamespaceMatch != nil {
+			if ns := field.Get("metadata.namespace"); len(ns) > 0 && !p.NamespaceMatch(ns) {
+				return false
+			}
+		}
+		return true
 	}
 	return filterFunc
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/openapi/zz_generated.openapi.go
@@ -1045,6 +1045,13 @@ func schema_pkg_apis_meta_v1_ListOptions(ref common.ReferenceCallback) common.Op
 							Format:      "",
 						},
 					},
+					"namespaceLabelSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A selector to restrict the set of namespaces that objects are returned from by the namespace label. Using this field with a resource that is not namespace scoped will return a bad request error. The default is to select all namespaces.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"watch": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/openapi/zz_generated.openapi.go
@@ -1049,6 +1049,13 @@ func schema_pkg_apis_meta_v1_ListOptions(ref common.ReferenceCallback) common.Op
 							Format:      "",
 						},
 					},
+					"namespaceLabelSelector": {
+						SchemaProps: spec.SchemaProps{
+							Description: "A selector to restrict the set of namespaces that objects are returned from by the namespace label. Using this field with a resource that is not namespace scoped will return a bad request error. The default is to select all namespaces.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"watch": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Watch for changes to the described resources and return them as a stream of add, update, and remove notifications. Specify resourceVersion.",


### PR DESCRIPTION
/kind api-change

This is just a toy to explore some ideas what subdivision within a cluster could look like, not for actual use or review.  

Experiment with:

1. A way to filter resources within namespaces that have a label (namespaceLabelSelector).  Possibly useful on its own.
2. A way for an authenticator to enforce a filter to be applied to LIST/GET/WATCH on cluster scoped resources (and also filter namespaces-resources by namespaces that match that filter)
3. A default pattern for the service account authenticator to impose that filter based on the namespace the service account is in
4. An admission controller that restricts mutation of filters (so you can't remove your stuff from your filter).

Gaps spotted in the first five minutes by Jordan

1. watch across namespaces has to either have a consistent bounding set from a start RV, or has to handle add/remove based on label changes on namespaces (which are super rare in theory, so you could make those synthetic)

```release-note
NONE
```
```docs
```