### PR TITLE
Refactor scheduler metric test with testutils

### DIFF
--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -43,7 +43,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -253,6 +253,11 @@ func Register() {
 	})
 }
 
+// GetGather returns the gatherer. It used by test case outside current package.
+func GetGather() metrics.Gatherer {
+	return legacyregistry.DefaultGatherer
+}
+
 // ActivePods returns the pending pods metrics with the label active
 func ActivePods() metrics.GaugeMetric {
 	return pendingPods.With(metrics.Labels{"queue": "active"})

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1668,6 +1668,7 @@ k8s.io/component-base/metrics/prometheus/clientgo/leaderelection
 k8s.io/component-base/metrics/prometheus/restclient
 k8s.io/component-base/metrics/prometheus/version
 k8s.io/component-base/metrics/prometheus/workqueue
+k8s.io/component-base/metrics/testutil
 k8s.io/component-base/version
 k8s.io/component-base/version/verflag
 # k8s.io/cri-api v0.0.0 => ./staging/src/k8s.io/cri-api


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Refactor UT with `staging/src/k8s.io/component-base/metrics/testutil` and remove direct reference to Prometheus.

To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**Which issue(s) this PR fixes**:
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:
After a [short discussion](https://github.com/kubernetes/kubernetes/pull/83220) with @Huang-Wei, we introduced a [testutil](https://github.com/kubernetes/kubernetes/pull/83299).

It will make the test case more readable.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/assign @Huang-Wei 