### PR TITLE
Automated cherry pick of #82640: fix: azure disk detach failure if node not exists

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -88,9 +88,9 @@ func TestCommonDetachDisk(t *testing.T) {
 		expectedErr bool
 	}{
 		{
-			desc:        "an error shall be returned if there's no such instance corresponding to given nodeName",
+			desc:        "error should not be returned if there's no such instance corresponding to given nodeName",
 			nodeName:    "vm1",
-			expectedErr: true,
+			expectedErr: false,
 		},
 		{
 			desc:        "no error shall be returned if there's no matching disk according to given diskName",


### PR DESCRIPTION
Cherry pick of #82640 on release-1.16.

#82640: fix: azure disk detach failure if node not exists

```release-note
fix: azure disk detach failure if node not exists
```