### PR TITLE
Automated cherry pick of #82597: Fix ipv6 ip allocation method for standard lb

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -546,8 +546,12 @@ func (az *Cloud) ensurePublicIPExists(service *v1.Service, pipName string, domai
 		if ipv6 {
 			pip.PublicIPAddressVersion = network.IPv6
 			klog.V(2).Infof("service(%s): pip(%s) - creating as ipv6 for clusterIP:%v", serviceName, *pip.Name, service.Spec.ClusterIP)
-			// static allocation on IPv6 on Azure is not allowed
+
 			pip.PublicIPAddressPropertiesFormat.PublicIPAllocationMethod = network.Dynamic
+			if az.useStandardLoadBalancer() {
+				// standard sku must have static allocation method for ipv6
+				pip.PublicIPAddressPropertiesFormat.PublicIPAllocationMethod = network.Static
+			}
 		} else {
 			pip.PublicIPAddressVersion = network.IPv4
 			klog.V(2).Infof("service(%s): pip(%s) - creating as ipv4 for clusterIP:%v", serviceName, *pip.Name, service.Spec.ClusterIP)


### PR DESCRIPTION
Cherry pick of #82597 on release-1.16.

#82597: Fix ipv6 ip allocation method for standard lb

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
azure: Fix ipv6 ip allocation method for standard lb
```