### PR TITLE
Update leader election resource type flag description

### DIFF
--- a/pkg/client/leaderelectionconfig/config.go
+++ b/pkg/client/leaderelectionconfig/config.go
@@ -42,7 +42,8 @@ func BindFlags(l *componentbaseconfig.LeaderElectionConfiguration, fs *pflag.Fla
 		"of a leadership. This is only applicable if leader election is enabled.")
 	fs.StringVar(&l.ResourceLock, "leader-elect-resource-lock", l.ResourceLock, ""+
 		"The type of resource object that is used for locking during "+
-		"leader election. Supported options are `endpoints` (default) and `configmaps`.")
+		"leader election. Supported options are 'endpoints', 'configmaps', "+
+		"'leases', 'endpointsleases' and 'configmapsleases'.")
 	fs.StringVar(&l.ResourceName, "leader-elect-resource-name", l.ResourceName, ""+
 		"The name of resource object that is used for locking during "+
 		"leader election.")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Removes "(default)" after endpoints which may not be true, and adds other leader election resource types which have been added since this flag description was originally written.

Compared to the example in the linked issue, the --help for this flag is now:

```
--leader-elect-resource-lock string
The type of resource object that is used for locking during leader election.
Supported options are 'endpoints', 'configmaps', 'leases', 'endpointsleases' and 'configmapsleases'. (default "leases")
```

I changed from using backquotes to single quotes since pflag tries to use the first substring in backquotes as the type of the flag (it was reporting the type as `endpoints` before).

**Which issue(s) this PR fixes**:

Fixes #83391

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
