### PR TITLE
Allow users to use custom tags

### DIFF
--- a/hack/lib/version.sh
+++ b/hack/lib/version.sh
@@ -66,7 +66,7 @@ kube::version::get_version_vars() {
     fi
 
     # Use git describe to find the version based on tags.
-    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
+    if [[ -n ${KUBE_GIT_VERSION-} ]] || KUBE_GIT_VERSION=$("${git[@]}" describe --tags --match='v*' --abbrev=14 "${KUBE_GIT_COMMIT}^{commit}" 2>/dev/null); then
       # This translates the "git describe" to an actual semver.org
       # compatible semantic version that looks something like this:
       #   v1.1.0-alpha.0.6+84c76d1142ea4d


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When discovering the kube version we only consider tags that match the
glob 'v*'. By doing so users can create/use their custom tags as long as
they don't look like a version (starting with a 'v').

**Which issue(s) this PR fixes**:

\-

**Special notes for your reviewer**:

We already do a similar thing when building the pause container, see how
the `REV` is set in git.k8s.io/kubernetes/build/pause/Makefile.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

