### PR TITLE
Rename Generate[Read|Write]FileCmd()s on e2e framework

### DIFF
--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -523,7 +523,7 @@ func testVolumeContent(client clientset.Interface, pod *v1.Pod, fsGroup *int64, 
 		if test.Mode == v1.PersistentVolumeBlock {
 			// Block: check content
 			deviceName := fmt.Sprintf("/opt/%d", i)
-			commands := GenerateReadBlockCmd(deviceName, len(test.ExpectedContent))
+			commands := generateReadBlockCmd(deviceName, len(test.ExpectedContent))
 			_, err := framework.LookForStringInPodExec(pod.Namespace, pod.Name, commands, test.ExpectedContent, time.Minute)
 			framework.ExpectNoError(err, "failed: finding the contents of the block device %s.", deviceName)
 
@@ -532,7 +532,7 @@ func testVolumeContent(client clientset.Interface, pod *v1.Pod, fsGroup *int64, 
 		} else {
 			// Filesystem: check content
 			fileName := fmt.Sprintf("/opt/%d/%s", i, test.File)
-			commands := GenerateReadFileCmd(fileName)
+			commands := generateReadFileCmd(fileName)
 			_, err := framework.LookForStringInPodExec(pod.Namespace, pod.Name, commands, test.ExpectedContent, time.Minute)
 			framework.ExpectNoError(err, "failed: finding the contents of the mounted file %s.", fileName)
 
@@ -593,12 +593,12 @@ func InjectContent(client clientset.Interface, config TestConfig, fsGroup *int64
 		if test.Mode == v1.PersistentVolumeBlock {
 			// Block: write content
 			deviceName := fmt.Sprintf("/opt/%d", i)
-			commands = append(commands, GenerateWriteBlockCmd(test.ExpectedContent, deviceName)...)
+			commands = append(commands, generateWriteBlockCmd(test.ExpectedContent, deviceName)...)
 
 		} else {
 			// Filesystem: write content
 			fileName := fmt.Sprintf("/opt/%d/%s", i, test.File)
-			commands = append(commands, GenerateWriteFileCmd(test.ExpectedContent, fileName)...)
+			commands = append(commands, generateWriteFileCmd(test.ExpectedContent, fileName)...)
 		}
 		out, err := framework.RunKubectl(commands...)
 		framework.ExpectNoError(err, "failed: writing the contents: %s", out)
@@ -634,9 +634,9 @@ func GenerateScriptCmd(command string) []string {
 	return commands
 }
 
-// GenerateWriteBlockCmd generates the corresponding command lines to write to a block device the given content.
+// generateWriteBlockCmd generates the corresponding command lines to write to a block device the given content.
 // Depending on the Node OS is Windows or linux, the command will use powershell or /bin/sh
-func GenerateWriteBlockCmd(content, fullPath string) []string {
+func generateWriteBlockCmd(content, fullPath string) []string {
 	var commands []string
 	if !framework.NodeOSDistroIs("windows") {
 		commands = []string{"/bin/sh", "-c", "echo '" + content + "' > " + fullPath}
@@ -646,9 +646,9 @@ func GenerateWriteBlockCmd(content, fullPath string) []string {
 	return commands
 }
 
-// GenerateWriteFileCmd generates the corresponding command lines to write a file with the given content and file path.
+// generateWriteFileCmd generates the corresponding command lines to write a file with the given content and file path.
 // Depending on the Node OS is Windows or linux, the command will use powershell or /bin/sh
-func GenerateWriteFileCmd(content, fullPath string) []string {
+func generateWriteFileCmd(content, fullPath string) []string {
 	var commands []string
 	if !framework.NodeOSDistroIs("windows") {
 		commands = []string{"/bin/sh", "-c", "echo '" + content + "' > " + fullPath}
@@ -658,9 +658,9 @@ func GenerateWriteFileCmd(content, fullPath string) []string {
 	return commands
 }
 
-// GenerateReadFileCmd generates the corresponding command lines to read from a file with the given file path.
+// generateReadFileCmd generates the corresponding command lines to read from a file with the given file path.
 // Depending on the Node OS is Windows or linux, the command will use powershell or /bin/sh
-func GenerateReadFileCmd(fullPath string) []string {
+func generateReadFileCmd(fullPath string) []string {
 	var commands []string
 	if !framework.NodeOSDistroIs("windows") {
 		commands = []string{"cat", fullPath}
@@ -670,9 +670,9 @@ func GenerateReadFileCmd(fullPath string) []string {
 	return commands
 }
 
-// GenerateReadBlockCmd generates the corresponding command lines to read from a block device with the given file path.
+// generateReadBlockCmd generates the corresponding command lines to read from a block device with the given file path.
 // Depending on the Node OS is Windows or linux, the command will use powershell or /bin/sh
-func GenerateReadBlockCmd(fullPath string, numberOfCharacters int) []string {
+func generateReadBlockCmd(fullPath string, numberOfCharacters int) []string {
 	var commands []string
 	if !framework.NodeOSDistroIs("windows") {
 		commands = []string{"head", "-c", strconv.Itoa(numberOfCharacters), fullPath}


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:

/kind cleanup

**What this PR does / why we need it**:

These functions are only used in fixtures.go module.
So it is not necessary to define them for exposing.
This renames these functions for making them local functions clearly.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
