### PR TITLE
Plumbing for dynamic apiserver serving certificates

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -233,9 +233,10 @@ type SecureServingInfo struct {
 
 	// Cert is the main server cert which is used if SNI does not match. Cert must be non-nil and is
 	// allowed to be in SNICerts.
-	Cert *tls.Certificate
+	Cert dynamiccertificates.CertKeyContentProvider
 
 	// SNICerts are the TLS certificates by name used for SNI.
+	// todo: use dynamic certificates
 	SNICerts map[string]*tls.Certificate
 
 	// ClientCA is the certificate bundle for all the signers that you'll recognize for incoming client certificates

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "cert_key.go",
         "client_ca.go",
         "static_content.go",
         "tlsconfig.go",
@@ -40,6 +41,7 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cert_key_test.go",
         "client_ca_test.go",
         "tlsconfig_test.go",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_key.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_key.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiccertificates
+
+import (
+	"bytes"
+)
+
+// CertKeyContentProvider provides a certificate and matching private key
+type CertKeyContentProvider interface {
+	// Name is just an identifier
+	Name() string
+	// CurrentCertKeyContent provides cert and key byte content
+	CurrentCertKeyContent() ([]byte, []byte)
+}
+
+// caBundleContent holds the content for the cert and key
+type certKeyContent struct {
+	cert []byte
+	key  []byte
+}
+
+func (c *certKeyContent) Equal(rhs *certKeyContent) bool {
+	if c == nil || rhs == nil {
+		return c == rhs
+	}
+
+	return bytes.Equal(c.key, rhs.key) && bytes.Equal(c.cert, rhs.cert)
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_key_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/cert_key_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dynamiccertificates
+
+import "testing"
+
+func TestCertKeyContentEquals(t *testing.T) {
+	tests := []struct {
+		name     string
+		lhs      *certKeyContent
+		rhs      *certKeyContent
+		expected bool
+	}{
+		{
+			name:     "both nil",
+			expected: true,
+		},
+		{
+			name:     "lhs nil",
+			rhs:      &certKeyContent{},
+			expected: false,
+		},
+		{
+			name:     "rhs nil",
+			lhs:      &certKeyContent{},
+			expected: false,
+		},
+		{
+			name:     "same",
+			lhs:      &certKeyContent{cert: []byte("foo"), key: []byte("baz")},
+			rhs:      &certKeyContent{cert: []byte("foo"), key: []byte("baz")},
+			expected: true,
+		},
+		{
+			name:     "different cert",
+			lhs:      &certKeyContent{cert: []byte("foo"), key: []byte("baz")},
+			rhs:      &certKeyContent{cert: []byte("bar"), key: []byte("baz")},
+			expected: false,
+		},
+		{
+			name:     "different key",
+			lhs:      &certKeyContent{cert: []byte("foo"), key: []byte("baz")},
+			rhs:      &certKeyContent{cert: []byte("foo"), key: []byte("qux")},
+			expected: false,
+		},
+		{
+			name:     "different cert and key",
+			lhs:      &certKeyContent{cert: []byte("foo"), key: []byte("baz")},
+			rhs:      &certKeyContent{cert: []byte("bar"), key: []byte("qux")},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.lhs.Equal(test.rhs)
+			if actual != test.expected {
+				t.Error(actual)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/client_ca.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/client_ca.go
@@ -30,10 +30,10 @@ type CAContentProvider interface {
 }
 
 // dynamicCertificateContent holds the content that overrides the baseTLSConfig
-// TODO add the serving certs to this struct
 type dynamicCertificateContent struct {
 	// clientCA holds the content for the clientCA bundle
-	clientCA caBundleContent
+	clientCA    caBundleContent
+	servingCert certKeyContent
 }
 
 // caBundleContent holds the content for the clientCA bundle.  Wrapping the bytes makes the Equals work nicely with the
@@ -48,6 +48,10 @@ func (c *dynamicCertificateContent) Equal(rhs *dynamicCertificateContent) bool {
 	}
 
 	if !c.clientCA.Equal(&rhs.clientCA) {
+		return false
+	}
+
+	if !c.servingCert.Equal(&rhs.servingCert) {
 		return false
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/client_ca_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/client_ca_test.go
@@ -59,6 +59,42 @@ func TestDynamicCertificateContentEquals(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name: "same with serving",
+			lhs: &dynamicCertificateContent{
+				clientCA:    caBundleContent{caBundle: []byte("foo")},
+				servingCert: certKeyContent{cert: []byte("foo"), key: []byte("foo")},
+			},
+			rhs: &dynamicCertificateContent{
+				clientCA:    caBundleContent{caBundle: []byte("foo")},
+				servingCert: certKeyContent{cert: []byte("foo"), key: []byte("foo")},
+			},
+			expected: true,
+		},
+		{
+			name: "different serving cert",
+			lhs: &dynamicCertificateContent{
+				clientCA:    caBundleContent{caBundle: []byte("foo")},
+				servingCert: certKeyContent{cert: []byte("foo"), key: []byte("foo")},
+			},
+			rhs: &dynamicCertificateContent{
+				clientCA:    caBundleContent{caBundle: []byte("foo")},
+				servingCert: certKeyContent{cert: []byte("bar"), key: []byte("foo")},
+			},
+			expected: false,
+		},
+		{
+			name: "different serving key",
+			lhs: &dynamicCertificateContent{
+				clientCA:    caBundleContent{caBundle: []byte("foo")},
+				servingCert: certKeyContent{cert: []byte("foo"), key: []byte("foo")},
+			},
+			rhs: &dynamicCertificateContent{
+				clientCA:    caBundleContent{caBundle: []byte("foo")},
+				servingCert: certKeyContent{cert: []byte("foo"), key: []byte("bar")},
+			},
+			expected: false,
+		},
 	}
 
 	for _, test := range tests {

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/static_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/static_content.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dynamiccertificates
 
 import (
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 )
@@ -55,4 +56,56 @@ func (c *staticCAContent) Name() string {
 // CurrentCABundleContent provides ca bundle byte content
 func (c *staticCAContent) CurrentCABundleContent() (cabundle []byte) {
 	return c.caBundle
+}
+
+type staticCertKeyContent struct {
+	name string
+	cert []byte
+	key  []byte
+}
+
+// NewStaticCertKeyContentFromFiles returns a CertKeyContentProvider based on a filename
+func NewStaticCertKeyContentFromFiles(certFile, keyFile string) (CertKeyContentProvider, error) {
+	if len(certFile) == 0 {
+		return nil, fmt.Errorf("missing filename for certificate")
+	}
+	if len(keyFile) == 0 {
+		return nil, fmt.Errorf("missing filename for key")
+	}
+
+	certPEMBlock, err := ioutil.ReadFile(certFile)
+	if err != nil {
+		return nil, err
+	}
+	keyPEMBlock, err := ioutil.ReadFile(keyFile)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewStaticCertKeyContent(fmt.Sprintf("cert: %s, key: %s", certFile, keyFile), certPEMBlock, keyPEMBlock)
+}
+
+// NewStaticCertKeyContent returns a CertKeyContentProvider that always returns the same value
+func NewStaticCertKeyContent(name string, cert, key []byte) (CertKeyContentProvider, error) {
+	// Ensure that the key matches the cert and both are valid
+	_, err := tls.X509KeyPair(cert, key)
+	if err != nil {
+		return nil, err
+	}
+
+	return &staticCertKeyContent{
+		name: name,
+		cert: cert,
+		key:  key,
+	}, nil
+}
+
+// Name is just an identifier
+func (c *staticCertKeyContent) Name() string {
+	return c.name
+}
+
+// CurrentCertKeyContent provides cert and key content
+func (c *staticCertKeyContent) CurrentCertKeyContent() ([]byte, []byte) {
+	return c.cert, c.key
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig_test.go
@@ -23,19 +23,76 @@ import (
 	"github.com/davecgh/go-spew/spew"
 )
 
+var serverKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA13f50PPWuR/InxLIoJjHdNSG+jVUd25CY7ZL2J023X2BAY+1
+M6jkLR6C2nSFZnn58ubiB74/d1g/Fg1Twd419iR615A013f+qOoyFx3LFHxU1S6e
+v22fgJ6ntK/+4QD5MwNgOwD8k1jN2WxHqNWn16IF4Tidbv8M9A35YHAdtYDYaOJC
+kzjVztzRw1y6bKRakpMXxHylQyWmAKDJ2GSbRTbGtjr7Ji54WBfG43k94tO5X8K4
+VGbz/uxrKe1IFMHNOlrjR438dbOXusksx9EIqDA9a42J3qjr5NKSqzCIbgBFl6qu
+45V3A7cdRI/sJ2G1aqlWIXh2fAQiaFQAEBrPfwIDAQABAoIBAAZbxgWCjJ2d8H+x
+QDZtC8XI18redAWqPU9P++ECkrHqmDoBkalanJEwS1BDDATAKL4gTh9IX/sXoZT3
+A7e+5PzEitN9r/GD2wIFF0FTYcDTAnXgEFM52vEivXQ5lV3yd2gn+1kCaHG4typp
+ZZv34iIc5+uDjjHOWQWCvA86f8XxX5EfYH+GkjfixTtN2xhWWlfi9vzYeESS4Jbt
+tqfH0iEaZ1Bm/qvb8vFgKiuSTOoSpaf+ojAdtPtXDjf1bBtQQG+RSQkP59O/taLM
+FCVuRrU8EtdB0+9anwmAP+O2UqjL5izA578lQtdIh13jHtGEgOcnfGNUphK11y9r
+Mg5V28ECgYEA9fwI6Xy1Rb9b9irp4bU5Ec99QXa4x2bxld5cDdNOZWJQu9OnaIbg
+kw/1SyUkZZCGMmibM/BiWGKWoDf8E+rn/ujGOtd70sR9U0A94XMPqEv7iHxhpZmD
+rZuSz4/snYbOWCZQYXFoD/nqOwE7Atnz7yh+Jti0qxBQ9bmkb9o0QW8CgYEA4D3d
+okzodg5QQ1y9L0J6jIC6YysoDedveYZMd4Un9bKlZEJev4OwiT4xXmSGBYq/7dzo
+OJOvN6qgPfibr27mSB8NkAk6jL/VdJf3thWxNYmjF4E3paLJ24X31aSipN1Ta6K3
+KKQUQRvixVoI1q+8WHAubBDEqvFnNYRHD+AjKvECgYBkekjhpvEcxme4DBtw+OeQ
+4OJXJTmhKemwwB12AERboWc88d3GEqIVMEWQJmHRotFOMfCDrMNfOxYv5+5t7FxL
+gaXHT1Hi7CQNJ4afWrKgmjjqrXPtguGIvq2fXzjVt8T9uNjIlNxe+kS1SXFjXsgH
+ftDY6VgTMB0B4ozKq6UAvQKBgQDER8K5buJHe+3rmMCMHn+Qfpkndr4ftYXQ9Kn4
+MFiy6sV0hdfTgRzEdOjXu9vH/BRVy3iFFVhYvIR42iTEIal2VaAUhM94Je5cmSyd
+eE1eFHTqfRPNazmPaqttmSc4cfa0D4CNFVoZR6RupIl6Cect7jvkIaVUD+wMXxWo
+osOFsQKBgDLwVhZWoQ13RV/jfQxS3veBUnHJwQJ7gKlL1XZ16mpfEOOVnJF7Es8j
+TIIXXYhgSy/XshUbsgXQ+YGliye/rXSCTXHBXvWShOqxEMgeMYMRkcm8ZLp/DH7C
+kC2pemkLPUJqgSh1PASGcJbDJIvFGUfP69tUCYpHpk3nHzexuAg3
+-----END RSA PRIVATE KEY-----`)
+
+var serverCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIDQDCCAiigAwIBAgIJANWw74P5KJk2MA0GCSqGSIb3DQEBCwUAMDQxMjAwBgNV
+BAMMKWdlbmVyaWNfd2ViaG9va19hZG1pc3Npb25fcGx1Z2luX3Rlc3RzX2NhMCAX
+DTE3MTExNjAwMDUzOVoYDzIyOTEwOTAxMDAwNTM5WjAjMSEwHwYDVQQDExh3ZWJo
+b29rLXRlc3QuZGVmYXVsdC5zdmMwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQDXd/nQ89a5H8ifEsigmMd01Ib6NVR3bkJjtkvYnTbdfYEBj7UzqOQtHoLa
+dIVmefny5uIHvj93WD8WDVPB3jX2JHrXkDTXd/6o6jIXHcsUfFTVLp6/bZ+Anqe0
+r/7hAPkzA2A7APyTWM3ZbEeo1afXogXhOJ1u/wz0DflgcB21gNho4kKTONXO3NHD
+XLpspFqSkxfEfKVDJaYAoMnYZJtFNsa2OvsmLnhYF8bjeT3i07lfwrhUZvP+7Gsp
+7UgUwc06WuNHjfx1s5e6ySzH0QioMD1rjYneqOvk0pKrMIhuAEWXqq7jlXcDtx1E
+j+wnYbVqqVYheHZ8BCJoVAAQGs9/AgMBAAGjZDBiMAkGA1UdEwQCMAAwCwYDVR0P
+BAQDAgXgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATApBgNVHREEIjAg
+hwR/AAABghh3ZWJob29rLXRlc3QuZGVmYXVsdC5zdmMwDQYJKoZIhvcNAQELBQAD
+ggEBAD/GKSPNyQuAOw/jsYZesb+RMedbkzs18sSwlxAJQMUrrXwlVdHrA8q5WhE6
+ABLqU1b8lQ8AWun07R8k5tqTmNvCARrAPRUqls/ryER+3Y9YEcxEaTc3jKNZFLbc
+T6YtcnkdhxsiO136wtiuatpYL91RgCmuSpR8+7jEHhuFU01iaASu7ypFrUzrKHTF
+bKwiLRQi1cMzVcLErq5CDEKiKhUkoDucyARFszrGt9vNIl/YCcBOkcNvM3c05Hn3
+M++C29JwS3Hwbubg6WO3wjFjoEhpCwU6qRYUz3MRp4tHO4kxKXx+oQnUiFnR7vW0
+YkNtGc1RUDHwecCTFpJtPb7Yu/E=
+-----END CERTIFICATE-----`)
+
 func TestNewTLSContent(t *testing.T) {
+	testCertProvider, err := NewStaticCertKeyContent("test-cert", serverCert, serverKey)
+	if err != nil {
+		t.Error(err)
+	}
+
 	tests := []struct {
-		name     string
-		clientCA CAContentProvider
+		name        string
+		clientCA    CAContentProvider
+		servingCert CertKeyContentProvider
 
 		expected    *dynamicCertificateContent
 		expectedErr string
 	}{
 		{
-			name:     "filled",
-			clientCA: NewStaticCAContent("test-ca", []byte("content-1")),
+			name:        "filled",
+			clientCA:    NewStaticCAContent("test-ca", []byte("content-1")),
+			servingCert: testCertProvider,
 			expected: &dynamicCertificateContent{
-				clientCA: caBundleContent{caBundle: []byte("content-1")},
+				clientCA:    caBundleContent{caBundle: []byte("content-1")},
+				servingCert: certKeyContent{cert: serverCert, key: serverKey},
 			},
 		},
 		{
@@ -44,12 +101,17 @@ func TestNewTLSContent(t *testing.T) {
 			expected:    nil,
 			expectedErr: `not loading an empty client ca bundle from "test-ca"`,
 		},
+		{
+			name:     "nil",
+			expected: &dynamicCertificateContent{clientCA: caBundleContent{}, servingCert: certKeyContent{}},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := &DynamicServingCertificateController{
-				clientCA: test.clientCA,
+				clientCA:    test.clientCA,
+				servingCert: test.servingCert,
 			}
 			actual, err := c.newTLSContent()
 			if !reflect.DeepEqual(actual, test.expected) {

--- a/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/BUILD
@@ -59,6 +59,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/egressselector:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR is initial plumbing towards allowing apiserver default (non-SNI) serving certificates to be reloaded from disk. We change the Cert field in the `SecureServingInfo` to be a `DynamicCertKeyContentProvider`, which currently is implemented by a static provider that doesn't re-read off of disk, but this can change in a subsequent PR which will add a dynamic provider.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```