### PR TITLE
apiextensions: use etag in openapi overlap protection integration test

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -907,6 +907,7 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 				body:        body,
 				contentType: contentType,
 				statusCode:  resp.StatusCode,
+				header:      resp.Header,
 			}
 		}
 	}
@@ -923,6 +924,7 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 			body:        body,
 			contentType: contentType,
 			statusCode:  resp.StatusCode,
+			header:      resp.Header,
 			decoder:     decoder,
 			err:         err,
 		}
@@ -932,6 +934,7 @@ func (r *Request) transformResponse(resp *http.Response, req *http.Request) Resu
 		body:        body,
 		contentType: contentType,
 		statusCode:  resp.StatusCode,
+		header:      resp.Header,
 		decoder:     decoder,
 	}
 }
@@ -1071,6 +1074,7 @@ type Result struct {
 	contentType string
 	err         error
 	statusCode  int
+	header      http.Header
 
 	decoder runtime.Decoder
 }
@@ -1111,6 +1115,12 @@ func (r Result) Get() (runtime.Object, error) {
 // error was returned.)
 func (r Result) StatusCode(statusCode *int) Result {
 	*statusCode = r.statusCode
+	return r
+}
+
+// Header returns the HTTP header of the response.
+func (r Result) Header(header *http.Header) Result {
+	*header = r.header
 	return r
 }
 

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -1111,14 +1111,14 @@ func (r Result) Get() (runtime.Object, error) {
 	return out, nil
 }
 
-// StatusCode returns the HTTP status code of the request. (Only valid if no
-// error was returned.)
+// StatusCode sets the provided statusCode to the HTTP status code of the request.
+// (Only valid if no error was returned.)
 func (r Result) StatusCode(statusCode *int) Result {
 	*statusCode = r.statusCode
 	return r
 }
 
-// Header returns the HTTP header of the response.
+// Header sets the provided header to the HTTP header of the response
 func (r Result) Header(header *http.Header) Result {
 	*header = r.header
 	return r


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Followup of https://github.com/kubernetes/kubernetes/pull/81436. Expose HTTP response header in rest client. Utilize ETag when downloading OpenAPI spec in integration test.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
Add a method to rest client `Result` that exposes the HTTP header of the response.
```

/sig api-machinery
/area custom-resources
/assign @sttts 