### PR TITLE
add-label flag for create configmap

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -53,11 +53,11 @@ var (
 		  # Create a new configmap named my-config from the key=value pairs in the file
 		  kubectl create configmap my-config --from-file=path/to/bar
 
-		  # Create a new configmap named my-config and add labels
-		  kubectl create configmap my-config --from-file=path/to/bar --add-label=key1=value1 --add-label=key2=value2
-
 		  # Create a new configmap named my-config from an env file
-		  kubectl create configmap my-config --from-env-file=path/to/bar.env`))
+		  kubectl create configmap my-config --from-env-file=path/to/bar.env
+
+		  # Create a new configmap named my-config and add labels
+		  kubectl create configmap my-config --from-file=path/to/bar --add-label=key1=value1 --add-label=key2=value2`))
 )
 
 // ConfigMapOpts holds properties for create configmap sub-command

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -29,7 +29,7 @@ import (
 
 var (
 	configMapLong = templates.LongDesc(i18n.T(`
-		Create a configmap based on a file, directory, or specified literal value.
+		Create as configmap based on a file, directory, or specified literal value.
 
 		A single configmap may package one or more key/value pairs.
 
@@ -53,6 +53,9 @@ var (
 		  # Create a new configmap named my-config from the key=value pairs in the file
 		  kubectl create configmap my-config --from-file=path/to/bar
 
+		  # Create a new configmap named my-config and add labels
+		  kubectl create configmap my-config --from-file=path/to/bar --add-label=key1=value1 --add-label=key2=value2
+
 		  # Create a new configmap named my-config from an env file
 		  kubectl create configmap my-config --from-env-file=path/to/bar.env`))
 )
@@ -69,7 +72,7 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]",
+		Use: "configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"cm"},
 		Short:                 i18n.T("Create a configmap from a local file, directory or literal value"),
@@ -90,6 +93,8 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	cmd.Flags().StringArray("from-literal", []string{}, "Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)")
 	cmd.Flags().String("from-env-file", "", "Specify the path to a file to read lines of key=val pairs to create a configmap (i.e. a Docker .env file).")
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the configmap to its name.")
+	cmd.Flags().StringSlice("add-label", []string{}, "Add a label as key=val pair.")
+
 	return cmd
 }
 
@@ -109,6 +114,7 @@ func (o *ConfigMapOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []s
 			LiteralSources: cmdutil.GetFlagStringArray(cmd, "from-literal"),
 			EnvFileSource:  cmdutil.GetFlagString(cmd, "from-env-file"),
 			AppendHash:     cmdutil.GetFlagBool(cmd, "append-hash"),
+			AddLabels:      cmdutil.GetFlagStringSlice(cmd, "add-label"),
 		}
 	default:
 		return errUnsupportedGenerator(cmd, generatorName)

--- a/staging/src/k8s.io/kubectl/pkg/util/util.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/util.go
@@ -91,3 +91,9 @@ func ParseLiteralSource(source string) (keyName, value string, err error) {
 
 	return items[0], items[1], nil
 }
+
+// ParseLabel see ParseLiteralSource.
+func ParseLabel(source string) (keyName, value string, err error) {
+
+	return ParseLiteralSource(source)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Allow setting labels when running kubectl create configmap.

Create a new configmap with labels 
`kubectl create configmap my-config --from-env-file=file --add-label=k1=v1 --add-label=k2=v2`
`kubectl create configmap my-config --from-file=file --add-label=k1=v1 --add-label=k2=v2`
`kubectl create configmap my-config --from-literal=key1=config1 --add-label=k1=v1 --add-label=k2=v2`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #60295

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
This PR introduces a new flag `--add-label` for the command `kubectl create configmap`
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
This PR makes the creation of configmaps that contain labels easier by using only one command, instead of:
- labelling the configmap after the creation (2 commands)
- adding the labels manually in the manifest (2 commands)

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
