### PR TITLE
Refactor kubelet collector test

### DIFF
--- a/pkg/kubelet/metrics/collectors/BUILD
+++ b/pkg/kubelet/metrics/collectors/BUILD
@@ -30,7 +30,6 @@ go_test(
         "//pkg/kubelet/server/stats/testing:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/metrics/collectors/log_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics_test.go
@@ -20,25 +20,19 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/component-base/metrics/testutil"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
 func TestNoMetricsCollected(t *testing.T) {
-	ch := make(chan prometheus.Metric)
-
 	collector := &logMetricsCollector{
 		podStats: func() ([]statsapi.PodStats, error) {
 			return []statsapi.PodStats{}, nil
 		},
 	}
-	collector.Collect(ch)
 
-	num := len(ch)
-	if num != 0 {
-		t.Fatalf("Channel expected to be empty, but received %d", num)
+	if err := testutil.CollectAndCompare(collector, strings.NewReader(""), ""); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Rewrite `TestNoMetricsCollected` with [testutils.CollectAndCompare](https://github.com/kubernetes/kubernetes/pull/83699).

We need to remove Prometheus reference to move [metrics stability](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) into Beta.

By the way, that might be a problem in the origin `TestNoMetricsCollected` implementation.
Because we can't send messages to a channel (`ch := make(chan prometheus.Metric)`) without a receiver. 
In other words, it will cause `fatal error: all goroutines are asleep - deadlock!` when the test failing.

**Which issue(s) this PR fixes**:
Ref https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
