### PR TITLE
Have an option to specify custom apiserver service IP

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -55,7 +55,7 @@ type ServerRunOptions struct {
 	EventTTL                   time.Duration
 	KubeletConfig              kubeletclient.KubeletClientConfig
 	KubernetesServiceNodePort  int
-	KubernetesServiceClusterIP string
+	KubernetesServiceClusterIP net.IP
 	MaxConnectionBytesPerSec   int64
 	// ServiceClusterIPRange is mapped to input provided by user
 	ServiceClusterIPRanges string
@@ -63,8 +63,6 @@ type ServerRunOptions struct {
 	// of parsing ServiceClusterIPRange into actual values
 	PrimaryServiceClusterIPRange   net.IPNet
 	SecondaryServiceClusterIPRange net.IPNet
-	// APIServerServiceIP is the result of parsing KubernetesServiceClusterIP
-	APIServerServiceIP net.IP
 
 	ServiceNodePortRange utilnet.PortRange
 	SSHKeyfile           string
@@ -198,9 +196,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 		"of type NodePort, using this as the value of the port. If zero, the Kubernetes master "+
 		"service will be of type ClusterIP.")
 
-	fs.StringVar(&s.KubernetesServiceClusterIP, "kubernetes-service-cluster-ip", s.KubernetesServiceClusterIP, ""+
-		"If non-empty, the Kubernetes master service (which apiserver creates/maintains) will use "+
-		"the IP as cluster-internal ip. If empty, it will be service cluster ip range base + 1.")
+	fs.IPVar(&s.KubernetesServiceClusterIP, "kubernetes-service-cluster-ip", s.KubernetesServiceClusterIP, ""+
+		"If non-empty, the Kubernetes master service (which apiserver creates/maintains) will use the "+
+		"IP address as cluster-internal IP address. If empty, it will be the service cluster IP range base + 1.")
 
 	// TODO (khenidak) change documentation as we move IPv6DualStack feature from ALPHA to BETA
 	fs.StringVar(&s.ServiceClusterIPRanges, "service-cluster-ip-range", s.ServiceClusterIPRanges, ""+

--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -50,18 +50,21 @@ type ServerRunOptions struct {
 	APIEnablement           *genericoptions.APIEnablementOptions
 	EgressSelector          *genericoptions.EgressSelectorOptions
 
-	AllowPrivileged           bool
-	EnableLogsHandler         bool
-	EventTTL                  time.Duration
-	KubeletConfig             kubeletclient.KubeletClientConfig
-	KubernetesServiceNodePort int
-	MaxConnectionBytesPerSec  int64
+	AllowPrivileged            bool
+	EnableLogsHandler          bool
+	EventTTL                   time.Duration
+	KubeletConfig              kubeletclient.KubeletClientConfig
+	KubernetesServiceNodePort  int
+	KubernetesServiceClusterIP string
+	MaxConnectionBytesPerSec   int64
 	// ServiceClusterIPRange is mapped to input provided by user
 	ServiceClusterIPRanges string
 	//PrimaryServiceClusterIPRange and SecondaryServiceClusterIPRange are the results
 	// of parsing ServiceClusterIPRange into actual values
 	PrimaryServiceClusterIPRange   net.IPNet
 	SecondaryServiceClusterIPRange net.IPNet
+	// APIServerServiceIP is the result of parsing KubernetesServiceClusterIP
+	APIServerServiceIP net.IP
 
 	ServiceNodePortRange utilnet.PortRange
 	SSHKeyfile           string
@@ -194,6 +197,10 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 		"If non-zero, the Kubernetes master service (which apiserver creates/maintains) will be "+
 		"of type NodePort, using this as the value of the port. If zero, the Kubernetes master "+
 		"service will be of type ClusterIP.")
+
+	fs.StringVar(&s.KubernetesServiceClusterIP, "kubernetes-service-cluster-ip", s.KubernetesServiceClusterIP, ""+
+		"If non-empty, the Kubernetes master service (which apiserver creates/maintains) will use "+
+		"the IP as cluster-internal ip. If empty, it will be service cluster ip range base + 1.")
 
 	// TODO (khenidak) change documentation as we move IPv6DualStack feature from ALPHA to BETA
 	fs.StringVar(&s.ServiceClusterIPRanges, "service-cluster-ip-range", s.ServiceClusterIPRanges, ""+

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -115,6 +115,7 @@ func TestAddFlags(t *testing.T) {
 		"--request-timeout=2m",
 		"--storage-backend=etcd3",
 		"--service-cluster-ip-range=192.168.128.0/17",
+		"--kubernetes-service-cluster-ip=192.168.128.5",
 	}
 	fs.Parse(args)
 
@@ -122,6 +123,7 @@ func TestAddFlags(t *testing.T) {
 	expected := &ServerRunOptions{
 		ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
 		ServiceClusterIPRanges: (&net.IPNet{IP: net.ParseIP("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
+		APIServerServiceIP:     net.IPv4(192, 168, 128, 5),
 		MasterCount:            5,
 		EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
 		AllowPrivileged:        false,

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -121,12 +121,12 @@ func TestAddFlags(t *testing.T) {
 
 	// This is a snapshot of expected options parsed by args.
 	expected := &ServerRunOptions{
-		ServiceNodePortRange:   kubeoptions.DefaultServiceNodePortRange,
-		ServiceClusterIPRanges: (&net.IPNet{IP: net.ParseIP("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
-		APIServerServiceIP:     net.IPv4(192, 168, 128, 5),
-		MasterCount:            5,
-		EndpointReconcilerType: string(reconcilers.LeaseEndpointReconcilerType),
-		AllowPrivileged:        false,
+		ServiceNodePortRange:       kubeoptions.DefaultServiceNodePortRange,
+		ServiceClusterIPRanges:     (&net.IPNet{IP: net.ParseIP("192.168.128.0"), Mask: net.CIDRMask(17, 32)}).String(),
+		KubernetesServiceClusterIP: net.ParseIP("192.168.128.5"),
+		MasterCount:                5,
+		EndpointReconcilerType:     string(reconcilers.LeaseEndpointReconcilerType),
+		AllowPrivileged:            false,
 		GenericServerRunOptions: &apiserveroptions.ServerRunOptions{
 			AdvertiseAddress:            net.ParseIP("192.168.10.10"),
 			CorsAllowedOriginList:       []string{"10.10.10.100", "10.10.10.200"},

--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -929,6 +929,24 @@ func (kl *Kubelet) PodResourcesAreReclaimed(pod *v1.Pod, status v1.PodStatus) bo
 		klog.V(3).Infof("Pod %q is terminated, but some containers have not been cleaned up: %s", format.Pod(pod), statusStr)
 		return false
 	}
+	// pod's sandboxes should be deleted
+	filter := &runtimeapi.PodSandboxFilter{
+		LabelSelector: map[string]string{kubetypes.KubernetesPodUIDLabel: string(pod.UID)},
+	}
+	sandboxes, err := kl.runtimeService.ListPodSandbox(filter)
+	if err != nil {
+		klog.V(3).Infof("Pod %q is terminated, Error getting pod sandboxes from the runtime service: %s", format.Pod(pod), err)
+		return false
+	}
+	if len(sandboxes) > 0 {
+		var sandboxStr string
+		for _, sandbox := range sandboxes {
+			sandboxStr += fmt.Sprintf("%+v ", sandbox)
+		}
+		klog.V(3).Infof("Pod %q is terminated, but some pod sandboxes have not been cleaned up: %s", format.Pod(pod), sandboxStr)
+		return false
+	}
+
 	if kl.podVolumesExist(pod.UID) && !kl.keepTerminatedPodVolumes {
 		// We shouldn't delete pods whose volumes have not been cleaned up if we are not keeping terminated pod volumes
 		klog.V(3).Infof("Pod %q is terminated, but some volumes have not been cleaned up", format.Pod(pod))

--- a/pkg/kubelet/kubelet_pods_test.go
+++ b/pkg/kubelet/kubelet_pods_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
+	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 	"os"
 	"path/filepath"
 	"sort"
@@ -42,6 +43,8 @@ import (
 	// api.Registry.GroupOrDie(v1.GroupName).GroupVersions[0].String() is changed
 	// to "v1"?
 
+	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	apitest "k8s.io/cri-api/pkg/apis/testing"
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -2383,5 +2386,83 @@ func TestTruncatePodHostname(t *testing.T) {
 		output, err := truncatePodHostnameIfNeeded("test-pod", test.input)
 		assert.NoError(t, err)
 		assert.Equal(t, test.output, output)
+	}
+}
+
+func TestKubelet_PodResourcesAreReclaimed(t *testing.T) {
+
+	type args struct {
+		pod           *v1.Pod
+		status        v1.PodStatus
+		runtimeStatus kubecontainer.PodStatus
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			"pod with running containers",
+			args{
+				pod: &v1.Pod{},
+				status: v1.PodStatus{
+					ContainerStatuses: []v1.ContainerStatus{
+						runningState("containerA"),
+						runningState("containerB"),
+					},
+				},
+			},
+			false,
+		},
+		{
+			"pod with containers in runtime cache",
+			args{
+				pod:    &v1.Pod{},
+				status: v1.PodStatus{},
+				runtimeStatus: kubecontainer.PodStatus{
+					ContainerStatuses: []*kubecontainer.ContainerStatus{
+						&kubecontainer.ContainerStatus{},
+					},
+				},
+			},
+			false,
+		},
+		{
+			"pod with sandbox present",
+			args{
+				pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						UID: types.UID("fakesandbox"),
+					},
+				},
+				status: v1.PodStatus{},
+			},
+			false,
+		},
+	}
+
+	testKubelet := newTestKubelet(t, false)
+	defer testKubelet.Cleanup()
+	kl := testKubelet.kubelet
+
+	runtimeService := apitest.NewFakeRuntimeService()
+	runtimeService.SetFakeSandboxes([]*apitest.FakePodSandbox{
+		{
+			PodSandboxStatus: runtimeapi.PodSandboxStatus{
+				Id: "fakesandbox",
+				Labels: map[string]string{
+					kubetypes.KubernetesPodUIDLabel: "fakesandbox",
+				},
+			},
+		},
+	})
+	kl.runtimeService = runtimeService
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testKubelet.fakeRuntime.PodStatus = tt.args.runtimeStatus
+			if got := kl.PodResourcesAreReclaimed(tt.args.pod, tt.args.status); got != tt.want {
+				t.Errorf("PodResourcesAreReclaimed() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -283,15 +283,10 @@ func (c *Config) Complete() CompletedConfig {
 		&c.ExtraConfig,
 	}
 
-	serviceIPRange, apiServerServiceIP, err := ServiceIPRange(cfg.ExtraConfig.ServiceIPRange)
+	var err error
+	cfg.ExtraConfig.ServiceIPRange, cfg.ExtraConfig.APIServerServiceIP, err = ServiceIPRange(cfg.ExtraConfig.ServiceIPRange, cfg.ExtraConfig.APIServerServiceIP)
 	if err != nil {
 		klog.Fatalf("Error determining service IP ranges: %v", err)
-	}
-	if cfg.ExtraConfig.ServiceIPRange.IP == nil {
-		cfg.ExtraConfig.ServiceIPRange = serviceIPRange
-	}
-	if cfg.ExtraConfig.APIServerServiceIP == nil {
-		cfg.ExtraConfig.APIServerServiceIP = apiServerServiceIP
 	}
 
 	discoveryAddresses := discovery.DefaultAddresses{DefaultAddress: cfg.GenericConfig.ExternalAddress}

--- a/pkg/master/services.go
+++ b/pkg/master/services.go
@@ -51,7 +51,7 @@ func ServiceIPRange(passedServiceClusterIPRange net.IPNet, passedAPIServiceClust
 			return net.IPNet{}, net.IP{}, err
 		}
 	} else if !serviceClusterIPRange.Contains(passedAPIServiceClusterIP) {
-		return net.IPNet{}, net.IP{}, fmt.Errorf("the service cluster IP must be in the range of %s", serviceClusterIPRange)
+		return net.IPNet{}, net.IP{}, fmt.Errorf("the service cluster IP address must be in the range of %s", serviceClusterIPRange)
 	}
 	klog.V(4).Infof("Setting service IP to %q (read-write).", passedAPIServiceClusterIP)
 

--- a/pkg/master/services_test.go
+++ b/pkg/master/services_test.go
@@ -1,0 +1,64 @@
+package master
+
+import (
+	"net"
+	"testing"
+)
+
+func TestServiceIPRange(t *testing.T) {
+	type args struct {
+		passedServiceClusterIPRange net.IPNet
+		passedAPIServiceClusterIP   net.IP
+	}
+	tests := []struct {
+		name                    string
+		args                    args
+		serviceRange, serviceIP string
+		wantErr                 bool
+	}{
+		{
+			name: "empty service cluster IP should fetch the first IP from the range",
+			args: args{
+				passedServiceClusterIPRange: net.IPNet{IP: net.IPv4(10, 96, 0, 0), Mask: net.CIDRMask(16, 32)},
+			},
+			serviceRange: "10.96.0.0/16",
+			serviceIP:    "10.96.0.1",
+			wantErr:      false,
+		},
+		{
+			name: "custom service cluster IP should just return it",
+			args: args{
+				passedServiceClusterIPRange: net.IPNet{IP: net.IPv4(10, 96, 0, 0), Mask: net.CIDRMask(16, 32)},
+				passedAPIServiceClusterIP:   net.IPv4(10, 96, 0, 5),
+			},
+			serviceRange: "10.96.0.0/16",
+			serviceIP:    "10.96.0.5",
+			wantErr:      false,
+		},
+		{
+			name: "custom service cluster IP not in service IP range should return error",
+			args: args{
+				passedServiceClusterIPRange: net.IPNet{IP: net.IPv4(10, 96, 0, 0), Mask: net.CIDRMask(16, 32)},
+				passedAPIServiceClusterIP:   net.IPv4(10, 91, 0, 5),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			serviceRange, serviceIP, err := ServiceIPRange(tt.args.passedServiceClusterIPRange, tt.args.passedAPIServiceClusterIP)
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("ServiceIPRange() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+			if serviceRange.String() != tt.serviceRange {
+				t.Errorf("ServiceIPRange() got = %v, want %s", serviceRange, tt.serviceRange)
+			}
+			if serviceIP.String() != tt.serviceIP {
+				t.Errorf("ServiceIPRange() got1 = %v, want %s", serviceIP, tt.serviceIP)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This will provide an option to override the apiserver cluster serviceIP. 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82743

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
