### PR TITLE
Bump github.com/heketi/heketi to c2e2a4ab7ab9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,10 +74,8 @@ require (
 	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.7.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.1
-	github.com/heketi/heketi v9.0.0+incompatible
-	github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413 // indirect
+	github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
 	github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 // indirect
-	github.com/heketi/utils v0.0.0-20170317161834-435bc5bdfa64 // indirect
 	github.com/json-iterator/go v1.1.7
 	github.com/karrick/godirwalk v1.7.5 // indirect
 	github.com/libopenstorage/openstorage v1.0.0
@@ -304,10 +302,8 @@ replace (
 	github.com/hashicorp/go-syslog => github.com/hashicorp/go-syslog v1.0.0
 	github.com/hashicorp/golang-lru => github.com/hashicorp/golang-lru v0.5.1
 	github.com/hashicorp/hcl => github.com/hashicorp/hcl v1.0.0
-	github.com/heketi/heketi => github.com/heketi/heketi v9.0.0+incompatible
-	github.com/heketi/rest => github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413
+	github.com/heketi/heketi => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
 	github.com/heketi/tests => github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6
-	github.com/heketi/utils => github.com/heketi/utils v0.0.0-20170317161834-435bc5bdfa64
 	github.com/hpcloud/tail => github.com/hpcloud/tail v1.0.0
 	github.com/imdario/mergo => github.com/imdario/mergo v0.3.5
 	github.com/inconshreveable/mousetrap => github.com/inconshreveable/mousetrap v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -239,14 +239,10 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/heketi/heketi v9.0.0+incompatible h1:B2ACAbYsCHkJXKozYVV7p2j+eEy/zNlLsicihMWCk30=
-github.com/heketi/heketi v9.0.0+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
-github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413 h1:nGZBOxRgSMbqjm2/FYDtO6BU4a+hfR7Om9VGQ9tbbSc=
-github.com/heketi/rest v0.0.0-20180404230133-aa6a65207413/go.mod h1:BeS3M108VzVlmAue3lv2WcGuPAX94/KN63MUURzbYSI=
+github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible h1:ysqc8k973k1lLJ4BOOHAkx14K2nt4cLjsIm+hwWDZDE=
+github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible/go.mod h1:bB9ly3RchcQqsQ9CpyaQwvva7RS5ytVoSoholZQON6o=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6 h1:oJ/NLadJn5HoxvonA6VxG31lg0d6XOURNA09BTtM4fY=
 github.com/heketi/tests v0.0.0-20151005000721-f3775cbcefd6/go.mod h1:xGMAM8JLi7UkZt1i4FQeQy0R2T8GLUwQhOP5M1gBhy4=
-github.com/heketi/utils v0.0.0-20170317161834-435bc5bdfa64 h1:dk3GEa55HcRVIyCeNQmwwwH3kIXnqJPNseKOkDD+7uQ=
-github.com/heketi/utils v0.0.0-20170317161834-435bc5bdfa64/go.mod h1:RYlF4ghFZPPmk2TC5REt5OFwvfb6lzxFWrTWB+qs28s=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=

--- a/vendor/github.com/heketi/heketi/client/api/go-client/block_volume.go
+++ b/vendor/github.com/heketi/heketi/client/api/go-client/block_volume.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -52,7 +51,7 @@ func (c *Client) BlockVolumeCreate(request *api.BlockVolumeCreateRequest) (
 		return nil, utils.GetErrorFromResponse(r)
 	}
 
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +147,7 @@ func (c *Client) BlockVolumeDelete(id string) error {
 		return utils.GetErrorFromResponse(r)
 	}
 
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/heketi/heketi/client/api/go-client/client.go
+++ b/vendor/github.com/heketi/heketi/client/api/go-client/client.go
@@ -34,8 +34,9 @@ const (
 	RETRY_COUNT             = 6
 
 	// default delay values
-	MIN_DELAY = 10
-	MAX_DELAY = 30
+	MIN_DELAY  = 10
+	MAX_DELAY  = 30
+	POLL_DELAY = 400 // milliseconds
 )
 
 type ClientTLSOptions struct {
@@ -49,8 +50,10 @@ type ClientTLSOptions struct {
 type ClientOptions struct {
 	RetryEnabled bool
 	RetryCount   int
-	// control waits between retries
+	// control waits between retries (seconds)
 	RetryMinDelay, RetryMaxDelay int
+	// control wait time while polling for responses (milliseconds)
+	PollDelay int
 }
 
 // Client object
@@ -75,6 +78,14 @@ var defaultClientOptions = ClientOptions{
 	RetryCount:    RETRY_COUNT,
 	RetryMinDelay: MIN_DELAY,
 	RetryMaxDelay: MAX_DELAY,
+	PollDelay:     POLL_DELAY,
+}
+
+// DefaultClientOptions returns a ClientOptions type with all the fields
+// initialized to the default values used internally by the new-client
+// functions.
+func DefaultClientOptions() ClientOptions {
+	return defaultClientOptions
 }
 
 // NewClient creates a new client to access a Heketi server
@@ -193,6 +204,11 @@ func (c *Client) doBasic(req *http.Request) (*http.Response, error) {
 // Here we create a new token before it makes the next request.
 func (c *Client) checkRedirect(req *http.Request, via []*http.Request) error {
 	return c.setToken(req)
+}
+
+func (c *Client) pollResponse(r *http.Response) (*http.Response, error) {
+	return c.waitForResponseWithTimer(
+		r, time.Millisecond*time.Duration(c.opts.PollDelay))
 }
 
 // Wait for the job to finish, waiting waitTime on every loop

--- a/vendor/github.com/heketi/heketi/client/api/go-client/device.go
+++ b/vendor/github.com/heketi/heketi/client/api/go-client/device.go
@@ -17,7 +17,6 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -54,7 +53,7 @@ func (c *Client) DeviceAdd(request *api.DeviceAddRequest) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -138,7 +137,7 @@ func (c *Client) DeviceDeleteWithOptions(
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -184,7 +183,7 @@ func (c *Client) DeviceState(id string,
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -220,7 +219,7 @@ func (c *Client) DeviceResync(id string) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Millisecond*250)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/heketi/heketi/client/api/go-client/node.go
+++ b/vendor/github.com/heketi/heketi/client/api/go-client/node.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -54,7 +53,7 @@ func (c *Client) NodeAdd(request *api.NodeAddRequest) (*api.NodeInfoResponse, er
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Millisecond*250)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +130,7 @@ func (c *Client) NodeDelete(id string) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Millisecond*250)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -175,7 +174,7 @@ func (c *Client) NodeState(id string, request *api.StateRequest) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/heketi/heketi/client/api/go-client/operations.go
+++ b/vendor/github.com/heketi/heketi/client/api/go-client/operations.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -151,7 +150,7 @@ func (c *Client) PendingOperationCleanUp(
 	// AND that the rest async framework in heketi needs to be
 	// polled in order to remove things from its map, the traditional
 	// poll server after request behavior is retained here.
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/heketi/heketi/client/api/go-client/volume.go
+++ b/vendor/github.com/heketi/heketi/client/api/go-client/volume.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	"time"
 
 	"github.com/heketi/heketi/pkg/glusterfs/api"
 	"github.com/heketi/heketi/pkg/utils"
@@ -57,7 +56,7 @@ func (c *Client) VolumeCreate(request *api.VolumeCreateRequest) (
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func (c *Client) VolumeSetBlockRestriction(id string, request *api.VolumeBlockRe
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +164,7 @@ func (c *Client) VolumeExpand(id string, request *api.VolumeExpandRequest) (
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}
@@ -277,7 +276,7 @@ func (c *Client) VolumeDelete(id string) error {
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return err
 	}
@@ -319,7 +318,7 @@ func (c *Client) VolumeClone(id string, request *api.VolumeCloneRequest) (*api.V
 	}
 
 	// Wait for response
-	r, err = c.waitForResponseWithTimer(r, time.Second)
+	r, err = c.pollResponse(r)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/heketi/heketi/pkg/glusterfs/api/types.go
+++ b/vendor/github.com/heketi/heketi/pkg/glusterfs/api/types.go
@@ -21,7 +21,7 @@ import (
 	"regexp"
 	"sort"
 
-	"github.com/go-ozzo/ozzo-validation"
+	validation "github.com/go-ozzo/ozzo-validation"
 	"github.com/go-ozzo/ozzo-validation/is"
 )
 
@@ -181,6 +181,8 @@ type DeviceInfo struct {
 	Device
 	Storage StorageSize `json:"storage"`
 	Id      string      `json:"id"`
+	Paths   []string    `json:"paths,omitempty"`
+	PvUUID  string      `json:"pv_uuid,omitempty"`
 }
 
 type DeviceInfoResponse struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -558,7 +558,7 @@ github.com/hashicorp/hcl/hcl/token
 github.com/hashicorp/hcl/json/parser
 github.com/hashicorp/hcl/json/scanner
 github.com/hashicorp/hcl/json/token
-# github.com/heketi/heketi v9.0.0+incompatible => github.com/heketi/heketi v9.0.0+incompatible
+# github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible => github.com/heketi/heketi v9.0.1-0.20190917153846-c2e2a4ab7ab9+incompatible
 github.com/heketi/heketi/client/api/go-client
 github.com/heketi/heketi/pkg/glusterfs/api
 github.com/heketi/heketi/pkg/utils


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

* Updates github.com/heketi/heketi to c2e2a4ab7ab9 to include https://github.com/heketi/heketi/pull/1649
* Resolves cycle of k8s.io/kubernetes -> github.com/heketi/heketi -> k8s.io/client-go v3.0

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/82506:

```sh
$ go version
go version go1.13 darwin/amd64

$ go mod tidy
warning: ignoring symlink /Users/liggitt/go/src/k8s.io/kubernetes/cluster/gce/cos
warning: ignoring symlink /Users/liggitt/go/src/k8s.io/kubernetes/cluster/gce/custom
warning: ignoring symlink /Users/liggitt/go/src/k8s.io/kubernetes/cluster/gce/ubuntu
warning: ignoring symlink /Users/liggitt/go/src/k8s.io/kubernetes/third_party/etcd

$ git status
On branch bump-heketi
Your branch is up to date with 'origin/bump-heketi'.

nothing to commit, working tree clean
```

**Special notes for your reviewer**:
This bumps heketi to a non-tagged SHA, but is needed to unblock go1.13 efforts and the diff is minimal and easily reviewed

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @dims @humblec 