### PR TITLE
WIP - Switch to minimum resource version semantics for paginated list

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -550,17 +550,6 @@ func (s *store) List(ctx context.Context, key, resourceVersion string, pred stor
 			returnedRV = continueRV
 		}
 	case s.pagingEnabled && pred.Limit > 0:
-		if len(resourceVersion) > 0 {
-			fromRV, err := s.versioner.ParseResourceVersion(resourceVersion)
-			if err != nil {
-				return apierrors.NewBadRequest(fmt.Sprintf("invalid resource version: %v", err))
-			}
-			if fromRV > 0 {
-				options = append(options, clientv3.WithRev(int64(fromRV)))
-			}
-			returnedRV = int64(fromRV)
-		}
-
 		rangeEnd := clientv3.GetPrefixRangeEnd(keyPrefix)
 		options = append(options, clientv3.WithRange(rangeEnd))
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Fixes issue found when implementing https://github.com/kubernetes/kubernetes/issues/83651

All other get and list operations except list with limit have already been updated to minimum resource version semantics.

**Special notes for your reviewer**:

```release-note
List with `limit=n` now returns a list response at a resource version no older than the requested 'resourceVersion'. Previously it returned a list response at the exact resource version requested if the resource version was non-zero. 
```

/sig api-machinery
/priority important-soon

@smarterclayton @liggitt @wojtek-t 