### PR TITLE
Unmount subpath should only scan the first level of files/directories

### DIFF
--- a/pkg/util/mount/fake.go
+++ b/pkg/util/mount/fake.go
@@ -32,11 +32,11 @@ type FakeMounter struct {
 	MountCheckErrors map[string]error
 	// Some tests run things in parallel, make sure the mounter does not produce
 	// any golang's DATA RACE warnings.
-	mutex      sync.Mutex
-	UmountFunc UmountFunc
+	mutex       sync.Mutex
+	UnmountFunc UnmountFunc
 }
 
-type UmountFunc func(path string) error
+type UnmountFunc func(path string) error
 
 var _ Interface = &FakeMounter{}
 
@@ -120,8 +120,8 @@ func (f *FakeMounter) Unmount(target string) error {
 	newMountpoints := []MountPoint{}
 	for _, mp := range f.MountPoints {
 		if mp.Path == absTarget {
-			if f.UmountFunc != nil {
-				err := f.UmountFunc(absTarget)
+			if f.UnmountFunc != nil {
+				err := f.UnmountFunc(absTarget)
 				if err != nil {
 					return err
 				}

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -241,7 +241,8 @@ func doCleanSubPaths(mounter mount.Interface, podDir string, volumeName string) 
 			if err = doCleanSubPath(mounter, fullContainerDirPath, filepath.Base(path)); err != nil {
 				return err
 			}
-			return nil
+			// skip subdirs of the volume: it only matters the first level to unmount, otherwise it would try to unmount subdir of the volume
+			return filepath.SkipDir
 		})
 		if err != nil {
 			return fmt.Errorf("error processing %s: %s", fullContainerDirPath, err)

--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -241,8 +241,13 @@ func doCleanSubPaths(mounter mount.Interface, podDir string, volumeName string) 
 			if err = doCleanSubPath(mounter, fullContainerDirPath, filepath.Base(path)); err != nil {
 				return err
 			}
-			// skip subdirs of the volume: it only matters the first level to unmount, otherwise it would try to unmount subdir of the volume
-			return filepath.SkipDir
+
+			if info.IsDir() {
+				// skip subdirs of the volume: it only matters the first level to unmount, otherwise it would try to unmount subdir of the volume
+				return filepath.SkipDir
+			}
+
+			return nil
 		})
 		if err != nil {
 			return fmt.Errorf("error processing %s: %s", fullContainerDirPath, err)

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -558,11 +558,19 @@ func TestCleanSubPaths(t *testing.T) {
 				return mounts, nil
 			},
 			umount: func(mountpath string) error {
-				fileInfo, err := ioutil.ReadDir(mountpath)
-				for _, file := range fileInfo {
-					if err = os.RemoveAll(filepath.Join(mountpath, file.Name())); err != nil {
+				err := filepath.Walk(mountpath, func(path string, info os.FileInfo, err error) error {
+					if path == mountpath {
+						// Skip top level directory
+						return nil
+					}
+
+					if err = os.RemoveAll(path); err != nil {
 						return err
 					}
+					return filepath.SkipDir
+				})
+				if err != nil {
+					return fmt.Errorf("error processing %s: %s", mountpath, err)
 				}
 
 				return nil

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -409,7 +409,7 @@ func TestCleanSubPaths(t *testing.T) {
 		// Function that validates directory structure after the test
 		validate    func(base string) error
 		expectError bool
-		umount      func(path string) error
+		unmount     func(path string) error
 	}{
 		{
 			name: "not-exists",
@@ -557,7 +557,7 @@ func TestCleanSubPaths(t *testing.T) {
 				}
 				return mounts, nil
 			},
-			umount: func(mountpath string) error {
+			unmount: func(mountpath string) error {
 				err := filepath.Walk(mountpath, func(path string, info os.FileInfo, err error) error {
 					if path == mountpath {
 						// Skip top level directory
@@ -593,7 +593,7 @@ func TestCleanSubPaths(t *testing.T) {
 			t.Fatalf("failed to prepare test %q: %v", test.name, err.Error())
 		}
 
-		fm := &mount.FakeMounter{MountPoints: mounts, UmountFunc: test.umount}
+		fm := &mount.FakeMounter{MountPoints: mounts, UnmountFunc: test.unmount}
 
 		err = doCleanSubPaths(fm, base, testVol)
 		if err != nil && !test.expectError {

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -583,7 +583,7 @@ func TestCleanSubPaths(t *testing.T) {
 						return nil
 					}
 
-					if err = os.RemoveAll(path); err != nil {
+					if err = os.Remove(path); err != nil {
 						return err
 					}
 					return filepath.SkipDir

--- a/pkg/volume/util/subpath/subpath_linux_test.go
+++ b/pkg/volume/util/subpath/subpath_linux_test.go
@@ -543,17 +543,36 @@ func TestCleanSubPaths(t *testing.T) {
 		{
 			name: "subpath-with-files",
 			prepare: func(base string) ([]mount.MountPoint, error) {
-				path := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1", "0")
-				path2 := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1", "1")
-				if err := os.MkdirAll(filepath.Join(path, "my-dir-1"), defaultPerm); err != nil {
+				containerPath := filepath.Join(base, containerSubPathDirectoryName, testVol, "container1")
+				if err := os.MkdirAll(containerPath, defaultPerm); err != nil {
 					return nil, err
 				}
-				if err := os.MkdirAll(filepath.Join(path2, "my-dir-2"), defaultPerm); err != nil {
+
+				file0 := filepath.Join(containerPath, "0")
+				if err := ioutil.WriteFile(file0, []byte{}, defaultPerm); err != nil {
 					return nil, err
 				}
+
+				dir1 := filepath.Join(containerPath, "1")
+				if err := os.MkdirAll(filepath.Join(dir1, "my-dir-1"), defaultPerm); err != nil {
+					return nil, err
+				}
+
+				dir2 := filepath.Join(containerPath, "2")
+				if err := os.MkdirAll(filepath.Join(dir2, "my-dir-2"), defaultPerm); err != nil {
+					return nil, err
+				}
+
+				file3 := filepath.Join(containerPath, "3")
+				if err := ioutil.WriteFile(file3, []byte{}, defaultPerm); err != nil {
+					return nil, err
+				}
+
 				mounts := []mount.MountPoint{
-					{Device: "/dev/sdb", Path: path},
-					{Device: "/dev/sdc", Path: path2},
+					{Device: "/dev/sdb", Path: file0},
+					{Device: "/dev/sdc", Path: dir1},
+					{Device: "/dev/sdd", Path: dir2},
+					{Device: "/dev/sde", Path: file3},
 				}
 				return mounts, nil
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Scenario:
Cronjobs with volume (nfs) mounted multiple time with different subpaths.

When the pod is deleted it tries to clean up all the mounting folders but it shows a lot of warns from files that are present in my volume itself

```
    I0912 16:27:57.717346    8731 mount_linux.go:247] Unmounting /var/lib/kubelet/pods/c15338f0-d579-11e9-8725-06831030d3a2/volume-subpaths/janario/app/1
    I0912 16:27:57.750994    8731 mount_helper.go:85] "/var/lib/kubelet/pods/c15338f0-d579-11e9-8725-06831030d3a2/volume-subpaths/janario/app/1" is unmounted, deleting the directory
    I0912 16:27:57.751043    8731 mount_linux.go:972] Successfully cleaned subpath directory /var/lib/kubelet/pods/c15338f0-d579-11e9-8725-06831030d3a2/volume-subpaths/janario/app/1
    I0912 16:27:57.751050    8731 mount_linux.go:965] Cleaning up subpath mounts for subpath my-dir
    

W0912 16:27:57.751059    8731 mount_helper.go:37] Warning: Unmount skipped because path does not exist: /var/lib/kubelet/pods/c15338f0-d579-11e9-8725-06831030d3a2/volume-subpaths/janario/app/my-dir

```

When I look the files before the umount `my-dir` is actually in a different path from the one printed out on the warn

`/var/lib/kubelet/pods/c15338f0-d579-11e9-8725-06831030d3a2/volume-subpaths/janario/app/1/my-dir` not `/var/lib/kubelet/pods/c15338f0-d579-11e9-8725-06831030d3a2/volume-subpaths/janario/app/my-dir`

Turns out, looking at the code, the umount process (subpath_linux.go doCleanSubPaths `filepath.Walk`) is doing:

* make a list of filenames under `volume-subpaths/janario/app/1/` ['my-dir']
* umounts `volume-subpaths/janario/app/1/, 'my-dir' was under it so it doesn't exists anymore
* interact with the list built at the first step and tries to umount each of them, concatenating it with the base path (volume-subpaths/janario/app/my-dir). Then shows warnings because it doesn't exist

`subpath_linux.go doCleanSubPaths` should only scans the first level of directories/files which are the actual mounting points



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

