### PR TITLE
Avoid unnecessary identifier computations

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/versioning/versioning_test.go
@@ -381,3 +381,16 @@ func TestCacheableObject(t *testing.T) {
 
 	runtimetesting.CacheableObjectTest(t, encoder)
 }
+
+func BenchmarkIdentifier(b *testing.B) {
+	encoder := &mockSerializer{}
+	gv := schema.GroupVersion{Group: "group", Version: "version"}
+
+	for i := 0; i < b.N; i++ {
+		id := identifier(gv, encoder)
+		// Avoid optimizing by compiler.
+		if id[0] != '{' {
+			b.Errorf("unexpected identifier: %s", id)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/log/backend.go
@@ -44,18 +44,18 @@ var AllowedFormats = []string{
 }
 
 type backend struct {
-	out          io.Writer
-	format       string
-	groupVersion schema.GroupVersion
+	out     io.Writer
+	format  string
+	encoder runtime.Encoder
 }
 
 var _ audit.Backend = &backend{}
 
 func NewBackend(out io.Writer, format string, groupVersion schema.GroupVersion) audit.Backend {
 	return &backend{
-		out:          out,
-		format:       format,
-		groupVersion: groupVersion,
+		out:     out,
+		format:  format,
+		encoder: audit.Codecs.LegacyCodec(groupVersion),
 	}
 }
 
@@ -73,7 +73,7 @@ func (b *backend) logEvent(ev *auditinternal.Event) bool {
 	case FormatLegacy:
 		line = audit.EventString(ev) + "\n"
 	case FormatJson:
-		bs, err := runtime.Encode(audit.Codecs.LegacyCodec(b.groupVersion), ev)
+		bs, err := runtime.Encode(b.encoder, ev)
 		if err != nil {
 			audit.HandlePluginError(PluginName, err, ev)
 			return false


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/83449

Also added a benchmark to see the impact.
Before the change:
```
BenchmarkIdentifier-12    	  500000	      3138 ns/op	    1072 B/op	      18 allocs/op
PASS
```
After the change:
```
BenchmarkIdentifier-12    	 5000000	       276 ns/op	      48 B/op	       2 allocs/op
PASS
```