### PR TITLE
Provide user friendly validation error message for kubectl apply

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -2130,7 +2130,7 @@ func validateEnvVarValueFrom(ev core.EnvVar, fldPath *field.Path) field.ErrorLis
 		allErrs = append(allErrs, field.Invalid(fldPath, "", "must specify one of: `fieldRef`, `resourceFieldRef`, `configMapKeyRef` or `secretKeyRef`"))
 	} else if len(ev.Value) != 0 {
 		if numSources != 0 {
-			allErrs = append(allErrs, field.Invalid(fldPath, "", "may not be specified when `value` is not empty"))
+			allErrs = append(allErrs, field.Invalid(fldPath, "", "may not be specified because resource has been modified since last applied configuration"))
 		}
 	} else if numSources > 1 {
 		allErrs = append(allErrs, field.Invalid(fldPath, "", "may not have more than one field specified at a time"))

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -4500,7 +4500,7 @@ func TestValidateEnv(t *testing.T) {
 					},
 				},
 			}},
-			expectedError: "[0].valueFrom: Invalid value: \"\": may not be specified when `value` is not empty",
+			expectedError: "[0].valueFrom: Invalid value: \"\": may not be specified because resource has been modified since last applied configuration",
 		},
 		{
 			name: "valueFrom without a source",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As mentioned in #78607, when `kubectl apply` a manifest whose resources have been previously modified using `kubectl edit`, the validation error message is not user friendly.

This PR modifies the error message to be more accurate.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
