### PR TITLE
[WIP] Migrate predicates functions into the scheduling framework

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -673,6 +673,7 @@ func (g *genericScheduler) podFitsOnNode(
 			}
 		}
 
+		pluginContext.Write(framework.ContextKeyPredicateMetadata, metaToUse)
 		status = g.framework.RunFilterPlugins(pluginContext, pod, info.Node().Name)
 		if !status.IsSuccess() && !status.IsUnschedulable() {
 			return false, failedPredicates, status, status.AsError()

--- a/pkg/scheduler/framework/v1alpha1/context.go
+++ b/pkg/scheduler/framework/v1alpha1/context.go
@@ -32,6 +32,9 @@ type ContextData interface{}
 // ContextKey is the type of keys stored in PluginContext.
 type ContextKey string
 
+// ContextKeyPredicateMetadata is the context key of predicate metadata.
+const ContextKeyPredicateMetadata = "predicate_metadata"
+
 // PluginContext provides a mechanism for plugins to store and retrieve arbitrary data.
 // ContextData stored by one plugin can be read, altered, or deleted by another plugin.
 // PluginContext does not provide any data protection, as all plugins are assumed to be

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -24,6 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
@@ -127,6 +128,11 @@ func NewStatus(code Code, msg string) *Status {
 		code:    code,
 		message: msg,
 	}
+}
+
+// NewPredicateStatus returns a status with predicates failure reason.
+func NewPredicateStatus(predicates []predicates.PredicateFailureReason) *Status {
+	return nil
 }
 
 // WaitingPod represents a pod currently waiting in the permit phase.

--- a/plugin/pkg/scheduling/podfitshost/plugin.go
+++ b/plugin/pkg/scheduling/podfitshost/plugin.go
@@ -1,0 +1,52 @@
+package podfitshost
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodFitsHost is the a scheduling framework plugin.
+type PodFitsHost struct {
+	nodeInfoSnapshot *nodeinfo.Snapshot
+
+	wantPorts []*v1.ContainerPort
+}
+
+// New returns a plugin.
+func New() framework.PluginFactory {
+	return func(_ *runtime.Unknown, fh framework.FrameworkHandle) (framework.Plugin, error) {
+		return &PodFitsHost{
+			nodeInfoSnapshot: fh.NodeInfoSnapshot(),
+		}, nil
+	}
+}
+
+// Name is the plugin name.
+const Name = "pod-fits-host-plugin"
+
+// Name .
+func (p *PodFitsHost) Name() string {
+	return Name
+}
+
+// Filter checks if a pod spec node name matches the current node.
+func (p *PodFitsHost) Filter(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+	nodeInfo, ok := p.nodeInfoSnapshot.NodeInfoMap[nodeName]
+	if !ok {
+		return framework.NewStatus(framework.Error, "node not found")
+	}
+
+	fit, reasons, err := predicates.PodFitsHost(pod, nil, nodeInfo)
+	if err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
+
+	if !fit {
+		return framework.NewPredicateStatus(reasons)
+	}
+
+	return nil
+}

--- a/plugin/pkg/scheduling/podfitshostports/plugin.go
+++ b/plugin/pkg/scheduling/podfitshostports/plugin.go
@@ -1,0 +1,54 @@
+package podfithostports
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodFitsHostPorts is the a scheduling framework plugin.
+type PodFitsHostPorts struct {
+	nodeInfoSnapshot *nodeinfo.Snapshot
+
+	wantPorts []*v1.ContainerPort
+}
+
+// New returns a plugin.
+func New() framework.PluginFactory {
+	return func(_ *runtime.Unknown, fh framework.FrameworkHandle) (framework.Plugin, error) {
+		return &PodFitsHostPorts{
+			nodeInfoSnapshot: fh.NodeInfoSnapshot(),
+		}, nil
+	}
+}
+
+// Name is the plugin name.
+const Name = "pod-fits-host-ports-plugin"
+
+// Name .
+func (p *PodFitsHostPorts) Name() string {
+	return Name
+}
+
+// Filter checks if a pod spec node name matches the current node.
+func (p *PodFitsHostPorts) Filter(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+	nodeInfo, ok := p.nodeInfoSnapshot.NodeInfoMap[nodeName]
+	if !ok {
+		return framework.NewStatus(framework.Error, "node not found")
+	}
+
+	metadata, _ := pc.Read(framework.ContextKeyPredicateMetadata)
+
+	fit, reasons, err := predicates.PodFitsHostPorts(pod, metadata.(predicates.PredicateMetadata), nodeInfo)
+	if err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
+
+	if !fit {
+		return framework.NewPredicateStatus(reasons)
+	}
+
+	return nil
+}

--- a/plugin/pkg/scheduling/podfitsresources/plugin.go
+++ b/plugin/pkg/scheduling/podfitsresources/plugin.go
@@ -1,0 +1,54 @@
+package podfitresources
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodFitsResources is the a scheduling framework plugin.
+type PodFitsResources struct {
+	nodeInfoSnapshot *nodeinfo.Snapshot
+
+	wantPorts []*v1.ContainerPort
+}
+
+// New returns a plugin.
+func New() framework.PluginFactory {
+	return func(_ *runtime.Unknown, fh framework.FrameworkHandle) (framework.Plugin, error) {
+		return &PodFitsResources{
+			nodeInfoSnapshot: fh.NodeInfoSnapshot(),
+		}, nil
+	}
+}
+
+// Name is the plugin name.
+const Name = "pod-fits-resources-plugin"
+
+// Name .
+func (p *PodFitsResources) Name() string {
+	return Name
+}
+
+// Filter checks if a node has free ports for the requested pod ports.
+func (p *PodFitsResources) Filter(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+	nodeInfo, ok := p.nodeInfoSnapshot.NodeInfoMap[nodeName]
+	if !ok {
+		return framework.NewStatus(framework.Error, "node not found")
+	}
+
+	metadata, _ := pc.Read(framework.ContextKeyPredicateMetadata)
+
+	fit, reasons, err := predicates.PodFitsResources(pod, metadata.(predicates.PredicateMetadata), nodeInfo)
+	if err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
+
+	if !fit {
+		return framework.NewPredicateStatus(reasons)
+	}
+
+	return nil
+}

--- a/plugin/pkg/scheduling/podmatchnodeselector/plugin.go
+++ b/plugin/pkg/scheduling/podmatchnodeselector/plugin.go
@@ -1,0 +1,52 @@
+package podmatchnodeselector
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodMatchNodeSelector is the a scheduling framework plugin.
+type PodMatchNodeSelector struct {
+	nodeInfoSnapshot *nodeinfo.Snapshot
+
+	wantPorts []*v1.ContainerPort
+}
+
+// New returns a plugin.
+func New() framework.PluginFactory {
+	return func(_ *runtime.Unknown, fh framework.FrameworkHandle) (framework.Plugin, error) {
+		return &PodMatchNodeSelector{
+			nodeInfoSnapshot: fh.NodeInfoSnapshot(),
+		}, nil
+	}
+}
+
+// Name is the plugin name.
+const Name = "pod-match-node-selector-plugin"
+
+// Name .
+func (p *PodMatchNodeSelector) Name() string {
+	return Name
+}
+
+// Filter checks if a pod node selector matches the node label.
+func (p *PodMatchNodeSelector) Filter(pc *framework.PluginContext, pod *v1.Pod, nodeName string) *framework.Status {
+	nodeInfo, ok := p.nodeInfoSnapshot.NodeInfoMap[nodeName]
+	if !ok {
+		return framework.NewStatus(framework.Error, "node not found")
+	}
+
+	fit, reasons, err := predicates.PodMatchNodeSelector(pod, nil, nodeInfo)
+	if err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
+
+	if !fit {
+		return framework.NewPredicateStatus(reasons)
+	}
+
+	return nil
+}


### PR DESCRIPTION
/kind feature
/sig scheduling

**What this PR does / why we need it**:

Migrate predicates functions into the scheduling framework

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/82715

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
