### PR TITLE
Automated cherry pick of #83609: Remove e2e/common package usage in volumemode testsuite

### DIFF
--- a/test/e2e/storage/testsuites/BUILD
+++ b/test/e2e/storage/testsuites/BUILD
@@ -43,7 +43,6 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/csi-translation-lib:go_default_library",
         "//staging/src/k8s.io/csi-translation-lib/plugins:go_default_library",
-        "//test/e2e/common:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/metrics:go_default_library",


### PR DESCRIPTION
Cherry pick of #83609 on release-1.16.

#83609: Remove e2e/common package usage in volumemode testsuite

```release-note
removed dependency on test/e2e/common from test/e2e/storage/testsuites
```