### PR TITLE
Fix bug The statefulset have duplicate revision after resource was up…

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
@@ -242,7 +242,7 @@ func (h *StatefulSetHistoryViewer) ViewHistory(namespace, name string, revision 
 	if len(history) <= 0 {
 		return "No rollout history found.", nil
 	}
-	revisions := make([]int64, len(history))
+	revisions := make([]int64, 0, len(history))
 	for _, revision := range history {
 		revisions = append(revisions, revision.Revision)
 	}


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug
> /kind cleanup

**What this PR does / why we need it**:
> get

```
# kubectl rollout history sts/test-sts 
statefulset.apps/test-sts 
REVISION
0
0
0
1
2
3
```

> except

```
# kubectl rollout history sts/test-sts 
statefulset.apps/test-sts 
REVISION
1
2
3
```
**Which issue(s) this PR fixes**:
Ref [#82613 ](https://github.com/kubernetes/kubernetes/issues/82613)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
Fixes spurious 0 revisions listed when running `kubectl rollout history` for a StatefulSet
```
