### PR TITLE
ingress: add IngressClass to v1 networking API

### DIFF
--- a/pkg/apis/networking/types.go
+++ b/pkg/apis/networking/types.go
@@ -254,7 +254,22 @@ type IngressSpec struct {
 	// no rule matches, all traffic is sent to the default backend.
 	// +optional
 	Rules []IngressRule
+
+	// Class references an IngressClass resource in kube-system. This is used
+	// by the cluster Ingress controllers to determine which controller operates
+	// on this resource.
+	Class IngressClass
 	// TODO: Add the ability to specify load-balancer IP through claims
+}
+
+// IngressClass represents the class of the Ingress, referenced by the
+// ingress.spec.
+type IngressClass struct {
+	metav1.TypeMeta
+	// Standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// +optional
+	metav1.ObjectMeta
 }
 
 // IngressTLS describes the transport layer security associated with an Ingress.


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Per the Ingress v1 KEP, this is a sketch of the IngressClass type under Ingress.Spec.

**Which issue(s) this PR fixes**:
Related kubernetes/enhancements#758

**Special notes for your reviewer**:

- This is missing a lot of updates, but I wanted to cross-link to the WIP KEP for feedback. 

**Does this PR introduce a user-facing change?**:
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**
[KEP Ingress v1](https://github.com/kubernetes/enhancements/blob/3994b90d1be28af3ddd69232a3d703163e0b7a95/keps/sig-network/20190125-ingress-api-group.md#ingress-class)

