### PR TITLE
Revert "Updated COS version to M77"

### DIFF
--- a/cluster/gce/config-default.sh
+++ b/cluster/gce/config-default.sh
@@ -83,7 +83,7 @@ fi
 # you are updating the os image versions, update this variable.
 # Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-GCI_VERSION=${KUBE_GCI_VERSION:-cos-rc-77-12371-44-0}
+GCI_VERSION=${KUBE_GCI_VERSION:-cos-73-11647-163-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}

--- a/cluster/gce/config-test.sh
+++ b/cluster/gce/config-test.sh
@@ -90,7 +90,7 @@ ALLOWED_NOTREADY_NODES="${ALLOWED_NOTREADY_NODES:-$(($(get-num-nodes) / 100))}"
 # you are updating the os image versions, update this variable.
 # Also please update corresponding image for node e2e at:
 # https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/jenkins/image-config.yaml
-GCI_VERSION=${KUBE_GCI_VERSION:-cos-rc-77-12371-44-0}
+GCI_VERSION=${KUBE_GCI_VERSION:-cos-73-11647-163-0}
 MASTER_IMAGE=${KUBE_GCE_MASTER_IMAGE:-}
 MASTER_IMAGE_PROJECT=${KUBE_GCE_MASTER_PROJECT:-cos-cloud}
 NODE_IMAGE=${KUBE_GCE_NODE_IMAGE:-${GCI_VERSION}}


### PR DESCRIPTION
This reverts commit bc3f4b269ab82327f1aefecb2d120be3c798a54a
which caused regression in scalability tests:
https://github.com/kubernetes/kubernetes/issues/83020

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Reverts "Updated COS version to M77"
Which caused regression in scalability tests.

**Which issue(s) this PR fixes**:
Fixes #83020

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```