### PR TITLE
Add comments documenting the contents of version.Info

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/version/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/version/types.go
@@ -17,15 +17,16 @@ limitations under the License.
 package version
 
 // Info contains versioning information.
+// See https://github.com/kubernetes/community/blob/master/contributors/design-proposals/release/versioning.md
 // TODO: Add []string of api versions supported? It's still unclear
 // how we'll want to distribute that information.
 type Info struct {
-	Major        string `json:"major"`
-	Minor        string `json:"minor"`
-	GitVersion   string `json:"gitVersion"`
-	GitCommit    string `json:"gitCommit"`
-	GitTreeState string `json:"gitTreeState"`
-	BuildDate    string `json:"buildDate"`
+	Major        string `json:"major"`        // major version, always numeric
+	Minor        string `json:"minor"`        // minor version, numeric possibly followed by "+"
+	GitVersion   string `json:"gitVersion"`   // semantic version, vX.Y.Z possibly followed by "beta", etc.
+	GitCommit    string `json:"gitCommit"`    // sha1 from git
+	GitTreeState string `json:"gitTreeState"` // state of git tree, either "clean" or "dirty"
+	BuildDate    string `json:"buildDate"`    // build date in ISO8601 format
 	GoVersion    string `json:"goVersion"`
 	Compiler     string `json:"compiler"`
 	Platform     string `json:"platform"`


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Add comments documenting the contents of `version.Info`, to aid someone calling the public API.

**Special notes for your reviewer**:

The text is taken from [component-base/version/base.go](https://github.com/kubernetes/kubernetes/blob/67d928acdc351d3d4f9e20a92cee4452a26ed0c4/staging/src/k8s.io/component-base/version/base.go#L43), which is the implementation side. I had to ask in Slack to find that.

I tried not to go too far into details, but things like the optional "+" on the end of what is logically a number seem important to me.

There is a comment in `base.go` saying that `Major` and `Minor` will be deprecated, which I would think also belongs on the public side, but it's marked "TODO" so I left it out.

```release-note
NONE
```
