### PR TITLE
Fix kube-proxy healthz server for proxier sync loop changes

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -482,7 +482,7 @@ type ProxyServer struct {
 	UseEndpointSlices      bool
 	OOMScoreAdj            *int32
 	ConfigSyncPeriod       time.Duration
-	HealthzServer          *healthcheck.HealthzServer
+	HealthzServer          *healthcheck.ProxierHealthServer
 }
 
 // createClients creates a kube client and an event client from the given config and masterOverride.

--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -125,11 +125,9 @@ func newProxyServer(
 		Namespace: "",
 	}
 
-	var healthzServer *healthcheck.HealthzServer
-	var healthzUpdater healthcheck.HealthzUpdater
+	var healthzServer *healthcheck.ProxierHealthServer
 	if len(config.HealthzBindAddress) > 0 {
-		healthzServer = healthcheck.NewDefaultHealthzServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
-		healthzUpdater = healthzServer
+		healthzServer = healthcheck.NewProxierHealthServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
 	}
 
 	var proxier proxy.Provider
@@ -162,7 +160,7 @@ func newProxyServer(
 			hostname,
 			nodeIP,
 			recorder,
-			healthzUpdater,
+			healthzServer,
 			config.NodePortAddresses,
 		)
 		if err != nil {

--- a/cmd/kube-proxy/app/server_windows.go
+++ b/cmd/kube-proxy/app/server_windows.go
@@ -87,11 +87,9 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 		Namespace: "",
 	}
 
-	var healthzServer *healthcheck.HealthzServer
-	var healthzUpdater healthcheck.HealthzUpdater
+	var healthzServer *healthcheck.ProxierHealthServer
 	if len(config.HealthzBindAddress) > 0 {
-		healthzServer = healthcheck.NewDefaultHealthzServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
-		healthzUpdater = healthzServer
+		healthzServer = healthcheck.NewProxierHealthServer(config.HealthzBindAddress, 2*config.IPTables.SyncPeriod.Duration, recorder, nodeRef)
 	}
 
 	var proxier proxy.Provider
@@ -108,7 +106,7 @@ func newProxyServer(config *proxyconfigapi.KubeProxyConfiguration, cleanupAndExi
 			hostname,
 			utilnode.GetNodeIP(client, hostname),
 			recorder,
-			healthzUpdater,
+			healthzServer,
 			config.Winkernel,
 		)
 		if err != nil {

--- a/pkg/proxy/healthcheck/BUILD
+++ b/pkg/proxy/healthcheck/BUILD
@@ -9,8 +9,10 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
+        "common.go",
         "doc.go",
-        "healthcheck.go",
+        "proxier_health.go",
+        "service_health.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/proxy/healthcheck",
     deps = [

--- a/pkg/proxy/healthcheck/common.go
+++ b/pkg/proxy/healthcheck/common.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"net"
+	"net/http"
+)
+
+// listener allows for testing of ServiceHealthServer and ProxierHealthServer.
+type listener interface {
+	// Listen is very much like net.Listen, except the first arg (network) is
+	// fixed to be "tcp".
+	Listen(addr string) (net.Listener, error)
+}
+
+// httpServerFactory allows for testing of ServiceHealthServer and ProxierHealthServer.
+type httpServerFactory interface {
+	// New creates an instance of a type satisfying HTTPServer.  This is
+	// designed to include http.Server.
+	New(addr string, handler http.Handler) httpServer
+}
+
+// httpServer allows for testing of ServiceHealthServer and ProxierHealthServer.
+// It is designed so that http.Server satisfies this interface,
+type httpServer interface {
+	Serve(listener net.Listener) error
+}
+
+// Implement listener in terms of net.Listen.
+type stdNetListener struct{}
+
+func (stdNetListener) Listen(addr string) (net.Listener, error) {
+	return net.Listen("tcp", addr)
+}
+
+var _ listener = stdNetListener{}
+
+// Implement httpServerFactory in terms of http.Server.
+type stdHTTPServerFactory struct{}
+
+func (stdHTTPServerFactory) New(addr string, handler http.Handler) httpServer {
+	return &http.Server{
+		Addr:    addr,
+		Handler: handler,
+	}
+}
+
+var _ httpServerFactory = stdHTTPServerFactory{}

--- a/pkg/proxy/healthcheck/healthcheck_test.go
+++ b/pkg/proxy/healthcheck/healthcheck_test.go
@@ -79,7 +79,7 @@ func newFakeHTTPServerFactory() *fakeHTTPServerFactory {
 	return &fakeHTTPServerFactory{}
 }
 
-func (fake *fakeHTTPServerFactory) New(addr string, handler http.Handler) HTTPServer {
+func (fake *fakeHTTPServerFactory) New(addr string, handler http.Handler) httpServer {
 	return &fakeHTTPServer{
 		addr:    addr,
 		handler: handler,
@@ -119,7 +119,7 @@ func TestServer(t *testing.T) {
 	listener := newFakeListener()
 	httpFactory := newFakeHTTPServerFactory()
 
-	hcsi := NewServer("hostname", nil, listener, httpFactory)
+	hcsi := newServiceHealthServer("hostname", nil, listener, httpFactory)
 	hcs := hcsi.(*server)
 	if len(hcs.services) != 0 {
 		t.Errorf("expected 0 services, got %d", len(hcs.services))
@@ -368,7 +368,7 @@ func TestHealthzServer(t *testing.T) {
 	httpFactory := newFakeHTTPServerFactory()
 	fakeClock := clock.NewFakeClock(time.Now())
 
-	hs := newHealthzServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second, nil, nil)
+	hs := newProxierHealthServer(listener, httpFactory, fakeClock, "127.0.0.1:10256", 10*time.Second, nil, nil)
 	server := hs.httpFactory.New(hs.addr, healthzHandler{hs: hs})
 
 	// Should return 200 "OK" by default.
@@ -385,7 +385,7 @@ func TestHealthzServer(t *testing.T) {
 	testHealthzHandler(server, http.StatusOK, t)
 }
 
-func testHealthzHandler(server HTTPServer, status int, t *testing.T) {
+func testHealthzHandler(server httpServer, status int, t *testing.T) {
 	handler := server.(*fakeHTTPServer).handler
 	req, err := http.NewRequest("GET", "/healthz", nil)
 	if err != nil {

--- a/pkg/proxy/healthcheck/proxier_health.go
+++ b/pkg/proxy/healthcheck/proxier_health.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package healthcheck
+
+import (
+	"fmt"
+	"net/http"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/klog"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/record"
+	api "k8s.io/kubernetes/pkg/apis/core"
+)
+
+var proxierHealthzRetryInterval = 60 * time.Second
+
+// ProxierHealthUpdater allows callers to update healthz timestamp only.
+type ProxierHealthUpdater interface {
+	UpdateTimestamp()
+}
+
+// ProxierHealthServer returns 200 "OK" by default. Once timestamp has been
+// updated, it verifies we don't exceed max no respond duration since
+// last update.
+type ProxierHealthServer struct {
+	listener    listener
+	httpFactory httpServerFactory
+	clock       clock.Clock
+
+	addr          string
+	port          int32
+	healthTimeout time.Duration
+	recorder      record.EventRecorder
+	nodeRef       *v1.ObjectReference
+
+	lastUpdated atomic.Value
+}
+
+// NewProxierHealthServer returns a proxier health http server.
+func NewProxierHealthServer(addr string, healthTimeout time.Duration, recorder record.EventRecorder, nodeRef *v1.ObjectReference) *ProxierHealthServer {
+	return newProxierHealthServer(stdNetListener{}, stdHTTPServerFactory{}, clock.RealClock{}, addr, healthTimeout, recorder, nodeRef)
+}
+
+func newProxierHealthServer(listener listener, httpServerFactory httpServerFactory, c clock.Clock, addr string, healthTimeout time.Duration, recorder record.EventRecorder, nodeRef *v1.ObjectReference) *ProxierHealthServer {
+	return &ProxierHealthServer{
+		listener:      listener,
+		httpFactory:   httpServerFactory,
+		clock:         c,
+		addr:          addr,
+		healthTimeout: healthTimeout,
+		recorder:      recorder,
+		nodeRef:       nodeRef,
+	}
+}
+
+// UpdateTimestamp updates the lastUpdated timestamp.
+func (hs *ProxierHealthServer) UpdateTimestamp() {
+	hs.lastUpdated.Store(hs.clock.Now())
+}
+
+// Run starts the healthz http server and returns.
+func (hs *ProxierHealthServer) Run() {
+	serveMux := http.NewServeMux()
+	serveMux.Handle("/healthz", healthzHandler{hs: hs})
+	server := hs.httpFactory.New(hs.addr, serveMux)
+
+	go wait.Until(func() {
+		klog.V(3).Infof("Starting goroutine for proxier healthz on %s", hs.addr)
+
+		listener, err := hs.listener.Listen(hs.addr)
+		if err != nil {
+			msg := fmt.Sprintf("Failed to start proxier healthz on %s: %v", hs.addr, err)
+			if hs.recorder != nil {
+				hs.recorder.Eventf(hs.nodeRef, api.EventTypeWarning, "FailedToStartProxierHealthcheck", msg)
+			}
+			klog.Error(msg)
+			return
+		}
+
+		if err := server.Serve(listener); err != nil {
+			klog.Errorf("Proxier healthz closed with error: %v", err)
+			return
+		}
+		klog.Error("Unexpected proxier healthz closed.")
+	}, proxierHealthzRetryInterval, wait.NeverStop)
+}
+
+type healthzHandler struct {
+	hs *ProxierHealthServer
+}
+
+func (h healthzHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
+	lastUpdated := time.Time{}
+	if val := h.hs.lastUpdated.Load(); val != nil {
+		lastUpdated = val.(time.Time)
+	}
+	currentTime := h.hs.clock.Now()
+
+	resp.Header().Set("Content-Type", "application/json")
+	resp.Header().Set("X-Content-Type-Options", "nosniff")
+	if !lastUpdated.IsZero() && currentTime.After(lastUpdated.Add(h.hs.healthTimeout)) {
+		resp.WriteHeader(http.StatusServiceUnavailable)
+	} else {
+		resp.WriteHeader(http.StatusOK)
+	}
+	fmt.Fprintf(resp, fmt.Sprintf(`{"lastUpdated": %q,"currentTime": %q}`, lastUpdated, currentTime))
+}

--- a/pkg/proxy/healthcheck/service_health.go
+++ b/pkg/proxy/healthcheck/service_health.go
@@ -22,27 +22,21 @@ import (
 	"net/http"
 	"strings"
 	"sync"
-	"sync/atomic"
-	"time"
 
 	"github.com/lithammer/dedent"
 	"k8s.io/klog"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/clock"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/record"
 	api "k8s.io/kubernetes/pkg/apis/core"
 )
 
-var nodeHealthzRetryInterval = 60 * time.Second
-
-// Server serves HTTP endpoints for each service name, with results
+// ServiceHealthServer serves HTTP endpoints for each service name, with results
 // based on the endpoints.  If there are 0 endpoints for a service, it returns a
 // 503 "Service Unavailable" error (telling LBs not to use this node).  If there
 // are 1 or more endpoints, it returns a 200 "OK".
-type Server interface {
+type ServiceHealthServer interface {
 	// Make the new set of services be active.  Services that were open before
 	// will be closed.  Services that are new will be opened.  Service that
 	// existed and are in the new set will be left alone.  The value of the map
@@ -54,73 +48,26 @@ type Server interface {
 	SyncEndpoints(newEndpoints map[types.NamespacedName]int) error
 }
 
-// Listener allows for testing of Server.  If the Listener argument
-// to NewServer() is nil, the real net.Listen function will be used.
-type Listener interface {
-	// Listen is very much like net.Listen, except the first arg (network) is
-	// fixed to be "tcp".
-	Listen(addr string) (net.Listener, error)
-}
-
-// HTTPServerFactory allows for testing of Server.  If the
-// HTTPServerFactory argument to NewServer() is nil, the real
-// http.Server type will be used.
-type HTTPServerFactory interface {
-	// New creates an instance of a type satisfying HTTPServer.  This is
-	// designed to include http.Server.
-	New(addr string, handler http.Handler) HTTPServer
-}
-
-// HTTPServer allows for testing of Server.
-type HTTPServer interface {
-	// Server is designed so that http.Server satisfies this interface,
-	Serve(listener net.Listener) error
-}
-
-// NewServer allocates a new healthcheck server manager.  If either
-// of the injected arguments are nil, defaults will be used.
-func NewServer(hostname string, recorder record.EventRecorder, listener Listener, httpServerFactory HTTPServerFactory) Server {
-	if listener == nil {
-		listener = stdNetListener{}
-	}
-	if httpServerFactory == nil {
-		httpServerFactory = stdHTTPServerFactory{}
-	}
+func newServiceHealthServer(hostname string, recorder record.EventRecorder, listener listener, factory httpServerFactory) ServiceHealthServer {
 	return &server{
 		hostname:    hostname,
 		recorder:    recorder,
 		listener:    listener,
-		httpFactory: httpServerFactory,
+		httpFactory: factory,
 		services:    map[types.NamespacedName]*hcInstance{},
 	}
 }
 
-// Implement Listener in terms of net.Listen.
-type stdNetListener struct{}
-
-func (stdNetListener) Listen(addr string) (net.Listener, error) {
-	return net.Listen("tcp", addr)
+// NewServiceHealthServer allocates a new service healthcheck server manager
+func NewServiceHealthServer(hostname string, recorder record.EventRecorder) ServiceHealthServer {
+	return newServiceHealthServer(hostname, recorder, stdNetListener{}, stdHTTPServerFactory{})
 }
-
-var _ Listener = stdNetListener{}
-
-// Implement HTTPServerFactory in terms of http.Server.
-type stdHTTPServerFactory struct{}
-
-func (stdHTTPServerFactory) New(addr string, handler http.Handler) HTTPServer {
-	return &http.Server{
-		Addr:    addr,
-		Handler: handler,
-	}
-}
-
-var _ HTTPServerFactory = stdHTTPServerFactory{}
 
 type server struct {
 	hostname    string
 	recorder    record.EventRecorder // can be nil
-	listener    Listener
-	httpFactory HTTPServerFactory
+	listener    listener
+	httpFactory httpServerFactory
 
 	lock     sync.RWMutex
 	services map[types.NamespacedName]*hcInstance
@@ -187,7 +134,7 @@ func (hcs *server) SyncServices(newServices map[types.NamespacedName]uint16) err
 type hcInstance struct {
 	port      uint16
 	listener  net.Listener
-	server    HTTPServer
+	server    httpServer
 	endpoints int // number of local endpoints for a service
 }
 
@@ -247,103 +194,20 @@ func (hcs *server) SyncEndpoints(newEndpoints map[types.NamespacedName]int) erro
 	return nil
 }
 
-// HealthzUpdater allows callers to update healthz timestamp only.
-type HealthzUpdater interface {
-	UpdateTimestamp()
+// FakeServiceHealthServer is a fake ServiceHealthServer for test programs
+type FakeServiceHealthServer struct{}
+
+// NewFakeServiceHealthServer allocates a new fake service healthcheck server manager
+func NewFakeServiceHealthServer() ServiceHealthServer {
+	return FakeServiceHealthServer{}
 }
 
-// HealthzServer returns 200 "OK" by default. Once timestamp has been
-// updated, it verifies we don't exceed max no respond duration since
-// last update.
-type HealthzServer struct {
-	listener    Listener
-	httpFactory HTTPServerFactory
-	clock       clock.Clock
-
-	addr          string
-	port          int32
-	healthTimeout time.Duration
-	recorder      record.EventRecorder
-	nodeRef       *v1.ObjectReference
-
-	lastUpdated atomic.Value
+// SyncServices is part of ServiceHealthServer
+func (fake FakeServiceHealthServer) SyncServices(_ map[types.NamespacedName]uint16) error {
+	return nil
 }
 
-// NewDefaultHealthzServer returns a default healthz http server.
-func NewDefaultHealthzServer(addr string, healthTimeout time.Duration, recorder record.EventRecorder, nodeRef *v1.ObjectReference) *HealthzServer {
-	return newHealthzServer(nil, nil, nil, addr, healthTimeout, recorder, nodeRef)
-}
-
-func newHealthzServer(listener Listener, httpServerFactory HTTPServerFactory, c clock.Clock, addr string, healthTimeout time.Duration, recorder record.EventRecorder, nodeRef *v1.ObjectReference) *HealthzServer {
-	if listener == nil {
-		listener = stdNetListener{}
-	}
-	if httpServerFactory == nil {
-		httpServerFactory = stdHTTPServerFactory{}
-	}
-	if c == nil {
-		c = clock.RealClock{}
-	}
-	return &HealthzServer{
-		listener:      listener,
-		httpFactory:   httpServerFactory,
-		clock:         c,
-		addr:          addr,
-		healthTimeout: healthTimeout,
-		recorder:      recorder,
-		nodeRef:       nodeRef,
-	}
-}
-
-// UpdateTimestamp updates the lastUpdated timestamp.
-func (hs *HealthzServer) UpdateTimestamp() {
-	hs.lastUpdated.Store(hs.clock.Now())
-}
-
-// Run starts the healthz http server and returns.
-func (hs *HealthzServer) Run() {
-	serveMux := http.NewServeMux()
-	serveMux.Handle("/healthz", healthzHandler{hs: hs})
-	server := hs.httpFactory.New(hs.addr, serveMux)
-
-	go wait.Until(func() {
-		klog.V(3).Infof("Starting goroutine for healthz on %s", hs.addr)
-
-		listener, err := hs.listener.Listen(hs.addr)
-		if err != nil {
-			msg := fmt.Sprintf("Failed to start node healthz on %s: %v", hs.addr, err)
-			if hs.recorder != nil {
-				hs.recorder.Eventf(hs.nodeRef, api.EventTypeWarning, "FailedToStartNodeHealthcheck", msg)
-			}
-			klog.Error(msg)
-			return
-		}
-
-		if err := server.Serve(listener); err != nil {
-			klog.Errorf("Healthz closed with error: %v", err)
-			return
-		}
-		klog.Error("Unexpected healthz closed.")
-	}, nodeHealthzRetryInterval, wait.NeverStop)
-}
-
-type healthzHandler struct {
-	hs *HealthzServer
-}
-
-func (h healthzHandler) ServeHTTP(resp http.ResponseWriter, req *http.Request) {
-	lastUpdated := time.Time{}
-	if val := h.hs.lastUpdated.Load(); val != nil {
-		lastUpdated = val.(time.Time)
-	}
-	currentTime := h.hs.clock.Now()
-
-	resp.Header().Set("Content-Type", "application/json")
-	resp.Header().Set("X-Content-Type-Options", "nosniff")
-	if !lastUpdated.IsZero() && currentTime.After(lastUpdated.Add(h.hs.healthTimeout)) {
-		resp.WriteHeader(http.StatusServiceUnavailable)
-	} else {
-		resp.WriteHeader(http.StatusOK)
-	}
-	fmt.Fprintf(resp, fmt.Sprintf(`{"lastUpdated": %q,"currentTime": %q}`, lastUpdated, currentTime))
+// SyncEndpoints is part of ServiceHealthServer
+func (fake FakeServiceHealthServer) SyncEndpoints(_ map[types.NamespacedName]int) error {
+	return nil
 }

--- a/pkg/proxy/iptables/BUILD
+++ b/pkg/proxy/iptables/BUILD
@@ -38,6 +38,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/proxy:go_default_library",
+        "//pkg/proxy/healthcheck:go_default_library",
         "//pkg/proxy/util:go_default_library",
         "//pkg/proxy/util/testing:go_default_library",
         "//pkg/util/async:go_default_library",

--- a/pkg/proxy/ipvs/BUILD
+++ b/pkg/proxy/ipvs/BUILD
@@ -16,6 +16,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/proxy:go_default_library",
+        "//pkg/proxy/healthcheck:go_default_library",
         "//pkg/proxy/ipvs/testing:go_default_library",
         "//pkg/proxy/util:go_default_library",
         "//pkg/proxy/util/testing:go_default_library",

--- a/pkg/proxy/winkernel/BUILD
+++ b/pkg/proxy/winkernel/BUILD
@@ -62,6 +62,7 @@ go_test(
     deps = select({
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/proxy:go_default_library",
+            "//pkg/proxy/healthcheck:go_default_library",
             "//staging/src/k8s.io/api/core/v1:go_default_library",
             "//staging/src/k8s.io/api/discovery/v1alpha1:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
#81517 changed the iptables proxier to only run `syncProxyRules` when things actually changed, thereby breaking the proxier health check, which assumed that it would get called every `iptablesSyncPeriod` no matter what. This changes the definition of proxier health to deal with this, essentially changing from "The proxier is unhealthy if the iptables rules are older than `healthCheckPeriod`" to "The proxier is unhealthy if the iptables rules correspond to a proxier state that is older than `healthCheckPeriod`".

We discussed some other proxy health ideas in #83263, and maybe we'll update this again later, but this at least unbreaks it for now.

(The PR also includes a bunch of renaming because there are two health servers in kube-proxy and I kept forgetting which was which...)

**Which issue(s) this PR fixes**:
Fixes part of #83263

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/priority important-soon
/sig network
