### PR TITLE
Utilize map for canBeExposed

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/canbeexposed.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/canbeexposed.go
@@ -25,19 +25,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var exposableGK = map[schema.GroupKind]bool {
+	corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(): true,
+	corev1.SchemeGroupVersion.WithKind("Service").GroupKind():               true,
+	corev1.SchemeGroupVersion.WithKind("Pod").GroupKind():                   true,
+	appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind():            true,
+	appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():            true,
+	extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(): true,
+	extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(): true,
+}
+
 // Check whether the kind of resources could be exposed
 func canBeExposed(kind schema.GroupKind) error {
-	switch kind {
-	case
-		corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind(),
-		corev1.SchemeGroupVersion.WithKind("Service").GroupKind(),
-		corev1.SchemeGroupVersion.WithKind("Pod").GroupKind(),
-		appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
-		appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind(),
-		extensionsv1beta1.SchemeGroupVersion.WithKind("Deployment").GroupKind(),
-		extensionsv1beta1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():
-		// nothing to do here
-	default:
+	if _, ok := exposableGK[kind]; !ok {
 		return fmt.Errorf("cannot expose a %s", kind)
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently canBeExposed checks known GroupKind's in sequence.

This PR utilizes map to make the check faster.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
