### PR TITLE
Optimize GetControllerOf method and add a benchmark for it

### DIFF
--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -64,7 +64,7 @@ func (m *BaseControllerRefManager) CanAdopt() error {
 //
 // No reconciliation will be attempted if the controller is being deleted.
 func (m *BaseControllerRefManager) ClaimObject(obj metav1.Object, match func(metav1.Object) bool, adopt, release func(metav1.Object) error) (bool, error) {
-	controllerRef := metav1.GetControllerOf(obj)
+	controllerRef := metav1.GetControllerOfNoCopy(obj)
 	if controllerRef != nil {
 		if controllerRef.UID != m.Controller.GetUID() {
 			// Owned by someone else. Ignore.

--- a/pkg/controller/history/controller_history.go
+++ b/pkg/controller/history/controller_history.go
@@ -224,7 +224,7 @@ func (rh *realHistory) ListControllerRevisions(parent metav1.Object, selector la
 	}
 	var owned []*apps.ControllerRevision
 	for i := range history {
-		ref := metav1.GetControllerOf(history[i])
+		ref := metav1.GetControllerOfNoCopy(history[i])
 		if ref == nil || ref.UID == parent.GetUID() {
 			owned = append(owned, history[i])
 		}
@@ -292,7 +292,7 @@ func (rh *realHistory) DeleteControllerRevision(revision *apps.ControllerRevisio
 
 func (rh *realHistory) AdoptControllerRevision(parent metav1.Object, parentKind schema.GroupVersionKind, revision *apps.ControllerRevision) (*apps.ControllerRevision, error) {
 	// Return an error if the parent does not own the revision
-	if owner := metav1.GetControllerOf(revision); owner != nil {
+	if owner := metav1.GetControllerOfNoCopy(revision); owner != nil {
 		return nil, fmt.Errorf("attempt to adopt revision owned by %v", owner)
 	}
 	// Use strategic merge patch to add an owner reference indicating a controller ref

--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/controller_ref.go
@@ -22,7 +22,7 @@ import (
 
 // IsControlledBy checks if the  object has a controllerRef set to the given owner
 func IsControlledBy(obj Object, owner Object) bool {
-	ref := GetControllerOf(obj)
+	ref := GetControllerOfNoCopy(obj)
 	if ref == nil {
 		return false
 	}
@@ -31,9 +31,20 @@ func IsControlledBy(obj Object, owner Object) bool {
 
 // GetControllerOf returns a pointer to a copy of the controllerRef if controllee has a controller
 func GetControllerOf(controllee Object) *OwnerReference {
-	for _, ref := range controllee.GetOwnerReferences() {
-		if ref.Controller != nil && *ref.Controller {
-			return &ref
+	ref := GetControllerOfNoCopy(controllee)
+	if ref == nil {
+		return nil
+	}
+	cp := *ref
+	return &cp
+}
+
+// GetControllerOf returns a pointer to the controllerRef if controllee has a controller
+func GetControllerOfNoCopy(controllee Object) *OwnerReference {
+	refs := controllee.GetOwnerReferences()
+	for i := range refs {
+		if refs[i].Controller != nil && *refs[i].Controller {
+			return &refs[i]
 		}
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
It optimizes the GetControllerOf method and adds a benchmark for it.
In addition it creates a similar method that doesn't copy objects.

Benchmark for the new no-copy method vs the old one:
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkGetControllerOf-12     214           14.8          -93.08%

benchmark                       old allocs     new allocs     delta
BenchmarkGetControllerOf-12     1              0              -100.00%

benchmark                       old bytes     new bytes     delta
BenchmarkGetControllerOf-12     80            0             -100.00%
```

Benchamrk for the new (copy) method vs the old one:
```
benchmark                       old ns/op     new ns/op     delta
BenchmarkGetControllerOf-12     128           114           -10.94%

benchmark                       old allocs     new allocs     delta
BenchmarkGetControllerOf-12     1              1              +0.00%

benchmark                       old bytes     new bytes     delta
BenchmarkGetControllerOf-12     80            80            +0.00%

```

Overall there is a 10% improvement for the old vs new (copy) method and
huge improvent (x10) for the old vs new (no-copy).

I changed the IsControlledBy method to use the new (no-copy) method.


Results of running the benchmark before and after the change:

```
benchmark                       old ns/op     new ns/op     delta
BenchmarkGetControllerOf-12     214           14.8          -93.08%

benchmark                       old allocs     new allocs     delta
BenchmarkGetControllerOf-12     1              0              -100.00%

benchmark                       old bytes     new bytes     delta
BenchmarkGetControllerOf-12     80            0             -100.00%
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```
/sig scalability
