### PR TITLE
Add warning when --certificate-key is set and --control-plane is not.

### DIFF
--- a/cmd/kubeadm/app/cmd/join.go
+++ b/cmd/kubeadm/app/cmd/join.go
@@ -342,6 +342,9 @@ func newJoinData(cmd *cobra.Command, args []string, opt *joinOptions, out io.Wri
 
 	// if not joining a control plane, unset the ControlPlane object
 	if !opt.controlPlane {
+		if opt.externalcfg.ControlPlane != nil {
+			klog.Warningf("[preflight] WARNING: JoinControlPane.controlPlane settings will be ignored when %s flag is not set.", options.ControlPlane)
+		}
 		opt.externalcfg.ControlPlane = nil
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Print warning when `--certificate-key` is set and `--control-plane` is not to notify users what happens.

For example, when users try to download certs via `kubeadm join phase control-plane-prepare download-certs <ip>:<port> --certificate-key <key> --discovery-token <token> --discovery-token-unsafe
-skip-ca-verification`, this command exits with no error and the certs will not be downloaded successfully, because `--control-plane` is not set. I was confused for hours and got to know the cause via reading source code. So, it would be helpful for users to print a warning.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/sig cluster-lifecycle
/assign @rosti 
/assign @neolit123 