### PR TITLE
Check the return value from store.Update

### DIFF
--- a/pkg/controller/volume/scheduling/scheduler_assume_cache.go
+++ b/pkg/controller/volume/scheduling/scheduler_assume_cache.go
@@ -185,8 +185,11 @@ func (c *assumeCache) add(obj interface{}) {
 	}
 
 	objInfo := &objInfo{name: name, latestObj: obj, apiObj: obj}
-	c.store.Update(objInfo)
-	klog.V(10).Infof("Adding %v %v to assume cache: %+v ", c.description, name, obj)
+	if err = c.store.Update(objInfo); err != nil {
+		klog.Warningf("got error when updating stored object : %v", err)
+	} else {
+		klog.V(10).Infof("Adding %v %v to assume cache: %+v ", c.description, name, obj)
+	}
 }
 
 func (c *assumeCache) update(oldObj interface{}, newObj interface{}) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently the error return from store.Update is ignored.

This PR adds check for the return value.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
