### PR TITLE
fix staticcheck  failures in test/e2e/windows

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -81,7 +81,6 @@ test/e2e/storage/utils
 test/e2e/storage/vsphere
 test/e2e/upgrades
 test/e2e/upgrades/storage
-test/e2e/windows
 test/images/agnhost/dns
 test/images/agnhost/inclusterclient
 test/images/agnhost/net/nat

--- a/test/e2e/windows/BUILD
+++ b/test/e2e/windows/BUILD
@@ -36,7 +36,6 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/kubelet/config/v1beta1:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/kubelet:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/framework/network:go_default_library",
         "//test/e2e/framework/node:go_default_library",

--- a/test/e2e/windows/density.go
+++ b/test/e2e/windows/density.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -75,8 +74,6 @@ var _ = SIGDescribe("[Feature:Windows] Density [Serial] [Slow]", func() {
 type densityTest struct {
 	// number of pods
 	podsNr int
-	// number of background pods
-	bgPodsNr int
 	// interval between creating pod (rate control)
 	interval time.Duration
 	// create pods in 'batch' or 'sequence'
@@ -84,8 +81,6 @@ type densityTest struct {
 	// API QPS limit
 	APIQPSLimit int
 	// performance limits
-	cpuLimits            e2ekubelet.ContainersCPUSummary
-	memLimits            e2ekubelet.ResourceUsagePerContainer
 	podStartupLimits     e2emetrics.LatencyMetric
 	podBatchStartupLimit time.Duration
 }
@@ -97,7 +92,7 @@ func runDensityBatchTest(f *framework.Framework, testArg densityTest) (time.Dura
 	)
 	var (
 		mutex      = &sync.Mutex{}
-		watchTimes = make(map[string]metav1.Time, 0)
+		watchTimes = make(map[string]metav1.Time)
 		stopCh     = make(chan struct{})
 	)
 
@@ -278,5 +273,4 @@ func deletePodsSync(f *framework.Framework, pods []*v1.Pod) {
 		}(pod)
 	}
 	wg.Wait()
-	return
 }

--- a/test/e2e/windows/dns.go
+++ b/test/e2e/windows/dns.go
@@ -28,9 +28,6 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-const dnsTestPodHostName = "dns-querier-1"
-const dnsTestServiceName = "dns-test-service"
-
 var _ = SIGDescribe("DNS", func() {
 
 	ginkgo.BeforeEach(func() {
@@ -76,6 +73,7 @@ var _ = SIGDescribe("DNS", func() {
 
 		framework.Logf("ipconfig /all:\n%s", stdout)
 		dnsRegex, err := regexp.Compile(`DNS Servers[\s*.]*:(\s*[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})+`)
+		framework.ExpectNoError(err)
 
 		if dnsRegex.MatchString(stdout) {
 			match := dnsRegex.FindString(stdout)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix the staticcheck failures for test/e2e/windows




**Which issue(s) this PR fixes**:
Ref #81657

**Special notes for your reviewer**:

density.go:79:2: field bgPodsNr is unused (U1000)
density.go:87:2: field cpuLimits is unused (U1000)
density.go:88:2: field memLimits is unused (U1000)
density.go: 100:45: should use make(map[string]metav1.Time) instead (S1019)
density.go:281:2: redundant return statement (S1023)
dns.go:31:7: const dnsTestPodHostName is unused (U1000)
dns.go:32:7: const dnsTestServiceName is unused (U1000)
dns.go:78:13: this value of err is never used (SA4006)
security_context.go:53:6: don't use Yoda conditions (ST1017)

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
