### PR TITLE
Deflake TestWatchBasedManager

### DIFF
--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -40,6 +40,7 @@ func TestWatchBasedManager(t *testing.T) {
 	defer server.TearDownFn()
 
 	server.ClientConfig.QPS = 10000
+	server.ClientConfig.Burst = 10000
 	client, err := kubernetes.NewForConfig(server.ClientConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/area deflake

**What this PR does / why we need it**:
Follow up to https://github.com/kubernetes/kubernetes/pull/80465

The TestWatchBasedManager integration test was using the loopback server client config as a starting point, and increasing QPS. Now that the loopback does not set QPS or Burst, the integration test needs to override both.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @lavalamp 
/sig api-machinery