### PR TITLE
Fix for SSH tunneler health check

### DIFF
--- a/pkg/master/tunneler/ssh.go
+++ b/pkg/master/tunneler/ssh.go
@@ -157,9 +157,14 @@ func (c *SSHTunneler) SecondsSinceSync() int64 {
 }
 
 func (c *SSHTunneler) SecondsSinceSSHKeySync() int64 {
-	now := c.clock.Now().Unix()
-	then := atomic.LoadInt64(&c.lastSSHKeySync)
-	return now - then
+	// If the CCM doesn't support installing SSH keys this function will eventually cause
+	// the health check to fail because the time is never updated.
+	if c.InstallSSHKey != nil {
+		now := c.clock.Now().Unix()
+		then := atomic.LoadInt64(&c.lastSSHKeySync)
+		return now - then
+	}
+	return 0
 }
 
 func (c *SSHTunneler) installSSHKeySyncLoop(user, publicKeyfile string) {

--- a/pkg/master/tunneler/ssh.go
+++ b/pkg/master/tunneler/ssh.go
@@ -157,8 +157,8 @@ func (c *SSHTunneler) SecondsSinceSync() int64 {
 }
 
 func (c *SSHTunneler) SecondsSinceSSHKeySync() int64 {
-	// If the CCM doesn't support installing SSH keys this function will eventually cause
-	// the health check to fail because the time is never updated.
+	// If the cloud-provider doesn't support installing SSH keys this function will
+	// eventually cause the health check to fail because the time is never updated.
 	if c.InstallSSHKey != nil {
 		now := c.clock.Now().Unix()
 		then := atomic.LoadInt64(&c.lastSSHKeySync)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

If the cloud-provider is external or doesn't support installing SSH keys and the api server is configured to use the SSH tunneler, the health check will always fail. This patch will fix the health check by basically skipping to verify the last SSH key sync time when syncing SSH keys is not supported.

I know that the SSH tunneler is deprecated, but I need it until the newer proxy solution is ready. 

Fixes one mentioned problem of #59347

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Skip SSH key sync verification during health check if SSH tunneling is enabled and syncing SSH keys is not supported.
```