### PR TITLE
Adding owners for EndpointSlice controller

### DIFF
--- a/pkg/controller/endpointslice/OWNERS
+++ b/pkg/controller/endpointslice/OWNERS
@@ -1,0 +1,15 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- bowei
+- freehan
+- MrHohn
+- thockin
+- sig-network-approvers
+reviewers:
+- robscott
+- freehan
+- bowei
+- sig-network-reviewers
+labels:
+- sig/network


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds an owners file for the EndpointSlice controller.

**Special notes for your reviewer**:
Mostly based on [owners file for Endpoints controller](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpoint/OWNERS).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @liggitt 