### PR TITLE
Fix AWS block volume reconstruction to be like file

### DIFF
--- a/pkg/volume/awsebs/aws_ebs_block.go
+++ b/pkg/volume/awsebs/aws_ebs_block.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
@@ -52,37 +51,27 @@ func (plugin *awsElasticBlockStorePlugin) ConstructBlockVolumeSpec(podUID types.
 		return nil, fmt.Errorf("failed to get volume plugin information from globalMapPathUUID: %v", globalMapPathUUID)
 	}
 
-	return getVolumeSpecFromGlobalMapPath(volumeName, globalMapPath)
+	return plugin.getVolumeSpecFromGlobalMapPath(volumeName, globalMapPath)
 }
 
-func getVolumeSpecFromGlobalMapPath(volumeName string, globalMapPath string) (*volume.Spec, error) {
+func (plugin *awsElasticBlockStorePlugin) getVolumeSpecFromGlobalMapPath(volumeName string, globalMapPath string) (*volume.Spec, error) {
 	// Get volume spec information from globalMapPath
 	// globalMapPath example:
 	//   plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumeID}
 	//   plugins/kubernetes.io/aws-ebs/volumeDevices/vol-XXXXXX
-	vID := filepath.Base(globalMapPath)
-	if len(vID) <= 1 {
-		return nil, fmt.Errorf("failed to get volumeID from global path=%s", globalMapPath)
+	pluginDir := plugin.host.GetVolumeDevicePluginDir(awsElasticBlockStorePluginName)
+	if !strings.HasPrefix(globalMapPath, pluginDir) {
+		return nil, fmt.Errorf("volume symlink %s is not in global plugin directory", globalMapPath)
 	}
-	if !strings.Contains(vID, "vol-") {
-		return nil, fmt.Errorf("failed to get volumeID from global path=%s, invalid volumeID format = %s", globalMapPath, vID)
-	}
-	block := v1.PersistentVolumeBlock
-	awsVolume := &v1.PersistentVolume{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: volumeName,
-		},
-		Spec: v1.PersistentVolumeSpec{
-			PersistentVolumeSource: v1.PersistentVolumeSource{
-				AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
-					VolumeID: vID,
-				},
-			},
-			VolumeMode: &block,
-		},
+	fullVolumeID := strings.TrimPrefix(globalMapPath, pluginDir) // /vol-XXXXXX
+	fullVolumeID = strings.TrimLeft(fullVolumeID, "/")           // vol-XXXXXX
+	vID, err := formatVolumeID(fullVolumeID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get AWS volume id from map path %q: %v", globalMapPath, err)
 	}
 
-	return volume.NewSpecFromPersistentVolume(awsVolume, true), nil
+	block := v1.PersistentVolumeBlock
+	return newAWSVolumeSpec(volumeName, vID, block), nil
 }
 
 // NewBlockVolumeMapper creates a new volume.BlockVolumeMapper from an API specification.

--- a/pkg/volume/awsebs/aws_ebs_block_test.go
+++ b/pkg/volume/awsebs/aws_ebs_block_test.go
@@ -51,14 +51,22 @@ func TestGetVolumeSpecFromGlobalMapPath(t *testing.T) {
 
 	expectedGlobalPath := filepath.Join(tmpVDir, testGlobalPath)
 
+	plugMgr := volume.VolumePluginMgr{}
+	plugMgr.InitPlugins(ProbeVolumePlugins(), nil /* prober */, volumetest.NewFakeVolumeHost(tmpVDir, nil, nil))
+	plug, err := plugMgr.FindMapperPluginByName(awsElasticBlockStorePluginName)
+	if err != nil {
+		os.RemoveAll(tmpVDir)
+		t.Fatalf("Can't find the plugin by name: %q", awsElasticBlockStorePluginName)
+	}
+
 	//Bad Path
-	badspec, err := getVolumeSpecFromGlobalMapPath("", "")
+	badspec, err := plug.(*awsElasticBlockStorePlugin).getVolumeSpecFromGlobalMapPath("", "")
 	if badspec != nil || err == nil {
 		t.Fatalf("Expected not to get spec from GlobalMapPath but did")
 	}
 
 	// Good Path
-	spec, err := getVolumeSpecFromGlobalMapPath("myVolume", expectedGlobalPath)
+	spec, err := plug.(*awsElasticBlockStorePlugin).getVolumeSpecFromGlobalMapPath("myVolume", expectedGlobalPath)
 	if spec == nil || err != nil {
 		t.Fatalf("Failed to get spec from GlobalMapPath: %v", err)
 	}

--- a/pkg/volume/awsebs/aws_ebs_test.go
+++ b/pkg/volume/awsebs/aws_ebs_test.go
@@ -414,3 +414,36 @@ func TestGetCandidateZone(t *testing.T) {
 		assert.Equal(t, test.expectedZones, zones)
 	}
 }
+
+func TestFormatVolumeID(t *testing.T) {
+	tests := []struct {
+		volumeIDFromPath string
+		expectedVolumeID string
+	}{
+		{
+			"aws/vol-1234",
+			"aws:///vol-1234",
+		},
+		{
+			"aws:/vol-1234",
+			"aws:///vol-1234",
+		},
+		{
+			"aws/us-east-1/vol-1234",
+			"aws://us-east-1/vol-1234",
+		},
+		{
+			"aws:/us-east-1/vol-1234",
+			"aws://us-east-1/vol-1234",
+		},
+		{
+			"vol-1234",
+			"vol-1234",
+		},
+	}
+	for _, test := range tests {
+		volumeID, err := formatVolumeID(test.volumeIDFromPath)
+		assert.Nil(t, err)
+		assert.Equal(t, test.expectedVolumeID, volumeID, test.volumeIDFromPath)
+	}
+}

--- a/pkg/volume/awsebs/aws_util.go
+++ b/pkg/volume/awsebs/aws_util.go
@@ -30,6 +30,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	cloudprovider "k8s.io/cloud-provider"
 	volumehelpers "k8s.io/cloud-provider/volume/helpers"
@@ -286,4 +287,51 @@ func findNvmeVolume(findName string) (device string, err error) {
 	}
 
 	return resolved, nil
+}
+
+func formatVolumeID(volumeID string) (string, error) {
+	// This is a workaround to fix the issue in converting aws volume id from globalPDPath and globalMapPath
+	// There are three formats for AWSEBSVolumeSource.VolumeID and they are stored on disk in paths like so:
+	// VolumeID									mountPath								mapPath
+	// aws:///vol-1234					aws/vol-1234						aws:/vol-1234
+	// aws://us-east-1/vol-1234 aws/us-east-1/vol-1234  aws:/us-east-1/vol-1234
+	// vol-1234									vol-1234								vol-1234
+	// This code is for converting volume ids from paths back to AWS style VolumeIDs
+	sourceName := volumeID
+	if strings.HasPrefix(volumeID, "aws/") || strings.HasPrefix(volumeID, "aws:/") {
+		names := strings.Split(volumeID, "/")
+		length := len(names)
+		if length < 2 || length > 3 {
+			return "", fmt.Errorf("invalid volume name format %q", volumeID)
+		}
+		volName := names[length-1]
+		if !strings.HasPrefix(volName, "vol-") {
+			return "", fmt.Errorf("Invalid volume name format for AWS volume (%q)", volName)
+		}
+		if length == 2 {
+			sourceName = awsURLNamePrefix + "" + "/" + volName // empty zone label
+		}
+		if length == 3 {
+			sourceName = awsURLNamePrefix + names[1] + "/" + volName // names[1] is the zone label
+		}
+		klog.V(4).Infof("Convert aws volume name from %q to %q ", volumeID, sourceName)
+	}
+	return sourceName, nil
+}
+
+func newAWSVolumeSpec(volumeName, volumeID string, mode v1.PersistentVolumeMode) *volume.Spec {
+	awsVolume := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: volumeName,
+		},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				AWSElasticBlockStore: &v1.AWSElasticBlockStoreVolumeSource{
+					VolumeID: volumeID,
+				},
+			},
+			VolumeMode: &mode,
+		},
+	}
+	return volume.NewSpecFromPersistentVolume(awsVolume, false)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: @jsafrane found 2 bugs with block volume reconstruction, one general & one specific to aws after he fixed the first. See https://github.com/kubernetes/kubernetes/pull/83451#issuecomment-538070334. We need to "format" the volume ID we get from the path on disk before putting it in a reconstructed PV, because it will be in an unexpected format like aws:/vol-1234 instead of aws:///vol-1234

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
