### PR TITLE
Benchmark for authn cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/BUILD
@@ -15,6 +15,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/authenticator:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//vendor/github.com/pborman/uuid:go_default_library",


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Provides the benchmark in #83519 separately since it's unclear what we'll do with the cache, maybe delete it.

We made the cache bigger, so I extended the benchmark to test numbers of tokens bigger than the cache to continue to illustrate the bi-modal performance of the cache.

```
pkg: k8s.io/apiserver/pkg/authentication/token/cache
BenchmarkCachedTokenAuthenticator/toks-100-12             535340              2772 ns/op
BenchmarkCachedTokenAuthenticator/toks-500-12             436530              2889 ns/op
BenchmarkCachedTokenAuthenticator/toks-2500-12            470738              3465 ns/op
BenchmarkCachedTokenAuthenticator/toks-12500-12            56622             20755 ns/op
BenchmarkCachedTokenAuthenticator/toks-62500-12            39487             27952 ns/op
```

Related to: #83259

```release-note
NONE
```
