### PR TITLE
WIP: Kick pull-kubernetes-e2e-gce-storage-slow

### DIFF
--- a/test/e2e/storage/flexvolume_mounted_volume_resize.go
+++ b/test/e2e/storage/flexvolume_mounted_volume_resize.go
@@ -37,10 +37,8 @@ import (
 	"k8s.io/kubernetes/test/e2e/storage/utils"
 )
 
-const (
-	// total time to wait for cloudprovider or file system resize to finish
-	totalResizeWaitPeriod = 5 * time.Minute
-)
+// total time to wait for cloudprovider or file system resize to finish
+const totalResizeWaitPeriod = 5 * time.Minute
 
 var _ = utils.SIGDescribe("Mounted flexvolume expand[Slow]", func() {
 	var (


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test
/kind flake

**What this PR does / why we need it**:

This PR is just for kicking pull-kubernetes-e2e-gce-storage-slow job at the CI to know
the job is super flaky or not today.
The change of `test/e2e/storage` can kick it according to https://github.com/kubernetes/test-infra/blob/master/config/jobs/kubernetes/sig-storage/sig-storage-gce-config.yaml#L15

This comes from https://github.com/kubernetes/kubernetes/pull/83480

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
