### PR TITLE
add test to show generic pod count counts all pods

### DIFF
--- a/pkg/quota/v1/evaluator/core/pods_test.go
+++ b/pkg/quota/v1/evaluator/core/pods_test.go
@@ -275,6 +275,24 @@ func TestPodEvaluatorUsage(t *testing.T) {
 				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
 			},
 		},
+		"terminated generic count still appears": {
+			pod: &api.Pod{
+				Spec: api.PodSpec{
+					Containers: []api.Container{{
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{api.ResourceName("example.com/dongle"): resource.MustParse("3")},
+							Limits:   api.ResourceList{api.ResourceName("example.com/dongle"): resource.MustParse("3")},
+						},
+					}},
+				},
+				Status: api.PodStatus{
+					Phase: api.PodSucceeded,
+				},
+			},
+			usage: corev1.ResourceList{
+				generic.ObjectCountQuotaResourceNameFor(schema.GroupResource{Resource: "pods"}): resource.MustParse("1"),
+			},
+		},
 		"init container maximums override sum of containers": {
 			pod: &api.Pod{
 				Spec: api.PodSpec{
@@ -417,12 +435,14 @@ func TestPodEvaluatorUsage(t *testing.T) {
 		},
 	}
 	for testName, testCase := range testCases {
-		actual, err := evaluator.Usage(testCase.pod)
-		if err != nil {
-			t.Errorf("%s unexpected error: %v", testName, err)
-		}
-		if !quota.Equals(testCase.usage, actual) {
-			t.Errorf("%s expected: %v, actual: %v", testName, testCase.usage, actual)
-		}
+		t.Run(testName, func(t *testing.T) {
+			actual, err := evaluator.Usage(testCase.pod)
+			if err != nil {
+				t.Error(err)
+			}
+			if !quota.Equals(testCase.usage, actual) {
+				t.Errorf("expected: %v, actual: %v", testCase.usage, actual)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Based on a question in slack. This test demonstrates pod quota evaluation includes all pods (not just non-terminated ones) in generic counts as expected.

/kind cleanup
/priority important-longterm
@kubernets/sig-api-machinery-misc

```release-note
NONE
```