### PR TITLE
[WIP] Adopt go1.13 error wrapping in StrictDecodingError

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/BUILD
@@ -13,6 +13,7 @@ go_test(
         "conversion_test.go",
         "converter_test.go",
         "embedded_test.go",
+        "error_test.go",
         "extension_test.go",
         "local_scheme_test.go",
         "mapper_test.go",

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/error_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/error_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package runtime
 
 import (

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/error_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/error_test.go
@@ -1,0 +1,22 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStrictDecodingErrorWrapping(t *testing.T) {
+	innerErrMsg := "some other error"
+	strictErr := NewStrictDecodingError(fmt.Errorf(innerErrMsg), "foo")
+	assert.NotNil(t, strictErr)
+
+	innerErr := errors.Unwrap(strictErr)
+	assert.Error(t, innerErr)
+	assert.Contains(t, innerErr.Error(), innerErrMsg)
+
+	wrappingErr := fmt.Errorf("wrapping: %w", strictErr)
+	assert.True(t, IsStrictDecodingError(errors.Unwrap(wrappingErr)))
+}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/json/json.go
@@ -277,7 +277,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 	// the actual error is that the object contains duplicate fields.
 	altered, err := yaml.YAMLToJSONStrict(originalData)
 	if err != nil {
-		return nil, actual, runtime.NewStrictDecodingError(err.Error(), string(originalData))
+		return nil, actual, runtime.NewStrictDecodingError(err, string(originalData))
 	}
 	// As performance is not an issue for now for the strict deserializer (one has regardless to do
 	// the unmarshal twice), we take the sanitized, altered data that is guaranteed to have no duplicated
@@ -286,7 +286,7 @@ func (s *Serializer) Decode(originalData []byte, gvk *schema.GroupVersionKind, i
 	// the actual error is that the object contains unknown field.
 	strictObj := obj.DeepCopyObject()
 	if err := strictCaseSensitiveJsonIterator.Unmarshal(altered, strictObj); err != nil {
-		return nil, actual, runtime.NewStrictDecodingError(err.Error(), string(originalData))
+		return nil, actual, runtime.NewStrictDecodingError(err, string(originalData))
 	}
 	// Always return the same object as the non-strict serializer to avoid any deviations.
 	return obj, actual, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This implements the go1.13 syle of error wrapping for `strictDecodingError`. We can now pass the original error to `NewStrictDecodingError`, which can later be unwrapped again via `Unwrap`. Additionally, the [new preferred style](https://github.com/golang/go/wiki/ErrorValueFAQ#how-should-i-change-my-error-handling-code-to-work-with-the-new-features) of error checking is used with `IsStrictDecodingError`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
