### PR TITLE
fix metrics-server rbac

### DIFF
--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -17,7 +17,7 @@ rules:
   - list
   - watch
 - apiGroups:
-  - "extensions"
+  - "apps"
   resources:
   - deployments
   verbs:


### PR DESCRIPTION
/kind cleanup

This PR updates metrics-server rbac definition according to extensions API deprecation
