### PR TITLE
feat(scheduler): scale the extender output in generic scheduler

### DIFF
--- a/pkg/scheduler/apis/extender/v1/types.go
+++ b/pkg/scheduler/apis/extender/v1/types.go
@@ -23,10 +23,10 @@ import (
 
 const (
 	// MinExtenderPriority defines the min priority value for extender.
-	MinExtenderPriority int = 0
+	MinExtenderPriority int64 = 0
 
 	// MaxExtenderPriority defines the max priority value for extender.
-	MaxExtenderPriority int = 10
+	MaxExtenderPriority int64 = 10
 )
 
 // ExtenderPreemptionResult represents the result returned by preemption phase of extender.

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -840,7 +840,9 @@ func PrioritizeNodes(
 		// wait for all go routines to finish
 		wg.Wait()
 		for i := range result {
-			result[i].Score += combinedScores[result[i].Name]
+			// MaxExtenderPriority may diverge from the max priority used in the scheduler and defined by MaxNodeScore,
+			// therefore we need to scale the score returned by extenders to the score range used by the scheduler.
+			result[i].Score += combinedScores[result[i].Name] * (framework.MaxNodeScore / extenderv1.MaxExtenderPriority)
 		}
 	}
 


### PR DESCRIPTION
/kind cleanup
/priority important-soon
/assign @ahg-g 


**What this PR does / why we need it**:

scale the extender output in generic scheduler

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref https://github.com/kubernetes/kubernetes/issues/81281


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
