### PR TITLE
Protect against DOS Plugin Registration

### DIFF
--- a/pkg/kubelet/pluginmanager/BUILD
+++ b/pkg/kubelet/pluginmanager/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kubelet/pluginmanager/reconciler:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/tools/record:go_default_library",
+        "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/kubelet/pluginmanager/plugin_manager.go
+++ b/pkg/kubelet/pluginmanager/plugin_manager.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	"k8s.io/kubernetes/pkg/kubelet/pluginmanager/cache"
@@ -67,10 +68,14 @@ func NewPluginManager(
 		asw,
 	)
 
+	registrationLimiter := flowcontrol.NewTokenBucketRateLimiter(
+		pluginwatcher.DefaultPluginRegistrationLimiterQPS, pluginwatcher.DefaultPluginRegistrationBurst)
+
 	pm := &pluginManager{
 		desiredStateOfWorldPopulator: pluginwatcher.NewWatcher(
 			sockDir,
 			dsw,
+			registrationLimiter,
 		),
 		reconciler:          reconciler,
 		desiredStateOfWorld: dsw,

--- a/pkg/kubelet/pluginmanager/pluginwatcher/BUILD
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/kubelet/pluginmanager/pluginwatcher/example_plugin_apis/v1beta2:go_default_library",
         "//pkg/kubelet/util:go_default_library",
         "//pkg/util/filesystem:go_default_library",
+        "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/kubelet/pkg/apis/pluginregistration/v1:go_default_library",
         "//vendor/github.com/fsnotify/fsnotify:go_default_library",
         "//vendor/golang.org/x/net/context:go_default_library",
@@ -30,6 +31,7 @@ go_test(
     deps = [
         "//pkg/kubelet/pluginmanager/cache:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/kubelet/pkg/apis/pluginregistration/v1:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use token bucket rate limiting to protect against denial of service
attacks (intentional or unintentional) when registering new/updatable plugins.

**Which issue(s) this PR fixes**:
Address TODO in the code base.

**Special notes for your reviewer**:
cc @taragu is that what you envisioned?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```