### PR TITLE
Feature/create resource with labels

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -60,6 +60,7 @@ type CreateOptions struct {
 	Selector         string
 	EditBeforeCreate bool
 	Raw              string
+	Labels           string
 
 	Recorder genericclioptions.Recorder
 	PrintObj func(obj kruntime.Object) error
@@ -133,6 +134,7 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to POST to the server.  Uses the transport specified by the kubeconfig file.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
 
 	o.PrintFlags.AddFlags(cmd)
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -67,6 +67,8 @@ type CreateClusterRoleOptions struct {
 	NonResourceURLs []string
 	AggregationRule map[string]string
 	FieldManager    string
+	// Labels to assign to the ClusterRole (optional)
+	Labels string
 }
 
 // NewCmdCreateClusterRole initializes and returns new ClusterRoles command
@@ -99,6 +101,7 @@ func NewCmdCreateClusterRole(f cmdutil.Factory, ioStreams genericclioptions.IOSt
 	cmd.Flags().StringArrayVar(&c.ResourceNames, "resource-name", c.ResourceNames, "Resource in the white list that the rule applies to, repeat this flag for multiple items")
 	cmd.Flags().Var(cliflag.NewMapStringString(&c.AggregationRule), "aggregation-rule", "An aggregation label selector for combining ClusterRoles.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &c.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &c.Labels)
 
 	return cmd
 }
@@ -187,6 +190,11 @@ func (c *CreateClusterRoleOptions) RunCreateRole() error {
 	clusterRole.Name = c.Name
 
 	var err error
+	clusterRole.Labels, err = cmdutil.ParseLabels(c.Labels)
+	if err != nil {
+		return err
+	}
+
 	if len(c.AggregationRule) == 0 {
 		rules, err := generateResourcePolicyRules(c.Mapper, c.Verbs, c.Resources, c.ResourceNames, c.NonResourceURLs)
 		if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole_test.go
@@ -45,6 +45,7 @@ func TestCreateClusterRole(t *testing.T) {
 		resourceNames       string
 		aggregationRule     string
 		expectedClusterRole *rbac.ClusterRole
+		labels              string
 	}{
 		"test-duplicate-resources": {
 			verbs:     "get,watch,list",
@@ -146,6 +147,30 @@ func TestCreateClusterRole(t *testing.T) {
 				},
 			},
 		},
+		"create_clusterrole_with_label_multiple_labels": {
+			verbs:     "get,watch,list",
+			resources: "pods",
+			labels:    "key1=val1,key2=val2,key3=val3",
+			expectedClusterRole: &rbac.ClusterRole{
+				TypeMeta: metav1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "ClusterRole"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: clusterRoleName,
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
+				},
+				Rules: []rbac.PolicyRule{
+					{
+						Verbs:         []string{"get", "watch", "list"},
+						Resources:     []string{"pods"},
+						APIGroups:     []string{""},
+						ResourceNames: []string{},
+					},
+				},
+			},
+		},
 	}
 
 	for name, test := range tests {
@@ -157,6 +182,7 @@ func TestCreateClusterRole(t *testing.T) {
 		cmd.Flags().Set("resource", test.resources)
 		cmd.Flags().Set("non-resource-url", test.nonResourceURL)
 		cmd.Flags().Set("aggregation-rule", test.aggregationRule)
+		cmd.Flags().Set("label", test.labels)
 		if test.resourceNames != "" {
 			cmd.Flags().Set("resource-name", test.resourceNames)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -57,6 +57,8 @@ type ClusterRoleBindingOptions struct {
 	ServiceAccounts  []string
 	FieldManager     string
 	CreateAnnotation bool
+	// Labels to assign to the ClusterRoleBinding (optional)
+	Labels string
 
 	Client         rbacclientv1.RbacV1Interface
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -104,6 +106,8 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptio
 	cmd.Flags().StringArrayVar(&o.Groups, "group", o.Groups, "Groups to bind to the clusterrole")
 	cmd.Flags().StringArrayVar(&o.ServiceAccounts, "serviceaccount", o.ServiceAccounts, "Service accounts to bind to the clusterrole, in the format <namespace>:<name>")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -188,6 +192,12 @@ func (o *ClusterRoleBindingOptions) createClusterRoleBinding() (*rbacv1.ClusterR
 			Kind:     "ClusterRole",
 			Name:     o.ClusterRole,
 		},
+	}
+
+	var err error
+	clusterRoleBinding.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
 	}
 
 	for _, user := range o.Users {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -90,6 +90,8 @@ type ConfigMapOptions struct {
 	EnvFileSource string
 	// AppendHash; if true, derive a hash from the ConfigMap and append it to the name
 	AppendHash bool
+	// Labels to assign to the ConfigMap (optional)
+	Labels string
 
 	FieldManager     string
 	CreateAnnotation bool
@@ -142,6 +144,8 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the configmap to its name.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
 
 	return cmd
 }
@@ -283,6 +287,12 @@ func (o *ConfigMapOptions) createConfigMap() (*corev1.ConfigMap, error) {
 			return nil, err
 		}
 		configMap.Name = fmt.Sprintf("%s-%s", configMap.Name, hash)
+	}
+
+	var err error
+	configMap.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
 	}
 
 	return configMap, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap_test.go
@@ -34,6 +34,7 @@ func TestCreateConfigMap(t *testing.T) {
 		fromLiteral   []string
 		fromFile      []string
 		fromEnvFile   string
+		labels        string
 		setup         func(t *testing.T, configMapOptions *ConfigMapOptions) func()
 
 		expected  *corev1.ConfigMap
@@ -395,6 +396,51 @@ func TestCreateConfigMap(t *testing.T) {
 			fromEnvFile:   "foo",
 			expectErr:     true,
 		},
+		"create_configmap_with_label": {
+			configMapName: "foo",
+			labels:        "key1=val1",
+			expected: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"key1": "val1",
+					},
+				},
+				Data:       map[string]string{},
+				BinaryData: map[string][]byte{},
+			},
+			expectErr: false,
+		},
+		"create_configmap_with_label_multiple_labels": {
+			configMapName: "foo",
+			labels:        "key1=val1,key2=val2,key3=val3",
+			expected: &corev1.ConfigMap{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "ConfigMap",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
+				},
+				Data:       map[string]string{},
+				BinaryData: map[string][]byte{},
+			},
+			expectErr: false,
+		},
+		"create_configmap_with_label_invalid_labels": {
+			configMapName: "foo",
+			labels:        "key1=val1,key2-val2,key3=val3",
+			expectErr:     true,
+		},
 	}
 
 	// run all the tests
@@ -407,6 +453,7 @@ func TestCreateConfigMap(t *testing.T) {
 				FileSources:    test.fromFile,
 				LiteralSources: test.fromLiteral,
 				EnvFileSource:  test.fromEnvFile,
+				Labels:         test.labels,
 			}
 
 			if test.setup != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
@@ -28,11 +28,13 @@ import (
 func TestCreateCronJob(t *testing.T) {
 	cronjobName := "test-job"
 	tests := map[string]struct {
-		image    string
-		command  []string
-		schedule string
-		restart  string
-		expected *batchv1.CronJob
+		image     string
+		command   []string
+		schedule  string
+		restart   string
+		labels    string
+		expected  *batchv1.CronJob
+		expectErr bool
 	}{
 		"just image and OnFailure restart policy": {
 			image:    "busybox",
@@ -100,6 +102,87 @@ func TestCreateCronJob(t *testing.T) {
 				},
 			},
 		},
+		"create configmap with label": {
+			image:    "busybox",
+			schedule: "0/5 * * * ?",
+			restart:  "OnFailure",
+			labels:   "key1=val1",
+			expected: &batchv1.CronJob{
+				TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "CronJob"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cronjobName,
+					Labels: map[string]string{
+						"key1": "val1",
+					},
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0/5 * * * ?",
+					JobTemplate: batchv1.JobTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: cronjobName,
+						},
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  cronjobName,
+											Image: "busybox",
+										},
+									},
+									RestartPolicy: corev1.RestartPolicyOnFailure,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"create configmap with multiple labels": {
+			image:    "busybox",
+			schedule: "0/5 * * * ?",
+			restart:  "OnFailure",
+			labels:   "key1=val1,key2=val2,key3=val3",
+			expected: &batchv1.CronJob{
+				TypeMeta: metav1.TypeMeta{APIVersion: batchv1.SchemeGroupVersion.String(), Kind: "CronJob"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: cronjobName,
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
+				},
+				Spec: batchv1.CronJobSpec{
+					Schedule: "0/5 * * * ?",
+					JobTemplate: batchv1.JobTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: cronjobName,
+						},
+						Spec: batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:  cronjobName,
+											Image: "busybox",
+										},
+									},
+									RestartPolicy: corev1.RestartPolicyOnFailure,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"create configmap with invalid labels": {
+			image:     "busybox",
+			schedule:  "0/5 * * * ?",
+			restart:   "OnFailure",
+			labels:    "key1=val1,key2-val2,key3=val3",
+			expectErr: true,
+		},
 	}
 
 	for name, tc := range tests {
@@ -110,8 +193,15 @@ func TestCreateCronJob(t *testing.T) {
 				Command:  tc.command,
 				Schedule: tc.schedule,
 				Restart:  tc.restart,
+				Labels:   tc.labels,
 			}
-			cronjob := o.createCronJob()
+			cronjob, err := o.createCronJob()
+			if !tc.expectErr && err != nil {
+				t.Errorf("test %s, unexpected error: %v", name, err)
+			}
+			if tc.expectErr && err == nil {
+				t.Errorf("test %s was expecting an error but no error occurred", name)
+			}
 			if !apiequality.Semantic.DeepEqual(cronjob, tc.expected) {
 				t.Errorf("expected:\n%#v\ngot:\n%#v", tc.expected, cronjob)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
@@ -56,6 +56,7 @@ func TestCreateDeployment(t *testing.T) {
 	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", "name")
 	cmd.Flags().Set("image", "hollywood/jonny.depp:v2")
+	cmd.Flags().Set("label", "k1=v1,k2=v2")
 	cmd.Run(cmd, []string{depName})
 	expectedOutput := "deployment.apps/" + depName + "\n"
 	if buf.String() != expectedOutput {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -68,6 +68,8 @@ type PodDisruptionBudgetOpts struct {
 	FieldManager     string
 	Namespace        string
 	EnforceNamespace bool
+	// Labels to assign to the PodDisruptionBudget (optional)
+	Labels string
 
 	Client         *policyclient.PolicyV1beta1Client
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -112,6 +114,8 @@ func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericcliopti
 	cmd.Flags().StringVar(&o.MaxUnavailable, "max-unavailable", o.MaxUnavailable, i18n.T("The maximum number or percentage of unavailable pods this budget requires."))
 	cmd.Flags().StringVar(&o.Selector, "selector", o.Selector, i18n.T("A label selector to use for this budget. Only equality-based selector requirements are supported."))
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -261,6 +265,11 @@ func (o *PodDisruptionBudgetOpts) createPodDisruptionBudgets() (*policyv1beta1.P
 	case len(o.MaxUnavailable) > 0:
 		maxUnavailable := intstr.Parse(o.MaxUnavailable)
 		podDisruptionBudget.Spec.MaxUnavailable = &maxUnavailable
+	}
+
+	podDisruptionBudget.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
 	}
 
 	return podDisruptionBudget, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb_test.go
@@ -96,6 +96,15 @@ func TestCreatePdbValidation(t *testing.T) {
 			},
 			expected: "",
 		},
+		"test-valid-with-labels": {
+			options: &PodDisruptionBudgetOpts{
+				Name:           "my-pdb",
+				Selector:       selectorOpts,
+				MaxUnavailable: podAmountNumber,
+				Labels:         "key1=val1,key2=val2,key3=val3",
+			},
+			expected: "",
+		},
 	}
 
 	for name, tc := range tests {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass_test.go
@@ -59,6 +59,7 @@ func TestCreatePriorityClass(t *testing.T) {
 	cmd.Flags().Set("dry-run", "client")
 	cmd.Flags().Set("output", outputFormat)
 	cmd.Flags().Set("preemption-policy", "Never")
+	cmd.Flags().Set("label", "k1=v1,k2=v2")
 
 	printFlags := genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme)
 	printFlags.OutputFormat = &outputFormat

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -64,6 +64,8 @@ type QuotaOpts struct {
 	FieldManager     string
 	Namespace        string
 	EnforceNamespace bool
+	// Labels to assign to the Quota (optional)
+	Labels string
 
 	Client         *coreclient.CoreV1Client
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -106,6 +108,8 @@ func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 	cmd.Flags().StringVar(&o.Hard, "hard", o.Hard, i18n.T("A comma-delimited set of resource=quantity pairs that define a hard limit."))
 	cmd.Flags().StringVar(&o.Scopes, "scopes", o.Scopes, i18n.T("A comma-delimited set of quota scopes that must all match each object tracked by the quota."))
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -220,6 +224,11 @@ func (o *QuotaOpts) createQuota() (*corev1.ResourceQuota, error) {
 
 	resourceQuota.Spec.Hard = resourceList
 	resourceQuota.Spec.Scopes = scopes
+
+	resourceQuota.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
+	}
 
 	return resourceQuota, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota_test.go
@@ -44,6 +44,7 @@ func TestCreateQuota(t *testing.T) {
 				Name:   "my-quota",
 				Hard:   hards[0],
 				Scopes: "",
+				Labels: "key1=val1,key2=val2,key3=val3",
 			},
 			expected: &corev1.ResourceQuota{
 				TypeMeta: metav1.TypeMeta{
@@ -52,6 +53,11 @@ func TestCreateQuota(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-quota",
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: resourceQuotaSpecLists[0],

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -138,6 +138,8 @@ type CreateRoleOptions struct {
 	PrintObj         func(obj runtime.Object) error
 	FieldManager     string
 	CreateAnnotation bool
+	// Labels to assign to the Role (optional)
+	Labels string
 
 	genericclioptions.IOStreams
 }
@@ -177,6 +179,8 @@ func NewCmdCreateRole(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) 
 	cmd.Flags().StringSlice("resource", []string{}, "Resource that the rule applies to")
 	cmd.Flags().StringArrayVar(&o.ResourceNames, "resource-name", o.ResourceNames, "Resource in the white list that the rule applies to, repeat this flag for multiple items")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -376,6 +380,11 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	role.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return err
 	}
 
 	return o.PrintObj(role)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -22,7 +22,7 @@ import (
 
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -44,16 +44,23 @@ func TestCreateRole(t *testing.T) {
 		verbs         string
 		resources     string
 		resourceNames string
+		labels        string
 		expectedRole  *rbac.Role
 	}{
 		"test-duplicate-resources": {
 			verbs:     "get,watch,list",
 			resources: "pods,pods",
+			labels:    "key1=val1,key2=val2,key3=val3",
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
 					Name:      roleName,
 					Namespace: testNameSpace,
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -138,6 +145,7 @@ func TestCreateRole(t *testing.T) {
 			cmd.Flags().Set("output", "yaml")
 			cmd.Flags().Set("verb", test.verbs)
 			cmd.Flags().Set("resource", test.resources)
+			cmd.Flags().Set("label", test.labels)
 			if test.resourceNames != "" {
 				cmd.Flags().Set("resource-name", test.resourceNames)
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -60,6 +60,8 @@ type RoleBindingOptions struct {
 	ServiceAccounts  []string
 	FieldManager     string
 	CreateAnnotation bool
+	// Labels to assign to the RoleBinding (optional)
+	Labels string
 
 	Client         rbacclientv1.RbacV1Interface
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -107,6 +109,8 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOSt
 	cmd.Flags().StringArrayVar(&o.Groups, "group", o.Groups, "Groups to bind to the role")
 	cmd.Flags().StringArrayVar(&o.ServiceAccounts, "serviceaccount", o.ServiceAccounts, "Service accounts to bind to the role, in the format <namespace>:<name>")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -249,5 +253,12 @@ func (o *RoleBindingOptions) createRoleBinding() (*rbacv1.RoleBinding, error) {
 			Name:      tokens[1],
 		})
 	}
+
+	var err error
+	roleBinding.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
+	}
+
 	return roleBinding, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding_test.go
@@ -22,7 +22,7 @@ import (
 
 	rbac "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestCreateRoleBinding(t *testing.T) {
@@ -37,6 +37,7 @@ func TestCreateRoleBinding(t *testing.T) {
 				Groups:          []string{"fake-group"},
 				ServiceAccounts: []string{"fake-namespace:fake-account"},
 				Name:            "fake-binding",
+				Labels:          "key1=val1,key2=val2,key3=val3",
 			},
 			expected: &rbac.RoleBinding{
 				TypeMeta: v1.TypeMeta{
@@ -45,6 +46,11 @@ func TestCreateRoleBinding(t *testing.T) {
 				},
 				ObjectMeta: v1.ObjectMeta{
 					Name: "fake-binding",
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 				RoleRef: rbac.RoleRef{
 					APIGroup: rbac.GroupName,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -111,6 +111,8 @@ type CreateSecretOptions struct {
 	CreateAnnotation bool
 	Namespace        string
 	EnforceNamespace bool
+	// Labels to assign to the Secret (optional)
+	Labels string
 
 	Client         corev1client.CoreV1Interface
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -156,6 +158,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericclioptions.IO
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the secret to its name.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
 
 	return cmd
 }
@@ -287,6 +290,12 @@ func (o *CreateSecretOptions) createSecret() (*corev1.Secret, error) {
 			return nil, err
 		}
 		secret.Name = fmt.Sprintf("%s-%s", secret.Name, hash)
+	}
+
+	var err error
+	secret.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
 	}
 
 	return secret, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker.go
@@ -107,6 +107,8 @@ type CreateSecretDockerRegistryOptions struct {
 	CreateAnnotation bool
 	Namespace        string
 	EnforceNamespace bool
+	// Labels to assign to the Secret (optional)
+	Labels string
 
 	Client         corev1client.CoreV1Interface
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -155,6 +157,7 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericcliopt
 	cmd.Flags().StringSliceVar(&o.FileSources, "from-file", o.FileSources, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
 
 	return cmd
 }
@@ -282,6 +285,12 @@ func (o *CreateSecretDockerRegistryOptions) createSecretDockerRegistry() (*corev
 			return nil, err
 		}
 		secretDockerRegistry.Name = fmt.Sprintf("%s-%s", secretDockerRegistry.Name, hash)
+	}
+
+	var err error
+	secretDockerRegistry.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
 	}
 	return secretDockerRegistry, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_docker_test.go
@@ -42,6 +42,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 		dockerPassword           string
 		dockerServer             string
 		appendHash               bool
+		labels                   string
 		expected                 *corev1.Secret
 		expectErr                bool
 	}{
@@ -51,6 +52,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 			dockerPassword:           password,
 			dockerEmail:              email,
 			dockerServer:             server,
+			labels:                   "key1=val1,key2=val2,key3=val3",
 			expected: &corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: corev1.SchemeGroupVersion.String(),
@@ -58,6 +60,11 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 				Type: corev1.SecretTypeDockerConfigJson,
 				Data: map[string][]byte{
@@ -165,6 +172,7 @@ func TestCreateSecretDockerRegistry(t *testing.T) {
 				Password:   test.dockerPassword,
 				Server:     test.dockerServer,
 				AppendHash: test.appendHash,
+				Labels:     test.labels,
 			}
 			err := secretDockerRegistryOptions.Validate()
 			if err == nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_test.go
@@ -55,6 +55,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 		fromFile    []string
 		fromEnvFile string
 		appendHash  bool
+		labels      string
 		setup       func(t *testing.T, secretGenericOptions *CreateSecretOptions) func()
 
 		expected  *corev1.Secret
@@ -62,6 +63,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 	}{
 		"create_secret_foo": {
 			secretName: "foo",
+			labels:     "key1=val1,key2=val2,key3=val3",
 			expected: &corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: corev1.SchemeGroupVersion.String(),
@@ -69,6 +71,11 @@ func TestCreateSecretGeneric(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 				Data: map[string][]byte{},
 			},
@@ -471,6 +478,7 @@ func TestCreateSecretGeneric(t *testing.T) {
 				FileSources:    test.fromFile,
 				LiteralSources: test.fromLiteral,
 				EnvFileSource:  test.fromEnvFile,
+				Labels:         test.labels,
 			}
 			if test.setup != nil {
 				if teardown := test.setup(t, &secretOptions); teardown != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls.go
@@ -68,6 +68,8 @@ type CreateSecretTLSOptions struct {
 	CreateAnnotation bool
 	Namespace        string
 	EnforceNamespace bool
+	// Labels to assign to the Secret (optional)
+	Labels string
 
 	Client         corev1client.CoreV1Interface
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -112,6 +114,7 @@ func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	cmd.Flags().BoolVar(&o.AppendHash, "append-hash", o.AppendHash, "Append a hash of the secret to its name.")
 
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
 
 	return cmd
 }
@@ -244,6 +247,11 @@ func (o *CreateSecretTLSOptions) createSecretTLS() (*corev1.Secret, error) {
 			return nil, err
 		}
 		secretTLS.Name = fmt.Sprintf("%s-%s", secretTLS.Name, hash)
+	}
+
+	secretTLS.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
 	}
 
 	return secretTLS, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret_tls_test.go
@@ -101,6 +101,7 @@ func TestCreateSecretTLS(t *testing.T) {
 		tlsKey        string
 		tlsCert       string
 		appendHash    bool
+		labels        string
 		expected      *corev1.Secret
 		expectErr     bool
 	}{
@@ -108,6 +109,7 @@ func TestCreateSecretTLS(t *testing.T) {
 			tlsSecretName: "foo",
 			tlsKey:        validKeyPath,
 			tlsCert:       validCertPath,
+			labels:        "key1=val1,key2=val2,key3=val3",
 			expected: &corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: corev1.SchemeGroupVersion.String(),
@@ -115,6 +117,11 @@ func TestCreateSecretTLS(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "foo",
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 				Type: corev1.SecretTypeTLS,
 				Data: map[string][]byte{
@@ -173,6 +180,7 @@ func TestCreateSecretTLS(t *testing.T) {
 				Key:        test.tlsKey,
 				Cert:       test.tlsCert,
 				AppendHash: test.appendHash,
+				Labels:     test.labels,
 			}
 			secretTLS, err := secretTLSOptions.createSecretTLS()
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -73,6 +73,8 @@ type ServiceOptions struct {
 	CreateAnnotation bool
 	Namespace        string
 	EnforceNamespace bool
+	// Labels to assign to the Service (optional)
+	Labels string
 
 	Client         corev1client.CoreV1Interface
 	DryRunStrategy cmdutil.DryRunStrategy
@@ -171,6 +173,15 @@ func (o *ServiceOptions) createService() (*corev1.Service, error) {
 	// setup default label and selector
 	labels := map[string]string{}
 	labels["app"] = o.Name
+
+	cliLabels, err := cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
+	}
+	for k, v := range cliLabels {
+		labels[k] = v
+	}
+
 	selector := map[string]string{}
 	selector["app"] = o.Name
 
@@ -263,6 +274,7 @@ func NewCmdCreateServiceClusterIP(f cmdutil.Factory, ioStreams genericclioptions
 	cmd.Flags().StringVar(&o.ClusterIP, "clusterip", o.ClusterIP, i18n.T("Assign your own ClusterIP or set to 'None' for a 'headless' service (no loadbalancing)."))
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
 
 	return cmd
 }
@@ -301,6 +313,8 @@ func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericclioptions.
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	cmd.Flags().StringSliceVar(&o.TCP, "tcp", o.TCP, "Port pairs can be specified as '<port>:<targetPort>'.")
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -337,6 +351,8 @@ func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, ioStreams genericcliopti
 	cmd.Flags().StringSliceVar(&o.TCP, "tcp", o.TCP, "Port pairs can be specified as '<port>:<targetPort>'.")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -379,6 +395,8 @@ func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericcliopti
 	cmd.MarkFlagRequired("external-name")
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service_test.go
@@ -37,6 +37,7 @@ func TestCreateServices(t *testing.T) {
 		clusterip    string
 		externalName string
 		nodeport     int
+		labels       string
 		expected     *v1.Service
 		expectErr    bool
 	}{
@@ -45,10 +46,16 @@ func TestCreateServices(t *testing.T) {
 			tcp:         []string{"456", "321:908"},
 			clusterip:   "",
 			serviceType: v1.ServiceTypeClusterIP,
+			labels:      "key1=val1,key2=val2,key3=val3",
 			expected: &v1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "clusterip-ok",
-					Labels: map[string]string{"app": "clusterip-ok"},
+					Name: "clusterip-ok",
+					Labels: map[string]string{
+						"app":  "clusterip-ok",
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 				Spec: v1.ServiceSpec{Type: "ClusterIP",
 					Ports: []v1.ServicePort{{Name: "456", Protocol: "TCP", Port: 456, TargetPort: intstr.IntOrString{Type: 0, IntVal: 456, StrVal: ""}, NodePort: 0},
@@ -250,6 +257,7 @@ func TestCreateServices(t *testing.T) {
 				ClusterIP:    tc.clusterip,
 				NodePort:     tc.nodeport,
 				ExternalName: tc.externalName,
+				Labels:       tc.labels,
 			}
 
 			var service *v1.Service

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
@@ -59,6 +59,8 @@ type ServiceAccountOpts struct {
 
 	Namespace        string
 	EnforceNamespace bool
+	// Labels to assign to the ServiceAccount (optional)
+	Labels string
 
 	Mapper meta.RESTMapper
 	Client *coreclient.CoreV1Client
@@ -98,6 +100,8 @@ func NewCmdCreateServiceAccount(f cmdutil.Factory, ioStreams genericclioptions.I
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
+	cmdutil.AddLabelFlagVar(cmd, &o.Labels)
+
 	return cmd
 }
 
@@ -200,5 +204,12 @@ func (o *ServiceAccountOpts) createServiceAccount() (*corev1.ServiceAccount, err
 		},
 	}
 	serviceAccount.Name = o.Name
+
+	var err error
+	serviceAccount.Labels, err = cmdutil.ParseLabels(o.Labels)
+	if err != nil {
+		return nil, err
+	}
+
 	return serviceAccount, nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount_test.go
@@ -31,7 +31,8 @@ func TestCreateServiceAccount(t *testing.T) {
 	}{
 		"service account": {
 			options: &ServiceAccountOpts{
-				Name: "my-service-account",
+				Name:   "my-service-account",
+				Labels: "key1=val1,key2=val2,key3=val3",
 			},
 			expected: &corev1.ServiceAccount{
 				TypeMeta: metav1.TypeMeta{
@@ -40,6 +41,11 @@ func TestCreateServiceAccount(t *testing.T) {
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "my-service-account",
+					Labels: map[string]string{
+						"key1": "val1",
+						"key2": "val2",
+						"key3": "val3",
+					},
 				},
 			},
 		},

--- a/staging/src/k8s.io/kubectl/pkg/generate/generate.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/generate.go
@@ -174,30 +174,6 @@ func ParseProtocols(protocols interface{}) (map[string]string, error) {
 	return portProtocolMap, nil
 }
 
-// ParseLabels turns a string representation of a label set into a map[string]string
-func ParseLabels(labelSpec interface{}) (map[string]string, error) {
-	labelString, isString := labelSpec.(string)
-	if !isString {
-		return nil, fmt.Errorf("expected string, found %v", labelSpec)
-	}
-	if len(labelString) == 0 {
-		return nil, fmt.Errorf("no label spec passed")
-	}
-	labels := map[string]string{}
-	labelSpecs := strings.Split(labelString, ",")
-	for ix := range labelSpecs {
-		labelSpec := strings.Split(labelSpecs[ix], "=")
-		if len(labelSpec) != 2 {
-			return nil, fmt.Errorf("unexpected label spec: %s", labelSpecs[ix])
-		}
-		if len(labelSpec[0]) == 0 {
-			return nil, fmt.Errorf("unexpected empty label key")
-		}
-		labels[labelSpec[0]] = labelSpec[1]
-	}
-	return labels, nil
-}
-
 func GetBool(params map[string]string, key string, defValue bool) (bool, error) {
 	if val, found := params[key]; !found {
 		return defValue, nil

--- a/staging/src/k8s.io/kubectl/pkg/generate/generate_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/generate_test.go
@@ -17,9 +17,7 @@ limitations under the License.
 package generate
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
@@ -264,95 +262,6 @@ func TestGetBool(t *testing.T) {
 				t.Errorf("%s: expect %v, got %v", tt.name, tt.expected, got)
 			}
 		})
-	}
-}
-
-func makeLabels(labels map[string]string) string {
-	out := []string{}
-	for key, value := range labels {
-		out = append(out, fmt.Sprintf("%s=%s", key, value))
-	}
-	return strings.Join(out, ",")
-}
-
-func TestMakeParseLabels(t *testing.T) {
-	successCases := []struct {
-		name     string
-		labels   map[string]string
-		expected map[string]string
-	}{
-		{
-			name: "test1",
-			labels: map[string]string{
-				"foo": "false",
-			},
-			expected: map[string]string{
-				"foo": "false",
-			},
-		},
-		{
-			name: "test2",
-			labels: map[string]string{
-				"foo": "true",
-				"bar": "123",
-			},
-			expected: map[string]string{
-				"foo": "true",
-				"bar": "123",
-			},
-		},
-	}
-	for _, tt := range successCases {
-		t.Run(tt.name, func(t *testing.T) {
-			labelString := makeLabels(tt.labels)
-			got, err := ParseLabels(labelString)
-			if err != nil {
-				t.Errorf("unexpected error :%v", err)
-			}
-			if !reflect.DeepEqual(tt.expected, got) {
-				t.Errorf("\nexpected:\n%v\ngot:\n%v", tt.expected, got)
-			}
-		})
-	}
-
-	errorCases := []struct {
-		name   string
-		labels interface{}
-	}{
-		{
-			name:   "non-string",
-			labels: 123,
-		},
-		{
-			name:   "empty string",
-			labels: "",
-		},
-		{
-			name:   "error format",
-			labels: "abc=456;bcd=789",
-		},
-		{
-			name:   "error format",
-			labels: "abc=456.bcd=789",
-		},
-		{
-			name:   "error format",
-			labels: "abc,789",
-		},
-		{
-			name:   "error format",
-			labels: "abc",
-		},
-		{
-			name:   "error format",
-			labels: "=abc",
-		},
-	}
-	for _, test := range errorCases {
-		_, err := ParseLabels(test.labels)
-		if err == nil {
-			t.Errorf("labels %s expect error, reason: %s, got nil", test.labels, test.name)
-		}
 	}
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/kubectl/pkg/cmd/util"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/generate"
 )
@@ -36,7 +37,7 @@ func getLabels(params map[string]string, name string) (map[string]string, error)
 	var labels map[string]string
 	var err error
 	if found && len(labelString) > 0 {
-		labels, err = generate.ParseLabels(labelString)
+		labels, err = util.ParseLabels(labelString)
 		if err != nil {
 			return nil, err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service.go
@@ -25,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/generate"
 )
 
@@ -90,7 +91,7 @@ func generateService(genericParams map[string]interface{}) (runtime.Object, erro
 	if !found || len(selectorString) == 0 {
 		return nil, fmt.Errorf("'selector' is a required parameter")
 	}
-	selector, err := generate.ParseLabels(selectorString)
+	selector, err := util.ParseLabels(selectorString)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +99,7 @@ func generateService(genericParams map[string]interface{}) (runtime.Object, erro
 	labelsString, found := params["labels"]
 	var labels map[string]string
 	if found && len(labelsString) > 0 {
-		labels, err = generate.ParseLabels(labelsString)
+		labels, err = util.ParseLabels(labelsString)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig cli

**What this PR does / why we need it**:
Allow setting labels when running kubectl create.

Example:
`kubectl create configmap my-config --from-env-file=file --label=k1=v1,k2=v2`
`kubectl create configmap my-config --from-file=file --label=k1=v1,k2=v2`
`kubectl create configmap my-config --from-literal=key1=config1 -b=k1=v1,k2=v2`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #60295

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
This PR introduces a new flag `--add-label` for the command `kubectl create configmap`
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
This PR makes the creation of resources that contain labels easier by using only one command, instead of:
- labelling the resource after the creation (2 commands)
- adding the labels manually in the manifest (2 commands)
```
