### PR TITLE
feat: update taint nodes by condition to GA

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -179,7 +179,6 @@ func startNodeLifecycleController(ctx ControllerContext) (http.Handler, bool, er
 		ctx.ComponentConfig.NodeLifecycleController.UnhealthyZoneThreshold,
 		ctx.ComponentConfig.NodeLifecycleController.EnableTaintManager,
 		utilfeature.DefaultFeatureGate.Enabled(features.TaintBasedEvictions),
-		utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition),
 	)
 	if err != nil {
 		return nil, true, err

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	apps "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1804,8 +1804,6 @@ func TestTaintPressureNodeDaemonLaunchesPod(t *testing.T) {
 			}
 			manager.nodeStore.Add(node)
 
-			// Enabling critical pod and taint nodes by condition feature gate should create critical pod
-			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TaintNodesByCondition, true)()
 			manager.dsStore.Add(ds)
 			syncAndValidateDaemonSets(t, manager, ds, podControl, 1, 0, 0)
 		}

--- a/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller_test.go
@@ -182,7 +182,6 @@ func newNodeLifecycleControllerFromClient(
 		unhealthyZoneThreshold,
 		useTaints,
 		useTaints,
-		useTaints,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -127,6 +127,7 @@ const (
 
 	// owner: @k82cn
 	// beta: v1.12
+	// GA: v1.17
 	//
 	// Taint nodes based on their condition status for 'NetworkUnavailable',
 	// 'MemoryPressure', 'PIDPressure' and 'DiskPressure'.
@@ -512,7 +513,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	EphemeralContainers:            {Default: false, PreRelease: featuregate.Alpha},
 	PodShareProcessNamespace:       {Default: true, PreRelease: featuregate.Beta},
 	PodPriority:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.18
-	TaintNodesByCondition:          {Default: true, PreRelease: featuregate.Beta},
+	TaintNodesByCondition:          {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.18
 	QOSReserved:                    {Default: false, PreRelease: featuregate.Alpha},
 	ExpandPersistentVolumes:        {Default: true, PreRelease: featuregate.Beta},
 	ExpandInUsePersistentVolumes:   {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -142,11 +142,8 @@ func DefaultOffAdmissionPlugins() sets.String {
 		resourcequota.PluginName,                //ResourceQuota
 		storageobjectinuseprotection.PluginName, //StorageObjectInUseProtection
 		podpriority.PluginName,                  //PodPriority
+		nodetaint.PluginName,                    //TaintNodesByCondition
 	)
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
-		defaultOnPlugins.Insert(nodetaint.PluginName) //TaintNodesByCondition
-	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) {
 		defaultOnPlugins.Insert(runtimeclass.PluginName) //RuntimeClass

--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -245,7 +245,6 @@ go_test(
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/client-go/util/testing:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",

--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -144,13 +144,12 @@ func (m *managerImpl) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAd
 			return lifecycle.PodAdmitResult{Admit: true}
 		}
 
-		// When node has memory pressure and TaintNodesByCondition is enabled, check BestEffort Pod's toleration:
+		// When node has memory pressure, check BestEffort Pod's toleration:
 		// admit it if tolerates memory pressure taint, fail for other tolerations, e.g. DiskPressure.
-		if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) &&
-			v1helper.TolerationsTolerateTaint(attrs.Pod.Spec.Tolerations, &v1.Taint{
-				Key:    schedulerapi.TaintNodeMemoryPressure,
-				Effect: v1.TaintEffectNoSchedule,
-			}) {
+		if v1helper.TolerationsTolerateTaint(attrs.Pod.Spec.Tolerations, &v1.Taint{
+			Key:    schedulerapi.TaintNodeMemoryPressure,
+			Effect: v1.TaintEffectNoSchedule,
+		}) {
 			return lifecycle.PodAdmitResult{Admit: true}
 		}
 	}

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -246,13 +246,11 @@ func (kl *Kubelet) initialNode() (*v1.Node, error) {
 		Effect: v1.TaintEffectNoSchedule,
 	}
 
-	// If TaintNodesByCondition enabled, taint node with TaintNodeUnschedulable when initializing
+	// Taint node with TaintNodeUnschedulable when initializing
 	// node to avoid race condition; refer to #63897 for more detail.
-	if utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition) {
-		if node.Spec.Unschedulable &&
-			!taintutil.TaintExists(nodeTaints, &unschedulableTaint) {
-			nodeTaints = append(nodeTaints, unschedulableTaint)
-		}
+	if node.Spec.Unschedulable &&
+		!taintutil.TaintExists(nodeTaints, &unschedulableTaint) {
+		nodeTaints = append(nodeTaints, unschedulableTaint)
 	}
 
 	if kl.externalCloudProvider {

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -48,7 +48,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
-	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/component-base/version"
 	"k8s.io/kubernetes/pkg/features"
@@ -1983,25 +1982,23 @@ func TestRegisterWithApiServerWithTaint(t *testing.T) {
 	// Make node to be unschedulable.
 	kubelet.registerSchedulable = false
 
-	forEachFeatureGate(t, []featuregate.Feature{features.TaintNodesByCondition}, func(t *testing.T) {
-		// Reset kubelet status for each test.
-		kubelet.registrationCompleted = false
+	// Reset kubelet status for each test.
+	kubelet.registrationCompleted = false
 
-		// Register node to apiserver.
-		kubelet.registerWithAPIServer()
+	// Register node to apiserver.
+	kubelet.registerWithAPIServer()
 
-		// Check the unschedulable taint.
-		got := gotNode.(*v1.Node)
-		unschedulableTaint := &v1.Taint{
-			Key:    schedulerapi.TaintNodeUnschedulable,
-			Effect: v1.TaintEffectNoSchedule,
-		}
+	// Check the unschedulable taint.
+	got := gotNode.(*v1.Node)
+	unschedulableTaint := &v1.Taint{
+		Key:    schedulerapi.TaintNodeUnschedulable,
+		Effect: v1.TaintEffectNoSchedule,
+	}
 
-		require.Equal(t,
-			utilfeature.DefaultFeatureGate.Enabled(features.TaintNodesByCondition),
-			taintutil.TaintExists(got.Spec.Taints, unschedulableTaint),
-			"test unschedulable taint for TaintNodesByCondition")
-	})
+	require.Equal(t,
+		true,
+		taintutil.TaintExists(got.Spec.Taints, unschedulableTaint),
+		"test unschedulable taint for TaintNodesByCondition")
 }
 
 func TestNodeStatusHasChanged(t *testing.T) {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -35,12 +35,9 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/wait"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/flowcontrol"
-	"k8s.io/component-base/featuregate"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	cadvisortest "k8s.io/kubernetes/pkg/kubelet/cadvisor/testing"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/config"
@@ -2029,17 +2026,6 @@ func runVolumeManager(kubelet *Kubelet) chan struct{} {
 	stopCh := make(chan struct{})
 	go kubelet.volumeManager.Run(kubelet.sourcesReady, stopCh)
 	return stopCh
-}
-
-func forEachFeatureGate(t *testing.T, fs []featuregate.Feature, tf func(t *testing.T)) {
-	for _, fg := range fs {
-		for _, f := range []bool{true, false} {
-			func() {
-				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, fg, f)()
-				t.Run(fmt.Sprintf("%v(%t)", fg, f), tf)
-			}()
-		}
-	}
 }
 
 // Sort pods by UID.

--- a/pkg/scheduler/algorithmprovider/BUILD
+++ b/pkg/scheduler/algorithmprovider/BUILD
@@ -17,12 +17,7 @@ go_test(
     name = "go_default_test",
     srcs = ["plugins_test.go"],
     embed = [":go_default_library"],
-    deps = [
-        "//pkg/features:go_default_library",
-        "//pkg/scheduler:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
-    ],
+    deps = ["//pkg/scheduler:go_default_library"],
 )
 
 filegroup(

--- a/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -78,12 +78,9 @@ func TestDefaultPredicates(t *testing.T) {
 		predicates.MatchInterPodAffinityPred,
 		predicates.NoDiskConflictPred,
 		predicates.GeneralPred,
-		predicates.CheckNodeMemoryPressurePred,
-		predicates.CheckNodeDiskPressurePred,
-		predicates.CheckNodePIDPressurePred,
-		predicates.CheckNodeConditionPred,
 		predicates.PodToleratesNodeTaintsPred,
 		predicates.CheckVolumeBindingPred,
+		predicates.CheckNodeUnschedulablePred,
 	)
 
 	if expected := defaultPredicates(); !result.Equal(expected) {

--- a/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
@@ -113,10 +113,13 @@ func init() {
 	scheduler.RegisterFitPredicate(predicates.CheckNodePIDPressurePred, predicates.CheckNodePIDPressurePredicate)
 
 	// Fit is determined by node conditions: not ready, network unavailable or out of disk.
-	scheduler.RegisterMandatoryFitPredicate(predicates.CheckNodeConditionPred, predicates.CheckNodeConditionPredicate)
+	scheduler.RegisterFitPredicate(predicates.CheckNodeConditionPred, predicates.CheckNodeConditionPredicate)
 
 	// Fit is determined based on whether a pod can tolerate all of the node's taints
-	scheduler.RegisterFitPredicate(predicates.PodToleratesNodeTaintsPred, predicates.PodToleratesNodeTaints)
+	scheduler.RegisterMandatoryFitPredicate(predicates.PodToleratesNodeTaintsPred, predicates.PodToleratesNodeTaints)
+
+	// Fit is determined based on whether a pod can tolerate unschedulable of node
+	scheduler.RegisterMandatoryFitPredicate(predicates.CheckNodeUnschedulablePred, predicates.CheckNodeUnschedulablePredicate)
 
 	// Fit is determined by volume topology requirements.
 	scheduler.RegisterFitPredicateFactory(

--- a/pkg/scheduler/algorithmprovider/plugins_test.go
+++ b/pkg/scheduler/algorithmprovider/plugins_test.go
@@ -20,9 +20,6 @@ import (
 	"fmt"
 	"testing"
 
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler"
 )
 
@@ -81,8 +78,8 @@ func TestApplyFeatureGates(t *testing.T) {
 				t.Fatalf("Error retrieving provider: %v", err)
 			}
 
-			if !p.FitPredicateKeys.Has("CheckNodeCondition") {
-				t.Fatalf("Failed to find predicate: 'CheckNodeCondition'")
+			if p.FitPredicateKeys.Has("CheckNodeCondition") {
+				t.Fatalf("Unexpected predicate: 'CheckNodeCondition'")
 			}
 
 			if !p.FitPredicateKeys.Has("PodToleratesNodeTaints") {
@@ -90,9 +87,6 @@ func TestApplyFeatureGates(t *testing.T) {
 			}
 		})
 	}
-
-	// Apply features for algorithm providers.
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TaintNodesByCondition, true)()
 
 	defer ApplyFeatureGates()()
 

--- a/pkg/scheduler/api/compatibility/compatibility_test.go
+++ b/pkg/scheduler/api/compatibility/compatibility_test.go
@@ -65,6 +65,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 					{Name: "NodeName"},
 					{Name: "NodePorts"},
 					{Name: "NodeAffinity"},
+					{Name: "TaintToleration"},
 				},
 			},
 		},
@@ -104,6 +105,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 					{Name: "NodeAffinity"},
 					{Name: "NodeResources"},
 					{Name: "VolumeRestrictions"},
+					{Name: "TaintToleration"},
 				},
 			},
 		},
@@ -150,6 +152,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 					{Name: "NodeAffinity"},
 					{Name: "NodeResources"},
 					{Name: "VolumeRestrictions"},
+					{Name: "TaintToleration"},
 				},
 			},
 		},
@@ -205,6 +208,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 					{Name: "NodeAffinity"},
 					{Name: "NodeResources"},
 					{Name: "VolumeRestrictions"},
+					{Name: "TaintToleration"},
 					{Name: "VolumeZone"},
 				},
 				"ScorePlugin": {
@@ -1207,7 +1211,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 	registeredPriorities := sets.NewString(scheduler.ListRegisteredPriorityFunctions()...)
 	seenPredicates := sets.NewString()
 	seenPriorities := sets.NewString()
-	mandatoryPredicates := sets.NewString("CheckNodeCondition")
+	mandatoryPredicates := sets.NewString("CheckNodeUnschedulable")
 	generalPredicateFilters := []string{"NodeResources", "NodeName", "NodePorts", "NodeAffinity"}
 	filterToPredicateMap := map[string]string{
 		"TaintToleration":    "PodToleratesNodeTaints",

--- a/plugin/pkg/admission/nodetaint/BUILD
+++ b/plugin/pkg/admission/nodetaint/BUILD
@@ -7,10 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/core:go_default_library",
-        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate:go_default_library",
     ],
 )
 
@@ -20,12 +17,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
-        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate:go_default_library",
     ],
 )
 

--- a/plugin/pkg/admission/podtolerationrestriction/BUILD
+++ b/plugin/pkg/admission/podtolerationrestriction/BUILD
@@ -12,7 +12,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
-        "//pkg/features:go_default_library",
         "//pkg/scheduler/api:go_default_library",
         "//plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -21,11 +20,9 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/initializer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/testing:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/plugin/pkg/admission/podtolerationrestriction/admission_test.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission_test.go
@@ -29,13 +29,10 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	genericadmissioninitializer "k8s.io/apiserver/pkg/admission/initializer"
 	admissiontesting "k8s.io/apiserver/pkg/admission/testing"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	pluginapi "k8s.io/kubernetes/plugin/pkg/admission/podtolerationrestriction/apis/podtolerationrestriction"
 )
@@ -86,8 +83,6 @@ func TestPodAdmission(t *testing.T) {
 			},
 		},
 	}
-
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TaintNodesByCondition, true)()
 
 	tests := []struct {
 		pod                       *api.Pod

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -966,10 +966,8 @@ func TestTaintedNode(t *testing.T) {
 }
 
 // TestUnschedulableNodeDaemonDoesLaunchPod tests that the DaemonSet Pods can still be scheduled
-// to the Unschedulable nodes when TaintNodesByCondition are enabled.
+// to the Unschedulable nodes.
 func TestUnschedulableNodeDaemonDoesLaunchPod(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.TaintNodesByCondition, true)()
-
 	forEachFeatureGate(t, func(t *testing.T) {
 		forEachStrategy(t, func(t *testing.T, strategy *apps.DaemonSetUpdateStrategy) {
 			server, closeFn, dc, informers, clientset := setup(t)

--- a/test/integration/scheduler/predicates_test.go
+++ b/test/integration/scheduler/predicates_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -875,56 +875,6 @@ func TestInterPodAffinity(t *testing.T) {
 			}
 		}
 	}
-}
-
-// TestNodePIDPressure verifies that scheduler's CheckNodePIDPressurePredicate predicate
-// functions works correctly.
-func TestNodePIDPressure(t *testing.T) {
-	context := initTest(t, "node-pid-pressure")
-	defer cleanupTest(t, context)
-	// Add a node.
-	node, err := createNode(context.clientSet, "testnode", nil)
-	if err != nil {
-		t.Fatalf("Cannot create node: %v", err)
-	}
-
-	cs := context.clientSet
-
-	// Adds PID pressure condition to the node.
-	node.Status.Conditions = []v1.NodeCondition{
-		{
-			Type:   v1.NodePIDPressure,
-			Status: v1.ConditionTrue,
-		},
-	}
-
-	// Update node condition.
-	err = updateNodeStatus(context.clientSet, node)
-	if err != nil {
-		t.Fatalf("Cannot update node: %v", err)
-	}
-
-	// Create test pod.
-	testPod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "pidpressure-fake-name"},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{Name: "container", Image: imageutils.GetPauseImageName()},
-			},
-		},
-	}
-
-	testPod, err = cs.CoreV1().Pods(context.ns.Name).Create(testPod)
-	if err != nil {
-		t.Fatalf("Test Failed: error: %v, while creating pod", err)
-	}
-
-	err = waitForPodUnschedulable(cs, testPod)
-	if err != nil {
-		t.Errorf("Test Failed: error, %v, while waiting for scheduled", err)
-	}
-
-	cleanupPods(cs, t, []*v1.Pod{testPod})
 }
 
 // TestEvenPodsSpreadPredicate verifies that EvenPodsSpread predicate functions well.

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -212,6 +212,7 @@ func initTestSchedulerWithOptions(
 	context.informerFactory.WaitForCacheSync(context.scheduler.StopEverything)
 
 	go context.scheduler.Run(context.ctx)
+
 	return context
 }
 


### PR DESCRIPTION
/kind feature
/sig scheduling
/priority important-soon
/assign @k82cn 

**What this PR does / why we need it**:

Graduate TaintNodesByCondition to GA

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82635

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Graduate TaintNodesByCondition to GA in 1.17. (feature gate will be removed in 1.18) action required
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
