### PR TITLE
Bind kubernetes dashboard containers to linux nodes to avoid Windows scheduling

### DIFF
--- a/cluster/addons/dashboard/dashboard-controller.yaml
+++ b/cluster/addons/dashboard/dashboard-controller.yaml
@@ -62,6 +62,8 @@ spec:
       - name: tmp-volume
         emptyDir: {}
       serviceAccountName: kubernetes-dashboard
+      nodeSelector:
+        "beta.kubernetes.io/os": linux
       tolerations:
       - key: "CriticalAddonsOnly"
         operator: "Exists"

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -26,7 +26,6 @@ spec:
       hostNetwork: true
       nodeSelector:
         node.kubernetes.io/kube-proxy-ds-ready: "true"
-        beta.kubernetes.io/os: linux
       tolerations:
       - operator: "Exists"
         effect: "NoExecute"

--- a/cluster/addons/kube-proxy/kube-proxy-ds.yaml
+++ b/cluster/addons/kube-proxy/kube-proxy-ds.yaml
@@ -26,6 +26,7 @@ spec:
       hostNetwork: true
       nodeSelector:
         node.kubernetes.io/kube-proxy-ds-ready: "true"
+        beta.kubernetes.io/os: linux
       tolerations:
       - operator: "Exists"
         effect: "NoExecute"


### PR DESCRIPTION
**What this PR does / why we need it**:

Add node selectors to support clustes with windows nodes.

Similar as the offical yaml

https://github.com/kubernetes/dashboard/blob/dd6f294b40242fa846a2a4d17e91bd2e40f23afa/aio/deploy/recommended/08_scraper-deployment.yaml#L57


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
dashboard: disable the dashboard Deployment on non-Linux nodes. This step is required to support Windows worker nodes.
```
/kind cleanup
/priority important-longterm
@kubernetes/sig-cluster-lifecycle-pr-reviews
/assign @bryk @floreks @maciaszczykm @rf232