### PR TITLE
Kubeadm: allow users to use 127.0.0.1 as advertise address

### DIFF
--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -123,6 +123,14 @@ func VerifyAPIServerBindAddress(address string) error {
 	if ip == nil {
 		return errors.Errorf("cannot parse IP address: %s", address)
 	}
+	// There are users with network setups where default routes are present, but network interfaces
+	// use only link-local addresses (e.g. as described in RFC5549).
+	// In many cases that matching global unicast IP address can be found on loopback interface,
+	// so kubeadm allows users to specify address=Loopback for handling supporting the scenario above.
+	// Nb. SetAPIEndpointDynamicDefaults will try to translate loopback to a valid address afterwards
+	if ip.IsLoopback() {
+		return nil
+	}
 	if !ip.IsGlobalUnicast() {
 		return errors.Errorf("cannot use %q as the bind address for the API Server", address)
 	}

--- a/cmd/kubeadm/app/util/config/common_test.go
+++ b/cmd/kubeadm/app/util/config/common_test.go
@@ -161,13 +161,13 @@ func TestVerifyAPIServerBindAddress(t *testing.T) {
 			address: "2001:db8:85a3::8a2e:370:7334",
 		},
 		{
-			name:          "invalid address: not a global unicast 0.0.0.0",
-			address:       "0.0.0.0",
-			expectedError: true,
+			name:          "valid address 127.0.0.1",
+			address:       "127.0.0.1",
+			expectedError: false,
 		},
 		{
-			name:          "invalid address: not a global unicast 127.0.0.1",
-			address:       "127.0.0.1",
+			name:          "invalid address: not a global unicast 0.0.0.0",
+			address:       "0.0.0.0",
 			expectedError: true,
 		},
 		{


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
There are network setups where default routes are present, but network interfaces use only link-local addresses (e.g. as described in RFC5549);  It is likely that matching global unicast IP address for this family of default route can be found on loopback interface.

This PR add support for kubeadm for the above scenario

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This is a rework of https://github.com/kubernetes/kubernetes/pull/69578, but with this PR we are not altering any existing defaulting rule. 

Instead, the user has to explicitly opt-in in this scenario by specifying 127.0.0.1 and kubeadm will try to resolve this to a  global unicast IP.

**Does this PR introduce a user-facing change?**:
```release-note
Kubeadm: add support for 127.0.0.1 as advertise address. kubeadm will automatically replace this value with matching global unicast IP address on the loopback interface. 
```

/area kubeadm
/sig cluster-lifecycle
/priority critical-urgent
/cc @kad 