### PR TITLE
Expose Shutdown func for EventBroadcaster

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_broadcaster.go
@@ -102,6 +102,10 @@ func newBroadcaster(sink EventSink, sleepDuration time.Duration, eventCache map[
 	}
 }
 
+func (e *eventBroadcasterImpl) Shutdown() {
+	e.Broadcaster.Shutdown()
+}
+
 // refreshExistingEventSeries refresh events TTL
 func (e *eventBroadcasterImpl) refreshExistingEventSeries() {
 	// TODO: Investigate whether lock contention won't be a problem

--- a/staging/src/k8s.io/client-go/tools/events/interfaces.go
+++ b/staging/src/k8s.io/client-go/tools/events/interfaces.go
@@ -54,6 +54,9 @@ type EventBroadcaster interface {
 	// NOTE: events received on your eventHandler should be copied before being used.
 	// TODO: figure out if this can be removed.
 	StartEventWatcher(eventHandler func(event runtime.Object)) func()
+
+	// Shutdown shuts down the broadcaster
+	Shutdown()
 }
 
 // EventSink knows how to store events (client-go implements it.)

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -127,6 +127,9 @@ type EventBroadcaster interface {
 	// NewRecorder returns an EventRecorder that can be used to send events to this EventBroadcaster
 	// with the event source set to the given event source.
 	NewRecorder(scheme *runtime.Scheme, source v1.EventSource) EventRecorder
+
+	// Shutdown shuts down the broadcaster
+	Shutdown()
 }
 
 // Creates a new event broadcaster.
@@ -167,6 +170,10 @@ func (eventBroadcaster *eventBroadcasterImpl) StartRecordingToSink(sink EventSin
 		func(event *v1.Event) {
 			recordToSink(sink, event, eventCorrelator, eventBroadcaster.sleepDuration)
 		})
+}
+
+func (e *eventBroadcasterImpl) Shutdown() {
+	e.Broadcaster.Shutdown()
 }
 
 func recordToSink(sink EventSink, event *v1.Event, eventCorrelator *EventCorrelator, sleepDuration time.Duration) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
this PR exposes Shutdown func for EventBroadcaster.

**Which issue(s) this PR fixes**:
Fixes #83487

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
