### PR TITLE
Fix comment typos in pkg/kubelet/prober

### DIFF
--- a/pkg/kubelet/prober/prober.go
+++ b/pkg/kubelet/prober/prober.go
@@ -47,8 +47,8 @@ const maxProbeRetries = 3
 // Prober helps to check the liveness/readiness/startup of a container.
 type prober struct {
 	exec execprobe.Prober
-	// probe types needs different httprobe instances so they don't
-	// share a connection pool which can cause collsions to the
+	// probe types needs different httpprobe instances so they don't
+	// share a connection pool which can cause collisions to the
 	// same host:port and transient failures. See #49740.
 	readinessHTTP httpprobe.Prober
 	livenessHTTP  httpprobe.Prober


### PR DESCRIPTION
Typo from ebb7b17f4dfb5ab705da1c7abedf12f03641b444

> None