### PR TITLE
Updating EndpointSliceCache sort function to be significantly faster.

### DIFF
--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -249,5 +249,5 @@ func (e byIP) Swap(i, j int) {
 	e[i], e[j] = e[j], e[i]
 }
 func (e byIP) Less(i, j int) bool {
-	return e[i].IP() < e[j].IP()
+	return e[i].String() < e[j].String()
 }

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -99,8 +99,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0"): {
-					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.10:80"},
+					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.4:80"},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The .IP() call that was previously used for sorting resulted in a call to netutil to parse an IP out of an IP:Port string. This was very slow and resulted in this sort taking up ~50% of total CPU util for kube-proxy.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Improved performance of kube-proxy with EndpointSlice enabled with more efficient sorting. 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752

/sig network
/priority important-soon
/cc @freehan @bowei