### PR TITLE
1.16: apiextensions: fix panic with x-kuberentes-int-or-string in CRDs

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/BUILD
@@ -48,6 +48,7 @@ go_test(
     srcs = [
         "convert_test.go",
         "goopenapi_test.go",
+        "unfold_test.go",
         "validation_test.go",
     ],
     embed = [":go_default_library"],

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/structural.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/structural.go
@@ -30,7 +30,7 @@ type Structural struct {
 	Generic
 	Extensions
 
-	*ValueValidation
+	ValueValidation *ValueValidation
 }
 
 // +k8s:deepcopy-gen=true

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/unfold.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/unfold.go
@@ -35,13 +35,16 @@ func (s *Structural) Unfold() *Structural {
 				return false
 			}
 
-			if s.AnyOf == nil {
-				s.AnyOf = []NestedValueValidation{
+			if s.ValueValidation == nil {
+				s.ValueValidation = &ValueValidation{}
+			}
+			if s.ValueValidation.AnyOf == nil {
+				s.ValueValidation.AnyOf = []NestedValueValidation{
 					{ForbiddenGenerics: Generic{Type: "integer"}},
 					{ForbiddenGenerics: Generic{Type: "string"}},
 				}
 			} else {
-				s.AllOf = append([]NestedValueValidation{
+				s.ValueValidation.AllOf = append([]NestedValueValidation{
 					{
 						ValueValidation: ValueValidation{
 							AnyOf: []NestedValueValidation{
@@ -50,7 +53,7 @@ func (s *Structural) Unfold() *Structural {
 							},
 						},
 					},
-				}, s.AllOf...)
+				}, s.ValueValidation.AllOf...)
 			}
 
 			return true

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/unfold_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/unfold_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schema
+
+import (
+	"testing"
+)
+
+// TestStructuralUnfoldNilValueValidation tests that Unfold() does not crash
+// on a IntOrString pattern with nil ValueValidation.
+func TestStructuralUnfoldIntOrString(t *testing.T) {
+	schema := Structural{
+		Extensions: Extensions{
+			XIntOrString: true,
+		},
+	}
+	schema.Unfold()
+}


### PR DESCRIPTION
Backport of https://github.com/kubernetes/kubernetes/pull/83787

/kind bug

```release-note
Fixed panic when accessing CustomResources of a CRD with x-kubernetes-int-or-string.
```