### PR TITLE
fix: remove reportingInstance field in eventKey.

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -53,7 +53,6 @@ type eventKey struct {
 	action              string
 	reason              string
 	reportingController string
-	reportingInstance   string
 	regarding           corev1.ObjectReference
 	related             corev1.ObjectReference
 }
@@ -264,7 +263,6 @@ func getKey(event *v1beta1.Event) eventKey {
 		action:              event.Action,
 		reason:              event.Reason,
 		reportingController: event.ReportingController,
-		reportingInstance:   event.ReportingInstance,
 		regarding:           event.Regarding,
 	}
 	if event.Related != nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

`reportingInstance` is consist of `reportingController` + `os.hostname()`, and `eventKey` is not shared/accessed among different processes (host), so this field is duplicated with `reportingController`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/sig scalability
/sig api-machinery
/assign @yastij