### PR TITLE
kubectl: namespace support in resource edits

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/0.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/0.response
@@ -1,0 +1,34 @@
+{
+	"kind": "Service",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "svc1",
+		"namespace": "arg-ns",
+		"selfLink": "/api/v1/namespaces/edit-test/services/svc1",
+		"uid": "5f7da8db-e8c3-11e6-b7e2-acbc32c1ca87",
+		"resourceVersion": "20715",
+		"creationTimestamp": "2017-02-01T21:14:09Z",
+		"labels": {
+			"app": "svc1"
+		}
+	},
+	"spec": {
+		"ports": [
+			{
+				"name": "80",
+				"protocol": "TCP",
+				"port": 80,
+				"targetPort": 80
+			}
+		],
+		"selector": {
+			"app": "svc1"
+		},
+		"clusterIP": "10.0.0.146",
+		"type": "ClusterIP",
+		"sessionAffinity": "None"
+	},
+	"status": {
+		"loadBalancer": {}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/1.edited
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/1.edited
@@ -1,0 +1,29 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2017-02-01T21:14:09Z"
+  labels:
+    app: svc1
+    new-label: new-value
+  name: svc1
+  namespace: arg-ns
+  resourceVersion: "20715"
+  selfLink: /api/v1/namespaces/edit-test/services/svc1
+  uid: 5f7da8db-e8c3-11e6-b7e2-acbc32c1ca87
+spec:
+  clusterIP: 10.0.0.146
+  ports:
+  - name: "80"
+    port: 81
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: svc1
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/1.original
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/1.original
@@ -1,0 +1,28 @@
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: "2017-02-01T21:14:09Z"
+  labels:
+    app: svc1
+  name: svc1
+  namespace: arg-ns
+  resourceVersion: "20715"
+  selfLink: /api/v1/namespaces/edit-test/services/svc1
+  uid: 5f7da8db-e8c3-11e6-b7e2-acbc32c1ca87
+spec:
+  clusterIP: 10.0.0.146
+  ports:
+  - name: "80"
+    port: 80
+    protocol: TCP
+    targetPort: 80
+  selector:
+    app: svc1
+  sessionAffinity: None
+  type: ClusterIP
+status:
+  loadBalancer: {}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/2.request
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/2.request
@@ -1,0 +1,26 @@
+{
+	"metadata": {
+		"labels": {
+			"new-label": "new-value"
+		}
+	},
+	"spec": {
+		"$setElementOrder/ports": [
+			{
+				"port": 81
+			}
+		],
+		"ports": [
+			{
+				"name": "80",
+				"port": 81,
+				"protocol": "TCP",
+				"targetPort": 80
+			},
+			{
+				"$patch": "delete",
+				"port": 80
+			}
+		]
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/2.response
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/2.response
@@ -1,0 +1,35 @@
+{
+	"kind": "Service",
+	"apiVersion": "v1",
+	"metadata": {
+		"name": "svc1",
+		"namespace": "arg-ns",
+		"selfLink": "/api/v1/namespaces/arg-ns/services/svc1",
+		"uid": "5f7da8db-e8c3-11e6-b7e2-acbc32c1ca87",
+		"resourceVersion": "20820",
+		"creationTimestamp": "2017-02-01T21:14:09Z",
+		"labels": {
+			"app": "svc1",
+			"new-label": "new-value"
+		}
+	},
+	"spec": {
+		"ports": [
+			{
+				"name": "80",
+				"protocol": "TCP",
+				"port": 81,
+				"targetPort": 80
+			}
+		],
+		"selector": {
+			"app": "svc1"
+		},
+		"clusterIP": "10.0.0.146",
+		"type": "ClusterIP",
+		"sessionAffinity": "None"
+	},
+	"status": {
+		"loadBalancer": {}
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/test.yaml
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/testdata/testcase-single-service-with-namespace/test.yaml
@@ -1,0 +1,28 @@
+# kubectl create namespace edit-test
+# kubectl create service clusterip svc1 --tcp 80 --namespace=edit-test
+# kubectl edit service svc1 --namespace=edit-test
+description: edit a single service, add a label and change a port
+mode: edit
+args:
+- arg-ns/service/svc1
+namespace: arg-ns
+expectedStdout:
+- service/svc1 edited
+expectedExitCode: 0
+steps:
+- type: request
+  expectedMethod: GET
+  expectedPath: /api/v1/namespaces/arg-ns/services/svc1
+  expectedInput: 0.request
+  resultingStatusCode: 200
+  resultingOutput: 0.response
+- type: edit
+  expectedInput: 1.original
+  resultingOutput: 1.edited
+- type: request
+  expectedMethod: PATCH
+  expectedPath: /api/v1/namespaces/arg-ns/services/svc1
+  expectedContentType: application/strategic-merge-patch+json
+  expectedInput: 2.request
+  resultingStatusCode: 200
+  resultingOutput: 2.response


### PR DESCRIPTION
/kind feature


**What this PR does / why we need it**:
As an Ops we need to rapidly modify k8s objects and avoid manipulation errors as much as possible. When modifying several "similar" objects from different namespaces, we need to modify object one after the other. This PR allows to edit a document with all resources across different namespaces.

**Does this PR introduce a user-facing change?**:
User can use namespace per resource argument. i.e:
```kubectl edit ns1/secret/secret1 ns2/secret/secret1 ns3/pod/pod1```

```release-note
kubectl users can edit objects by providing the namespace in the resource name. I.e.: kubectl edit pod ns1/secret/secret1
```