### PR TITLE
Remove direct reference to prometheus from kubelet

### DIFF
--- a/pkg/kubelet/prober/BUILD
+++ b/pkg/kubelet/prober/BUILD
@@ -35,7 +35,6 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -20,9 +20,9 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/metrics"
 	"k8s.io/klog"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -69,9 +69,9 @@ type worker struct {
 
 	// proberResultsMetricLabels holds the labels attached to this worker
 	// for the ProberResults metric by result.
-	proberResultsSuccessfulMetricLabels prometheus.Labels
-	proberResultsFailedMetricLabels     prometheus.Labels
-	proberResultsUnknownMetricLabels    prometheus.Labels
+	proberResultsSuccessfulMetricLabels metrics.Labels
+	proberResultsFailedMetricLabels     metrics.Labels
+	proberResultsUnknownMetricLabels    metrics.Labels
 }
 
 // Creates and starts a new probe worker.
@@ -104,7 +104,7 @@ func newWorker(
 		w.initialValue = results.Failure
 	}
 
-	basicMetricLabels := prometheus.Labels{
+	basicMetricLabels := metrics.Labels{
 		"probe_type": w.probeType.String(),
 		"container":  w.container.Name,
 		"pod":        w.pod.Name,
@@ -284,8 +284,8 @@ func (w *worker) doProbe() (keepGoing bool) {
 	return true
 }
 
-func deepCopyPrometheusLabels(m prometheus.Labels) prometheus.Labels {
-	ret := make(prometheus.Labels, len(m))
+func deepCopyPrometheusLabels(m metrics.Labels) metrics.Labels {
+	ret := make(metrics.Labels, len(m))
 	for k, v := range m {
 		ret[k] = v
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove direct reference to Prometheus.

To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority important-soon
