### PR TITLE
Remove block volume capability from GCE PD CSI Driver because not supported in v0.5.2

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -393,7 +393,6 @@ func InitGcePDCSIDriver() testsuites.TestDriver {
 				testsuites.CapFsGroup:     true,
 				testsuites.CapExec:        true,
 				testsuites.CapMultiPODs:   true,
-				testsuites.CapBlock:       true,
 				// GCE supports volume limits, but the test creates large
 				// number of volumes and times out test suites.
 				testsuites.CapVolumeLimits: false,


### PR DESCRIPTION
Oops my bad. I added Block Volume support in >v0.5.2 but that is our latest released version. Removing this :)

/assign @msau42 
/kind bug
/kind failing-test
/sig storage
/priority important-soon

```release-note
NONE
```
