### PR TITLE
authproxy request headers support comma split

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -156,7 +156,7 @@ func allHeaderValues(h http.Header, headerNames []string) []string {
 
 		for _, headerValue := range values {
 			if len(headerValue) > 0 {
-				ret = append(ret, headerValue)
+				ret = append(ret, strings.Split(headerValue, ",")...)
 			}
 		}
 	}

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader_test.go
@@ -96,6 +96,20 @@ func TestRequestHeader(t *testing.T) {
 			},
 			expectedOk: true,
 		},
+		"groups comma separated": {
+			nameHeaders:  []string{"X-Remote-User"},
+			groupHeaders: []string{"X-Remote-Group"},
+			requestHeaders: http.Header{
+				"X-Remote-User":  {"Bob"},
+				"X-Remote-Group": {"one-a,one-b"},
+			},
+			expectedUser: &user.DefaultInfo{
+				Name:   "Bob",
+				Groups: []string{"one-a", "one-b"},
+				Extra:  map[string][]string{},
+			},
+			expectedOk: true,
+		},
 		"groups all matches": {
 			nameHeaders:  []string{"X-Remote-User"},
 			groupHeaders: []string{"X-Remote-Group-1", "X-Remote-Group-2"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
This PR make authproxy requestheaders support comma split.

As mentioned in #82468, The HTTP spec [RFC 2616](https://tools.ietf.org/html/rfc2616#section-4.2) specifies how multiple headers of the same name can be combined into one.

> Multiple message-header fields with the same field-name MAY be
present in a message if and only if the entire field-value for that
header field is defined as a comma-separated list [i.e., #(values)].
It MUST be possible to combine the multiple header fields into one
"field-name: field-value" pair, without changing the semantics of the
message, by appending each subsequent field-value to the first, each
separated by a comma.

And we have encountered X-Remote-Groups more than once because it does not support comma splitting, which causes users to not easily use the auth proxy. 

For example:
1. Python's WSGI not support sending multiple headers of the same name
2. nginx auth_request and envoy ext_authz don't support multiple headers of the same name.

So supporting this feature is not only in line with RFC 2616, but also better integrated with other tools.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82468
Fixes #66754

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
This change may have compatibility issues if the group name contains a comma. So user need to check group names and escape the comma.
```
