### PR TITLE
Fixing EndpointSlice kubectl output

### DIFF
--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -70,6 +70,7 @@ go_library(
         "//pkg/apis/core/helper:go_default_library",
         "//pkg/apis/core/install:go_default_library",
         "//pkg/apis/discovery:go_default_library",
+        "//pkg/apis/discovery/install:go_default_library",
         "//pkg/apis/events/install:go_default_library",
         "//pkg/apis/extensions/install:go_default_library",
         "//pkg/apis/networking:go_default_library",

--- a/pkg/printers/internalversion/import_known_versions.go
+++ b/pkg/printers/internalversion/import_known_versions.go
@@ -27,6 +27,7 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/certificates/install"
 	_ "k8s.io/kubernetes/pkg/apis/coordination/install"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	_ "k8s.io/kubernetes/pkg/apis/discovery/install"
 	_ "k8s.io/kubernetes/pkg/apis/events/install"
 	_ "k8s.io/kubernetes/pkg/apis/extensions/install"
 	_ "k8s.io/kubernetes/pkg/apis/policy/install"

--- a/pkg/registry/discovery/endpointslice/storage/BUILD
+++ b/pkg/registry/discovery/endpointslice/storage/BUILD
@@ -7,6 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/discovery:go_default_library",
+        "//pkg/printers:go_default_library",
+        "//pkg/printers/internalversion:go_default_library",
+        "//pkg/printers/storage:go_default_library",
         "//pkg/registry/discovery/endpointslice:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/discovery/endpointslice/storage/storage.go
+++ b/pkg/registry/discovery/endpointslice/storage/storage.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/apis/discovery"
+	"k8s.io/kubernetes/pkg/printers"
+	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/discovery/endpointslice"
 )
 
@@ -32,16 +35,15 @@ type REST struct {
 // NewREST returns a RESTStorage object that will work against endpoint slices.
 func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 	store := &genericregistry.Store{
-		NewFunc:     func() runtime.Object { return &discovery.EndpointSlice{} },
-		NewListFunc: func() runtime.Object { return &discovery.EndpointSliceList{} },
-		ObjectNameFunc: func(obj runtime.Object) (string, error) {
-			return obj.(*discovery.EndpointSlice).Name, nil
-		},
+		NewFunc:                  func() runtime.Object { return &discovery.EndpointSlice{} },
+		NewListFunc:              func() runtime.Object { return &discovery.EndpointSliceList{} },
 		DefaultQualifiedResource: discovery.Resource("endpointslices"),
 
 		CreateStrategy: endpointslice.Strategy,
 		UpdateStrategy: endpointslice.Strategy,
 		DeleteStrategy: endpointslice.Strategy,
+
+		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter}
 	if err := store.CompleteWithOptions(options); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Unfortunately there were a couple pieces missing in the initial EndpointSlice kubectl integration so it was defaulting to just show name and age on get/list requests. This PR fixes that. Sample output now looks like this:

```
kubectl get endpointslice 
NAME         ADDRESS TYPE   PORTS   ENDPOINTS        AGE
kubernetes   IP             443     35.239.237.102   5m1s
```

**Special notes for your reviewer**:
This is intended for 1.16, but open to feedback on when/where it should land. I've added [corresponding e2e tests in a separate PR](https://github.com/kubernetes/kubernetes/pull/83748) that should prevent this from happening in the future.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed kubectl endpointslice output for get requests
```