### PR TITLE
Wrap promethues.Labels to stability framework.

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/BUILD
@@ -13,6 +13,7 @@ go_library(
         "counter.go",
         "gauge.go",
         "histogram.go",
+        "labels.go",
         "metric.go",
         "opts.go",
         "processstarttime.go",

--- a/staging/src/k8s.io/component-base/metrics/labels.go
+++ b/staging/src/k8s.io/component-base/metrics/labels.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// Labels represents a collection of label name -> value mappings.
+type Labels prometheus.Labels


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Provide a wrapper for prometheus.Label. 

After this PR we can continue migration before https://github.com/kubernetes/kubernetes/issues/82509 for the packages that already migrated to stability framework but still refer a prometheus.Label.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


/assign @logicalhan 