### PR TITLE
Dump GKE windows test logs via diagnostics tool

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -218,17 +218,33 @@ function export-windows-docker-event-log() {
     done
 }
 
-# Save log files and serial console output from Windows node $1 into local
-# directory $2.
-# This function shouldn't ever trigger errexit.
-function save-logs-windows() {
-    local -r node="${1}"
-    local -r dest_dir="${2}"
+# Saves log files from diagnostics tool.(https://github.com/GoogleCloudPlatform/compute-image-tools/tree/master/cli_tools/diagnostics)
+function save-windows-logs-via-diagnostics-tool() {
+    local node="${1}"
+    local dest_dir="${2}"
+    
+    gcloud compute instances add-metadata ${node} --metadata enable-diagnostics=true --project=${PROJECT} --zone=${ZONE}
+    local logs_archive_in_gcs=$(gcloud alpha compute diagnose export-logs ${node} --zone=${ZONE} --project=${PROJECT} | tail -n 1)
+    local temp_local_path="${node}.zip"
+    for retry in {1..20}; do
+      if gsutil mv "${logs_archive_in_gcs}" "${temp_local_path}"  > /dev/null 2>&1; then
+        echo "Downloaded diagnostics log from ${logs_archive_in_gcs}"
+        break
+      else
+        sleep 10
+      fi
+    done
 
-    if [[ ! "${gcloud_supported_providers}" =~ "${KUBERNETES_PROVIDER}" ]]; then
-      echo "Not saving logs for ${node}, Windows log dumping requires gcloud support"
-      return
+    if [[ -f "${temp_local_path}" ]]; then
+      unzip ${temp_local_path} -d "${dest_dir}" > /dev/null
+      rm -f ${temp_local_path}
     fi
+}
+
+# Saves log files from SSH
+function save-windows-logs-via-ssh() {
+    local node="${1}"
+    local dest_dir="${2}"
 
     export-windows-docker-event-log "${node}"
 
@@ -253,6 +269,25 @@ function save-logs-windows() {
         fi
       done
     done
+}
+
+# Save log files and serial console output from Windows node $1 into local
+# directory $2.
+# This function shouldn't ever trigger errexit.
+function save-logs-windows() {
+    local -r node="${1}"
+    local -r dest_dir="${2}"
+
+    if [[ ! "${gcloud_supported_providers}" =~ "${KUBERNETES_PROVIDER}" ]]; then
+      echo "Not saving logs for ${node}, Windows log dumping requires gcloud support"
+      return
+    fi
+
+    if [[ "${KUBERNETES_PROVIDER}" == "gke" ]]; then
+      save-windows-logs-via-diagnostics-tool "${node}" "${dest_dir}"
+    else
+      save-windows-logs-via-ssh "${node}" "${dest_dir}"
+    fi
 
     # Serial port 1 contains the Windows console output.
     gcloud compute instances get-serial-port-output --project "${PROJECT}" \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
SSH on GKE windows node hasn't been enabled yet, so not able to get the archived logs after prow test. We have to use stackdriver to check logs which is way chunkier. 
Use diagnostics tool dumping windows logs to mitigate the pain.

**Special notes for your reviewer**:
The diagnostics tool repo: https://github.com/GoogleCloudPlatform/compute-image-tools/tree/master/cli_tools/diagnostics

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Utilize diagnostics tool to dump GKE windows test logs 
```
