### PR TITLE
Fix Errorf arguments in tests

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/helpers_test.go
@@ -272,10 +272,10 @@ func TestSetCRDCondition(t *testing.T) {
 		}
 		for i := range tc.expectedcrdCondition {
 			if !IsCRDConditionEquivalent(&tc.expectedcrdCondition[i], &crd.Status.Conditions[i]) {
-				t.Errorf("%v expected %v, got %v", tc.name, tc.expectedcrdCondition, crd.Status.Conditions)
+				t.Errorf("%v expected %v, got %v", tc.name, tc.expectedcrdCondition[i], crd.Status.Conditions[i])
 			}
 			if crd.Status.Conditions[i].LastTransitionTime.IsZero() {
-				t.Errorf("%q lastTransitionTime should not be null: %v", tc.name, i, crd.Status.Conditions)
+				t.Errorf("%q/%d lastTransitionTime should not be null: %v", tc.name, i, crd.Status.Conditions[i])
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind failing-test

**What this PR does / why we need it**:
Fixes arguments in `Errorf` invocation.

**Special notes for your reviewer**:
/assign @deads2k @sttts 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
