### PR TITLE
Kuberuntime: Get imagefs stats directly from CRI

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_image.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image.go
@@ -125,18 +125,15 @@ func (m *kubeGenericRuntimeManager) RemoveImage(image kubecontainer.ImageSpec) e
 }
 
 // ImageStats returns the statistics of the image.
-// Notice that current logic doesn't really work for images which share layers (e.g. docker image),
-// this is a known issue, and we'll address this by getting imagefs stats directly from CRI.
-// TODO: Get imagefs stats directly from CRI.
 func (m *kubeGenericRuntimeManager) ImageStats() (*kubecontainer.ImageStats, error) {
-	allImages, err := m.imageService.ListImages(nil)
+	filesystemUsages, err := m.imageService.ImageFsInfo()
 	if err != nil {
-		klog.Errorf("ListImages failed: %v", err)
+		klog.Errorf("Fetching Filesystem Usage Information from CRI failed: %v", err)
 		return nil, err
 	}
 	stats := &kubecontainer.ImageStats{}
-	for _, img := range allImages {
-		stats.TotalStorageBytes += img.Size_
+	for _, filesystemUsage := range filesystemUsages {
+		stats.TotalStorageBytes += filesystemUsage.GetUsedBytes().GetValue()
 	}
 	return stats, nil
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_image_test.go
@@ -91,13 +91,19 @@ func TestImageStats(t *testing.T) {
 	assert.NoError(t, err)
 
 	const imageSize = 64
-	fakeImageService.SetFakeImageSize(imageSize)
-	images := []string{"1111", "2222", "3333"}
-	fakeImageService.SetFakeImages(images)
+	const countImages int = 3
+
+	fakeFilesystemUsages := make([]*runtimeapi.FilesystemUsage, countImages)
+
+	for i := 0; i < countImages; i++ {
+		fakeFilesystemUsages = append(fakeFilesystemUsages, &runtimeapi.FilesystemUsage{UsedBytes: &runtimeapi.UInt64Value{Value: imageSize}})
+	}
+
+	fakeImageService.SetFakeFilesystemUsage(fakeFilesystemUsages)
 
 	actualStats, err := fakeManager.ImageStats()
 	assert.NoError(t, err)
-	expectedStats := &kubecontainer.ImageStats{TotalStorageBytes: imageSize * uint64(len(images))}
+	expectedStats := &kubecontainer.ImageStats{TotalStorageBytes: imageSize * uint64(countImages)}
 	assert.Equal(t, expectedStats, actualStats)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

 /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Make use of the CRI filesystem usage information in the `ImageStats()` calculation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
