### PR TITLE
Deprecate unused field MaxFileSize

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -77,12 +77,12 @@ func initHostPathCSIDriver(name string, capabilities map[testsuites.Capability]b
 		driverInfo: testsuites.DriverInfo{
 			Name:        name,
 			FeatureTag:  "",
-			MaxFileSize: testpatterns.FileSizeMedium,
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
 			SupportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			Capabilities: capabilities,
 		},
@@ -252,7 +252,9 @@ func InitMockCSIDriver(driverOpts CSIMockDriverOpts) testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:        "csi-mock",
 			FeatureTag:  "",
-			MaxFileSize: testpatterns.FileSizeMedium,
+			SupportedSizeRange: volume.SizeRange{
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -375,9 +377,9 @@ func InitGcePDCSIDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:        GCEPDCSIDriverName,
 			FeatureTag:  "[Serial]",
-			MaxFileSize: testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -91,9 +91,9 @@ func InitNFSDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "nfs",
 			InTreePluginName: "kubernetes.io/nfs",
-			MaxFileSize:      testpatterns.FileSizeLarge,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeLarge, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -233,9 +233,9 @@ func InitGlusterFSDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "gluster",
 			InTreePluginName: "kubernetes.io/glusterfs",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -356,7 +356,9 @@ func InitISCSIDriver() testsuites.TestDriver {
 			Name:             "iscsi",
 			InTreePluginName: "kubernetes.io/iscsi",
 			FeatureTag:       "[Feature:Volumes]",
-			MaxFileSize:      testpatterns.FileSizeMedium,
+			SupportedSizeRange: volume.SizeRange{
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext2",
@@ -470,9 +472,9 @@ func InitRbdDriver() testsuites.TestDriver {
 			Name:             "rbd",
 			InTreePluginName: "kubernetes.io/rbd",
 			FeatureTag:       "[Feature:Volumes][Serial]",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -602,9 +604,9 @@ func InitCephFSDriver() testsuites.TestDriver {
 			Name:             "ceph",
 			InTreePluginName: "kubernetes.io/cephfs",
 			FeatureTag:       "[Feature:Volumes][Serial]",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -705,7 +707,9 @@ func InitHostPathDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "hostPath",
 			InTreePluginName: "kubernetes.io/host-path",
-			MaxFileSize:      testpatterns.FileSizeMedium,
+			SupportedSizeRange: volume.SizeRange{
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -780,7 +784,9 @@ func InitHostPathSymlinkDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "hostPathSymlink",
 			InTreePluginName: "kubernetes.io/host-path",
-			MaxFileSize:      testpatterns.FileSizeMedium,
+			SupportedSizeRange: volume.SizeRange{
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -923,7 +929,9 @@ func InitEmptydirDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "emptydir",
 			InTreePluginName: "kubernetes.io/empty-dir",
-			MaxFileSize:      testpatterns.FileSizeMedium,
+			SupportedSizeRange: volume.SizeRange{
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
+			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -990,9 +998,9 @@ func InitCinderDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "cinder",
 			InTreePluginName: "kubernetes.io/cinder",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -1162,9 +1170,9 @@ func InitGcePdDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "gcepd",
 			InTreePluginName: "kubernetes.io/gce-pd",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType:      supportedTypes,
 			SupportedMountOption: sets.NewString("debug", "nouid32"),
@@ -1297,9 +1305,9 @@ func InitVSphereDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "vsphere",
 			InTreePluginName: "kubernetes.io/vsphere-volume",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -1419,9 +1427,9 @@ func InitAzureDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "azure",
 			InTreePluginName: "kubernetes.io/azure-file",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -1553,9 +1561,9 @@ func InitAwsDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "aws",
 			InTreePluginName: "kubernetes.io/aws-ebs",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
@@ -1749,7 +1757,9 @@ func InitLocalDriverWithVolumeType(volumeType utils.LocalVolumeType) func() test
 				Name:             "local",
 				InTreePluginName: "kubernetes.io/local-volume",
 				FeatureTag:       featureTag,
-				MaxFileSize:      maxFileSize,
+				SupportedSizeRange: volume.SizeRange{
+					Max: strconv.FormatInt(maxFileSize, 10),
+				},
 				SupportedFsType:  supportedFsTypes,
 				Capabilities:     capabilities,
 			},

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -67,6 +68,7 @@ func InitSubPathTestSuite() TestSuite {
 			},
 			supportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
+				Max: strconv.FormatInt(testpatterns.FileSizeMedium, 10),
 			},
 		},
 	}

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -167,6 +167,7 @@ type DriverInfo struct {
 	FeatureTag       string // FeatureTag for the driver
 
 	// Max file size to be tested for this driver
+	// Deprecated - see SupportedSizeRange
 	MaxFileSize int64
 	// The range of size supported by this driver
 	SupportedSizeRange volume.SizeRange

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -142,7 +142,8 @@ func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 		defer cleanup()
 
 		cs := f.ClientSet
-		fileSizes := createFileSizes(dInfo.MaxFileSize)
+		sz, _ := strconv.Atoi(dInfo.SupportedSizeRange.Max)
+		fileSizes := createFileSizes(int64(sz))
 		testFile := fmt.Sprintf("%s_io_test_%s", dInfo.Name, f.Namespace.Name)
 		var fsGroup *int64
 		if !framework.NodeOSDistroIs("windows") && dInfo.Capabilities[CapFsGroup] {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As #83689 pointed out, MaxFileSize field is not used.

This PR deprecates the field, referring to SupportedSizeRange.

**Which issue(s) this PR fixes**:
Fixes #83689

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
