### PR TITLE
Migrate etcd version monitor to metrics stability framework

### DIFF
--- a/cluster/images/etcd-version-monitor/BUILD
+++ b/cluster/images/etcd-version-monitor/BUILD
@@ -16,8 +16,8 @@ go_library(
     srcs = ["etcd-version-monitor.go"],
     importpath = "k8s.io/kubernetes/cluster/images/etcd-version-monitor",
     deps = [
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//vendor/github.com/gogo/protobuf/proto:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
         "//vendor/github.com/prometheus/common/expfmt:go_default_library",

--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -26,11 +26,12 @@ import (
 	"time"
 
 	"github.com/gogo/protobuf/proto"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 	"github.com/spf13/pflag"
+
+	"k8s.io/component-base/metrics"
 	"k8s.io/klog"
 )
 
@@ -58,15 +59,16 @@ const (
 // Initialize prometheus metrics to be exported.
 var (
 	// Register all custom metrics with a dedicated registry to keep them separate.
-	customMetricRegistry = prometheus.NewRegistry()
+	customMetricRegistry = metrics.NewKubeRegistry()
 
 	// Custom etcd version metric since etcd 3.2- does not export one.
 	// This will be replaced by https://github.com/coreos/etcd/pull/8960 in etcd 3.3.
-	etcdVersion = prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Namespace: namespace,
-			Name:      "version_info",
-			Help:      "Etcd server's binary version",
+	etcdVersion = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Namespace:      namespace,
+			Name:           "version_info",
+			Help:           "Etcd server's binary version",
+			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"binary_version"})
 
@@ -227,14 +229,14 @@ func getVersion(lastSeenBinaryVersion *string) error {
 
 	// Delete the metric for the previous version.
 	if *lastSeenBinaryVersion != "" {
-		deleted := etcdVersion.Delete(prometheus.Labels{"binary_version": *lastSeenBinaryVersion})
+		deleted := etcdVersion.Delete(metrics.Labels{"binary_version": *lastSeenBinaryVersion})
 		if !deleted {
 			return errors.New("failed to delete previous version's metric")
 		}
 	}
 
 	// Record the new version in a metric.
-	etcdVersion.With(prometheus.Labels{
+	etcdVersion.With(metrics.Labels{
 		"binary_version": version.BinaryVersion,
 	}).Set(0)
 	*lastSeenBinaryVersion = version.BinaryVersion
@@ -392,7 +394,6 @@ func main() {
 
 	// Register the metrics we defined above with prometheus.
 	customMetricRegistry.MustRegister(etcdVersion)
-	customMetricRegistry.Unregister(prometheus.NewGoCollector())
 
 	// Spawn threads for periodically scraping etcd version metrics.
 	stopCh := make(chan struct{})


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR migrates etcd version monitor metrics to the [metrics stability framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md).

**Which issue(s) this PR fixes**:
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:
Following comes from my local cluster(all metrics start from `ALPHA`):
```
# HELP etcd_version_info [ALPHA] Etcd server's binary version
# TYPE etcd_version_info gauge
etcd_version_info{binary_version="3.3.15"} 0
```

**Does this PR introduce a user-facing change?**:
```release-note
ETCD version monitor metrics are now marked as with the ALPHA stability level.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/13a778c6a4a84dbde9e691e8dcf930a6eaa7ca51/keps/sig-instrumentation/20190605-metrics-stability-migration.md
```
