### PR TITLE
Modify the ip range size from 20 to 16

### DIFF
--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -48,7 +48,7 @@ func validateClusterIPFlags(options *ServerRunOptions) []error {
 	// Complete() expected to have set Primary* and Secondary*
 	// primary CIDR validation
 	var ones, bits = options.PrimaryServiceClusterIPRange.Mask.Size()
-	if bits-ones > 20 {
+	if bits-ones > 16 {
 		errs = append(errs, errors.New("specified --service-cluster-ip-range is too large"))
 	}
 
@@ -77,7 +77,7 @@ func validateClusterIPFlags(options *ServerRunOptions) []error {
 		// bigger cidr (specially those offered by IPv6) will add no value
 		// significantly increase snapshotting time.
 		var ones, bits = options.SecondaryServiceClusterIPRange.Mask.Size()
-		if bits-ones > 20 {
+		if bits-ones > 16 {
 			errs = append(errs, errors.New("specified --secondary-service-cluster-ip-range is too large"))
 		}
 	}


### PR DESCRIPTION
Due to the allocator keeping track of all the allocated IP's in a bitmap.
This will keep the size of the bitmap to 64K. So here I think we should
change it.