### PR TITLE
Fix pre pull of images in DiskPressure tests

### DIFF
--- a/test/e2e_node/system_node_critical_test.go
+++ b/test/e2e_node/system_node_critical_test.go
@@ -110,6 +110,13 @@ var _ = framework.KubeDescribe("SystemNodeCriticalPod [Slow] [Serial] [Disruptiv
 					return checkMirrorPodDisappear(f.ClientSet, mirrorPodName, ns)
 				}, time.Minute, time.Second*2).Should(gomega.BeNil())
 
+				ginkgo.By("making sure that node no longer has DiskPressure")
+				gomega.Eventually(func() error {
+					if hasNodeCondition(f, v1.NodeDiskPressure) {
+						return fmt.Errorf("Conditions havent returned to normal, node still has DiskPressure")
+					}
+					return nil
+				}, pressureDissapearTimeout, evictionPollInterval).Should(gomega.BeNil())
 			})
 		})
 	})


### PR DESCRIPTION


**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Fix pre pull of images in DiskPressure tests

This waits for DiskPressure to no longer exist before pre pulling images
after a DiskPressure test. Otherwise we risk to pull images, while
kubelet evicts/removes them.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref https://github.com/kubernetes/kubernetes/issues/82017

**Special notes for your reviewer**:

Follow up on #82018.

/sig node
/sig testing

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```