### PR TITLE
Automated cherry pick of #83570: Mark startupProbe test as NodeAlphaFeature and fix podClient

### DIFF
--- a/test/e2e_node/startup_probe_test.go
+++ b/test/e2e_node/startup_probe_test.go
@@ -38,9 +38,12 @@ const (
 	defaultObservationTimeout = time.Minute * 4
 )
 
-var _ = framework.KubeDescribe("StartupProbe [Serial] [Disruptive] [NodeFeature:StartupProbe]", func() {
-	f := framework.NewDefaultFramework("critical-pod-test")
+var _ = framework.KubeDescribe("StartupProbe [Serial] [Disruptive] [NodeAlphaFeature:StartupProbe]", func() {
+	f := framework.NewDefaultFramework("startup-probe-test")
 	var podClient *framework.PodClient
+	ginkgo.BeforeEach(func() {
+		podClient = f.PodClient()
+	})
 
 	/*
 		These tests are located here as they require tempSetCurrentKubeletConfig to enable the feature gate for startupProbe.


### PR DESCRIPTION
Cherry pick of #83570 on release-1.16.

#83570: Mark startupProbe test as NodeAlphaFeature and fix podClient

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```