### PR TITLE
Use $STACKDRIVER_ENDPOINT to set exporter sd endpoint

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2548,7 +2548,7 @@ function update-daemon-set-prometheus-to-sd-parameters {
 function update-event-exporter {
     local -r stackdriver_resource_model="${LOGGING_STACKDRIVER_RESOURCE_TYPES:-old}"
     sed -i -e "s@{{ exporter_sd_resource_model }}@${stackdriver_resource_model}@g" "$1"
-    sed -i -e "s@{{ exporter_sd_endpoint }}@${STACKDRIVER_TEST_ENDPOINT:-}@g" "$1"
+    sed -i -e "s@{{ exporter_sd_endpoint }}@${STACKDRIVER_ENDPOINT:-}@g" "$1"
 }
 
 function update-dashboard-controller {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Instead of the old `$STACKDRIVER_TEST_ENDPOINT` which only sets to test endpoint in test cluster, we should start using `$STACKDRIVER_ENDPOINT` which is set in kube-env according to the cluster env (test, staging, prod).
This gives us the ability to send event-exporter logs to the Stackdriver which lives in the same env as the cluster, aka (test_cluster->test_sd, staging_cluster->staging_sd, prod_cluster->prod_sd).

**Special notes for your reviewer**:
* Use of `$STACKDRIVER_TEST_ENDPOINT` was introduced in [PR 81681](https://github.com/kubernetes/kubernetes/pull/81681)
* `$STACKDRIVER_TEST_ENDPOINT` was introduced to kube-env through CL/264595983
* `$STACKDRIVER_ENDPOINT` was introduced to kube-env through CL/270739995

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```