### PR TITLE
Update Cluster Autoscaler to 1.15.2.

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.15.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.15.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler to 1.15.2
 - https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.2

```release-note
Update Cluster Autoscaler to 1.15.2 (https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.15.2)
```