### PR TITLE
Use log functions of core framework on testsuites/topology.go

### DIFF
--- a/test/e2e/storage/testsuites/BUILD
+++ b/test/e2e/storage/testsuites/BUILD
@@ -46,7 +46,6 @@ go_library(
         "//staging/src/k8s.io/csi-translation-lib/plugins:go_default_library",
         "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -29,7 +29,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
@@ -263,7 +262,7 @@ func (t *topologyTestSuite) getCurrentTopologies(cs clientset.Interface, keys []
 			}
 		}
 		if !found {
-			e2elog.Logf("found topology %v", topo)
+			framework.Logf("found topology %v", topo)
 			topos = append(topos, topo)
 		}
 		if len(topos) >= maxCount {
@@ -318,12 +317,12 @@ func (t *topologyTestSuite) verifyNodeTopology(node *v1.Node, allowedTopos []top
 			}
 		}
 	}
-	e2elog.Failf("node %v topology labels %+v doesn't match allowed topologies +%v", node.Name, node.Labels, allowedTopos)
+	framework.Failf("node %v topology labels %+v doesn't match allowed topologies +%v", node.Name, node.Labels, allowedTopos)
 }
 
 func (t *topologyTestSuite) createResources(cs clientset.Interface, l *topologyTest, affinity *v1.Affinity) {
 	var err error
-	e2elog.Logf("Creating storage class object and pvc object for driver - sc: %v, pvc: %v", l.resource.sc, l.resource.pvc)
+	framework.Logf("Creating storage class object and pvc object for driver - sc: %v, pvc: %v", l.resource.sc, l.resource.pvc)
 
 	ginkgo.By("Creating sc")
 	l.resource.sc, err = cs.StorageV1().StorageClasses().Create(l.resource.sc)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR makes test/e2e/storage/testsuites/topology.go to use log functions of core framework.

**Which issue(s) this PR fixes**:
Ref #81427

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```