### PR TITLE
feat(scheduler): consolidate ScoreWithNormalizePlugin into ScorePlugin

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -34,22 +34,21 @@ import (
 // framework is the component responsible for initializing and running scheduler
 // plugins.
 type framework struct {
-	registry                  Registry
-	nodeInfoSnapshot          *schedulernodeinfo.Snapshot
-	waitingPods               *waitingPodsMap
-	pluginNameToWeightMap     map[string]int
-	queueSortPlugins          []QueueSortPlugin
-	preFilterPlugins          []PreFilterPlugin
-	filterPlugins             []FilterPlugin
-	postFilterPlugins         []PostFilterPlugin
-	scorePlugins              []ScorePlugin
-	scoreWithNormalizePlugins []ScoreWithNormalizePlugin
-	reservePlugins            []ReservePlugin
-	preBindPlugins            []PreBindPlugin
-	bindPlugins               []BindPlugin
-	postBindPlugins           []PostBindPlugin
-	unreservePlugins          []UnreservePlugin
-	permitPlugins             []PermitPlugin
+	registry              Registry
+	nodeInfoSnapshot      *schedulernodeinfo.Snapshot
+	waitingPods           *waitingPodsMap
+	pluginNameToWeightMap map[string]int
+	queueSortPlugins      []QueueSortPlugin
+	preFilterPlugins      []PreFilterPlugin
+	filterPlugins         []FilterPlugin
+	postFilterPlugins     []PostFilterPlugin
+	scorePlugins          []ScorePlugin
+	reservePlugins        []ReservePlugin
+	preBindPlugins        []PreBindPlugin
+	bindPlugins           []BindPlugin
+	postBindPlugins       []PostBindPlugin
+	unreservePlugins      []UnreservePlugin
+	permitPlugins         []PermitPlugin
 }
 
 const (
@@ -133,7 +132,6 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 	if plugins.Score != nil {
 		for _, sc := range plugins.Score.Enabled {
 			if pg, ok := pluginsMap[sc.Name]; ok {
-				// First, make sure the plugin implements ScorePlugin interface.
 				p, ok := pg.(ScorePlugin)
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend score plugin", sc.Name)
@@ -142,13 +140,6 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 					return nil, fmt.Errorf("score plugin %q is not configured with weight", p.Name())
 				}
 				f.scorePlugins = append(f.scorePlugins, p)
-
-				// Next, if the plugin also implements ScoreWithNormalizePlugin interface,
-				// add it to the normalizeScore plugin list.
-				np, ok := pg.(ScoreWithNormalizePlugin)
-				if ok {
-					f.scoreWithNormalizePlugins = append(f.scoreWithNormalizePlugins, np)
-				}
 			} else {
 				return nil, fmt.Errorf("score plugin %q does not exist", sc.Name)
 			}
@@ -422,9 +413,9 @@ func (f *framework) RunScorePlugins(pc *PluginContext, pod *v1.Pod, nodes []*v1.
 		return nil, NewStatus(Error, msg)
 	}
 
-	// Run NormalizeScore method for each ScoreWithNormalizePlugin in parallel.
-	workqueue.ParallelizeUntil(ctx, 16, len(f.scoreWithNormalizePlugins), func(index int) {
-		pl := f.scoreWithNormalizePlugins[index]
+	// Run NormalizeScore method for each ScorePlugin in parallel.
+	workqueue.ParallelizeUntil(ctx, 16, len(f.scorePlugins), func(index int) {
+		pl := f.scorePlugins[index]
 		nodeScoreList := pluginToNodeScores[pl.Name()]
 		status := pl.NormalizeScore(pc, pod, nodeScoreList)
 		if !status.IsSuccess() {

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -39,7 +39,7 @@ const (
 
 // TestScoreWithNormalizePlugin implements ScoreWithNormalizePlugin interface.
 // TestScorePlugin only implements ScorePlugin interface.
-var _ = ScoreWithNormalizePlugin(&TestScoreWithNormalizePlugin{})
+var _ = ScorePlugin(&TestScoreWithNormalizePlugin{})
 var _ = ScorePlugin(&TestScorePlugin{})
 
 func newScoreWithNormalizePlugin1(injArgs *runtime.Unknown, f FrameworkHandle) (Plugin, error) {
@@ -99,6 +99,10 @@ func (pl *TestScorePlugin) Name() string {
 
 func (pl *TestScorePlugin) Score(pc *PluginContext, p *v1.Pod, nodeName string) (int, *Status) {
 	return setScoreRes(pl.inj)
+}
+
+func (pl *TestScorePlugin) NormalizeScore(pc *PluginContext, pod *v1.Pod, scores NodeScoreList) *Status {
+	return nil
 }
 
 // PluginNotImplementingScore doesn't implement the ScorePlugin interface.

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -238,16 +238,13 @@ type ScorePlugin interface {
 	// indicating the rank of the node. All scoring plugins must return success or
 	// the pod will be rejected.
 	Score(pc *PluginContext, p *v1.Pod, nodeName string) (int, *Status)
-}
 
-// ScoreWithNormalizePlugin is an interface that must be implemented by "score"
-// plugins that also need to normalize the node scoring results produced by the same
-// plugin's "Score" method.
-type ScoreWithNormalizePlugin interface {
-	ScorePlugin
 	// NormalizeScore is called for all node scores produced by the same plugin's "Score"
 	// method. A successful run of NormalizeScore will update the scores list and return
 	// a success status.
+	//
+	// NOTE: This function is optional, and you could implement it as a no-op by simply
+	// returning nil.
 	NormalizeScore(pc *PluginContext, p *v1.Pod, scores NodeScoreList) *Status
 }
 

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -118,7 +118,7 @@ var _ = framework.PreFilterPlugin(&PreFilterPlugin{})
 var _ = framework.ScorePlugin(&ScorePlugin{})
 var _ = framework.FilterPlugin(&FilterPlugin{})
 var _ = framework.ScorePlugin(&ScorePlugin{})
-var _ = framework.ScoreWithNormalizePlugin(&ScoreWithNormalizePlugin{})
+var _ = framework.ScorePlugin(&ScoreWithNormalizePlugin{})
 var _ = framework.ReservePlugin(&ReservePlugin{})
 var _ = framework.PostFilterPlugin(&PostFilterPlugin{})
 var _ = framework.PreBindPlugin(&PreBindPlugin{})
@@ -160,6 +160,10 @@ func (sp *ScorePlugin) Score(pc *framework.PluginContext, p *v1.Pod, nodeName st
 		score = framework.MaxNodeScore
 	}
 	return score, nil
+}
+
+func (sp *ScorePlugin) NormalizeScore(pc *framework.PluginContext, pod *v1.Pod, scores framework.NodeScoreList) *framework.Status {
+	return nil
 }
 
 // Name returns name of the score plugin.


### PR DESCRIPTION
/kind feature
/sig scheduling
/assign @ahg-g @Huang-Wei 

**What this PR does / why we need it**:

After the discussion in https://github.com/kubernetes/kubernetes/pull/82912#discussion_r327278464, we should remove the scoreWithNormalizePlugin in the scheduling framework.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Consolidate ScoreWithNormalizePlugin into the ScorePlugin interface
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
