### PR TITLE
Automated cherry pick of #78498: fix bug that awsSDKGO expect nil instead empty slice for

### DIFF
--- a/pkg/cloudprovider/providers/aws/instances.go
+++ b/pkg/cloudprovider/providers/aws/instances.go
@@ -158,7 +158,7 @@ func (c *instanceCache) describeAllInstancesUncached() (*allInstancesSnapshot, e
 
 	klog.V(4).Infof("EC2 DescribeInstances - fetching all instances")
 
-	filters := []*ec2.Filter{}
+	var filters []*ec2.Filter
 	instances, err := c.cloud.describeInstances(filters)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Cherry pick of #78498 on release-1.14.

#78498: fix bug that awsSDKGO expect nil instead empty slice for

```release-note
Fix bug that AWS ELB fails to register instances.
```