### PR TITLE
Ensure all conditions for publishing openapi are satisfied in kubectl e2e tests

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -41,6 +41,7 @@ import (
 	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/utils/crd"
+	utilpointer "k8s.io/utils/pointer"
 	"sigs.k8s.io/yaml"
 )
 
@@ -439,6 +440,7 @@ func setupCRDAndVerifySchema(f *framework.Framework, schema, expect []byte, grou
 
 		// set up validation when input schema isn't nil
 		if schema != nil {
+			crd.Spec.PreserveUnknownFields = utilpointer.BoolPtr(false)
 			crd.Spec.Validation = &v1beta1.CustomResourceValidation{
 				OpenAPIV3Schema: props,
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The e2e test checking kubectl and openapi interaction was setting up a CRD that should not have published openapi specs.

**Special notes for your reviewer**:
Test-only change. Needed to properly test compatibility with https://github.com/kubernetes/kubernetes/pull/82653 which will merge to 1.16 in https://github.com/kubernetes/kubernetes/pull/82658

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/assign @sttts @roycaihw 
/priority critical-urgent