### PR TITLE
feat(scheduler): return error when plugin already registered

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -108,6 +108,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend prefilter plugin", pf.Name)
 				}
+
+				for _, plugin := range f.preFilterPlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered prefilter plugin", plugin.Name())
+					}
+				}
+
 				f.preFilterPlugins = append(f.preFilterPlugins, p)
 			} else {
 				return nil, fmt.Errorf("prefilter plugin %q does not exist", pf.Name)
@@ -122,6 +129,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend filter plugin", r.Name)
 				}
+
+				for _, plugin := range f.filterPlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered filter plugin", plugin.Name())
+					}
+				}
+
 				f.filterPlugins = append(f.filterPlugins, p)
 			} else {
 				return nil, fmt.Errorf("filter plugin %q does not exist", r.Name)
@@ -139,6 +153,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if f.pluginNameToWeightMap[p.Name()] == 0 {
 					return nil, fmt.Errorf("score plugin %q is not configured with weight", p.Name())
 				}
+
+				for _, plugin := range f.scorePlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered score plugin", plugin.Name())
+					}
+				}
+
 				f.scorePlugins = append(f.scorePlugins, p)
 			} else {
 				return nil, fmt.Errorf("score plugin %q does not exist", sc.Name)
@@ -153,6 +174,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend reserve plugin", r.Name)
 				}
+
+				for _, plugin := range f.reservePlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered reserve plugin", plugin.Name())
+					}
+				}
+
 				f.reservePlugins = append(f.reservePlugins, p)
 			} else {
 				return nil, fmt.Errorf("reserve plugin %q does not exist", r.Name)
@@ -165,11 +193,18 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 			if pg, ok := pluginsMap[r.Name]; ok {
 				p, ok := pg.(PostFilterPlugin)
 				if !ok {
-					return nil, fmt.Errorf("plugin %q does not extend post-filter plugin", r.Name)
+					return nil, fmt.Errorf("plugin %q does not extend postfilter plugin", r.Name)
 				}
+
+				for _, plugin := range f.postFilterPlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered postfilter plugin", plugin.Name())
+					}
+				}
+
 				f.postFilterPlugins = append(f.postFilterPlugins, p)
 			} else {
-				return nil, fmt.Errorf("post-filter plugin %q does not exist", r.Name)
+				return nil, fmt.Errorf("postfilter plugin %q does not exist", r.Name)
 			}
 		}
 	}
@@ -179,11 +214,18 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 			if pg, ok := pluginsMap[pb.Name]; ok {
 				p, ok := pg.(PreBindPlugin)
 				if !ok {
-					return nil, fmt.Errorf("plugin %q does not extend prebind plugin", pb.Name)
+					return nil, fmt.Errorf("plugin %q does not extend pre-bind plugin", pb.Name)
 				}
+
+				for _, plugin := range f.preBindPlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered pre-bind plugin", plugin.Name())
+					}
+				}
+
 				f.preBindPlugins = append(f.preBindPlugins, p)
 			} else {
-				return nil, fmt.Errorf("prebind plugin %q does not exist", pb.Name)
+				return nil, fmt.Errorf("pre-bind plugin %q does not exist", pb.Name)
 			}
 		}
 	}
@@ -195,6 +237,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend bind plugin", pb.Name)
 				}
+
+				for _, plugin := range f.bindPlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered bind plugin", plugin.Name())
+					}
+				}
+
 				f.bindPlugins = append(f.bindPlugins, p)
 			} else {
 				return nil, fmt.Errorf("bind plugin %q does not exist", pb.Name)
@@ -209,6 +258,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend postbind plugin", pb.Name)
 				}
+
+				for _, plugin := range f.postBindPlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered postbind plugin", plugin.Name())
+					}
+				}
+
 				f.postBindPlugins = append(f.postBindPlugins, p)
 			} else {
 				return nil, fmt.Errorf("postbind plugin %q does not exist", pb.Name)
@@ -223,6 +279,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend unreserve plugin", ur.Name)
 				}
+
+				for _, plugin := range f.unreservePlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered unreserve plugin", plugin.Name())
+					}
+				}
+
 				f.unreservePlugins = append(f.unreservePlugins, p)
 			} else {
 				return nil, fmt.Errorf("unreserve plugin %q does not exist", ur.Name)
@@ -237,6 +300,13 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 				if !ok {
 					return nil, fmt.Errorf("plugin %q does not extend permit plugin", pr.Name)
 				}
+
+				for _, plugin := range f.permitPlugins {
+					if plugin.Name() == p.Name() {
+						return nil, fmt.Errorf("plugin %q already registered permit plugin", plugin.Name())
+					}
+				}
+
 				f.permitPlugins = append(f.permitPlugins, p)
 			} else {
 				return nil, fmt.Errorf("permit plugin %q does not exist", pr.Name)

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -35,6 +36,7 @@ const (
 	pluginNotImplementingScore     = "plugin-not-implementing-score"
 	preFilterPluginName            = "prefilter-plugin"
 	preFilterWithUpdaterPluginName = "prefilter-with-updater-plugin"
+	duplicatePluginName            = "duplicate-plugin"
 )
 
 // TestScoreWithNormalizePlugin implements ScoreWithNormalizePlugin interface.
@@ -162,12 +164,34 @@ func (pl *TestPreFilterWithUpdaterPlugin) Updater() Updater {
 	return pl
 }
 
+type TestDuplicatePlugin struct {
+}
+
+func (dp *TestDuplicatePlugin) Name() string {
+	return duplicatePluginName
+}
+
+func (dp *TestDuplicatePlugin) PreFilter(pc *PluginContext, p *v1.Pod) *Status {
+	return nil
+}
+
+func (dp *TestDuplicatePlugin) Updater() Updater {
+	return nil
+}
+
+var _ PreFilterPlugin = &TestDuplicatePlugin{}
+
+func newDuplicatePlugin(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
+	return &TestDuplicatePlugin{}, nil
+}
+
 var registry Registry = func() Registry {
 	r := make(Registry)
 	r.Register(scoreWithNormalizePlugin1, newScoreWithNormalizePlugin1)
 	r.Register(scoreWithNormalizePlugin2, newScoreWithNormalizePlugin2)
 	r.Register(scorePlugin1, newScorePlugin1)
 	r.Register(pluginNotImplementingScore, newPluginNotImplementingScore)
+	r.Register(duplicatePluginName, newDuplicatePlugin)
 	return r
 }()
 
@@ -232,6 +256,28 @@ func TestInitFrameworkWithScorePlugins(t *testing.T) {
 				t.Fatalf("Failed to create framework for testing: %v", err)
 			}
 		})
+	}
+}
+
+func TestRegisterDuplicatePluginWouldFail(t *testing.T) {
+	plugin := config.Plugin{Name: duplicatePluginName, Weight: 1}
+
+	pluginSet := config.PluginSet{
+		Enabled: []config.Plugin{
+			plugin,
+			plugin,
+		},
+	}
+	plugins := config.Plugins{}
+	plugins.PreFilter = &pluginSet
+
+	_, err := NewFramework(registry, &plugins, emptyArgs)
+	if err == nil {
+		t.Fatal("Framework initialization should fail")
+	}
+
+	if err != nil && !strings.Contains(err.Error(), "already registered") {
+		t.Fatalf("Unexpected error, got %s, expect: plugin already registered", err.Error())
 	}
 }
 


### PR DESCRIPTION
/kind feature
/priority important-soon
/sig scheduling
/assign @ahg-g 

**What this PR does / why we need it**:

Return error when plugin already registered the same extension point.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/83194

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
The scheduling framework will return error when plugin already registered the same extension point
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
