### PR TITLE
[migration] Mapping Layer - 2. Convert predicates/priorities configurations to a framework plugin one.

### DIFF
--- a/pkg/scheduler/factory/BUILD
+++ b/pkg/scheduler/factory/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/scheduler/api/validation:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/core:go_default_library",
+        "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/internal/cache/debugger:go_default_library",
@@ -65,6 +66,7 @@ go_test(
         "//pkg/scheduler/api/latest:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/plugins:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/internal/queue:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
@@ -79,6 +81,7 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/pkg/scheduler/framework/plugins/default_registry.go
+++ b/pkg/scheduler/framework/plugins/default_registry.go
@@ -53,8 +53,8 @@ type ConfigProducerRegistry struct {
 	PriorityToConfigProducer  map[string]ConfigProducer
 }
 
-// NewConfigProducerRegistry creates a new producer registry.
-func NewConfigProducerRegistry() *ConfigProducerRegistry {
+// NewDefaultConfigProducerRegistry creates a new producer registry.
+func NewDefaultConfigProducerRegistry() *ConfigProducerRegistry {
 	return &ConfigProducerRegistry{
 		PredicateToConfigProducer: make(map[string]ConfigProducer),
 		PriorityToConfigProducer:  make(map[string]ConfigProducer),

--- a/pkg/scheduler/framework/plugins/default_registry_test.go
+++ b/pkg/scheduler/framework/plugins/default_registry_test.go
@@ -53,7 +53,7 @@ func produceConfig(keys []string, producersMap map[string]ConfigProducer, args C
 }
 
 func TestRegisterConfigProducers(t *testing.T) {
-	registry := NewConfigProducerRegistry()
+	registry := NewDefaultConfigProducerRegistry()
 	testPredicateName1 := "testPredicate1"
 	testFilterName1 := "testFilter1"
 	registry.RegisterPredicate(testPredicateName1,


### PR DESCRIPTION
**What type of PR is this?**
/sig scheduling
/kind feature
/priority important-soon
/hold

**What this PR does / why we need it**:

To facilitate predicates/priorities migration to the framework. This PR converts configured predicates/priorities into their equivalent framework plugins for the one that actually have a mapping.

This PR is based on the changes in #83080

**Which issue(s) this PR fixes**:
Part of #82708

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```