### PR TITLE
don't stop kube-controller-manager when hpa controller failed

### DIFF
--- a/cmd/kube-controller-manager/app/autoscaling.go
+++ b/cmd/kube-controller-manager/app/autoscaling.go
@@ -32,6 +32,8 @@ import (
 	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 	"k8s.io/metrics/pkg/client/custom_metrics"
 	"k8s.io/metrics/pkg/client/external_metrics"
+
+	"k8s.io/klog"
 )
 
 func startHPAController(ctx ControllerContext) (http.Handler, bool, error) {
@@ -88,7 +90,8 @@ func startHPAControllerWithMetricsClient(ctx ControllerContext, metricsClient me
 	scaleKindResolver := scale.NewDiscoveryScaleKindResolver(hpaClient.Discovery())
 	scaleClient, err := scale.NewForConfig(hpaClientConfig, ctx.RESTMapper, dynamic.LegacyAPIPathResolverFunc, scaleKindResolver)
 	if err != nil {
-		return nil, false, err
+		klog.Warningf("failed to start HPA controller: %s", err)
+		return nil, false, nil
 	}
 
 	go podautoscaler.NewHorizontalController(


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
don't stop kube-controller-manager when hpa controller failed as other controllers.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```