### PR TITLE
Move PatchContainerImages to core e2e framework

### DIFF
--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -661,17 +661,3 @@ func GetPodsScheduled(masterNodes sets.String, pods *v1.PodList) (scheduledPods,
 	}
 	return
 }
-
-// PatchContainerImages replaces the specified Container Registry with a custom
-// one provided via the KUBE_TEST_REPO_LIST env variable
-func PatchContainerImages(containers []v1.Container) error {
-	var err error
-	for _, c := range containers {
-		c.Image, err = imageutils.ReplaceRegistryInImageURL(c.Image)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

PatchContainerImages() is used at core e2e framework only.
To remove dependency to the subpackage from the core framework,
this moves the function to the core.

Ref: https://github.com/kubernetes/kubernetes/issues/81427

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
