### PR TITLE
Automated cherry pick of #73138: Do not move deletionTimestamp to the future

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -2109,6 +2109,50 @@ func TestDeletionFinalizersForGarbageCollection(t *testing.T) {
 	}
 }
 
+func TestMarkAsDeleting(t *testing.T) {
+	now := time.Now()
+	soon := now.Add(time.Second)
+	past := now.Add(-time.Second)
+
+	newTimePointer := func(t time.Time) *metav1.Time {
+		metaTime := metav1.NewTime(t)
+		return &metaTime
+	}
+	testcases := []struct {
+		name                    string
+		deletionTimestamp       *metav1.Time
+		expectDeletionTimestamp *metav1.Time
+	}{
+		{
+			name:                    "unset",
+			deletionTimestamp:       nil,
+			expectDeletionTimestamp: newTimePointer(now),
+		},
+		{
+			name:                    "set to future",
+			deletionTimestamp:       newTimePointer(soon),
+			expectDeletionTimestamp: newTimePointer(now),
+		},
+		{
+			name:                    "set to past",
+			deletionTimestamp:       newTimePointer(past),
+			expectDeletionTimestamp: newTimePointer(past),
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			rs := &example.ReplicaSet{}
+			rs.DeletionTimestamp = tc.deletionTimestamp
+			if err := markAsDeleting(rs, now); err != nil {
+				t.Error(err)
+			}
+			if reflect.DeepEqual(*rs.DeletionTimestamp, tc.expectDeletionTimestamp) {
+				t.Errorf("expected %v, got %v", tc.expectDeletionTimestamp, *rs.DeletionTimestamp)
+			}
+		})
+	}
+}
+
 type staleGuaranteedUpdateStorage struct {
 	storage.Interface
 	cachedObj runtime.Object


### PR DESCRIPTION
Cherry pick of #73138 on release-1.13.

#73138: Do not move deletionTimestamp to the future

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.