### PR TITLE
Migrate prometheus bucket functionality for metrics stability framework

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -20,8 +20,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/client-go/tools/metrics"
 	k8smetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -34,7 +32,7 @@ var (
 		&k8smetrics.HistogramOpts{
 			Name:    "rest_client_request_duration_seconds",
 			Help:    "Request latency in seconds. Broken down by verb and URL.",
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+			Buckets: k8smetrics.ExponentialBuckets(0.001, 2, 10),
 		},
 		[]string{"verb", "url"},
 	)
@@ -44,7 +42,7 @@ var (
 		&k8smetrics.HistogramOpts{
 			Name:    "rest_client_request_latency_seconds",
 			Help:    "(Deprecated) Request latency in seconds. Broken down by verb and URL.",
-			Buckets: prometheus.ExponentialBuckets(0.001, 2, 10),
+			Buckets: k8smetrics.ExponentialBuckets(0.001, 2, 10),
 		},
 		[]string{"verb", "url"},
 	)

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/workqueue/metrics.go
@@ -17,8 +17,6 @@ limitations under the License.
 package workqueue
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/client-go/util/workqueue"
 	k8smetrics "k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
@@ -56,14 +54,14 @@ var (
 		Subsystem: WorkQueueSubsystem,
 		Name:      QueueLatencyKey,
 		Help:      "How long in seconds an item stays in workqueue before being requested.",
-		Buckets:   prometheus.ExponentialBuckets(10e-9, 10, 10),
+		Buckets:   k8smetrics.ExponentialBuckets(10e-9, 10, 10),
 	}, []string{"name"})
 
 	workDuration = k8smetrics.NewHistogramVec(&k8smetrics.HistogramOpts{
 		Subsystem: WorkQueueSubsystem,
 		Name:      WorkDurationKey,
 		Help:      "How long in seconds processing an item from workqueue takes.",
-		Buckets:   prometheus.ExponentialBuckets(10e-9, 10, 10),
+		Buckets:   k8smetrics.ExponentialBuckets(10e-9, 10, 10),
 	}, []string{"name"})
 
 	unfinished = k8smetrics.NewGaugeVec(&k8smetrics.GaugeOpts{


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR migrate Prometheus bucket to metrics stability framework.
The [metrics stability framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-stability-migration.md) has provided bucket functionality. (refer: https://github.com/kubernetes/kubernetes/pull/82583)

**Which issue(s) this PR fixes**:
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:
I tried to migrate the regression test in this PR, but I ultimately decide to do it later, maybe after go through [Metrics Validation and Verification](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-validation-and-verification.md) and the related code. 

Maybe we want to consider the scenario that user(other packages) just import `Prometheus`(no kube-metrics) to emit metrics. I'm not sure it's allowed.  If no, we should add UT for it. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

