### PR TITLE
Add known issue to release notes for 1.14.7

### DIFF
--- a/CHANGELOG-1.14.md
+++ b/CHANGELOG-1.14.md
@@ -182,6 +182,10 @@ filename | sha512 hash
 [kubernetes-node-linux-s390x.tar.gz](https://dl.k8s.io/v1.14.7/kubernetes-node-linux-s390x.tar.gz) | `bca2c439588fccb4f10f6bb5f2f06bdb9606ed9baf3101cd792b8b826c668905fddc82bd81b99204592f8b42a3e3ded9da9b96418a3ba20e41a1f67d20520cce`
 [kubernetes-node-windows-amd64.tar.gz](https://dl.k8s.io/v1.14.7/kubernetes-node-windows-amd64.tar.gz) | `e67828b5998342f8095f102e9c91e6ad5c59dbae3566c5acc4a83bb042b3ddb8118f224a11a44bbcb4af8c34a852c973b52f4d871584f718f982629206b29153`
 
+## Known Issues
+
+* There is a known issue [#82923](https://github.com/kubernetes/kubernetes/issues/82923) in the AWS cloudprovider, where ELBs fail to register instances.  The fix has been merged [#82954](https://github.com/kubernetes/kubernetes/pull/82954) and will be included in v1.14.8.
+
 ## Changelog since v1.14.6
 
 ### Other notable changes
@@ -197,8 +201,6 @@ filename | sha512 hash
 * remove iSCSI volume storage cleartext secrets in logs ([#81215](https://github.com/kubernetes/kubernetes/pull/81215), [@zouyee](https://github.com/zouyee))
 * Fix a bug in server printer that could cause kube-apiserver to panic. ([#79349](https://github.com/kubernetes/kubernetes/pull/79349), [@roycaihw](https://github.com/roycaihw))
 * Fix a bug in the IPVS proxier where virtual servers are not cleaned up even though the corresponding Service object was deleted. ([#80942](https://github.com/kubernetes/kubernetes/pull/80942), [@gongguan](https://github.com/gongguan))
-
-
 
 # v1.14.6
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Document bug for AWS cloudprovider in release notes of 1.14.7 which causes instances to not be registered to ELBs.  

```release-note
NONE
```
