### PR TITLE
Move hostPID tests to common

### DIFF
--- a/test/e2e_node/security_context_test.go
+++ b/test/e2e_node/security_context_test.go
@@ -22,9 +22,8 @@ import (
 	"os/exec"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/kubernetes/pkg/features"
@@ -110,86 +109,6 @@ var _ = framework.KubeDescribe("Security Context", func() {
 			pid2 := f.ExecCommandInContainer("shared-pid-ns-test-pod", "test-container-2", "/bin/pidof", "top")
 			if pid1 != pid2 {
 				framework.Failf("PIDs are not the same in different containers: test-container-1=%v, test-container-2=%v", pid1, pid2)
-			}
-		})
-	})
-
-	ginkgo.Context("when creating a pod in the host PID namespace", func() {
-		makeHostPidPod := func(podName, image string, command []string, hostPID bool) *v1.Pod {
-			return &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: podName,
-				},
-				Spec: v1.PodSpec{
-					RestartPolicy: v1.RestartPolicyNever,
-					HostPID:       hostPID,
-					Containers: []v1.Container{
-						{
-							Image:   image,
-							Name:    podName,
-							Command: command,
-						},
-					},
-				},
-			}
-		}
-		createAndWaitHostPidPod := func(podName string, hostPID bool) {
-			podClient.Create(makeHostPidPod(podName,
-				busyboxImage,
-				[]string{"sh", "-c", "pidof nginx || true"},
-				hostPID,
-			))
-
-			podClient.WaitForSuccess(podName, framework.PodStartTimeout)
-		}
-
-		nginxPid := ""
-		ginkgo.BeforeEach(func() {
-			nginxPodName := "nginx-hostpid-" + string(uuid.NewUUID())
-			podClient.CreateSync(makeHostPidPod(nginxPodName,
-				imageutils.GetE2EImage(imageutils.Nginx),
-				nil,
-				true,
-			))
-
-			output := f.ExecShellInContainer(nginxPodName, nginxPodName,
-				"cat /var/run/nginx.pid")
-			nginxPid = strings.TrimSpace(output)
-		})
-
-		ginkgo.It("should show its pid in the host PID namespace [NodeFeature:HostAccess]", func() {
-			busyboxPodName := "busybox-hostpid-" + string(uuid.NewUUID())
-			createAndWaitHostPidPod(busyboxPodName, true)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
-			if err != nil {
-				framework.Failf("GetPodLogs for pod %q failed: %v", busyboxPodName, err)
-			}
-
-			pids := strings.TrimSpace(logs)
-			framework.Logf("Got nginx's pid %q from pod %q", pids, busyboxPodName)
-			if pids == "" {
-				framework.Failf("nginx's pid should be seen by hostpid containers")
-			}
-
-			pidSets := sets.NewString(strings.Split(pids, " ")...)
-			if !pidSets.Has(nginxPid) {
-				framework.Failf("nginx's pid should be seen by hostpid containers")
-			}
-		})
-
-		ginkgo.It("should not show its pid in the non-hostpid containers [NodeFeature:HostAccess]", func() {
-			busyboxPodName := "busybox-non-hostpid-" + string(uuid.NewUUID())
-			createAndWaitHostPidPod(busyboxPodName, false)
-			logs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, busyboxPodName, busyboxPodName)
-			if err != nil {
-				framework.Failf("GetPodLogs for pod %q failed: %v", busyboxPodName, err)
-			}
-
-			pids := strings.TrimSpace(logs)
-			framework.Logf("Got nginx's pid %q from pod %q", pids, busyboxPodName)
-			pidSets := sets.NewString(strings.Split(pids, " ")...)
-			if pidSets.Has(nginxPid) {
-				framework.Failf("nginx's pid should not be seen by non-hostpid containers")
 			}
 		})
 	})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Move hostpid tests from `test/e2e_node` to `test/e2e/common`. These tests should be eligible to be promoted to Conformance.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubernetes/issues/82547

**Special notes for your reviewer**:

These tests are a duplicate of the hostpid tests in `e2e_node`. I removed the check for shared pid namespace support (https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/security_context_test.go#L77) since it was only checking the Docker version (https://github.com/kubernetes/kubernetes/blob/master/test/e2e_node/docker_util.go#L53). Docker should not be an assumption we should be making about the container runtime.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

/area conformance
/priority important-longterm
/ok-to-test
/sig node
/cc @johnbelamaric 
/cc @tallclair 
