### PR TITLE
Automated cherry pick of #83036: Use ipv4 in wincat port forward

### DIFF
--- a/pkg/kubelet/dockershim/docker_streaming_windows.go
+++ b/pkg/kubelet/dockershim/docker_streaming_windows.go
@@ -28,7 +28,7 @@ import (
 
 func (r *streamingRuntime) portForward(podSandboxID string, port int32, stream io.ReadWriteCloser) error {
 	stderr := new(bytes.Buffer)
-	err := r.exec(podSandboxID, []string{"wincat.exe", "localhost", fmt.Sprint(port)}, stream, stream, ioutils.WriteCloserWrapper(stderr), false, nil, 0)
+	err := r.exec(podSandboxID, []string{"wincat.exe", "127.0.0.1", fmt.Sprint(port)}, stream, stream, ioutils.WriteCloserWrapper(stderr), false, nil, 0)
 	if err != nil {
 		return fmt.Errorf("%v: %s", err, stderr.String())
 	}


### PR DESCRIPTION
Cherry pick of #83036 on release-1.16.

#83036: Use ipv4 in wincat port forward

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.