### PR TITLE
Automated cherry pick of #82873: Fix closing of dirs in doSafeMakeDir

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/util/mount/mount_linux.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/util/mount/mount_linux.go
@@ -1132,7 +1132,7 @@ func doSafeMakeDir(pathname string, base string, perm os.FileMode) error {
 			return fmt.Errorf("cannot create directory %s: %s", currentPath, err)
 		}
 		// Dive into the created directory
-		childFD, err := syscall.Openat(parentFD, dir, nofollowFlags, 0)
+		childFD, err = syscall.Openat(parentFD, dir, nofollowFlags, 0)
 		if err != nil {
 			return fmt.Errorf("cannot open %s: %s", currentPath, err)
 		}


### PR DESCRIPTION
Cherry pick of #82873 on release-1.16.

#82873: Fix closing of dirs in doSafeMakeDir

```release-note
Fix possible fd leak and closing of dirs when using openstack
```