### PR TITLE
Refactor kubelet ut with metrics testutil

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -530,6 +530,11 @@ func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.C
 	})
 }
 
+// GetGather returns the gatherer. It used by test case outside current package.
+func GetGather() metrics.Gatherer {
+	return legacyregistry.DefaultGatherer
+}
+
 // SinceInMicroseconds gets the time since the specified start in microseconds.
 func SinceInMicroseconds(start time.Time) float64 {
 	return float64(time.Since(start).Nanoseconds() / time.Microsecond.Nanoseconds())

--- a/pkg/kubelet/pleg/BUILD
+++ b/pkg/kubelet/pleg/BUILD
@@ -37,7 +37,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/priority important-soon

**What this PR does / why we need it**:
Refactor `TestRunningPodAndContainerCount` test case with [testutils](https://github.com/kubernetes/kubernetes/pull/83299).

And it's also on the way to remove direct reference to Prometheus.

**Which issue(s) this PR fixes**:
Refer https://github.com/kubernetes/enhancements/issues/1238.

**Special notes for your reviewer**:
To get [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta, we will make it illegal to directly import prometheus methods in Kubernetes components.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
