### PR TITLE
Skip e2e tests that require node independent volume for the drivers that don't support node independent volumes

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -96,6 +96,7 @@ func InitHostPathCSIDriver() testsuites.TestDriver {
 		testsuites.CapBlock:               true,
 		testsuites.CapPVCDataSource:       true,
 		testsuites.CapControllerExpansion: true,
+		testsuites.CapSingleNodeVolume:    true,
 	}
 	return initHostPathCSIDriver("csi-hostpath",
 		capabilities,
@@ -345,7 +346,7 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 // InitHostPathV0CSIDriver returns a variant of hostpathCSIDriver with different manifests.
 func InitHostPathV0CSIDriver() testsuites.TestDriver {
 	return initHostPathCSIDriver("csi-hostpath-v0",
-		map[testsuites.Capability]bool{testsuites.CapPersistence: true, testsuites.CapMultiPODs: true},
+		map[testsuites.Capability]bool{testsuites.CapPersistence: true, testsuites.CapMultiPODs: true, testsuites.CapSingleNodeVolume: true},
 		nil, /* no volume attributes -> no ephemeral volume testing */
 		// Using the current set of rbac.yaml files is problematic here because they don't
 		// match the version of the rules that were written for the releases of external-attacher

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -701,8 +701,9 @@ func InitHostPathDriver() testsuites.TestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapPersistence: true,
-				testsuites.CapMultiPODs:   true,
+				testsuites.CapPersistence:      true,
+				testsuites.CapMultiPODs:        true,
+				testsuites.CapSingleNodeVolume: true,
 			},
 		},
 	}
@@ -775,8 +776,9 @@ func InitHostPathSymlinkDriver() testsuites.TestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapPersistence: true,
-				testsuites.CapMultiPODs:   true,
+				testsuites.CapPersistence:      true,
+				testsuites.CapMultiPODs:        true,
+				testsuites.CapSingleNodeVolume: true,
 			},
 		},
 	}
@@ -917,7 +919,8 @@ func InitEmptydirDriver() testsuites.TestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapExec: true,
+				testsuites.CapExec:             true,
+				testsuites.CapSingleNodeVolume: true,
 			},
 		},
 	}
@@ -1677,19 +1680,21 @@ type localVolume struct {
 var (
 	// capabilities
 	defaultLocalVolumeCapabilities = map[testsuites.Capability]bool{
-		testsuites.CapPersistence: true,
-		testsuites.CapFsGroup:     true,
-		testsuites.CapBlock:       false,
-		testsuites.CapExec:        true,
-		testsuites.CapMultiPODs:   true,
+		testsuites.CapPersistence:      true,
+		testsuites.CapFsGroup:          true,
+		testsuites.CapBlock:            false,
+		testsuites.CapExec:             true,
+		testsuites.CapMultiPODs:        true,
+		testsuites.CapSingleNodeVolume: true,
 	}
 	localVolumeCapabitilies = map[utils.LocalVolumeType]map[testsuites.Capability]bool{
 		utils.LocalVolumeBlock: {
-			testsuites.CapPersistence: true,
-			testsuites.CapFsGroup:     true,
-			testsuites.CapBlock:       true,
-			testsuites.CapExec:        true,
-			testsuites.CapMultiPODs:   true,
+			testsuites.CapPersistence:      true,
+			testsuites.CapFsGroup:          true,
+			testsuites.CapBlock:            true,
+			testsuites.CapExec:             true,
+			testsuites.CapMultiPODs:        true,
+			testsuites.CapSingleNodeVolume: true,
 		},
 	}
 	// fstype

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -161,6 +161,9 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		defer cleanup()
 
 		// Check different-node test requirement
+		if l.driver.GetDriverInfo().Capabilities[CapSingleNodeVolume] {
+			framework.Skipf("Driver %s only supports %v -- skipping", l.driver.GetDriverInfo().Name, CapSingleNodeVolume)
+		}
 		nodes := framework.GetReadySchedulableNodesOrDie(l.cs)
 		if len(nodes.Items) < 2 {
 			framework.Skipf("Number of available nodes is less than 2 - skipping")
@@ -241,6 +244,9 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		defer cleanup()
 
 		// Check different-node test requirement
+		if l.driver.GetDriverInfo().Capabilities[CapSingleNodeVolume] {
+			framework.Skipf("Driver %s only supports %v -- skipping", l.driver.GetDriverInfo().Name, CapSingleNodeVolume)
+		}
 		nodes := framework.GetReadySchedulableNodesOrDie(l.cs)
 		if len(nodes.Items) < 2 {
 			framework.Skipf("Number of available nodes is less than 2 - skipping")

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -155,7 +155,8 @@ const (
 	CapRWX                 Capability = "RWX"                 // support ReadWriteMany access modes
 	CapControllerExpansion Capability = "controllerExpansion" // support volume expansion for controller
 	CapNodeExpansion       Capability = "nodeExpansion"       // support volume expansion for node
-	CapVolumeLimits                   = "volumeLimits"        // support volume limits (can be *very* slow)
+	CapVolumeLimits        Capability = "volumeLimits"        // support volume limits (can be *very* slow)
+	CapSingleNodeVolume    Capability = "singleNodeVolume"    // support volume that can run on single node (like hostpath)
 )
 
 // DriverInfo represents static information about a TestDriver.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig storage

**What this PR does / why we need it**:
Skip e2e tests that run on multi node cluster and require node independent volume for the drivers that don't support node independent volumes, like hostpath.

**Which issue(s) this PR fixes**:
Fixes #82675

**Special notes for your reviewer**:
I added a new capability as `CapNodeIndependentVolume` and set this true all csi and in tree test drivers other than hostpath, local and emptydir.

Currently we need to make these tests off for only csi hostpath driver's tests, I'm open to a more simple solution.

cc @msau42 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```