### PR TITLE
fix: kubectl label output msg.

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/BUILD
@@ -36,6 +36,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/BUILD
@@ -37,6 +37,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

the output from `kubectl label` command is a bit confusing when user deletes label, it prints `labeled` rather than something like `unlabeled`.

In this PR, if
 - only adding new labels, prints `labeled`
 - only deleting new labels, prints `unlabeled`
 - both adding and deleting labels, prints `modified`
 - otherwise, `not labeled`

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
