### PR TITLE
Remove direct reference to prometheus from openstack

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/BUILD
@@ -65,7 +65,6 @@ go_library(
         "//vendor/github.com/gophercloud/gophercloud/openstack/networking/v2/ports:go_default_library",
         "//vendor/github.com/gophercloud/gophercloud/pagination:go_default_library",
         "//vendor/github.com/mitchellh/mapstructure:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -35,6 +35,7 @@ import (
 	cloudvolume "k8s.io/cloud-provider/volume"
 	volerr "k8s.io/cloud-provider/volume/errors"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
+	"k8s.io/component-base/metrics"
 
 	"github.com/gophercloud/gophercloud"
 	volumeexpand "github.com/gophercloud/gophercloud/openstack/blockstorage/extensions/volumeactions"
@@ -42,8 +43,6 @@ import (
 	volumes_v2 "github.com/gophercloud/gophercloud/openstack/blockstorage/v2/volumes"
 	volumes_v3 "github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/compute/v2/extensions/volumeattach"
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/klog"
 )
 
@@ -745,8 +744,8 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 // recordOpenstackOperationMetric records openstack operation metrics
 func recordOpenstackOperationMetric(operation string, timeTaken float64, err error) {
 	if err != nil {
-		openstackAPIRequestErrors.With(prometheus.Labels{"request": operation}).Inc()
+		openstackAPIRequestErrors.With(metrics.Labels{"request": operation}).Inc()
 	} else {
-		openstackOperationsLatency.With(prometheus.Labels{"request": operation}).Observe(timeTaken)
+		openstackOperationsLatency.With(metrics.Labels{"request": operation}).Observe(timeTaken)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove direct reference to Prometheus.

To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority important-soon
/assign @dims 
/cc @logicalhan 