### PR TITLE
Refactor CSI Translation Library into a struct that is injected into various components to simplify unit testing 

### DIFF
--- a/cmd/kube-controller-manager/app/BUILD
+++ b/cmd/kube-controller-manager/app/BUILD
@@ -141,6 +141,7 @@ go_library(
         "//staging/src/k8s.io/component-base/cli/globalflag:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//staging/src/k8s.io/component-base/version/verflag:go_default_library",
+        "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/custom_metrics:go_default_library",
         "//staging/src/k8s.io/metrics/pkg/client/external_metrics:go_default_library",

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -36,6 +36,7 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/metadata"
 	restclient "k8s.io/client-go/rest"
+	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/controller"
 	cloudcontroller "k8s.io/kubernetes/pkg/controller/cloud"
 	endpointcontroller "k8s.io/kubernetes/pkg/controller/endpoint"
@@ -309,7 +310,8 @@ func startVolumeExpandController(ctx ControllerContext) (http.Handler, bool, err
 			ctx.InformerFactory.Core().V1().PersistentVolumes(),
 			ctx.InformerFactory.Storage().V1().StorageClasses(),
 			ctx.Cloud,
-			ProbeExpandableVolumePlugins(ctx.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration))
+			ProbeExpandableVolumePlugins(ctx.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration),
+			csitrans.New())
 
 		if expandControllerErr != nil {
 			return nil, true, fmt.Errorf("failed to start volume expand controller : %v", expandControllerErr)

--- a/pkg/controller/volume/expand/BUILD
+++ b/pkg/controller/volume/expand/BUILD
@@ -32,7 +32,6 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
-        "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -75,6 +74,7 @@ go_test(
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//staging/src/k8s.io/csi-translation-lib/plugins:go_default_library",
     ],
 )

--- a/pkg/controller/volume/expand/expand_controller_test.go
+++ b/pkg/controller/volume/expand/expand_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/informers"
 	coretesting "k8s.io/client-go/testing"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
+	csitrans "k8s.io/csi-translation-lib"
 	csitranslationplugins "k8s.io/csi-translation-lib/plugins"
 	"k8s.io/kubernetes/pkg/controller"
 	controllervolumetesting "k8s.io/kubernetes/pkg/controller/volume/attachdetach/testing"
@@ -123,7 +124,7 @@ func TestSyncHandler(t *testing.T) {
 		if tc.storageClass != nil {
 			informerFactory.Storage().V1().StorageClasses().Informer().GetIndexer().Add(tc.storageClass)
 		}
-		expc, err := NewExpandController(fakeKubeClient, pvcInformer, pvInformer, storageClassInformer, nil, allPlugins)
+		expc, err := NewExpandController(fakeKubeClient, pvcInformer, pvInformer, storageClassInformer, nil, allPlugins, csitrans.New())
 		if err != nil {
 			t.Fatalf("error creating expand controller : %v", err)
 		}

--- a/pkg/controller/volume/persistentvolume/BUILD
+++ b/pkg/controller/volume/persistentvolume/BUILD
@@ -101,6 +101,7 @@ go_test(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/tools/reference:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/controller/volume/persistentvolume/framework_test.go
+++ b/pkg/controller/volume/persistentvolume/framework_test.go
@@ -521,6 +521,12 @@ func wrapTestWithProvisionCalls(expectedProvisionCalls []provisionCall, toWrap t
 	return wrapTestWithPluginCalls(nil, nil, expectedProvisionCalls, toWrap)
 }
 
+type fakeCSINameTranslator struct{}
+
+func (t fakeCSINameTranslator) GetCSINameFromInTreeName(pluginName string) (string, error) {
+	return "vendor.com/MockCSIPlugin", nil
+}
+
 // wrapTestWithCSIMigrationProvisionCalls returns a testCall that:
 // - configures controller with a volume plugin that emulates CSI migration
 // - calls given testCall
@@ -530,9 +536,7 @@ func wrapTestWithCSIMigrationProvisionCalls(toWrap testCall) testCall {
 			isMigratedToCSI: true,
 		}
 		ctrl.volumePluginMgr.InitPlugins([]vol.VolumePlugin{plugin}, nil /* prober */, ctrl)
-		ctrl.csiNameFromIntreeNameHook = func(string) (string, error) {
-			return "vendor.com/MockCSIPlugin", nil
-		}
+		ctrl.translator = fakeCSINameTranslator{}
 		return toWrap(ctrl, reactor, test)
 	}
 }

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -38,6 +38,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	cloudprovider "k8s.io/cloud-provider"
+	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume/metrics"
 	pvutil "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/util"
@@ -93,6 +94,7 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 		volumeQueue:                   workqueue.NewNamed("volumes"),
 		resyncPeriod:                  p.SyncPeriod,
 		operationTimestamps:           metrics.NewOperationStartTimeCache(),
+		translator:                    csitrans.New(),
 	}
 
 	// Prober is nil because PV is not aware of Flexvolume.

--- a/pkg/controller/volume/persistentvolume/pv_controller_test.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_test.go
@@ -30,6 +30,7 @@ import (
 	storagelisters "k8s.io/client-go/listers/storage/v1"
 	core "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
+	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/controller"
 	pvtesting "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/testing"
@@ -438,6 +439,7 @@ func TestDelayBindingMode(t *testing.T) {
 	classInformer := informerFactory.Storage().V1().StorageClasses()
 	ctrl := &PersistentVolumeController{
 		classLister: classInformer.Lister(),
+		translator:  csitrans.New(),
 	}
 
 	for _, class := range classes {

--- a/pkg/volume/util/operationexecutor/BUILD
+++ b/pkg/volume/util/operationexecutor/BUILD
@@ -67,6 +67,7 @@ go_test(
         "//staging/src/k8s.io/component-base/featuregate:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
+        "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//staging/src/k8s.io/csi-translation-lib/plugins:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",

--- a/pkg/volume/util/operationexecutor/fakegenerator.go
+++ b/pkg/volume/util/operationexecutor/fakegenerator.go
@@ -21,6 +21,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
@@ -86,6 +87,10 @@ func (f *fakeOGCounter) GenerateUnmapDeviceFunc(deviceToDetach AttachedVolume, a
 
 func (f *fakeOGCounter) GetVolumePluginMgr() *volume.VolumePluginMgr {
 	return nil
+}
+
+func (f *fakeOGCounter) GetCSITranslator() InTreeToCSITranslator {
+	return csitrans.New()
 }
 
 func (f *fakeOGCounter) GenerateBulkVolumeVerifyFunc(

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -641,14 +641,14 @@ func (oe *operationExecutor) VerifyVolumesAreAttached(
 			}
 
 			// Migration: Must also check the Node since Attach would have been done with in-tree if node is not using Migration
-			nu, err := nodeUsingCSIPlugin(oe.operationGenerator, volumeAttached.VolumeSpec, node)
+			nu, err := nodeUsingCSIPlugin(oe.operationGenerator.GetCSITranslator(), oe.operationGenerator.GetVolumePluginMgr(), volumeAttached.VolumeSpec, node)
 			if err != nil {
 				klog.Errorf(volumeAttached.GenerateErrorDetailed("VolumesAreAttached.NodeUsingCSIPlugin failed", err).Error())
 				continue
 			}
 
 			var volumePlugin volume.VolumePlugin
-			if useCSIPlugin(oe.operationGenerator.GetVolumePluginMgr(), volumeAttached.VolumeSpec) && nu {
+			if useCSIPlugin(oe.operationGenerator.GetCSITranslator(), oe.operationGenerator.GetVolumePluginMgr(), volumeAttached.VolumeSpec) && nu {
 				// The volume represented by this spec is CSI and thus should be migrated
 				volumePlugin, err = oe.operationGenerator.GetVolumePluginMgr().FindPluginByName(csi.CSIPluginName)
 				if err != nil || volumePlugin == nil {
@@ -661,7 +661,7 @@ func (oe *operationExecutor) VerifyVolumesAreAttached(
 					continue
 				}
 
-				csiSpec, err := translateSpec(volumeAttached.VolumeSpec)
+				csiSpec, err := translateSpec(oe.operationGenerator.GetCSITranslator(), volumeAttached.VolumeSpec)
 				if err != nil {
 					klog.Errorf(volumeAttached.GenerateErrorDetailed("VolumesAreAttached.TranslateSpec failed", err).Error())
 					continue

--- a/pkg/volume/util/operationexecutor/operation_executor_test.go
+++ b/pkg/volume/util/operationexecutor/operation_executor_test.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
+	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/util/hostutil"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
@@ -518,6 +519,10 @@ func (fopg *fakeOperationGenerator) GenerateUnmapDeviceFunc(deviceToDetach Attac
 
 func (fopg *fakeOperationGenerator) GetVolumePluginMgr() *volume.VolumePluginMgr {
 	return nil
+}
+
+func (fopg *fakeOperationGenerator) GetCSITranslator() InTreeToCSITranslator {
+	return csitrans.New()
 }
 
 func getTestPodWithSecret(podName, secretName string) *v1.Pod {

--- a/pkg/volume/util/operationexecutor/operation_generator_test.go
+++ b/pkg/volume/util/operationexecutor/operation_generator_test.go
@@ -125,7 +125,7 @@ func TestOperationGenerator_GenerateUnmapVolumeFunc_PluginName(t *testing.T) {
 			// csi plugin looks a file that contains some information about the volume,
 			// and GenerateUnmapVolumeFuncfails if csi plugin can't find that file.
 			// So the reason for calling plugin.NewBlockVolumeMapper for csi enabled case is creating that file.
-			csiSpec, err := translateSpec(volumeToUnmount.VolumeSpec)
+			csiSpec, err := translateSpec(operationGenerator.GetCSITranslator(), volumeToUnmount.VolumeSpec)
 			if err != nil {
 				t.Fatalf("Can't translate volume to CSI")
 			}

--- a/staging/src/k8s.io/csi-translation-lib/translate.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate.go
@@ -35,9 +35,20 @@ var (
 	}
 )
 
+// CSITranslator translates in-tree storage API objects to their equivalent CSI
+// API objects. It also provides many helper functions to determine whether
+// translation logic exists and the mappings between "in-tree plugin <-> csi driver"
+type CSITranslator struct{}
+
+// New creates a new CSITranslator which does real translation
+// for "in-tree plugins <-> csi drivers"
+func New() CSITranslator {
+	return CSITranslator{}
+}
+
 // TranslateInTreeStorageClassToCSI takes in-tree Storage Class
 // and translates it to a set of parameters consumable by CSI plugin
-func TranslateInTreeStorageClassToCSI(inTreePluginName string, sc *storage.StorageClass) (*storage.StorageClass, error) {
+func (ctl CSITranslator) TranslateInTreeStorageClassToCSI(inTreePluginName string, sc *storage.StorageClass) (*storage.StorageClass, error) {
 	newSC := sc.DeepCopy()
 	for _, curPlugin := range inTreePlugins {
 		if inTreePluginName == curPlugin.GetInTreePluginName() {
@@ -50,7 +61,7 @@ func TranslateInTreeStorageClassToCSI(inTreePluginName string, sc *storage.Stora
 // TranslateInTreeInlineVolumeToCSI takes a inline volume and will translate
 // the in-tree volume source to a CSIPersistentVolumeSource (wrapped in a PV)
 // if the translation logic has been implemented.
-func TranslateInTreeInlineVolumeToCSI(volume *v1.Volume) (*v1.PersistentVolume, error) {
+func (ctl CSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Volume) (*v1.PersistentVolume, error) {
 	if volume == nil {
 		return nil, fmt.Errorf("persistent volume was nil")
 	}
@@ -66,7 +77,7 @@ func TranslateInTreeInlineVolumeToCSI(volume *v1.Volume) (*v1.PersistentVolume, 
 // the in-tree source to a CSI Source if the translation logic
 // has been implemented. The input persistent volume will not
 // be modified
-func TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+func (ctl CSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	if pv == nil {
 		return nil, errors.New("persistent volume was nil")
 	}
@@ -82,7 +93,7 @@ func TranslateInTreePVToCSI(pv *v1.PersistentVolume) (*v1.PersistentVolume, erro
 // TranslateCSIPVToInTree takes a PV with a CSI PersistentVolume Source and will translate
 // it to a in-tree Persistent Volume Source for the specific in-tree volume specified
 // by the `Driver` field in the CSI Source. The input PV object will not be modified.
-func TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
+func (ctl CSITranslator) TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, error) {
 	if pv == nil || pv.Spec.CSI == nil {
 		return nil, errors.New("CSI persistent volume was nil")
 	}
@@ -97,7 +108,7 @@ func TranslateCSIPVToInTree(pv *v1.PersistentVolume) (*v1.PersistentVolume, erro
 
 // IsMigratableIntreePluginByName tests whether there is migration logic for the in-tree plugin
 // whose name matches the given name
-func IsMigratableIntreePluginByName(inTreePluginName string) bool {
+func (ctl CSITranslator) IsMigratableIntreePluginByName(inTreePluginName string) bool {
 	for _, curPlugin := range inTreePlugins {
 		if curPlugin.GetInTreePluginName() == inTreePluginName {
 			return true
@@ -108,7 +119,7 @@ func IsMigratableIntreePluginByName(inTreePluginName string) bool {
 
 // IsMigratedCSIDriverByName tests whether there exists an in-tree plugin with logic
 // to migrate to the CSI driver with given name
-func IsMigratedCSIDriverByName(csiPluginName string) bool {
+func (ctl CSITranslator) IsMigratedCSIDriverByName(csiPluginName string) bool {
 	if _, ok := inTreePlugins[csiPluginName]; ok {
 		return true
 	}
@@ -116,7 +127,7 @@ func IsMigratedCSIDriverByName(csiPluginName string) bool {
 }
 
 // GetInTreePluginNameFromSpec returns the plugin name
-func GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (string, error) {
+func (ctl CSITranslator) GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (string, error) {
 	if pv != nil {
 		for _, curPlugin := range inTreePlugins {
 			if curPlugin.CanSupport(pv) {
@@ -138,7 +149,7 @@ func GetInTreePluginNameFromSpec(pv *v1.PersistentVolume, vol *v1.Volume) (strin
 
 // GetCSINameFromInTreeName returns the name of a CSI driver that supersedes the
 // in-tree plugin with the given name
-func GetCSINameFromInTreeName(pluginName string) (string, error) {
+func (ctl CSITranslator) GetCSINameFromInTreeName(pluginName string) (string, error) {
 	for csiDriverName, curPlugin := range inTreePlugins {
 		if curPlugin.GetInTreePluginName() == pluginName {
 			return csiDriverName, nil
@@ -149,7 +160,7 @@ func GetCSINameFromInTreeName(pluginName string) (string, error) {
 
 // GetInTreeNameFromCSIName returns the name of the in-tree plugin superseded by
 // a CSI driver with the given name
-func GetInTreeNameFromCSIName(pluginName string) (string, error) {
+func (ctl CSITranslator) GetInTreeNameFromCSIName(pluginName string) (string, error) {
 	if plugin, ok := inTreePlugins[pluginName]; ok {
 		return plugin.GetInTreePluginName(), nil
 	}
@@ -157,7 +168,7 @@ func GetInTreeNameFromCSIName(pluginName string) (string, error) {
 }
 
 // IsPVMigratable tests whether there is migration logic for the given Persistent Volume
-func IsPVMigratable(pv *v1.PersistentVolume) bool {
+func (ctl CSITranslator) IsPVMigratable(pv *v1.PersistentVolume) bool {
 	for _, curPlugin := range inTreePlugins {
 		if curPlugin.CanSupport(pv) {
 			return true
@@ -167,7 +178,7 @@ func IsPVMigratable(pv *v1.PersistentVolume) bool {
 }
 
 // IsInlineMigratable tests whether there is Migration logic for the given Inline Volume
-func IsInlineMigratable(vol *v1.Volume) bool {
+func (ctl CSITranslator) IsInlineMigratable(vol *v1.Volume) bool {
 	for _, curPlugin := range inTreePlugins {
 		if curPlugin.CanSupportInline(vol) {
 			return true

--- a/staging/src/k8s.io/csi-translation-lib/translate_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/translate_test.go
@@ -61,12 +61,13 @@ func TestTranslationStability(t *testing.T) {
 		},
 	}
 	for _, test := range testCases {
+		ctl := New()
 		t.Logf("Testing %v", test.name)
-		csiSource, err := TranslateInTreePVToCSI(test.pv)
+		csiSource, err := ctl.TranslateInTreePVToCSI(test.pv)
 		if err != nil {
 			t.Errorf("Error when translating to CSI: %v", err)
 		}
-		newPV, err := TranslateCSIPVToInTree(csiSource)
+		newPV, err := ctl.TranslateCSIPVToInTree(csiSource)
 		if err != nil {
 			t.Errorf("Error when translating CSI Source to in tree volume: %v", err)
 		}
@@ -95,18 +96,19 @@ func TestPluginNameMappings(t *testing.T) {
 	}
 	for _, test := range testCases {
 		t.Logf("Testing %v", test.name)
-		csiPluginName, err := GetCSINameFromInTreeName(test.inTreePluginName)
+		ctl := New()
+		csiPluginName, err := ctl.GetCSINameFromInTreeName(test.inTreePluginName)
 		if err != nil {
 			t.Errorf("Error when mapping In-tree plugin name to CSI plugin name %s", err)
 		}
-		if !IsMigratedCSIDriverByName(csiPluginName) {
+		if !ctl.IsMigratedCSIDriverByName(csiPluginName) {
 			t.Errorf("%s expected to supersede an In-tree plugin", csiPluginName)
 		}
-		inTreePluginName, err := GetInTreeNameFromCSIName(csiPluginName)
+		inTreePluginName, err := ctl.GetInTreeNameFromCSIName(csiPluginName)
 		if err != nil {
 			t.Errorf("Error when mapping CSI plugin name to In-tree plugin name %s", err)
 		}
-		if !IsMigratableIntreePluginByName(inTreePluginName) {
+		if !ctl.IsMigratableIntreePluginByName(inTreePluginName) {
 			t.Errorf("%s expected to be migratable to a CSI name", inTreePluginName)
 		}
 		if inTreePluginName != test.inTreePluginName || csiPluginName != test.csiPluginName {

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -34,7 +34,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	clientset "k8s.io/client-go/kubernetes"
-	csilib "k8s.io/csi-translation-lib"
+	csitrans "k8s.io/csi-translation-lib"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/metrics"
 	"k8s.io/kubernetes/test/e2e/framework/podlogs"
@@ -557,7 +557,8 @@ func addOpCounts(o1 opCounts, o2 opCounts) opCounts {
 func getMigrationVolumeOpCounts(cs clientset.Interface, pluginName string) (opCounts, opCounts) {
 	if len(pluginName) > 0 {
 		var migratedOps opCounts
-		csiName, err := csilib.GetCSINameFromInTreeName(pluginName)
+		l := csitrans.New()
+		csiName, err := l.GetCSINameFromInTreeName(pluginName)
 		if err != nil {
 			framework.Logf("Could not find CSI Name for in-tree plugin %v", pluginName)
 			migratedOps = opCounts{}


### PR DESCRIPTION
Fixes: #82670

An example of a unit test possible with this new struct: https://github.com/kubernetes-csi/external-provisioner/pull/343

/kind cleanup
/priority important-soon
/sig storage
/assign @ddebroy @jsafrane @msau42 
/cc @ddebroy @leakingtapan @saad-ali @shanesiebken

```release-note
NONE
```
