### PR TITLE
Automated cherry pick of #83196: using online instead to fix kubelet service failed with wrong

### DIFF
--- a/pkg/kubelet/cm/cpumanager/topology/topology.go
+++ b/pkg/kubelet/cm/cpumanager/topology/topology.go
@@ -293,7 +293,7 @@ func GetNUMANodeInfo() (NUMANodeInfo, error) {
 	// nil NUMANodeInfo, indicating that no NUMA information is available
 	// on this machine. This should implicitly be interpreted as having a
 	// single NUMA node with id 0 for all CPUs.
-	nodelist, err := ioutil.ReadFile("/sys/devices/system/node/possible")
+	nodelist, err := ioutil.ReadFile("/sys/devices/system/node/online")
 	if err != nil {
 		return nil, nil
 	}


### PR DESCRIPTION
Cherry pick of #83196 on release-1.16.

#83196: using online instead to fix kubelet service failed with wrong

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Use online nodes instead of possible nodes when discovering available NUMA nodes
```