### PR TITLE
Check error return from WaitForCacheSync

### DIFF
--- a/pkg/volume/csi/csi_plugin.go
+++ b/pkg/volume/csi/csi_plugin.go
@@ -60,8 +60,6 @@ const (
 	CsiResyncPeriod = time.Minute
 )
 
-var deprecatedSocketDirVersions = []string{"0.1.0", "0.2.0", "0.3.0", "0.4.0"}
-
 type csiPlugin struct {
 	host            volume.VolumeHost
 	blockEnabled    bool
@@ -745,7 +743,9 @@ func (p *csiPlugin) skipAttach(driver string) (bool, error) {
 
 	kletHost, ok := p.host.(volume.KubeletVolumeHost)
 	if ok {
-		kletHost.WaitForCacheSync()
+		if err := kletHost.WaitForCacheSync(); err != nil {
+			return false, err
+		}
 	}
 
 	if p.csiDriverLister == nil {
@@ -784,7 +784,9 @@ func (p *csiPlugin) supportsVolumeLifecycleMode(driver string, volumeMode storag
 	if p.csiDriverLister != nil {
 		kletHost, ok := p.host.(volume.KubeletVolumeHost)
 		if ok {
-			kletHost.WaitForCacheSync()
+			if err := kletHost.WaitForCacheSync(); err != nil {
+				return err
+			}
 		}
 
 		c, err := p.csiDriverLister.Get(driver)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In csiPlugin#supportsVolumeLifecycleMode, the return value from WaitForCacheSync is ignored.

If the cache sync doesn't go through, subsequent logic may give wrong result.

Also removed unused variable deprecatedSocketDirVersions.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
