### PR TITLE
Remove Unused Variables in scheduler api types

### DIFF
--- a/pkg/scheduler/api/types.go
+++ b/pkg/scheduler/api/types.go
@@ -26,16 +26,12 @@ import (
 )
 
 const (
-	// MaxUint defines the max unsigned int value.
-	MaxUint = ^uint(0)
-	// MaxInt defines the max signed int value.
-	MaxInt = int(MaxUint >> 1)
 	// MaxTotalPriority defines the max total priority value.
 	MaxTotalPriority = int64(math.MaxInt64)
 	// MaxPriority defines the max priority value.
 	MaxPriority = 10
 	// MaxWeight defines the max weight value.
-	MaxWeight = int64(math.MaxInt64 / MaxPriority)
+	MaxWeight = MaxTotalPriority / MaxPriority
 	// DefaultPercentageOfNodesToScore defines the percentage of nodes of all nodes
 	// that once found feasible, the scheduler stops looking for more nodes.
 	DefaultPercentageOfNodesToScore = 50

--- a/pkg/scheduler/factory/plugins_test.go
+++ b/pkg/scheduler/factory/plugins_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package factory
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,13 +58,13 @@ func TestValidatePriorityConfigOverFlow(t *testing.T) {
 		expected    bool
 	}{
 		{
-			description: "one of the weights is MaxInt64",
-			configs:     []priorities.PriorityConfig{{Weight: math.MaxInt64}, {Weight: 5}},
+			description: "one of the weights is MaxTotalPriority(MaxInt64)",
+			configs:     []priorities.PriorityConfig{{Weight: api.MaxTotalPriority}, {Weight: 5}},
 			expected:    true,
 		},
 		{
 			description: "after multiplication with MaxPriority the weight is larger than MaxWeight",
-			configs:     []priorities.PriorityConfig{{Weight: math.MaxInt64/api.MaxPriority + api.MaxPriority}, {Weight: 5}},
+			configs:     []priorities.PriorityConfig{{Weight: api.MaxWeight + api.MaxPriority}, {Weight: 5}},
 			expected:    true,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

/sig scheduling
/assign @alculquicondor 

**What this PR does / why we need it**:
removing unused variables in `kubernetes/pkg/scheduler/api/types.go`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82306

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
