### PR TITLE
bumps kube-state-metrics version to v1.7.2

### DIFF
--- a/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
@@ -7,24 +7,24 @@ metadata:
     k8s-app: kube-state-metrics
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v1.3.0
+    version: v1.7.2
 spec:
   selector:
     matchLabels:
       k8s-app: kube-state-metrics
-      version: v1.3.0
+      version: v1.7.2
   replicas: 1
   template:
     metadata:
       labels:
         k8s-app: kube-state-metrics
-        version: v1.3.0
+        version: v1.7.2
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
-        image: quay.io/coreos/kube-state-metrics:v1.3.0
+        image: quay.io/coreos/kube-state-metrics:v1.7.2
         ports:
         - name: http-metrics
           containerPort: 8080


### PR DESCRIPTION

**What type of PR is this?**

**What this PR does / why we need it**:

bumps kube-state-metrics version 

**Does this PR introduce a user-facing change?**:
bumps kube-state-metrics version to v1.7.2