### PR TITLE
[WIP][migration phase 1]Added the predicates as filter plugins: PodFitsHostPort、PodFitsResour…

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -62,8 +62,12 @@ const (
 	GeneralPred = "GeneralPredicates"
 	// HostNamePred defines the name of predicate HostName.
 	HostNamePred = "HostName"
+	// PodFitsHostPred defines the name of predicate PodFitsHost.
+	PodFitsHostPred = "PodFitsHost"
 	// PodFitsHostPortsPred defines the name of predicate PodFitsHostPorts.
 	PodFitsHostPortsPred = "PodFitsHostPorts"
+	// PodMatchNodeSelectorPred defines the name of predicate PodMatchNodeSelector.
+	PodMatchNodeSelectorPred = "PodMatchNodeSelector"
 	// MatchNodeSelectorPred defines the name of predicate MatchNodeSelector.
 	MatchNodeSelectorPred = "MatchNodeSelector"
 	// PodFitsResourcesPred defines the name of predicate PodFitsResources.

--- a/pkg/scheduler/api/compatibility/compatibility_test.go
+++ b/pkg/scheduler/api/compatibility/compatibility_test.go
@@ -104,8 +104,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsHostPorts",
-				"PodFitsResources",
 				"NoDiskConflict",
 				"HostName",
 				"TestServiceAffinity",
@@ -118,6 +116,10 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"SelectorSpreadPriority",
 				"TestServiceAntiAffinity",
 				"TestLabelPreference",
+			),
+			wantFilterPlugins: sets.NewString(
+				"PodFitsHostPorts",
+				"PodFitsResources",
 			),
 		},
 
@@ -152,8 +154,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -172,6 +172,10 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"SelectorSpreadPriority",
 				"TestServiceAntiAffinity",
 				"TestLabelPreference",
+			),
+			wantFilterPlugins: sets.NewString(
+				"PodFitsHostPorts",
+				"PodFitsResources",
 			),
 		},
 
@@ -210,8 +214,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -220,7 +222,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxGCEPDVolumeCount",
 				"MaxAzureDiskVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
 			),
@@ -236,6 +237,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 		},
 
@@ -277,8 +281,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -288,7 +290,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxGCEPDVolumeCount",
 				"MaxAzureDiskVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
 			),
@@ -306,6 +307,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 		},
 		// Do not change this JSON after the corresponding release has been tagged.
@@ -356,8 +360,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -367,7 +369,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxGCEPDVolumeCount",
 				"MaxAzureDiskVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
 			),
@@ -385,6 +386,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -447,8 +451,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -459,7 +461,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxGCEPDVolumeCount",
 				"MaxAzureDiskVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
 			),
@@ -477,6 +478,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -540,8 +544,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -552,7 +554,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxGCEPDVolumeCount",
 				"MaxAzureDiskVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"CheckVolumeBinding",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
@@ -571,6 +572,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -638,8 +642,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -651,7 +653,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxGCEPDVolumeCount",
 				"MaxAzureDiskVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"CheckVolumeBinding",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
@@ -670,6 +671,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -749,8 +753,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -762,7 +764,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxGCEPDVolumeCount",
 				"MaxAzureDiskVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"CheckVolumeBinding",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
@@ -782,6 +783,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -862,8 +866,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -876,7 +878,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxAzureDiskVolumeCount",
 				"MaxCSIVolumeCountPred",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"CheckVolumeBinding",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
@@ -896,6 +897,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -975,8 +978,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -990,7 +991,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxCSIVolumeCountPred",
 				"MaxCinderVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"CheckVolumeBinding",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
@@ -1010,6 +1010,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -1093,8 +1096,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 		}`,
 			wantPredicates: sets.NewString(
 				"MatchNodeSelector",
-				"PodFitsResources",
-				"PodFitsHostPorts",
 				"HostName",
 				"NoDiskConflict",
 				"NoVolumeZoneConflict",
@@ -1108,7 +1109,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"MaxCSIVolumeCountPred",
 				"MaxCinderVolumeCount",
 				"MatchInterPodAffinity",
-				"GeneralPredicates",
 				"CheckVolumeBinding",
 				"TestServiceAffinity",
 				"TestLabelsPresence",
@@ -1128,6 +1128,9 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantFilterPlugins: sets.NewString(
 				"TaintToleration",
+				"PodFitsResources",
+				"PodFitsHostPorts",
+				"General",
 			),
 			wantExtenders: []schedulerapi.ExtenderConfig{{
 				URLPrefix:        "/prefix",
@@ -1150,7 +1153,10 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 	seenPriorities := sets.NewString()
 	mandatoryPredicates := sets.NewString("CheckNodeCondition")
 	filterToPredicateMap := map[string]string{
-		"TaintToleration": "PodToleratesNodeTaints",
+		"TaintToleration":  "PodToleratesNodeTaints",
+		"PodFitsResources": "PodFitsResources",
+		"PodFitsHostPorts": "PodFitsHostPorts",
+		"General":          "GeneralPredicates",
 	}
 
 	for v, tc := range schedulerFiles {

--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -8,6 +8,9 @@ go_library(
     deps = [
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
+        "//pkg/scheduler/framework/plugins/general:go_default_library",
+        "//pkg/scheduler/framework/plugins/podfitshostports:go_default_library",
+        "//pkg/scheduler/framework/plugins/podfitsresources:go_default_library",
         "//pkg/scheduler/framework/plugins/tainttoleration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
     ],
@@ -25,8 +28,13 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/scheduler/framework/plugins/examples:all-srcs",
+        "//pkg/scheduler/framework/plugins/general:all-srcs",
         "//pkg/scheduler/framework/plugins/migration:all-srcs",
         "//pkg/scheduler/framework/plugins/noop:all-srcs",
+        "//pkg/scheduler/framework/plugins/podfitshost:all-srcs",
+        "//pkg/scheduler/framework/plugins/podfitshostports:all-srcs",
+        "//pkg/scheduler/framework/plugins/podfitsresources:all-srcs",
+        "//pkg/scheduler/framework/plugins/podmatchnnodeselector:all-srcs",
         "//pkg/scheduler/framework/plugins/tainttoleration:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/scheduler/framework/plugins/default_registry.go
+++ b/pkg/scheduler/framework/plugins/default_registry.go
@@ -21,6 +21,9 @@ import (
 
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/general"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podfitshostports"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/podfitsresources"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
@@ -30,7 +33,10 @@ import (
 // runs custom plugins, can pass a different Registry when initializing the scheduler.
 func NewDefaultRegistry() framework.Registry {
 	return framework.Registry{
-		tainttoleration.Name: tainttoleration.New,
+		tainttoleration.Name:  tainttoleration.New,
+		podfitshostports.Name: podfitshostports.New,
+		podfitsresources.Name: podfitsresources.New,
+		general.Name:          general.New,
 	}
 }
 
@@ -61,6 +67,21 @@ func NewDefaultConfigProducerRegistry() *ConfigProducerRegistry {
 	registry.RegisterPredicate(predicates.PodToleratesNodeTaintsPred,
 		func(_ ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
 			plugins.Filter = appendToPluginSet(plugins.Filter, tainttoleration.Name, nil)
+			return
+		})
+	registry.RegisterPredicate(predicates.PodFitsHostPortsPred,
+		func(_ ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
+			plugins.Filter = appendToPluginSet(plugins.Filter, podfitshostports.Name, nil)
+			return
+		})
+	registry.RegisterPredicate(predicates.PodFitsResourcesPred,
+		func(_ ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
+			plugins.Filter = appendToPluginSet(plugins.Filter, podfitsresources.Name, nil)
+			return
+		})
+	registry.RegisterPredicate(predicates.GeneralPred,
+		func(_ ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
+			plugins.Filter = appendToPluginSet(plugins.Filter, general.Name, nil)
 			return
 		})
 

--- a/pkg/scheduler/framework/plugins/general/BUILD
+++ b/pkg/scheduler/framework/plugins/general/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["general.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/general",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/plugins/migration:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/nodeinfo:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/plugins/general/general.go
+++ b/pkg/scheduler/framework/plugins/general/general.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package general
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// General is a plugin that checks if a pod tolerates a node's taints.
+type General struct{}
+
+var _ = framework.FilterPlugin(&General{})
+
+// Name is the name of the plugin used in the plugin registry and configurations.
+const Name = "General"
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *General) Name() string {
+	return Name
+}
+
+// Filter invoked at the filter extension point.
+func (pl *General) Filter(_ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
+	_, reasons, err := predicates.GeneralPredicates(pod, nil, nodeInfo)
+	return migration.PredicateResultToFrameworkStatus(reasons, err)
+}
+
+// New initializes a new plugin and returns it.
+func New(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
+	return &General{}, nil
+}

--- a/pkg/scheduler/framework/plugins/podfitshost/BUILD
+++ b/pkg/scheduler/framework/plugins/podfitshost/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["podfitshost.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/podfitshost",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/plugins/migration:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/nodeinfo:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/plugins/podfitshost/podfitshost.go
+++ b/pkg/scheduler/framework/plugins/podfitshost/podfitshost.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podfitshost
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodFitsHost is a plugin that checks if a pod tolerates a node's taints.
+type PodFitsHost struct{}
+
+var _ = framework.FilterPlugin(&PodFitsHost{})
+
+// Name is the name of the plugin used in the plugin registry and configurations.
+const Name = "PodFitsHost"
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *PodFitsHost) Name() string {
+	return Name
+}
+
+// Filter invoked at the filter extension point.
+func (pl *PodFitsHost) Filter(_ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
+	_, reasons, err := predicates.PodFitsHost(pod, nil, nodeInfo)
+	return migration.PredicateResultToFrameworkStatus(reasons, err)
+}
+
+// New initializes a new plugin and returns it.
+func New(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
+	return &PodFitsHost{}, nil
+}

--- a/pkg/scheduler/framework/plugins/podfitshostports/BUILD
+++ b/pkg/scheduler/framework/plugins/podfitshostports/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["podfitshostports.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/podfitshostports",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/plugins/migration:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/nodeinfo:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/plugins/podfitshostports/podfitshostports.go
+++ b/pkg/scheduler/framework/plugins/podfitshostports/podfitshostports.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podfitshostports
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodFitsHost is a plugin that checks if a pod tolerates a node's taints.
+type PodFitsHostPorts struct{}
+
+var _ = framework.FilterPlugin(&PodFitsHostPorts{})
+
+// Name is the name of the plugin used in the plugin registry and configurations.
+const Name = "PodFitsHostPorts"
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *PodFitsHostPorts) Name() string {
+	return Name
+}
+
+// Filter invoked at the filter extension point.
+func (pl *PodFitsHostPorts) Filter(_ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
+	_, reasons, err := predicates.PodFitsHostPorts(pod, nil, nodeInfo)
+	return migration.PredicateResultToFrameworkStatus(reasons, err)
+}
+
+// New initializes a new plugin and returns it.
+func New(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
+	return &PodFitsHostPorts{}, nil
+}

--- a/pkg/scheduler/framework/plugins/podfitsresources/BUILD
+++ b/pkg/scheduler/framework/plugins/podfitsresources/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["podfitsresources.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/podfitsresources",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/plugins/migration:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/nodeinfo:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/plugins/podfitsresources/podfitsresources.go
+++ b/pkg/scheduler/framework/plugins/podfitsresources/podfitsresources.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podfitsresources
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodFitsResources is a plugin that checks if a pod tolerates a node's taints.
+type PodFitsResources struct{}
+
+var _ = framework.FilterPlugin(&PodFitsResources{})
+
+// Name is the name of the plugin used in the plugin registry and configurations.
+const Name = "PodFitsResources"
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *PodFitsResources) Name() string {
+	return Name
+}
+
+// Filter invoked at the filter extension point.
+func (pl *PodFitsResources) Filter(_ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
+	_, reasons, err := predicates.PodFitsResources(pod, nil, nodeInfo)
+	return migration.PredicateResultToFrameworkStatus(reasons, err)
+}
+
+// New initializes a new plugin and returns it.
+func New(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
+	return &PodFitsResources{}, nil
+}

--- a/pkg/scheduler/framework/plugins/podmatchnnodeselector/BUILD
+++ b/pkg/scheduler/framework/plugins/podmatchnnodeselector/BUILD
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["podmatchnnodeselector.go"],
+    importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/podmatchnnodeselector",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/scheduler/algorithm/predicates:go_default_library",
+        "//pkg/scheduler/framework/plugins/migration:go_default_library",
+        "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/nodeinfo:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/scheduler/framework/plugins/podmatchnnodeselector/podmatchnnodeselector.go
+++ b/pkg/scheduler/framework/plugins/podmatchnnodeselector/podmatchnnodeselector.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package podmatchnnodeselector
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
+	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+// PodMatchNodeSelector is a plugin that checks if a pod tolerates a node's taints.
+type PodMatchNodeSelector struct{}
+
+var _ = framework.FilterPlugin(&PodMatchNodeSelector{})
+
+// Name is the name of the plugin used in the plugin registry and configurations.
+const Name = "PodMatchNodeSelector"
+
+// Name returns name of the plugin. It is used in logs, etc.
+func (pl *PodMatchNodeSelector) Name() string {
+	return Name
+}
+
+// Filter invoked at the filter extension point.
+func (pl *PodMatchNodeSelector) Filter(_ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
+	_, reasons, err := predicates.PodMatchNodeSelector(pod, nil, nodeInfo)
+	return migration.PredicateResultToFrameworkStatus(reasons, err)
+}
+
+// New initializes a new plugin and returns it.
+func New(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
+	return &PodMatchNodeSelector{}, nil
+}


### PR DESCRIPTION
…ces、PodFitsHost 、PodMatchNodeSelector and GeneralPred

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake


**What this PR does / why we need it**:

Part of #83554

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #



**Special notes for your reviewer**:
/sig scheduling
/assign @ahg-g 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
[migration phase 1]Added the predicates as filter plugins: PodFitsHostPort、PodFitsResources、PodFitsHost 、PodMatchNodeSelector and GeneralPred.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
