### PR TITLE
Don't include apiserver's health-checking for KMS providers in /livez.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -211,6 +211,12 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 		if err != nil {
 			return err
 		}
+		// We explicitly don't use AddHealthChecks here, because we don't want
+		// to add to /livez. An unhealthy KMS provider is not likely to be
+		// fixed by an apiserver restart, so it should not mark the apiserver
+		// unhealthy, only unready. (We still add to /healthz, because when
+		// using /healthz it is up to the caller to distinguish between
+		// liveness and readiness checks by using ?exclude.)
 		c.HealthzChecks = append(c.ReadyzChecks, kmsPluginHealthzChecks...)
 		c.ReadyzChecks = append(c.ReadyzChecks, kmsPluginHealthzChecks...)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/etcd.go
@@ -211,7 +211,8 @@ func (s *EtcdOptions) addEtcdHealthEndpoint(c *server.Config) error {
 		if err != nil {
 			return err
 		}
-		c.AddHealthChecks(kmsPluginHealthzChecks...)
+		c.HealthzChecks = append(c.ReadyzChecks, kmsPluginHealthzChecks...)
+		c.ReadyzChecks = append(c.ReadyzChecks, kmsPluginHealthzChecks...)
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
A KMS provider becoming unavailable is highly unlikely to be fixed by                                                                                                                                                                        
restarting apiserver, so it makes more sense for a failure of this check to                                                                                                                                                                  
only mark the apiserver as unready, not unhealthy.                                                                                                                                                                                           
                                                                                                                                                                                                                                             
Since the /healthz system does not allow for easy differentiation between                                                                                                                                                                    
liveness and readiness checks, we still include the KMS provider health checks                                                                                                                                                               
on /healthz as well; it is up to users to exclude the relevant KMS provider                                                                                                                                                                  
checks from liveness checks with /healthz?exclude= (as is done for GCE in                                                                                                                                                                    
PR #82840).                                                                                                                                                                                                                                  

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
KMS plugin health-checks will no longer mark the apiserver as unhealthy upon failure, only unready.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
