### PR TITLE
increase auth cache size

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
@@ -62,7 +62,14 @@ func newWithClock(authenticator authenticator.Token, cacheErrs bool, successTTL,
 		cacheErrs:     cacheErrs,
 		successTTL:    successTTL,
 		failureTTL:    failureTTL,
-		cache:         newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(128, clock) }),
+		// Cache performance degrades noticeably when the number of
+		// tokens in operation exceeds the size of the cache. It is
+		// cheap to make the cache big in the second dimension below,
+		// the memory is only consumed when that many tokens are being
+		// used. Currently we advertise support 5k nodes and 10k
+		// namespaces; a 32k entry cache is therefore a 2x safety
+		// margin.
+		cache: newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(1024, clock) }),
 	}
 }
 


### PR DESCRIPTION
The benchmark in https://github.com/kubernetes/kubernetes/pull/83519 demonstrates that cache performance gets drastically worse when the number of tokens exceeds the size of the cache.

We advertise 5k nodes and 10k namespaces, it's reasonable to assume each node has a token and each namespace has a service account, which has a token.

This PR makes the cache accept 32k tokens. (It was 4k.)

```release-note
Authentication token cache size is increased (from 4k to 32k) to support clusters with many nodes or many namespaces with active service accounts.
```

/kind bug
/priority important-soon