### PR TITLE
Move format validation of unix domain socket for KMS plugin to apiserver/pkg/server/options/encryptionconfig/config package.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -438,16 +438,16 @@ func getEnvelopePrefixTransformer(config *apiserverconfig.KMSConfiguration, enve
 // parseEndpoint parses the endpoint to extract schema, host or path.
 func parseEndpoint(endpoint string) (string, error) {
 	if len(endpoint) == 0 {
-		return "", fmt.Errorf("remote KMS provider can't use empty string as endpoint")
+		return "", fmt.Errorf("invalid empty Resources[].KMS.Endpoint in encryption configuration for KMS provider")
 	}
 
 	u, err := url.Parse(endpoint)
 	if err != nil {
-		return "", fmt.Errorf("invalid endpoint %q for remote KMS provider, error: %v", endpoint, err)
+		return "", fmt.Errorf("invalid Resources[].KMS.Endpoint %q in encryption configuration for KMS provider, error: %v", endpoint, err)
 	}
 
 	if u.Scheme != "unix" {
-		return "", fmt.Errorf("unsupported scheme %q for remote KMS provider", u.Scheme)
+		return "", fmt.Errorf("invalid Resources[].KMS.Endpoint in encryption configuration, only only 'unix' scheme is currently supported, but %q was supplied", u.Scheme)
 	}
 
 	// Linux abstract namespace socket - no physical file required

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -452,7 +452,7 @@ resources:
     - kms:
         name: foo
 `,
-			wantErr: "remote KMS provider can't use empty string as endpoint",
+			wantErr: "invalid empty Resources[].KMS.Endpoint in encryption configuration for KMS provider",
 		},
 		{
 			desc: "not a unix socket endpoint",
@@ -466,7 +466,7 @@ resources:
         name: foo
         endpoint: /tmp/testprovider.sock
 `,
-			wantErr: `unsupported scheme "" for remote KMS provider`,
+			wantErr: `invalid Resources[].KMS.Endpoint in encryption configuration, only only 'unix' scheme is currently supported, but "" was supplied`,
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
Detect issues related to the format of KMS' endpoint earlier - while parsing the encryption config.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
NONE
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
