### PR TITLE
Show the complete docker info command

### DIFF
--- a/cmd/kubeadm/app/util/cgroupdriver.go
+++ b/cmd/kubeadm/app/util/cgroupdriver.go
@@ -48,7 +48,7 @@ func GetCgroupDriverDocker(execer utilsexec.Interface) (string, error) {
 func callDockerInfo(execer utilsexec.Interface) (string, error) {
 	out, err := execer.Command("docker", "info", "-f", "{{.CgroupDriver}}").Output()
 	if err != nil {
-		return "", errors.Wrap(err, "cannot execute 'docker info'")
+		return "", errors.Wrap(err, "cannot execute 'docker info -f {{.CgroupDriver}}'")
 	}
 	return string(out), nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Over #83225, Santos was looking at /etc/docker/daemon.json initially.

Once he ran the docker info command, it didn't take long before he found the cause.

This PR shows the full docker info command so that users can perform validation themselves.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
