### PR TITLE
add 'kubectl get all' command specification

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -99,6 +99,9 @@ var (
 		of the --template flag, you can filter the attributes of the fetched resources.`)
 
 	getExample = templates.Examples(i18n.T(`
+		# List all resources in ps output format.
+		kubectl get all		
+
 		# List all pods in ps output format.
 		kubectl get pods
 


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug
> /kind cleanup

**What this PR does / why we need it**:

I think we need this help manual, otherwise we can't get all the resources in the namespace clearly.

**Which issue(s) this PR fixes**:
Ref [#82979 ](https://github.com/kubernetes/kubernetes/issues/82979)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
None
```
