### PR TITLE
Provide prometheus desc wrapper

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "counter.go",
+        "desc.go",
         "gauge.go",
         "histogram.go",
         "http.go",
@@ -13,6 +14,7 @@ go_library(
         "processstarttime.go",
         "registry.go",
         "summary.go",
+        "value.go",
         "version.go",
         "version_parser.go",
         "wrappers.go",

--- a/staging/src/k8s.io/component-base/metrics/desc.go
+++ b/staging/src/k8s.io/component-base/metrics/desc.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Desc is a prometheus.Desc extension.
+//
+// Use NewDesc to create new Desc instances.
+type Desc prometheus.Desc
+
+func (d *Desc) toPromDesc() *prometheus.Desc {
+	return (*prometheus.Desc)(d)
+}
+
+// NewDesc allocates and initializes a new Desc. Errors are recorded in the Desc
+// and will be reported on registration time. variableLabels and constLabels can
+// be nil if no such labels should be set. fqName must not be empty.
+//
+// variableLabels only contain the label names. Their label values are variable
+// and therefore not part of the Desc. (They are managed within the Metric.)
+//
+// For constLabels, the label values are constant. Therefore, they are fully
+// specified in the Desc. See the Collector example for a usage pattern.
+func NewDesc(fqName string, help string, variableLabels []string, constLabels Labels) *Desc {
+	// TODO(RainbowMango): Here just force all metrics defined through a Desc as an ALPHA metric.
+	// This should be changed after we have a better solution for this use case.
+	helpWithStability := fmt.Sprintf("[ALPHA] %v", help)
+
+	return (*Desc)(prometheus.NewDesc(fqName, helpWithStability, variableLabels, prometheus.Labels(constLabels)))
+}

--- a/staging/src/k8s.io/component-base/metrics/value.go
+++ b/staging/src/k8s.io/component-base/metrics/value.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// ValueType is an enumeration of metric types that represent a simple value.
+type ValueType prometheus.ValueType
+
+func (v *ValueType) toPromValueType() prometheus.ValueType {
+	return prometheus.ValueType(*v)
+}
+
+// Possible values for the ValueType enum.
+const (
+	_ ValueType = iota
+	CounterValue
+	GaugeValue
+	UntypedValue
+)
+
+// MustNewConstMetric is a version of NewConstMetric that panics where
+// NewConstMetric would have returned an error.
+func MustNewConstMetric(desc *Desc, valueType ValueType, value float64, labelValues ...string) Metric {
+	m, err := prometheus.NewConstMetric(desc.toPromDesc(), valueType.toPromValueType(), value, labelValues...)
+	if err != nil {
+		panic(err)
+	}
+	return m
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Provide  wrapper for prometheus.Desc.

Let's split some small and standalone task for the issue #82509.
This PR only focus on the interface that the stability framework provides to users when they need a Desc.
In later PRs will handle how to annotate custom collector with stability metadata.

**Which issue(s) this PR fixes**:
Part of #82509.

**Special notes for your reviewer**:
The full implementation for custom collector covered by #83062 (a little more complicated, can not be fully reviewed in a short time)

Current on only provides basic, incomplete implementation just to push migration forward.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


/assign @logicalhan 