### PR TITLE
Cache the OpenAPI schema in the memory-cached discovery client

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -50,6 +50,7 @@ type memCacheClient struct {
 	lock                   sync.RWMutex
 	groupToServerResources map[string]*cacheEntry
 	groupList              *metav1.APIGroupList
+	schema                 *openapi_v2.Document
 	cacheValid             bool
 }
 
@@ -156,7 +157,18 @@ func (d *memCacheClient) ServerVersion() (*version.Info, error) {
 }
 
 func (d *memCacheClient) OpenAPISchema() (*openapi_v2.Document, error) {
-	return d.delegate.OpenAPISchema()
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if d.schema == nil {
+		sch, err := d.delegate.OpenAPISchema()
+		if err != nil {
+			return nil, err
+		}
+		d.schema = sch
+	}
+
+	return d.schema, nil
 }
 
 func (d *memCacheClient) Fresh() bool {
@@ -176,6 +188,7 @@ func (d *memCacheClient) Invalidate() {
 	d.cacheValid = false
 	d.groupToServerResources = nil
 	d.groupList = nil
+	d.schema = nil
 }
 
 // refreshLocked refreshes the state of cache. The caller must hold d.lock for


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
For the memory-cached discovery client, cache the OpenAPI schema in the OpenAPISchema method rather than re-fetching it on every call to this method.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #83639

**Special notes for your reviewer**:
We're using this change in a forked version of this file in [another project](https://github.com/pulumi/pulumi-kubernetes/pull/833)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
