### PR TITLE
Add known issue for informer-gen for packages with dots

### DIFF
--- a/CHANGELOG-1.16.md
+++ b/CHANGELOG-1.16.md
@@ -178,6 +178,7 @@ The main themes of this release are:
 
 - The etcd and KMS plugin health checks are not exposed in the new `livez` and `readyz` endpoints. This will be fixed in 1.16.1.
 - Systems running `iptables` 1.8.0 or newer should start it in legacy mode. Please note that this affects all versions of Kubernetes and not only v1.16.0. For more detailed information about the issue and how to apply a workaround, please refer to the official documentation
+- Generating informers for packages in directories containing dots in their name is broken. This will be fixed in v1.16.1. ([#82860](https://github.com/kubernetes/kubernetes/issues/82860))
 
 ## Urgent Upgrade Notes
 


### PR DESCRIPTION
Issue: https://github.com/kubernetes/kubernetes/issues/82860
Fix in: https://github.com/kubernetes/kubernetes/pull/82410

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/sig release
/kind documentation
/cc @munnerz @sttts @liggitt 
/assign @liggitt 
