### PR TITLE
Remove direct reference to prometheus.Label from metrics API.

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -139,7 +139,7 @@ func (v *CounterVec) WithLabelValues(lvs ...string) CounterMetric {
 // must match those of the VariableLabels in Desc). If that label map is
 // accessed for the first time, a new Counter is created IFF the counterVec has
 // been registered to a metrics registry.
-func (v *CounterVec) With(labels prometheus.Labels) CounterMetric {
+func (v *CounterVec) With(labels map[string]string) CounterMetric {
 	if !v.IsCreated() {
 		return noop // return no-op counter
 	}
@@ -153,7 +153,7 @@ func (v *CounterVec) With(labels prometheus.Labels) CounterMetric {
 // with those of the VariableLabels in Desc. However, such inconsistent Labels
 // can never match an actual metric, so the method will always return false in
 // that case.
-func (v *CounterVec) Delete(labels prometheus.Labels) bool {
+func (v *CounterVec) Delete(labels map[string]string) bool {
 	if !v.IsCreated() {
 		return false // since we haven't created the metric, we haven't deleted a metric with the passed in values
 	}

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -138,7 +138,7 @@ func (v *GaugeVec) WithLabelValues(lvs ...string) GaugeMetric {
 // must match those of the VariableLabels in Desc). If that label map is
 // accessed for the first time, a new GaugeMetric is created IFF the gaugeVec has
 // been registered to a metrics registry.
-func (v *GaugeVec) With(labels prometheus.Labels) GaugeMetric {
+func (v *GaugeVec) With(labels map[string]string) GaugeMetric {
 	if !v.IsCreated() {
 		return noop // return no-op gauge
 	}
@@ -152,7 +152,7 @@ func (v *GaugeVec) With(labels prometheus.Labels) GaugeMetric {
 // with those of the VariableLabels in Desc. However, such inconsistent Labels
 // can never match an actual metric, so the method will always return false in
 // that case.
-func (v *GaugeVec) Delete(labels prometheus.Labels) bool {
+func (v *GaugeVec) Delete(labels map[string]string) bool {
 	if !v.IsCreated() {
 		return false // since we haven't created the metric, we haven't deleted a metric with the passed in values
 	}

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -146,7 +146,7 @@ func (v *HistogramVec) WithLabelValues(lvs ...string) ObserverMetric {
 // must match those of the VariableLabels in Desc). If that label map is
 // accessed for the first time, a new ObserverMetric is created IFF the HistogramVec has
 // been registered to a metrics registry.
-func (v *HistogramVec) With(labels prometheus.Labels) ObserverMetric {
+func (v *HistogramVec) With(labels map[string]string) ObserverMetric {
 	if !v.IsCreated() {
 		return noop
 	}
@@ -160,7 +160,7 @@ func (v *HistogramVec) With(labels prometheus.Labels) ObserverMetric {
 // with those of the VariableLabels in Desc. However, such inconsistent Labels
 // can never match an actual metric, so the method will always return false in
 // that case.
-func (v *HistogramVec) Delete(labels prometheus.Labels) bool {
+func (v *HistogramVec) Delete(labels map[string]string) bool {
 	if !v.IsCreated() {
 		return false // since we haven't created the metric, we haven't deleted a metric with the passed in values
 	}

--- a/staging/src/k8s.io/component-base/metrics/opts.go
+++ b/staging/src/k8s.io/component-base/metrics/opts.go
@@ -34,7 +34,7 @@ type KubeOpts struct {
 	Subsystem         string
 	Name              string
 	Help              string
-	ConstLabels       prometheus.Labels
+	ConstLabels       map[string]string
 	DeprecatedVersion string
 	deprecateOnce     sync.Once
 	annotateOnce      sync.Once
@@ -132,7 +132,7 @@ type HistogramOpts struct {
 	Subsystem         string
 	Name              string
 	Help              string
-	ConstLabels       prometheus.Labels
+	ConstLabels       map[string]string
 	Buckets           []float64
 	DeprecatedVersion string
 	deprecateOnce     sync.Once
@@ -178,7 +178,7 @@ type SummaryOpts struct {
 	Subsystem         string
 	Name              string
 	Help              string
-	ConstLabels       prometheus.Labels
+	ConstLabels       map[string]string
 	Objectives        map[float64]float64
 	MaxAge            time.Duration
 	AgeBuckets        uint32

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -140,7 +140,7 @@ func (v *SummaryVec) WithLabelValues(lvs ...string) ObserverMetric {
 // must match those of the VariableLabels in Desc). If that label map is
 // accessed for the first time, a new ObserverMetric is created IFF the summaryVec has
 // been registered to a metrics registry.
-func (v *SummaryVec) With(labels prometheus.Labels) ObserverMetric {
+func (v *SummaryVec) With(labels map[string]string) ObserverMetric {
 	if !v.IsCreated() {
 		return noop
 	}
@@ -154,7 +154,7 @@ func (v *SummaryVec) With(labels prometheus.Labels) ObserverMetric {
 // with those of the VariableLabels in Desc. However, such inconsistent Labels
 // can never match an actual metric, so the method will always return false in
 // that case.
-func (v *SummaryVec) Delete(labels prometheus.Labels) bool {
+func (v *SummaryVec) Delete(labels map[string]string) bool {
 	if !v.IsCreated() {
 		return false // since we haven't created the metric, we haven't deleted a metric with the passed in values
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove direct reference to `prometheus.Label` that will make it possible for downstream migrate to stability framework.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

