### PR TITLE
Add support for reserving hugepages for system and kube in kubelet

### DIFF
--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -40,8 +40,8 @@ func TestValueOfAllocatableResources(t *testing.T) {
 			name:           "invalid quantity unit",
 		},
 		{
-			kubeReserved:   map[string]string{"cpu": "200m", "memory": "15G", "ephemeral-storage": "10Gi"},
-			systemReserved: map[string]string{"cpu": "200m", "memory": "15Ki"},
+			kubeReserved:   map[string]string{"cpu": "200m", "memory": "15G", "ephemeral-storage": "10Gi", "hugepages-2Mi": "40Mi"},
+			systemReserved: map[string]string{"cpu": "200m", "memory": "15Ki", "hugepages-64Ki": "2Mi"},
 			errorExpected:  false,
 			name:           "Valid resource quantity",
 		},

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -651,6 +651,11 @@ func (cm *containerManagerImpl) Start(node *v1.Node,
 		}
 	}
 
+	// Ensure that reserved resoures are valid and supported by the node.
+	if err := cm.verifyReservedResourcesHaveCapacity(); err != nil {
+		return err
+	}
+
 	// Ensure that node allocatable configuration is valid.
 	if err := cm.validateNodeAllocatable(); err != nil {
 		return err

--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -229,6 +229,21 @@ func (cm *containerManagerImpl) GetNodeAllocatableReservation() v1.ResourceList 
 	return result
 }
 
+// verifyReservedResourcesHaveCapacity validates reserved resources against the capacity of the resources collected from cAdvisor.
+func (cm *containerManagerImpl) verifyReservedResourcesHaveCapacity() error {
+	for k := range cm.NodeConfig.SystemReserved {
+		if _, ok := cm.capacity[k]; !ok {
+			return fmt.Errorf("cannot reserve %q resource", k)
+		}
+	}
+	for k := range cm.NodeConfig.KubeReserved {
+		if _, ok := cm.capacity[k]; !ok {
+			return fmt.Errorf("cannot reserve %q resource", k)
+		}
+	}
+	return nil
+}
+
 // validateNodeAllocatable ensures that the user specified Node Allocatable Configuration doesn't reserve more than the node capacity.
 // Returns error if the configuration is invalid, nil otherwise.
 func (cm *containerManagerImpl) validateNodeAllocatable() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind feature

**What this PR does / why we need it**:

Via the --kube-reserved and --system-reserved flags, and their
respective configs.

Implements it ref hugepages KEP: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190129-hugepages.md#L158

/sig node


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #83542

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for reserving hugepages for system or kubelet via --{system,kube}-reserved
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/20190129-hugepages.md#L158
- [Usage]: https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/
- [Other doc]: https://kubernetes.io/docs/tasks/manage-hugepages/scheduling-hugepages/
```