### PR TITLE
fix pv-binder-controller delete new created PV when controller is on heavy loader

### DIFF
--- a/pkg/controller/volume/persistentvolume/pv_controller.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller.go
@@ -519,7 +519,7 @@ func (ctrl *PersistentVolumeController) syncVolume(volume *v1.PersistentVolume) 
 		if err != nil {
 			return err
 		}
-		if !found && metav1.HasAnnotation(volume.ObjectMeta, pvutil.AnnBoundByController) {
+		if !found {
 			// If PV is bound by external PV binder (e.g. kube-scheduler), it's
 			// possible on heavy load that corresponding PVC is not synced to
 			// controller local cache yet. So we need to double-check PVC in

--- a/pkg/controller/volume/persistentvolume/pv_controller_base.go
+++ b/pkg/controller/volume/persistentvolume/pv_controller_base.go
@@ -102,8 +102,22 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 
 	p.VolumeInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(controller.volumeQueue, newObj) },
+			AddFunc: func(obj interface{}) {
+				// The cache should be update immediately when received event from informer.
+				// Update the cache item when controller/worker processing the item may cause a long latency to
+				// update the item in the cache,
+				// because the controller/worker may on heavy load state and busy with processing backlog items.
+				controller.storeVolumeUpdate(obj)
+				controller.enqueueWork(controller.volumeQueue, obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				// The cache should be update immediately when received event from informer.
+				// Update the cache item when controller/worker processing the item may cause a long latency to
+				// update the item in the cache,
+				// because the controller/worker may on heavy load state and busy with processing backlog items.
+				controller.storeVolumeUpdate(newObj)
+				controller.enqueueWork(controller.volumeQueue, newObj)
+			},
 			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.volumeQueue, obj) },
 		},
 	)
@@ -112,8 +126,22 @@ func NewController(p ControllerParameters) (*PersistentVolumeController, error) 
 
 	p.ClaimInformer.Informer().AddEventHandler(
 		cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { controller.enqueueWork(controller.claimQueue, obj) },
-			UpdateFunc: func(oldObj, newObj interface{}) { controller.enqueueWork(controller.claimQueue, newObj) },
+			AddFunc: func(obj interface{}) {
+				// The cache should be update immediately when received event from informer.
+				// Update the cache item when controller/worker processing the item may cause a long latency to
+				// update the item in the cache,
+				// because the controller/worker may on heavy load state and busy with processing backlog items.
+				controller.storeClaimUpdate(obj)
+				controller.enqueueWork(controller.claimQueue, obj)
+			},
+			UpdateFunc: func(oldObj, newObj interface{}) {
+				// The cache should be update immediately when received event from informer.
+				// Update the cache item when controller/worker processing the item may cause a long latency to
+				// update the item in the cache,
+				// because the controller/worker may on heavy load state and busy with processing backlog items.
+				controller.storeClaimUpdate(newObj)
+				controller.enqueueWork(controller.claimQueue, newObj)
+			},
 			DeleteFunc: func(obj interface{}) { controller.enqueueWork(controller.claimQueue, obj) },
 		},
 	)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

fix pv-binder-controller delete new created PV when controller is on heavy loader

**Which issue(s) this PR fixes**:

Fixes #83177

**Special notes for your reviewer**:

1. The [cache](https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/volume/persistentvolume/pv_controller.go#L181) in the controller should be update immediately when received event from informer. Update the cache item when controller/worker processing the item may cause a long latency to update the item in the cache, because the controller/worker may on heavy load state and busy with processing backlog items.
2. The new created PV has no annotation `pv.kubernetes.io/bound-by-controller`

**Does this PR introduce a user-facing change?**:

```release-note
fix pv-binder-controller delete new created PV when controller is on heavy loader
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

None