### PR TITLE
more e2eservice.TestJig cleanups

### DIFF
--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -899,9 +899,9 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	framework.ExpectNoError(err)
 
 	framework.Logf("Creating a service %s with type=LoadBalancer and externalTrafficPolicy=Local in namespace %s", name, ns)
-	jig := e2eservice.NewTestJig(c, name)
+	jig := e2eservice.NewTestJig(c, ns, name)
 	jig.Labels = podLabels
-	service, err := jig.CreateLoadBalancerService(ns, name, e2eservice.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
+	service, err := jig.CreateLoadBalancerService(e2eservice.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 	})
 	framework.ExpectNoError(err)
@@ -922,14 +922,14 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	defer close(done)
 	go func() {
 		defer ginkgo.GinkgoRecover()
-		expectedNodes, err := jig.GetEndpointNodeNames(service)
+		expectedNodes, err := jig.GetEndpointNodeNames()
 		framework.ExpectNoError(err)
 		// The affinity policy should ensure that before an old pod is
 		// deleted, a new pod will have been created on the same node.
 		// Thus the set of nodes with local endpoints for the service
 		// should remain unchanged.
 		wait.Until(func() {
-			actualNodes, err := jig.GetEndpointNodeNames(service)
+			actualNodes, err := jig.GetEndpointNodeNames()
 			framework.ExpectNoError(err)
 			if !actualNodes.Equal(expectedNodes) {
 				framework.Logf("The set of nodes with local endpoints changed; started with %v, now have %v", expectedNodes.List(), actualNodes.List())

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -901,9 +901,10 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	framework.Logf("Creating a service %s with type=LoadBalancer and externalTrafficPolicy=Local in namespace %s", name, ns)
 	jig := e2eservice.NewTestJig(c, name)
 	jig.Labels = podLabels
-	service := jig.CreateLoadBalancerService(ns, name, e2eservice.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
+	service, err := jig.CreateLoadBalancerService(ns, name, e2eservice.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
 		svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 	})
+	framework.ExpectNoError(err)
 
 	lbNameOrAddress := e2eservice.GetIngressPoint(&service.Status.LoadBalancer.Ingress[0])
 	svcPort := int(service.Spec.Ports[0].Port)
@@ -921,13 +922,15 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	defer close(done)
 	go func() {
 		defer ginkgo.GinkgoRecover()
-		expectedNodes := jig.GetEndpointNodeNames(service)
+		expectedNodes, err := jig.GetEndpointNodeNames(service)
+		framework.ExpectNoError(err)
 		// The affinity policy should ensure that before an old pod is
 		// deleted, a new pod will have been created on the same node.
 		// Thus the set of nodes with local endpoints for the service
 		// should remain unchanged.
 		wait.Until(func() {
-			actualNodes := jig.GetEndpointNodeNames(service)
+			actualNodes, err := jig.GetEndpointNodeNames(service)
+			framework.ExpectNoError(err)
 			if !actualNodes.Equal(expectedNodes) {
 				framework.Logf("The set of nodes with local endpoints changed; started with %v, now have %v", expectedNodes.List(), actualNodes.List())
 				failed <- struct{}{}

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -851,7 +851,6 @@ func (cont *NginxIngressController) Init() {
 			{Name: "stats", Port: 18080}}
 	})
 	cont.lbSvc = serviceJig.WaitForLoadBalancerOrFail(cont.Ns, "nginx-ingress-lb", e2eservice.GetServiceLoadBalancerCreationTimeout(cont.Client))
-	serviceJig.SanityCheckService(cont.lbSvc, v1.ServiceTypeLoadBalancer)
 
 	read := func(file string) string {
 		return string(testfiles.ReadOrDie(filepath.Join(IngressManifestPath, "nginx", file)))

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -841,8 +841,8 @@ func (cont *NginxIngressController) Init() {
 	// --publish-service flag (see <IngressManifestPath>/nginx/rc.yaml) to make it work in private
 	// clusters, i.e. clusters where nodes don't have public IPs.
 	framework.Logf("Creating load balancer service for nginx ingress controller")
-	serviceJig := e2eservice.NewTestJig(cont.Client, "nginx-ingress-lb")
-	_, err := serviceJig.CreateTCPService(cont.Ns, func(svc *v1.Service) {
+	serviceJig := e2eservice.NewTestJig(cont.Client, cont.Ns, "nginx-ingress-lb")
+	_, err := serviceJig.CreateTCPService(func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		svc.Spec.Selector = map[string]string{"k8s-app": "nginx-ingress-lb"}
 		svc.Spec.Ports = []v1.ServicePort{
@@ -851,7 +851,7 @@ func (cont *NginxIngressController) Init() {
 			{Name: "stats", Port: 18080}}
 	})
 	framework.ExpectNoError(err)
-	cont.lbSvc, err = serviceJig.WaitForLoadBalancer(cont.Ns, "nginx-ingress-lb", e2eservice.GetServiceLoadBalancerCreationTimeout(cont.Client))
+	cont.lbSvc, err = serviceJig.WaitForLoadBalancer(e2eservice.GetServiceLoadBalancerCreationTimeout(cont.Client))
 	framework.ExpectNoError(err)
 
 	read := func(file string) string {

--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -842,7 +842,7 @@ func (cont *NginxIngressController) Init() {
 	// clusters, i.e. clusters where nodes don't have public IPs.
 	framework.Logf("Creating load balancer service for nginx ingress controller")
 	serviceJig := e2eservice.NewTestJig(cont.Client, "nginx-ingress-lb")
-	serviceJig.CreateTCPServiceOrFail(cont.Ns, func(svc *v1.Service) {
+	_, err := serviceJig.CreateTCPService(cont.Ns, func(svc *v1.Service) {
 		svc.Spec.Type = v1.ServiceTypeLoadBalancer
 		svc.Spec.Selector = map[string]string{"k8s-app": "nginx-ingress-lb"}
 		svc.Spec.Ports = []v1.ServicePort{
@@ -850,7 +850,9 @@ func (cont *NginxIngressController) Init() {
 			{Name: "https", Port: 443},
 			{Name: "stats", Port: 18080}}
 	})
-	cont.lbSvc = serviceJig.WaitForLoadBalancerOrFail(cont.Ns, "nginx-ingress-lb", e2eservice.GetServiceLoadBalancerCreationTimeout(cont.Client))
+	framework.ExpectNoError(err)
+	cont.lbSvc, err = serviceJig.WaitForLoadBalancer(cont.Ns, "nginx-ingress-lb", e2eservice.GetServiceLoadBalancerCreationTimeout(cont.Client))
+	framework.ExpectNoError(err)
 
 	read := func(file string) string {
 		return string(testfiles.ReadOrDie(filepath.Join(IngressManifestPath, "nginx", file)))

--- a/test/e2e/framework/service/BUILD
+++ b/test/e2e/framework/service/BUILD
@@ -15,7 +15,6 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/framework/service",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/core:go_default_library",
         "//pkg/registry/core/service/portallocator:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/policy/v1beta1:go_default_library",

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -164,20 +164,6 @@ func (j *TestJig) CreateExternalNameServiceOrFail(namespace string, tweak func(s
 	return result
 }
 
-// CreateServiceWithServicePort creates a new Service with ServicePort.
-func (j *TestJig) CreateServiceWithServicePort(labels map[string]string, namespace string, ports []v1.ServicePort) (*v1.Service, error) {
-	service := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: j.Name,
-		},
-		Spec: v1.ServiceSpec{
-			Selector: labels,
-			Ports:    ports,
-		},
-	}
-	return j.Client.CoreV1().Services(namespace).Create(service)
-}
-
 // ChangeServiceType updates the given service's ServiceType to the given newType.
 func (j *TestJig) ChangeServiceType(namespace, name string, newType v1.ServiceType, timeout time.Duration) {
 	ingressIP := ""

--- a/test/e2e/network/dual_stack.go
+++ b/test/e2e/network/dual_stack.go
@@ -210,7 +210,7 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 	ginkgo.It("should create service with cluster ip from primary service range [Feature:IPv6DualStackAlphaFeature:Phase2]", func() {
 		serviceName := "defaultclusterip"
 		ns := f.Namespace.Name
-		jig := e2eservice.NewTestJig(cs, serviceName)
+		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		defaultIPFamily := v1.IPv4Protocol
 		if framework.TestContext.ClusterIsIPv6() {
@@ -229,7 +229,8 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 		service := createService(t.ServiceName, t.Namespace, t.Labels, nil)
 
 		jig.Labels = t.Labels
-		jig.CreateServicePods(cs, ns, 2)
+		err := jig.CreateServicePods(2)
+		framework.ExpectNoError(err)
 		svc, err := t.CreateService(service)
 		framework.ExpectNoError(err, "failed to create service: %s in namespace: %s", serviceName, ns)
 
@@ -251,7 +252,7 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 		ns := f.Namespace.Name
 		ipv4 := v1.IPv4Protocol
 
-		jig := e2eservice.NewTestJig(cs, serviceName)
+		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		t := e2eservice.NewServerTest(cs, ns, serviceName)
 		defer func() {
@@ -265,7 +266,8 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 		service := createService(t.ServiceName, t.Namespace, t.Labels, &ipv4)
 
 		jig.Labels = t.Labels
-		jig.CreateServicePods(cs, ns, 2)
+		err := jig.CreateServicePods(2)
+		framework.ExpectNoError(err)
 		svc, err := t.CreateService(service)
 		framework.ExpectNoError(err, "failed to create service: %s in namespace: %s", serviceName, ns)
 
@@ -287,7 +289,7 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 		ns := f.Namespace.Name
 		ipv6 := v1.IPv6Protocol
 
-		jig := e2eservice.NewTestJig(cs, serviceName)
+		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 
 		t := e2eservice.NewServerTest(cs, ns, serviceName)
 		defer func() {
@@ -301,7 +303,8 @@ var _ = SIGDescribe("[Feature:IPv6DualStackAlphaFeature] [LinuxOnly]", func() {
 		service := createService(t.ServiceName, t.Namespace, t.Labels, &ipv6)
 
 		jig.Labels = t.Labels
-		jig.CreateServicePods(cs, ns, 2)
+		err := jig.CreateServicePods(2)
+		framework.ExpectNoError(err)
 		svc, err := t.CreateService(service)
 		framework.ExpectNoError(err, "failed to create service: %s in namespace: %s", serviceName, ns)
 

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -71,7 +71,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 		framework.ExpectNoError(err)
 		framework.Logf("Got cluster ID: %v", clusterID)
 
-		jig := e2eservice.NewTestJig(cs, serviceName)
+		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		nodeList, err := e2enode.GetBoundedReadySchedulableNodes(cs, e2eservice.MaxNodesForEndpointsTests)
 		framework.ExpectNoError(err)
 
@@ -82,13 +82,13 @@ var _ = SIGDescribe("Firewall rule", func() {
 		nodesSet := sets.NewString(nodesNames...)
 
 		ginkgo.By("Creating a LoadBalancer type service with ExternalTrafficPolicy=Global")
-		svc, err := jig.CreateLoadBalancerService(ns, serviceName, e2eservice.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
+		svc, err := jig.CreateLoadBalancerService(e2eservice.LoadBalancerCreateTimeoutDefault, func(svc *v1.Service) {
 			svc.Spec.Ports = []v1.ServicePort{{Protocol: v1.ProtocolTCP, Port: firewallTestHTTPPort}}
 			svc.Spec.LoadBalancerSourceRanges = firewallTestSourceRanges
 		})
 		framework.ExpectNoError(err)
 		defer func() {
-			_, err = jig.UpdateService(svc.Namespace, svc.Name, func(svc *v1.Service) {
+			_, err = jig.UpdateService(func(svc *v1.Service) {
 				svc.Spec.Type = v1.ServiceTypeNodePort
 				svc.Spec.LoadBalancerSourceRanges = nil
 			})
@@ -118,7 +118,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 
 		// OnlyLocal service is needed to examine which exact nodes the requests are being forwarded to by the Load Balancer on GCE
 		ginkgo.By("Updating LoadBalancer service to ExternalTrafficPolicy=Local")
-		svc, err = jig.UpdateService(svc.Namespace, svc.Name, func(svc *v1.Service) {
+		svc, err = jig.UpdateService(func(svc *v1.Service) {
 			svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 		})
 		framework.ExpectNoError(err)

--- a/test/e2e/network/network_tiers.go
+++ b/test/e2e/network/network_tiers.go
@@ -154,7 +154,6 @@ func waitAndVerifyLBWithTier(jig *e2eservice.TestJig, ns, svcName, existingIP st
 		// Verify that the new ingress IP is the requested IP if it's set.
 		framework.ExpectEqual(ingressIP, svc.Spec.LoadBalancerIP)
 	}
-	jig.SanityCheckService(svc, v1.ServiceTypeLoadBalancer)
 	// If the IP has been used by previous test, sometimes we get the lingering
 	// 404 errors even after the LB is long gone. Tolerate and retry until the
 	// the new LB is fully established since this feature is still Alpha in GCP.

--- a/test/e2e/upgrades/services.go
+++ b/test/e2e/upgrades/services.go
@@ -52,7 +52,6 @@ func (t *ServiceUpgradeTest) Setup(f *framework.Framework) {
 		s.Spec.Type = v1.ServiceTypeLoadBalancer
 	})
 	tcpService = jig.WaitForLoadBalancerOrFail(ns.Name, tcpService.Name, e2eservice.LoadBalancerCreateTimeoutDefault)
-	jig.SanityCheckService(tcpService, v1.ServiceTypeLoadBalancer)
 
 	// Get info to hit it with
 	tcpIngressIP := e2eservice.GetIngressPoint(&tcpService.Status.LoadBalancer.Ingress[0])
@@ -111,11 +110,9 @@ func (t *ServiceUpgradeTest) test(f *framework.Framework, done <-chan struct{}, 
 		<-done
 	}
 
-	// Sanity check and hit it once more
+	// Hit it once more
 	ginkgo.By("hitting the pod through the service's LoadBalancer")
 	e2eservice.TestReachableHTTP(t.tcpIngressIP, t.svcPort, e2eservice.LoadBalancerLagTimeoutDefault)
-	t.jig.SanityCheckService(t.tcpService, v1.ServiceTypeLoadBalancer)
-
 	if testFinalizer {
 		defer func() {
 			ginkgo.By("Check that service can be deleted with finalizer")

--- a/test/e2e/windows/service.go
+++ b/test/e2e/windows/service.go
@@ -44,20 +44,19 @@ var _ = SIGDescribe("Services", func() {
 
 		jig := e2eservice.NewTestJig(cs, serviceName)
 		nodeIP, err := e2enode.PickIP(jig.Client)
-		if err != nil {
-			framework.Logf("Unexpected error occurred: %v", err)
-		}
-		// TODO: write a wrapper for ExpectNoErrorWithOffset()
-		framework.ExpectNoErrorWithOffset(0, err)
+		framework.ExpectNoError(err)
 
 		ginkgo.By("creating service " + serviceName + " with type=NodePort in namespace " + ns)
-		e2eservice := jig.CreateTCPServiceOrFail(ns, func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(ns, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 		})
-		nodePort := int(e2eservice.Spec.Ports[0].NodePort)
+		framework.ExpectNoError(err)
+
+		nodePort := int(svc.Spec.Ports[0].NodePort)
 
 		ginkgo.By("creating Pod to be part of service " + serviceName)
-		jig.RunOrFail(ns, nil)
+		_, err = jig.Run(ns, nil)
+		framework.ExpectNoError(err)
 
 		//using hybrid_network methods
 		ginkgo.By("creating Windows testing Pod")

--- a/test/e2e/windows/service.go
+++ b/test/e2e/windows/service.go
@@ -42,12 +42,12 @@ var _ = SIGDescribe("Services", func() {
 		serviceName := "nodeport-test"
 		ns := f.Namespace.Name
 
-		jig := e2eservice.NewTestJig(cs, serviceName)
+		jig := e2eservice.NewTestJig(cs, ns, serviceName)
 		nodeIP, err := e2enode.PickIP(jig.Client)
 		framework.ExpectNoError(err)
 
 		ginkgo.By("creating service " + serviceName + " with type=NodePort in namespace " + ns)
-		svc, err := jig.CreateTCPService(ns, func(svc *v1.Service) {
+		svc, err := jig.CreateTCPService(func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 		})
 		framework.ExpectNoError(err)
@@ -55,7 +55,7 @@ var _ = SIGDescribe("Services", func() {
 		nodePort := int(svc.Spec.Ports[0].NodePort)
 
 		ginkgo.By("creating Pod to be part of service " + serviceName)
-		_, err = jig.Run(ns, nil)
+		_, err = jig.Run(nil)
 		framework.ExpectNoError(err)
 
 		//using hybrid_network methods

--- a/test/e2e/windows/service.go
+++ b/test/e2e/windows/service.go
@@ -54,7 +54,6 @@ var _ = SIGDescribe("Services", func() {
 		e2eservice := jig.CreateTCPServiceOrFail(ns, func(svc *v1.Service) {
 			svc.Spec.Type = v1.ServiceTypeNodePort
 		})
-		jig.SanityCheckService(e2eservice, v1.ServiceTypeNodePort)
 		nodePort := int(e2eservice.Spec.Ports[0].NodePort)
 
 		ginkgo.By("creating Pod to be part of service " + serviceName)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`e2eservice.TestJig` has a method `SanityCheckService` which is called in many places after creating or updating a service, and there's really no good reason to not just call it automatically from the end of the create/update methods instead.

(EDIT: additional cleanups were added beyond just this)

```release-note
NONE
```

/priority backlog