### PR TITLE
Stop building the kubernetes-test mondo tarball

### DIFF
--- a/build/release-tars/BUILD
+++ b/build/release-tars/BUILD
@@ -36,9 +36,6 @@ release_filegroup(
         for_test = [
             ":kubernetes-test-portable.tar.gz",
             ":kubernetes-test-{OS}-{ARCH}.tar.gz",
-            # TODO(ixdy): remove once the "mondo-test" tarball is deprecated.
-            # It isn't really mondo under Bazel anyway.
-            ":kubernetes-test.tar.gz",
         ],
     ),
 )
@@ -188,63 +185,6 @@ pkg_tar(
         ],
     }),
 ) for arch in archs] for os, archs in SERVER_PLATFORMS.items()]
-
-# The mondo test tarball is deprecated.
-pkg_tar(
-    name = "_test-mondo-bin",
-    srcs = ["//build:test-targets"],
-    mode = "0755",
-    package_dir = select(for_platforms(
-        for_test = "platforms/{OS}/{ARCH}",
-    )),
-    tags = [
-        "manual",
-        "no-cache",
-    ],
-    visibility = ["//visibility:private"],
-)
-
-genrule(
-    name = "kubernetes-test-mondo-deprecation",
-    outs = ["DEPRECATION_NOTICE"],
-    cmd = """cat <<EOF >$@
-The mondo test tarball containing binaries for all platforms is
-DEPRECATED as of Kubernetes 1.14.
-
-Users of this tarball should migrate to using the platform-specific
-tarballs in combination with the "portable" tarball which contains
-scripts, test images, and other manifests.
-
-For more details, please see KEP
-sig-testing/20190118-breaking-apart-the-kubernetes-test-tarball.
-EOF
-""",
-    visibility = ["//visibility:private"],
-)
-
-# The mondo test tarball is deprecated.
-# This one was never really correct, anyway, since we can't include
-# binaries from multiple platforms in a single tarball.
-pkg_tar(
-    name = "kubernetes-test",
-    srcs = [
-        ":kubernetes-test-mondo-deprecation",
-        "//build:test-portable-targets",
-    ],
-    extension = "tar.gz",
-    package_dir = "kubernetes",
-    remap_paths = {
-        "build/release-tars/DEPRECATION_NOTICE": "DEPRECATION_NOTICE",
-    },
-    strip_prefix = "//",
-    tags = [
-        "manual",
-        "no-cache",
-    ],
-    deps = select(for_platforms(
-        for_test = [":_test-mondo-bin"],
-    )),
-)
 
 pkg_tar(
     name = "kubernetes-test-portable",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: This is a continuation of https://github.com/kubernetes/kubernetes/pull/74065, and finishes implementing https://github.com/kubernetes/enhancements/blob/master/keps/sig-testing/20190118-breaking-apart-the-kubernetes-test-tarball.md.

As of this change, the deprecated "mondo" `kubernetes-test` tarball is no longer built. Users running e2e tests should use `kubernetes-test-portable.tar.gz` and `kubernetes-test-{OS}-{ARCH}.tar.gz`, which have been produced since Kubernetes v1.14.0.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/82767
Fixes https://github.com/kubernetes/enhancements/issues/714

**Special notes for your reviewer**:
I haven't found any references to the mondo test tarball, except in `cluster/get-kube-binaries.sh`, where it's used as a fallback. I haven't removed that fallback path yet (it would be needed for k8s <= 1.13).

**Does this PR introduce a user-facing change?**:
```release-note
The deprecated mondo `kubernetes-test` tarball is no longer built. Users running Kubernetes e2e tests should use the `kubernetes-test-portable` and `kubernetes-test-{OS}-{ARCH}` tarballs instead.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-testing/20190118-breaking-apart-the-kubernetes-test-tarball.md
```
