### PR TITLE
Promote pod PreemptionExecutionPath verification - +3 conformance endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1715,7 +1715,7 @@
     restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first
     followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected
     number of Replicas.
-  release: v1.17
+  release: v1.18
   file: test/e2e/scheduling/preemption.go
 - testname: Scheduler, resource limits
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates resource limits

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1708,6 +1708,15 @@
     be evicted if the taint is removed before toleration time ends.
   release: v1.16
   file: test/e2e/scheduling/taints.go
+- testname: Pod preemption verification
+  codename: '[sig-scheduling] PreemptionExecutionPath runs ReplicaSets to verify preemption
+    running path [Conformance]'
+  description: Four levels of Pods in ReplicaSets with different levels of Priority,
+    restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first
+    followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected
+    number of Replicas.
+  release: v1.17
+  file: test/e2e/scheduling/preemption.go
 - testname: Scheduler, resource limits
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates resource limits
     of pods that are allowed to run  [Conformance]'

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1708,15 +1708,6 @@
     be evicted if the taint is removed before toleration time ends.
   release: v1.16
   file: test/e2e/scheduling/taints.go
-- testname: Pod preemption verification
-  codename: '[sig-scheduling] PreemptionExecutionPath runs ReplicaSets to verify preemption
-    running path [Conformance]'
-  description: Four levels of Pods in ReplicaSets with different levels of Priority,
-    restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first
-    followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected
-    number of Replicas.
-  release: v1.18
-  file: test/e2e/scheduling/preemption.go
 - testname: Scheduler, resource limits
   codename: '[sig-scheduling] SchedulerPredicates [Serial] validates resource limits
     of pods that are allowed to run  [Conformance]'
@@ -1767,6 +1758,15 @@
     same node if the HostIP or Protocol is different.
   release: v1.16
   file: test/e2e/scheduling/predicates.go
+- testname: Pod preemption verification
+  codename: '[sig-scheduling] SchedulerPreemption [Serial] PreemptionExecutionPath
+    runs ReplicaSets to verify preemption running path [Conformance]'
+  description: Four levels of Pods in ReplicaSets with different levels of Priority,
+    restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first
+    followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected
+    number of Replicas.
+  release: v1.18
+  file: test/e2e/scheduling/preemption.go
 - testname: ConfigMap Volume, text data, binary data
   codename: '[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]
     [Conformance]'

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1765,7 +1765,7 @@
     restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first
     followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected
     number of Replicas.
-  release: v1.18
+  release: v1.19
   file: test/e2e/scheduling/preemption.go
 - testname: ConfigMap Volume, text data, binary data
   codename: '[sig-storage] ConfigMap binary data should be reflected in volume [NodeConformance]

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -500,7 +500,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		})
 
 		/*
-			Release: v1.18
+			Release: v1.19
 			Testname: Pod preemption verification
 			Description: Four levels of Pods in ReplicaSets with different levels of Priority, restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected number of Replicas.
 		*/

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -499,7 +499,12 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			}
 		})
 
-		ginkgo.It("runs ReplicaSets to verify preemption running path", func() {
+		/*
+			Release: v1.17
+			Testname: Pod preemption verification
+			Description: Four levels of Pods in ReplicaSets with different levels of Priority, restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected number of Replicas.
+		*/
+		framework.ConformanceIt("runs ReplicaSets to verify preemption running path", func() {
 			podNamesSeen := []int32{0, 0, 0}
 			stopCh := make(chan struct{})
 

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -500,7 +500,7 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 		})
 
 		/*
-			Release: v1.17
+			Release: v1.18
 			Testname: Pod preemption verification
 			Description: Four levels of Pods in ReplicaSets with different levels of Priority, restricted by given CPU limits MUST launch. Priority 1 - 3 Pods MUST spawn first followed by Priority 4 Pod. The ReplicaSets with Replicas MUST contain the expected number of Replicas.
 		*/


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes test to conformance:
`test/e2e/scheduling/preemption.go: "runs ReplicaSets to verify preemption running path"`

Endpoints to become conformance included in test:
- createSchedulingV1PriorityClass
- deleteSchedulingV1PriorityClass
- replaceCoreV1NodeStatus

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```