### PR TITLE
Differentiate build process for non-amd platforms

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -140,24 +140,36 @@ build() {
       ${SED} -i "s|BASEARCH|${arch}|g" $dockerfile_name
     fi
 
-    # copy the qemu-*-static binary to docker image to build the multi architecture image on x86 platform
-    if grep -q "CROSS_BUILD_" Dockerfile; then
-      if [[ "${arch}" == "amd64" ]]; then
-        ${SED} -i "/CROSS_BUILD_/d" Dockerfile
-      else
-        ${SED} -i "s|QEMUARCH|${QEMUARCHS[$arch]}|g" Dockerfile
-        # Register qemu-*-static for all supported processors except the current one
-        echo "Registering qemu-*-static binaries in the kernel"
-        local sudo=""
-        if [[ $(id -u) != 0 ]]; then
-          sudo=sudo
+    # Only the cross-build on x86 is guaranteed by far, other arches like aarch64 doesn't support cross-build
+    # thus, there is no need to tackle a disability feature on those platforms, and also help to prevent from
+    # ending up a wrong image tag on non-amd64 platforms.
+    build_arch=$(uname -m)
+    if [[ ${build_arch} = "x86_64" ]]; then
+        # copy the qemu-*-static binary to docker image to build the multi architecture image on x86 platform
+        if grep -q "CROSS_BUILD_" Dockerfile; then
+          if [[ "${arch}" == "amd64" ]]; then
+            ${SED} -i "/CROSS_BUILD_/d" Dockerfile
+          else
+            ${SED} -i "s|QEMUARCH|${QEMUARCHS[$arch]}|g" Dockerfile
+            # Register qemu-*-static for all supported processors except the current one
+            echo "Registering qemu-*-static binaries in the kernel"
+            local sudo=""
+            if [[ $(id -u) != 0 ]]; then
+	          sudo=sudo
+            fi
+            ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset -p yes
+            curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/"${QEMUVERSION}"/x86_64_qemu-"${QEMUARCHS[$arch]}"-static.tar.gz | tar -xz -C "${temp_dir}"
+            # Ensure we don't get surprised by umask settings
+            chmod 0755 "${temp_dir}/qemu-${QEMUARCHS[$arch]}-static"
+            ${SED} -i "s/CROSS_BUILD_//g" Dockerfile
+          fi
         fi
-        ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset -p yes
-        curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/"${QEMUVERSION}"/x86_64_qemu-"${QEMUARCHS[$arch]}"-static.tar.gz | tar -xz -C "${temp_dir}"
-        # Ensure we don't get surprised by umask settings
-        chmod 0755 "${temp_dir}/qemu-${QEMUARCHS[$arch]}-static"
-        ${SED} -i "s/CROSS_BUILD_//g" Dockerfile
-      fi
+    elif [[ "${QEMUARCHS[$arch]}" != "${build_arch}" ]]; then
+		echo "skip cross-build $arch on non-supported platform ${build_arch}."
+		popd
+        continue
+    else
+        ${SED} -i "/CROSS_BUILD_/d" Dockerfile
     fi
 
     docker buildx build --progress=plain --no-cache --pull --output=type="${output_type}" --platform "${os_name}/${arch}" \

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -136,32 +136,32 @@ build() {
 
     base_image=""
     if [[ -f BASEIMAGE ]]; then
-      base_image=$(getBaseImage "${os_arch}" | ${SED} "s|REGISTRY|${REGISTRY}|g")
-      ${SED} -i "s|BASEARCH|${arch}|g" $dockerfile_name
+      base_image=$(getBaseImage "${os_arch}" | "${SED}" "s|REGISTRY|${REGISTRY}|g")
+      "${SED}" -i "s|BASEARCH|${arch}|g" $dockerfile_name
     fi
 
     # Only the cross-build on x86 is guaranteed by far, other arches like aarch64 doesn't support cross-build
     # thus, there is no need to tackle a disability feature on those platforms, and also help to prevent from
     # ending up a wrong image tag on non-amd64 platforms.
     build_arch=$(uname -m)
-    if [[ ${build_arch} = "x86_64" ]]; then
+    if [[ ${build_arch} = 'x86_64' ]]; then
         # copy the qemu-*-static binary to docker image to build the multi architecture image on x86 platform
-        if grep -q "CROSS_BUILD_" Dockerfile; then
-          if [[ "${arch}" == "amd64" ]]; then
-            ${SED} -i "/CROSS_BUILD_/d" Dockerfile
+        if grep -q 'CROSS_BUILD_' Dockerfile; then
+          if [[ "${arch}" = 'amd64' ]]; then
+            "${SED}" -i '/CROSS_BUILD_/d' Dockerfile
           else
-            ${SED} -i "s|QEMUARCH|${QEMUARCHS[$arch]}|g" Dockerfile
+            "${SED}" -i "s|QEMUARCH|${QEMUARCHS[$arch]}|g" Dockerfile
             # Register qemu-*-static for all supported processors except the current one
-            echo "Registering qemu-*-static binaries in the kernel"
-            local sudo=""
-            if [[ $(id -u) != 0 ]]; then
-	          sudo=sudo
+            echo 'Registering qemu-*-static binaries in the kernel'
+            local sudo
+            if [[ $(id -u) -ne 0 ]]; then
+	            sudo=sudo
             fi
             ${sudo} "${KUBE_ROOT}/third_party/multiarch/qemu-user-static/register/register.sh" --reset -p yes
             curl -sSL https://github.com/multiarch/qemu-user-static/releases/download/"${QEMUVERSION}"/x86_64_qemu-"${QEMUARCHS[$arch]}"-static.tar.gz | tar -xz -C "${temp_dir}"
             # Ensure we don't get surprised by umask settings
             chmod 0755 "${temp_dir}/qemu-${QEMUARCHS[$arch]}-static"
-            ${SED} -i "s/CROSS_BUILD_//g" Dockerfile
+            "${SED}" -i 's/CROSS_BUILD_//g' Dockerfile
           fi
         fi
     elif [[ "${QEMUARCHS[$arch]}" != "${build_arch}" ]]; then
@@ -169,7 +169,7 @@ build() {
 		popd
         continue
     else
-        ${SED} -i "/CROSS_BUILD_/d" Dockerfile
+        "${SED}" -i '/CROSS_BUILD_/d' Dockerfile
     fi
 
     docker buildx build --progress=plain --no-cache --pull --output=type="${output_type}" --platform "${os_name}/${arch}" \
@@ -207,7 +207,7 @@ push() {
   # reset manifest list; needed in case multiple images are being built / pushed.
   manifest=()
   # Make os_archs list into image manifest. Eg: 'linux/amd64 linux/ppc64le' to '${REGISTRY}/${image}:${TAG}-linux-amd64 ${REGISTRY}/${image}:${TAG}-linux-ppc64le'
-  while IFS='' read -r line; do manifest+=("$line"); done < <(echo "$os_archs" | ${SED} "s~\/~-~g" | ${SED} -e "s~[^ ]*~$REGISTRY\/$image:$TAG\-&~g")
+  while IFS='' read -r line; do manifest+=("$line"); done < <(echo "$os_archs" | "${SED}" "s~\/~-~g" | "${SED}" -e "s~[^ ]*~$REGISTRY\/$image:$TAG\-&~g")
   docker manifest create --amend "${REGISTRY}/${image}:${TAG}" "${manifest[@]}"
 
   # We will need the full registry name in order to set the "os.version" for Windows images.


### PR DESCRIPTION
- reset `binfmt_misc` is needn't when the building platform is non-amd64 and the
target arch is the same as building platform

- non-amd64 platform doesn't supported cross-build well, and there is no binary of
`qemu-user-static` able to do that, and thus skip the cross-build on non-amd64
platform.

Here is what it looks like for apparmor-loader build on ARM64.
```# make all WHAT=apparmor-loader
./image-util.sh build apparmor-loader
Building image for apparmor-loader OS/ARCH: linux/amd64...
make[1]: Entering directory '/go/src/k8s.io/kubernetes/test/images/apparmor-loader'
../image-util.sh bin loader
go: downloading k8s.io/klog v1.0.0
go: extracting k8s.io/klog v1.0.0
go: finding k8s.io/klog v1.0.0
make[1]: Leaving directory '/go/src/k8s.io/kubernetes/test/images/apparmor-loader'
/go/src/k8s.io/kubernetes/_tmp/test-images-build.g6iRGF /go/src/k8s.io/kubernetes/test/images
skip cross-build amd64 on non-supported platform aarch64.
...
Building image for apparmor-loader OS/ARCH: linux/arm64...
make[1]: Entering directory '/go/src/k8s.io/kubernetes/test/images/apparmor-loader'
../image-util.sh bin loader
...
Successfully built efc23c2ab906
Successfully tagged gcr.io/kubernetes-e2e-test-images/apparmor-loader:1.1-linux-arm64
```

Signed-off-by: Dave Chen <dave.chen@arm.com>


**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #82775
Fixes #81920
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

