### PR TITLE
Clean up sig-auth OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -20,7 +20,6 @@ aliases:
     - jianhuiz
     - lavalamp
     - liggitt
-    - mbohlool
     - mikedanese
     - sttts
     - wojtek-t
@@ -30,16 +29,13 @@ aliases:
     - liggitt
     - mikedanese
   sig-auth-authorizers-reviewers:
-    - david-mcmahon
     - deads2k
     - dims
     - enj
     - erictune
     - jianhuiz
-    - krousey
     - lavalamp
     - liggitt
-    - mbohlool
     - mikedanese
     - mml
     - ncdc
@@ -56,16 +52,13 @@ aliases:
   sig-auth-certificates-reviewers:
     - awly
     - caesarxuchao
-    - david-mcmahon
     - deads2k
     - dims
     - enj
     - errordeveloper
-    - hongchaodeng
     - jianhuiz
     - lavalamp
     - liggitt
-    - mbohlool
     - mikedanese
     - smarterclayton
     - sttts
@@ -81,7 +74,6 @@ aliases:
     - immutableT
     - lavalamp
     - liggitt
-    - sakshamsharma
     - smarterclayton
     - wojtek-t
 
@@ -102,11 +94,9 @@ aliases:
     - tallclair
   sig-auth-policy-reviewers:
     - deads2k
-    - hongchaodeng
     - jianhuiz
     - liggitt
     - mbohlool
-    - pweil-
     - tallclair
     - krmayankk
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Remove a few inactive maintainers from the sig-auth reviewer pool.

**Special notes for your reviewer**:

Please let me know if you want to remain as a reviewer, or think you're being removed in error! I used a fuzzy error-prone algorithm based on recent github activity to generate this list, please don't take it personally if you don't think you should be removed! If you resume work on Kubernetes, and would like to be added back to the list, let us know.

/assign @mbohlool 
/assign @david-mcmahon 
/assign @krousey 
/assign @hongchaodeng 
/assign @sakshamsharma 
/assign @pweil- 

I will leave this PR open until 2019-10-14.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
/sig auth