### PR TITLE
Bind kube-proxy containers to linux nodes to avoid Windows scheduling

### DIFF
--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -26,6 +26,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node.kubernetes.io/kube-proxy-ds-ready: "true"
+        beta.kubernetes.io/os: linux
       tolerations:
       - operator: "Exists"
         effect: "NoExecute"


### PR DESCRIPTION
**What this PR does / why we need it**:

Windows worker nodes run kube-proxy as a Windows service.
In the future the kube-proxy DaemonSet might run on Windows nodes
too, but for now a temporary measure is needed to disable it.

Add a linux node selector in the kube-proxy yaml spec.
Similar was done already for CoreDNS.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubeadm: disable the kube-proxy DaemonSet on non-Linux nodes. This step is required to support Windows worker nodes.
```
/kind cleanup
/kind bug
/priority important-longterm
@kubernetes/sig-cluster-lifecycle-pr-reviews
/assign @timothysc @fabriziopandini @MrHohn
cc @PatrickLang