### PR TITLE
Fix aggressive VM calls for Azure VMSS

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
@@ -86,8 +86,9 @@ func (ss *scaleSet) AttachDisk(isManagedDisk bool, diskName, diskURI string, nod
 	defer cancel()
 
 	// Invalidate the cache right after updating
-	key := buildVmssCacheKey(nodeResourceGroup, ss.makeVmssVMName(ssName, instanceID))
-	defer ss.vmssVMCache.Delete(key)
+	if err = ss.deleteCacheForNode(vmName); err != nil {
+		return err
+	}
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk(%s, %s)", nodeResourceGroup, nodeName, diskName, diskURI)
 	_, err = ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "attach_disk")
@@ -157,8 +158,9 @@ func (ss *scaleSet) DetachDisk(diskName, diskURI string, nodeName types.NodeName
 	defer cancel()
 
 	// Invalidate the cache right after updating
-	key := buildVmssCacheKey(nodeResourceGroup, ss.makeVmssVMName(ssName, instanceID))
-	defer ss.vmssVMCache.Delete(key)
+	if err = ss.deleteCacheForNode(vmName); err != nil {
+		return nil, err
+	}
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%s, %s)", nodeResourceGroup, nodeName, diskName, diskURI)
 	return ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "detach_disk")

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
@@ -21,9 +21,12 @@ package azure
 import (
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 )
@@ -32,18 +35,19 @@ var (
 	vmssNameSeparator  = "_"
 	vmssCacheSeparator = "#"
 
-	nodeNameToScaleSetMappingKey = "k8sNodeNameToScaleSetMappingKey"
-	availabilitySetNodesKey      = "k8sAvailabilitySetNodesKey"
+	vmssVirtualMachinesKey  = "k8svmssVirtualMachinesKey"
+	availabilitySetNodesKey = "k8sAvailabilitySetNodesKey"
 
-	vmssCacheTTL                      = time.Minute
-	vmssVMCacheTTL                    = time.Minute
-	availabilitySetNodesCacheTTL      = 5 * time.Minute
-	nodeNameToScaleSetMappingCacheTTL = 5 * time.Minute
+	availabilitySetNodesCacheTTL = 15 * time.Minute
+	vmssVirtualMachinesTTL       = 10 * time.Minute
 )
 
-// nodeNameToScaleSetMapping maps nodeName to scaleSet name.
-// The map is required because vmss nodeName is not equal to its vmName.
-type nodeNameToScaleSetMapping map[string]string
+type vmssVirtualMachinesEntry struct {
+	resourceGroup  string
+	vmssName       string
+	instanceID     string
+	virtualMachine *compute.VirtualMachineScaleSetVM
+}
 
 func (ss *scaleSet) makeVmssVMName(scaleSetName, instanceID string) string {
 	return fmt.Sprintf("%s%s%s", scaleSetName, vmssNameSeparator, instanceID)
@@ -63,32 +67,9 @@ func extractVmssVMName(name string) (string, string, error) {
 	return ssName, instanceID, nil
 }
 
-// vmssCache only holds vmss from ss.ResourceGroup because nodes from other resourceGroups
-// will be excluded from LB backends.
-func (ss *scaleSet) newVmssCache() (*timedCache, error) {
+func (ss *scaleSet) newVMSSVirtualMachinesCache() (*timedCache, error) {
 	getter := func(key string) (interface{}, error) {
-		ctx, cancel := getContextWithCancel()
-		defer cancel()
-		result, err := ss.VirtualMachineScaleSetsClient.Get(ctx, ss.ResourceGroup, key)
-		exists, message, realErr := checkResourceExistsFromError(err)
-		if realErr != nil {
-			return nil, realErr
-		}
-
-		if !exists {
-			klog.V(2).Infof("Virtual machine scale set %q not found with message: %q", key, message)
-			return nil, nil
-		}
-
-		return &result, nil
-	}
-
-	return newTimedcache(vmssCacheTTL, getter)
-}
-
-func (ss *scaleSet) newNodeNameToScaleSetMappingCache() (*timedCache, error) {
-	getter := func(key string) (interface{}, error) {
-		localCache := make(nodeNameToScaleSetMapping)
+		localCache := &sync.Map{} // [nodeName]*vmssVirtualMachinesEntry
 
 		allResourceGroups, err := ss.GetResourceGroups()
 		if err != nil {
@@ -107,14 +88,20 @@ func (ss *scaleSet) newNodeNameToScaleSetMappingCache() (*timedCache, error) {
 					return nil, err
 				}
 
-				for _, vm := range vms {
+				for i := range vms {
+					vm := vms[i]
 					if vm.OsProfile == nil || vm.OsProfile.ComputerName == nil {
 						klog.Warningf("failed to get computerName for vmssVM (%q)", ssName)
 						continue
 					}
 
 					computerName := strings.ToLower(*vm.OsProfile.ComputerName)
-					localCache[computerName] = ssName
+					localCache.Store(computerName, &vmssVirtualMachinesEntry{
+						resourceGroup:  resourceGroup,
+						vmssName:       ssName,
+						instanceID:     to.String(vm.InstanceID),
+						virtualMachine: &vm,
+					})
 				}
 			}
 		}
@@ -122,7 +109,18 @@ func (ss *scaleSet) newNodeNameToScaleSetMappingCache() (*timedCache, error) {
 		return localCache, nil
 	}
 
-	return newTimedcache(nodeNameToScaleSetMappingCacheTTL, getter)
+	return newTimedcache(vmssVirtualMachinesTTL, getter)
+}
+
+func (ss *scaleSet) deleteCacheForNode(nodeName string) error {
+	cached, err := ss.vmssVMCache.Get(vmssVirtualMachinesKey)
+	if err != nil {
+		return err
+	}
+
+	virtualMachines := cached.(*sync.Map)
+	virtualMachines.Delete(nodeName)
+	return nil
 }
 
 func (ss *scaleSet) newAvailabilitySetNodesCache() (*timedCache, error) {
@@ -150,91 +148,6 @@ func (ss *scaleSet) newAvailabilitySetNodesCache() (*timedCache, error) {
 	}
 
 	return newTimedcache(availabilitySetNodesCacheTTL, getter)
-}
-
-func buildVmssCacheKey(resourceGroup, name string) string {
-	// key is composed of <resourceGroup>#<vmName>
-	return fmt.Sprintf("%s%s%s", strings.ToLower(resourceGroup), vmssCacheSeparator, name)
-}
-
-func extractVmssCacheKey(key string) (string, string, error) {
-	// key is composed of <resourceGroup>#<vmName>
-	keyItems := strings.Split(key, vmssCacheSeparator)
-	if len(keyItems) != 2 {
-		return "", "", fmt.Errorf("key %q is not in format '<resourceGroup>#<vmName>'", key)
-	}
-
-	resourceGroup := keyItems[0]
-	vmName := keyItems[1]
-	return resourceGroup, vmName, nil
-}
-
-func (ss *scaleSet) newVmssVMCache() (*timedCache, error) {
-	getter := func(key string) (interface{}, error) {
-		// key is composed of <resourceGroup>#<vmName>
-		resourceGroup, vmName, err := extractVmssCacheKey(key)
-		if err != nil {
-			return nil, err
-		}
-
-		// vmName's format is 'scaleSetName_instanceID'
-		ssName, instanceID, err := extractVmssVMName(vmName)
-		if err != nil {
-			return nil, err
-		}
-
-		// Not found, the VM doesn't belong to any known scale sets.
-		if ssName == "" {
-			return nil, nil
-		}
-
-		ctx, cancel := getContextWithCancel()
-		defer cancel()
-		result, err := ss.VirtualMachineScaleSetVMsClient.Get(ctx, resourceGroup, ssName, instanceID, compute.InstanceView)
-		exists, message, realErr := checkResourceExistsFromError(err)
-		if realErr != nil {
-			return nil, realErr
-		}
-
-		if !exists {
-			klog.V(2).Infof("Virtual machine scale set VM %q not found with message: %q", key, message)
-			return nil, nil
-		}
-
-		return &result, nil
-	}
-
-	return newTimedcache(vmssVMCacheTTL, getter)
-}
-
-func (ss *scaleSet) getScaleSetNameByNodeName(nodeName string) (string, error) {
-	getScaleSetName := func(nodeName string) (string, error) {
-		nodeNameMapping, err := ss.nodeNameToScaleSetMappingCache.Get(nodeNameToScaleSetMappingKey)
-		if err != nil {
-			return "", err
-		}
-
-		realMapping := nodeNameMapping.(nodeNameToScaleSetMapping)
-		if ssName, ok := realMapping[nodeName]; ok {
-			return ssName, nil
-		}
-
-		return "", nil
-	}
-
-	ssName, err := getScaleSetName(nodeName)
-	if err != nil {
-		return "", err
-	}
-
-	if ssName != "" {
-		return ssName, nil
-	}
-
-	// ssName is still not found, it is likely that new Nodes are created.
-	// Force refresh the cache and try again.
-	ss.nodeNameToScaleSetMappingCache.Delete(nodeNameToScaleSetMappingKey)
-	return getScaleSetName(nodeName)
 }
 
 func (ss *scaleSet) isNodeManagedByAvailabilitySet(nodeName string) (bool, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Fix aggressive VM calls for Azure VMSS by

* Replacing GET VM with LIST VM so as to reduce the number of API calls
* Do not LIST VMs when VMSS capacity is 0

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82948

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Fix aggressive VM calls for Azure VMSS
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind bug
/area provider/azure
/priority critial-urgent
/assign @andyzhangx 