### PR TITLE
Remove nested loop in pruneInitContainersBeforeStart of kuberuntime_container

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -39,7 +39,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/sets"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/events"
@@ -631,39 +630,38 @@ func (m *kubeGenericRuntimeManager) killContainersWithSyncResult(pod *v1.Pod, ru
 func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
 	// only the last execution of each init container should be preserved, and only preserve it if it is in the
 	// list of init containers to keep.
-	initContainerNames := sets.NewString()
+	initContainerNames := make(map[string]int, len(pod.Spec.InitContainers))
 	for _, container := range pod.Spec.InitContainers {
-		initContainerNames.Insert(container.Name)
+		initContainerNames[container.Name] = 0
 	}
-	for name := range initContainerNames {
-		count := 0
-		for _, status := range podStatus.ContainerStatuses {
-			if status.Name != name ||
-				(status.State != kubecontainer.ContainerStateExited &&
-					status.State != kubecontainer.ContainerStateUnknown) {
-				continue
-			}
-			// Remove init containers in unknown state. It should have
-			// been stopped before pruneInitContainersBeforeStart is
-			// called.
-			count++
-			// keep the first init container for this name
-			if count == 1 {
-				continue
-			}
-			// prune all other init containers that match this container name
-			klog.V(4).Infof("Removing init container %q instance %q %d", status.Name, status.ID.ID, count)
-			if err := m.removeContainer(status.ID.ID); err != nil {
-				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
-				continue
-			}
+	for _, status := range podStatus.ContainerStatuses {
+		if _, ok := initContainerNames[status.Name]; !ok {
+			continue
+		}
+		if status.State != kubecontainer.ContainerStateExited &&
+			status.State != kubecontainer.ContainerStateUnknown {
+			continue
+		}
+		// Remove init containers in unknown state. It should have
+		// been stopped before pruneInitContainersBeforeStart is
+		// called.
+		initContainerNames[status.Name]++
+		// keep the first init container for this name
+		if initContainerNames[status.Name] == 1 {
+			continue
+		}
+		// prune all other init containers that match this container name
+		klog.V(4).Infof("Removing init container %q instance %q %d", status.Name, status.ID.ID, initContainerNames[status.Name])
+		if err := m.removeContainer(status.ID.ID); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
+			continue
+		}
 
-			// remove any references to this container
-			if _, ok := m.containerRefManager.GetRef(status.ID); ok {
-				m.containerRefManager.ClearRef(status.ID)
-			} else {
-				klog.Warningf("No ref for container %q", status.ID)
-			}
+		// remove any references to this container
+		if _, ok := m.containerRefManager.GetRef(status.ID); ok {
+			m.containerRefManager.ClearRef(status.ID)
+		} else {
+			klog.Warningf("No ref for container %q", status.ID)
 		}
 	}
 }
@@ -672,29 +670,26 @@ func (m *kubeGenericRuntimeManager) pruneInitContainersBeforeStart(pod *v1.Pod, 
 // of the container because it assumes all init containers have been stopped
 // before the call happens.
 func (m *kubeGenericRuntimeManager) purgeInitContainers(pod *v1.Pod, podStatus *kubecontainer.PodStatus) {
-	initContainerNames := sets.NewString()
+	initContainerNames := make(map[string]int, len(pod.Spec.InitContainers))
 	for _, container := range pod.Spec.InitContainers {
-		initContainerNames.Insert(container.Name)
+		initContainerNames[container.Name] = 0
 	}
-	for name := range initContainerNames {
-		count := 0
-		for _, status := range podStatus.ContainerStatuses {
-			if status.Name != name {
-				continue
-			}
-			count++
-			// Purge all init containers that match this container name
-			klog.V(4).Infof("Removing init container %q instance %q %d", status.Name, status.ID.ID, count)
-			if err := m.removeContainer(status.ID.ID); err != nil {
-				utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
-				continue
-			}
-			// Remove any references to this container
-			if _, ok := m.containerRefManager.GetRef(status.ID); ok {
-				m.containerRefManager.ClearRef(status.ID)
-			} else {
-				klog.Warningf("No ref for container %q", status.ID)
-			}
+	for _, status := range podStatus.ContainerStatuses {
+		if _, ok := initContainerNames[status.Name]; !ok {
+			continue
+		}
+		initContainerNames[status.Name]++
+		// Purge all init containers that match this container name
+		klog.V(4).Infof("Removing init container %q instance %q %d", status.Name, status.ID.ID, initContainerNames[status.Name])
+		if err := m.removeContainer(status.ID.ID); err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to remove pod init container %q: %v; Skipping pod %q", status.Name, err, format.Pod(pod)))
+			continue
+		}
+		// Remove any references to this container
+		if _, ok := m.containerRefManager.GetRef(status.ID); ok {
+			m.containerRefManager.ClearRef(status.ID)
+		} else {
+			klog.Warningf("No ref for container %q", status.ID)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently we use nested loop in pruneInitContainersBeforeStart to prune InitContainer. This unnecessarily loops podStatus.ContainerStatuses where there is no single match in initContainerNames Set.
This PR removes the outer loop. We can use a map to record the number of times any initContainer name has been seen and prune accordingly.

Same change is applied to purgeInitContainers as well.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
