### PR TITLE
exclude kms provider check from livez and readyz

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -211,7 +211,9 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 		if err != nil {
 			return err
 		}
-		c.AddHealthChecks(kmsPluginHealthzChecks...)
+
+		// kmsPluginHealzChecks should NOT be added to LivezChecks
+		c.HealthzChecks = append(c.HealthzChecks, kmsPluginHealthzChecks...)
 	}
 
 	return nil


### PR DESCRIPTION
Change-Id: I9f5c7c420416c8ebe5eea3fad7984accc21891dd

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
we should not add kms provider check to livez probe because the kube-apiserver will restart if kms provider is not unhealthy and result in a large number of requests to kms provider. restarting kube-apiserver doesn't help in this case.

```release-note
NONE
```