### PR TITLE
Topology manager aligns pods of all QoS classes.

### DIFF
--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -321,16 +321,16 @@ func (m *manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitR
 	pod := attrs.Pod
 	c := make(map[string]TopologyHint)
 
-  for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-    result := m.calculateAffinity(*pod, container)
-    admitPod := m.policy.CanAdmitPodResult(&result)
-    if !admitPod.Admit {
-      return admitPod
-    }
-    c[container.Name] = result
-  }
-  m.podTopologyHints[string(pod.UID)] = c
-  klog.Infof("[topologymanager] Topology Affinity for Pod: %v are %v", pod.UID, m.podTopologyHints[string(pod.UID)])
+	for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		result := m.calculateAffinity(*pod, container)
+		admitPod := m.policy.CanAdmitPodResult(&result)
+		if !admitPod.Admit {
+			return admitPod
+		}
+		c[container.Name] = result
+	}
+	m.podTopologyHints[string(pod.UID)] = c
+	klog.Infof("[topologymanager] Topology Affinity for Pod: %v are %v", pod.UID, m.podTopologyHints[string(pod.UID)])
 
 	return lifecycle.PodAdmitResult{
 		Admit: true,

--- a/pkg/kubelet/cm/topologymanager/topology_manager.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager.go
@@ -320,23 +320,17 @@ func (m *manager) Admit(attrs *lifecycle.PodAdmitAttributes) lifecycle.PodAdmitR
 	}
 	pod := attrs.Pod
 	c := make(map[string]TopologyHint)
-	klog.Infof("[topologymanager] Pod QoS Level: %v", pod.Status.QOSClass)
 
-	if pod.Status.QOSClass == v1.PodQOSGuaranteed {
-		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-			result := m.calculateAffinity(*pod, container)
-			admitPod := m.policy.CanAdmitPodResult(&result)
-			if !admitPod.Admit {
-				return admitPod
-			}
-			c[container.Name] = result
-		}
-		m.podTopologyHints[string(pod.UID)] = c
-		klog.Infof("[topologymanager] Topology Affinity for Pod: %v are %v", pod.UID, m.podTopologyHints[string(pod.UID)])
-
-	} else {
-		klog.Infof("[topologymanager] Topology Manager only affinitises Guaranteed pods.")
-	}
+  for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+    result := m.calculateAffinity(*pod, container)
+    admitPod := m.policy.CanAdmitPodResult(&result)
+    if !admitPod.Admit {
+      return admitPod
+    }
+    c[container.Name] = result
+  }
+  m.podTopologyHints[string(pod.UID)] = c
+  klog.Infof("[topologymanager] Topology Affinity for Pod: %v are %v", pod.UID, m.podTopologyHints[string(pod.UID)])
 
 	return lifecycle.PodAdmitResult{
 		Admit: true,

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -875,6 +875,32 @@ func TestAdmit(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "QOSClass set as Burstable. BestEffort Policy. More than one Preferred Affinity.",
+			qosClass: v1.PodQOSBurstable,
+			policy:   NewBestEffortPolicy(),
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(1),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name:     "QOSClass set as Guaranteed. BestEffort Policy. No Preferred Affinity.",
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   NewBestEffortPolicy(),
@@ -895,6 +921,28 @@ func TestAdmit(t *testing.T) {
 		{
 			name:     "QOSClass set as Guaranteed. Restricted Policy. Preferred Affinity.",
 			qosClass: v1.PodQOSGuaranteed,
+			policy:   NewRestrictedPolicy(),
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Burstable. Restricted Policy. Preferred Affinity.",
+			qosClass: v1.PodQOSBurstable,
 			policy:   NewRestrictedPolicy(),
 			hp: []HintProvider{
 				&mockHintProvider{
@@ -941,8 +989,52 @@ func TestAdmit(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "QOSClass set as Burstable. Restricted Policy. More than one Preferred affinity.",
+			qosClass: v1.PodQOSBurstable,
+			policy:   NewRestrictedPolicy(),
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(1),
+								Preferred:        true,
+							},
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
 			name:     "QOSClass set as Guaranteed. Restricted Policy. No Preferred affinity.",
 			qosClass: v1.PodQOSGuaranteed,
+			policy:   NewRestrictedPolicy(),
+			hp: []HintProvider{
+				&mockHintProvider{
+					map[string][]TopologyHint{
+						"resource": {
+							{
+								NUMANodeAffinity: NewTestBitMask(0, 1),
+								Preferred:        false,
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name:     "QOSClass set as Burstable. Restricted Policy. No Preferred affinity.",
+			qosClass: v1.PodQOSBurstable,
 			policy:   NewRestrictedPolicy(),
 			hp: []HintProvider{
 				&mockHintProvider{


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, the Kubelet only aligns device allocations with respect to NUMA locality for containers in the Guaranteed QoS class. However, there's no particular reason for this restriction. This limitation forces users to set resource limits (and in particular, CPU quota) to get aligned devices. As shown below, the set of pods affected by this change are already "opting in" to special handling by virtue of the resource requirements, and would benefit from alignment being the default behavior. Note when the topology manager graduates to beta, the feature gate will be on by default but the policy will still be "none." Long term, we should work toward making the "best-effort" policy default.

In order for the topology manager to do any attempted alignment for a given pod, the node must have more than one NUMA node and at least two of the following must be true:
* Node is using the static CPU manager policy (if true, implies pod is Guaranteed QoS anyway)
* Pod consumes some device A that exports locality hints
* Pod consumes some device B that exports locality hints
* (In the future) Pod consumes pre-allocated hugepages

**Which issue(s) this PR fixes**:
xref #83479
xref https://github.com/kubernetes/enhancements/issues/693

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
The topology manager aligns resources for pods of all QoS classes with respect to NUMA locality, not just Guaranteed QoS pods.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/c1e2ceed191fa3b1d7bc0a1e3ae6c472083ad09b/keps/sig-node/0035-20190130-topology-manager.md
```

@levovar @klueska @lmdaly @derekwaynecarr 