### PR TITLE
Cleaned up skip* functions from framework/util.go

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -20,6 +20,7 @@ go_library(
         "rc_util.go",
         "resource_usage_gatherer.go",
         "size.go",
+        "skip.go",
         "suites.go",
         "test_context.go",
         "util.go",

--- a/test/e2e/framework/skip.go
+++ b/test/e2e/framework/skip.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/pkg/features"
+	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
+	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
+)
+
+func skipInternalf(caller int, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	log("INFO", msg)
+	ginkgowrapper.Skip(msg, caller+1)
+}
+
+// Skipf skips with information about why the test is being skipped.
+func Skipf(format string, args ...interface{}) {
+	skipInternalf(1, format, args...)
+}
+
+// SkipUnlessNodeCountIsAtLeast skips if the number of nodes is less than the minNodeCount.
+func SkipUnlessNodeCountIsAtLeast(minNodeCount int) {
+	if TestContext.CloudConfig.NumNodes < minNodeCount {
+		skipInternalf(1, "Requires at least %d nodes (not %d)", minNodeCount, TestContext.CloudConfig.NumNodes)
+	}
+}
+
+// SkipUnlessNodeCountIsAtMost skips if the number of nodes is greater than the maxNodeCount.
+func SkipUnlessNodeCountIsAtMost(maxNodeCount int) {
+	if TestContext.CloudConfig.NumNodes > maxNodeCount {
+		skipInternalf(1, "Requires at most %d nodes (not %d)", maxNodeCount, TestContext.CloudConfig.NumNodes)
+	}
+}
+
+// SkipUnlessAtLeast skips if the value is less than the minValue.
+func SkipUnlessAtLeast(value int, minValue int, message string) {
+	if value < minValue {
+		skipInternalf(1, message)
+	}
+}
+
+// SkipIfProviderIs skips if the provider is included in the unsupportedProviders.
+func SkipIfProviderIs(unsupportedProviders ...string) {
+	if ProviderIs(unsupportedProviders...) {
+		skipInternalf(1, "Not supported for providers %v (found %s)", unsupportedProviders, TestContext.Provider)
+	}
+}
+
+// SkipUnlessLocalEphemeralStorageEnabled skips if the LocalStorageCapacityIsolation is not enabled.
+func SkipUnlessLocalEphemeralStorageEnabled() {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+		skipInternalf(1, "Only supported when %v feature is enabled", features.LocalStorageCapacityIsolation)
+	}
+}
+
+// SkipUnlessSSHKeyPresent skips if no SSH key is found.
+func SkipUnlessSSHKeyPresent() {
+	if _, err := e2essh.GetSigner(TestContext.Provider); err != nil {
+		skipInternalf(1, "No SSH Key for provider %s: '%v'", TestContext.Provider, err)
+	}
+}
+
+// SkipUnlessProviderIs skips if the provider is not included in the supportedProviders.
+func SkipUnlessProviderIs(supportedProviders ...string) {
+	if !ProviderIs(supportedProviders...) {
+		skipInternalf(1, "Only supported for providers %v (not %s)", supportedProviders, TestContext.Provider)
+	}
+}
+
+// SkipUnlessMultizone skips if the cluster does not have multizone.
+func SkipUnlessMultizone(c clientset.Interface) {
+	zones, err := GetClusterZones(c)
+	if err != nil {
+		skipInternalf(1, "Error listing cluster zones")
+	}
+	if zones.Len() <= 1 {
+		skipInternalf(1, "Requires more than one zone")
+	}
+}
+
+// SkipIfMultizone skips if the cluster has multizone.
+func SkipIfMultizone(c clientset.Interface) {
+	zones, err := GetClusterZones(c)
+	if err != nil {
+		skipInternalf(1, "Error listing cluster zones")
+	}
+	if zones.Len() > 1 {
+		skipInternalf(1, "Requires at most one zone")
+	}
+}
+
+// SkipUnlessPrometheusMonitoringIsEnabled skips if the prometheus monitoring is not enabled.
+func SkipUnlessPrometheusMonitoringIsEnabled(supportedMonitoring ...string) {
+	if !TestContext.EnablePrometheusMonitoring {
+		skipInternalf(1, "Skipped because prometheus monitoring is not enabled")
+	}
+}
+
+// SkipUnlessMasterOSDistroIs skips if the master OS distro is not included in the supportedMasterOsDistros.
+func SkipUnlessMasterOSDistroIs(supportedMasterOsDistros ...string) {
+	if !MasterOSDistroIs(supportedMasterOsDistros...) {
+		skipInternalf(1, "Only supported for master OS distro %v (not %s)", supportedMasterOsDistros, TestContext.MasterOSDistro)
+	}
+}
+
+// SkipUnlessNodeOSDistroIs skips if the node OS distro is not included in the supportedNodeOsDistros.
+func SkipUnlessNodeOSDistroIs(supportedNodeOsDistros ...string) {
+	if !NodeOSDistroIs(supportedNodeOsDistros...) {
+		skipInternalf(1, "Only supported for node OS distro %v (not %s)", supportedNodeOsDistros, TestContext.NodeOSDistro)
+	}
+}
+
+// SkipIfNodeOSDistroIs skips if the node OS distro is included in the unsupportedNodeOsDistros.
+func SkipIfNodeOSDistroIs(unsupportedNodeOsDistros ...string) {
+	if NodeOSDistroIs(unsupportedNodeOsDistros...) {
+		skipInternalf(1, "Not supported for node OS distro %v (is %s)", unsupportedNodeOsDistros, TestContext.NodeOSDistro)
+	}
+}
+
+// SkipUnlessTaintBasedEvictionsEnabled skips if the TaintBasedEvictions is not enabled.
+func SkipUnlessTaintBasedEvictionsEnabled() {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.TaintBasedEvictions) {
+		skipInternalf(1, "Only supported when %v feature is enabled", features.TaintBasedEvictions)
+	}
+}
+
+// SkipIfContainerRuntimeIs skips if the container runtime is included in the runtimes.
+func SkipIfContainerRuntimeIs(runtimes ...string) {
+	for _, containerRuntime := range runtimes {
+		if containerRuntime == TestContext.ContainerRuntime {
+			skipInternalf(1, "Not supported under container runtime %s", containerRuntime)
+		}
+	}
+}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -62,7 +62,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
@@ -75,10 +74,8 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/client/conditions"
 	"k8s.io/kubernetes/pkg/controller"
-	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/master/ports"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
-	"k8s.io/kubernetes/test/e2e/framework/ginkgowrapper"
 	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
@@ -193,6 +190,9 @@ var (
 	// For parsing Kubectl version for version-skewed testing.
 	gitVersionRegexp = regexp.MustCompile("GitVersion:\"(v.+?)\"")
 
+	// ProvidersWithSSH are those providers where each node is accessible with SSH
+	ProvidersWithSSH = []string{"gce", "gke", "aws", "local"}
+
 	// ServeHostnameImage is a serve hostname image name.
 	ServeHostnameImage = imageutils.GetE2EImage(imageutils.Agnhost)
 )
@@ -217,132 +217,6 @@ func nowStamp() string {
 
 func log(level string, format string, args ...interface{}) {
 	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
-}
-
-func skipInternalf(caller int, format string, args ...interface{}) {
-	msg := fmt.Sprintf(format, args...)
-	log("INFO", msg)
-	ginkgowrapper.Skip(msg, caller+1)
-}
-
-// Skipf skips with information about why the test is being skipped.
-func Skipf(format string, args ...interface{}) {
-	skipInternalf(1, format, args...)
-}
-
-// SkipUnlessNodeCountIsAtLeast skips if the number of nodes is less than the minNodeCount.
-func SkipUnlessNodeCountIsAtLeast(minNodeCount int) {
-	if TestContext.CloudConfig.NumNodes < minNodeCount {
-		skipInternalf(1, "Requires at least %d nodes (not %d)", minNodeCount, TestContext.CloudConfig.NumNodes)
-	}
-}
-
-// SkipUnlessNodeCountIsAtMost skips if the number of nodes is greater than the maxNodeCount.
-func SkipUnlessNodeCountIsAtMost(maxNodeCount int) {
-	if TestContext.CloudConfig.NumNodes > maxNodeCount {
-		skipInternalf(1, "Requires at most %d nodes (not %d)", maxNodeCount, TestContext.CloudConfig.NumNodes)
-	}
-}
-
-// SkipUnlessAtLeast skips if the value is less than the minValue.
-func SkipUnlessAtLeast(value int, minValue int, message string) {
-	if value < minValue {
-		skipInternalf(1, message)
-	}
-}
-
-// SkipIfProviderIs skips if the provider is included in the unsupportedProviders.
-func SkipIfProviderIs(unsupportedProviders ...string) {
-	if ProviderIs(unsupportedProviders...) {
-		skipInternalf(1, "Not supported for providers %v (found %s)", unsupportedProviders, TestContext.Provider)
-	}
-}
-
-// SkipUnlessLocalEphemeralStorageEnabled skips if the LocalStorageCapacityIsolation is not enabled.
-func SkipUnlessLocalEphemeralStorageEnabled() {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
-		skipInternalf(1, "Only supported when %v feature is enabled", features.LocalStorageCapacityIsolation)
-	}
-}
-
-// SkipUnlessSSHKeyPresent skips if no SSH key is found.
-func SkipUnlessSSHKeyPresent() {
-	if _, err := e2essh.GetSigner(TestContext.Provider); err != nil {
-		skipInternalf(1, "No SSH Key for provider %s: '%v'", TestContext.Provider, err)
-	}
-}
-
-// SkipUnlessProviderIs skips if the provider is not included in the supportedProviders.
-func SkipUnlessProviderIs(supportedProviders ...string) {
-	if !ProviderIs(supportedProviders...) {
-		skipInternalf(1, "Only supported for providers %v (not %s)", supportedProviders, TestContext.Provider)
-	}
-}
-
-// SkipUnlessMultizone skips if the cluster does not have multizone.
-func SkipUnlessMultizone(c clientset.Interface) {
-	zones, err := GetClusterZones(c)
-	if err != nil {
-		skipInternalf(1, "Error listing cluster zones")
-	}
-	if zones.Len() <= 1 {
-		skipInternalf(1, "Requires more than one zone")
-	}
-}
-
-// SkipIfMultizone skips if the cluster has multizone.
-func SkipIfMultizone(c clientset.Interface) {
-	zones, err := GetClusterZones(c)
-	if err != nil {
-		skipInternalf(1, "Error listing cluster zones")
-	}
-	if zones.Len() > 1 {
-		skipInternalf(1, "Requires at most one zone")
-	}
-}
-
-// SkipUnlessPrometheusMonitoringIsEnabled skips if the prometheus monitoring is not enabled.
-func SkipUnlessPrometheusMonitoringIsEnabled(supportedMonitoring ...string) {
-	if !TestContext.EnablePrometheusMonitoring {
-		skipInternalf(1, "Skipped because prometheus monitoring is not enabled")
-	}
-}
-
-// SkipUnlessMasterOSDistroIs skips if the master OS distro is not included in the supportedMasterOsDistros.
-func SkipUnlessMasterOSDistroIs(supportedMasterOsDistros ...string) {
-	if !MasterOSDistroIs(supportedMasterOsDistros...) {
-		skipInternalf(1, "Only supported for master OS distro %v (not %s)", supportedMasterOsDistros, TestContext.MasterOSDistro)
-	}
-}
-
-// SkipUnlessNodeOSDistroIs skips if the node OS distro is not included in the supportedNodeOsDistros.
-func SkipUnlessNodeOSDistroIs(supportedNodeOsDistros ...string) {
-	if !NodeOSDistroIs(supportedNodeOsDistros...) {
-		skipInternalf(1, "Only supported for node OS distro %v (not %s)", supportedNodeOsDistros, TestContext.NodeOSDistro)
-	}
-}
-
-// SkipIfNodeOSDistroIs skips if the node OS distro is included in the unsupportedNodeOsDistros.
-func SkipIfNodeOSDistroIs(unsupportedNodeOsDistros ...string) {
-	if NodeOSDistroIs(unsupportedNodeOsDistros...) {
-		skipInternalf(1, "Not supported for node OS distro %v (is %s)", unsupportedNodeOsDistros, TestContext.NodeOSDistro)
-	}
-}
-
-// SkipUnlessTaintBasedEvictionsEnabled skips if the TaintBasedEvictions is not enabled.
-func SkipUnlessTaintBasedEvictionsEnabled() {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.TaintBasedEvictions) {
-		skipInternalf(1, "Only supported when %v feature is enabled", features.TaintBasedEvictions)
-	}
-}
-
-// SkipIfContainerRuntimeIs skips if the container runtime is included in the runtimes.
-func SkipIfContainerRuntimeIs(runtimes ...string) {
-	for _, containerRuntime := range runtimes {
-		if containerRuntime == TestContext.ContainerRuntime {
-			skipInternalf(1, "Not supported under container runtime %s", containerRuntime)
-		}
-	}
 }
 
 // RunIfContainerRuntimeIs runs if the container runtime is included in the runtimes.
@@ -499,9 +373,6 @@ func SkipIfMissingResource(dynamicClient dynamic.Interface, gvr schema.GroupVers
 		e2elog.Failf("Unexpected error getting %v: %v", gvr, err)
 	}
 }
-
-// ProvidersWithSSH are those providers where each node is accessible with SSH
-var ProvidersWithSSH = []string{"gce", "gke", "aws", "local"}
 
 // WaitForDaemonSets for all daemonsets in the given namespace to be ready
 // (defined as all but 'allowedNotReadyNodes' pods associated with that


### PR DESCRIPTION
Signed-off-by: alejandrox1 <alarcj137@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is an effort to clean up the framework util.go file so that it
makes more sense and it is more managable.

**Which issue(s) this PR fixes**:
tangentially related to https://github.com/kubernetes/kubernetes/issues/77095

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/area e2e-test-framework
/sig testing
/priority backlog
/milestone v1.17