### PR TITLE
Removal of kubernetes error dependencies 

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -546,10 +546,10 @@ func (sysver SystemVerificationCheck) Check() (warnings, errorList []error) {
 	for _, v := range validators {
 		warn, err := v.Validate(system.DefaultSysSpec)
 		if err != nil {
-			errs = append(errs, err)
+			errs = append(errs, err...)
 		}
 		if warn != nil {
-			warns = append(warns, warn)
+			warns = append(warns, warn...)
 		}
 	}
 

--- a/cmd/kubeadm/app/util/system/BUILD
+++ b/cmd/kubeadm/app/util/system/BUILD
@@ -23,7 +23,6 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/util/system",
     deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
     ],

--- a/cmd/kubeadm/app/util/system/cgroup_validator.go
+++ b/cmd/kubeadm/app/util/system/cgroup_validator.go
@@ -41,12 +41,15 @@ const (
 )
 
 // Validate is part of the system.Validator interface.
-func (c *CgroupsValidator) Validate(spec SysSpec) (error, error) {
+func (c *CgroupsValidator) Validate(spec SysSpec) ([]error, []error) {
 	subsystems, err := c.getCgroupSubsystems()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get cgroup subsystems")
+		return nil, []error{errors.Wrap(err, "failed to get cgroup subsystems")}
 	}
-	return nil, c.validateCgroupSubsystems(spec.Cgroups, subsystems)
+	if err = c.validateCgroupSubsystems(spec.Cgroups, subsystems); err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
 }
 
 func (c *CgroupsValidator) validateCgroupSubsystems(cgroupSpec, subsystems []string) error {

--- a/cmd/kubeadm/app/util/system/kernel_validator.go
+++ b/cmd/kubeadm/app/util/system/kernel_validator.go
@@ -30,8 +30,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
-	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 )
 
 var _ Validator = &KernelValidator{}
@@ -63,20 +61,24 @@ const (
 )
 
 // Validate is part of the system.Validator interface.
-func (k *KernelValidator) Validate(spec SysSpec) (error, error) {
+func (k *KernelValidator) Validate(spec SysSpec) ([]error, []error) {
 	helper := KernelValidatorHelperImpl{}
 	release, err := helper.GetKernelReleaseVersion()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get kernel release")
+		return nil, []error{errors.Wrap(err, "failed to get kernel release")}
 	}
 	k.kernelRelease = release
 	var errs []error
-	errs = append(errs, k.validateKernelVersion(spec.KernelSpec))
+	if err = k.validateKernelVersion(spec.KernelSpec); err != nil {
+		errs = append(errs, err)
+	}
 	// only validate kernel config when necessary (currently no kernel config for windows)
 	if len(spec.KernelSpec.Required) > 0 || len(spec.KernelSpec.Forbidden) > 0 || len(spec.KernelSpec.Optional) > 0 {
-		errs = append(errs, k.validateKernelConfig(spec.KernelSpec))
+		if err = k.validateKernelConfig(spec.KernelSpec); err != nil {
+			errs = append(errs, err)
+		}
 	}
-	return nil, errorsutil.NewAggregate(errs)
+	return nil, errs
 }
 
 // validateKernelVersion validates the kernel version.

--- a/cmd/kubeadm/app/util/system/os_validator.go
+++ b/cmd/kubeadm/app/util/system/os_validator.go
@@ -36,12 +36,15 @@ func (o *OSValidator) Name() string {
 }
 
 // Validate is part of the system.Validator interface.
-func (o *OSValidator) Validate(spec SysSpec) (error, error) {
+func (o *OSValidator) Validate(spec SysSpec) ([]error, []error) {
 	os, err := exec.Command("uname").CombinedOutput()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to get os name")
+		return nil, []error{errors.Wrap(err, "failed to get os name")}
 	}
-	return nil, o.validateOS(strings.TrimSpace(string(os)), spec.OS)
+	if err = o.validateOS(strings.TrimSpace(string(os)), spec.OS); err != nil {
+		return nil, []error{err}
+	}
+	return nil, nil
 }
 
 func (o *OSValidator) validateOS(os, specOS string) error {

--- a/cmd/kubeadm/app/util/system/package_validator.go
+++ b/cmd/kubeadm/app/util/system/package_validator.go
@@ -24,8 +24,6 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/pkg/errors"
-
-	errorsutil "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // semVerDotsCount is the number of dots in a valid semantic version.
@@ -92,22 +90,22 @@ func (validator *packageValidator) Name() string {
 // Validate checks packages and their versions against the spec using the
 // package manager on the running machine, and returns an error on any
 // package/version mismatch.
-func (validator *packageValidator) Validate(spec SysSpec) (error, error) {
+func (validator *packageValidator) Validate(spec SysSpec) ([]error, []error) {
 	if len(spec.PackageSpecs) == 0 {
 		return nil, nil
 	}
 
 	var err error
 	if validator.kernelRelease, err = getKernelRelease(); err != nil {
-		return nil, err
+		return nil, []error{err}
 	}
 	if validator.osDistro, err = getOSDistro(); err != nil {
-		return nil, err
+		return nil, []error{err}
 	}
 
 	manager, err := newPackageManager()
 	if err != nil {
-		return nil, err
+		return nil, []error{err}
 	}
 	specs := applyPackageSpecOverride(spec.PackageSpecs, spec.PackageSpecOverrides, validator.osDistro)
 	return validator.validate(specs, manager)
@@ -115,7 +113,7 @@ func (validator *packageValidator) Validate(spec SysSpec) (error, error) {
 
 // Validate checks packages and their versions against the packageSpecs using
 // the packageManager, and returns an error on any package/version mismatch.
-func (validator *packageValidator) validate(packageSpecs []PackageSpec, manager packageManager) (error, error) {
+func (validator *packageValidator) validate(packageSpecs []PackageSpec, manager packageManager) ([]error, []error) {
 	var errs []error
 	for _, spec := range packageSpecs {
 		// Substitute variables in package name.
@@ -155,7 +153,7 @@ func (validator *packageValidator) validate(packageSpecs []PackageSpec, manager 
 			validator.reporter.Report(nameWithVerRange, version, bad)
 		}
 	}
-	return nil, errorsutil.NewAggregate(errs)
+	return nil, errs
 }
 
 // getKernelRelease returns the kernel release of the local machine.

--- a/test/e2e_node/e2e_node_suite_test.go
+++ b/test/e2e_node/e2e_node_suite_test.go
@@ -125,7 +125,7 @@ func TestE2eNode(t *testing.T) {
 				klog.Exitf("chroot %q failed: %v", rootfs, err)
 			}
 		}
-		if _, err := system.ValidateSpec(*spec, framework.TestContext.ContainerRuntime); err != nil {
+		if _, err := system.ValidateSpec(*spec, framework.TestContext.ContainerRuntime); len(err) != 0 {
 			klog.Exitf("system validation failed: %v", err)
 		}
 		return


### PR DESCRIPTION
removed kubernetes error dependencies from validation logic.

/kind cleanup

**What this PR does / why we need it**:

Removes kubernetes dependencies from the validation package. This will enable the removal from the k/k package and enable other tools to consume it without depending on k/k.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubeadm/issues/1738

**Special notes for your reviewer**:

Went with []error to replace k/k error aggregator. slightly change preflight/checks.go code to support the change.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
