### PR TITLE
Fix kubectl panic when handling invalid error.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -131,9 +131,13 @@ func checkErr(err error, handleErr func(string, int)) {
 		handleErr("", DefaultErrorExitCode)
 	case kerrors.IsInvalid(err):
 		details := err.(*kerrors.StatusError).Status().Details
-		s := fmt.Sprintf("The %s %q is invalid", details.Kind, details.Name)
-		if len(details.Kind) == 0 && len(details.Name) == 0 {
-			s = "The request is invalid"
+		s := "The request is invalid"
+		if details == nil {
+			handleErr(s, DefaultErrorExitCode)
+			return
+		}
+		if len(details.Kind) != 0 || len(details.Name) != 0 {
+			s = fmt.Sprintf("The %s %q is invalid", details.Kind, details.Name)
 		}
 		if len(details.Causes) > 0 {
 			errs := statusCausesToAggrError(details.Causes)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -19,6 +19,7 @@ package util
 import (
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"strings"
 	"syscall"
@@ -224,6 +225,16 @@ func TestCheckInvalidErr(t *testing.T) {
 		{
 			errors.NewInvalid(corev1.SchemeGroupVersion.WithKind("Invalid4").GroupKind(), "invalidation", field.ErrorList{field.Invalid(field.NewPath("field4"), "multi4", "details"), field.Invalid(field.NewPath("field4"), "multi4", "details")}),
 			"The Invalid4 \"invalidation\" is invalid: field4: Invalid value: \"multi4\": details\n",
+			DefaultErrorExitCode,
+		},
+		{
+			&errors.StatusError{metav1.Status{
+				Status: metav1.StatusFailure,
+				Code:   http.StatusUnprocessableEntity,
+				Reason: metav1.StatusReasonInvalid,
+				// Details is nil.
+			}},
+			"The request is invalid",
 			DefaultErrorExitCode,
 		},
 	})


### PR DESCRIPTION
My kubectl version:
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"15", GitVersion:"v1.15.3", GitCommit:"2d3c76f9091b6bec110a5e63777c332469e0cba2", GitTreeState:"clean", BuildDate:"2019-08-19T11:13:54Z", GoVersion:"go1.12.9", Compiler:"gc", Platform:"linux/amd64"}
...
```

Admission webhooks may not add `Details` into the admission invalid error, e.g.:
```golang
review.Response = &admv1beta1.AdmissionResponse{
  Result: &metav1.Status{
    Reason:  metav1.StatusReasonInvalid,
    Message: fmt.Sprintf("unexpected operation %s", review.Request.Operation),
  },
}
```

`kubectl` will panic when that happens:
```
$ kubectl create -f ~/test.yaml
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x11845eb]

goroutine 1 [running]:
k8s.io/kubernetes/pkg/kubectl/cmd/util.checkErr(0x1bb4ba0, 0xc00041a3c0, 0x19e9800)
	/usr/local/google/home/lantaol/workspace/src/k8s.io/oss-kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go:134 +0x17b
k8s.io/kubernetes/pkg/kubectl/cmd/util.CheckErr(...)
	/usr/local/google/home/lantaol/workspace/src/k8s.io/oss-kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/util/helpers.go:114
k8s.io/kubernetes/pkg/kubectl/cmd/create.NewCmdCreate.func1(0xc00032c000, 0xc0003d7340, 0x0, 0x2)
	/usr/local/google/home/lantaol/workspace/src/k8s.io/oss-kubernetes/_output/local/go/src/k8s.io/kubernetes/pkg/kubectl/cmd/create/create.go:114 +0x216
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).execute(0xc00032c000, 0xc0003d7320, 0x2, 0x2, 0xc00032c000, 0xc0003d7320)
	/usr/local/google/home/lantaol/workspace/src/k8s.io/oss-kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:760 +0x2ae
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).ExecuteC(0xc000142a00, 0x19e99e8, 0xc0000c6000, 0x4)
	/usr/local/google/home/lantaol/workspace/src/k8s.io/oss-kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:846 +0x2ec
k8s.io/kubernetes/vendor/github.com/spf13/cobra.(*Command).Execute(...)
	/usr/local/google/home/lantaol/workspace/src/k8s.io/oss-kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/github.com/spf13/cobra/command.go:794
```

@kubernetes/sig-cli-misc 

```release-note
none
```