### PR TITLE
feat(apiserver): add user-agent and remote info into trace log for endpoints handlers.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -10,6 +10,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "create_test.go",
+        "helpers_test.go",
         "namer_test.go",
         "rest_test.go",
     ],
@@ -38,6 +39,7 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
     ],
 )
@@ -49,6 +51,7 @@ go_library(
         "delete.go",
         "doc.go",
         "get.go",
+        "helpers.go",
         "namer.go",
         "patch.go",
         "response.go",
@@ -74,6 +77,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/mergepatch:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -46,7 +46,7 @@ import (
 func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Interface, includeName bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		// For performance tracking purposes.
-		trace := utiltrace.New("Create", utiltrace.Field{"url", req.URL.Path})
+		trace := utiltrace.New("Create", utiltrace.Field{Key: "url", Value: req.URL.Path}, utiltrace.Field{Key: "user-agent", Value: &lazyTruncatedUserAgent{req}}, utiltrace.Field{Key: "client", Value: &lazyClientIP{req}})
 		defer trace.LogIfLong(500 * time.Millisecond)
 
 		if isDryRun(req.URL) && !utilfeature.DefaultFeatureGate.Enabled(features.DryRun) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/delete.go
@@ -45,7 +45,7 @@ import (
 func DeleteResource(r rest.GracefulDeleter, allowsOptions bool, scope *RequestScope, admit admission.Interface) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		// For performance tracking purposes.
-		trace := utiltrace.New("Delete", utiltrace.Field{"url", req.URL.Path})
+		trace := utiltrace.New("Delete", utiltrace.Field{Key: "url", Value: req.URL.Path}, utiltrace.Field{Key: "user-agent", Value: &lazyTruncatedUserAgent{req}}, utiltrace.Field{Key: "client", Value: &lazyClientIP{req}})
 		defer trace.LogIfLong(500 * time.Millisecond)
 
 		if isDryRun(req.URL) && !utilfeature.DefaultFeatureGate.Enabled(features.DryRun) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -49,7 +49,7 @@ type getterFunc func(ctx context.Context, name string, req *http.Request, trace 
 // passed-in getterFunc to perform the actual get.
 func getResourceHandler(scope *RequestScope, getter getterFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
-		trace := utiltrace.New("Get", utiltrace.Field{"url", req.URL.Path})
+		trace := utiltrace.New("Get", utiltrace.Field{Key: "url", Value: req.URL.Path}, utiltrace.Field{Key: "user-agent", Value: &lazyTruncatedUserAgent{req}}, utiltrace.Field{Key: "client", Value: &lazyClientIP{req}})
 		defer trace.LogIfLong(500 * time.Millisecond)
 
 		namespace, name, err := scope.Namer.Name(req)
@@ -166,7 +166,7 @@ func getRequestOptions(req *http.Request, scope *RequestScope, into runtime.Obje
 func ListResource(r rest.Lister, rw rest.Watcher, scope *RequestScope, forceWatch bool, minRequestTimeout time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		// For performance tracking purposes.
-		trace := utiltrace.New("List", utiltrace.Field{"url", req.URL.Path})
+		trace := utiltrace.New("List", utiltrace.Field{Key: "url", Value: req.URL.Path}, utiltrace.Field{Key: "user-agent", Value: &lazyTruncatedUserAgent{req}}, utiltrace.Field{Key: "client", Value: &lazyClientIP{req}})
 
 		namespace, err := scope.Namer.Namespace(req)
 		if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"net/http"
+
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+)
+
+const (
+	maxUserAgentLength      = 1024
+	userAgentTruncateSuffix = "...TRUNCATED"
+)
+
+// lazyTruncatedUserAgent implements String() string and it will
+// return user-agent which may be truncated.
+type lazyTruncatedUserAgent struct {
+	req *http.Request
+}
+
+func (lazy *lazyTruncatedUserAgent) String() string {
+	ua := "unknown"
+	if lazy.req != nil {
+		ua = utilnet.GetHTTPClient(lazy.req)
+		if len(ua) > maxUserAgentLength {
+			ua = ua[:maxUserAgentLength] + userAgentTruncateSuffix
+		}
+	}
+	return ua
+}
+
+// LazyClientIP implements String() string and it will
+// calls GetClientIP() lazily only when required.
+type lazyClientIP struct {
+	req *http.Request
+}
+
+func (lazy *lazyClientIP) String() string {
+	if lazy.req != nil {
+		if ip := utilnet.GetClientIP(lazy.req); ip != nil {
+			return ip.String()
+		}
+	}
+	return "unknown"
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/helpers_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"testing"
+)
+
+func TestLazyTruncatedUserAgent(t *testing.T) {
+	req := &http.Request{}
+	req.Header = http.Header{}
+
+	ua := "short-agent"
+	req.Header.Set("User-Agent", ua)
+	uaNotTruncated := &lazyTruncatedUserAgent{req}
+	assert.Equal(t, ua, fmt.Sprintf("%v", uaNotTruncated))
+
+	ua = ""
+	for i := 0; i < maxUserAgentLength*2; i++ {
+		ua = ua + "a"
+	}
+	req.Header.Set("User-Agent", ua)
+	uaTruncated := &lazyTruncatedUserAgent{req}
+	assert.NotEqual(t, ua, fmt.Sprintf("%v", uaTruncated))
+
+	usUnknown := &lazyTruncatedUserAgent{}
+	assert.Equal(t, "unknown", fmt.Sprintf("%v", usUnknown))
+}
+
+func TestLazyClientIP(t *testing.T) {
+	req := &http.Request{}
+	req.Header = http.Header{}
+
+	ip := "127.0.0.1"
+	req.Header.Set("X-Forwarded-For", ip)
+
+	clientIPWithReq := &lazyClientIP{req}
+	assert.Equal(t, ip, fmt.Sprintf("%v", clientIPWithReq))
+
+	clientIPWithoutReq := &lazyClientIP{}
+	assert.Equal(t, "unknown", fmt.Sprintf("%v", clientIPWithoutReq))
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -59,7 +59,7 @@ const (
 func PatchResource(r rest.Patcher, scope *RequestScope, admit admission.Interface, patchTypes []string) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		// For performance tracking purposes.
-		trace := utiltrace.New("Patch", utiltrace.Field{"url", req.URL.Path})
+		trace := utiltrace.New("Patch", utiltrace.Field{Key: "url", Value: req.URL.Path}, utiltrace.Field{Key: "user-agent", Value: &lazyTruncatedUserAgent{req}}, utiltrace.Field{Key: "client", Value: &lazyClientIP{req}})
 		defer trace.LogIfLong(500 * time.Millisecond)
 
 		if isDryRun(req.URL) && !utilfeature.DefaultFeatureGate.Enabled(features.DryRun) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/update.go
@@ -45,7 +45,7 @@ import (
 func UpdateResource(r rest.Updater, scope *RequestScope, admit admission.Interface) http.HandlerFunc {
 	return func(w http.ResponseWriter, req *http.Request) {
 		// For performance tracking purposes.
-		trace := utiltrace.New("Update", utiltrace.Field{"url", req.URL.Path})
+		trace := utiltrace.New("Update", utiltrace.Field{Key: "url", Value: req.URL.Path}, utiltrace.Field{Key: "user-agent", Value: &lazyTruncatedUserAgent{req}}, utiltrace.Field{Key: "client", Value: &lazyClientIP{req}})
 		defer trace.LogIfLong(500 * time.Millisecond)
 
 		if isDryRun(req.URL) && !utilfeature.DefaultFeatureGate.Enabled(features.DryRun) {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add user agent and remote information into trace log, so that trace log would be more helpful for debugging.

PS: I observed lots of trace log about `List` operation and would like to know the source of the `List` operations, but currently, it is a bit hard to achieve this.

```
I0927 07:28:28.801664       1 trace.go:81] Trace[1305200132]: "List /api/v1/pods" (started: 2019-09-27 07:28:26.948385138 +0000 UTC m=+3023176.145333466) (total time: 1.853263146s):
Trace[1305200132]: [1.852869459s] [1.852827424s] Listing from storage done
I0927 07:28:28.887649       1 trace.go:81] Trace[45825598]: "List /api/v1/pods" (started: 2019-09-27 07:28:26.732673362 +0000 UTC m=+3023175.929621690) (total time: 2.154960137s):
Trace[45825598]: [2.154548736s] [2.154518683s] Listing from storage done
I0927 07:28:28.982571       1 trace.go:81] Trace[1437621767]: "List /api/v1/pods" (started: 2019-09-27 07:28:26.563537074 +0000 UTC m=+3023175.760485413) (total time: 2.419016573s):
Trace[1437621767]: [2.418571522s] [2.418529997s] Listing from storage done
I0927 07:28:29.889047       1 trace.go:81] Trace[350029645]: "List /api/v1/pods" (started: 2019-09-27 07:28:27.591300993 +0000 UTC m=+3023176.788249322) (total time: 2.29772571s):
Trace[350029645]: [2.297281521s] [2.297237823s] Listing from storage done
I0927 07:28:29.966654       1 trace.go:81] Trace[76814124]: "List /api/v1/pods" (started: 2019-09-27 07:28:26.563498008 +0000 UTC m=+3023175.760446336) (total time: 3.403139202s):
Trace[76814124]: [3.402522175s] [3.402484317s] Listing from storage done
I0927 07:28:30.021033       1 trace.go:81] Trace[1580770584]: "List /api/v1/pods" (started: 2019-09-27 07:28:27.540909617 +0000 UTC m=+3023176.737857945) (total time: 2.480106868s):
Trace[1580770584]: [2.477826259s] [2.477797349s] Listing from storage done
```

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/assign @sttts
/assign @caesarxuchao
/assign @deads2k
/assign @smarterclayton

/sig api-machinery