### PR TITLE
Move port_allocator to apimachinery

### DIFF
--- a/pkg/proxy/userspace/BUILD
+++ b/pkg/proxy/userspace/BUILD
@@ -10,7 +10,6 @@ go_library(
     name = "go_default_library",
     srcs = [
         "loadbalancer.go",
-        "port_allocator.go",
         "proxier.go",
         "proxysocket.go",
         "rlimit.go",
@@ -33,7 +32,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ] + select({
@@ -74,7 +72,6 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
-        "port_allocator_test.go",
         "proxier_test.go",
         "roundrobin_test.go",
     ],
@@ -86,7 +83,6 @@ go_test(
         "//staging/src/k8s.io/api/discovery/v1alpha1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",

--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -125,7 +125,7 @@ type Proxier struct {
 	listenIP        net.IP
 	iptables        iptables.Interface
 	hostIP          net.IP
-	proxyPorts      PortAllocator
+	proxyPorts      utilnet.PortAllocator
 	makeProxySocket ProxySocketFunc
 	exec            utilexec.Interface
 	// endpointsSynced and servicesSynced are set to 1 when the corresponding
@@ -208,16 +208,16 @@ func NewCustomProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptab
 		return nil, fmt.Errorf("failed to set open file handler limit: %v", err)
 	}
 
-	proxyPorts := newPortAllocator(pr)
+	proxyPorts := utilnet.NewPortAllocator(pr)
 
 	klog.V(2).Infof("Setting proxy IP to %v and initializing iptables", hostIP)
 	return createProxier(loadBalancer, listenIP, iptables, exec, hostIP, proxyPorts, syncPeriod, minSyncPeriod, udpIdleTimeout, makeProxySocket)
 }
 
-func createProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.Interface, exec utilexec.Interface, hostIP net.IP, proxyPorts PortAllocator, syncPeriod, minSyncPeriod, udpIdleTimeout time.Duration, makeProxySocket ProxySocketFunc) (*Proxier, error) {
+func createProxier(loadBalancer LoadBalancer, listenIP net.IP, iptables iptables.Interface, exec utilexec.Interface, hostIP net.IP, proxyPorts utilnet.PortAllocator, syncPeriod, minSyncPeriod, udpIdleTimeout time.Duration, makeProxySocket ProxySocketFunc) (*Proxier, error) {
 	// convenient to pass nil for tests..
 	if proxyPorts == nil {
-		proxyPorts = newPortAllocator(utilnet.PortRange{})
+		proxyPorts = utilnet.NewPortAllocator(utilnet.PortRange{})
 	}
 	// Set up the iptables foundations we need.
 	if err := iptablesInit(iptables); err != nil {

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "http_test.go",
         "interface_test.go",
+        "port_allocator_test.go",
         "port_range_test.go",
         "port_split_test.go",
         "util_test.go",
@@ -29,6 +30,7 @@ go_library(
     srcs = [
         "http.go",
         "interface.go",
+        "port_allocator.go",
         "port_range.go",
         "port_split.go",
         "util.go",
@@ -37,6 +39,7 @@ go_library(
     importpath = "k8s.io/apimachinery/pkg/util/net",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/golang.org/x/net/http2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/port_allocator.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/port_allocator.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package userspace
+package net
 
 import (
 	"errors"
@@ -23,7 +23,6 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -31,6 +30,7 @@ var (
 	errPortRangeNoPortsRemaining = errors.New("port allocation failed; there are no remaining ports left to allocate in the accepted range")
 )
 
+// PortAllocator is an interface for port allocation.
 type PortAllocator interface {
 	AllocateNext() (int, error)
 	Release(int)
@@ -50,10 +50,10 @@ func (r *randomAllocator) Release(_ int) {
 	// noop
 }
 
-// newPortAllocator builds PortAllocator for a given PortRange. If the PortRange is empty
+// NewPortAllocator builds PortAllocator for a given PortRange. If the PortRange is empty
 // then a random port allocator is returned; otherwise, a new range-based allocator
 // is returned.
-func newPortAllocator(r net.PortRange) PortAllocator {
+func NewPortAllocator(r PortRange) PortAllocator {
 	if r.Base == 0 {
 		return &randomAllocator{}
 	}
@@ -67,14 +67,14 @@ const (
 )
 
 type rangeAllocator struct {
-	net.PortRange
+	PortRange
 	ports chan int
 	used  big.Int
 	lock  sync.Mutex
 	rand  *rand.Rand
 }
 
-func newPortRangeAllocator(r net.PortRange, autoFill bool) PortAllocator {
+func newPortRangeAllocator(r PortRange, autoFill bool) PortAllocator {
 	if r.Base == 0 || r.Size == 0 {
 		panic("illegal argument: may not specify an empty port range")
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/port_allocator_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/port_allocator_test.go
@@ -14,17 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package userspace
+package net
 
 import (
 	"reflect"
 	"testing"
-
-	"k8s.io/apimachinery/pkg/util/net"
 )
 
 func TestRangeAllocatorEmpty(t *testing.T) {
-	r := &net.PortRange{}
+	r := &PortRange{}
 	r.Set("0-0")
 	defer func() {
 		if rv := recover(); rv == nil {
@@ -35,7 +33,7 @@ func TestRangeAllocatorEmpty(t *testing.T) {
 }
 
 func TestRangeAllocatorFullyAllocated(t *testing.T) {
-	r := &net.PortRange{}
+	r := &PortRange{}
 	r.Set("1-1")
 	// Don't auto-fill ports, we'll manually turn the crank
 	pra := newPortRangeAllocator(*r, false)
@@ -105,7 +103,7 @@ func TestRangeAllocatorFullyAllocated(t *testing.T) {
 }
 
 func TestRangeAllocator_RandomishAllocation(t *testing.T) {
-	r := &net.PortRange{}
+	r := &PortRange{}
 	r.Set("1-100")
 	pra := newPortRangeAllocator(*r, false)
 	a := pra.(*rangeAllocator)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Move port_allocator to staging so that it can be reused by other projects.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82590

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
