### PR TITLE
update the link of Kubernetes API conventions

### DIFF
--- a/staging/src/k8s.io/sample-controller/README.md
+++ b/staging/src/k8s.io/sample-controller/README.md
@@ -159,7 +159,7 @@ The CRD in [`crd-status-subresource.yaml`](./artifacts/examples/crd-status-subre
 for custom resources.
 This means that [`UpdateStatus`](./controller.go#L330) can be used by the controller to update only the status part of the custom resource.
 
-To understand why only the status part of the custom resource should be updated, please refer to the [Kubernetes API conventions](https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
+To understand why only the status part of the custom resource should be updated, please refer to the [Kubernetes API conventions](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status).
 
 In the above steps, use `crd-status-subresource.yaml` to create the CRD:
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
No PR

**Which issue(s) this PR fixes**:
Fixes # 

**Special notes for your reviewer**:
The fix will update the link of "Kubernetes API conventions".

The issue is:
1: The old link cannot be accessed in some network environment.
2: Even the old link can be accessed, it will be converted to the new link.
3: The new one is always accessable.

So the fix is to update the link to the new one.

**Does this PR introduce a user-facing change?**:
```release-note

```NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
