### PR TITLE
apiextensions: add integration test for not publishing non-structural CRDs

### DIFF
--- a/test/integration/master/crd_test.go
+++ b/test/integration/master/crd_test.go
@@ -19,6 +19,7 @@ package master
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -160,13 +161,36 @@ func TestCRDOpenAPI(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
-	t.Logf("Trying to create a custom resource without conflict")
-	crd := &apiextensionsv1beta1.CustomResourceDefinition{
+
+	t.Logf("Trying to create a CustomResourceDefinitions")
+	nonStructuralCRD := &apiextensionsv1beta1.CustomResourceDefinition{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "foos.cr.bar.com",
+			Name: "foos.nonstructural.cr.bar.com",
 		},
 		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
-			Group:   "cr.bar.com",
+			Group:   "nonstructural.cr.bar.com",
+			Version: "v1",
+			Scope:   apiextensionsv1beta1.NamespaceScoped,
+			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
+				Plural: "foos",
+				Kind:   "Foo",
+			},
+			Validation: &apiextensionsv1beta1.CustomResourceValidation{
+				OpenAPIV3Schema: &apiextensionsv1beta1.JSONSchemaProps{
+					Type: "object",
+					Properties: map[string]apiextensionsv1beta1.JSONSchemaProps{
+						"foo": {},
+					},
+				},
+			},
+		},
+	}
+	structuralCRD := &apiextensionsv1beta1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foos.structural.cr.bar.com",
+		},
+		Spec: apiextensionsv1beta1.CustomResourceDefinitionSpec{
+			Group:   "structural.cr.bar.com",
 			Version: "v1",
 			Scope:   apiextensionsv1beta1.NamespaceScoped,
 			Names: apiextensionsv1beta1.CustomResourceDefinitionNames{
@@ -184,55 +208,95 @@ func TestCRDOpenAPI(t *testing.T) {
 			},
 		},
 	}
-	etcd.CreateTestCRDs(t, apiextensionsclient, false, crd)
-	waitForSpec := func(expectedType string) {
+	etcd.CreateTestCRDs(t, apiextensionsclient, false, nonStructuralCRD)
+	etcd.CreateTestCRDs(t, apiextensionsclient, false, structuralCRD)
+
+	getPublishedSchema := func(defName string) (*spec.Schema, error) {
+		bs, err := kubeclient.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+		if err != nil {
+			return nil, err
+		}
+		spec := spec.Swagger{}
+		if err := json.Unmarshal(bs, &spec); err != nil {
+			return nil, err
+		}
+		if spec.SwaggerProps.Paths == nil {
+			return nil, nil
+		}
+		d, ok := spec.SwaggerProps.Definitions[defName]
+		if !ok {
+			return nil, nil
+		}
+		return &d, nil
+	}
+
+	waitForSpec := func(crd *apiextensionsv1beta1.CustomResourceDefinition, expectedType string) {
 		t.Logf(`Waiting for {properties: {"foo": {"type":"%s"}}} to show up in schema`, expectedType)
 		lastMsg := ""
 		if err := wait.PollImmediate(500*time.Millisecond, 10*time.Second, func() (bool, error) {
 			lastMsg = ""
-			bs, err := kubeclient.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+			defName := crdDefinitionName(crd)
+			schema, err := getPublishedSchema(defName)
 			if err != nil {
-				return false, err
-			}
-			spec := spec.Swagger{}
-			if err := json.Unmarshal(bs, &spec); err != nil {
-				return false, err
-			}
-			if spec.SwaggerProps.Paths == nil {
-				lastMsg = "spec.SwaggerProps.Paths is nil"
+				lastMsg = err.Error()
 				return false, nil
 			}
-			d, ok := spec.SwaggerProps.Definitions["com.bar.cr.v1.Foo"]
-			if !ok {
-				lastMsg = `spec.SwaggerProps.Definitions["com.bar.cr.v1.Foo"] not found`
+			if schema == nil {
+				lastMsg = fmt.Sprintf("spec.SwaggerProps.Definitions[%q] not found", defName)
 				return false, nil
 			}
-			p, ok := d.Properties["foo"]
+			p, ok := schema.Properties["foo"]
 			if !ok {
-				lastMsg = `spec.SwaggerProps.Definitions["com.bar.cr.v1.Foo"].Properties["foo"] not found`
+				lastMsg = fmt.Sprintf(`spec.SwaggerProps.Definitions[%q].Properties["foo"] not found`, defName)
 				return false, nil
 			}
 			if !p.Type.Contains(expectedType) {
-				lastMsg = fmt.Sprintf(`spec.SwaggerProps.Definitions["com.bar.cr.v1.Foo"].Properties["foo"].Type should be %q, but got: %q`, expectedType, p.Type)
+				lastMsg = fmt.Sprintf(`spec.SwaggerProps.Definitions[%q].Properties["foo"].Type should be %q, but got: %q`, defName, expectedType, p.Type)
 				return false, nil
 			}
 			return true, nil
 		}); err != nil {
-			t.Fatalf("Failed to see %s OpenAPI spec in discovery: %v, last message: %s", crd.Name, err, lastMsg)
+			t.Fatalf("Failed to see %s OpenAPI spec in discovery: %v, last message: %s", structuralCRD.Name, err, lastMsg)
 		}
 	}
-	waitForSpec("string")
-	crd, err = apiextensionsclient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(crd.Name, metav1.GetOptions{})
+
+	t.Logf("Check that structural schema is published")
+	waitForSpec(structuralCRD, "string")
+	structuralCRD, err = apiextensionsclient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(structuralCRD.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	prop := crd.Spec.Validation.OpenAPIV3Schema.Properties["foo"]
+	prop := structuralCRD.Spec.Validation.OpenAPIV3Schema.Properties["foo"]
 	prop.Type = "boolean"
-	crd.Spec.Validation.OpenAPIV3Schema.Properties["foo"] = prop
-	if _, err = apiextensionsclient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(crd); err != nil {
+	structuralCRD.Spec.Validation.OpenAPIV3Schema.Properties["foo"] = prop
+	if _, err = apiextensionsclient.ApiextensionsV1beta1().CustomResourceDefinitions().Update(structuralCRD); err != nil {
 		t.Fatal(err)
 	}
-	waitForSpec("boolean")
+	waitForSpec(structuralCRD, "boolean")
+
+	t.Logf("Check that non-structural schema is not published")
+	schema, err := getPublishedSchema(crdDefinitionName(nonStructuralCRD))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if schema == nil {
+		t.Fatal("expected a non-nil schema")
+	}
+	if foo, ok := schema.Properties["foo"]; ok {
+		t.Fatalf("unexpected published 'foo' property: %#v", foo)
+	}
+}
+
+func crdDefinitionName(crd *apiextensionsv1beta1.CustomResourceDefinition) string {
+	sgmts := strings.Split(crd.Spec.Group, ".")
+	reverse(sgmts)
+	return strings.Join(append(sgmts, crd.Spec.Version, crd.Spec.Names.Kind), ".")
+}
+
+func reverse(s []string) {
+	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
+		s[i], s[j] = s[j], s[i]
+	}
 }
 
 type Foo struct {


### PR DESCRIPTION
Follow-up of https://github.com/kubernetes/kubernetes/pull/82653.

/kind bug

```release-note
NONE
```