### PR TITLE
Deprecate ssh tunnel metrics, since ssh tunnel is a deprecated feature

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -55,25 +55,27 @@ import (
  * the metric stability policy.
  */
 var (
-	deprecatedTunnelOpenCounter = metrics.NewCounter(
+	tunnelOpenCounter = metrics.NewCounter(
 		&metrics.CounterOpts{
-			Name:           "ssh_tunnel_open_count",
-			Help:           "(Deprecated since v1.17) Counter of ssh tunnel total open attempts",
-			StabilityLevel: metrics.ALPHA,
+			Name:              "ssh_tunnel_open_count",
+			Help:              "Counter of ssh tunnel total open attempts",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.18.0",
 		},
 	)
-	deprecatedTunnelOpenFailCounter = metrics.NewCounter(
+	tunnelOpenFailCounter = metrics.NewCounter(
 		&metrics.CounterOpts{
-			Name:           "ssh_tunnel_open_fail_count",
-			Help:           "(Deprecated since v1.17) Counter of ssh tunnel failed open attempts",
-			StabilityLevel: metrics.ALPHA,
+			Name:              "ssh_tunnel_open_fail_count",
+			Help:              "Counter of ssh tunnel failed open attempts",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.18.0",
 		},
 	)
 )
 
 func init() {
-	legacyregistry.MustRegister(deprecatedTunnelOpenCounter)
-	legacyregistry.MustRegister(deprecatedTunnelOpenFailCounter)
+	legacyregistry.MustRegister(tunnelOpenCounter)
+	legacyregistry.MustRegister(tunnelOpenFailCounter)
 }
 
 // TODO: Unit tests for this code, we can spin up a test SSH server with instructions here:
@@ -101,9 +103,9 @@ func makeSSHTunnel(user string, signer ssh.Signer, host string) (*sshTunnel, err
 func (s *sshTunnel) Open() error {
 	var err error
 	s.client, err = realTimeoutDialer.Dial("tcp", net.JoinHostPort(s.Host, s.SSHPort), s.Config)
-	deprecatedTunnelOpenCounter.Inc()
+	tunnelOpenCounter.Inc()
 	if err != nil {
-		deprecatedTunnelOpenFailCounter.Inc()
+		tunnelOpenFailCounter.Inc()
 	}
 	return err
 }

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -55,25 +55,25 @@ import (
  * the metric stability policy.
  */
 var (
-	tunnelOpenCounter = metrics.NewCounter(
+	deprecatedTunnelOpenCounter = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Name:           "ssh_tunnel_open_count",
-			Help:           "Counter of ssh tunnel total open attempts",
+			Help:           "(Deprecated since v1.17) Counter of ssh tunnel total open attempts",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
-	tunnelOpenFailCounter = metrics.NewCounter(
+	deprecatedTunnelOpenFailCounter = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Name:           "ssh_tunnel_open_fail_count",
-			Help:           "Counter of ssh tunnel failed open attempts",
+			Help:           "(Deprecated since v1.17) Counter of ssh tunnel failed open attempts",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
 )
 
 func init() {
-	legacyregistry.MustRegister(tunnelOpenCounter)
-	legacyregistry.MustRegister(tunnelOpenFailCounter)
+	legacyregistry.MustRegister(deprecatedTunnelOpenCounter)
+	legacyregistry.MustRegister(deprecatedTunnelOpenFailCounter)
 }
 
 // TODO: Unit tests for this code, we can spin up a test SSH server with instructions here:
@@ -101,9 +101,9 @@ func makeSSHTunnel(user string, signer ssh.Signer, host string) (*sshTunnel, err
 func (s *sshTunnel) Open() error {
 	var err error
 	s.client, err = realTimeoutDialer.Dial("tcp", net.JoinHostPort(s.Host, s.SSHPort), s.Config)
-	tunnelOpenCounter.Inc()
+	deprecatedTunnelOpenCounter.Inc()
 	if err != nil {
-		tunnelOpenFailCounter.Inc()
+		deprecatedTunnelOpenFailCounter.Inc()
 	}
 	return err
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We want to deprecate ssh tunnel metrics since ssh tunnels are a deprecated feature

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/81984

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
ssh tunnel metrics, namely `ssh_tunnel_open_count` and  `ssh_tunnel_open_fail_count` are deprecated 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```