### PR TITLE
Log error from AddIndexers in NewAttachDetachController

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller.go
@@ -203,9 +203,12 @@ func NewAttachDetachController(
 
 	// This custom indexer will index pods by its PVC keys. Then we don't need
 	// to iterate all pods every time to find pods which reference given PVC.
-	adc.podIndexer.AddIndexers(kcache.Indexers{
+	err := adc.podIndexer.AddIndexers(kcache.Indexers{
 		pvcKeyIndex: indexByPVCKey,
 	})
+	if err != nil {
+		klog.Warningf("adding indexer got %v", err)
+	}
 
 	nodeInformer.Informer().AddEventHandler(kcache.ResourceEventHandlerFuncs{
 		AddFunc:    adc.nodeAdd,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When AddIndexers encounters error for indexer addition, we should log the error.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
