### PR TITLE
[v1.16.1] Automated cherry pick of #82887: TokenCleaner#evalSecret should enqueue the key

### DIFF
--- a/pkg/controller/bootstrap/tokencleaner.go
+++ b/pkg/controller/bootstrap/tokencleaner.go
@@ -202,6 +202,11 @@ func (tc *TokenCleaner) evalSecret(o interface{}) {
 			klog.V(3).Infof("Error deleting Secret: %v", err)
 		}
 	} else if ttl > 0 {
-		tc.queue.AddAfter(o, ttl)
+		key, err := controller.KeyFunc(o)
+		if err != nil {
+			utilruntime.HandleError(err)
+			return
+		}
+		tc.queue.AddAfter(key, ttl)
 	}
 }

--- a/pkg/controller/bootstrap/tokencleaner_test.go
+++ b/pkg/controller/bootstrap/tokencleaner_test.go
@@ -110,10 +110,11 @@ func TestCleanerExpiredAt(t *testing.T) {
 
 	secret := newTokenSecret("tokenID", "tokenSecret")
 	addSecretExpiration(secret, timeString(2*time.Second))
+	secrets.Informer().GetIndexer().Add(secret)
+	cleaner.enqueueSecrets(secret)
 	expected := []core.Action{}
 	verifyFunc := func() {
-		secrets.Informer().GetIndexer().Add(secret)
-		cleaner.evalSecret(secret)
+		cleaner.processNextWorkItem()
 		verifyActions(t, expected, cl.Actions())
 	}
 	// token has not expired currently


### PR DESCRIPTION
Cherry pick of #82887 on release-1.16.

#82887: TokenCleaner#evalSecret should enqueue the key

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.