### PR TITLE
[migration phase 1] Implement PodToleratesNodeTaint as a filter plugin

### DIFF
--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -82,6 +82,38 @@ var (
 	ErrFakePredicate = newPredicateFailureError("FakePredicateError", "Nodes failed the fake predicate")
 )
 
+var unresolvablePredicateFailureErrors = map[PredicateFailureReason]struct{}{
+	ErrNodeSelectorNotMatch:      {},
+	ErrPodAffinityRulesNotMatch:  {},
+	ErrPodNotMatchHostName:       {},
+	ErrTaintsTolerationsNotMatch: {},
+	ErrNodeLabelPresenceViolated: {},
+	// Node conditions won't change when scheduler simulates removal of preemption victims.
+	// So, it is pointless to try nodes that have not been able to host the pod due to node
+	// conditions. These include ErrNodeNotReady, ErrNodeUnderPIDPressure, ErrNodeUnderMemoryPressure, ....
+	ErrNodeNotReady:            {},
+	ErrNodeNetworkUnavailable:  {},
+	ErrNodeUnderDiskPressure:   {},
+	ErrNodeUnderPIDPressure:    {},
+	ErrNodeUnderMemoryPressure: {},
+	ErrNodeUnschedulable:       {},
+	ErrNodeUnknownCondition:    {},
+	ErrVolumeZoneConflict:      {},
+	ErrVolumeNodeConflict:      {},
+	ErrVolumeBindConflict:      {},
+}
+
+// UnresolvablePredicateExists checks if there is at least one unresolvable predicate failure reason, if true
+// returns the first one in the list.
+func UnresolvablePredicateExists(reasons []PredicateFailureReason) PredicateFailureReason {
+	for _, r := range reasons {
+		if _, ok := unresolvablePredicateFailureErrors[r]; ok {
+			return r
+		}
+	}
+	return nil
+}
+
 // InsufficientResourceError is an error type that indicates what kind of resource limit is
 // hit and caused the unfitting failure.
 type InsufficientResourceError struct {

--- a/pkg/scheduler/api/compatibility/compatibility_test.go
+++ b/pkg/scheduler/api/compatibility/compatibility_test.go
@@ -37,10 +37,11 @@ import (
 func TestCompatibility_v1_Scheduler(t *testing.T) {
 	// Add serialized versions of scheduler config that exercise available options to ensure compatibility between releases
 	schedulerFiles := map[string]struct {
-		JSON             string
-		wantPredicates   sets.String
-		wantPrioritizers sets.String
-		wantExtenders    []schedulerapi.ExtenderConfig
+		JSON              string
+		wantPredicates    sets.String
+		wantPrioritizers  sets.String
+		wantFilterPlugins sets.String
+		wantExtenders     []schedulerapi.ExtenderConfig
 	}{
 		// Do not change this JSON after the corresponding release has been tagged.
 		// A failure indicates backwards compatibility with the specified release was broken.
@@ -214,7 +215,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"MaxEBSVolumeCount",
 				"MaxGCEPDVolumeCount",
@@ -233,6 +233,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"NodeAffinityPriority",
 				"TaintTolerationPriority",
 				"InterPodAffinityPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 		},
 
@@ -279,7 +282,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"MaxEBSVolumeCount",
@@ -301,6 +303,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TaintTolerationPriority",
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 		},
 		// Do not change this JSON after the corresponding release has been tagged.
@@ -356,7 +361,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"MaxEBSVolumeCount",
@@ -378,6 +382,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TaintTolerationPriority",
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -445,7 +452,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"CheckNodeCondition",
@@ -468,6 +474,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TaintTolerationPriority",
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -536,7 +545,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"CheckNodeCondition",
@@ -560,6 +568,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TaintTolerationPriority",
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -632,7 +643,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"CheckNodePIDPressure",
@@ -657,6 +667,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TaintTolerationPriority",
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -741,7 +754,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"CheckNodePIDPressure",
@@ -767,6 +779,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
 				"RequestedToCapacityRatioPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -852,7 +867,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"CheckNodePIDPressure",
@@ -879,6 +893,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
 				"RequestedToCapacityRatioPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -963,7 +980,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"CheckNodePIDPressure",
@@ -991,6 +1007,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"InterPodAffinityPriority",
 				"MostRequestedPriority",
 				"RequestedToCapacityRatioPriority",
+			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -1079,7 +1098,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
-				"PodToleratesNodeTaints",
 				"CheckNodeMemoryPressure",
 				"CheckNodeDiskPressure",
 				"CheckNodePIDPressure",
@@ -1108,6 +1126,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MostRequestedPriority",
 				"RequestedToCapacityRatioPriority",
 			),
+			wantFilterPlugins: sets.NewString(
+				"TaintToleration",
+			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
 				FilterVerb:       "filter",
@@ -1128,6 +1149,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 	seenPredicates := sets.NewString()
 	seenPriorities := sets.NewString()
 	mandatoryPredicates := sets.NewString("CheckNodeCondition")
+	filterToPredicateMap := map[string]string{
+		"TaintToleration": "PodToleratesNodeTaints",
+	}
 
 	for v, tc := range schedulerFiles {
 		t.Run(v, func(t *testing.T) {
@@ -1163,26 +1187,39 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				algorithmSrc,
 				make(chan struct{}),
 			)
+
 			if err != nil {
 				t.Fatalf("%s: Error constructing: %v", v, err)
 			}
-			schedPredicates := sets.NewString()
+			gotPredicates := sets.NewString()
 			for p := range sched.Algorithm.Predicates() {
-				schedPredicates.Insert(p)
+				gotPredicates.Insert(p)
 			}
 			wantPredicates := tc.wantPredicates.Union(mandatoryPredicates)
-			if !schedPredicates.Equal(wantPredicates) {
-				t.Errorf("Got predicates %v, want %v", schedPredicates, wantPredicates)
-			}
-			schedPrioritizers := sets.NewString()
-			for _, p := range sched.Algorithm.Prioritizers() {
-				schedPrioritizers.Insert(p.Name)
+			if !gotPredicates.Equal(wantPredicates) {
+				t.Errorf("Got predicates %v, want %v", gotPredicates, wantPredicates)
 			}
 
-			if !schedPrioritizers.Equal(tc.wantPrioritizers) {
-				t.Errorf("Got prioritizers %v, want %v", schedPrioritizers, tc.wantPrioritizers)
+			gotPrioritizers := sets.NewString()
+			for _, p := range sched.Algorithm.Prioritizers() {
+				gotPrioritizers.Insert(p.Name)
 			}
-			schedExtenders := sched.Algorithm.Extenders()
+			if !gotPrioritizers.Equal(tc.wantPrioritizers) {
+				t.Errorf("Got prioritizers %v, want %v", gotPrioritizers, tc.wantPrioritizers)
+			}
+
+			gotFilterPlugins := sets.NewString()
+			plugins := sched.Framework.ListPlugins()
+			for _, p := range plugins["FilterPlugin"] {
+				gotFilterPlugins.Insert(p)
+				seenPredicates.Insert(filterToPredicateMap[p])
+
+			}
+			if !gotFilterPlugins.Equal(tc.wantFilterPlugins) {
+				t.Errorf("Got filter plugins %v, want %v", gotFilterPlugins, tc.wantFilterPlugins)
+			}
+
+			gotExtenders := sched.Algorithm.Extenders()
 			var wantExtenders []*core.HTTPExtender
 			for _, e := range tc.wantExtenders {
 				extender, err := core.NewHTTPExtender(&e)
@@ -1191,13 +1228,14 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				}
 				wantExtenders = append(wantExtenders, extender.(*core.HTTPExtender))
 			}
-			for i := range schedExtenders {
-				if !core.Equal(wantExtenders[i], schedExtenders[i].(*core.HTTPExtender)) {
-					t.Errorf("Got extender #%d %+v, want %+v", i, schedExtenders[i], wantExtenders[i])
+			for i := range gotExtenders {
+				if !core.Equal(wantExtenders[i], gotExtenders[i].(*core.HTTPExtender)) {
+					t.Errorf("Got extender #%d %+v, want %+v", i, gotExtenders[i], wantExtenders[i])
 				}
 			}
-			seenPredicates = seenPredicates.Union(schedPredicates)
-			seenPriorities = seenPriorities.Union(schedPrioritizers)
+
+			seenPredicates = seenPredicates.Union(gotPredicates)
+			seenPriorities = seenPriorities.Union(gotPrioritizers)
 		})
 	}
 

--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -6,8 +6,9 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
-        "//pkg/scheduler/framework/plugins/noop:go_default_library",
+        "//pkg/scheduler/framework/plugins/tainttoleration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
     ],
 )
@@ -24,7 +25,9 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/scheduler/framework/plugins/examples:all-srcs",
+        "//pkg/scheduler/framework/plugins/migration:all-srcs",
         "//pkg/scheduler/framework/plugins/noop:all-srcs",
+        "//pkg/scheduler/framework/plugins/tainttoleration:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/scheduler/framework/plugins/default_registry_test.go
+++ b/pkg/scheduler/framework/plugins/default_registry_test.go
@@ -25,18 +25,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
-func appendToPluginSet(pluginSet *config.PluginSet, name string, weight *int32) *config.PluginSet {
-	if pluginSet == nil {
-		pluginSet = &config.PluginSet{}
-	}
-	config := config.Plugin{Name: name}
-	if weight != nil {
-		config.Weight = *weight
-	}
-	pluginSet.Enabled = append(pluginSet.Enabled, config)
-	return pluginSet
-}
-
 func produceConfig(keys []string, producersMap map[string]ConfigProducer, args ConfigProducerArgs) (*config.Plugins, []config.PluginConfig, error) {
 	var plugins config.Plugins
 	var pluginConfig []config.PluginConfig

--- a/pkg/scheduler/framework/plugins/migration/BUILD
+++ b/pkg/scheduler/framework/plugins/migration/BUILD
@@ -1,0 +1,36 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["utils.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["utils_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+    ],
+)

--- a/pkg/scheduler/framework/plugins/migration/utils.go
+++ b/pkg/scheduler/framework/plugins/migration/utils.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+// PredicateResultToFrameworkStatus converts a predicate result (PredicateFailureReason + error)
+// to a framework status.
+func PredicateResultToFrameworkStatus(reasons []predicates.PredicateFailureReason, err error) *framework.Status {
+	if s := ErrorToFrameworkStatus(err); s != nil {
+		return s
+	}
+
+	if len(reasons) == 0 {
+		return nil
+	}
+
+	if r := predicates.UnresolvablePredicateExists(reasons); r != nil {
+		return framework.NewStatus(framework.UnschedulableAndUnresolvable, r.GetReason())
+	}
+
+	// We will just use the first reason.
+	return framework.NewStatus(framework.Unschedulable, reasons[0].GetReason())
+}
+
+// ErrorToFrameworkStatus converts an error to a framework status.
+func ErrorToFrameworkStatus(err error) *framework.Status {
+	if err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
+	}
+	return nil
+}

--- a/pkg/scheduler/framework/plugins/migration/utils_test.go
+++ b/pkg/scheduler/framework/plugins/migration/utils_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migration
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+)
+
+func TestPredicateResultToFrameworkStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		err        error
+		reasons    []predicates.PredicateFailureReason
+		wantStatus *framework.Status
+	}{
+		{
+			name: "Success",
+		},
+		{
+			name:       "Error",
+			err:        errors.New("Failed with error"),
+			wantStatus: framework.NewStatus(framework.Error, "Failed with error"),
+		},
+		{
+			name:       "Error with reason",
+			err:        errors.New("Failed with error"),
+			reasons:    []predicates.PredicateFailureReason{predicates.ErrDiskConflict},
+			wantStatus: framework.NewStatus(framework.Error, "Failed with error"),
+		},
+		{
+			name:       "Unschedulable",
+			reasons:    []predicates.PredicateFailureReason{predicates.ErrExistingPodsAntiAffinityRulesNotMatch},
+			wantStatus: framework.NewStatus(framework.Unschedulable, "node(s) didn't satisfy existing pods anti-affinity rules"),
+		},
+		{
+			name:       "Unschedulable and Unresolvable",
+			reasons:    []predicates.PredicateFailureReason{predicates.ErrDiskConflict, predicates.ErrNodeSelectorNotMatch},
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't match node selector"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatus := PredicateResultToFrameworkStatus(tt.reasons, tt.err)
+			if !reflect.DeepEqual(tt.wantStatus, gotStatus) {
+				t.Errorf("Got status %v, want %v", gotStatus, tt.wantStatus)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/framework/plugins/tainttoleration/BUILD
+++ b/pkg/scheduler/framework/plugins/tainttoleration/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["taint_toleration.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/plugins/migration:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/nodeinfo:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tainttoleration
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// TaintToleration is a plugin that checks if a pod tolerates a node's taints.
+type TaintToleration struct{}
+
+var _ = framework.FilterPlugin(&TaintToleration{})
+
+// Name is the name of the plugin used in the plugin registry and configurations.
+const Name = "TaintToleration"
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *TaintToleration) Name() string {
+	return Name
+}
+
+// Filter invoked at the filter extension point.
+func (pl *TaintToleration) Filter(_ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
+	_, reasons, err := predicates.PodToleratesNodeTaints(pod, nil, nodeInfo)
+	return migration.PredicateResultToFrameworkStatus(reasons, err)
+}
+
+// New initializes a new plugin and returns it.
+func New(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
+	return &TaintToleration{}, nil
+}

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -405,6 +405,10 @@ type Framework interface {
 	// or "Success". If none of the plugins handled binding, RunBindPlugins returns
 	// code=4("skip") status.
 	RunBindPlugins(state *CycleState, pod *v1.Pod, nodeName string) *Status
+
+	// ListPlugins returns a map of extension point name to plugin names
+	// configured at each extension point.
+	ListPlugins() map[string][]string
 }
 
 // FrameworkHandle provides data and some tools that plugins can use. It is

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -163,6 +163,10 @@ func (*fakeFramework) QueueSortFunc() framework.LessFunc {
 	}
 }
 
+func (f *fakeFramework) ListPlugins() map[string][]string {
+	return nil
+}
+
 func (*fakeFramework) NodeInfoSnapshot() *schedulernodeinfo.Snapshot {
 	return nil
 }

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -66,6 +66,7 @@ go_test(
         "//test/integration/framework:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -899,7 +899,8 @@ func TestBindPlugin(t *testing.T) {
 	context := initTestSchedulerWithOptions(t, testContext, false, nil, time.Second,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(pluginConfig),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkRegistry(registry),
+		scheduler.WithFrameworkConfigProducerRegistry(nil))
 	defer cleanupTest(t, context)
 
 	// Add a few nodes.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:

Running the first predicate as a filter plugin. The predicate is PodToleratesNodeTaints.

This is done by translating a predicate config to a filter config. The filter that corresponds to this predicate simply calls back into the predicate function.

**Which issue(s) this PR fixes**:
Part of #83531

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

