### PR TITLE
Optionally run e2e pod as privileged for SELinux

### DIFF
--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -45,7 +45,7 @@ import (
 	"strconv"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -443,7 +443,7 @@ func TestCleanup(f *framework.Framework, config TestConfig) {
 	}
 }
 
-func runVolumeTesterPod(client clientset.Interface, config TestConfig, podSuffix string, fsGroup *int64, tests []Test) (*v1.Pod, error) {
+func runVolumeTesterPod(client clientset.Interface, config TestConfig, podSuffix string, privileged bool, fsGroup *int64, tests []Test) (*v1.Pod, error) {
 	ginkgo.By(fmt.Sprint("starting ", config.Prefix, "-", podSuffix))
 	var gracePeriod int64 = 1
 	var command string
@@ -488,6 +488,17 @@ func runVolumeTesterPod(client clientset.Interface, config TestConfig, podSuffix
 
 	for i, test := range tests {
 		volumeName := fmt.Sprintf("%s-%s-%d", config.Prefix, "volume", i)
+
+		// We need to make the container privileged when SELinux is enabled on the
+		// host,  so the test can write data to a location like /tmp. Also, due to
+		// the Docker bug below, it's not currently possible to map a device with
+		// a privileged container, so we don't go privileged for block volumes.
+		// https://github.com/moby/moby/issues/35991
+		if privileged && test.Mode == v1.PersistentVolumeBlock {
+			privileged = false
+		}
+		clientPod.Spec.Containers[0].SecurityContext = GenerateSecurityContext(privileged)
+
 		if test.Mode == v1.PersistentVolumeBlock {
 			clientPod.Spec.Containers[0].VolumeDevices = append(clientPod.Spec.Containers[0].VolumeDevices, v1.VolumeDevice{
 				Name:       volumeName,
@@ -564,7 +575,7 @@ func testVolumeContent(client clientset.Interface, pod *v1.Pod, fsGroup *int64, 
 // Multiple Tests can be specified to mount multiple volumes to a single
 // pod.
 func TestVolumeClient(client clientset.Interface, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
-	clientPod, err := runVolumeTesterPod(client, config, "client", fsGroup, tests)
+	clientPod, err := runVolumeTesterPod(client, config, "client", false, fsGroup, tests)
 	if err != nil {
 		framework.Failf("Failed to create client pod: %v", err)
 
@@ -577,7 +588,11 @@ func TestVolumeClient(client clientset.Interface, config TestConfig, fsGroup *in
 // starting and auxiliary pod which writes the file there.
 // The volume must be writable.
 func InjectContent(client clientset.Interface, config TestConfig, fsGroup *int64, fsType string, tests []Test) {
-	injectorPod, err := runVolumeTesterPod(client, config, "injector", fsGroup, tests)
+	privileged := true
+	if framework.NodeOSDistroIs("windows") {
+		privileged = false
+	}
+	injectorPod, err := runVolumeTesterPod(client, config, "injector", privileged, fsGroup, tests)
 	if err != nil {
 		framework.Failf("Failed to create injector pod: %v", err)
 		return


### PR DESCRIPTION
This PR adds back the SecurityContext field missed during the consolidation of redundant code in https://github.com/kubernetes/kubernetes/pull/79730. 

Also, it only runs the pod as privileged if the system has SELinux enabled and the volume isn't block (due to https://github.com/moby/moby/issues/35991).

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

This is necessary for running some e2e tests on SELinux systems.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

/sig storage
CC @jsafrane @msau42 