### PR TITLE
Introduce sig-instrumentation aliases in OWNERS_ALISES and simplify OWNERS files

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -273,6 +273,20 @@ aliases:
     - bskiba
     - MaciekPytel
     - mwielgus
+  sig-instrumentation-approvers:
+    - piosz
+    - brancz
+  sig-instrumentation-reviewers:
+    - kawych
+    - s-urbaniak
+    - DirectXMan12
+    - x13n
+    - loburm
+    - huangyuqi
+    - andyxning
+    - coffeepac
+    - monotek
+    - logicalhan
 
   api-approvers:
     - erictune

--- a/cluster/addons/cluster-monitoring/OWNERS
+++ b/cluster/addons/cluster-monitoring/OWNERS
@@ -2,7 +2,8 @@
 
 approvers:
 - kawych
-- piosz
+- sig-instrumentation-approvers
 reviewers:
-- kawych
-- piosz
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation

--- a/cluster/addons/fluentd-elasticsearch/OWNERS
+++ b/cluster/addons/fluentd-elasticsearch/OWNERS
@@ -3,10 +3,8 @@
 approvers:
 - coffeepac
 - monotek
-- piosz
+- sig-instrumentation-approvers
 reviewers:
-- coffeepac
-- monotek
-- piosz
+- sig-instrumentation-reviewers
 labels:
 - sig/instrumentation

--- a/cluster/addons/fluentd-gcp/OWNERS
+++ b/cluster/addons/fluentd-gcp/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- piosz
+- sig-instrumentation-approvers
 - x13n
 reviewers:
-- piosz
-- x13n
+- sig-instrumentation-reviewers
 labels:
 - sig/gcp
+- sig/instrumentation

--- a/cluster/addons/metadata-agent/OWNERS
+++ b/cluster/addons/metadata-agent/OWNERS
@@ -2,9 +2,9 @@
 
 approvers:
 - kawych
-- piosz
+- sig-instrumentation-approvers
 - x13n
 reviewers:
-- kawych
-- piosz
-- x13n
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation

--- a/cluster/addons/metrics-server/OWNERS
+++ b/cluster/addons/metrics-server/OWNERS
@@ -2,7 +2,8 @@
 
 approvers:
 - kawych
-- piosz
+- sig-instrumentation-approvers
 reviewers:
-- kawych
-- piosz
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation

--- a/staging/src/k8s.io/component-base/metrics/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/OWNERS
@@ -1,12 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- piosz
-- brancz
+- sig-instrumentation-approvers
 - logicalhan
 reviewers:
-- piosz
-- brancz
-- logicalhan
+- sig-instrumentation-reviewers
 labels:
 - sig/instrumentation

--- a/staging/src/k8s.io/component-base/metrics/prometheus/ratelimiter/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/ratelimiter/OWNERS
@@ -1,12 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- piosz
-- brancz
+- sig-instrumentation-approvers
 - logicalhan
 reviewers:
-- piosz
-- brancz
-- logicalhan
+- sig-instrumentation-reviewers
 labels:
 - sig/instrumentation

--- a/staging/src/k8s.io/metrics/OWNERS
+++ b/staging/src/k8s.io/metrics/OWNERS
@@ -1,4 +1,6 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- piosz
+- sig-instrumentation-approvers
+labels:
+- sig/instrumentation

--- a/test/e2e/instrumentation/OWNERS
+++ b/test/e2e/instrumentation/OWNERS
@@ -3,8 +3,10 @@
 approvers:
 - fabxc
 - fgrzadkowski
-- piosz
+- sig-instrumentation-approvers
 - x13n
 - kawych
 reviewers:
-- sig-instrumentation-pr-reviews
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation

--- a/test/e2e/instrumentation/logging/OWNERS
+++ b/test/e2e/instrumentation/logging/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-reviewers:
-  - coffeepac
-  - monotek
-  - piosz
 approvers:
-  - coffeepac
-  - monotek
-  - piosz
+- coffeepac
+- monotek
+- sig-instrumentation-approvers
+reviewers:
+- sig-instrumentation-reviewers
+labels:
+- sig/instrumentation

--- a/test/instrumentation/OWNERS
+++ b/test/instrumentation/OWNERS
@@ -1,12 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- piosz
-- brancz
+- sig-instrumentation-approvers
 - logicalhan
 reviewers:
-- piosz
-- brancz
-- logicalhan
+- sig-instrumentation-reviewers
 labels:
 - sig/instrumentation

--- a/test/instrumentation/testdata/OWNERS
+++ b/test/instrumentation/testdata/OWNERS
@@ -1,11 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- piosz
-- brancz
+- sig-instrumentation-approvers
 reviewers:
-- piosz
-- brancz
-- logicalhan
+- sig-instrumentation-reviewers
 labels:
 - sig/instrumentation


### PR DESCRIPTION
/kind cleanup
This PR introduces aliases groups and applies them in OWNERS files. As results sig-instrumentation directories have:
* sig-instrumentation label
* both sig leads as approves 
* one common set of reviewers for sig-instrumentation to allow faster review

For now only SIG leads were moved to `sig-instrumentation-approvers`, we can expand list in next PRs.
OWNERS files were found by greping for any sig leads github handle.

Algorithm for each OWNERS file
For approves: replace sig lead with `sig-instrumentation-approvers`, leave others untouched. 
For reviewers:  replace all entries with `sig-instrumentation-reviewers` and add replaced entries to `sig-instrumentation-reviewers` alias.

```release-note
NONE
```
/cc @piosz @brancz
