### PR TITLE
Clean up TODOs

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -357,7 +357,7 @@ func (p *Plugin) admitNode(nodeName string, a admission.Attributes) error {
 			return admission.NewForbidden(a, fmt.Errorf("node %q is not allowed to set the following labels: %s", nodeName, strings.Join(forbiddenLabels.List(), ", ")))
 		}
 		// check and warn if nodes set labels on create that would have been forbidden on update
-		// TODO(liggitt): in 1.17, expand getForbiddenCreateLabels to match getForbiddenUpdateLabels and drop this
+		// TODO(liggitt): in 1.19, expand getForbiddenCreateLabels to match getForbiddenUpdateLabels and drop this
 		if forbiddenUpdateLabels := p.getForbiddenUpdateLabels(modifiedLabels); len(forbiddenUpdateLabels) > 0 {
 			klog.Warningf("node %q added disallowed labels on node creation: %s", nodeName, strings.Join(forbiddenUpdateLabels.List(), ", "))
 		}
@@ -435,7 +435,7 @@ func getLabelNamespace(key string) string {
 }
 
 // getForbiddenCreateLabels returns the set of labels that may not be set by the node.
-// TODO(liggitt): in 1.17, expand to match getForbiddenUpdateLabels()
+// TODO(liggitt): in 1.19, expand to match getForbiddenUpdateLabels()
 func (p *Plugin) getForbiddenCreateLabels(modifiedLabels sets.String) sets.String {
 	if len(modifiedLabels) == 0 {
 		return nil

--- a/plugin/pkg/admission/security/podsecuritypolicy/admission.go
+++ b/plugin/pkg/admission/security/podsecuritypolicy/admission.go
@@ -118,7 +118,6 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 	}
 
 	// only mutate if this is a CREATE request. On updates we only validate.
-	// TODO(liggitt): allow spec mutation during initializing updates?
 	if a.GetOperation() != admission.Create {
 		return nil
 	}
@@ -228,7 +227,6 @@ func (p *Plugin) computeSecurityContext(ctx context.Context, a admission.Attribu
 
 	// sort policies by name to make order deterministic
 	// If mutation is not allowed and validatedPSPHint is provided, check the validated policy first.
-	// TODO(liggitt): add priority field to allow admins to bucket differently
 	sort.SliceStable(policies, func(i, j int) bool {
 		if !specMutationAllowed {
 			if policies[i].Name == validatedPSPHint {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Cleans up or adjusts TODOs

**Special notes for your reviewer**:
Kubelets stopped setting k8s.io-prefixed labels in 1.16, so the API server has to wait until 1.19 to start disallowing that.

```release-note
NONE
```

/cc @mikedanese 