### PR TITLE
Automated cherry pick of #82264: openstack: do not delete LB in case of security group

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_loadbalancer.go
@@ -999,9 +999,7 @@ func (lbaas *LbaasV2) EnsureLoadBalancer(ctx context.Context, clusterName string
 	if lbaas.opts.ManageSecurityGroups {
 		err := lbaas.ensureSecurityGroup(clusterName, apiService, nodes, loadbalancer)
 		if err != nil {
-			// cleanup what was created so far
-			_ = lbaas.EnsureLoadBalancerDeleted(ctx, clusterName, apiService)
-			return status, err
+			return status, fmt.Errorf("Error reconciling security groups for LB service %v/%v: %v", apiService.Namespace, apiService.Name, err)
 		}
 	}
 


### PR DESCRIPTION
Cherry pick of #82264 on release-1.16.

#82264: openstack: do not delete LB in case of security group

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.