### PR TITLE
[migration phase 1] Make scheduler cache, volume binder and listers available when registering default plugins

### DIFF
--- a/cmd/kube-scheduler/app/BUILD
+++ b/cmd/kube-scheduler/app/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//pkg/scheduler:go_default_library",
         "//pkg/scheduler/algorithmprovider:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/metrics:go_default_library",
         "//pkg/util/configz:go_default_library",

--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -51,7 +51,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	plugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	"k8s.io/kubernetes/pkg/util/configz"
@@ -159,9 +158,9 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}, regis
 	// To help debugging, immediately log version
 	klog.V(1).Infof("Starting Kubernetes Scheduler version %+v", version.Get())
 
-	registry := plugins.NewDefaultRegistry()
+	outOfTreeRegistry := make(framework.Registry)
 	for _, option := range registryOptions {
-		if err := option(registry); err != nil {
+		if err := option(outOfTreeRegistry); err != nil {
 			return err
 		}
 	}
@@ -187,7 +186,7 @@ func Run(cc schedulerserverconfig.CompletedConfig, stopCh <-chan struct{}, regis
 		scheduler.WithPreemptionDisabled(cc.ComponentConfig.DisablePreemption),
 		scheduler.WithPercentageOfNodesToScore(cc.ComponentConfig.PercentageOfNodesToScore),
 		scheduler.WithBindTimeoutSeconds(*cc.ComponentConfig.BindTimeoutSeconds),
-		scheduler.WithFrameworkRegistry(registry),
+		scheduler.WithFrameworkOutOfTreeRegistry(outOfTreeRegistry),
 		scheduler.WithFrameworkPlugins(cc.ComponentConfig.Plugins),
 		scheduler.WithFrameworkPluginConfig(cc.ComponentConfig.PluginConfig),
 		scheduler.WithPodMaxBackoffSeconds(*cc.ComponentConfig.PodMaxBackoffSeconds),

--- a/pkg/scheduler/factory/factory_test.go
+++ b/pkg/scheduler/factory/factory_test.go
@@ -480,36 +480,36 @@ func newConfigFactoryWithFrameworkRegistry(
 	registry framework.Registry, pluginConfigProducerRegistry *frameworkplugins.ConfigProducerRegistry) *Configurator {
 	informerFactory := informers.NewSharedInformerFactory(client, 0)
 	return NewConfigFactory(&ConfigFactoryArgs{
-		client,
-		informerFactory.Core().V1().Nodes(),
-		informerFactory.Core().V1().Pods(),
-		informerFactory.Core().V1().PersistentVolumes(),
-		informerFactory.Core().V1().PersistentVolumeClaims(),
-		informerFactory.Core().V1().ReplicationControllers(),
-		informerFactory.Apps().V1().ReplicaSets(),
-		informerFactory.Apps().V1().StatefulSets(),
-		informerFactory.Core().V1().Services(),
-		informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
-		informerFactory.Storage().V1().StorageClasses(),
-		informerFactory.Storage().V1beta1().CSINodes(),
-		hardPodAffinitySymmetricWeight,
-		disablePodPreemption,
-		schedulerapi.DefaultPercentageOfNodesToScore,
-		bindTimeoutSeconds,
-		podMaxBackoffDurationSeconds,
-		podInitialBackoffDurationSeconds,
-		stopCh,
-		registry,
-		nil,
-		[]config.PluginConfig{},
-		pluginConfigProducerRegistry,
+		Client:                         client,
+		NodeInformer:                   informerFactory.Core().V1().Nodes(),
+		PodInformer:                    informerFactory.Core().V1().Pods(),
+		PvInformer:                     informerFactory.Core().V1().PersistentVolumes(),
+		PvcInformer:                    informerFactory.Core().V1().PersistentVolumeClaims(),
+		ReplicationControllerInformer:  informerFactory.Core().V1().ReplicationControllers(),
+		ReplicaSetInformer:             informerFactory.Apps().V1().ReplicaSets(),
+		StatefulSetInformer:            informerFactory.Apps().V1().StatefulSets(),
+		ServiceInformer:                informerFactory.Core().V1().Services(),
+		PdbInformer:                    informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
+		StorageClassInformer:           informerFactory.Storage().V1().StorageClasses(),
+		CSINodeInformer:                informerFactory.Storage().V1beta1().CSINodes(),
+		HardPodAffinitySymmetricWeight: hardPodAffinitySymmetricWeight,
+		DisablePreemption:              disablePodPreemption,
+		PercentageOfNodesToScore:       schedulerapi.DefaultPercentageOfNodesToScore,
+		BindTimeoutSeconds:             bindTimeoutSeconds,
+		PodInitialBackoffSeconds:       podInitialBackoffDurationSeconds,
+		PodMaxBackoffSeconds:           podMaxBackoffDurationSeconds,
+		StopCh:                         stopCh,
+		Registry:                       registry,
+		Plugins:                        nil,
+		PluginConfig:                   []config.PluginConfig{},
+		PluginConfigProducerRegistry:   pluginConfigProducerRegistry,
 	})
 }
 
 func newConfigFactory(
 	client clientset.Interface, hardPodAffinitySymmetricWeight int32, stopCh <-chan struct{}) *Configurator {
 	return newConfigFactoryWithFrameworkRegistry(client, hardPodAffinitySymmetricWeight, stopCh,
-		frameworkplugins.NewDefaultRegistry(), frameworkplugins.NewDefaultConfigProducerRegistry())
+		frameworkplugins.NewDefaultRegistry(&frameworkplugins.RegistryArgs{}), frameworkplugins.NewDefaultConfigProducerRegistry())
 }
 
 type fakeExtender struct {

--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -6,10 +6,15 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/algorithm:go_default_library",
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/plugins/tainttoleration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/internal/cache:go_default_library",
+        "//pkg/scheduler/volumebinder:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/storage/v1:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/default_registry.go
+++ b/pkg/scheduler/framework/plugins/default_registry.go
@@ -19,16 +19,35 @@ package plugins
 import (
 	"fmt"
 
+	corelisters "k8s.io/client-go/listers/core/v1"
+	storagelistersv1 "k8s.io/client-go/listers/storage/v1"
+	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/tainttoleration"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
+	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
 )
+
+// RegistryArgs arguments needed to create default plugin factories.
+type RegistryArgs struct {
+	SchedulerCache     internalcache.Cache
+	ServiceLister      algorithm.ServiceLister
+	ControllerLister   algorithm.ControllerLister
+	ReplicaSetLister   algorithm.ReplicaSetLister
+	StatefulSetLister  algorithm.StatefulSetLister
+	PDBLister          algorithm.PDBLister
+	PVLister           corelisters.PersistentVolumeLister
+	PVCLister          corelisters.PersistentVolumeClaimLister
+	StorageClassLister storagelistersv1.StorageClassLister
+	VolumeBinder       *volumebinder.VolumeBinder
+}
 
 // NewDefaultRegistry builds a default registry with all the default plugins.
 // This is the registry that Kubernetes default scheduler uses. A scheduler that
 // runs custom plugins, can pass a different Registry when initializing the scheduler.
-func NewDefaultRegistry() framework.Registry {
+func NewDefaultRegistry(args *RegistryArgs) framework.Registry {
 	return framework.Registry{
 		tainttoleration.Name: tainttoleration.New,
 	}

--- a/pkg/scheduler/framework/v1alpha1/registry.go
+++ b/pkg/scheduler/framework/v1alpha1/registry.go
@@ -68,3 +68,13 @@ func (r Registry) Unregister(name string) error {
 	delete(r, name)
 	return nil
 }
+
+// Merge merges the provided registry to the current one.
+func (r Registry) Merge(in Registry) error {
+	for name, factory := range in {
+		if err := r.Register(name, factory); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -34,7 +34,6 @@ go_test(
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/apis/extender/v1:go_default_library",
         "//pkg/scheduler/factory:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/scheduler/testing:go_default_library",

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -461,7 +461,7 @@ func TestPreFilterPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "prefilter-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -532,7 +532,7 @@ func TestScorePlugin(t *testing.T) {
 
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "score-plugin", nil), 10,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for i, fail := range []bool{false, true} {
@@ -590,7 +590,7 @@ func TestNormalizeScorePlugin(t *testing.T) {
 	}
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "score-plugin", nil), 10,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 
 	defer cleanupTest(t, context)
 
@@ -635,7 +635,7 @@ func TestReservePlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "reserve-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for _, fail := range []bool{false, true} {
@@ -694,7 +694,7 @@ func TestPrebindPlugin(t *testing.T) {
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "prebind-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(preBindPluginConfig),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -789,7 +789,7 @@ func TestUnreservePlugin(t *testing.T) {
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "unreserve-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(pluginConfig),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -899,7 +899,7 @@ func TestBindPlugin(t *testing.T) {
 	context := initTestSchedulerWithOptions(t, testContext, false, nil, time.Second,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(pluginConfig),
-		scheduler.WithFrameworkRegistry(registry),
+		scheduler.WithFrameworkDefaultRegistry(registry),
 		scheduler.WithFrameworkConfigProducerRegistry(nil))
 	defer cleanupTest(t, context)
 
@@ -1072,7 +1072,7 @@ func TestPostBindPlugin(t *testing.T) {
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "postbind-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(pluginConfig),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -1147,7 +1147,7 @@ func TestPermitPlugin(t *testing.T) {
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "permit-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(pluginConfig),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -1253,7 +1253,7 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "permit-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(pluginConfig),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -1334,7 +1334,7 @@ func TestFilterPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "filter-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for _, fail := range []bool{false, true} {
@@ -1385,7 +1385,7 @@ func TestPostFilterPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "post-filter-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for _, fail := range []bool{false, true} {
@@ -1444,7 +1444,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "preempt-with-permit-plugin", nil), 0,
 		scheduler.WithFrameworkPlugins(plugins),
 		scheduler.WithFrameworkPluginConfig(pluginConfig),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkDefaultRegistry(registry))
 	defer cleanupTest(t, context)
 
 	// Add one node.

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 	"k8s.io/kubernetes/pkg/scheduler"
 	schedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	frameworkplugins "k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	"k8s.io/kubernetes/plugin/pkg/admission/priority"
@@ -124,8 +123,7 @@ var _ = framework.FilterPlugin(&tokenFilter{})
 func TestPreemption(t *testing.T) {
 	// Initialize scheduler with a filter plugin.
 	var filter tokenFilter
-	registry := frameworkplugins.NewDefaultRegistry()
-
+	registry := make(framework.Registry)
 	registry.Register(filterPluginName, func(_ *runtime.Unknown, fh framework.FrameworkHandle) (framework.Plugin, error) {
 		return &filter, nil
 	})
@@ -149,7 +147,7 @@ func TestPreemption(t *testing.T) {
 		initTestMaster(t, "preemptiom", nil),
 		false, nil, time.Second,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkRegistry(registry))
+		scheduler.WithFrameworkOutOfTreeRegistry(registry))
 
 	defer cleanupTest(t, context)
 	cs := context.clientSet


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>

/kind feature

**What this PR does / why we need it**:

Plumped handlers necessary to instantiate some predicates/priorities. This is necessary during phase 1 of framework migration.

**Which issue(s) this PR fixes**:
Fixes #83687

```release-note
NONE
```

