### PR TITLE
Automated cherry pick of #81767: Do not cleanup node lease namespace in e2e setup suite

### DIFF
--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -30,6 +30,7 @@ import (
 	"github.com/onsi/gomega"
 	"k8s.io/klog"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeutils "k8s.io/apimachinery/pkg/util/runtime"
 	clientset "k8s.io/client-go/kubernetes"
@@ -88,6 +89,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 				metav1.NamespaceSystem,
 				metav1.NamespaceDefault,
 				metav1.NamespacePublic,
+				corev1.NamespaceNodeLease,
 			})
 		if err != nil {
 			framework.Failf("Error deleting orphaned namespaces: %v", err)


### PR DESCRIPTION
Cherry pick of #81767 on release-1.14.

#81767: Do not cleanup node lease namespace in e2e setup suite

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.