### PR TITLE
Remove direct reference to prometheus.Label

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/BUILD
@@ -29,7 +29,6 @@ go_library(
         "//staging/src/k8s.io/client-go/pkg/version:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/vmware/govmomi/find:go_default_library",
         "//vendor/github.com/vmware/govmomi/object:go_default_library",
         "//vendor/github.com/vmware/govmomi/pbm:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/vsphere_metrics.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/vsphere_metrics.go
@@ -19,8 +19,6 @@ package vclib
 import (
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -103,17 +101,17 @@ func RecordvSphereMetric(actionName string, requestTime time.Time, err error) {
 
 func recordvSphereAPIMetric(actionName string, requestTime time.Time, err error) {
 	if err != nil {
-		vsphereAPIErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
+		vsphereAPIErrorMetric.With(metrics.Labels{"request": actionName}).Inc()
 	} else {
-		vsphereAPIMetric.With(prometheus.Labels{"request": actionName}).Observe(calculateTimeTaken(requestTime))
+		vsphereAPIMetric.With(metrics.Labels{"request": actionName}).Observe(calculateTimeTaken(requestTime))
 	}
 }
 
 func recordvSphereOperationMetric(actionName string, requestTime time.Time, err error) {
 	if err != nil {
-		vsphereOperationErrorMetric.With(prometheus.Labels{"operation": actionName}).Inc()
+		vsphereOperationErrorMetric.With(metrics.Labels{"operation": actionName}).Inc()
 	} else {
-		vsphereOperationMetric.With(prometheus.Labels{"operation": actionName}).Observe(calculateTimeTaken(requestTime))
+		vsphereOperationMetric.With(metrics.Labels{"operation": actionName}).Observe(calculateTimeTaken(requestTime))
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove direct reference to Prometheus.Label.

To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**Which issue(s) this PR fixes**:
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority important-soon
/assign @dims @mikedanese 
/cc @logicalhan 