### PR TITLE
Automated cherry pick of #82929: fix map assignment to entry in nil map,when use

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/defaults.go
+++ b/cmd/kubeadm/app/componentconfigs/defaults.go
@@ -58,7 +58,7 @@ const (
 
 // DefaultKubeProxyConfiguration assigns default values for the kube-proxy ComponentConfig
 func DefaultKubeProxyConfiguration(internalcfg *kubeadmapi.ClusterConfiguration) {
-	externalproxycfg := &kubeproxyconfigv1alpha1.KubeProxyConfiguration{}
+	externalproxycfg := &kubeproxyconfigv1alpha1.KubeProxyConfiguration{FeatureGates: make(map[string]bool)}
 	kind := "KubeProxyConfiguration"
 
 	// Do a roundtrip to the external version for defaulting


### PR DESCRIPTION
Cherry pick of #82929 on release-1.16.

Fixes #82978

#82929: fix map assignment to entry in nil map,when use

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: fix potential panic when using --feature-gates with dual stack support
```