### PR TITLE
Introduce testutil package to support metrics testing

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/BUILD
@@ -73,6 +73,7 @@ filegroup(
         "//staging/src/k8s.io/component-base/metrics/prometheus/restclient:all-srcs",
         "//staging/src/k8s.io/component-base/metrics/prometheus/version:all-srcs",
         "//staging/src/k8s.io/component-base/metrics/prometheus/workqueue:all-srcs",
+        "//staging/src/k8s.io/component-base/metrics/testutil:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -26,7 +26,7 @@ import (
 var (
 	defaultRegistry = metrics.NewKubeRegistry()
 	// DefaultGatherer exposes the global registry gatherer
-	DefaultGatherer prometheus.Gatherer = defaultRegistry
+	DefaultGatherer metrics.Gatherer = defaultRegistry
 )
 
 func init() {

--- a/staging/src/k8s.io/component-base/metrics/testutil/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/testutil/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testutil.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/component-base/metrics/testutil",
+    importpath = "k8s.io/component-base/metrics/testutil",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/testutil:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"io"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"k8s.io/component-base/metrics"
+)
+
+// GatherAndCompare gathers all metrics from the provided Gatherer and compares
+// it to an expected output read from the provided Reader in the Prometheus text
+// exposition format. If any metricNames are provided, only metrics with those
+// names are compared.
+func GatherAndCompare(g metrics.Gatherer, expected io.Reader, metricNames ...string) error {
+	return testutil.GatherAndCompare(g, expected, metricNames...)
+}

--- a/staging/src/k8s.io/component-base/metrics/wrappers.go
+++ b/staging/src/k8s.io/component-base/metrics/wrappers.go
@@ -79,3 +79,9 @@ type PromRegistry interface {
 	Unregister(prometheus.Collector) bool
 	Gather() ([]*dto.MetricFamily, error)
 }
+
+// Gatherer is the interface for the part of a registry in charge of gathering
+// the collected metrics into a number of MetricFamilies.
+type Gatherer interface {
+	prometheus.Gatherer
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Wrap `prometheus/testutil` in metrics stability framework, that will help:
1. Remove direct reference to Prometheus from k/k.
2. Improve components test cases making them more readable.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
