### PR TITLE
Properly close the file in makeFile

### DIFF
--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -489,7 +489,9 @@ func makeDir(pathname string) error {
 // If pathname already exists, whether a file or directory, no error is returned.
 func makeFile(pathname string) error {
 	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
-	defer f.Close()
+	if f != nil {
+		f.Close()
+	}
 	if err != nil {
 		if !os.IsExist(err) {
 			return err


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In makeFile, the File pointer returned from os.OpenFile may be nil.
We shouldn't blindly call Close on the File pointer.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
