### PR TITLE
Suppress printing the null char in scheduler log

### DIFF
--- a/pkg/scheduler/internal/cache/node_tree.go
+++ b/pkg/scheduler/internal/cache/node_tree.go
@@ -90,7 +90,9 @@ func (nt *NodeTree) addNode(n *v1.Node) {
 		nt.zones = append(nt.zones, zone)
 		nt.tree[zone] = &nodeArray{nodes: []string{n.Name}, lastIndex: 0}
 	}
-	klog.V(2).Infof("Added node %q in group %q to NodeTree", n.Name, zone)
+	// Using \"%v\" instead of %q, because %q can't help printing
+	// the null character(\x00) in string
+	klog.V(2).Infof("Added node %q in group \"%v\" to NodeTree", n.Name, zone)
 	nt.numNodes++
 }
 
@@ -110,7 +112,9 @@ func (nt *NodeTree) removeNode(n *v1.Node) error {
 				if len(na.nodes) == 0 {
 					nt.removeZone(zone)
 				}
-				klog.V(2).Infof("Removed node %q in group %q from NodeTree", n.Name, zone)
+				// Using \"%v\" instead of %q, because %q can't help printing
+				// the null character(\x00) in string
+				klog.V(2).Infof("Removed node %q in group \"%v\" from NodeTree", n.Name, zone)
 				nt.numNodes--
 				return nil
 			}


### PR DESCRIPTION
> zone := utilnode.GetZoneKey(n)

`GetZoneKey` returns string such as "my-region:\x00:my-zone".
As a result, kube-scheduler logs `Added node "node1" in group "my-region:\x00:my-zone" to NodeTree`.

This PR helps to suppress printing the null char in scheduler log.

**What type of PR is this?**
/kind cleanup

```release-note
Suppress printing the null char in scheduler log
```