### PR TITLE
Add KUBE_COVER_REPORT_DIR to specify coverage output dir.

### DIFF
--- a/hack/make-rules/test.sh
+++ b/hack/make-rules/test.sh
@@ -72,6 +72,9 @@ kube::test::find_dirs() {
 KUBE_TIMEOUT=${KUBE_TIMEOUT:--timeout=120s}
 KUBE_COVER=${KUBE_COVER:-n} # set to 'y' to enable coverage collection
 KUBE_COVERMODE=${KUBE_COVERMODE:-atomic}
+# The directory to save test coverage reports to, if generating them. If unset,
+# a semi-predictable temporary directory will be used.
+KUBE_COVER_REPORT_DIR="${KUBE_COVER_REPORT_DIR:-}"
 # How many 'go test' instances to run simultaneously when running tests in
 # coverage mode.
 KUBE_COVERPROCS=${KUBE_COVERPROCS:-4}
@@ -279,7 +282,11 @@ runTests() {
 
   # Create coverage report directories.
   KUBE_TEST_API_HASH="$(echo -n "${KUBE_TEST_API//\//-}"| ${SHA1SUM} |awk '{print $1}')"
-  cover_report_dir="/tmp/k8s_coverage/${KUBE_TEST_API_HASH}/$(kube::util::sortable_date)"
+  if [[ -z "${KUBE_COVER_REPORT_DIR}" ]]; then
+    cover_report_dir="/tmp/k8s_coverage/${KUBE_TEST_API_HASH}/$(kube::util::sortable_date)"
+  else
+    cover_report_dir="${KUBE_COVER_REPORT_DIR}"
+  fi
   cover_profile="coverage.out"  # Name for each individual coverage profile
   kube::log::status "Saving coverage output in '${cover_report_dir}'"
   mkdir -p "${@+${@/#/${cover_report_dir}/}}"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR makes it possible to specify where you would like coverage information to be written to when using `KUBE_COVER=y` by setting `KUBE_COVER_REPORT_DIR` to some directory. If not set, constructs a temporary directory using the same logic as today.

```release-note
NONE
```

/cc @BenTheElder 