### PR TITLE
fix compiling failure: execvp: /bin/bash: Argument list too long

### DIFF
--- a/build/root/Makefile.generated_files
+++ b/build/root/Makefile.generated_files
@@ -182,7 +182,7 @@ $(META_DIR)/$(DEEPCOPY_GEN).todo: $(DEEPCOPY_FILES)
 
 $(DEEPCOPY_FILES): $(DEEPCOPY_GEN)
 	if [[ "$(DBG_CODEGEN)" == 1 ]]; then        \
-	    echo "DBG: deepcopy needed $(@D): $?";  \
+	    echo "DBG: deepcopy needed $(@D):";  \
 	    ls -lf --full-time $@ $? || true;       \
 	fi
 	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(DEEPCOPY_GEN).todo
@@ -276,7 +276,7 @@ $(META_DIR)/$(DEFAULTER_GEN).todo: $(DEFAULTER_FILES)
 
 $(DEFAULTER_FILES): $(DEFAULTER_GEN)
 	if [[ "$(DBG_CODEGEN)" == 1 ]]; then         \
-	    echo "DBG: defaulter needed $(@D): $?";  \
+	    echo "DBG: defaulter needed $(@D):";  \
 	    ls -lf --full-time $@ $? || true;        \
 	fi
 	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(DEFAULTER_GEN).todo
@@ -380,7 +380,7 @@ $(META_DIR)/$(CONVERSION_GEN).todo: $(CONVERSION_FILES)
 
 $(CONVERSION_FILES): $(CONVERSION_GEN)
 	if [[ "$(DBG_CODEGEN)" == 1 ]]; then          \
-	    echo "DBG: conversion needed $(@D): $?";  \
+	    echo "DBG: conversion needed $(@D):";  \
 	    ls -lf --full-time $@ $? || true;         \
 	fi
 	echo $(PRJ_SRC_PATH)/$(@D) >> $(META_DIR)/$(CONVERSION_GEN).todo


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Fix compiling failure: execvp: /bin/bash: Argument list too long

**Which issue(s) this PR fixes**:
Use GNU Make 4.2.1(such as fedora-29) to build k8s in a long directory,
it failed with `execvp: /bin/bash: Argument list too long'
[snip]
$ cd /buildarea1/hjia/wrlinux-1019/I_/suspect_/that_/if_/you_/create_/your_/project_/in_/a_/very_/deep_/directory/build_master-wr_qemux86-64_faw_2019090509/build/tmp-glibc/work/core2-64-wrs-linux/kubernetes/v1.16.0-alpha+git7054e3ead7e1a00ca6ac3ec47ea355b76061a35a-r0/kubernetes-v1.16.0-alpha+git7054e3ead7e1a00ca6ac3ec47ea355b76061a35a/src/import
$ make cross KUBE_BUILD_PLATFORMS=linux/amd64 GOLDFLAGS=""
|+++ [0804 16:38:32] Building go targets for linux/amd64:
|    ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
|make[1]: execvp: /bin/bash: Argument list too long
|make[1]: *** [Makefile.generated_files:184: pkg/kubectl/cmd/testing/zz_generated.deepcopy.go] Error 127
|make: *** [Makefile:557: generated_files] Error 2
...
[snip]

From make manual [1]
$?
  The names of all the prerequisites that are newer than the target, with spaces between them.

While two `$?' was passed to bash in a line, it caused above failure,
drop a duplicated one could workaround the issue.

[1] https://www.gnu.org/software/make/manual/html_node/Automatic-Variables.html

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#82852

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
