### PR TITLE
Automated cherry pick of #83250: Deflake TestWatchBasedManager

### DIFF
--- a/test/integration/kubelet/watch_manager_test.go
+++ b/test/integration/kubelet/watch_manager_test.go
@@ -40,6 +40,7 @@ func TestWatchBasedManager(t *testing.T) {
 	defer server.TearDownFn()
 
 	server.ClientConfig.QPS = 10000
+	server.ClientConfig.Burst = 10000
 	client, err := kubernetes.NewForConfig(server.ClientConfig)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)


### PR DESCRIPTION
Cherry pick of #83250 on release-1.15.

#83250: Deflake TestWatchBasedManager

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```