### PR TITLE
Automated cherry pick of #82446: Check cache is synced first before sleeping

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -105,7 +105,7 @@ const (
 // WaitForCacheSync waits for caches to populate.  It returns true if it was successful, false
 // if the controller should shutdown
 func WaitForCacheSync(stopCh <-chan struct{}, cacheSyncs ...InformerSynced) bool {
-	err := wait.PollUntil(syncedPollPeriod,
+	err := wait.PollImmediateUntil(syncedPollPeriod,
 		func() (bool, error) {
 			for _, syncFunc := range cacheSyncs {
 				if !syncFunc() {


### PR DESCRIPTION
Cherry pick of #82446 on release-1.14.

#82446: Check cache is synced first before sleeping

/kind cleanup

```release-note
Check cache is synced first before sleeping. Fixed by @ibuildthecloud
```