### PR TITLE
Address `staticcheck` failures for `test/e2e/node/...`

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -88,7 +88,6 @@ test/e2e/lifecycle
 test/e2e/lifecycle/bootstrap
 test/e2e/manifest
 test/e2e/network
-test/e2e/node
 test/e2e/storage
 test/e2e/storage/drivers
 test/e2e/storage/testsuites

--- a/test/e2e/node/node_problem_detector.go
+++ b/test/e2e/node/node_problem_detector.go
@@ -281,7 +281,9 @@ func getCPUStat(f *framework.Framework, host string) (usage, uptime float64) {
 	lines := strings.Split(result.Stdout, "\n")
 
 	usage, err = strconv.ParseFloat(lines[0], 64)
+	framework.ExpectNoError(err, "Cannot parse float for usage")
 	uptime, err = strconv.ParseFloat(lines[1], 64)
+	framework.ExpectNoError(err, "Cannot parse float for uptime")
 
 	// Convert from nanoseconds to seconds
 	usage *= 1e-9

--- a/test/e2e/node/pod_gc.go
+++ b/test/e2e/node/pod_gc.go
@@ -39,9 +39,12 @@ var _ = SIGDescribe("Pod garbage collector [Feature:PodGarbageCollector] [Slow]"
 		var count int
 		for count < 1000 {
 			pod, err := createTerminatingPod(f)
+			if err != nil {
+				framework.Failf("err creating pod: %v", err)
+			}
 			pod.ResourceVersion = ""
 			pod.Status.Phase = v1.PodFailed
-			pod, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).UpdateStatus(pod)
+			_, err = f.ClientSet.CoreV1().Pods(f.Namespace.Name).UpdateStatus(pod)
 			if err != nil {
 				framework.Failf("err failing pod: %v", err)
 			}

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -223,6 +223,8 @@ var _ = SIGDescribe("PreStop", func() {
 			}
 			return false, err
 		})
+
+		framework.ExpectNoError(err, "validate-pod-is-running")
 	})
 })
 

--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -267,5 +267,6 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	framework.ExpectNoError(err, "Error waiting for pod to run %v", pod)
 
 	content, err = f.ReadFileViaContainer(pod.Name, "test-container", testFilePath)
+	framework.ExpectNoError(err, "Error reading file via container")
 	gomega.Expect(content).NotTo(gomega.ContainSubstring(testContent))
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix the `staticcheck` failures for `test/e2e/node`. All of the
staticcheck errors were for variables which were never used. When these
values were `err`, we added processing for the errors. When they were
values that were just never used, we stopped giving them a name.

Ref #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
