### PR TITLE
Remove unnecessary traversal of pod.Status.Conditions

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/podutils/podutils.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/podutils/podutils.go
@@ -170,12 +170,10 @@ func afterOrZero(t1, t2 *metav1.Time) bool {
 }
 
 func podReadyTime(pod *corev1.Pod) *metav1.Time {
-	if IsPodReady(pod) {
-		for _, c := range pod.Status.Conditions {
-			// we only care about pod ready conditions
-			if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
-				return &c.LastTransitionTime
-			}
+	for _, c := range pod.Status.Conditions {
+		// we only care about pod ready conditions
+		if c.Type == corev1.PodReady && c.Status == corev1.ConditionTrue {
+			return &c.LastTransitionTime
 		}
 	}
 	return &metav1.Time{}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In podReadyTime, we traverse pod.Status.Conditions twice.
The first one is not needed since it doesn't retrieve the value of LastTransitionTime.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
