### PR TITLE
Modified the name of the Extensions method in the scheduler's framework.

### DIFF
--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -635,7 +635,7 @@ func (t *TestPlugin) Score(state *framework.CycleState, p *v1.Pod, nodeName stri
 	return 1, nil
 }
 
-func (t *TestPlugin) Extensions() framework.ScoreExtensions {
+func (t *TestPlugin) ScoreExtensions() framework.ScoreExtensions {
 	return nil
 }
 

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -229,10 +229,10 @@ func (f *framework) RunPreFilterPlugins(
 func (f *framework) RunPreFilterExtensionAddPod(state *CycleState, podToSchedule *v1.Pod,
 	podToAdd *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) *Status {
 	for _, pl := range f.preFilterPlugins {
-		if pl.Extensions() == nil {
+		if pl.PreFilterExtensions() == nil {
 			continue
 		}
-		if status := pl.Extensions().AddPod(state, podToSchedule, podToAdd, nodeInfo); !status.IsSuccess() {
+		if status := pl.PreFilterExtensions().AddPod(state, podToSchedule, podToAdd, nodeInfo); !status.IsSuccess() {
 			msg := fmt.Sprintf("error while running AddPod for plugin %q while scheduling pod %q: %v",
 				pl.Name(), podToSchedule.Name, status.Message())
 			klog.Error(msg)
@@ -249,10 +249,10 @@ func (f *framework) RunPreFilterExtensionAddPod(state *CycleState, podToSchedule
 func (f *framework) RunPreFilterExtensionRemovePod(state *CycleState, podToSchedule *v1.Pod,
 	podToRemove *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) *Status {
 	for _, pl := range f.preFilterPlugins {
-		if pl.Extensions() == nil {
+		if pl.PreFilterExtensions() == nil {
 			continue
 		}
-		if status := pl.Extensions().RemovePod(state, podToSchedule, podToRemove, nodeInfo); !status.IsSuccess() {
+		if status := pl.PreFilterExtensions().RemovePod(state, podToSchedule, podToRemove, nodeInfo); !status.IsSuccess() {
 			msg := fmt.Sprintf("error while running RemovePod for plugin %q while scheduling pod %q: %v",
 				pl.Name(), podToSchedule.Name, status.Message())
 			klog.Error(msg)
@@ -343,10 +343,10 @@ func (f *framework) RunScorePlugins(state *CycleState, pod *v1.Pod, nodes []*v1.
 	workqueue.ParallelizeUntil(ctx, 16, len(f.scorePlugins), func(index int) {
 		pl := f.scorePlugins[index]
 		nodeScoreList := pluginToNodeScores[pl.Name()]
-		if pl.Extensions() == nil {
+		if pl.ScoreExtensions() == nil {
 			return
 		}
-		if status := pl.Extensions().NormalizeScore(state, pod, nodeScoreList); !status.IsSuccess() {
+		if status := pl.ScoreExtensions().NormalizeScore(state, pod, nodeScoreList); !status.IsSuccess() {
 			err := fmt.Errorf("normalize score plugin %q failed with error %v", pl.Name(), status.Message())
 			errCh.SendErrorWithCancel(err, cancel)
 			return

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -89,7 +89,7 @@ func (pl *TestScoreWithNormalizePlugin) Score(state *CycleState, p *v1.Pod, node
 	return setScoreRes(pl.inj)
 }
 
-func (pl *TestScoreWithNormalizePlugin) Extensions() ScoreExtensions {
+func (pl *TestScoreWithNormalizePlugin) ScoreExtensions() ScoreExtensions {
 	return pl
 }
 
@@ -107,7 +107,7 @@ func (pl *TestScorePlugin) Score(state *CycleState, p *v1.Pod, nodeName string) 
 	return setScoreRes(pl.inj)
 }
 
-func (pl *TestScorePlugin) Extensions() ScoreExtensions {
+func (pl *TestScorePlugin) ScoreExtensions() ScoreExtensions {
 	return nil
 }
 
@@ -132,7 +132,7 @@ func (pl *TestPreFilterPlugin) PreFilter(state *CycleState, p *v1.Pod) *Status {
 	return nil
 }
 
-func (pl *TestPreFilterPlugin) Extensions() PreFilterExtensions {
+func (pl *TestPreFilterPlugin) PreFilterExtensions() PreFilterExtensions {
 	return nil
 }
 
@@ -164,7 +164,7 @@ func (pl *TestPreFilterWithExtensionsPlugin) RemovePod(state *CycleState, podToS
 	return nil
 }
 
-func (pl *TestPreFilterWithExtensionsPlugin) Extensions() PreFilterExtensions {
+func (pl *TestPreFilterWithExtensionsPlugin) PreFilterExtensions() PreFilterExtensions {
 	return pl
 }
 
@@ -179,7 +179,7 @@ func (dp *TestDuplicatePlugin) PreFilter(state *CycleState, p *v1.Pod) *Status {
 	return nil
 }
 
-func (dp *TestDuplicatePlugin) Extensions() PreFilterExtensions {
+func (dp *TestDuplicatePlugin) PreFilterExtensions() PreFilterExtensions {
 	return nil
 }
 

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -190,13 +190,13 @@ type PreFilterPlugin interface {
 	// PreFilter is called at the beginning of the scheduling cycle. All PreFilter
 	// plugins must return success or the pod will be rejected.
 	PreFilter(state *CycleState, p *v1.Pod) *Status
-	// Extensions returns a PreFilterExtensions interface if the plugin implements one,
+	// PreFilterExtensions returns a PreFilterExtensions interface if the plugin implements one,
 	// or nil if it does not. A Pre-filter plugin can provide extensions to incrementally
 	// modify its pre-processed info. The framework guarantees that the extensions
 	// AddPod/RemovePod will only be called after PreFilter, possibly on a cloned
 	// CycleState, and may call those functions more than once before calling
 	// Filter again on a specific node.
-	Extensions() PreFilterExtensions
+	PreFilterExtensions() PreFilterExtensions
 }
 
 // FilterPlugin is an interface for Filter plugins. These plugins are called at the
@@ -253,8 +253,8 @@ type ScorePlugin interface {
 	// the pod will be rejected.
 	Score(state *CycleState, p *v1.Pod, nodeName string) (int, *Status)
 
-	// Extensions returns a ScoreExtensions interface if it implements one, or nil if does not.
-	Extensions() ScoreExtensions
+	// ScoreExtensions returns a ScoreExtensions interface if it implements one, or nil if does not.
+	ScoreExtensions() ScoreExtensions
 }
 
 // ReservePlugin is an interface for Reserve plugins. These plugins are called

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -163,7 +163,7 @@ func (sp *ScorePlugin) Score(state *framework.CycleState, p *v1.Pod, nodeName st
 	return score, nil
 }
 
-func (sp *ScorePlugin) Extensions() framework.ScoreExtensions {
+func (sp *ScorePlugin) ScoreExtensions() framework.ScoreExtensions {
 	return nil
 }
 
@@ -190,7 +190,7 @@ func (sp *ScoreWithNormalizePlugin) NormalizeScore(state *framework.CycleState, 
 	return nil
 }
 
-func (sp *ScoreWithNormalizePlugin) Extensions() framework.ScoreExtensions {
+func (sp *ScoreWithNormalizePlugin) ScoreExtensions() framework.ScoreExtensions {
 	return sp
 }
 
@@ -336,7 +336,7 @@ func (pp *PreFilterPlugin) Name() string {
 }
 
 // Extensions returns the PreFilterExtensions interface.
-func (pp *PreFilterPlugin) Extensions() framework.PreFilterExtensions {
+func (pp *PreFilterPlugin) PreFilterExtensions() framework.PreFilterExtensions {
 	return nil
 }
 

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -114,7 +114,7 @@ func (fp *tokenFilter) RemovePod(state *framework.CycleState, podToSchedule *v1.
 	return nil
 }
 
-func (fp *tokenFilter) Extensions() framework.PreFilterExtensions {
+func (fp *tokenFilter) PreFilterExtensions() framework.PreFilterExtensions {
 	return fp
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
PreFilter and Score offers an ```Extensions``` API. If we want to implement plugins that register at multiple extensions points, in this case PreFilter and Score, the Extensions will cause a conflict.

This PR adds a prefix to the Extensions method depending on which extension point it is intended for.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @alculquicondor 