### PR TITLE
Improve 'No resource limits' message

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -474,7 +474,7 @@ func describeLimitRangeSpec(spec corev1.LimitRangeSpec, prefix string, w PrefixW
 // DescribeLimitRanges merges a set of limit range items into a single tabular description
 func DescribeLimitRanges(limitRanges *corev1.LimitRangeList, w PrefixWriter) {
 	if len(limitRanges.Items) == 0 {
-		w.Write(LEVEL_0, "No resource limits.\n")
+		w.Write(LEVEL_0, "No LimitRange resource.\n")
 		return
 	}
 	w.Write(LEVEL_0, "Resource Limits\n Type\tResource\tMin\tMax\tDefault Request\tDefault Limit\tMax Limit/Request Ratio\n")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As #78918 stated, the message for 'No resource limits' should indicate which resource is missing.

**Which issue(s) this PR fixes**:
Fixes #78918

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
