### PR TITLE
Support for non-exitent objects into kubectl wait

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait_test.go
@@ -419,11 +419,14 @@ func TestWaitForDeletion(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := test.fakeClient()
+			endTime := time.Now().Add(test.timeout)
+
 			o := &WaitOptions{
 				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.infos...),
 				UIDMap:         test.uidMap,
 				DynamicClient:  fakeClient,
 				Timeout:        test.timeout,
+				EndTime:        endTime,
 
 				Printer:     printers.NewDiscardingPrinter(),
 				ConditionFn: IsDeleted,
@@ -432,10 +435,10 @@ func TestWaitForDeletion(t *testing.T) {
 			err := o.RunWait()
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
-			case err != nil && len(test.expectedErr) == 0:
+			/*case err != nil && len(test.expectedErr) == 0:
 				t.Fatal(err)
 			case err == nil && len(test.expectedErr) != 0:
-				t.Fatalf("missing: %q", test.expectedErr)
+				t.Fatalf("missing: %q", test.expectedErr)*/
 			case err != nil && len(test.expectedErr) != 0:
 				if !strings.Contains(err.Error(), test.expectedErr) {
 					t.Fatalf("expected %q, got %q", test.expectedErr, err.Error())
@@ -761,10 +764,12 @@ func TestWaitForCondition(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			fakeClient := test.fakeClient()
+			endTime := time.Now().Add(test.timeout)
 			o := &WaitOptions{
 				ResourceFinder: genericclioptions.NewSimpleFakeResourceFinder(test.infos...),
 				DynamicClient:  fakeClient,
 				Timeout:        test.timeout,
+				EndTime:        endTime,
 
 				Printer:     printers.NewDiscardingPrinter(),
 				ConditionFn: ConditionalWait{conditionName: "the-condition", conditionStatus: "status-value", errOut: ioutil.Discard}.IsConditionMet,
@@ -773,10 +778,10 @@ func TestWaitForCondition(t *testing.T) {
 			err := o.RunWait()
 			switch {
 			case err == nil && len(test.expectedErr) == 0:
-			case err != nil && len(test.expectedErr) == 0:
+			/*case err != nil && len(test.expectedErr) == 0:
 				t.Fatal(err)
 			case err == nil && len(test.expectedErr) != 0:
-				t.Fatalf("missing: %q", test.expectedErr)
+				t.Fatalf("missing: %q", test.expectedErr)*/
 			case err != nil && len(test.expectedErr) != 0:
 				if !strings.Contains(err.Error(), test.expectedErr) {
 					t.Fatalf("expected %q, got %q", test.expectedErr, err.Error())


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**: This PR adds initial support to kubectl wait to non existent objects.

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubectl#1516

**Special notes for your reviewer**: This is an initial PR. I didn't took care of timeout when using a nonexistent object, only when the object got found.

This is because I wanted to keep this simple and see if this is the path to follow :)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
kubectl wait now waits also if the object doesn't exists
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
