### PR TITLE
Updated ContextData and PluginContext with Clone methods.

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -43,6 +43,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "context_test.go",
         "framework_test.go",
         "interface_test.go",
         "registry_test.go",

--- a/pkg/scheduler/framework/v1alpha1/context.go
+++ b/pkg/scheduler/framework/v1alpha1/context.go
@@ -27,7 +27,12 @@ const (
 )
 
 // ContextData is a generic type for arbitrary data stored in PluginContext.
-type ContextData interface{}
+type ContextData interface {
+	// Clone is an interface to make a copy of ContextData. For performance reasons,
+	// clone should make shallow copies for members (e.g., slices or maps) that are not
+	// impacted by PreFilter's optional AddPod/RemovePod methods.
+	Clone() ContextData
+}
 
 // ContextKey is the type of keys stored in PluginContext.
 type ContextKey string
@@ -46,6 +51,15 @@ func NewPluginContext() *PluginContext {
 	return &PluginContext{
 		storage: make(map[ContextKey]ContextData),
 	}
+}
+
+// Clone creates a copy of PluginContext and returns its pointer.
+func (c *PluginContext) Clone() *PluginContext {
+	copy := NewPluginContext()
+	for k, v := range c.storage {
+		copy.Write(k, v.Clone())
+	}
+	return copy
 }
 
 // Read retrieves data with the given "key" from PluginContext. If the key is not

--- a/pkg/scheduler/framework/v1alpha1/context_test.go
+++ b/pkg/scheduler/framework/v1alpha1/context_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+)
+
+type fakeData struct {
+	data string
+}
+
+func (f *fakeData) Clone() ContextData {
+	copy := &fakeData{
+		data: f.data,
+	}
+	return copy
+}
+
+func TestPluginContextClone(t *testing.T) {
+	var key ContextKey = "key"
+	data1 := "value1"
+	data2 := "value2"
+
+	pc := NewPluginContext()
+	originalValue := &fakeData{
+		data: data1,
+	}
+	pc.Write(key, originalValue)
+	pcCopy := pc.Clone()
+
+	valueCopy, err := pcCopy.Read(key)
+	if err != nil {
+		t.Errorf("failed to read copied value: %v", err)
+	}
+	if v, ok := valueCopy.(*fakeData); ok && v.data != data1 {
+		t.Errorf("clone failed, got %q, expected %q", v.data, data1)
+	}
+
+	originalValue.data = data2
+	original, err := pc.Read(key)
+	if err != nil {
+		t.Errorf("failed to read original value: %v", err)
+	}
+	if v, ok := original.(*fakeData); ok && v.data != data2 {
+		t.Errorf("original value should change, got %q, expected %q", v.data, data2)
+	}
+
+	if v, ok := valueCopy.(*fakeData); ok && v.data != data1 {
+		t.Errorf("cloned copy should not change, got %q, expected %q", v.data, data1)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind feature

**What this PR does / why we need it**:
Adds ContextData and PluginContext in the scheduling framework. This is necessary to be able to clone PluginContext during preemption.


**Which issue(s) this PR fixes**:
Part of #82897

-->
```release-note
Added Clone method to the scheduling framework's PluginContext and ContextData.
```

/sig scheduling
/assign @Huang-Wei @alculquicondor 