### PR TITLE
Add nil checks for Azure CSI translation

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -78,19 +78,21 @@ func (t *azureDiskCSITranslator) TranslateInTreeInlineVolumeToCSI(volume *v1.Vol
 				CSI: &v1.CSIPersistentVolumeSource{
 					Driver:           AzureDiskDriverName,
 					VolumeHandle:     azureSource.DataDiskURI,
-					ReadOnly:         *azureSource.ReadOnly,
-					FSType:           *azureSource.FSType,
 					VolumeAttributes: map[string]string{azureDiskKind: "Managed"},
 				},
 			},
 			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 		},
 	}
+	if azureSource.ReadOnly != nil {
+		pv.Spec.PersistentVolumeSource.CSI.ReadOnly = *azureSource.ReadOnly
+	}
 
-	if *azureSource.CachingMode != "" {
+	if azureSource.CachingMode != nil && *azureSource.CachingMode != "" {
 		pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[azureDiskCachingMode] = string(*azureSource.CachingMode)
 	}
-	if *azureSource.FSType != "" {
+	if azureSource.FSType != nil {
+		pv.Spec.PersistentVolumeSource.CSI.FSType = *azureSource.FSType
 		pv.Spec.PersistentVolumeSource.CSI.VolumeAttributes[azureDiskFSType] = *azureSource.FSType
 	}
 	if azureSource.Kind != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #78524 stated, we should check pointer against nil before dereferencing.

**Which issue(s) this PR fixes**:
Fixes #78524

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
