### PR TITLE
Refactor scheduler's framework permit API

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -150,10 +150,14 @@ func NewStatus(code Code, msg string) *Status {
 type WaitingPod interface {
 	// GetPod returns a reference to the waiting pod.
 	GetPod() *v1.Pod
-	// Allow the waiting pod to be scheduled. Returns true if the allow signal was
-	// successfully delivered, false otherwise.
-	Allow() bool
-	// Reject declares the waiting pod unschedulable. Returns true if the allow signal
+	// GetPendingPlugins returns a list of pending permit plugin's name.
+	GetPendingPlugins() []string
+	// Allow declares the waiting pod is allowed to be scheduled by plugin pluginName.
+	// If this is the last remaining plugin to allow, then a success signal is delivered
+	// to unblock the pod.
+	// Returns true if the allow signal was successfully dealt with, false otherwise.
+	Allow(pluginName string) bool
+	// Reject declares the waiting pod unschedulable. Returns true if the reject signal
 	// was successfully delivered, false otherwise.
 	Reject(msg string) bool
 }

--- a/pkg/scheduler/framework/v1alpha1/waiting_pods_map.go
+++ b/pkg/scheduler/framework/v1alpha1/waiting_pods_map.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -69,16 +71,30 @@ func (m *waitingPodsMap) iterate(callback func(WaitingPod)) {
 
 // waitingPod represents a pod waiting in the permit phase.
 type waitingPod struct {
-	pod *v1.Pod
-	s   chan *Status
+	pod            *v1.Pod
+	pendingPlugins map[string]*time.Timer
+	s              chan *Status
+	mu             sync.RWMutex
 }
 
 // newWaitingPod returns a new waitingPod instance.
-func newWaitingPod(pod *v1.Pod) *waitingPod {
-	return &waitingPod{
+func newWaitingPod(pod *v1.Pod, pluginsMaxWaitTime map[string]time.Duration) *waitingPod {
+	wp := &waitingPod{
 		pod: pod,
 		s:   make(chan *Status),
 	}
+
+	wp.pendingPlugins = make(map[string]*time.Timer, len(pluginsMaxWaitTime))
+	for k, v := range pluginsMaxWaitTime {
+		plugin, waitTime := k, v
+		wp.pendingPlugins[plugin] = time.AfterFunc(waitTime, func() {
+			msg := fmt.Sprintf("rejected due to timeout after waiting %v at plugin %v",
+				waitTime, plugin)
+			wp.Reject(msg)
+		})
+	}
+
+	return wp
 }
 
 // GetPod returns a reference to the waiting pod.
@@ -86,9 +102,35 @@ func (w *waitingPod) GetPod() *v1.Pod {
 	return w.pod
 }
 
-// Allow the waiting pod to be scheduled. Returns true if the allow signal was
-// successfully delivered, false otherwise.
-func (w *waitingPod) Allow() bool {
+// GetPendingPlugins returns a list of pending permit plugin's name.
+func (w *waitingPod) GetPendingPlugins() []string {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	plugins := make([]string, 0, len(w.pendingPlugins))
+	for p := range w.pendingPlugins {
+		plugins = append(plugins, p)
+	}
+
+	return plugins
+}
+
+// Allow declares the waiting pod is allowed to be scheduled by plugin pluginName.
+// If this is the last remaining plugin to allow, then a success signal is delivered
+// to unblock the pod.
+// Returns true if the allow signal was successfully dealt with, false otherwise.
+func (w *waitingPod) Allow(pluginName string) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if timer, exist := w.pendingPlugins[pluginName]; exist {
+		timer.Stop()
+		delete(w.pendingPlugins, pluginName)
+	}
+
+	// Only signal success status after all plugins have allowed
+	if len(w.pendingPlugins) != 0 {
+		return true
+	}
+
 	select {
 	case w.s <- NewStatus(Success, ""):
 		return true
@@ -97,9 +139,15 @@ func (w *waitingPod) Allow() bool {
 	}
 }
 
-// Reject declares the waiting pod unschedulable. Returns true if the allow signal
+// Reject declares the waiting pod unschedulable. Returns true if the reject signal
 // was successfully delivered, false otherwise.
 func (w *waitingPod) Reject(msg string) bool {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+	for _, timer := range w.pendingPlugins {
+		timer.Stop()
+	}
+
 	select {
 	case w.s <- NewStatus(Unschedulable, msg):
 		return true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As said in https://github.com/kubernetes/kubernetes/issues/82385:

> At the high-level, we need to change the permit API so that an accept is done for a specific plugin, and the pod will be accepted only after all plugins that issued wait get an accept. We also may want to keep adjusting the timeout every time the pod gets accepted by a plugin 

Design doc: https://docs.google.com/document/d/1ftrPlERI5GVzWh0qAM_fChrhcpsBTYyyCleVvmMNEJ4/edit?usp=sharing

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82385

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Refactor scheduler's framework permit API.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig scheduling
