### PR TITLE
update images to Debian buster, detect iptables mode

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -94,8 +94,8 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
-  local debian_base_version=v1.0.0
-  local debian_iptables_version=v11.0.2
+  local debian_base_version=v2.0.0
+  local debian_iptables_version=v12.0.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(

--- a/build/common.sh
+++ b/build/common.sh
@@ -95,7 +95,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
   local debian_base_version=v2.0.0
-  local debian_iptables_version=v12.0.0
+  local debian_iptables_version=v12.0.1
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(

--- a/build/debian-base/Dockerfile.build
+++ b/build/debian-base/Dockerfile.build
@@ -41,28 +41,14 @@ RUN apt-mark hold apt gnupg adduser passwd libsemanage1 libcap2
 # Several utilities (e.g. ping) were kept for usefulness, but may be removed in later versions.
 RUN echo "Yes, do as I say!" | apt-get purge \
     bash \
-    debconf-i18n \
-    e2fslibs \
     e2fsprogs \
-    init \
-    initscripts \
     libcap2-bin \
-    libkmod2 \
     libmount1 \
     libsmartcols1 \
-    libudev1 \
     libblkid1 \
-    libncursesw5 \
-    libprocps6 \
-    libslang2 \
     libss2 \
-    libsystemd0 \
-    libtext-charwidth-perl libtext-iconv-perl libtext-wrapi18n-perl \
     ncurses-base \
     ncurses-bin \
-    systemd \
-    systemd-sysv \
-    sysv-rc \
     tzdata
 
 # No-op stubs replace some unnecessary binaries that may be depended on in the install process (in

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -18,7 +18,7 @@ REGISTRY ?= staging-k8s.gcr.io
 IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 
-TAG ?= v1.0.0
+TAG ?= v2.0.0
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64
@@ -33,22 +33,22 @@ SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
 export DOCKER_CLI_EXPERIMENTAL := enabled
 
 ifeq ($(ARCH),amd64)
-	BASEIMAGE?=debian:stretch
+	BASEIMAGE?=debian:buster-slim
 endif
 ifeq ($(ARCH),arm)
-	BASEIMAGE?=arm32v7/debian:stretch
+	BASEIMAGE?=arm32v7/debian:buster-slim
 	QEMUARCH=arm
 endif
 ifeq ($(ARCH),arm64)
-	BASEIMAGE?=arm64v8/debian:stretch
+	BASEIMAGE?=arm64v8/debian:buster-slim
 	QEMUARCH=aarch64
 endif
 ifeq ($(ARCH),ppc64le)
-	BASEIMAGE?=ppc64le/debian:stretch
+	BASEIMAGE?=ppc64le/debian:buster-slim
 	QEMUARCH=ppc64le
 endif
 ifeq ($(ARCH),s390x)
-	BASEIMAGE?=s390x/debian:stretch
+	BASEIMAGE?=s390x/debian:buster-slim
 	QEMUARCH=s390x
 endif
 

--- a/build/debian-iptables/Dockerfile
+++ b/build/debian-iptables/Dockerfile
@@ -14,10 +14,28 @@
 
 FROM BASEIMAGE
 
+# Install latest iptables package from buster-backports
+RUN echo deb http://deb.debian.org/debian buster-backports main >> /etc/apt/sources.list; \
+    apt-get update; \
+    apt-get -t buster-backports -y --no-install-recommends install iptables
+
+# Install other dependencies and then clean up apt caches
 RUN clean-install \
     conntrack \
     ebtables \
     ipset \
-    iptables \
     kmod \
     netbase
+
+# Install iptables wrapper scripts to detect the correct iptables mode
+# the first time any of them is run
+COPY iptables-wrapper /usr/sbin/iptables-wrapper
+
+RUN update-alternatives \
+	--install /usr/sbin/iptables iptables /usr/sbin/iptables-wrapper 100 \
+	--slave /usr/sbin/iptables-restore iptables-restore /usr/sbin/iptables-wrapper \
+	--slave /usr/sbin/iptables-save iptables-save /usr/sbin/iptables-wrapper
+RUN update-alternatives \
+	--install /usr/sbin/ip6tables ip6tables /usr/sbin/iptables-wrapper 100 \
+	--slave /usr/sbin/ip6tables-restore ip6tables-restore /usr/sbin/iptables-wrapper \
+	--slave /usr/sbin/ip6tables-save ip6tables-save /usr/sbin/iptables-wrapper

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,12 +16,12 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=$(REGISTRY)/debian-iptables
-TAG?=v11.0.2
+TAG?=v12.0.0
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)
 
-BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
+BASEIMAGE?=k8s.gcr.io/debian-base-$(ARCH):v2.0.0
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="staging-k8s.gcr.io"
 IMAGE=$(REGISTRY)/debian-iptables
-TAG?=v12.0.0
+TAG?=v12.0.1
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-iptables/iptables-wrapper
+++ b/build/debian-iptables/iptables-wrapper
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Detect whether the base system is using iptables-legacy or
+# iptables-nft. This assumes that some non-containerized process (eg
+# kubelet) has already created some iptables rules.
+num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+num_nft_lines=$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+    mode=legacy
+else
+    mode=nft
+fi
+
+update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null
+update-alternatives --set ip6tables "/usr/sbin/ip6tables-${mode}" > /dev/null
+
+# Now re-exec the original command with the newly-selected alternative
+exec "$0" "$@"

--- a/build/debian-iptables/iptables-wrapper
+++ b/build/debian-iptables/iptables-wrapper
@@ -19,12 +19,22 @@ set -e
 # Detect whether the base system is using iptables-legacy or
 # iptables-nft. This assumes that some non-containerized process (eg
 # kubelet) has already created some iptables rules.
+
+# Bugs in iptables-nft 1.8.3 may cause it to get stuck in a loop in
+# some circumstances, so we have to run the nft check in a timeout. To
+# avoid hitting that timeout, we only bother to even check nft if
+# legacy iptables was empty / mostly empty.
+
 num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
-num_nft_lines=$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
-if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+if [ "${num_legacy_lines}" -ge 10 ]; then
     mode=legacy
 else
-    mode=nft
+    num_nft_lines=$( (timeout 5 sh -c "iptables-nft-save; ip6tables-nft-save" || true) 2>/dev/null | grep '^-' | wc -l)
+    if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+	mode=legacy
+    else
+	mode=nft
+    fi
 fi
 
 update-alternatives --set iptables "/usr/sbin/iptables-${mode}" > /dev/null

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -82,12 +82,12 @@ _DEBIAN_BASE_DIGEST = {
 }
 
 _DEBIAN_IPTABLES_DIGEST = {
-    "manifest": "sha256:f6ba11114c271a0dfb45ac7b7ab4e70539de6d9b270cf97880df08c2bef5b7db",
-    "amd64": "sha256:1d3e860f05352ffaa67533abbe9b7529a894c8ba6f7b47b9279f1940b0414ad5",
-    "arm": "sha256:fd5df8611e9d8e6ce5a65bac0e534254459beabe38cdf406e67b52e4bfee0276",
-    "arm64": "sha256:956d737ef34ff799b2f56596be67bf59b5894851cef1ce573a85d56549eabbd6",
-    "ppc64le": "sha256:bb6f6f73cba298fd9e8eda9e9643c2f61cda8439fe96f9a20cdec0f54fe4c597",
-    "s390x": "sha256:7d061ebb9a97ec1ffce68a26ded81483293d26d08d475719f41fedecf2821a18",
+    "manifest": "sha256:d1cd487e89fb4cba853cd3a948a6e9016faf66f2a7bb53cb1ac6b6c9cb58f5ed",
+    "amd64": "sha256:852d3c569932059bcab3a52cb6105c432d85b4b7bbd5fc93153b78010e34a783",
+    "arm": "sha256:c10f01b414a7cd4b2f3e26e152c90c64a1e781d99f83a6809764cf74ecbc46c3",
+    "arm64": "sha256:5725e6fde13a6405cf800e22846ebd2bde24b0860f1dc3f6f5f256f03cfa85bd",
+    "ppc64le": "sha256:b6d6e56a0c34c0393dcba0d5faaa531b92e5876114c5ab5a90e82e4889724c5a",
+    "s390x": "sha256:39e67e9bf25d67fe35bd9dcb25367277e5967368e02f2741e0efd4ce8874db14",
 }
 
 _DEBIAN_HYPERKUBE_BASE_DIGEST = {

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -113,7 +113,7 @@ def debian_image_dependencies():
             digest = _digest(_DEBIAN_BASE_DIGEST, arch),
             registry = "k8s.gcr.io",
             repository = "debian-base",
-            tag = "0.4.1",  # ignored, but kept here for documentation
+            tag = "v2.0.0",  # ignored, but kept here for documentation
         )
 
         container_pull(
@@ -122,7 +122,7 @@ def debian_image_dependencies():
             digest = _digest(_DEBIAN_IPTABLES_DIGEST, arch),
             registry = "k8s.gcr.io",
             repository = "debian-iptables",
-            tag = "v11.0.2",  # ignored, but kept here for documentation
+            tag = "v12.0.0",  # ignored, but kept here for documentation
         )
 
         container_pull(

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -73,12 +73,12 @@ def cri_tarballs():
 
 # Use go get -u github.com/estesp/manifest-tool to find these values
 _DEBIAN_BASE_DIGEST = {
-    "manifest": "sha256:6966a0aedd7592c18ff2dd803c08bd85780ee19f5e3a2e7cf908a4cd837afcde",
-    "amd64": "sha256:8ccb65cd2dd7e0c24193d0742a20e4a673dbd11af5a33f16fcd471a31486866c",
-    "arm": "sha256:3432b41de3f6dfffdc1386fce961cfd1f9f8e208b3a35070e10ef3e2a733cb17",
-    "arm64": "sha256:9189251e1d1eb4126d6e6add2e272338f9c8a6a3db38863044625bca4b667f31",
-    "ppc64le": "sha256:50aa659e1e75e4231ee8293c3b4115e5755bb0517142b9b4bddbc134bf4354db",
-    "s390x": "sha256:bbb8ee3a2aaca738c00809f450233d98029fea4e319d8faaa30aa94c8b17a806",
+    "manifest": "sha256:ebda8587ec0f49eb88ee3a608ef018484908cbc5aa32556a0d78356088c185d4",
+    "amd64": "sha256:d7be39e143d4e6677a28c81c0a84868b40800fc979dea1848bb19d526668a00c",
+    "arm": "sha256:fc731da13b0bc9013b85a86b583fc92e50869b5bc8e7aa6ca730ec0240954c7d",
+    "arm64": "sha256:12502c3eed050fa9b6d5fe353a44bfc5f437dc325c8912b1a48dcc180df36f1e",
+    "ppc64le": "sha256:4277aa59b63c5a1369e6d84a295ecc4ffa08985dcf114de9f7b6de1af4fcbc86",
+    "s390x": "sha256:78ef2a6b017539379c1654b4e52ba8519bfec821c62d0b3a1dbd15104b711e21",
 }
 
 _DEBIAN_IPTABLES_DIGEST = {

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -122,7 +122,7 @@ def debian_image_dependencies():
             digest = _digest(_DEBIAN_IPTABLES_DIGEST, arch),
             registry = "k8s.gcr.io",
             repository = "debian-iptables",
-            tag = "v12.0.0",  # ignored, but kept here for documentation
+            tag = "v12.0.1",  # ignored, but kept here for documentation
         )
 
         container_pull(

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -82,12 +82,12 @@ _DEBIAN_BASE_DIGEST = {
 }
 
 _DEBIAN_IPTABLES_DIGEST = {
-    "manifest": "sha256:b522b0035dba3ac2d5c0dbaaf8217bd66248e790332ccfdf653e0f943a280dcf",
-    "amd64": "sha256:adc40e9ec817c15d35b26d1d6aa4d0f8096fba4c99e26a026159bb0bc98c6a89",
-    "arm": "sha256:58e8a1d3b187eed2d8d3664cd1c9723e5029698714a24dfca4b6ef42ea27a9d4",
-    "arm64": "sha256:1a63fdd216fe7b84561d40ab1ebaa0daae1fc73e4232a6caffbd8353d9a14cea",
-    "ppc64le": "sha256:9f90adbc7513cc96d92fcec7633c4b29e766dd31cf876af03c0b54374e22fa9c",
-    "s390x": "sha256:4f147708deff2a0163ee49b6980cc95423514bec5f4091612d65773b898fbdae",
+    "manifest": "sha256:f6ba11114c271a0dfb45ac7b7ab4e70539de6d9b270cf97880df08c2bef5b7db",
+    "amd64": "sha256:1d3e860f05352ffaa67533abbe9b7529a894c8ba6f7b47b9279f1940b0414ad5",
+    "arm": "sha256:fd5df8611e9d8e6ce5a65bac0e534254459beabe38cdf406e67b52e4bfee0276",
+    "arm64": "sha256:956d737ef34ff799b2f56596be67bf59b5894851cef1ce573a85d56549eabbd6",
+    "ppc64le": "sha256:bb6f6f73cba298fd9e8eda9e9643c2f61cda8439fe96f9a20cdec0f54fe4c597",
+    "s390x": "sha256:7d061ebb9a97ec1ffce68a26ded81483293d26d08d475719f41fedecf2821a18",
 }
 
 _DEBIAN_HYPERKUBE_BASE_DIGEST = {


### PR DESCRIPTION
**What this PR does / why we need it**:
On systems running iptables 1.8, containers that run iptables in the root network namespace (such as our kube-proxy image) need to run iptables in the same mode (legacy / nft) as the base system. As of 1.16 our solution was "you have to run the base system in legacy mode"; this makes us able to support either mode (and provides a template for other image creators to follow, although we'll want to provide some slightly-more-generic scripts for them eventually).

**Which issue(s) this PR fixes**:
Fixes #71305
Fixes #81729

**Does this PR introduce a user-facing change?**:
```release-note
The official kube-proxy image (used by kubeadm, among other things) is now
compatible with systems running iptables 1.8 in "nft" mode, and will autodetect
which mode it should use.
```

/kind feature
/sig network
/priority important-soon