### PR TITLE
Automated cherry pick of #81681: added override for sd testing env in event-exporter yaml #83205: using STACKDRIVER_ENDPOINT to set exporter sd endpoint

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,11 +29,11 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: event-exporter-v0.2.5
+  name: event-exporter-v0.3.0
   namespace: kube-system
   labels:
     k8s-app: event-exporter
-    version: v0.2.5
+    version: v0.3.0
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -41,20 +41,20 @@ spec:
   selector:
     matchLabels:
       k8s-app: event-exporter
-      version: v0.2.5
+      version: v0.3.0
   template:
     metadata:
       labels:
         k8s-app: event-exporter
-        version: v0.2.5
+        version: v0.3.0
     spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: k8s.gcr.io/event-exporter:v0.2.5
+        image: k8s.gcr.io/event-exporter:v0.3.0
         command:
         - /event-exporter
-        - -sink-opts=-stackdriver-resource-model={{ exporter_sd_resource_model }}
+        - -sink-opts=-stackdriver-resource-model={{ exporter_sd_resource_model }} -endpoint={{ exporter_sd_endpoint }}
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
         image: k8s.gcr.io/prometheus-to-sd:v0.5.0

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2376,6 +2376,7 @@ function update-daemon-set-prometheus-to-sd-parameters {
 function update-event-exporter {
     local -r stackdriver_resource_model="${LOGGING_STACKDRIVER_RESOURCE_TYPES:-old}"
     sed -i -e "s@{{ exporter_sd_resource_model }}@${stackdriver_resource_model}@g" "$1"
+    sed -i -e "s@{{ exporter_sd_endpoint }}@${STACKDRIVER_TEST_ENDPOINT:-}@g" "$1"
 }
 
 function update-dashboard-controller {

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2376,7 +2376,7 @@ function update-daemon-set-prometheus-to-sd-parameters {
 function update-event-exporter {
     local -r stackdriver_resource_model="${LOGGING_STACKDRIVER_RESOURCE_TYPES:-old}"
     sed -i -e "s@{{ exporter_sd_resource_model }}@${stackdriver_resource_model}@g" "$1"
-    sed -i -e "s@{{ exporter_sd_endpoint }}@${STACKDRIVER_TEST_ENDPOINT:-}@g" "$1"
+    sed -i -e "s@{{ exporter_sd_endpoint }}@${STACKDRIVER_ENDPOINT:-}@g" "$1"
 }
 
 function update-dashboard-controller {


### PR DESCRIPTION
Cherry pick of #81681 #83205 on release-1.15.

#81681: added override for sd testing env in event-exporter yaml
#83205: using STACKDRIVER_ENDPOINT to set exporter sd endpoint

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Make event-exporter send logs to Stackdriver in the same env as the clusters are located.
```