### PR TITLE
Bump version of event-exporter and prometheus-to-sd.

### DIFF
--- a/cluster/addons/fluentd-gcp/event-exporter.yaml
+++ b/cluster/addons/fluentd-gcp/event-exporter.yaml
@@ -29,11 +29,11 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: event-exporter-v0.3.0
+  name: event-exporter-v0.3.1
   namespace: kube-system
   labels:
     k8s-app: event-exporter
-    version: v0.3.0
+    version: v0.3.1
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
@@ -41,23 +41,23 @@ spec:
   selector:
     matchLabels:
       k8s-app: event-exporter
-      version: v0.3.0
+      version: v0.3.1
   template:
     metadata:
       labels:
         k8s-app: event-exporter
-        version: v0.3.0
+        version: v0.3.1
     spec:
       serviceAccountName: event-exporter-sa
       containers:
       - name: event-exporter
-        image: k8s.gcr.io/event-exporter:v0.3.0
+        image: k8s.gcr.io/event-exporter:v0.3.1
         command:
         - /event-exporter
         - -sink-opts=-stackdriver-resource-model={{ exporter_sd_resource_model }} -endpoint={{ exporter_sd_endpoint }}
       # BEGIN_PROMETHEUS_TO_SD
       - name: prometheus-to-sd-exporter
-        image: k8s.gcr.io/prometheus-to-sd:v0.5.0
+        image: k8s.gcr.io/prometheus-to-sd:v0.7.2
         command:
           - /monitor
           - --stackdriver-prefix={{ prometheus_to_sd_prefix }}/addons


### PR DESCRIPTION


**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
Version 0.3.1 of event-exporter switches from json usage to protobuf. This has positive impact on resource usage of event-exporter.
Version 0.7.2 of prometheus-to-sd introduces security fixes to image and new metrics for debugging exported metrics.

```release-note
Bump version of event-exporter to 0.3.1, to switch it to protobuf.
```