### PR TITLE
Allow disruptive conformance tests and tag 2 as such

### DIFF
--- a/test/conformance/walk.go
+++ b/test/conformance/walk.go
@@ -44,7 +44,7 @@ var (
 	totalConfTests, totalLegacyTests, missingComments int
 
 	// If a test name contains any of these tags, it is ineligble for promotion to conformance
-	regexIneligibleTags = regexp.MustCompile(`\[(Alpha|Disruptive|Feature:[^\]]+|Flaky)\]`)
+	regexIneligibleTags = regexp.MustCompile(`\[(Alpha|Feature:[^\]]+|Flaky)\]`)
 )
 
 const regexDescribe = "Describe|KubeDescribe|SIGDescribe"

--- a/test/conformance/walk_test.go
+++ b/test/conformance/walk_test.go
@@ -156,16 +156,12 @@ func TestValidateTestName(t *testing.T) {
 			"",
 		},
 		{
-			"a test case with valid tags [LinuxOnly] [NodeConformance] [Serial]",
+			"a test case with valid tags [LinuxOnly] [NodeConformance] [Serial] [Disruptive]",
 			"",
 		},
 		{
 			"a flaky test case that is invalid [Flaky]",
 			"[Flaky]",
-		},
-		{
-			"a disruptive test case that is invalid [Disruptive]",
-			"[Disruptive]",
 		},
 		{
 			"a feature test case that is invalid [Feature:Awesome]",
@@ -176,12 +172,12 @@ func TestValidateTestName(t *testing.T) {
 			"[Alpha]",
 		},
 		{
-			"a test case with multiple invalid tags [Flaky][Disruptive] [Feature:Awesome] [Alpha]",
-			"[Flaky],[Disruptive],[Feature:Awesome],[Alpha]",
+			"a test case with multiple invalid tags [Flaky] [Feature:Awesome] [Alpha]",
+			"[Flaky],[Feature:Awesome],[Alpha]",
 		},
 		{
-			"[sig-awesome] [Disruptive] a test case with valid and invalid tags [Alpha] [Serial] [Flaky]",
-			"[Disruptive],[Alpha],[Flaky]",
+			"[sig-awesome] [Alpha] [Disruptive] a test case with valid and invalid tags [Serial] [Flaky]",
+			"[Alpha],[Flaky]",
 		},
 	}
 	for i, tc := range testCases {

--- a/test/e2e/scheduling/taints.go
+++ b/test/e2e/scheduling/taints.go
@@ -283,7 +283,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Single Pod [Serial]", func() {
 		Description: The Pod with toleration timeout scheduled on a tainted Node MUST not be
 		evicted if the taint is removed before toleration time ends.
 	*/
-	framework.ConformanceIt("removing taint cancels eviction", func() {
+	framework.ConformanceIt("removing taint cancels eviction [Disruptive]", func() {
 		podName := "taint-eviction-4"
 		pod := createPodForTaintsTest(true, 2*additionalWaitPerDeleteSeconds, podName, podName, ns)
 		observedDeletions := make(chan string, 100)
@@ -413,7 +413,7 @@ var _ = SIGDescribe("NoExecuteTaintManager Multiple Pods [Serial]", func() {
 		Description: In a multi-pods scenario with tolerationSeconds, the pods MUST be evicted as per
 		the toleration time limit.
 	*/
-	framework.ConformanceIt("evicts pods with minTolerationSeconds", func() {
+	framework.ConformanceIt("evicts pods with minTolerationSeconds [Disruptive]", func() {
 		podGroup := "taint-eviction-b"
 		observedDeletions := make(chan string, 100)
 		stopCh := make(chan struct{})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Adjusts tooling to allow disrutpive tests to be marked conformance
 - Adds the disruptive tag to both tests (disruptive due to tainting
nodes and evicting other workloads)

**Which issue(s) this PR fixes**:
Fixes #82663
Fixes #82787

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Conformance tests may now include disruptive tests. If you are running tests against a live cluster, consider skipping those tests tagged as `Disruptive` to avoid non-test workloads being impacted. Be aware, skipping any conformance tests (even disruptive ones) will make the results ineligible for consideration for the CNCF Certified Kubernetes program.
```
