### PR TITLE
remove trailing dots from the parsed searches from host resolv.conf

### DIFF
--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -230,6 +230,7 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 			}
 		}
 		if fields[0] == "search" {
+			// Strip redundant trailing dot to avoid hitting search validation limits.
 			trimTrailingDot := []string{}
 			for _, s := range fields[1:] {
 				trimTrailingDot = append(trimTrailingDot, strings.TrimSuffix(s, "."))

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -230,7 +230,7 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 			}
 		}
 		if fields[0] == "search" {
-			// Strip redundant trailing dot to avoid hitting search validation limits.
+			// Normalise search fields so the same domain with and without trailing dot will only count once, to avoid hitting search validation limits.
 			trimTrailingDot := []string{}
 			for _, s := range fields[1:] {
 				trimTrailingDot = append(trimTrailingDot, strings.TrimSuffix(s, "."))

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -230,7 +230,11 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 			}
 		}
 		if fields[0] == "search" {
-			searches = fields[1:]
+			trimTrailingDot := []string{}
+			for _, s := range fields[1:] {
+				trimTrailingDot = append(trimTrailingDot, strings.TrimSuffix(s, "."))
+			}
+			searches = trimTrailingDot
 		}
 		if fields[0] == "options" {
 			options = fields[1:]

--- a/pkg/kubelet/network/dns/dns.go
+++ b/pkg/kubelet/network/dns/dns.go
@@ -231,11 +231,10 @@ func parseResolvConf(reader io.Reader) (nameservers []string, searches []string,
 		}
 		if fields[0] == "search" {
 			// Normalise search fields so the same domain with and without trailing dot will only count once, to avoid hitting search validation limits.
-			trimTrailingDot := []string{}
+			searches = []string{}
 			for _, s := range fields[1:] {
-				trimTrailingDot = append(trimTrailingDot, strings.TrimSuffix(s, "."))
+				searches = append(searches, strings.TrimSuffix(s, "."))
 			}
-			searches = trimTrailingDot
 		}
 		if fields[0] == "options" {
 			options = fields[1:]

--- a/pkg/kubelet/network/dns/dns_test.go
+++ b/pkg/kubelet/network/dns/dns_test.go
@@ -74,6 +74,7 @@ func TestParseResolvConf(t *testing.T) {
 		{"search ", []string{}, []string{}, []string{}, false}, // search empty
 		{"search foo", []string{}, []string{"foo"}, []string{}, false},
 		{"search foo bar", []string{}, []string{"foo", "bar"}, []string{}, false},
+		{"search foo. bar", []string{}, []string{"foo", "bar"}, []string{}, false},
 		{"search foo bar bat\n", []string{}, []string{"foo", "bar", "bat"}, []string{}, false},
 		{"search foo\nsearch bar", []string{}, []string{"bar"}, []string{}, false},
 		{"nameserver 1.2.3.4\nsearch foo bar", []string{"1.2.3.4"}, []string{"foo", "bar"}, []string{}, false},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:
In short: This will make kubelet ignore trailing dots `.` in search lines from host resolv.conf files, so when `omitDuplicates` function gets called, is de-duplicated and we don't hit validation limits. Please 

Long story: We provision our Debian stretch based clusters (1.15.3) with [kubespray](https://github.com/kubernetes-sigs/kubespray), which supersedes search lines to add `svc.clusterFqdn` and `default.svc.clusterFqdn` to the host resolvconf conifg file (`/etc/resolv.conf`).

https://github.com/kubernetes-sigs/kubespray/blob/da50ed0936742bb633c6b48a84ffca98d8ab03ad/roles/kubernetes/preinstall/tasks/0040-set_facts.yml#L121

When a server restart, dhclient runs, adds trailing dots are added to those search lines. 

When a pod with DNS policy `ClusterFirst` gets scheduled, kubelet will add `svc.clusterFqdn` and `namespace.clusterFqdn` to the pod `resolv.conf` and it will be merged with the host `resolv.conf` deduplicating entries and doing limit validations.

https://github.com/kubernetes/kubernetes/blob/26cc580e65b12d230c18dc9c947084dd918633a6/pkg/kubelet/network/dns/dns.go#L146

https://github.com/kubernetes/kubernetes/blob/26cc580e65b12d230c18dc9c947084dd918633a6/pkg/kubelet/network/dns/dns.go#L85

https://github.com/kubernetes/kubernetes/blob/26cc580e65b12d230c18dc9c947084dd918633a6/pkg/kubelet/network/dns/dns.go#L98

So, if the search line now contains trailing `.`, and you have things like `svc.clusterFqdn.` when scheduling a pod, `svc.clusterFqdn` and `svc.clusterFqdn.` are not deduplicated and you can hit one of the validation limits (MaxDNSSearchPaths) and the resulting line may be cut down to this limit, 6.

In our case it removed our search for services outside our kubernetes cluster, so dns request were not sent to upstream resolver and we had some timeouts affecting our production workload.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
**NOTE** I'm not saying this is a bug. Adding trailing dots to search lines don't provide any values, but it is harmless, and I think it'd would be nice that kubelet can detect them and remove them so we don't have garbage in pod resolv.conf or we hit a validation limit.

Some facts:
- Kubernetes version: `v1.15.3`
- Kernel: `4.19.0-0.bpo.4-amd64 #1 SMP Debian 4.19.28-2~bpo9+1 (2019-03-27) x86_64 GNU/Linux
`
- Os release:

```
PRETTY_NAME="Debian GNU/Linux 9 (stretch)"
NAME="Debian GNU/Linux"
VERSION_ID="9"
VERSION="9 (stretch)"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
``` 
- Cloud: NONE. bare-metal servers,
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
