### PR TITLE
StatefulSetStatus CurrentRevision should update with OnDelete update strategy

### DIFF
--- a/pkg/controller/statefulset/stateful_set_utils.go
+++ b/pkg/controller/statefulset/stateful_set_utils.go
@@ -374,7 +374,8 @@ func inconsistentStatus(set *apps.StatefulSet, status *apps.StatefulSetStatus) b
 // is set to the empty string. status's currentReplicas is set to updateReplicas and its updateReplicas
 // are set to 0.
 func completeRollingUpdate(set *apps.StatefulSet, status *apps.StatefulSetStatus) {
-	if set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType &&
+	if (set.Spec.UpdateStrategy.Type == apps.RollingUpdateStatefulSetStrategyType ||
+		set.Spec.UpdateStrategy.Type == apps.OnDeleteStatefulSetStrategyType) &&
 		status.UpdatedReplicas == status.Replicas &&
 		status.ReadyReplicas == status.Replicas {
 		status.CurrentReplicas = status.UpdatedReplicas


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #73492 reported, StatefulSetStatus shouldn't be left with the old CurrentRevision across restart.

**Which issue(s) this PR fixes**:
Fixes #73492

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
