### PR TITLE
Migrate prometheus bucket functionality to kube-metrics for proxy metrics

### DIFF
--- a/pkg/proxy/metrics/BUILD
+++ b/pkg/proxy/metrics/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 

--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -20,8 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -35,7 +33,7 @@ var (
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_duration_seconds",
 			Help:           "SyncProxyRules latency in seconds",
-			Buckets:        prometheus.ExponentialBuckets(0.001, 2, 15),
+			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
@@ -46,7 +44,7 @@ var (
 			Subsystem:      kubeProxySubsystem,
 			Name:           "sync_proxy_rules_latency_microseconds",
 			Help:           "(Deprecated) SyncProxyRules latency in microseconds",
-			Buckets:        prometheus.ExponentialBuckets(1000, 2, 15),
+			Buckets:        metrics.ExponentialBuckets(1000, 2, 15),
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
@@ -75,10 +73,10 @@ var (
 			Name:      "network_programming_duration_seconds",
 			Help:      "In Cluster Network Programming Latency in seconds",
 			Buckets: merge(
-				prometheus.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
-				prometheus.LinearBuckets(1, 1, 59),      // 1s, 2s, 3s, ... 59s
-				prometheus.LinearBuckets(60, 5, 12),     // 60s, 65s, 70s, ... 115s
-				prometheus.LinearBuckets(120, 30, 7),    // 2min, 2.5min, 3min, ..., 5min
+				metrics.LinearBuckets(0.25, 0.25, 2), // 0.25s, 0.50s
+				metrics.LinearBuckets(1, 1, 59),      // 1s, 2s, 3s, ... 59s
+				metrics.LinearBuckets(60, 5, 12),     // 60s, 65s, 70s, ... 115s
+				metrics.LinearBuckets(120, 30, 7),    // 2min, 2.5min, 3min, ..., 5min
 			),
 			StabilityLevel: metrics.ALPHA,
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR migrate Prometheus bucket to metrics stability framework.
The [metrics stability framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-stability-migration.md) has provided bucket functionality. (refer: https://github.com/kubernetes/kubernetes/pull/82583)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: