### PR TITLE
Add scheduler cache size metrics

### DIFF
--- a/pkg/scheduler/internal/cache/BUILD
+++ b/pkg/scheduler/internal/cache/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/features:go_default_library",
         "//pkg/scheduler/listers:go_default_library",
+        "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/scheduler/nodeinfo/snapshot:go_default_library",
         "//pkg/util/node:go_default_library",

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -272,6 +272,14 @@ var (
 		},
 		[]string{"result"})
 
+	CacheSize = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "scheduler_cache_size",
+			Help:           "Number of nodes, pods, and assumed (bound) pods in the scheduler cache.",
+			StabilityLevel: metrics.ALPHA,
+		}, []string{"type"})
+
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,
 		SchedulingLatency,
@@ -297,6 +305,7 @@ var (
 		SchedulerQueueIncomingPods,
 		SchedulerGoroutines,
 		PermitWaitDuration,
+		CacheSize,
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds a metric for the scheduler cache size and updates that metric in certain cache functions

**Which issue(s) this PR fixes**:
Fixes #83404

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Scheduler now reports metrics on cache size including nodes, pods, and assumed pods
```
