### PR TITLE
fix auth import statement in client-go

### DIFF
--- a/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/create-update-delete-deployment/main.go
@@ -33,7 +33,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	//
 	// Uncomment to load all auth plugins
-	// _ "k8s.io/client-go/plugin/pkg/client/auth
+	// _ "k8s.io/client-go/plugin/pkg/client/auth"
 	//
 	// Or uncomment to load specific auth plugins
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"

--- a/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
@@ -34,7 +34,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	//
 	// Uncomment to load all auth plugins
-	// _ "k8s.io/client-go/plugin/pkg/client/auth
+	// _ "k8s.io/client-go/plugin/pkg/client/auth"
 	//
 	// Or uncomment to load specific auth plugins
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"

--- a/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
+++ b/staging/src/k8s.io/client-go/examples/in-cluster-client-configuration/main.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/client-go/rest"
 	//
 	// Uncomment to load all auth plugins
-	// _ "k8s.io/client-go/plugin/pkg/client/auth
+	// _ "k8s.io/client-go/plugin/pkg/client/auth"
 	//
 	// Or uncomment to load specific auth plugins
 	// _ "k8s.io/client-go/plugin/pkg/client/auth/azure"


### PR DESCRIPTION
**What type of PR is this?**

> /kind cleanup

**What this PR does / why we need it**:

Currently, the following line fails to build as the string literal is not terminated.

```
// Uncomment to load all auth plugins
_ "k8s.io/client-go/plugin/pkg/client/auth
```
`main.go:37:4: string literal not terminated`

This PR fixes it and keeps consistency with other code examples.

**Special notes for your reviewer**:


