### PR TITLE
Revert "Bugfix: remove PV dir when umount raw block device"

### DIFF
--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 
 	"k8s.io/klog"
@@ -362,25 +361,5 @@ func (m *csiBlockMapper) TearDownDevice(globalMapPath, devicePath string) error 
 		}
 	}
 
-	dataDir := getVolumeDeviceDataDir(m.specName, m.plugin.host)
-
-	// remove ~/${pv}/data/vol_data.json first, then remove the other dir.
-	volDataFile := path.Join(dataDir, volDataFileName)
-	err = os.Remove(volDataFile)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	// remove ~/${pv}/data
-	err = os.Remove(dataDir)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	// remove ~/${pv}
-	pvPath := filepath.Dir(dataDir)
-	err = os.Remove(pvPath)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
 	return nil
 }


### PR DESCRIPTION
Reverts kubernetes/kubernetes#79784

See comment here: https://github.com/kubernetes/kubernetes/pull/79784#issuecomment-537254635
This PR broke block volumes for all CSI Drivers.

/assign @jsafrane @msau42 

/sig storage
/kind bug
/priority important-critical

```release-note
NONE
```