### PR TITLE
RemoveTaintOffNode should utilize the return value from DeleteTaint

### DIFF
--- a/pkg/util/taints/taints.go
+++ b/pkg/util/taints/taints.go
@@ -273,13 +273,9 @@ func RemoveTaint(node *v1.Node, taint *v1.Taint) (*v1.Node, bool, error) {
 		return newNode, false, nil
 	}
 
-	if !TaintExists(nodeTaints, taint) {
-		return newNode, false, nil
-	}
-
-	newTaints, _ := DeleteTaint(nodeTaints, taint)
+	newTaints, deleted := DeleteTaint(nodeTaints, taint)
 	newNode.Spec.Taints = newTaints
-	return newNode, true, nil
+	return newNode, deleted, nil
 }
 
 // AddOrUpdateTaint tries to add a taint to annotations list. Returns a new copy of updated Node and true if something was updated


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In RemoveTaint, by default, true is returned to the caller.
The TaintExists call is not needed - if we exit RemoveTaint due to false being returned from TaintExists, we have traversed the taints.

We should utilize the return value from DeleteTaint - this way, if the taint does exist, we only traverse once.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
