### PR TITLE
Clean up dynamic client pre-flight check

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -1994,3 +1994,66 @@ func defaultResourcePathWithPrefix(prefix, resource, namespace, name string) str
 	}
 	return path
 }
+
+func TestRequestPreflightCheck(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		verbs        []string
+		namespace    string
+		resourceName string
+		namespaceSet bool
+		expectsErr   bool
+	}{
+		{
+			name:         "no namespace set",
+			verbs:        []string{"GET", "PUT", "DELETE", "POST"},
+			namespaceSet: false,
+			expectsErr:   false,
+		},
+		{
+			name:         "empty resource name and namespace",
+			verbs:        []string{"GET", "PUT", "DELETE"},
+			namespaceSet: true,
+			expectsErr:   false,
+		},
+		{
+			name:         "resource name with empty namespace",
+			verbs:        []string{"GET", "PUT", "DELETE"},
+			namespaceSet: true,
+			resourceName: "ResourceName",
+			expectsErr:   true,
+		},
+		{
+			name:         "post empty resource name and namespace",
+			verbs:        []string{"POST"},
+			namespaceSet: true,
+			expectsErr:   true,
+		},
+		{
+			name:         "working requests",
+			verbs:        []string{"GET", "PUT", "DELETE", "POST"},
+			namespaceSet: true,
+			resourceName: "ResourceName",
+			namespace:    "Namespace",
+			expectsErr:   false,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, verb := range tt.verbs {
+				r := &Request{
+					verb:         verb,
+					namespace:    tt.namespace,
+					resourceName: tt.resourceName,
+					namespaceSet: tt.namespaceSet,
+				}
+
+				err := r.requestPreflightCheck()
+				hasErr := err != nil
+				if hasErr == tt.expectsErr {
+					return
+				}
+				t.Errorf("%s: expects error: %v, has error: %v", verb, tt.expectsErr, hasErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This patch moves pre-request validations to a function and implements tests for it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: