### PR TITLE
Allow all special characters in the environment variable name except "="

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -1732,7 +1732,7 @@ type VolumeDevice struct {
 
 // EnvVar represents an environment variable present in a Container.
 type EnvVar struct {
-	// Required: This must be a C_IDENTIFIER.
+	// Required: Name of the environment variable. Except '=' character all other characters allowed.
 	Name string
 	// Optional: no more than one of the following may be specified.
 	// Optional: Defaults to ""; variable references $(VAR_NAME) are expanded
@@ -2019,9 +2019,8 @@ type Container struct {
 	// +optional
 	Ports []ContainerPort
 	// List of sources to populate environment variables in the container.
-	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
-	// will be reported as an event when the container is starting. When a key exists in multiple
-	// sources, the value associated with the last source will take precedence.
+	// All invalid keys will be reported as an event when the container is starting.
+	// When a key exists in multiple sources, the value associated with the last source will take precedence.
 	// Values defined by an Env with a duplicate key will take precedence.
 	// Cannot be updated.
 	// +optional

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -42,7 +42,7 @@ import (
 const (
 	dnsLabelErrMsg          = "a DNS-1123 label must consist of"
 	dnsSubdomainLabelErrMsg = "a DNS-1123 subdomain"
-	envVarNameErrMsg        = "a valid environment variable name must consist of"
+	envVarNameErrMsg        = "a valid environment variable name must not contain '=' character"
 )
 
 func newHostPathType(pathType string) *core.HostPathType {
@@ -4469,24 +4469,9 @@ func TestValidateEnv(t *testing.T) {
 			expectedError: "[0].name: Required value",
 		},
 		{
-			name:          "illegal character",
-			envs:          []core.EnvVar{{Name: "a!b"}},
-			expectedError: `[0].name: Invalid value: "a!b": ` + envVarNameErrMsg,
-		},
-		{
-			name:          "dot only",
-			envs:          []core.EnvVar{{Name: "."}},
-			expectedError: `[0].name: Invalid value: ".": must not be`,
-		},
-		{
-			name:          "double dots only",
-			envs:          []core.EnvVar{{Name: ".."}},
-			expectedError: `[0].name: Invalid value: "..": must not be`,
-		},
-		{
-			name:          "leading double dots",
-			envs:          []core.EnvVar{{Name: "..abc"}},
-			expectedError: `[0].name: Invalid value: "..abc": must not start with`,
+			name:          "name with '=' character",
+			envs:          []core.EnvVar{{Name: "a=b"}},
+			expectedError: `[0].name: Invalid value: "a=b": ` + envVarNameErrMsg,
 		},
 		{
 			name: "value and valueFrom specified",
@@ -4801,12 +4786,12 @@ func TestValidateEnvFrom(t *testing.T) {
 			name: "invalid prefix",
 			envs: []core.EnvFromSource{
 				{
-					Prefix: "a!b",
+					Prefix: "=a!b",
 					ConfigMapRef: &core.ConfigMapEnvSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "abc"}},
 				},
 			},
-			expectedError: `field[0].prefix: Invalid value: "a!b": ` + envVarNameErrMsg,
+			expectedError: `field[0].prefix: Invalid value: "=a!b": ` + envVarNameErrMsg,
 		},
 		{
 			name: "zero-length name",
@@ -4832,12 +4817,12 @@ func TestValidateEnvFrom(t *testing.T) {
 			name: "invalid prefix",
 			envs: []core.EnvFromSource{
 				{
-					Prefix: "a!b",
+					Prefix: "=a!b",
 					SecretRef: &core.SecretEnvSource{
 						LocalObjectReference: core.LocalObjectReference{Name: "abc"}},
 				},
 			},
-			expectedError: `field[0].prefix: Invalid value: "a!b": ` + envVarNameErrMsg,
+			expectedError: `field[0].prefix: Invalid value: "=a!b": ` + envVarNameErrMsg,
 		},
 		{
 			name: "no refs",

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -5919,7 +5919,7 @@ func TestValidateContainers(t *testing.T) {
 				ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"},
 		},
 		"invalid env var name": {
-			{Name: "abc", Image: "image", Env: []core.EnvVar{{Name: "ev!1"}}, ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"},
+			{Name: "abc", Image: "image", Env: []core.EnvVar{{Name: "=ev!1"}}, ImagePullPolicy: "IfNotPresent", TerminationMessagePolicy: "File"},
 		},
 		"unknown volume name": {
 			{Name: "abc", Image: "image", VolumeMounts: []core.VolumeMount{{Name: "anything", MountPath: "/foo"}},

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -312,8 +312,8 @@ func IsHTTPHeaderName(value string) []string {
 	return nil
 }
 
-const envVarNameFmt = "[-._a-zA-Z][-._a-zA-Z0-9]*"
-const envVarNameFmtErrMsg string = "a valid environment variable name must consist of alphabetic characters, digits, '_', '-', or '.', and must not start with a digit"
+const envVarNameFmt = "[^=]+"
+const envVarNameFmtErrMsg string = "a valid environment variable name must not contain '=' character"
 
 var envVarNameRegexp = regexp.MustCompile("^" + envVarNameFmt + "$")
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -539,3 +539,30 @@ func TestIsValidSocketAddr(t *testing.T) {
 		}
 	}
 }
+
+
+
+func TestIsValidEnvVarName(t *testing.T) {
+	goodValues := []string{
+		"-", ":", "_", "a", "A", "a-", "$a",
+		"a.", "a..", "a:", "a_", "aa", "aA",
+		"a0", "a-a", "a.a", "a:a", "a_a", "aAz",
+		"a0a", "a9", "a a", "_9", ".9", "a9a",
+		"0a", "0 a",
+	}
+	for _, val := range goodValues {
+		if msgs := IsEnvVarName(val); len(msgs) != 0 {
+			t.Errorf("expected true for '%s': %v", val, msgs)
+		}
+	}
+
+	badValues := []string{
+		"", "=", "a=", "1=a", "a=b", "#%=&&",
+		"= =", "=a", "a=",
+	}
+	for _, val := range badValues {
+		if msgs := IsEnvVarName(val); len(msgs) == 0 {
+			t.Errorf("expected false for '%s'", val)
+		}
+	}
+}

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -540,8 +540,6 @@ func TestIsValidSocketAddr(t *testing.T) {
 	}
 }
 
-
-
 func TestIsValidEnvVarName(t *testing.T) {
 	goodValues := []string{
 		"-", ":", "_", "a", "A", "a-", "$a",

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/env_file_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/env_file_test.go
@@ -37,7 +37,10 @@ func Test_processEnvFileLine(t *testing.T) {
 			append(utf8bom, 'a', '=', 'c'), 0, "a", "c", ""},
 
 		{"the utf8bom is NOT trimmed on the second line",
-			append(utf8bom, 'a', '=', 'c'), 1, "", "", "not a valid key name"},
+			append(utf8bom, 'a', '=', 'c'), 1, "\ufeffa", "c", ""},
+
+		{"the key should not contain '='",
+			[]byte{' ', '=', '=', 'c'}, 0, "", "", "not a valid key name"},
 
 		{"no key is returned on a comment line",
 			[]byte{' ', '#', 'c'}, 0, "", "", ""},

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -109,7 +109,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 								ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: name}},
 							},
 							{
-								Prefix:       "p_",
+								Prefix:       "0$#@..//TEST p_",
 								ConfigMapRef: &v1.ConfigMapEnvSource{LocalObjectReference: v1.LocalObjectReference{Name: name}},
 							},
 						},
@@ -121,7 +121,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 
 		f.TestContainerOutput("consume configMaps", pod, 0, []string{
 			"data_1=value-1", "data_2=value-2", "data_3=value-3",
-			"p_data_1=value-1", "p_data_2=value-2", "p_data_3=value-3",
+			"0$#@..//TEST p_data_1=value-1", "0$#@..//TEST p_data_2=value-2", "0$#@..//TEST p_data_3=value-3",
 		})
 	})
 

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -58,7 +58,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 						Command: []string{"sh", "-c", "env"},
 						Env: []v1.EnvVar{
 							{
-								Name:  "FOO",
+								Name:  "/\\%~*A55&&!!__F{}OO..T:E$T",
 								Value: "foo-value",
 							},
 							{
@@ -67,7 +67,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 							},
 							{
 								Name:  "FOOBAR",
-								Value: "$(FOO);;$(BAR)",
+								Value: "$(/\\%~*A55&&!!__F{}OO..T:E$T);;$(BAR)",
 							},
 						},
 					},
@@ -77,7 +77,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 		}
 
 		f.TestContainerOutput("env composition", pod, 0, []string{
-			"FOO=foo-value",
+			"/\\%~*A55&&!!__F{}OO..T:E$T=foo-value",
 			"BAR=bar-value",
 			"FOOBAR=foo-value;;bar-value",
 		})
@@ -234,7 +234,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 						Image: imageutils.GetE2EImage(imageutils.BusyBox),
 						Env: []v1.EnvVar{
 							{
-								Name:  "POD_NAME",
+								Name:  "POD_NAM{E}@#$",
 								Value: "..",
 							},
 						},
@@ -242,7 +242,7 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 							{
 								Name:        "workdir1",
 								MountPath:   "/logscontainer",
-								SubPathExpr: "$(POD_NAME)",
+								SubPathExpr: "$(POD_NAM{E}@#$)",
 							},
 						},
 					},

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -59,7 +59,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 						Command: []string{"sh", "-c", "env"},
 						Env: []v1.EnvVar{
 							{
-								Name: "SECRET_DATA",
+								Name: "0{}&&!!55__SECRET_$DATA",
 								ValueFrom: &v1.EnvVarSource{
 									SecretKeyRef: &v1.SecretKeySelector{
 										LocalObjectReference: v1.LocalObjectReference{
@@ -77,7 +77,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		}
 
 		f.TestContainerOutput("consume secrets", pod, 0, []string{
-			"SECRET_DATA=value-1",
+			"0{}&&!!55__SECRET_$DATA=value-1",
 		})
 	})
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

>
/kind api-change


**What this PR does / why we need it**:
This PR relaxes the restrictions on the use of special characters in the Environment variable names. It allows all the characters except `=` 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes [Issue 47](https://github.com/kubernetes/kubectl/issues/47)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Relaxing the restrictions on the use of special characters in the Environment variable names. It allows all the characters except `=` . A valid variable name should not start with a digit. Older version of Kubelet ignores the environment variable names having other than [-._a-zA-Z0-9] characters and using these variables names will prevent api-server rollback to older versions.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
