### PR TITLE
Migrate prometheus bucket functionality to kube-metrics for volume

### DIFF
--- a/pkg/controller/volume/scheduling/metrics/BUILD
+++ b/pkg/controller/volume/scheduling/metrics/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 

--- a/pkg/controller/volume/scheduling/metrics/metrics.go
+++ b/pkg/controller/volume/scheduling/metrics/metrics.go
@@ -17,8 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -43,7 +41,7 @@ var (
 			Subsystem:      VolumeSchedulerSubsystem,
 			Name:           "scheduling_duration_seconds",
 			Help:           "Volume scheduling stage latency",
-			Buckets:        prometheus.ExponentialBuckets(1000, 2, 15),
+			Buckets:        metrics.ExponentialBuckets(1000, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"operation"},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR migrate prometheus bucket to metrics stability framework.
The [metrics stability framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-stability-migration.md) has provided bucket functionality. (refer: https://github.com/kubernetes/kubernetes/pull/82583)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

