### PR TITLE
Update cluster autoscaler version to 1.16.1

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This PR updates Cluster Autoscaler version in manifest to patch release 1.16.1
CA changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.1

```release-note
Update Cluster Autoscaler version to 1.16.1 (release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.16.1)
```
