### PR TITLE
Remove direct reference to prometheus from aws

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/BUILD
@@ -66,7 +66,6 @@ go_library(
         "//vendor/github.com/aws/aws-sdk-go/service/elbv2:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/kms:go_default_library",
         "//vendor/github.com/aws/aws-sdk-go/service/sts:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/gopkg.in/gcfg.v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_metrics.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_metrics.go
@@ -21,8 +21,6 @@ package aws
 import (
 	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
 )
@@ -55,14 +53,14 @@ var (
 
 func recordAWSMetric(actionName string, timeTaken float64, err error) {
 	if err != nil {
-		awsAPIErrorMetric.With(prometheus.Labels{"request": actionName}).Inc()
+		awsAPIErrorMetric.With(metrics.Labels{"request": actionName}).Inc()
 	} else {
-		awsAPIMetric.With(prometheus.Labels{"request": actionName}).Observe(timeTaken)
+		awsAPIMetric.With(metrics.Labels{"request": actionName}).Observe(timeTaken)
 	}
 }
 
 func recordAWSThrottlesMetric(operation string) {
-	awsAPIThrottlesMetric.With(prometheus.Labels{"operation_name": operation}).Inc()
+	awsAPIThrottlesMetric.With(metrics.Labels{"operation_name": operation}).Inc()
 }
 
 var registerOnce sync.Once

--- a/staging/src/k8s.io/legacy-cloud-providers/go.mod
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/dnaeon/go-vcr v1.0.1 // indirect
 	github.com/gophercloud/gophercloud v0.1.0
 	github.com/mitchellh/mapstructure v1.1.2
-	github.com/prometheus/client_golang v0.9.4
 	github.com/rubiojr/go-vhd v0.0.0-20160810183302-0bfd3b39853c
 	github.com/satori/go.uuid v1.2.0 // indirect
 	github.com/stretchr/testify v1.3.0


### PR DESCRIPTION
Remove direct reference to Prometheus.Label.

To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove direct reference to Prometheus.

To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority important-soon