### PR TITLE
Fix data race in leader election

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -99,6 +99,11 @@ func NewLeaderElector(lec LeaderElectionConfig) (*LeaderElector, error) {
 	if lec.Lock == nil {
 		return nil, fmt.Errorf("Lock must not be nil.")
 	}
+	var err error
+	lec.Lock, err = rl.AsSafeLock(lec.Lock)
+	if err != nil {
+		return nil, err
+	}
 	le := LeaderElector{
 		config:  lec,
 		clock:   clock.RealClock{},

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection_test.go
@@ -277,7 +277,9 @@ func testTryAcquireOrRenew(t *testing.T, objectType string) {
 				observedTime:      test.observedTime,
 				clock:             clock.RealClock{},
 			}
-			if test.expectSuccess != le.tryAcquireOrRenew() {
+
+			result := le.tryAcquireOrRenew()
+			if test.expectSuccess != le.applyAcquireOrRenewResult(result) {
 				t.Errorf("unexpected result of tryAcquireOrRenew: [succeeded=%v]", !test.expectSuccess)
 			}
 
@@ -860,7 +862,9 @@ func testTryAcquireOrRenewMultiLock(t *testing.T, objectType string) {
 				observedTime:      test.observedTime,
 				clock:             clock.RealClock{},
 			}
-			if test.expectSuccess != le.tryAcquireOrRenew() {
+
+			result := le.tryAcquireOrRenew()
+			if test.expectSuccess != le.applyAcquireOrRenewResult(result) {
 				t.Errorf("unexpected result of tryAcquireOrRenew: [succeeded=%v]", !test.expectSuccess)
 			}
 

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/BUILD
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/BUILD
@@ -8,6 +8,7 @@ go_library(
         "interface.go",
         "leaselock.go",
         "multilock.go",
+        "safelock.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/tools/leaderelection/resourcelock",
     importpath = "k8s.io/client-go/tools/leaderelection/resourcelock",

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/safelock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/safelock.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"sync"
+)
+
+var _ Interface = &safeLock{}
+
+// safeLock is a wrapper for an existing resourcelock interface meant to be
+// used by multiple goroutines.
+type safeLock struct {
+	base Interface
+	mu   sync.Mutex
+}
+
+// Get returns the election record from a Lease spec
+func (sl *safeLock) Get() (*LeaderElectionRecord, []byte, error) {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+	return sl.base.Get()
+}
+
+// Create attempts to create a Lease
+func (sl *safeLock) Create(ler LeaderElectionRecord) error {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+	return sl.base.Create(ler)
+}
+
+// Update will update an existing Lease spec.
+func (sl *safeLock) Update(ler LeaderElectionRecord) error {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+	return sl.base.Update(ler)
+}
+
+// RecordEvent in leader election while adding meta-data
+func (sl *safeLock) RecordEvent(s string) {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+	sl.base.RecordEvent(s)
+}
+
+// Describe is used to convert details on current resource lock into a string
+func (sl *safeLock) Describe() string {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+	return sl.base.Describe()
+}
+
+// Identity returns the Identity of the lock
+func (sl *safeLock) Identity() string {
+	sl.mu.Lock()
+	defer sl.mu.Unlock()
+	return sl.base.Identity()
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

This PR fixes the data race found in leader election that was reported in #83078.

These races all have a common trigger, the goroutine started at:
https://github.com/kubernetes/kubernetes/blob/948870b5840add1ba4068e3d27d54ea353839992/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go#L266-L269

The reason this goroutine exists is to support a timeout in calls to the kubernetes API server. If client-go supported contexts on API calls this goroutine would not need to exist and neither would these race conditions exist, but since that's not the case this PR exists. :)

**Which issue(s) this PR fixes**:

Fixes #83078

**Special notes for your reviewer**:

At first I considered using as base the work started in #77818 which was not merged, but in the end I decided following a different approach, here's my reasoning.

There are two different race conditions handled by this PR.

The first one is concurrent access to the internal state in the `* LeaderElector` instance, namely `observedRecord` and `observedTime` fields. To circumvent this problem this PR changes the code executed inside the goroutine (`tryAcquireOrRenew` method) not to change any internal state and instead return a structure with the intended changes. This structure is then read and applied to the internal state in the main goroutine only if we're sure the concurrent goroutine has exited. This allow the first race to be fixed without any additional locks.

The second one is concurrent access to internal state in the resource lock instance. This problem is present on all `resourcelock.Interface` implementations (the [`e` field in `EndpointsLock`](https://github.com/kubernetes/kubernetes/blob/948870b5840add1ba4068e3d27d54ea353839992/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go#L35), the [`lease` field in `LeaseLock`](https://github.com/kubernetes/kubernetes/blob/948870b5840add1ba4068e3d27d54ea353839992/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/leaselock.go#L35), ...). There is no way to prevent the concurrent goroutine to make calls to the resourcelock since that's the reason it exists in the first place, so the solution here was adding mutexes.

Instead of adding individual locks on each `resourcelock.Interface` implementation I went with creating a new implementation called `safeLock` which wraps a `resourcelock.Interface` and locks a mutex on each method call. The `resourcelock.New` call was changed to always return a `SafeLock` instance and the LeaderElector ensures it's always handling a `safeLock`.

/sig api-machinery

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
