### PR TITLE
Fix sig-node test by adding back the numNodes

### DIFF
--- a/test/e2e/node/kubelet.go
+++ b/test/e2e/node/kubelet.go
@@ -272,6 +272,7 @@ var _ = SIGDescribe("kubelet", func() {
 			nodeLabels = make(map[string]string)
 			nodeLabels["kubelet_cleanup"] = "true"
 			nodes, err := e2enode.GetBoundedReadySchedulableNodes(c, maxNodesToCheck)
+			numNodes = len(nodes.Items)
 			framework.ExpectNoError(err)
 			nodeNames = sets.NewString()
 			for i := 0; i < len(nodes.Items); i++ {
@@ -284,7 +285,7 @@ var _ = SIGDescribe("kubelet", func() {
 			}
 
 			// Start resourceMonitor only in small clusters.
-			if len(nodes.Items) <= maxNodesToCheck {
+			if numNodes <= maxNodesToCheck {
 				resourceMonitor = e2ekubelet.NewResourceMonitor(f.ClientSet, e2ekubelet.TargetContainers(), containerStatsPollingInterval)
 				resourceMonitor.Start()
 			}


### PR DESCRIPTION
**What type of PR is this?**

> /kind failing-test

**What this PR does / why we need it**:

Adding back an accidentally removed variable `numNodes`, which was causing sig-node test to fail.

**Which issue(s) this PR fixes**:

Fixes #83316

```release-note
NONE
```
