### PR TITLE
Fix typo in v1.16 CHANGELOG

### DIFF
--- a/CHANGELOG-1.16.md
+++ b/CHANGELOG-1.16.md
@@ -16,7 +16,7 @@
   - [Metrics Changes](#metrics-changes)
     - [Added metrics](#added-metrics)
     - [Removed metrics](#removed-metrics)
-    - [Depreciated/changed metrics](#depreciatedchanged-metrics)
+    - [Deprecated/changed metrics](#deprecatedchanged-metrics)
   - [Notable Features](#notable-features)
     - [Beta](#beta)
     - [Alpha](#alpha)
@@ -310,7 +310,7 @@ The main themes of this release are:
 
 - Removed cadvisor metric labels `pod_name` and `container_name` to match instrumentation guidelines. Any Prometheus queries that match `pod_name` and `container_name` labels (e.g. cadvisor or kubelet probe metrics) must be updated to use `pod` and `container` instead. ([#80376](https://github.com/kubernetes/kubernetes/pull/80376), [@ehashman](https://github.com/ehashman))
 
-### Depreciated/changed metrics
+### Deprecated/changed metrics
 
 - kube-controller-manager and cloud-controller-manager metrics are now marked as with the ALPHA stability level. ([#81624](https://github.com/kubernetes/kubernetes/pull/81624), [@logicalhan](https://github.com/logicalhan))
 - kube-proxy metrics are now marked as with the ALPHA stability level. ([#81626](https://github.com/kubernetes/kubernetes/pull/81626), [@logicalhan](https://github.com/logicalhan))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix a typo in https://github.com/kubernetes/kubernetes and https://kubernetes.io/docs/setup/release/notes/ (“depreciated” should be “deprecated”).

**Which issue(s) this PR fixes**:

Fixes #82866

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Also fix https://kubernetes.io/docs/setup/release/notes/#v1-16-0 via a change to [k/website](https://github.com/kubernetes/website/) (pull request available).

```docs

```
