### PR TITLE
Drop unnecessary variable for skipping

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/templater.go
@@ -268,14 +268,14 @@ func filter(cmds []*cobra.Command, names ...string) []*cobra.Command {
 		if c.Hidden {
 			continue
 		}
-		skip := false
-		for _, name := range names {
-			if name == c.Name() {
-				skip = true
-				break
+		if func() bool {
+			for _, name := range names {
+				if name == c.Name() {
+					return true
+				}
 			}
-		}
-		if skip {
+			return false
+		}() {
 			continue
 		}
 		out = append(out, c)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
filter uses a variable, skip, in order to continue with the outer loop.

This variable is not needed.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
