### PR TITLE
Remove direct reference to label

### DIFF
--- a/pkg/scheduler/metrics/BUILD
+++ b/pkg/scheduler/metrics/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//pkg/controller/volume/scheduling/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -20,8 +20,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 	volumeschedulingmetrics "k8s.io/kubernetes/pkg/controller/volume/scheduling/metrics"
@@ -60,11 +58,11 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result"})
 	// PodScheduleSuccesses counts how many pods were scheduled.
-	PodScheduleSuccesses = scheduleAttempts.With(prometheus.Labels{"result": "scheduled"})
+	PodScheduleSuccesses = scheduleAttempts.With(metrics.Labels{"result": "scheduled"})
 	// PodScheduleFailures counts how many pods could not be scheduled.
-	PodScheduleFailures = scheduleAttempts.With(prometheus.Labels{"result": "unschedulable"})
+	PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
 	// PodScheduleErrors counts how many pods could not be scheduled due to a scheduler error.
-	PodScheduleErrors = scheduleAttempts.With(prometheus.Labels{"result": "error"})
+	PodScheduleErrors = scheduleAttempts.With(metrics.Labels{"result": "error"})
 	SchedulingLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
 			Subsystem: SchedulerSubsystem,
@@ -257,17 +255,17 @@ func Register() {
 
 // ActivePods returns the pending pods metrics with the label active
 func ActivePods() metrics.GaugeMetric {
-	return pendingPods.With(prometheus.Labels{"queue": "active"})
+	return pendingPods.With(metrics.Labels{"queue": "active"})
 }
 
 // BackoffPods returns the pending pods metrics with the label backoff
 func BackoffPods() metrics.GaugeMetric {
-	return pendingPods.With(prometheus.Labels{"queue": "backoff"})
+	return pendingPods.With(metrics.Labels{"queue": "backoff"})
 }
 
 // UnschedulablePods returns the pending pods metrics with the label unschedulable
 func UnschedulablePods() metrics.GaugeMetric {
-	return pendingPods.With(prometheus.Labels{"queue": "unschedulable"})
+	return pendingPods.With(metrics.Labels{"queue": "unschedulable"})
 }
 
 // Reset resets metrics


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove direct reference to Prometheus.Label.

To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**Which issue(s) this PR fixes**:
Refer #https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/milestone v1.17
/priority important-soon
/assign @k82cn 