### PR TITLE
Switch from admission-control flag to enable-admission-plugins

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -1948,7 +1948,7 @@ function start-kube-apiserver {
   fi
 
   if [[ -n "${ADMISSION_CONTROL:-}" ]]; then
-    params+=" --admission-control=${ADMISSION_CONTROL}"
+    params+=" --enable-admission-plugins=${ADMISSION_CONTROL}"
     params+=" --admission-control-config-file=/etc/srv/kubernetes/admission_controller_config.yaml"
   fi
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Switches from the [deprecated](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#is-there-a-recommended-set-of-admission-controllers-to-use) admission-control flag to enable-admission-controllers.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
