### PR TITLE
Run ceph-fuse in its own systemd scope.

### DIFF
--- a/pkg/util/system/BUILD
+++ b/pkg/util/system/BUILD
@@ -1,0 +1,32 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["slice.go"],
+    importpath = "k8s.io/kubernetes/pkg/util/system",
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["system_utils_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/pkg/util/system/system_utils.go
+++ b/pkg/util/system/system_utils.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// detectSystemd returns true if OS runs with systemd as init. When not sure
+// (permission errors, ...), it returns false.
+// There may be different ways how to detect systemd, this one makes sure that
+// systemd-runs (needed by Mount()) works.
+func DetectSystemd() bool {
+	if _, err := exec.LookPath("systemd-run"); err != nil {
+		return false
+	}
+	// Try to run systemd-run --scope /bin/true, that should be enough
+	// to make sure that systemd is really running and not just installed,
+	// which happens when running in a container with a systemd-based image
+	// but with different pid 1.
+	cmd := exec.Command("systemd-run", "--description=Kubernetes systemd probe", "--scope", "true")
+	_, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return true
+}
+
+
+// AddSystemdScope adds "system-run --scope" to given command line
+// implementation is shared with NsEnterMounter
+func AddSystemdScope(systemdRunPath, mountName, command string, args []string) (string, []string) {
+	descriptionArg := fmt.Sprintf("--description=Kubernetes transient %s for %s", command, mountName)
+	systemdRunArgs := []string{descriptionArg, "--scope", "--", command}
+	return systemdRunPath, append(systemdRunArgs, args...)
+}

--- a/pkg/util/system/system_utils_test.go
+++ b/pkg/util/system/system_utils_test.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package system
+
+import (
+	"os"
+	"reflect"
+	"testing"
+)
+
+func TestDetectSystemd(t *testing.T) {
+	if info, err := os.Stat("/usr/bin/systemd-run"); os.IsNotExist(err) && info.Mode() & 0111 != 0 {
+		if !DetectSystemd() {
+			t.Errorf("case: expected true, got false")
+		}
+	}
+}
+
+func TestAddSystemdScope(t *testing.T) {
+	type inputType struct {
+		systemdRunPath string
+		mountName      string
+		command        string
+		args           []string
+	}
+	type resultType struct{
+		command string
+		args []string
+	}
+	testCases := []struct {
+		input inputType
+		result resultType
+	}{
+		{
+			inputType{"systemd-run", "/somewhere",
+				"mount",[]string{"/dev/sda1", "/somewhere"}},
+			resultType{"systemd-run",
+				[]string{"--description=Kubernetes transient mount for /somewhere", "--scope","--",
+					"mount", "/dev/sda1", "/somewhere"}},
+		},
+	}
+	for _, tc := range testCases {
+		command, args := AddSystemdScope(tc.input.systemdRunPath, tc.input.mountName, tc.input.command, tc.input.args)
+		actualResult := resultType{command,args}
+		if !reflect.DeepEqual(actualResult, tc.result) {
+			t.Errorf("case \"%v\": expected %v, got %v", tc.input, tc.result, actualResult)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
ceph-fuse should run with "systemd-run" when "systemd-run" is ready

**Which issue(s) this PR fixes**:

Fixes #77209
 