### PR TITLE
Allow to create REST Client directly through rest.Config

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/cr_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*CrV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/apiextensions_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*ApiextensionsV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/apiextensions_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*ApiextensionsV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/apiextensions_client.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/internalclientset/typed/apiextensions/internalversion/apiextensions_client.go
@@ -43,7 +43,7 @@ func NewForConfig(c *rest.Config) (*ApiextensionsClient, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/admissionregistration_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*AdmissionregistrationV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/admissionregistration_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*AdmissionregistrationV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/apps_client.go
@@ -64,7 +64,7 @@ func NewForConfig(c *rest.Config) (*AppsV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/apps_client.go
@@ -54,7 +54,7 @@ func NewForConfig(c *rest.Config) (*AppsV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/apps_client.go
@@ -64,7 +64,7 @@ func NewForConfig(c *rest.Config) (*AppsV1beta2Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditregistration_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditregistration_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*AuditregistrationV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/authentication_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*AuthenticationV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/authentication_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*AuthenticationV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/authorization_client.go
@@ -59,7 +59,7 @@ func NewForConfig(c *rest.Config) (*AuthorizationV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/authorization_client.go
@@ -59,7 +59,7 @@ func NewForConfig(c *rest.Config) (*AuthorizationV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/autoscaling_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*AutoscalingV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/autoscaling_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*AutoscalingV2beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/autoscaling_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*AutoscalingV2beta2Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/batch_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*BatchV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/batch_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*BatchV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/batch_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/batch_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*BatchV2alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificates_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*CertificatesV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/coordination_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*CoordinationV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/coordination_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*CoordinationV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/core_client.go
@@ -119,7 +119,7 @@ func NewForConfig(c *rest.Config) (*CoreV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/discovery_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/discovery_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*DiscoveryV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/events_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*EventsV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/extensions_client.go
@@ -69,7 +69,7 @@ func NewForConfig(c *rest.Config) (*ExtensionsV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networking_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*NetworkingV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/networking_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*NetworkingV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/node_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*NodeV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/node_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*NodeV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/policy_client.go
@@ -54,7 +54,7 @@ func NewForConfig(c *rest.Config) (*PolicyV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rbac_client.go
@@ -59,7 +59,7 @@ func NewForConfig(c *rest.Config) (*RbacV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rbac_client.go
@@ -59,7 +59,7 @@ func NewForConfig(c *rest.Config) (*RbacV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rbac_client.go
@@ -59,7 +59,7 @@ func NewForConfig(c *rest.Config) (*RbacV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/scheduling_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*SchedulingV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/scheduling_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*SchedulingV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/scheduling_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*SchedulingV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/settings_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/settings_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*SettingsV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storage_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*StorageV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/storage_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*StorageV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storage_client.go
@@ -59,7 +59,7 @@ func NewForConfig(c *rest.Config) (*StorageV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/rest/config.go
+++ b/staging/src/k8s.io/client-go/rest/config.go
@@ -131,6 +131,11 @@ type Config struct {
 	// Version forces a specific version to be used (if registered)
 	// Do we need this?
 	// Version string
+
+	// RESTClientBuilder allows to inject function for building REST client.
+	// E.g. for mocking REST client to be used by various clientset clients.
+	// If not set, Config.RESTClient() falls to the default RESTClientFor.
+	RESTClientBuilder func(config *Config) (Interface, error)
 }
 
 var _ fmt.Stringer = new(Config)
@@ -145,6 +150,17 @@ func (sanitizedAuthConfigPersister) GoString() string {
 }
 func (sanitizedAuthConfigPersister) String() string {
 	return "rest.AuthProviderConfigPersister(--- REDACTED ---)"
+}
+
+// RESTClient returns a RESTClient that satisfies the requested attributes on a client Config
+// object. Note that a RESTClient may require fields that are optional when initializing a Client.
+// A RESTClient created by this method is generic - it expects to operate on an API that follows
+// the Kubernetes conventions, but may not be the Kubernetes API.
+func (c *Config) RESTClient() (Interface, error) {
+	if c.RESTClientBuilder == nil {
+		return RESTClientFor(c)
+	}
+	return c.RESTClientBuilder(c)
 }
 
 // GoString implements fmt.GoStringer and sanitizes sensitive fields of Config

--- a/staging/src/k8s.io/client-go/rest/config_test.go
+++ b/staging/src/k8s.io/client-go/rest/config_test.go
@@ -263,6 +263,9 @@ func TestAnonymousConfig(t *testing.T) {
 		},
 		// Dial does not require fuzzer
 		func(r *func(ctx context.Context, network, addr string) (net.Conn, error), f fuzz.Continue) {},
+		func(r *func(c *Config) (Interface, error), f fuzz.Continue) {
+			*r = nil
+		},
 	)
 	for i := 0; i < 20; i++ {
 		original := &Config{}
@@ -338,6 +341,9 @@ func TestCopyConfig(t *testing.T) {
 		},
 		func(r *func(ctx context.Context, network, addr string) (net.Conn, error), f fuzz.Continue) {
 			*r = fakeDialFunc
+		},
+		func(r *func(c *Config) (Interface, error), f fuzz.Continue) {
+			*r = nil
 		},
 	)
 	for i := 0; i < 20; i++ {
@@ -509,7 +515,7 @@ func TestConfigSprint(t *testing.T) {
 		Dial:          fakeDialFunc,
 	}
 	want := fmt.Sprintf(
-		`&rest.Config{Host:"localhost:8080", APIPath:"v1", ContentConfig:rest.ContentConfig{AcceptContentTypes:"application/json", ContentType:"application/json", GroupVersion:(*schema.GroupVersion)(nil), NegotiatedSerializer:runtime.NegotiatedSerializer(nil)}, Username:"gopher", Password:"--- REDACTED ---", BearerToken:"--- REDACTED ---", BearerTokenFile:"", Impersonate:rest.ImpersonationConfig{UserName:"gopher2", Groups:[]string(nil), Extra:map[string][]string(nil)}, AuthProvider:api.AuthProviderConfig{Name: "gopher", Config: map[string]string{--- REDACTED ---}}, AuthConfigPersister:rest.AuthProviderConfigPersister(--- REDACTED ---), ExecProvider:api.AuthProviderConfig{Command: "sudo", Args: []string{"--- REDACTED ---"}, Env: []ExecEnvVar{--- REDACTED ---}, APIVersion: ""}, TLSClientConfig:rest.sanitizedTLSClientConfig{Insecure:false, ServerName:"", CertFile:"a.crt", KeyFile:"a.key", CAFile:"", CertData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x54, 0x52, 0x55, 0x4e, 0x43, 0x41, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, KeyData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x52, 0x45, 0x44, 0x41, 0x43, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, CAData:[]uint8(nil), NextProtos:[]string{"h2", "http/1.1"}}, UserAgent:"gobot", DisableCompression:false, Transport:(*rest.fakeRoundTripper)(%p), WrapTransport:(transport.WrapperFunc)(%p), QPS:1, Burst:2, RateLimiter:(*rest.fakeLimiter)(%p), Timeout:3000000000, Dial:(func(context.Context, string, string) (net.Conn, error))(%p)}`,
+		`&rest.Config{Host:"localhost:8080", APIPath:"v1", ContentConfig:rest.ContentConfig{AcceptContentTypes:"application/json", ContentType:"application/json", GroupVersion:(*schema.GroupVersion)(nil), NegotiatedSerializer:runtime.NegotiatedSerializer(nil)}, Username:"gopher", Password:"--- REDACTED ---", BearerToken:"--- REDACTED ---", BearerTokenFile:"", Impersonate:rest.ImpersonationConfig{UserName:"gopher2", Groups:[]string(nil), Extra:map[string][]string(nil)}, AuthProvider:api.AuthProviderConfig{Name: "gopher", Config: map[string]string{--- REDACTED ---}}, AuthConfigPersister:rest.AuthProviderConfigPersister(--- REDACTED ---), ExecProvider:api.AuthProviderConfig{Command: "sudo", Args: []string{"--- REDACTED ---"}, Env: []ExecEnvVar{--- REDACTED ---}, APIVersion: ""}, TLSClientConfig:rest.sanitizedTLSClientConfig{Insecure:false, ServerName:"", CertFile:"a.crt", KeyFile:"a.key", CAFile:"", CertData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x54, 0x52, 0x55, 0x4e, 0x43, 0x41, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, KeyData:[]uint8{0x2d, 0x2d, 0x2d, 0x20, 0x52, 0x45, 0x44, 0x41, 0x43, 0x54, 0x45, 0x44, 0x20, 0x2d, 0x2d, 0x2d}, CAData:[]uint8(nil), NextProtos:[]string{"h2", "http/1.1"}}, UserAgent:"gobot", DisableCompression:false, Transport:(*rest.fakeRoundTripper)(%p), WrapTransport:(transport.WrapperFunc)(%p), QPS:1, Burst:2, RateLimiter:(*rest.fakeLimiter)(%p), Timeout:3000000000, Dial:(func(context.Context, string, string) (net.Conn, error))(%p), RESTClientBuilder:(func(*rest.Config) (rest.Interface, error))(nil)}`,
 		c.Transport, fakeWrapperFunc, c.RateLimiter, fakeDialFunc,
 	)
 

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/example_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*ExampleGroupV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/example_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*ExampleV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/example_client.go
@@ -43,7 +43,7 @@ func NewForConfig(c *rest.Config) (*ExampleClient, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/example2_client.go
@@ -43,7 +43,7 @@ func NewForConfig(c *rest.Config) (*SecondExampleClient, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/example_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*ExampleV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/example2_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*SecondExampleV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/example_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/example_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*ExampleV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/example2_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*SecondExampleV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_group.go
@@ -169,7 +169,7 @@ func NewForConfig(c *$.restConfig|raw$) (*$.GroupGoName$$.Version$Client, error)
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := $.restRESTClientFor|raw$(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiregistration_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*ApiregistrationV1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiregistration_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*ApiregistrationV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/metrics_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*MetricsV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/metrics_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*MetricsV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/node_client.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/node_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*NodeV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/wardle_client.go
@@ -49,7 +49,7 @@ func NewForConfig(c *rest.Config) (*WardleV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/wardle_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*WardleV1beta1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/samplecontroller_client.go
@@ -44,7 +44,7 @@ func NewForConfig(c *rest.Config) (*SamplecontrollerV1alpha1Client, error) {
 	if err := setConfigDefaults(&config); err != nil {
 		return nil, err
 	}
-	client, err := rest.RESTClientFor(&config)
+	client, err := config.RESTClient()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:

Currently, `k8s.io/client-go/kubernetes.New` function allows to create a clientset
with pre-created REST client. However, the REST client passed into individual clientset
clients (e.g. AppsV1, BatchV1, ...) has fixed `GroupVersion` and does not take into account
`GroupVersion` of other clientset clients. The REST client (among other things) carries serializer
configuration for a single `GroupVersion`. So, only a single clientset client initialized
with the `GroupVersion` can be actually used to perform serialization. Any other clientset client
will complain about impossible conversion from its `GroupVersion` to the only `GroupVersion`.
Which makes `k8s.io/client-go/kubernetes.New` function generally unusable for serialization.
    
Documentation for `rest.ContentConfig.GroupVersion` field says:
```
// GroupVersion is the API version to talk to. Must be provided when initializing
// a RESTClient directly. When initializing a Client, will be set with the default
// code version.
```
However, k8s.io/client-go/kubernetes.New call does not lead to invocation of any
defaulting mechanism.
    
Instead of invoking function New, I suggest to invoke `NewForConfig`, resp. `NewForConfigOrDie`
functions with `rest.Config` containing new public field `RESTClientBuilder`. Both functions lead
to invocation of `GroupVersion` client specific `setConfigDefaults` function that sets the right
`GroupVersion` field. Followed by invocation of a function stored under `RESTClientBuilder` which
allows to decide which `GroupVersion` is actually requested and thus build the REST client with
the right `GroupVersion`-ed serializer. If `RESTClientBuilder` field is not set,
it defaults to the original `rest.RESTClientFor` function.
    
Example of usage:
```go
...
import (
	"k8s.io/client-go/kubernetes"
	...
)
...
kubernetes.NewForConfigOrDie(&rest.Config{
	RESTClientBuilder: func(config *rest.Config) (rest.Interface, error) {
		switch config.GroupVersion.String() {
		case "v1":
			return coreRestClient, nil
		case "policy/v1beta1":
			return policyRestClient, nil
		case "storage.k8s.io/v1":
			return storageRestClient, nil
		case "apps/v1":
			return appsRestClient, nil
		default:
			return nil, fmt.Errorf("unknown GroupVersion: %v", config.GroupVersion.String())
		}
	},
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
`k8s.io/client-go/rest.Config` data type extended with `RESTClient()` method and `RESTClientBuilder` field to provide control over building REST client for `GroupVersion`-ed clientset clients.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
