### PR TITLE
Fixed a scheduler panic when using PodAffinity (k8s version >= 1.15)

### DIFF
--- a/pkg/scheduler/algorithm/predicates/metadata_test.go
+++ b/pkg/scheduler/algorithm/predicates/metadata_test.go
@@ -1682,7 +1682,7 @@ func BenchmarkTestGetTPMapMatchingSpreadConstraints(b *testing.B) {
 	}
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
-			existingPods, allNodes, _ := st.MakeNodesAndPods(tt.pod, tt.existingPodsNum, tt.allNodesNum, tt.filteredNodesNum)
+			existingPods, allNodes, _ := st.MakeNodesAndPodsForEvenPodsSpread(tt.pod, tt.existingPodsNum, tt.allNodesNum, tt.filteredNodesNum)
 			nodeNameToInfo := schedulernodeinfo.CreateNodeNameToInfoMap(existingPods, allNodes)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/pkg/scheduler/algorithm/priorities/even_pods_spread_test.go
+++ b/pkg/scheduler/algorithm/priorities/even_pods_spread_test.go
@@ -483,7 +483,7 @@ func BenchmarkTestCalculateEvenPodsSpreadPriority(b *testing.B) {
 	}
 	for _, tt := range tests {
 		b.Run(tt.name, func(b *testing.B) {
-			existingPods, allNodes, filteredNodes := st.MakeNodesAndPods(tt.pod, tt.existingPodsNum, tt.allNodesNum, tt.filteredNodesNum)
+			existingPods, allNodes, filteredNodes := st.MakeNodesAndPodsForEvenPodsSpread(tt.pod, tt.existingPodsNum, tt.allNodesNum, tt.filteredNodesNum)
 			nodeNameToInfo := schedulernodeinfo.CreateNodeNameToInfoMap(existingPods, allNodes)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -51,17 +51,16 @@ func NewInterPodAffinityPriority(
 }
 
 type podAffinityPriorityMap struct {
-	// nodes contain all nodes that should be considered
+	// nodes contain all nodes that should be considered.
 	nodes []*v1.Node
-	// counts store the mapping from node name to so-far computed score of
-	// the node.
-	counts map[string]*int64
+	// counts store the so-far computed score for each node.
+	counts []int64
 }
 
 func newPodAffinityPriorityMap(nodes []*v1.Node) *podAffinityPriorityMap {
 	return &podAffinityPriorityMap{
 		nodes:  nodes,
-		counts: make(map[string]*int64, len(nodes)),
+		counts: make([]int64, len(nodes)),
 	}
 }
 
@@ -73,9 +72,9 @@ func (p *podAffinityPriorityMap) processTerm(term *v1.PodAffinityTerm, podDefini
 	}
 	match := priorityutil.PodMatchesTermsNamespaceAndSelector(podToCheck, namespaces, selector)
 	if match {
-		for _, node := range p.nodes {
+		for i, node := range p.nodes {
 			if priorityutil.NodesHaveSameTopologyKey(node, fixedNode, term.TopologyKey) {
-				atomic.AddInt64(p.counts[node.Name], weight)
+				atomic.AddInt64(&p.counts[i], weight)
 			}
 		}
 	}
@@ -102,17 +101,11 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 	hasAffinityConstraints := affinity != nil && affinity.PodAffinity != nil
 	hasAntiAffinityConstraints := affinity != nil && affinity.PodAntiAffinity != nil
 
-	// priorityMap stores the mapping from node name to so-far computed score of
-	// the node.
+	// pm stores (1) all nodes that should be considered and (2) the so-far computed score for each node.
 	pm := newPodAffinityPriorityMap(nodes)
 	allNodeNames := make([]string, 0, len(nodeNameToInfo))
-	lazyInit := hasAffinityConstraints || hasAntiAffinityConstraints
 	for name := range nodeNameToInfo {
 		allNodeNames = append(allNodeNames, name)
-		// if pod has affinity defined, or target node has affinityPods
-		if lazyInit || len(nodeNameToInfo[name].PodsWithAffinity()) != 0 {
-			pm.counts[name] = new(int64)
-		}
 	}
 
 	// convert the topology key based weights to the node name based weights
@@ -216,25 +209,22 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, node
 		return nil, err
 	}
 
-	for _, node := range nodes {
-		if pm.counts[node.Name] == nil {
-			continue
+	for i := range nodes {
+		if pm.counts[i] > maxCount {
+			maxCount = pm.counts[i]
 		}
-		if *pm.counts[node.Name] > maxCount {
-			maxCount = *pm.counts[node.Name]
-		}
-		if *pm.counts[node.Name] < minCount {
-			minCount = *pm.counts[node.Name]
+		if pm.counts[i] < minCount {
+			minCount = pm.counts[i]
 		}
 	}
 
 	// calculate final priority score for each node
 	result := make(schedulerapi.HostPriorityList, 0, len(nodes))
 	maxMinDiff := maxCount - minCount
-	for _, node := range nodes {
+	for i, node := range nodes {
 		fScore := float64(0)
-		if maxMinDiff > 0 && pm.counts[node.Name] != nil {
-			fScore = float64(schedulerapi.MaxPriority) * (float64(*pm.counts[node.Name]-minCount) / float64(maxCount-minCount))
+		if maxMinDiff > 0 {
+			fScore = float64(schedulerapi.MaxPriority) * (float64(pm.counts[i]-minCount) / float64(maxCount-minCount))
 		}
 		result = append(result, schedulerapi.HostPriority{Host: node.Name, Score: int64(fScore)})
 		if klog.V(10) {

--- a/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity_test.go
@@ -507,6 +507,22 @@ func TestInterPodAffinityPriority(t *testing.T) {
 			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: 0}, {Host: "machine3", Score: schedulerapi.MaxPriority}, {Host: "machine4", Score: 0}},
 			name:         "Affinity and Anti Affinity and symmetry: considered only preferredDuringSchedulingIgnoredDuringExecution in both pod affinity & anti affinity & symmetry",
 		},
+		// Cover https://github.com/kubernetes/kubernetes/issues/82796 which panics upon:
+		// 1. Some nodes in a topology don't have pods with affinity, but other nodes in the same topology have.
+		// 2. The incoming pod doesn't have affinity.
+		{
+			pod: &v1.Pod{Spec: v1.PodSpec{NodeName: ""}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelSecurityS1}},
+			pods: []*v1.Pod{
+				{Spec: v1.PodSpec{NodeName: "machine1"}, ObjectMeta: metav1.ObjectMeta{Labels: podLabelSecurityS1}},
+				{Spec: v1.PodSpec{NodeName: "machine2", Affinity: stayWithS1InRegionAwayFromS2InAz}},
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: labelRgChina}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "machine2", Labels: labelRgChina}},
+			},
+			expectedList: []schedulerapi.HostPriority{{Host: "machine1", Score: schedulerapi.MaxPriority}, {Host: "machine2", Score: schedulerapi.MaxPriority}},
+			name:         "Avoid panic when partial nodes in a topology don't have pods with affinity",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig scheduling
/priority critical-urgent

**What this PR does / why we need it**:

A bug was introduced in 1.15 which can cause the scheduler panic.

**Which issue(s) this PR fixes**:

Fixes #82796.

**Special notes for your reviewer**:

**>Background:** There was an attempt in 1.15 to improve PodAffinity performance - which tried to use `atomic.AddInt64()` to replace explicit lock. Which was expected to work well for PodAffinity and it did, but it exposed penalties on regular workloads. So we reverted that PR. And later on, the penalties lied in the unconditional initialization on the int64 pointer for every node. So we introduced a dynamic/lazy initialization for only the necessary nodes, which is the current version.

**>Why it panics?** #82796 indicated that the idea of "pre-detecting the nodes and then initialize them with *int64" is hard to achieve. In other words, we can't deduce which nodes could be pre-counted. For example, there is 1 zone having 2 nodes, nodeA has pods with Pod(Anti-)Affinity, while nodeB doesn't have pods with Pod(Anti-)Affinity. In this case, we need to know the exact `topologyKey` each pod (holding Pod(Anti-Affinity) in nodeA, so that we can know whether nodeB is a qualified node can be scored (and hence should be initialized). The logic is way too complex and wasn't covered. And in runtime, if it ends up with nodeB is a qualified one, adding a score to `counts[nodeB]` will panic as it's nil.
(The panic case is included in the unit test of this PR.)

**>Solutions:** At a first glance, it seems we only need to check if `counts[nodeB]` is nil and if it's not, initialize it in runtime (#82798). Which looks good, but it happens in each concurrent goroutine, and they're operating the same `map` obj, so it can cause a race condition. Another solution is to initialize every node with an int64 pointer, as aforementioned, it will regress the regular workloads.

**>Solution in this PR:** (Not sure why I didn't think of this in 1.15...) This PR replaced `map` with a fixed `slice` when calculating counts. So that `&slice[i]` is addressable, and the `slice` is initialized with the nil value (0), without additional overhead.

**>Performance:** A benchmark test is included in this PR. It's expected that our current PR performs the best.

The following tests are using the same benchmark test to simulate a 1000-nodes cluster with 10k pods with shuffled PodAffinity. (The unit is "ns/op")

> Master (Baseline)

|                                                                                    | average  | run1     | run2     | run3     |
|------------------------------------------------------------------------------------|----------|----------|----------|----------|
| incoming_pod_without_PodAffinity_and_existing_pods_without_PodAffinity-8 | 209589   | 208704   | 210674   | 209389   |
| incoming_pod_with_PodAffinity_and_existing_pods_without_PodAffinity-8    | 8888500  | 9090174  | 8938776  | 8636551  |
| incoming_pod_without_PodAffinity_and_existing_pods_with_PodAffinity-8    | 58973078 | 58118594 | 60900042 | 57900597 |
| incoming_pod_with_PodAffinity_and_existing_pods_with_PodAffinity-8       | 64750096 | 65891670 | 65887335 | 62471282 |

> Master + This PR

|                                                                          | average  | run1     | run2     | run3     |
|--------------------------------------------------------------------------|----------|----------|----------|----------|
| incoming_pod_without_PodAffinity_and_existing_pods_without_PodAffinity-8 | 197480   | 189574   | 212554   | 190311   |
| incoming_pod_with_PodAffinity_and_existing_pods_without_PodAffinity-8    | 8527400  | 8647236  | 8491254  | 8443710  |
| incoming_pod_without_PodAffinity_and_existing_pods_with_PodAffinity-8    | 43504498 | 41093945 | 46569620 | 42849928 |
| incoming_pod_with_PodAffinity_and_existing_pods_with_PodAffinity-8       | 45220779 | 44766175 | 46500664 | 44395499 |

> Master + #82798 (it can cause a potential racing though)

|                                                                          | average  | run1     | run2     | run3     |
|--------------------------------------------------------------------------|----------|----------|----------|----------|
| incoming_pod_without_PodAffinity_and_existing_pods_without_PodAffinity-8 | 212721   | 215281   | 210121   | 212760   |
| incoming_pod_with_PodAffinity_and_existing_pods_without_PodAffinity-8    | 8778035  | 8714004  | 8885097  | 8735004  |
| incoming_pod_without_PodAffinity_and_existing_pods_with_PodAffinity-8    | 65006391 | 63493375 | 65481544 | 66044255 |
| incoming_pod_with_PodAffinity_and_existing_pods_with_PodAffinity-8       | 68722439 | 71596582 | 68081107 | 66489627 |

**Does this PR introduce a user-facing change?**:

```release-note
Fixed a scheduler panic when using PodAffinity.
```