### PR TITLE
Adjust nginx lb timeout depending on the cluster size in tests

### DIFF
--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -738,6 +738,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
 				framework.DescribeIng(ns)
 			}
+			defer nginxController.TearDown()
 			if jig.Ingress == nil {
 				ginkgo.By("No ingress created, no cleanup necessary")
 				return


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
It adjusts the nginx ingress LoadBalancer timeout depending on the cluster size.
In addition we'll now delete the Service and LoadBalancer before ending to test to avoid the case when deleting the namespace times out due to long LB deletion.

This is to fix the https://github.com/kubernetes/kubernetes/issues/82695


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
