### PR TITLE
When node name is empty, return early

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -534,12 +534,13 @@ func (adc *attachDetachController) podDelete(obj interface{}) {
 
 func (adc *attachDetachController) nodeAdd(obj interface{}) {
 	node, ok := obj.(*v1.Node)
-	// TODO: investigate if nodeName is empty then if we can return
-	// kubernetes/kubernetes/issues/37777
 	if node == nil || !ok {
 		return
 	}
 	nodeName := types.NodeName(node.Name)
+	if len(nodeName) == 0 {
+		return
+	}
 	adc.nodeUpdate(nil, obj)
 	// kubernetes/kubernetes/issues/37586
 	// This is to workaround the case when a node add causes to wipe out
@@ -550,12 +551,14 @@ func (adc *attachDetachController) nodeAdd(obj interface{}) {
 
 func (adc *attachDetachController) nodeUpdate(oldObj, newObj interface{}) {
 	node, ok := newObj.(*v1.Node)
-	// TODO: investigate if nodeName is empty then if we can return
 	if node == nil || !ok {
 		return
 	}
 
 	nodeName := types.NodeName(node.Name)
+	if len(nodeName) == 0 {
+		return
+	}
 	adc.addNodeToDswp(node, nodeName)
 	adc.processVolumesInUse(nodeName, node.Status.VolumesInUse)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes https://github.com/kubernetes/kubernetes/issues/37777
For nodeAdd and nodeUpdate, when node name is empty, we can return early from the func.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
