### PR TITLE
Improve error message for projected tokens when API is not enabled

### DIFF
--- a/pkg/kubelet/token/BUILD
+++ b/pkg/kubelet/token/BUILD
@@ -21,6 +21,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/authentication/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Improves the error message returned from the kubelet if a token cannot be fetched because the API server doesn't have TokenRequest APIs enabled

**Which issue(s) this PR fixes**:
xref #83189

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig auth
/cc @mikedanese 