### PR TITLE
Apply currently parses the yaml object 3 times, please remove 2

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -216,7 +216,7 @@ func (f *fieldManager) Apply(liveObj runtime.Object, patch []byte, fieldManager 
 	}
 	internal.RemoveObjectManagedFields(liveObjVersioned)
 
-	patchObjTyped, err := f.typeConverter.YAMLToTyped(patch)
+	patchObjTyped, err := f.typeConverter.ObjectToTyped(patchObj)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create typed patch object: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/BUILD
@@ -27,7 +27,6 @@ go_library(
         "//vendor/sigs.k8s.io/structured-merge-diff/merge:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/typed:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/value:go_default_library",
-        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/typeconverter_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/typeconverter_test.go
@@ -124,9 +124,6 @@ spec:
 		t.Run(fmt.Sprintf("%v ObjectToTyped with TypeConverter", testCase.name), func(t *testing.T) {
 			testObjectToTyped(t, tc, testCase.yaml)
 		})
-		t.Run(fmt.Sprintf("%v YAMLToTyped with TypeConverter", testCase.name), func(t *testing.T) {
-			testYAMLToTyped(t, tc, testCase.yaml)
-		})
 		t.Run(fmt.Sprintf("%v ObjectToTyped with DeducedTypeConverter", testCase.name), func(t *testing.T) {
 			testObjectToTyped(t, dtc, testCase.yaml)
 		})
@@ -155,31 +152,9 @@ Final object:
 	}
 }
 
-func testYAMLToTyped(t *testing.T, tc internal.TypeConverter, y string) {
-	obj := &unstructured.Unstructured{Object: map[string]interface{}{}}
-	if err := yaml.Unmarshal([]byte(y), &obj.Object); err != nil {
-		t.Fatalf("Failed to parse yaml object: %v", err)
-	}
-	yamlTyped, err := tc.YAMLToTyped([]byte(y))
-	if err != nil {
-		t.Fatalf("Failed to convert yaml to typed: %v", err)
-	}
-	newObj, err := tc.TypedToObject(yamlTyped)
-	if err != nil {
-		t.Fatalf("Failed to convert typed to object: %v", err)
-	}
-	if !reflect.DeepEqual(obj, newObj) {
-		t.Errorf(`YAML conversion resulted in different object failed:
-Original object:
-%#v
-Final object:
-%#v`, obj, newObj)
-	}
-}
-
 var result typed.TypedValue
 
-func BenchmarkYAMLToTyped(b *testing.B) {
+func BenchmarkObjectToTyped(b *testing.B) {
 	y := `
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
This is super expensive and not needed at all since we don't have to
reparse the entire object. Remove all allocations but the first one.

Using the benchmarks from #82847
```
benchmark                                 old ns/op     new ns/op     delta
BenchmarkApplyNewObject/Pod-12            2348652       1505817       -35.89%
BenchmarkApplyNewObject/Node-12           4569184       2656921       -41.85%
BenchmarkApplyNewObject/Endpoints-12      90670338      38864724      -57.14%
BenchmarkUpdateNewObject/Pod-12           1073668       1067810       -0.55%
BenchmarkUpdateNewObject/Node-12          1510927       1531581       +1.37%
BenchmarkUpdateNewObject/Endpoints-12     5866342       5929641       +1.08%
BenchmarkRepeatedUpdate-12                937133        967885        +3.28%

benchmark                                 old allocs     new allocs     delta
BenchmarkApplyNewObject/Pod-12            8819           5028           -42.99%
BenchmarkApplyNewObject/Node-12           17696          9528           -46.16%
BenchmarkApplyNewObject/Endpoints-12      409593         176869         -56.82%
BenchmarkUpdateNewObject/Pod-12           3977           3977           +0.00%
BenchmarkUpdateNewObject/Node-12          5742           5742           +0.00%
BenchmarkUpdateNewObject/Endpoints-12     21442          21442          +0.00%
BenchmarkRepeatedUpdate-12                3027           3027           +0.00%
```

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
