### PR TITLE
Check whether releasing IP is successful

### DIFF
--- a/pkg/registry/core/service/ipallocator/controller/repair.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair.go
@@ -230,7 +230,9 @@ func (c *Repair) runOnce() error {
 			actualStored := c.selectAllocForIP(ip, stored, secondaryStored)
 			if actualStored.Has(ip) {
 				// remove it from the old set, so we can find leaks
-				actualStored.Release(ip)
+				if releaseErr := actualStored.Release(ip); releaseErr != nil {
+					runtime.HandleError(fmt.Errorf("releasing %v encountered %v", ip, releaseErr))
+				}
 			} else {
 				// cluster IP doesn't seem to be allocated
 				c.recorder.Eventf(&svc, v1.EventTypeWarning, "ClusterIPNotAllocated", "Cluster IP %s is not allocated; repairing", ip)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently when Repair#runOnce encounters error releasing ip (around line 233), the error is ignored.

This PR adds runtime.HandleError call for the error when error is not nil.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
