### PR TITLE
tests: Simplifies image pulling tests 

### DIFF
--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -359,30 +359,10 @@ while true; do sleep 1; done
 				imagePullTest(image, false, v1.PodPending, true, false)
 			})
 
-			ginkgo.It("should not be able to pull non-existing image from gcr.io [NodeConformance]", func() {
-				image := imageutils.GetE2EImage(imageutils.Invalid)
-				imagePullTest(image, false, v1.PodPending, true, false)
-			})
-
-			ginkgo.It("should be able to pull image from gcr.io [NodeConformance]", func() {
-				image := imageutils.GetE2EImage(imageutils.DebianBase)
-				isWindows := false
-				if framework.NodeOSDistroIs("windows") {
-					image = imageutils.GetE2EImage(imageutils.WindowsNanoServer)
-					isWindows = true
-				}
-				imagePullTest(image, false, v1.PodRunning, false, isWindows)
-			})
-
-			ginkgo.It("should be able to pull image from docker hub [NodeConformance]", func() {
-				image := imageutils.GetE2EImage(imageutils.Alpine)
-				isWindows := false
-				if framework.NodeOSDistroIs("windows") {
-					// TODO(claudiub): Switch to nanoserver image manifest list.
-					image = "e2eteam/busybox:1.29"
-					isWindows = true
-				}
-				imagePullTest(image, false, v1.PodRunning, false, isWindows)
+			ginkgo.It("should be able to pull image [NodeConformance]", func() {
+				// NOTE(claudiub): The agnhost image is supposed to work on both Linux and Windows.
+				image := imageutils.GetE2EImage(imageutils.Agnhost)
+				imagePullTest(image, false, v1.PodRunning, false, false)
 			})
 
 			ginkgo.It("should not be able to pull from private registry without secret [NodeConformance]", func() {

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -118,8 +118,6 @@ var (
 const (
 	// Agnhost image
 	Agnhost = iota
-	// Alpine image
-	Alpine
 	// APIServer image
 	APIServer
 	// AppArmorLoader image
@@ -138,8 +136,6 @@ const (
 	CudaVectorAdd2
 	// Dnsutils image
 	Dnsutils
-	// DebianBase image
-	DebianBase
 	// EchoServer image
 	EchoServer
 	// Etcd image
@@ -152,8 +148,6 @@ const (
 	Httpd
 	// HttpdNew image
 	HttpdNew
-	// Invalid image
-	Invalid
 	// InvalidRegistryImage image
 	InvalidRegistryImage
 	// IpcUtils image
@@ -209,14 +203,11 @@ const (
 	VolumeGlusterServer
 	// VolumeRBDServer image
 	VolumeRBDServer
-	// WindowsNanoServer image
-	WindowsNanoServer
 )
 
 func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
 	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.6"}
-	configs[Alpine] = Config{dockerLibraryRegistry, "alpine", "3.7"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}
 	configs[APIServer] = Config{e2eRegistry, "sample-apiserver", "1.10"}
@@ -226,14 +217,12 @@ func initImageConfigs() map[int]Config {
 	configs[CudaVectorAdd] = Config{e2eRegistry, "cuda-vector-add", "1.0"}
 	configs[CudaVectorAdd2] = Config{e2eRegistry, "cuda-vector-add", "2.0"}
 	configs[Dnsutils] = Config{e2eRegistry, "dnsutils", "1.1"}
-	configs[DebianBase] = Config{googleContainerRegistry, "debian-base", "0.4.1"}
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
 	configs[Etcd] = Config{gcRegistry, "etcd", "3.3.15"}
 	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
 	configs[GlusterDynamicProvisioner] = Config{dockerGluster, "glusterdynamic-provisioner", "v1.0"}
 	configs[Httpd] = Config{dockerLibraryRegistry, "httpd", "2.4.38-alpine"}
 	configs[HttpdNew] = Config{dockerLibraryRegistry, "httpd", "2.4.39-alpine"}
-	configs[Invalid] = Config{gcRegistry, "invalid-image", "invalid-tag"}
 	configs[InvalidRegistryImage] = Config{invalidRegistry, "alpine", "3.1"}
 	configs[IpcUtils] = Config{e2eRegistry, "ipc-utils", "1.0"}
 	configs[JessieDnsutils] = Config{e2eRegistry, "jessie-dnsutils", "1.0"}
@@ -262,7 +251,6 @@ func initImageConfigs() map[int]Config {
 	configs[VolumeISCSIServer] = Config{e2eRegistry, "volume/iscsi", "2.0"}
 	configs[VolumeGlusterServer] = Config{e2eRegistry, "volume/gluster", "1.0"}
 	configs[VolumeRBDServer] = Config{e2eRegistry, "volume/rbd", "1.0.1"}
-	configs[WindowsNanoServer] = Config{e2eRegistry, "windows-nanoserver", "v1"}
 	return configs
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig windows
/sig testing
/area conformance

**What this PR does / why we need it**:

Melds the ``pull image from gcr.io`` and ``pull image from docker hub`` tests into a single test that pulls the ``agnhost`` image from the configured ``e2eRegistry``.

This also removes the need to maintain and update the image ``gcr.io/kubernetes-e2e-test-images/windows-nanoserver:v1``. It should have been a manifest list that also includes future Windows releases, like Windows Server 1903. Additionally, the image has ~300 MB, meaning that with this change, it won't have to wait as much to spawn a pod.

Removes ``should not be able to pull non-existing image from gcr.io``, since the test ``should not be able to pull image from invalid registry`` test already exists, and both of them test the same effect: cannot spawn a pod with an image that does not exist.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #83397

**Special notes for your reviewer**:

This issue was fixed once before: https://github.com/kubernetes/kubernetes/issues/79171

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
