### PR TITLE
add shell completion for --kustomize directory

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/filename_flags.go
@@ -75,5 +75,7 @@ func (o *FileNameFlags) AddFlags(flags *pflag.FlagSet) {
 	if o.Kustomize != nil {
 		flags.StringVarP(o.Kustomize, "kustomize", "k", *o.Kustomize,
 			"Process a kustomization directory. This flag can't be used together with -f or -R.")
+		var annotations []string
+		flags.SetAnnotation("kustomize", cobra.BashCompSubdirsInDir, annotations)
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -405,6 +405,8 @@ func AddJsonFilenameFlag(flags *pflag.FlagSet, value *[]string, usage string) {
 // AddKustomizeFlag adds kustomize flag to a command
 func AddKustomizeFlag(flags *pflag.FlagSet, value *string) {
 	flags.StringVarP(value, "kustomize", "k", *value, "Process the kustomization directory. This flag can't be used together with -f or -R.")
+	var annotations []string
+	flags.SetAnnotation("kustomize", cobra.BashCompSubdirsInDir, annotations)
 }
 
 // AddDryRunFlag adds dry-run flag to a command. Usually used by mutations.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Enables directory completion for the `--kustomize` flag in bash/zsh completion code.

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubectl#723

**Special notes for your reviewer**:
Are there any additional tests for shell completion besides the tests that come with cobra itself?
Not sure if this is worth mentioning in the release notes.
Let me know if anything needs to be changed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
