### PR TITLE
Migrating from AtoI to ParsePort() for String Port to Int Port Conversion.

### DIFF
--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/kube-scheduler/config/v1alpha1:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strconv"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,6 +48,7 @@ import (
 	kubeschedulerscheme "k8s.io/kubernetes/pkg/scheduler/apis/config/scheme"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config/validation"
 	"k8s.io/kubernetes/pkg/scheduler/factory"
+	netutils "k8s.io/utils/net"
 )
 
 // Options has all the params needed to run a Scheduler
@@ -122,11 +122,12 @@ func splitHostIntPort(s string) (string, int, error) {
 	if err != nil {
 		return "", 0, err
 	}
-	portInt, err := strconv.Atoi(port)
+	// False in ParsePort presumes 0 is not allowed as a port value.
+	portInt, err := netutils.ParsePort(port, false)
 	if err != nil {
 		return "", 0, err
 	}
-	return host, portInt, err
+	return host, port, err
 }
 
 func newDefaultComponentConfig() (*kubeschedulerconfig.KubeSchedulerConfiguration, error) {

--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/cmd/kubeadm/app/util/endpoint.go
+++ b/cmd/kubeadm/app/util/endpoint.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	netutils "k8s.io/utils/net"
 )
 
 // GetControlPlaneEndpoint returns a properly formatted endpoint for the control plane built according following rules:
@@ -115,8 +116,8 @@ func ParseHostPort(hostport string) (string, string, error) {
 // ParsePort parses a string representing a TCP port.
 // If the string is not a valid representation of a TCP port, ParsePort returns an error.
 func ParsePort(port string) (int, error) {
-	portInt, err := strconv.Atoi(port)
-	if err == nil && (1 <= portInt && portInt <= 65535) {
+	portInt, err := netutils.ParsePort(port, false)
+	if err == nil {
 		return portInt, nil
 	}
 

--- a/pkg/kubelet/lifecycle/BUILD
+++ b/pkg/kubelet/lifecycle/BUILD
@@ -29,6 +29,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/io:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/lifecycle/handlers.go
+++ b/pkg/kubelet/lifecycle/handlers.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/util/format"
 	"k8s.io/kubernetes/pkg/security/apparmor"
 	utilio "k8s.io/utils/io"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -92,7 +93,7 @@ func resolvePort(portReference intstr.IntOrString, container *v1.Container) (int
 		return portReference.IntValue(), nil
 	}
 	portName := portReference.StrVal
-	port, err := strconv.Atoi(portName)
+	port, err := netutils.ParsePort(portName, false)
 	if err == nil {
 		return port, nil
 	}

--- a/pkg/kubelet/server/portforward/BUILD
+++ b/pkg/kubelet/server/portforward/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/server/httplog:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/wsstream:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/server/portforward/websocket.go
+++ b/pkg/kubelet/server/portforward/websocket.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/apiserver/pkg/server/httplog"
 	"k8s.io/apiserver/pkg/util/wsstream"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -68,7 +68,7 @@ func NewV4Options(req *http.Request) (*V4Options, error) {
 			return nil, fmt.Errorf("query parameter %q cannot be empty", api.PortHeader)
 		}
 		for _, p := range strings.Split(portString, ",") {
-			port, err := strconv.ParseUint(p, 10, 16)
+			port, err := netutils.ParsePort(p, false)
 			if err != nil {
 				return nil, fmt.Errorf("unable to parse %q as a port: %v", portString, err)
 			}

--- a/pkg/probe/http/BUILD
+++ b/pkg/probe/http/BUILD
@@ -28,6 +28,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/probe/http/http_test.go
+++ b/pkg/probe/http/http_test.go
@@ -24,7 +24,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/probe"
+	netutils "k8s.io/utils/net"
 )
 
 const FailureCode int = -1
@@ -242,7 +242,7 @@ func TestHTTPProbeChecker(t *testing.T) {
 			if err != nil {
 				t.Errorf("case %d: unexpected error: %v", i, err)
 			}
-			_, err = strconv.Atoi(port)
+			_, err = netutils.ParsePort(port, false)
 			if err != nil {
 				t.Errorf("case %d: unexpected error: %v", i, err)
 			}

--- a/pkg/proxy/apis/config/validation/BUILD
+++ b/pkg/proxy/apis/config/validation/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/component-base/config:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/proxy/apis/config/validation/validation.go
+++ b/pkg/proxy/apis/config/validation/validation.go
@@ -30,6 +30,7 @@ import (
 	apivalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	kubeproxyconfig "k8s.io/kubernetes/pkg/proxy/apis/config"
+	netutils "k8s.io/utils/net"
 )
 
 // Validate validates the configuration of kube-proxy
@@ -212,7 +213,7 @@ func validateHostPort(input string, fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, field.Invalid(fldPath, hostIP, "must be a valid IP"))
 	}
 
-	if p, err := strconv.Atoi(port); err != nil {
+	if p, err := netutils.ParsePort(port, false); err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath, port, "must be a valid port"))
 	} else if p < 1 || p > 65535 {
 		allErrs = append(allErrs, field.Invalid(fldPath, port, "must be a valid port"))

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -1849,7 +1849,8 @@ func (proxier *Proxier) syncEndpoint(svcPortName proxy.ServicePortName, onlyNode
 			klog.Errorf("Failed to parse endpoint: %v, error: %v", ep, err)
 			continue
 		}
-		portNum, err := strconv.Atoi(port)
+		// False assumes we don't allow port 0.
+		portNum, err := utilnet.ParsePort(port, false)
 		if err != nil {
 			klog.Errorf("Failed to parse endpoint port %s, error: %v", port, err)
 			continue

--- a/pkg/proxy/userspace/BUILD
+++ b/pkg/proxy/userspace/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "//vendor/golang.org/x/sys/unix:go_default_library",
@@ -91,6 +92,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
         "//vendor/k8s.io/utils/exec/testing:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -41,6 +41,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/conntrack"
 	"k8s.io/kubernetes/pkg/util/iptables"
 	utilexec "k8s.io/utils/exec"
+	netutils "k8s.io/utils/net"
 )
 
 type portal struct {
@@ -433,7 +434,7 @@ func (proxier *Proxier) addServiceOnPortInternal(service proxy.ServicePortName, 
 		sock.Close()
 		return nil, err
 	}
-	portNum, err := strconv.Atoi(portStr)
+	portNum, err := netutils.ParsePort(port, false)
 	if err != nil {
 		sock.Close()
 		return nil, err

--- a/pkg/proxy/userspace/proxier_test.go
+++ b/pkg/proxy/userspace/proxier_test.go
@@ -25,12 +25,11 @@ import (
 	"net/url"
 	"os"
 	"reflect"
-	"strconv"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -40,6 +39,7 @@ import (
 	ipttest "k8s.io/kubernetes/pkg/util/iptables/testing"
 	"k8s.io/utils/exec"
 	fakeexec "k8s.io/utils/exec/testing"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -146,7 +146,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse: %v", err))
 	}
-	tcpServerPortValue, err := strconv.Atoi(port)
+	tcpServerPortValue, err := netutils.ParsePort(port, false)
 	if err != nil {
 		panic(fmt.Sprintf("failed to atoi(%s): %v", port, err))
 	}
@@ -161,7 +161,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse: %v", err))
 	}
-	udpServerPortValue, err := strconv.Atoi(port)
+	udpServerPortValue, err := netutils.ParsePort(port, false)
 	if err != nil {
 		panic(fmt.Sprintf("failed to atoi(%s): %v", port, err))
 	}

--- a/pkg/proxy/util/endpoints.go
+++ b/pkg/proxy/util/endpoints.go
@@ -19,9 +19,9 @@ package util
 import (
 	"fmt"
 	"net"
-	"strconv"
 
 	"k8s.io/klog"
+	netutils "k8s.io/utils/net"
 )
 
 // IPPart returns just the IP part of an IP or IP:port or endpoint string. If the IP
@@ -55,7 +55,7 @@ func PortPart(s string) (int, error) {
 		klog.Errorf("Error parsing '%s': %v", s, err)
 		return -1, err
 	}
-	portNumber, err := strconv.Atoi(port)
+	portNumber, err := netutils.ParsePort(port, false)
 	if err != nil {
 		klog.Errorf("Error parsing '%s': %v", port, err)
 		return -1, err

--- a/pkg/proxy/winuserspace/BUILD
+++ b/pkg/proxy/winuserspace/BUILD
@@ -49,6 +49,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/proxy/winuserspace/proxier_test.go
+++ b/pkg/proxy/winuserspace/proxier_test.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/kubernetes/pkg/proxy"
 	netshtest "k8s.io/kubernetes/pkg/util/netsh/testing"
+	netutils "k8s.io/utils/net"
 )
 
 const (
@@ -132,7 +133,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse: %v", err))
 	}
-	tcpServerPortValue, err := strconv.Atoi(port)
+	tcpServerPortValue, err := netutils.ParsePort(port, false)
 	if err != nil {
 		panic(fmt.Sprintf("failed to atoi(%s): %v", port, err))
 	}
@@ -147,7 +148,7 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(fmt.Sprintf("failed to parse: %v", err))
 	}
-	udpServerPortValue, err := strconv.Atoi(port)
+	udpServerPortValue, err := netutils.ParsePort(port, false)
 	if err != nil {
 		panic(fmt.Sprintf("failed to atoi(%s): %v", port, err))
 	}
@@ -230,7 +231,7 @@ func getPortNum(t *testing.T, addr string) int {
 		t.Errorf("error getting port from %s", addr)
 		return 0
 	}
-	portNum, err := strconv.Atoi(portStr)
+	portNum, err := netutils.ParsePort(port, false)
 	if err != nil {
 		t.Errorf("error getting port from %s", addr)
 		return 0

--- a/pkg/registry/core/rest/BUILD
+++ b/pkg/registry/core/rest/BUILD
@@ -61,6 +61,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -65,6 +64,7 @@ import (
 	servicestore "k8s.io/kubernetes/pkg/registry/core/service/storage"
 	serviceaccountstore "k8s.io/kubernetes/pkg/registry/core/serviceaccount/storage"
 	"k8s.io/kubernetes/pkg/serviceaccount"
+	netutils "k8s.io/utils/net"
 )
 
 // LegacyRESTStorageProvider provides information needed to build RESTStorage for core, but
@@ -358,7 +358,11 @@ func (s componentStatusStorage) serversToValidate() map[string]*componentstatus.
 				klog.Errorf("Failed to split host/port: %s (%v)", etcdUrl.Host, err)
 				continue
 			}
-			port, _ = strconv.Atoi(portString)
+			port, err = netutils.ParsePort(port, false)
+			if err != nil {
+				klog.Errorf("Failed to parse port: %d", port)
+				continue
+			}
 		} else {
 			addr = etcdUrl.Host
 			port = 2379

--- a/pkg/util/flag/BUILD
+++ b/pkg/util/flag/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/klog"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	netutils "k8s.io/utils/net"
 )
 
 // PrintFlags logs the flags in the flagset
@@ -109,7 +110,7 @@ func (v IPPortVar) Set(s string) error {
 	if net.ParseIP(host) == nil {
 		return fmt.Errorf("%q is not a valid IP address", host)
 	}
-	if _, err := strconv.Atoi(port); err != nil {
+	if _, err := netutils.ParsePort(port, true); err != nil {
 		return fmt.Errorf("%q is not a valid number", port)
 	}
 	*v.Val = s

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/BUILD
@@ -74,6 +74,7 @@ go_library(
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
         "//vendor/github.com/gogo/protobuf/sortkeys:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/conversion.go
@@ -18,7 +18,6 @@ package v1
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -27,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	netutils "k8s.io/utils/net"
 )
 
 func AddConversionFuncs(scheme *runtime.Scheme) error {
@@ -323,7 +323,7 @@ func Convert_v1_LabelSelector_To_Map_string_To_string(in *LabelSelector, out *ma
 func Convert_Slice_string_To_Slice_int32(in *[]string, out *[]int32, s conversion.Scope) error {
 	for _, s := range *in {
 		for _, v := range strings.Split(s, ",") {
-			x, err := strconv.ParseUint(v, 10, 16)
+			x, err := netutils.ParsePort(v, false)
 			if err != nil {
 				return fmt.Errorf("cannot convert to []int32: %v", err)
 			}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/BUILD
@@ -18,7 +18,10 @@ go_library(
     srcs = ["validation.go"],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/validation",
     importpath = "k8s.io/apimachinery/pkg/util/validation",
-    deps = ["//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
+    ],
 )
 
 filegroup(

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -21,10 +21,10 @@ import (
 	"math"
 	"net"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	netutils "k8s.io/utils/net"
 )
 
 const qnameCharFmt string = "[A-Za-z0-9]"
@@ -409,7 +409,7 @@ func IsValidSocketAddr(value string) []string {
 		errs = append(errs, "must be a valid socket address format, (e.g. 0.0.0.0:10254 or [::]:10254)")
 		return errs
 	}
-	portInt, _ := strconv.Atoi(port)
+	portInt, _ := netutils.ParsePort(port, false)
 	errs = append(errs, IsValidPortNum(portInt)...)
 	errs = append(errs, IsValidIP(ip)...)
 	return errs

--- a/staging/src/k8s.io/apiserver/pkg/server/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/BUILD
@@ -121,6 +121,7 @@ go_library(
         "//vendor/k8s.io/kube-openapi/pkg/handler:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -67,6 +67,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
+	netutils "k8s.io/utils/net"
 
 	// install apis
 	_ "k8s.io/apiserver/pkg/apis/apiserver/install"
@@ -707,7 +708,7 @@ func (s *SecureServingInfo) HostPort() (string, int, error) {
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to get port from listener address %q: %v", addr, err)
 	}
-	port, err := strconv.Atoi(portStr)
+	port, err := netutils.ParsePort(portStr, false)
 	if err != nil {
 		return "", 0, fmt.Errorf("invalid non-numeric port %q", portStr)
 	}

--- a/staging/src/k8s.io/client-go/tools/portforward/BUILD
+++ b/staging/src/k8s.io/client-go/tools/portforward/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/httpstream:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/tools/portforward/portforward.go
+++ b/staging/src/k8s.io/client-go/tools/portforward/portforward.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	netutils "k8s.io/utils/net"
 )
 
 // PortForwardProtocolV1Name is the subprotocol used for port forwarding.
@@ -93,12 +94,12 @@ func parsePorts(ports []string) ([]ForwardedPort, error) {
 			return nil, fmt.Errorf("invalid port format '%s'", portString)
 		}
 
-		localPort, err := strconv.ParseUint(localString, 10, 16)
+		localPort, err := netutils.ParsePort(localString, false)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing local port '%s': %s", localString, err)
 		}
 
-		remotePort, err := strconv.ParseUint(remoteString, 10, 16)
+		remotePort, err := netutils.ParsePort(remoteString, false)
 		if err != nil {
 			return nil, fmt.Errorf("error parsing remote port '%s': %s", remoteString, err)
 		}
@@ -281,7 +282,7 @@ func (pf *PortForwarder) getListener(protocol string, hostname string, port *For
 	}
 	listenerAddress := listener.Addr().String()
 	host, localPort, _ := net.SplitHostPort(listenerAddress)
-	localPortUInt, err := strconv.ParseUint(localPort, 10, 16)
+	localPortUInt, err := netutils.ParsePort(localPort, false)
 
 	if err != nil {
 		fmt.Fprintf(pf.out, "Failed to forward from %s:%d -> %d\n", hostname, localPortUInt, port.Remote)

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/BUILD
@@ -50,6 +50,7 @@ go_library(
         "//staging/src/k8s.io/kubectl/pkg/generate:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/hash:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/kubectl/pkg/generate"
+	netutils "k8s.io/utils/net"
 )
 
 type ServiceCommonGeneratorV1 struct {
@@ -86,7 +87,7 @@ func (ServiceExternalNameGeneratorV1) ParamNames() []generate.GeneratorParam {
 func parsePorts(portString string) (int32, intstr.IntOrString, error) {
 	portStringSlice := strings.Split(portString, ":")
 
-	port, err := strconv.Atoi(portStringSlice[0])
+	port, err := netutils.ParsePort(portStringSlice[0], false)
 	if err != nil {
 		return 0, intstr.FromInt(0), err
 	}
@@ -100,7 +101,7 @@ func parsePorts(portString string) (int32, intstr.IntOrString, error) {
 	}
 
 	var targetPort intstr.IntOrString
-	if portNum, err := strconv.Atoi(portStringSlice[1]); err != nil {
+	if portNum, err := netutils.ParsePort(portStringSlice[1], false); err != nil {
 		if errs := validation.IsValidPortName(portStringSlice[1]); len(errs) != 0 {
 			return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
 		}

--- a/test/e2e/framework/providers/gce/BUILD
+++ b/test/e2e/framework/providers/gce/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
         "//vendor/google.golang.org/api/googleapi:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -25,12 +25,13 @@ import (
 
 	compute "google.golang.org/api/compute/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/kubernetes/test/e2e/framework"
 	gcecloud "k8s.io/legacy-cloud-providers/gce"
+	netutils "k8s.io/utils/net"
 )
 
 // MakeFirewallNameForLBService return the expected firewall name for a LB service.
@@ -276,17 +277,17 @@ func toPortRange(s string) (pr portRange, err error) {
 	ports := strings.Split(protoPorts[1], "-")
 	switch len(ports) {
 	case 1:
-		v, err := strconv.Atoi(ports[0])
+		v, err := netutils.ParsePort(ports[0], false)
 		if err != nil {
 			return pr, err
 		}
 		pr.min, pr.max = v, v
 	case 2:
-		start, err := strconv.Atoi(ports[0])
+		start, err := netutils.ParsePort(ports[0], false)
 		if err != nil {
 			return pr, err
 		}
-		end, err := strconv.Atoi(ports[1])
+		end, err := netutils.ParsePort(ports[1], false)
 		if err != nil {
 			return pr, err
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This migrates us from AtoI to a ParsePort method which accounts for overflow.

**Which issue(s) this PR fixes**:
Fixes: #81121

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE