### PR TITLE
[WIP] Set ownership of `spec.replicas` to scale subresource

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -58,6 +58,20 @@ type fieldManager struct {
 
 var _ FieldManager = &fieldManager{}
 
+type scaleFieldManager struct{}
+
+func NewScaleFieldManager() (FieldManager, error) {
+	return nil, fmt.Errorf("TODO-implement")
+}
+
+func (f *scaleFieldManager) Update(liveObj, newObj runtime.Object, manager string) (runtime.Object, error) {
+	return nil, fmt.Errorf("TODO-implement Update logic")
+}
+
+func (f *scaleFieldManager) Apply(liveObj runtime.Object, patch []byte, fieldManager string, force bool) (runtime.Object, error) {
+	return nil, fmt.Errorf("TODO-implement Apply logic")
+}
+
 // NewFieldManager creates a new FieldManager that merges apply requests
 // and update managed fields for other types of requests.
 func NewFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, gv schema.GroupVersion, hub schema.GroupVersion) (FieldManager, error) {


### PR DESCRIPTION
(with @hoegaarden )

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
This PR implements field ownership on `replicas.scale` for the scale subresource, so that changes to that field would behave the same way (including conflicts where applicable) as a server-side apply of the main resource.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref: https://github.com/kubernetes/kubernetes/issues/82046

**Special notes for your reviewer**:
* The path that we're exploring in this PR is adding a `managedField` entry for `spec.replicas`, on behalf of the scale subresource (i.e. the scale subresource appears as the manager of the field).
  * To begin with we've implemented it for replica sets; if we see that the approach works we'd have to extend that to other resources too... I'm cautious of duplication there.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @apelisse @jennybuckley @julianvmodesto @hoegaarden 
