### PR TITLE
Correct the error variable for releasing CIDR

### DIFF
--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -346,7 +346,7 @@ func (r *rangeAllocator) updateCIDRsAllocation(data nodeReservedCIDRs) error {
 	if len(node.Spec.PodCIDRs) != 0 {
 		klog.Errorf("Node %v already has a CIDR allocated %v. Releasing the new one.", node.Name, node.Spec.PodCIDRs)
 		for idx, cidr := range data.allocatedCIDRs {
-			if releaseErr := r.cidrSets[idx].Release(cidr); err != nil {
+			if releaseErr := r.cidrSets[idx].Release(cidr); releaseErr != nil {
 				klog.Errorf("Error when releasing CIDR idx:%v value: %v err:%v", idx, cidr, releaseErr)
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In rangeAllocator#updateCIDRsAllocation, the wrong error variable was used to check whether releasing CIDR has had an issue.

This PR fixes the variable reference.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
