### PR TITLE
Move leader election cancelation to lock level

### DIFF
--- a/staging/src/k8s.io/client-go/examples/leader-election/main.go
+++ b/staging/src/k8s.io/client-go/examples/leader-election/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	// we use the Lease lock type since edits to Leases are less common
 	// and fewer objects in the cluster watch "all Leases".
-	lock := &resourcelock.LeaseLock{
+	lock := resourcelock.MakeCancelable(&resourcelock.LeaseLock{
 		LeaseMeta: metav1.ObjectMeta{
 			Name:      leaseLockName,
 			Namespace: leaseLockNamespace,
@@ -93,7 +93,7 @@ func main() {
 		LockConfig: resourcelock.ResourceLockConfig{
 			Identity: id,
 		},
-	}
+	})
 
 	// use a Go context so we can tell the leaderelection code when we
 	// want to step down

--- a/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/healthzadaptor_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package leaderelection
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -32,17 +33,17 @@ type fakeLock struct {
 }
 
 // Get is a dummy to allow us to have a fakeLock for testing.
-func (fl *fakeLock) Get() (ler *rl.LeaderElectionRecord, rawRecord []byte, err error) {
+func (fl *fakeLock) Get(_ context.Context) (ler *rl.LeaderElectionRecord, rawRecord []byte, err error) {
 	return nil, nil, nil
 }
 
 // Create is a dummy to allow us to have a fakeLock for testing.
-func (fl *fakeLock) Create(ler rl.LeaderElectionRecord) error {
+func (fl *fakeLock) Create(_ context.Context, ler rl.LeaderElectionRecord) error {
 	return nil
 }
 
 // Update is a dummy to allow us to have a fakeLock for testing.
-func (fl *fakeLock) Update(ler rl.LeaderElectionRecord) error {
+func (fl *fakeLock) Update(_ context.Context, ler rl.LeaderElectionRecord) error {
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/leaderelection.go
@@ -241,7 +241,7 @@ func (le *LeaderElector) acquire(ctx context.Context) bool {
 	desc := le.config.Lock.Describe()
 	klog.Infof("attempting to acquire leader lease  %v...", desc)
 	wait.JitterUntil(func() {
-		succeeded = le.tryAcquireOrRenew()
+		succeeded = le.tryAcquireOrRenew(ctx)
 		le.maybeReportTransition()
 		if !succeeded {
 			klog.V(4).Infof("failed to acquire lease %v", desc)
@@ -263,18 +263,7 @@ func (le *LeaderElector) renew(ctx context.Context) {
 		timeoutCtx, timeoutCancel := context.WithTimeout(ctx, le.config.RenewDeadline)
 		defer timeoutCancel()
 		err := wait.PollImmediateUntil(le.config.RetryPeriod, func() (bool, error) {
-			done := make(chan bool, 1)
-			go func() {
-				defer close(done)
-				done <- le.tryAcquireOrRenew()
-			}()
-
-			select {
-			case <-timeoutCtx.Done():
-				return false, fmt.Errorf("failed to tryAcquireOrRenew %s", timeoutCtx.Err())
-			case result := <-done:
-				return result, nil
-			}
+			return le.tryAcquireOrRenew(timeoutCtx), nil
 		}, timeoutCtx.Done())
 
 		le.maybeReportTransition()
@@ -303,7 +292,7 @@ func (le *LeaderElector) release() bool {
 	leaderElectionRecord := rl.LeaderElectionRecord{
 		LeaderTransitions: le.observedRecord.LeaderTransitions,
 	}
-	if err := le.config.Lock.Update(leaderElectionRecord); err != nil {
+	if err := le.config.Lock.Update(context.Background(), leaderElectionRecord); err != nil {
 		klog.Errorf("Failed to release lock: %v", err)
 		return false
 	}
@@ -315,7 +304,7 @@ func (le *LeaderElector) release() bool {
 // tryAcquireOrRenew tries to acquire a leader lease if it is not already acquired,
 // else it tries to renew the lease if it has already been acquired. Returns true
 // on success else returns false.
-func (le *LeaderElector) tryAcquireOrRenew() bool {
+func (le *LeaderElector) tryAcquireOrRenew(ctx context.Context) bool {
 	now := metav1.Now()
 	leaderElectionRecord := rl.LeaderElectionRecord{
 		HolderIdentity:       le.config.Lock.Identity(),
@@ -325,13 +314,13 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 	}
 
 	// 1. obtain or create the ElectionRecord
-	oldLeaderElectionRecord, oldLeaderElectionRawRecord, err := le.config.Lock.Get()
+	oldLeaderElectionRecord, oldLeaderElectionRawRecord, err := le.config.Lock.Get(ctx)
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			klog.Errorf("error retrieving resource lock %v: %v", le.config.Lock.Describe(), err)
 			return false
 		}
-		if err = le.config.Lock.Create(leaderElectionRecord); err != nil {
+		if err = le.config.Lock.Create(ctx, leaderElectionRecord); err != nil {
 			klog.Errorf("error initially creating leader election record: %v", err)
 			return false
 		}
@@ -363,7 +352,7 @@ func (le *LeaderElector) tryAcquireOrRenew() bool {
 	}
 
 	// update the lock itself
-	if err = le.config.Lock.Update(leaderElectionRecord); err != nil {
+	if err = le.config.Lock.Update(ctx, leaderElectionRecord); err != nil {
 		klog.Errorf("Failed to update lock: %v", err)
 		return false
 	}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/BUILD
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "cancelable.go",
         "configmaplock.go",
         "endpointslock.go",
         "interface.go",

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/cancelable.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/cancelable.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package resourcelock
+
+import (
+	"context"
+)
+
+// TODO(directxman12): get rid of this when we get generated clients that accept contexts --
+// the underlying machinery is there in RESTClient, but it's not exposed.  The contents of
+// this file are just a stopgap until then.
+
+// StubbornInterface is like Interface, except that it does not support using a
+// context for timeout/cancelation.
+//
+// Use MakeCancelable to convert a StubbornInterface into an Interface, but prefer
+// to just write using cancelable code natively.
+type StubbornInterface interface {
+	// Get returns the LeaderElectionRecord
+	Get() (*LeaderElectionRecord, []byte, error)
+
+	// Create attempts to create a LeaderElectionRecord
+	Create(ler LeaderElectionRecord) error
+
+	// Update will update and existing LeaderElectionRecord
+	Update(ler LeaderElectionRecord) error
+
+	// RecordEvent is used to record events
+	RecordEvent(string)
+
+	// Identity will return the locks Identity
+	Identity() string
+
+	// Describe is used to convert details on current resource lock
+	// into a string
+	Describe() string
+}
+
+// MakeCancelable makes a stubborn (non-cancelable) StubbornInterface into a (cancelable) Interface
+// using goroutines.  This won't magically time out the underlying HTTP requests, etc.
+func MakeCancelable(raw StubbornInterface) Interface {
+	return &cancelableLockWrapper{wrapped: raw}
+}
+
+// cancelableLockWrapper embeds a non-cancelable StubbornInterface
+// and turns it into a cancelable interface using goroutines.
+type cancelableLockWrapper struct {
+	wrapped StubbornInterface
+}
+
+func (w *cancelableLockWrapper) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	errCh := make(chan error, 1)
+	var rec *LeaderElectionRecord
+	var raw []byte
+	go func() {
+		defer close(errCh)
+		var err error
+		rec, raw, err = w.wrapped.Get()
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		return rec, raw, err
+	case <-ctx.Done():
+		// timeout
+		return nil, nil, ctx.Err()
+	}
+}
+func (w *cancelableLockWrapper) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		errCh <- w.wrapped.Create(ler)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		// timeout
+		return ctx.Err()
+	}
+}
+func (w *cancelableLockWrapper) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(errCh)
+		errCh <- w.wrapped.Update(ler)
+	}()
+
+	select {
+	case err := <-errCh:
+		return err
+	case <-ctx.Done():
+		// timeout
+		return ctx.Err()
+	}
+}
+func (w *cancelableLockWrapper) RecordEvent(evt string) {
+	w.wrapped.RecordEvent(evt)
+}
+func (w *cancelableLockWrapper) Identity() string {
+	return w.wrapped.Identity()
+}
+func (w *cancelableLockWrapper) Describe() string {
+	return w.wrapped.Describe()
+}

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/multilock.go
@@ -18,6 +18,7 @@ package resourcelock
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -34,13 +35,13 @@ type MultiLock struct {
 }
 
 // Get returns the older election record of the lock
-func (ml *MultiLock) Get() (*LeaderElectionRecord, []byte, error) {
-	primary, primaryRaw, err := ml.Primary.Get()
+func (ml *MultiLock) Get(ctx context.Context) (*LeaderElectionRecord, []byte, error) {
+	primary, primaryRaw, err := ml.Primary.Get(ctx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	secondary, secondaryRaw, err := ml.Secondary.Get()
+	secondary, secondaryRaw, err := ml.Secondary.Get(ctx)
 	if err != nil {
 		// Lock is held by old client
 		if apierrors.IsNotFound(err) && primary.HolderIdentity != ml.Identity() {
@@ -60,25 +61,25 @@ func (ml *MultiLock) Get() (*LeaderElectionRecord, []byte, error) {
 }
 
 // Create attempts to create both primary lock and secondary lock
-func (ml *MultiLock) Create(ler LeaderElectionRecord) error {
-	err := ml.Primary.Create(ler)
+func (ml *MultiLock) Create(ctx context.Context, ler LeaderElectionRecord) error {
+	err := ml.Primary.Create(ctx, ler)
 	if err != nil && !apierrors.IsAlreadyExists(err) {
 		return err
 	}
-	return ml.Secondary.Create(ler)
+	return ml.Secondary.Create(ctx, ler)
 }
 
 // Update will update and existing annotation on both two resources.
-func (ml *MultiLock) Update(ler LeaderElectionRecord) error {
-	err := ml.Primary.Update(ler)
+func (ml *MultiLock) Update(ctx context.Context, ler LeaderElectionRecord) error {
+	err := ml.Primary.Update(ctx, ler)
 	if err != nil {
 		return err
 	}
-	_, _, err = ml.Secondary.Get()
+	_, _, err = ml.Secondary.Get(ctx)
 	if err != nil && apierrors.IsNotFound(err) {
-		return ml.Secondary.Create(ler)
+		return ml.Secondary.Create(ctx, ler)
 	}
-	return ml.Secondary.Update(ler)
+	return ml.Secondary.Update(ctx, ler)
 }
 
 // RecordEvent in leader election while adding meta-data


### PR DESCRIPTION
This moves the leader election cancelation down to the lock level.  This
lets the lock actually natively cancel when we get clients that support
it, and cleanly solves a race condition in which we cancel a request but
continue to evaluate the high-level leader election code in the
background.

Fixes #83078

```release-note
Fix race condition on cancelation/timeout in the leader election utilities
```

/sig api-machinery
/kind bug