### PR TITLE
For kubectl get events Added default sorting by lastTimestamp

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -138,6 +138,11 @@ const (
 	useServerPrintColumns          = "server-print"
 )
 
+var eventSorting = map[string]string{
+	"events": ".lastTimestamp",
+	"event":  ".lastTimestamp",
+}
+
 // NewGetOptions returns a GetOptions with default chunk size 500.
 func NewGetOptions(parent string, streams genericclioptions.IOStreams) *GetOptions {
 	return &GetOptions{
@@ -211,11 +216,15 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 		return err
 	}
 	// For kubectl get events Added default sorting by lastTimestamp
-	if sortBy == "" {
-		if len(args) == 1 && args[0] == "events" {
-			sortBy = ".lastTimestamp"
+	if !cmd.Flags().Changed("sort-by") {
+		if len(args) == 1 {
+			value, ok := eventSorting[args[0]]
+			if ok {
+				sortBy = value
+			}
 		}
 	}
+
 	o.Sort = len(sortBy) > 0
 
 	o.NoHeaders = cmdutil.GetFlagBool(cmd, "no-headers")
@@ -513,9 +522,12 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	}
 
 	// For kubectl get events Added default sorting by .lastTimestamp
-	if sorting == "" {
-		if len(args) == 1 && args[0] == "events" {
-			sorting = ".lastTimestamp"
+	if !cmd.Flags().Changed("sort-by") {
+		if len(args) == 1 {
+			value, ok := eventSorting[args[0]]
+			if ok {
+				sorting = value
+			}
 		}
 	}
 

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -210,6 +210,12 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 	if err != nil {
 		return err
 	}
+	// For kubectl get events Added default sorting by lastTimestamp
+	if sortBy == "" {
+		if len(args) == 1 && args[0] == "events" {
+			sortBy = ".lastTimestamp"
+		}
+	}
 	o.Sort = len(sortBy) > 0
 
 	o.NoHeaders = cmdutil.GetFlagBool(cmd, "no-headers")
@@ -504,6 +510,13 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	sorting, err := cmd.Flags().GetString("sort-by")
 	if err != nil {
 		return err
+	}
+
+	// For kubectl get events Added default sorting by .lastTimestamp
+	if sorting == "" {
+		if len(args) == 1 && args[0] == "events" {
+			sorting = ".lastTimestamp"
+		}
 	}
 
 	var positioner OriginalPositioner


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`Kubectl get events` gives results which, byt default, are not sorted by the `lastTimestamp` across the resources. One way to achieve is by passing the argument `--sort-by='.lastTimestamp'` . This PR handles this scenario. In case no `--sort-by` flag is passed, the default sort order will be by `.lastTimestamp`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #29838

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```