### PR TITLE
Automated cherry pick of #82640: fix: azure disk detach failure if node not exists

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_controller_common.go
+++ b/pkg/cloudprovider/providers/azure/azure_controller_common.go
@@ -147,15 +147,21 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 
 // DetachDisk detaches a disk from host. The vhd can be identified by diskName or diskURI.
 func (c *controllerCommon) DetachDisk(diskName, diskURI string, nodeName types.NodeName) error {
+	instanceid, err := c.cloud.InstanceID(context.TODO(), nodeName)
+	if err != nil {
+		if err == cloudprovider.InstanceNotFound {
+			// if host doesn't exist, no need to detach
+			klog.Warningf("azureDisk - failed to get azure instance id(%q), DetachDisk(%s) will assume disk is already detached",
+				nodeName, diskURI)
+			return nil
+		}
+		klog.Warningf("failed to get azure instance id (%v)", err)
+		return fmt.Errorf("failed to get azure instance id for node %q (%v)", nodeName, err)
+	}
+
 	vmset, err := c.getNodeVMSet(nodeName)
 	if err != nil {
 		return err
-	}
-
-	instanceid, err := c.cloud.InstanceID(context.TODO(), nodeName)
-	if err != nil {
-		klog.Warningf("failed to get azure instance id (%v)", err)
-		return fmt.Errorf("failed to get azure instance id for node %q (%v)", nodeName, err)
 	}
 
 	klog.V(2).Infof("detach %v from node %q", diskURI, nodeName)

--- a/pkg/cloudprovider/providers/azure/azure_controller_common_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_controller_common_test.go
@@ -59,8 +59,6 @@ func TestDetachDisk(t *testing.T) {
 
 	err := common.DetachDisk("", diskURI, "node1")
 	if err != nil {
-		fmt.Printf("TestAttachDisk return expected error: %v", err)
-	} else {
-		t.Errorf("TestAttachDisk unexpected nil err")
+		t.Errorf("TestAttachDisk got unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
Cherry pick of #82640 on release-1.13.

#82640: fix: azure disk detach failure if node not exists