### PR TITLE
Automated cherry pick of #83015: Bump metrics-server version to v0.3.5

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,24 +23,24 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.3.4
+  name: metrics-server-v0.3.5
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.3.4
+    version: v0.3.5
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.3.4
+      version: v0.3.5
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.3.4
+        version: v0.3.5
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.5
         command:
         - /metrics-server
         - --metric-resolution=30s
@@ -90,7 +90,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.3.4
+          - --deployment=metrics-server-v0.3.5
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential


### PR DESCRIPTION
Cherry pick of #83015 on release-1.16.

#83015: Bump metrics-server version to v0.3.5

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.