### PR TITLE
Refactor scheduler.New so that all framework-related parameters are options

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -182,14 +182,15 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}, regis
 		cc.Recorder,
 		cc.ComponentConfig.AlgorithmSource,
 		stopCh,
-		registry,
-		cc.ComponentConfig.Plugins,
-		cc.ComponentConfig.PluginConfig,
 		scheduler.WithName(cc.ComponentConfig.SchedulerName),
 		scheduler.WithHardPodAffinitySymmetricWeight(cc.ComponentConfig.HardPodAffinitySymmetricWeight),
 		scheduler.WithPreemptionDisabled(cc.ComponentConfig.DisablePreemption),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),
-		scheduler.WithBindTimeoutSeconds(*cc.ComponentConfig.BindTimeoutSeconds))
+		scheduler.WithBindTimeoutSeconds(*cc.ComponentConfig.BindTimeoutSeconds),
+		scheduler.WithFrameworkRegistry(registry),
+		scheduler.WithFrameworkPlugins(cc.ComponentConfig.Plugins),
+		scheduler.WithFrameworkPluginConfig(cc.ComponentConfig.PluginConfig),
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/core:go_default_library",
         "//pkg/scheduler/factory:go_default_library",
+        "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/internal/queue:go_default_library",

--- a/pkg/scheduler/api/compatibility/BUILD
+++ b/pkg/scheduler/api/compatibility/BUILD
@@ -11,7 +11,6 @@ go_test(
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/core:go_default_library",
         "//pkg/scheduler/factory:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/scheduler/api/compatibility/compatibility_test.go
+++ b/pkg/scheduler/api/compatibility/compatibility_test.go
@@ -32,7 +32,6 @@ import (
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/core"
 	"k8s.io/kubernetes/pkg/scheduler/factory"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 )
 
 func TestCompatibility_v1_Scheduler(t *testing.T) {
@@ -1163,9 +1162,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				nil,
 				algorithmSrc,
 				make(chan struct{}),
-				schedulerframework.NewDefaultRegistry(),
-				nil,
-				[]kubeschedulerconfig.PluginConfig{},
 			)
 			if err != nil {
 				t.Fatalf("%s: Error constructing: %v", v, err)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -40,6 +40,7 @@ import (
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/core"
 	"k8s.io/kubernetes/pkg/scheduler/factory"
+	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	internalqueue "k8s.io/kubernetes/pkg/scheduler/internal/queue"
@@ -109,11 +110,15 @@ func (sched *Scheduler) Cache() internalcache.Cache {
 }
 
 type schedulerOptions struct {
-	schedulerName                  string
-	hardPodAffinitySymmetricWeight int32
-	disablePreemption              bool
-	percentageOfNodesToScore       int32
-	bindTimeoutSeconds             int64
+	schedulerName                   string
+	hardPodAffinitySymmetricWeight  int32
+	disablePreemption               bool
+	percentageOfNodesToScore        int32
+	bindTimeoutSeconds              int64
+	frameworkRegistry               framework.Registry
+	frameworkConfigProducerRegistry *frameworkplugins.ConfigProducerRegistry
+	frameworkPlugins                *kubeschedulerconfig.Plugins
+	frameworkPluginConfig           []kubeschedulerconfig.PluginConfig
 }
 
 // Option configures a Scheduler
@@ -154,12 +159,51 @@ func WithBindTimeoutSeconds(bindTimeoutSeconds int64) Option {
 	}
 }
 
+// WithFrameworkRegistry sets the framework registry.
+func WithFrameworkRegistry(registry framework.Registry) Option {
+	return func(o *schedulerOptions) {
+		o.frameworkRegistry = registry
+	}
+}
+
+// WithFrameworkConfigProducerRegistry sets the framework plugin producer registry.
+func WithFrameworkConfigProducerRegistry(registry *frameworkplugins.ConfigProducerRegistry) Option {
+	return func(o *schedulerOptions) {
+		o.frameworkConfigProducerRegistry = registry
+	}
+}
+
+// WithFrameworkPlugins sets the plugins that the framework should be configured with.
+func WithFrameworkPlugins(plugins *kubeschedulerconfig.Plugins) Option {
+	return func(o *schedulerOptions) {
+		o.frameworkPlugins = plugins
+	}
+}
+
+// WithFrameworkPluginConfig sets the PluginConfig slice that the framework should be configured with.
+func WithFrameworkPluginConfig(pluginConfig []kubeschedulerconfig.PluginConfig) Option {
+	return func(o *schedulerOptions) {
+		o.frameworkPluginConfig = pluginConfig
+	}
+}
+
 var defaultSchedulerOptions = schedulerOptions{
-	schedulerName:                  v1.DefaultSchedulerName,
-	hardPodAffinitySymmetricWeight: v1.DefaultHardPodAffinitySymmetricWeight,
-	disablePreemption:              false,
-	percentageOfNodesToScore:       schedulerapi.DefaultPercentageOfNodesToScore,
-	bindTimeoutSeconds:             BindTimeoutSeconds,
+	schedulerName:                   v1.DefaultSchedulerName,
+	hardPodAffinitySymmetricWeight:  v1.DefaultHardPodAffinitySymmetricWeight,
+	disablePreemption:               false,
+	percentageOfNodesToScore:        schedulerapi.DefaultPercentageOfNodesToScore,
+	bindTimeoutSeconds:              BindTimeoutSeconds,
+	frameworkRegistry:               frameworkplugins.NewDefaultRegistry(),
+	frameworkConfigProducerRegistry: frameworkplugins.NewDefaultConfigProducerRegistry(),
+	// The plugins and pluginConfig options are currently nil because we currently don't have
+	// "default" plugins. All plugins that we run through the framework currently come from two
+	// sources: 1) specified in component config, in which case those two options should be
+	// set using their corresponding With* functions, 2) predicate/priority-mapped plugins, which
+	// pluginConfigProducerRegistry contains a mapping for and produces their configurations.
+	// TODO(ahg-g) Once predicates and priorities are migrated to natively run as plugins, the
+	// below two parameters will be populated accordingly.
+	frameworkPlugins:      nil,
+	frameworkPluginConfig: nil,
 }
 
 // New returns a Scheduler
@@ -178,9 +222,6 @@ func New(client clientset.Interface,
 	recorder events.EventRecorder,
 	schedulerAlgorithmSource kubeschedulerconfig.SchedulerAlgorithmSource,
 	stopCh <-chan struct{},
-	registry framework.Registry,
-	plugins *kubeschedulerconfig.Plugins,
-	pluginConfig []kubeschedulerconfig.PluginConfig,
 	opts ...Option) (*Scheduler, error) {
 
 	options := defaultSchedulerOptions
@@ -205,9 +246,10 @@ func New(client clientset.Interface,
 		DisablePreemption:              options.disablePreemption,
 		PercentageOfNodesToScore:       options.percentageOfNodesToScore,
 		BindTimeoutSeconds:             options.bindTimeoutSeconds,
-		Registry:                       registry,
-		Plugins:                        plugins,
-		PluginConfig:                   pluginConfig,
+		Registry:                       options.frameworkRegistry,
+		PluginConfigProducerRegistry:   options.frameworkConfigProducerRegistry,
+		Plugins:                        options.frameworkPlugins,
+		PluginConfig:                   options.frameworkPluginConfig,
 	})
 	var config *factory.Config
 	source := schedulerAlgorithmSource

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -59,11 +59,9 @@ import (
 
 var (
 	emptyPluginRegistry = framework.Registry{}
-	// emptyPluginConfig is an empty plugin config used in tests.
-	emptyPluginConfig []kubeschedulerconfig.PluginConfig
 	// emptyFramework is an empty framework used in tests.
 	// Note: If the test runs in goroutine, please don't use this variable to avoid a race condition.
-	emptyFramework, _ = framework.NewFramework(emptyPluginRegistry, nil, emptyPluginConfig)
+	emptyFramework, _ = framework.NewFramework(emptyPluginRegistry, nil, nil)
 )
 
 type fakeBinder struct {
@@ -178,7 +176,6 @@ func TestSchedulerCreation(t *testing.T) {
 	testSource := "testProvider"
 	eventBroadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client.EventsV1beta1().Events("")})
 
-	defaultBindTimeout := int64(30)
 	factory.RegisterFitPredicate("PredicateOne", PredicateOne)
 	factory.RegisterPriorityFunction("PriorityOne", PriorityOne, 1)
 	factory.RegisterAlgorithmProvider(testSource, sets.NewString("PredicateOne"), sets.NewString("PriorityOne"))
@@ -200,10 +197,7 @@ func TestSchedulerCreation(t *testing.T) {
 		eventBroadcaster.NewRecorder(scheme.Scheme, "scheduler"),
 		kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &testSource},
 		stopCh,
-		emptyPluginRegistry,
-		nil,
-		emptyPluginConfig,
-		WithBindTimeoutSeconds(defaultBindTimeout))
+	)
 
 	if err != nil {
 		t.Fatalf("Failed to create scheduler: %v", err)

--- a/test/integration/daemonset/BUILD
+++ b/test/integration/daemonset/BUILD
@@ -23,7 +23,6 @@ go_test(
         "//pkg/scheduler/algorithmprovider:go_default_library",
         "//pkg/scheduler/api:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/util/labels:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/test/integration/daemonset/daemonset_test.go
+++ b/test/integration/daemonset/daemonset_test.go
@@ -51,7 +51,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	labelsutil "k8s.io/kubernetes/pkg/util/labels"
 	"k8s.io/kubernetes/test/integration/framework"
 )
@@ -126,9 +125,6 @@ func setupScheduler(
 			Provider: &defaultProviderName,
 		},
 		stopCh,
-		schedulerframework.NewDefaultRegistry(),
-		nil,
-		[]schedulerconfig.PluginConfig{},
 	)
 	if err != nil {
 		t.Fatalf("Couldn't create scheduler: %v", err)

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -97,8 +97,6 @@ go_library(
         "//pkg/scheduler/api/latest:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/factory:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
-        "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/util/taints:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -41,7 +41,6 @@ import (
 	_ "k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/factory"
-	schedulerplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	"k8s.io/kubernetes/test/integration/framework"
@@ -265,9 +264,6 @@ priorities: []
 				},
 			},
 			nil,
-			schedulerplugins.NewDefaultRegistry(),
-			nil,
-			[]kubeschedulerconfig.PluginConfig{},
 			scheduler.WithName(v1.DefaultSchedulerName),
 			scheduler.WithHardPodAffinitySymmetricWeight(v1.DefaultHardPodAffinitySymmetricWeight),
 			scheduler.WithBindTimeoutSeconds(defaultBindTimeout),
@@ -336,9 +332,6 @@ func TestSchedulerCreationFromNonExistentConfigMap(t *testing.T) {
 			},
 		},
 		nil,
-		schedulerplugins.NewDefaultRegistry(),
-		nil,
-		[]kubeschedulerconfig.PluginConfig{},
 		scheduler.WithName(v1.DefaultSchedulerName),
 		scheduler.WithHardPodAffinitySymmetricWeight(v1.DefaultHardPodAffinitySymmetricWeight),
 		scheduler.WithBindTimeoutSeconds(defaultBindTimeout))
@@ -596,7 +589,7 @@ func TestMultiScheduler(t *testing.T) {
 	}
 
 	// 5. create and start a scheduler with name "foo-scheduler"
-	context = initTestSchedulerWithOptions(t, context, true, nil, schedulerplugins.NewDefaultRegistry(), nil, []kubeschedulerconfig.PluginConfig{}, time.Second, scheduler.WithName(fooScheduler))
+	context = initTestSchedulerWithOptions(t, context, true, nil, time.Second, scheduler.WithName(fooScheduler))
 
 	//	6. **check point-2**:
 	//		- testPodWithAnnotationFitsFoo should be scheduled

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -56,8 +56,6 @@ import (
 	_ "k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	"k8s.io/kubernetes/pkg/scheduler/factory"
-	schedulerplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/kubernetes/test/integration/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -142,8 +140,7 @@ func initTestScheduler(
 	policy *schedulerapi.Policy,
 ) *testContext {
 	// Pod preemption is enabled by default scheduler configuration.
-	return initTestSchedulerWithOptions(t, context, setPodInformer, policy, schedulerplugins.NewDefaultRegistry(),
-		nil, []schedulerconfig.PluginConfig{}, time.Second)
+	return initTestSchedulerWithOptions(t, context, setPodInformer, policy, time.Second)
 }
 
 // initTestSchedulerWithOptions initializes a test environment and creates a scheduler with default
@@ -153,9 +150,6 @@ func initTestSchedulerWithOptions(
 	context *testContext,
 	setPodInformer bool,
 	policy *schedulerapi.Policy,
-	pluginRegistry schedulerframework.Registry,
-	plugins *schedulerconfig.Plugins,
-	pluginConfig []schedulerconfig.PluginConfig,
 	resyncPeriod time.Duration,
 	opts ...scheduler.Option,
 ) *testContext {
@@ -204,9 +198,6 @@ func initTestSchedulerWithOptions(
 		recorder,
 		algorithmSrc,
 		context.stopCh,
-		pluginRegistry,
-		plugins,
-		pluginConfig,
 		opts...,
 	)
 
@@ -273,7 +264,6 @@ func initTest(t *testing.T, nsPrefix string) *testContext {
 func initTestDisablePreemption(t *testing.T, nsPrefix string) *testContext {
 	return initTestSchedulerWithOptions(
 		t, initTestMaster(t, nsPrefix, nil), true, nil,
-		schedulerplugins.NewDefaultRegistry(), nil, []schedulerconfig.PluginConfig{},
 		time.Second, scheduler.WithPreemptionDisabled(true))
 }
 

--- a/test/integration/util/BUILD
+++ b/test/integration/util/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//pkg/scheduler:go_default_library",
         "//pkg/scheduler/algorithmprovider/defaults:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -31,7 +31,6 @@ import (
 	// import DefaultProvider
 	_ "k8s.io/kubernetes/pkg/scheduler/algorithmprovider/defaults"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	schedulerplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
@@ -124,8 +123,5 @@ func createScheduler(
 			Provider: &defaultProviderName,
 		},
 		stopCh,
-		schedulerplugins.NewDefaultRegistry(),
-		nil,
-		[]schedulerconfig.PluginConfig{},
 	)
 }

--- a/test/integration/volumescheduling/BUILD
+++ b/test/integration/volumescheduling/BUILD
@@ -60,8 +60,6 @@ go_library(
         "//pkg/scheduler:go_default_library",
         "//pkg/scheduler/algorithmprovider/defaults:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
-        "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/test/integration/volumescheduling/util.go
+++ b/test/integration/volumescheduling/util.go
@@ -37,8 +37,6 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	schedulerplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
-	schedulerframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/test/integration/framework"
 
 	// Install "DefaultProvider" algorithprovider
@@ -116,8 +114,7 @@ func initTestSchedulerWithOptions(
 
 	var err error
 	context.scheduler, err = createSchedulerWithPodInformer(
-		context.clientSet, podInformer, context.informerFactory, schedulerplugins.NewDefaultRegistry(), nil,
-		[]schedulerconfig.PluginConfig{}, recorder, context.stopCh)
+		context.clientSet, podInformer, context.informerFactory, recorder, context.stopCh)
 
 	if err != nil {
 		t.Fatalf("Couldn't create scheduler: %v", err)
@@ -138,9 +135,6 @@ func createSchedulerWithPodInformer(
 	clientSet clientset.Interface,
 	podInformer coreinformers.PodInformer,
 	informerFactory informers.SharedInformerFactory,
-	pluginRegistry schedulerframework.Registry,
-	plugins *schedulerconfig.Plugins,
-	pluginConfig []schedulerconfig.PluginConfig,
 	recorder events.EventRecorder,
 	stopCh <-chan struct{},
 ) (*scheduler.Scheduler, error) {
@@ -164,9 +158,6 @@ func createSchedulerWithPodInformer(
 			Provider: &defaultProviderName,
 		},
 		stopCh,
-		pluginRegistry,
-		plugins,
-		pluginConfig,
 	)
 }
 


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Makes all framework-related scheduler parameters optional. This is needed to force using default framework parameters in all places (tests, kube-scheduler, CA in the future) unless otherwise specified. The cases where we expect those parameters to be modified is in framework-specific tests only.

**Which issue(s) this PR fixes**:
Part of #82708

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @Huang-Wei 