### PR TITLE
kubeadm: remove OutputFlagSpecified from PrintFlags

### DIFF
--- a/cmd/kubeadm/app/util/output/output.go
+++ b/cmd/kubeadm/app/util/output/output.go
@@ -49,10 +49,6 @@ type PrintFlags struct {
 	TypeSetterPrinter *printers.TypeSetterPrinter
 	// OutputFormat contains currently set output format
 	OutputFormat *string
-
-	// OutputFlagSpecified indicates whether the user specifically requested a certain kind of output.
-	// Using this function allows a sophisticated caller to change the flag binding logic if they so desire.
-	OutputFlagSpecified func() bool
 }
 
 // AllowedFormats returns list of allowed output formats


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

OutputFlagSpecified is not used in the kubeadm code. It was brought from
cli-runtime where it's used to support complex relationship between
command line parameters, which is not present in kubeadm.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
