### PR TITLE
expose and use an AddHealthChecks method directly on config

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -380,6 +380,17 @@ type CompletedConfig struct {
 	*completedConfig
 }
 
+// AddHealthChecks adds a health check to our config to be exposed by the health endpoints
+// of our configured apiserver. We should prefer this to adding healthChecks directly to
+// the config unless we explicitly want to add a healthcheck only to a specific health endpoint.
+func (c *Config) AddHealthChecks(healthChecks ...healthz.HealthChecker) {
+	for _, check := range healthChecks {
+		c.HealthzChecks = append(c.HealthzChecks, check)
+		c.LivezChecks = append(c.LivezChecks, check)
+		c.ReadyzChecks = append(c.ReadyzChecks, check)
+	}
+}
+
 // Complete fills in any fields not set that are required to have valid data and can be derived
 // from other fields. If you're going to `ApplyOptions`, do that first. It's mutating the receiver.
 func (c *Config) Complete(informers informers.SharedInformerFactory) CompletedConfig {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -202,7 +202,7 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 	if err != nil {
 		return err
 	}
-	c.HealthzChecks = append(c.HealthzChecks, healthz.NamedCheck("etcd", func(r *http.Request) error {
+	c.AddHealthChecks(healthz.NamedCheck("etcd", func(r *http.Request) error {
 		return healthCheck()
 	}))
 
@@ -211,8 +211,7 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 		if err != nil {
 			return err
 		}
-
-		c.HealthzChecks = append(c.HealthzChecks, kmsPluginHealthzChecks...)
+		c.AddHealthChecks(kmsPluginHealthzChecks...)
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

KMS and etcd health checks are not being properly added to the livez/readyz endpoints. This fixes that.

**Which issue(s) this PR fixes**:

Fixes #82712

```release-note
Resolves issue with /readyz and /livez not including etcd and kms health checks
```