### PR TITLE
to use existing validating function

### DIFF
--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -55,10 +55,9 @@ func (s *BuiltInAuthorizationOptions) Validate() []error {
 		allErrors = append(allErrors, fmt.Errorf("at least one authorization-mode must be passed"))
 	}
 
-	allowedModes := sets.NewString(authzmodes.AuthorizationModeChoices...)
 	modes := sets.NewString(s.Modes...)
 	for _, mode := range s.Modes {
-		if !allowedModes.Has(mode) {
+		if !authzmodes.IsValidAuthorizationMode(mode) {
 			allErrors = append(allErrors, fmt.Errorf("authorization-mode %q is not a valid mode", mode))
 		}
 		if mode == authzmodes.ModeABAC {


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
/kind cleanup

**What this PR does / why we need it**:
To use an existing a function to validate access mode. No need to write it again.
https://github.com/kubernetes/kubernetes/blob/0541d0bb79537431421774465721f33fd3b053bc/pkg/kubeapiserver/authorizer/modes/modes.go#L36-L42

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```