### PR TITLE
Check for terminated reason appropriate for containerD and dockershim

### DIFF
--- a/test/e2e/windows/security_context.go
+++ b/test/e2e/windows/security_context.go
@@ -50,8 +50,8 @@ var _ = SIGDescribe("[Feature:Windows] SecurityContext RunAsUserName", func() {
 
 		podInvalid, _ = f.PodClient().Get(podInvalid.Name, metav1.GetOptions{})
 		podTerminatedReason := testutils.TerminatedContainers(podInvalid)[runAsUserNameContainerName]
-		if "ContainerCannotRun" != podTerminatedReason {
-			framework.Failf("The container terminated reason was supposed to be: 'ContainerCannotRun', not: '%q'", podTerminatedReason)
+		if podTerminatedReason != "ContainerCannotRun" && podTerminatedReason != "StartError" {
+			framework.Failf("The container terminated reason was supposed to be: 'ContainerCannotRun' or 'StartError', not: '%q'", podTerminatedReason)
 		}
 	})
 


### PR DESCRIPTION
Dockershim and containerD return different reasons for container not
starting. This test should check for both in order to pass on both
runtimes.

```release-note
NONE
```