### PR TITLE
Clean up redundant post-finalizer deletions

### DIFF
--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter_test.go
@@ -147,7 +147,6 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 				strings.Join([]string{"create", "namespaces", "finalize"}, "-"),
 				strings.Join([]string{"list", "pods", ""}, "-"),
 				strings.Join([]string{"update", "namespaces", "status"}, "-"),
-				strings.Join([]string{"delete", "namespaces", ""}, "-"),
 			),
 			metadataClientActionSet: metadataClientActionSet,
 		},
@@ -155,7 +154,6 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 			testNamespace: testNamespaceFinalizeComplete,
 			kubeClientActionSet: sets.NewString(
 				strings.Join([]string{"get", "namespaces", ""}, "-"),
-				strings.Join([]string{"delete", "namespaces", ""}, "-"),
 			),
 			metadataClientActionSet: sets.NewString(),
 		},
@@ -163,7 +161,6 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 			testNamespace: testNamespaceFinalizeComplete,
 			kubeClientActionSet: sets.NewString(
 				strings.Join([]string{"get", "namespaces", ""}, "-"),
-				strings.Join([]string{"delete", "namespaces", ""}, "-"),
 			),
 			metadataClientActionSet: sets.NewString(),
 			gvrError:                fmt.Errorf("test error"),
@@ -202,7 +199,7 @@ func testSyncNamespaceThatIsTerminating(t *testing.T, versions *metav1.APIVersio
 			fn := func() ([]*metav1.APIResourceList, error) {
 				return resources, testInput.gvrError
 			}
-			d := NewNamespacedResourcesDeleter(mockClient.CoreV1().Namespaces(), metadataClient, mockClient.CoreV1(), fn, v1.FinalizerKubernetes, true)
+			d := NewNamespacedResourcesDeleter(mockClient.CoreV1().Namespaces(), metadataClient, mockClient.CoreV1(), fn, v1.FinalizerKubernetes)
 			if err := d.Delete(testInput.testNamespace.Name); !matchErrors(err, testInput.expectErrorOnDelete) {
 				t.Errorf("expected error %q when syncing namespace, got %q, %v", testInput.expectErrorOnDelete, err, testInput.expectErrorOnDelete == err)
 			}
@@ -300,7 +297,7 @@ func TestSyncNamespaceThatIsActive(t *testing.T) {
 		return testResources(), nil
 	}
 	d := NewNamespacedResourcesDeleter(mockClient.CoreV1().Namespaces(), nil, mockClient.CoreV1(),
-		fn, v1.FinalizerKubernetes, true)
+		fn, v1.FinalizerKubernetes)
 	err := d.Delete(testNamespace.Name)
 	if err != nil {
 		t.Errorf("Unexpected error when synching namespace %v", err)

--- a/pkg/controller/namespace/namespace_controller.go
+++ b/pkg/controller/namespace/namespace_controller.go
@@ -72,7 +72,7 @@ func NewNamespaceController(
 	// create the controller so we can inject the enqueue function
 	namespaceController := &NamespaceController{
 		queue:                      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "namespace"),
-		namespacedResourcesDeleter: deletion.NewNamespacedResourcesDeleter(kubeClient.CoreV1().Namespaces(), metadataClient, kubeClient.CoreV1(), discoverResourcesFn, finalizerToken, true),
+		namespacedResourcesDeleter: deletion.NewNamespacedResourcesDeleter(kubeClient.CoreV1().Namespaces(), metadataClient, kubeClient.CoreV1(), discoverResourcesFn, finalizerToken),
 	}
 
 	if kubeClient != nil && kubeClient.CoreV1().RESTClient().GetRateLimiter() != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer/crd_finalizer.go
@@ -170,16 +170,6 @@ func (c *CRDFinalizer) sync(key string) error {
 		// deleted or changed in the meantime, we'll get called again
 		return nil
 	}
-	if err != nil {
-		return err
-	}
-
-	// and now issue another delete, which should clean it all up if no finalizers remain or no-op if they do
-	// TODO(liggitt): just return in 1.16, once n-1 apiservers automatically delete when finalizers are all removed
-	err = c.crdClient.CustomResourceDefinitions().Delete(crd.Name, nil)
-	if apierrors.IsNotFound(err) {
-		return nil
-	}
 	return err
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since v1.15 (xref https://github.com/kubernetes/kubernetes/pull/77952), updating to remove the last finalizer automatically deletes API objects.

This removes redundant Delete() API requests from the namespace and CRD finalizing controllers

```release-note
NONE
```

/cc @caesarxuchao @deads2k 
/sig api-machinery