### PR TITLE
Refactor cmd/kubemark to use legacyflags

### DIFF
--- a/Godeps/LICENSES
+++ b/Godeps/LICENSES
@@ -23172,6 +23172,215 @@ third-party archives.
 
 
 ================================================================================
+= vendor/sigs.k8s.io/legacyflag licensed under: =
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+= vendor/sigs.k8s.io/legacyflag/LICENSE e3fc50a88d0a364313df4b21ef20c29e
+================================================================================
+
+
+================================================================================
 = vendor/sigs.k8s.io/structured-merge-diff licensed under: =
 
                                  Apache License

--- a/cmd/kubemark/BUILD
+++ b/cmd/kubemark/BUILD
@@ -41,6 +41,7 @@ go_library(
         "//staging/src/k8s.io/component-base/version/verflag:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/sigs.k8s.io/legacyflag/pkg/legacyflag:all-srcs",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec/testing:go_default_library",
     ],

--- a/go.mod
+++ b/go.mod
@@ -169,6 +169,7 @@ require (
 	k8s.io/sample-apiserver v0.0.0
 	k8s.io/utils v0.0.0-20190920012459-5008bf6f8cd6
 	sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/legacyflag v0.0.0-20190711104526-ba9a5f230ff1
 	sigs.k8s.io/yaml v1.1.0
 	vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc
 )
@@ -489,6 +490,7 @@ replace (
 	modernc.org/strutil => modernc.org/strutil v1.0.0
 	modernc.org/xc => modernc.org/xc v1.0.0
 	sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
+	sigs.k8s.io/legacyflag => sigs.k8s.io/legacyflag v0.0.0-20190711104526-ba9a5f230ff1
 	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca
 	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.1.0
 	vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc

--- a/go.sum
+++ b/go.sum
@@ -524,6 +524,8 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
+sigs.k8s.io/legacyflag v0.0.0-20190711104526-ba9a5f230ff1 h1:2umCSjTzrEHgJikKJqkUh+r6nMfRM3cxFp7NDUEnyTs=
+sigs.k8s.io/legacyflag v0.0.0-20190711104526-ba9a5f230ff1/go.mod h1:KJXbUpMOwuccHy8cuugAYolIVfoWToGNLp7mbJ30gYk=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=

--- a/pkg/master/ports/ports.go
+++ b/pkg/master/ports/ports.go
@@ -54,4 +54,8 @@ const (
 	// KubeSchedulerPort is the default port for the scheduler status server.
 	// May be overridden by a flag at startup.
 	KubeSchedulerPort = 10259
+
+	// KubeApiServerPort is the default port for the server api.
+	// May be overridden by a flag at startup.
+	KubeApiServerPort = 443
 )

--- a/vendor/BUILD
+++ b/vendor/BUILD
@@ -530,6 +530,7 @@ filegroup(
         "//vendor/sigs.k8s.io/kustomize/pkg/target:all-srcs",
         "//vendor/sigs.k8s.io/kustomize/pkg/transformers:all-srcs",
         "//vendor/sigs.k8s.io/kustomize/pkg/types:all-srcs",
+        "//vendor/sigs.k8s.io/legacyflag/pkg/legacyflag:all-srcs",
         "//vendor/sigs.k8s.io/structured-merge-diff/fieldpath:all-srcs",
         "//vendor/sigs.k8s.io/structured-merge-diff/merge:all-srcs",
         "//vendor/sigs.k8s.io/structured-merge-diff/schema:all-srcs",

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1921,6 +1921,8 @@ sigs.k8s.io/kustomize/pkg/transformers
 sigs.k8s.io/kustomize/pkg/transformers/config
 sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig
 sigs.k8s.io/kustomize/pkg/types
+# sigs.k8s.io/legacyflag v0.0.0-20190711104526-ba9a5f230ff1 => sigs.k8s.io/legacyflag v0.0.0-20190711104526-ba9a5f230ff1
+sigs.k8s.io/legacyflag/pkg/legacyflag
 # sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca => sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca
 sigs.k8s.io/structured-merge-diff/fieldpath
 sigs.k8s.io/structured-merge-diff/merge

--- a/vendor/sigs.k8s.io/legacyflag/LICENSE
+++ b/vendor/sigs.k8s.io/legacyflag/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/BUILD
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/BUILD
@@ -1,0 +1,52 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "bool.go",
+        "bool_slice.go",
+        "flag.go",
+        "float32.go",
+        "float64.go",
+        "global.go",
+        "int.go",
+        "int16.go",
+        "int32.go",
+        "int64.go",
+        "int8.go",
+        "int_slice.go",
+        "map.go",
+        "map_string_bool.go",
+        "map_string_string.go",
+        "net_ip.go",
+        "net_ipnet.go",
+        "string.go",
+        "string_slice.go",
+        "time_duration.go",
+        "uint.go",
+        "uint16.go",
+        "uint32.go",
+        "uint64.go",
+        "uint8.go",
+        "uint_slice.go",
+        "var.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag",
+    importpath = "sigs.k8s.io/legacyflag/pkg/legacyflag",
+    visibility = ["//visibility:public"],
+    deps = ["//vendor/github.com/spf13/pflag:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// BoolValue is a reference to a registered bool flag value.
+type BoolValue struct {
+	name string
+	value bool
+	fs *pflag.FlagSet
+}
+
+// BoolVar registers a flag for bool against the FlagSet, and returns
+// a BoolValue reference to the registered flag value.
+func (fs *FlagSet) BoolVar(name string, def bool, usage string) *BoolValue {
+	v := &BoolValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.BoolVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *BoolValue) Set(target *bool) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *BoolValue) Apply(apply func(value bool)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/bool_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// BoolSliceValue is a reference to a registered []bool flag value.
+type BoolSliceValue struct {
+	name string
+	value []bool
+	fs *pflag.FlagSet
+}
+
+// BoolSliceVar registers a flag for []bool against the FlagSet, and
+// returns a BoolSliceValue reference to the registered flag value.
+func (fs *FlagSet) BoolSliceVar(name string, def []bool, usage string) *BoolSliceValue {
+	v := &BoolSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.BoolSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *BoolSliceValue) Set(target *[]bool) {
+	if v.fs.Changed(v.name) {
+		*target = make([]bool, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *BoolSliceValue) Apply(apply func(value []bool)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/flag.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/flag.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// FlagSet tracks the registered flags.
+type FlagSet struct {
+	fs *pflag.FlagSet
+}
+
+// NewFlagSet constructs a new FlagSet.
+func NewFlagSet(name string) *FlagSet {
+	return &FlagSet{
+		fs: pflag.NewFlagSet(name, pflag.ContinueOnError),
+	}
+}
+
+// NewFromPFlagSet creates a new FlagSet given a PFlagSet.
+func NewFromPFlagSet(fs *pflag.FlagSet) *FlagSet {
+	return &FlagSet{fs: fs}
+}
+
+// PflagFlagSet returns the underlying pflag.FlagSet.
+func (fs *FlagSet) PflagFlagSet() *pflag.FlagSet {
+	return fs.fs
+}
+
+// Parse parses the flags.
+func (fs *FlagSet) Parse(args []string) error {
+	return fs.fs.Parse(args)
+}
+
+// MarkDeprecated marks a flag as deprecated.
+func (fs *FlagSet) MarkDeprecated(name, message string) error {
+	return fs.fs.MarkDeprecated(name, message)
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float32.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float32.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Float32Value is a reference to a registered float32 flag value.
+type Float32Value struct {
+	name string
+	value float32
+	fs *pflag.FlagSet
+}
+
+// Float32Var registers a flag for float32 against the FlagSet, and returns
+// a Float32Value reference to the registered flag value.
+func (fs *FlagSet) Float32Var(name string, def float32, usage string) *Float32Value {
+	v := &Float32Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Float32Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Float32Value) Set(target *float32) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Float32Value) Apply(apply func(value float32)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float64.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/float64.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Float64Value is a reference to a registered float64 flag value.
+type Float64Value struct {
+	name string
+	value float64
+	fs *pflag.FlagSet
+}
+
+// Float64Var registers a flag for float64 against the FlagSet, and returns
+// a Float64Value reference to the registered flag value.
+func (fs *FlagSet) Float64Var(name string, def float64, usage string) *Float64Value {
+	v := &Float64Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Float64Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Float64Value) Set(target *float64) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Float64Value) Apply(apply func(value float64)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/global.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/global.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// Based on the Kubelet's k8s.io/kubernetes/cmd/kubelet/app/options/globalflags.go
+
+// MustAddGlobalFlag adds the flag from the global Go flag command line, and
+// panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddGlobalFlag(name string) {
+	if f := flag.CommandLine.Lookup(name); f != nil {
+		pflagFlag := pflag.PFlagFromGoFlag(f)
+		pflagFlag.Name = normalize(pflagFlag.Name)
+		fs.fs.AddFlag(pflagFlag)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (flag): %s", name))
+	}
+}
+
+// MustAddGlobalPflag adds the flag from the global pflag command line, and
+// panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddGlobalPflag(name string) {
+	if f := pflag.CommandLine.Lookup(name); f != nil {
+		f.Name = normalize(f.Name)
+		fs.fs.AddFlag(f)
+	} else {
+		panic(fmt.Sprintf("failed to find flag in global flagset (pflag): %s", name))
+	}
+}
+
+// For legacy reasons, components may wish to mark global
+// flags deprecated before removing them:
+
+const deprecated = "This flag has been deprecated and will be removed in a future version."
+
+// MustAddDeprecatedGlobalFlag adds the flag from the global Go flag command
+// line, marks it deprecated, and panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddDeprecatedGlobalFlag(name string) {
+	fs.MustAddGlobalFlag(name)
+	fs.fs.Lookup(normalize(name)).Deprecated = deprecated
+}
+
+// MustAddDeprecatedGlobalPflag adds the flag from the global pflag command
+// line, marks it deprecated, and panics if the flag doesn't exist.
+func (fs *FlagSet) MustAddDeprecatedGlobalPflag(name string) {
+	fs.MustAddGlobalPflag(name)
+	fs.fs.Lookup(normalize(name)).Deprecated = deprecated
+}
+
+// normalize replaces underscores with hyphens
+func normalize(s string) string {
+	return strings.Replace(s, "_", "-", -1)
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// IntValue is a reference to a registered int flag value.
+type IntValue struct {
+	name string
+	value int
+	fs *pflag.FlagSet
+}
+
+// IntVar registers a flag for int against the FlagSet, and returns
+// a IntValue reference to the registered flag value.
+func (fs *FlagSet) IntVar(name string, def int, usage string) *IntValue {
+	v := &IntValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IntVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IntValue) Set(target *int) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IntValue) Apply(apply func(value int)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int16.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int16.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int16Value is a reference to a registered int16 flag value.
+type Int16Value struct {
+	name string
+	value int16
+	fs *pflag.FlagSet
+}
+
+// Int16Var registers a flag for int16 against the FlagSet, and returns
+// a Int16Value reference to the registered flag value.
+func (fs *FlagSet) Int16Var(name string, def int16, usage string) *Int16Value {
+	v := &Int16Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int16Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int16Value) Set(target *int16) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int16Value) Apply(apply func(value int16)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int32.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int32.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int32Value is a reference to a registered int32 flag value.
+type Int32Value struct {
+	name string
+	value int32
+	fs *pflag.FlagSet
+}
+
+// Int32Var registers a flag for int32 against the FlagSet, and returns
+// a Int32Value reference to the registered flag value.
+func (fs *FlagSet) Int32Var(name string, def int32, usage string) *Int32Value {
+	v := &Int32Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int32Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int32Value) Set(target *int32) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int32Value) Apply(apply func(value int32)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int64.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int64.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int64Value is a reference to a registered int64 flag value.
+type Int64Value struct {
+	name string
+	value int64
+	fs *pflag.FlagSet
+}
+
+// Int64Var registers a flag for int64 against the FlagSet, and returns
+// a Int64Value reference to the registered flag value.
+func (fs *FlagSet) Int64Var(name string, def int64, usage string) *Int64Value {
+	v := &Int64Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int64Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int64Value) Set(target *int64) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int64Value) Apply(apply func(value int64)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int8.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int8.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Int8Value is a reference to a registered int8 flag value.
+type Int8Value struct {
+	name string
+	value int8
+	fs *pflag.FlagSet
+}
+
+// Int8Var registers a flag for int8 against the FlagSet, and returns
+// a Int8Value reference to the registered flag value.
+func (fs *FlagSet) Int8Var(name string, def int8, usage string) *Int8Value {
+	v := &Int8Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Int8Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Int8Value) Set(target *int8) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Int8Value) Apply(apply func(value int8)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/int_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// IntSliceValue is a reference to a registered []int flag value.
+type IntSliceValue struct {
+	name string
+	value []int
+	fs *pflag.FlagSet
+}
+
+// IntSliceVar registers a flag for []int against the FlagSet, and
+// returns a IntSliceValue reference to the registered flag value.
+func (fs *FlagSet) IntSliceVar(name string, def []int, usage string) *IntSliceValue {
+	v := &IntSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IntSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IntSliceValue) Set(target *[]int) {
+	if v.fs.Changed(v.name) {
+		*target = make([]int, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IntSliceValue) Apply(apply func(value []int)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+// TODO(mtaufen): wait until https://github.com/kubernetes/kubernetes/pull/76354
+// is finalized and port those decisions to here.
+
+// MapOptions contains options that control how the values are parsed
+type MapOptions struct {
+	// DisableCommaSeparatedPairs disables parsing multiple comma-separated
+	// key-value pairs from a single invocation. Instead, the entire string
+	// after the = separator will be parsed as the value. This can be convenient
+	// if values contain commas.
+	DisableCommaSeparatedPairs bool
+
+	// KeyValueSep is the separator between a key and its corresponding value.
+	// Default: equals sign (=).
+	KeyValueSep string
+
+	// PairSep is the separator between key-value pairs.
+	// Default: comma (,).
+	PairSep string
+}
+
+// Default applies defaults to uninitialized values in MapOptions.
+func (o *MapOptions) Default() {
+	if o.KeyValueSep == "" {
+		o.KeyValueSep = "="
+	}
+	if o.PairSep == "" {
+		o.PairSep = ","
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_bool.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_bool.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// MapStringBoolValue is a reference to a registered map[string]bool flag value.
+type MapStringBoolValue struct {
+	name  string
+	value map[string]bool
+	fs    *pflag.FlagSet
+}
+
+// MapStringBoolVar registers a flag for map[string]bool against the FlagSet,
+// and returns a MapStringBoolValue reference to the registered flag value.
+// Format: `--flag "string=bool"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported.
+// Example usage: `--flag "a=true,b=false"`.
+// Multiple flag invocations are supported.
+// Example usage: `--flag "a=true" --flag "b=false"`.
+func (fs *FlagSet) MapStringBoolVar(name string, def map[string]bool, usage string, options *MapOptions) *MapStringBoolValue {
+	val := &MapStringBoolValue{
+		name:  name,
+		value: make(map[string]bool),
+		fs:    fs.fs,
+	}
+	for k, v := range def {
+		val.value[k] = v
+	}
+	fs.fs.Var(newMapStringBool(&val.value, options), name, usage)
+	return val
+}
+
+// Set copies the map over the target if the flag was set.
+// It completely overwrites any existing target.
+func (v *MapStringBoolValue) Set(target *map[string]bool) {
+	if v.fs.Changed(v.name) {
+		*target = make(map[string]bool)
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Merge copies the map keys/values piecewise into the target if the flag
+// was set. Values in the flag's map override values for corresponding
+// keys in the target map.
+func (v *MapStringBoolValue) Merge(target *map[string]bool) {
+	if v.fs.Changed(v.name) {
+		if *target == nil {
+			*target = make(map[string]bool)
+		}
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Apply calls the user-provided apply function with the map if the flag was set.
+func (v *MapStringBoolValue) Apply(apply func(value map[string]bool)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}
+
+// mapStringBool implements pflag.Value for map[string]bool
+type mapStringBool struct {
+	m           *map[string]bool
+	initialized bool
+	options     *MapOptions
+}
+
+// newMapStringBool takes a pointer to a map[string]string and returns the
+// mapStringBool flag parsing shim for that map
+func newMapStringBool(m *map[string]bool, o *MapOptions) *mapStringBool {
+	o.Default()
+	return &mapStringBool{m: m, options: o}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *mapStringBool) String() string {
+	if m == nil || m.m == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.m {
+		pairs = append(pairs, fmt.Sprintf("%s%s%t", k, m.options.KeyValueSep, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, m.options.PairSep)
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *mapStringBool) Set(value string) error {
+	if m.m == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]bool)")
+	}
+	if !m.initialized || *m.m == nil {
+		// clear default values, or allocate if no existing map
+		*m.m = make(map[string]bool)
+		m.initialized = true
+	}
+	if !m.options.DisableCommaSeparatedPairs {
+		for _, s := range strings.Split(value, m.options.PairSep) {
+			if len(s) == 0 {
+				continue
+			}
+			arr := strings.SplitN(s, m.options.KeyValueSep, 2)
+			if len(arr) != 2 {
+				return fmt.Errorf("malformed pair, expect string%sbool", m.options.KeyValueSep)
+			}
+			k := strings.TrimSpace(arr[0])
+			v := strings.TrimSpace(arr[1])
+			boolValue, err := strconv.ParseBool(v)
+			if err != nil {
+				return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
+			}
+			(*m.m)[k] = boolValue
+		}
+		return nil
+	}
+
+	// account for only one key-value pair in a single invocation
+	arr := strings.SplitN(value, m.options.KeyValueSep, 2)
+	if len(arr) != 2 {
+		return fmt.Errorf("malformed pair, expect string%sbool", m.options.KeyValueSep)
+	}
+	k := strings.TrimSpace(arr[0])
+	v := strings.TrimSpace(arr[1])
+	boolValue, err := strconv.ParseBool(v)
+	if err != nil {
+		return fmt.Errorf("invalid value of %s: %s, err: %v", k, v, err)
+	}
+	(*m.m)[k] = boolValue
+
+	return nil
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*mapStringBool) Type() string {
+	return "mapStringBool"
+}
+
+// Empty implements OmitEmpty
+func (m *mapStringBool) Empty() bool {
+	return len(*m.m) == 0
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_string.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/map_string_string.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// MapStringStringValue is a reference to a registered map[string]string flag value.
+type MapStringStringValue struct {
+	name  string
+	value map[string]string
+	fs    *pflag.FlagSet
+}
+
+// MapStringStringVar registers a flag for map[string]string against the FlagSet,
+// and returns a MapStringStringValue reference to the registered flag value.
+// Format: `--flag "string=string"`.
+// Multiple comma-separated key-value pairs in a single invocation are supported,
+// when MapOptions.DisableBatch=false.
+// For example: `--flag "a=foo,b=bar"`.
+// Multiple flag invocations are supported.
+// For example: `--flag "a=foo" --flag "b=bar"`.
+func (fs *FlagSet) MapStringStringVar(name string, def map[string]string, usage string, options *MapOptions) *MapStringStringValue {
+	val := &MapStringStringValue{
+		name:  name,
+		value: make(map[string]string),
+		fs:    fs.fs,
+	}
+	for k, v := range def {
+		val.value[k] = v
+	}
+	fs.fs.Var(newMapStringString(&val.value, options), name, usage)
+	return val
+}
+
+// Set copies the map over the target if the flag was set.
+// It completely overwrites any existing target.
+func (v *MapStringStringValue) Set(target *map[string]string) {
+	if v.fs.Changed(v.name) {
+		*target = make(map[string]string)
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Merge copies the map keys/values piecewise into the target if the flag
+// was set. Values in the flag's map override values for corresponding
+// keys in the target map.
+func (v *MapStringStringValue) Merge(target *map[string]string) {
+	if v.fs.Changed(v.name) {
+		if *target == nil {
+			*target = make(map[string]string)
+		}
+		for k, v := range v.value {
+			(*target)[k] = v
+		}
+	}
+}
+
+// Apply calls the user-provided apply function with the map if the flag was set.
+func (v *MapStringStringValue) Apply(apply func(value map[string]string)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}
+
+// mapStringString implements plfag.Value for map[string]string
+type mapStringString struct {
+	m           *map[string]string
+	initialized bool
+	options     *MapOptions
+}
+
+// newMapStringString takes a pointer to a map[string]string and returns the
+// mapStringString flag parsing shim for that map.
+func newMapStringString(m *map[string]string, o *MapOptions) *mapStringString {
+	o.Default()
+	return &mapStringString{m: m, options: o}
+}
+
+// String implements github.com/spf13/pflag.Value
+func (m *mapStringString) String() string {
+	if m == nil || m.m == nil {
+		return ""
+	}
+	pairs := []string{}
+	for k, v := range *m.m {
+		pairs = append(pairs, fmt.Sprintf("%s%s%s", k, m.options.KeyValueSep, v))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, m.options.PairSep)
+}
+
+// Set implements github.com/spf13/pflag.Value
+func (m *mapStringString) Set(value string) error {
+	if m.m == nil {
+		return fmt.Errorf("no target (nil pointer to map[string]string)")
+	}
+	if !m.initialized || *m.m == nil {
+		// clear default values, or allocate if no existing map
+		*m.m = make(map[string]string)
+		m.initialized = true
+	}
+
+	// account for multiple key-value pairs in a single invocation
+	if !m.options.DisableCommaSeparatedPairs {
+		for _, s := range strings.Split(value, m.options.PairSep) {
+			if len(s) == 0 {
+				continue
+			}
+			arr := strings.SplitN(s, m.options.KeyValueSep, 2)
+			if len(arr) != 2 {
+				return fmt.Errorf("malformed pair, expect string%sstring", m.options.KeyValueSep)
+			}
+			k := strings.TrimSpace(arr[0])
+			v := strings.TrimSpace(arr[1])
+			(*m.m)[k] = v
+		}
+		return nil
+	}
+
+	// account for only one key-value pair in a single invocation
+	arr := strings.SplitN(value, m.options.KeyValueSep, 2)
+	if len(arr) != 2 {
+		return fmt.Errorf("malformed pair, expect string%sstring", m.options.KeyValueSep)
+	}
+	k := strings.TrimSpace(arr[0])
+	v := strings.TrimSpace(arr[1])
+	(*m.m)[k] = v
+	return nil
+
+}
+
+// Type implements github.com/spf13/pflag.Value
+func (*mapStringString) Type() string {
+	return "mapStringString"
+}
+
+// Empty implements OmitEmpty
+func (m *mapStringString) Empty() bool {
+	return len(*m.m) == 0
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ip.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ip.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	"net"
+)
+
+// IPValue is a reference to a registered net.IP flag value.
+type IPValue struct {
+	name string
+	value net.IP
+	fs *pflag.FlagSet
+}
+
+// IPVar registers a flag for net.IP against the FlagSet, and returns
+// a IPValue reference to the registered flag value.
+func (fs *FlagSet) IPVar(name string, def net.IP, usage string) *IPValue {
+	v := &IPValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IPVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IPValue) Set(target *net.IP) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IPValue) Apply(apply func(value net.IP)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ipnet.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/net_ipnet.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	"net"
+)
+
+// IPNetValue is a reference to a registered net.IPNet flag value.
+type IPNetValue struct {
+	name string
+	value net.IPNet
+	fs *pflag.FlagSet
+}
+
+// IPNetVar registers a flag for net.IPNet against the FlagSet, and returns
+// a IPNetValue reference to the registered flag value.
+func (fs *FlagSet) IPNetVar(name string, def net.IPNet, usage string) *IPNetValue {
+	v := &IPNetValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.IPNetVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *IPNetValue) Set(target *net.IPNet) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *IPNetValue) Apply(apply func(value net.IPNet)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// StringValue is a reference to a registered string flag value.
+type StringValue struct {
+	name string
+	value string
+	fs *pflag.FlagSet
+}
+
+// StringVar registers a flag for string against the FlagSet, and returns
+// a StringValue reference to the registered flag value.
+func (fs *FlagSet) StringVar(name string, def string, usage string) *StringValue {
+	v := &StringValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.StringVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *StringValue) Set(target *string) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *StringValue) Apply(apply func(value string)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/string_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// StringSliceValue is a reference to a registered []string flag value.
+type StringSliceValue struct {
+	name string
+	value []string
+	fs *pflag.FlagSet
+}
+
+// StringSliceVar registers a flag for []string against the FlagSet, and
+// returns a StringSliceValue reference to the registered flag value.
+func (fs *FlagSet) StringSliceVar(name string, def []string, usage string) *StringSliceValue {
+	v := &StringSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.StringSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *StringSliceValue) Set(target *[]string) {
+	if v.fs.Changed(v.name) {
+		*target = make([]string, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *StringSliceValue) Apply(apply func(value []string)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/time_duration.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/time_duration.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	"time"
+)
+
+// DurationValue is a reference to a registered time.Duration flag value.
+type DurationValue struct {
+	name string
+	value time.Duration
+	fs *pflag.FlagSet
+}
+
+// DurationVar registers a flag for time.Duration against the FlagSet, and returns
+// a DurationValue reference to the registered flag value.
+func (fs *FlagSet) DurationVar(name string, def time.Duration, usage string) *DurationValue {
+	v := &DurationValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.DurationVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *DurationValue) Set(target *time.Duration) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *DurationValue) Apply(apply func(value time.Duration)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// UintValue is a reference to a registered uint flag value.
+type UintValue struct {
+	name string
+	value uint
+	fs *pflag.FlagSet
+}
+
+// UintVar registers a flag for uint against the FlagSet, and returns
+// a UintValue reference to the registered flag value.
+func (fs *FlagSet) UintVar(name string, def uint, usage string) *UintValue {
+	v := &UintValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.UintVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *UintValue) Set(target *uint) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *UintValue) Apply(apply func(value uint)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint16.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint16.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint16Value is a reference to a registered uint16 flag value.
+type Uint16Value struct {
+	name string
+	value uint16
+	fs *pflag.FlagSet
+}
+
+// Uint16Var registers a flag for uint16 against the FlagSet, and returns
+// a Uint16Value reference to the registered flag value.
+func (fs *FlagSet) Uint16Var(name string, def uint16, usage string) *Uint16Value {
+	v := &Uint16Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint16Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint16Value) Set(target *uint16) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint16Value) Apply(apply func(value uint16)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint32.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint32.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint32Value is a reference to a registered uint32 flag value.
+type Uint32Value struct {
+	name string
+	value uint32
+	fs *pflag.FlagSet
+}
+
+// Uint32Var registers a flag for uint32 against the FlagSet, and returns
+// a Uint32Value reference to the registered flag value.
+func (fs *FlagSet) Uint32Var(name string, def uint32, usage string) *Uint32Value {
+	v := &Uint32Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint32Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint32Value) Set(target *uint32) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint32Value) Apply(apply func(value uint32)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint64.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint64.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint64Value is a reference to a registered uint64 flag value.
+type Uint64Value struct {
+	name string
+	value uint64
+	fs *pflag.FlagSet
+}
+
+// Uint64Var registers a flag for uint64 against the FlagSet, and returns
+// a Uint64Value reference to the registered flag value.
+func (fs *FlagSet) Uint64Var(name string, def uint64, usage string) *Uint64Value {
+	v := &Uint64Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint64Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint64Value) Set(target *uint64) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint64Value) Apply(apply func(value uint64)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint8.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint8.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// Uint8Value is a reference to a registered uint8 flag value.
+type Uint8Value struct {
+	name string
+	value uint8
+	fs *pflag.FlagSet
+}
+
+// Uint8Var registers a flag for uint8 against the FlagSet, and returns
+// a Uint8Value reference to the registered flag value.
+func (fs *FlagSet) Uint8Var(name string, def uint8, usage string) *Uint8Value {
+	v := &Uint8Value{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.Uint8Var(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *Uint8Value) Set(target *uint8) {
+	if v.fs.Changed(v.name) {
+		*target = v.value
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *Uint8Value) Apply(apply func(value uint8)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint_slice.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/uint_slice.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file is generated. DO NOT EDIT.
+
+package legacyflag
+
+import(
+	"github.com/spf13/pflag"
+	
+)
+
+// UintSliceValue is a reference to a registered []uint flag value.
+type UintSliceValue struct {
+	name string
+	value []uint
+	fs *pflag.FlagSet
+}
+
+// UintSliceVar registers a flag for []uint against the FlagSet, and
+// returns a UintSliceValue reference to the registered flag value.
+func (fs *FlagSet) UintSliceVar(name string, def []uint, usage string) *UintSliceValue {
+	v := &UintSliceValue{
+		name: name,
+		fs: fs.fs,
+	}
+	fs.fs.UintSliceVar(&v.value, name, def, usage)
+	return v
+}
+
+// Set copies the flag value to the target if the flag was set.
+func (v *UintSliceValue) Set(target *[]uint) {
+	if v.fs.Changed(v.name) {
+		*target = make([]uint, len(v.value))
+		copy(*target, v.value)
+	}
+}
+
+// Apply calls the apply func with the flag value if the flag was set.
+func (v *UintSliceValue) Apply(apply func(value []uint)) {
+	if v.fs.Changed(v.name) {
+		apply(v.value)
+	}
+}

--- a/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/var.go
+++ b/vendor/sigs.k8s.io/legacyflag/pkg/legacyflag/var.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package legacyflag
+
+import (
+	"github.com/spf13/pflag"
+)
+
+// VarValue references a registered Var flag.
+type VarValue struct {
+	name string
+	fs   *pflag.FlagSet
+}
+
+// Var registers a flag for a type that implements the pflag.Value interface
+// against the FlagSet, and returns a VarValue that references this flag.
+func (fs *FlagSet) Var(value pflag.Value, name string, usage string) *VarValue {
+	v := &VarValue{
+		name: name,
+		fs:   fs.fs,
+	}
+	fs.fs.Var(value, name, usage)
+	return v
+}
+
+// Apply calls the apply function if the flag associated with VarValue was set.
+// Since users supply the scratch-space when constructing the VarValue, they
+// must read the scratch space directly in their apply function.
+func (v *VarValue) Apply(apply func()) {
+	if v.fs.Changed(v.name) {
+		apply()
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Refactoring of kubemark to use https://github.com/kubernetes-sigs/legacyflag

**Which issue(s) this PR fixes**:
Fixes #83165 

**Special notes for your reviewer**:
Is legacyflag going to support AddGoFlagSet and SetNormalizeFunc? I need some steer as to how to remove the dependencies below:
```
pflag.CommandLine.SetNormalizeFunc(cliflag.WordSepNormalizeFunc)
pflag.CommandLine.AddGoFlagSet(goflag.CommandLine)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/cc @kubernetes/wg-component-standard @stealthybox 
/wg component-standard
/priority important-longterm