### PR TITLE
Rename e2e framework functions used locally

### DIFF
--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -104,7 +104,7 @@ func CreatePod(client clientset.Interface, namespace string, nodeSelector map[st
 
 // CreateNginxPod creates an enginx pod.
 func CreateNginxPod(client clientset.Interface, namespace string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim) (*v1.Pod, error) {
-	pod := MakeNginxPod(namespace, nodeSelector, pvclaims)
+	pod := makeNginxPod(namespace, nodeSelector, pvclaims)
 	pod, err := client.CoreV1().Pods(namespace).Create(pod)
 	if err != nil {
 		return nil, fmt.Errorf("pod Create API error: %v", err)
@@ -198,8 +198,8 @@ func MakePod(ns string, nodeSelector map[string]string, pvclaims []*v1.Persisten
 	return podSpec
 }
 
-// MakeNginxPod returns a pod definition based on the namespace using nginx image
-func MakeNginxPod(ns string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim) *v1.Pod {
+// makeNginxPod returns a pod definition based on the namespace using nginx image
+func makeNginxPod(ns string, nodeSelector map[string]string, pvclaims []*v1.PersistentVolumeClaim) *v1.Pod {
 	podSpec := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",

--- a/test/e2e/framework/pod/node_selection.go
+++ b/test/e2e/framework/pod/node_selection.go
@@ -28,8 +28,8 @@ type NodeSelection struct {
 	Affinity *v1.Affinity
 }
 
-// SetNodeAffinityRequirement sets affinity with specified operator to nodeName to nodeSelection
-func SetNodeAffinityRequirement(nodeSelection *NodeSelection, operator v1.NodeSelectorOperator, nodeName string) {
+// setNodeAffinityRequirement sets affinity with specified operator to nodeName to nodeSelection
+func setNodeAffinityRequirement(nodeSelection *NodeSelection, operator v1.NodeSelectorOperator, nodeName string) {
 	// Add node-anti-affinity.
 	if nodeSelection.Affinity == nil {
 		nodeSelection.Affinity = &v1.Affinity{}
@@ -50,10 +50,10 @@ func SetNodeAffinityRequirement(nodeSelection *NodeSelection, operator v1.NodeSe
 
 // SetAffinity sets affinity to nodeName to nodeSelection
 func SetAffinity(nodeSelection *NodeSelection, nodeName string) {
-	SetNodeAffinityRequirement(nodeSelection, v1.NodeSelectorOpIn, nodeName)
+	setNodeAffinityRequirement(nodeSelection, v1.NodeSelectorOpIn, nodeName)
 }
 
 // SetAntiAffinity sets anti-affinity to nodeName to nodeSelection
 func SetAntiAffinity(nodeSelection *NodeSelection, nodeName string) {
-	SetNodeAffinityRequirement(nodeSelection, v1.NodeSelectorOpNotIn, nodeName)
+	setNodeAffinityRequirement(nodeSelection, v1.NodeSelectorOpNotIn, nodeName)
 }

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -389,9 +389,9 @@ func LogPodStates(pods []v1.Pod) {
 	e2elog.Logf("") // Final empty line helps for readability.
 }
 
-// LogPodTerminationMessages logs termination messages for failing pods.  It's a short snippet (much smaller than full logs), but it often shows
+// logPodTerminationMessages logs termination messages for failing pods.  It's a short snippet (much smaller than full logs), but it often shows
 // why pods crashed and since it is in the API, it's fast to retrieve.
-func LogPodTerminationMessages(pods []v1.Pod) {
+func logPodTerminationMessages(pods []v1.Pod) {
 	for _, pod := range pods {
 		for _, status := range pod.Status.InitContainerStatuses {
 			if status.LastTerminationState.Terminated != nil && len(status.LastTerminationState.Terminated.Message) > 0 {
@@ -413,7 +413,7 @@ func DumpAllPodInfoForNamespace(c clientset.Interface, namespace string) {
 		e2elog.Logf("unable to fetch pod debug info: %v", err)
 	}
 	LogPodStates(pods.Items)
-	LogPodTerminationMessages(pods.Items)
+	logPodTerminationMessages(pods.Items)
 }
 
 // FilterNonRestartablePods filters out pods that will never get recreated if
@@ -551,19 +551,19 @@ func CreatePodOrFail(c clientset.Interface, ns, name string, labels map[string]s
 // podNames in namespace ns are running and ready, using c and waiting at most
 // timeout.
 func CheckPodsRunningReady(c clientset.Interface, ns string, podNames []string, timeout time.Duration) bool {
-	return CheckPodsCondition(c, ns, podNames, timeout, testutils.PodRunningReady, "running and ready")
+	return checkPodsCondition(c, ns, podNames, timeout, testutils.PodRunningReady, "running and ready")
 }
 
 // CheckPodsRunningReadyOrSucceeded returns whether all pods whose names are
 // listed in podNames in namespace ns are running and ready, or succeeded; use
 // c and waiting at most timeout.
 func CheckPodsRunningReadyOrSucceeded(c clientset.Interface, ns string, podNames []string, timeout time.Duration) bool {
-	return CheckPodsCondition(c, ns, podNames, timeout, testutils.PodRunningReadyOrSucceeded, "running and ready, or succeeded")
+	return checkPodsCondition(c, ns, podNames, timeout, testutils.PodRunningReadyOrSucceeded, "running and ready, or succeeded")
 }
 
-// CheckPodsCondition returns whether all pods whose names are listed in podNames
+// checkPodsCondition returns whether all pods whose names are listed in podNames
 // in namespace ns are in the condition, using c and waiting at most timeout.
-func CheckPodsCondition(c clientset.Interface, ns string, podNames []string, timeout time.Duration, condition podCondition, desc string) bool {
+func checkPodsCondition(c clientset.Interface, ns string, podNames []string, timeout time.Duration, condition podCondition, desc string) bool {
 	np := len(podNames)
 	e2elog.Logf("Waiting up to %v for %d pods to be %s: %s", timeout, np, desc, podNames)
 	type waitPodResult struct {

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -162,7 +162,7 @@ func SSH(cmd, host, provider string) (Result, error) {
 	}
 
 	if bastion := os.Getenv("KUBE_SSH_BASTION"); len(bastion) > 0 {
-		stdout, stderr, code, err := RunSSHCommandViaBastion(cmd, result.User, bastion, host, signer)
+		stdout, stderr, code, err := runSSHCommandViaBastion(cmd, result.User, bastion, host, signer)
 		result.Stdout = stdout
 		result.Stderr = stderr
 		result.Code = code
@@ -177,11 +177,11 @@ func SSH(cmd, host, provider string) (Result, error) {
 	return result, err
 }
 
-// RunSSHCommandViaBastion returns the stdout, stderr, and exit code from running cmd on
+// runSSHCommandViaBastion returns the stdout, stderr, and exit code from running cmd on
 // host as specific user, along with any SSH-level error. It uses an SSH proxy to connect
 // to bastion, then via that tunnel connects to the remote host. Similar to
 // sshutil.RunSSHCommand but scoped to the needs of the test infrastructure.
-func RunSSHCommandViaBastion(cmd, user, bastion, host string, signer ssh.Signer) (string, string, int, error) {
+func runSSHCommandViaBastion(cmd, user, bastion, host string, signer ssh.Signer) (string, string, int, error) {
 	// Setup the config, dial the server, and open a session.
 	config := &ssh.ClientConfig{
 		User:            user,


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The following functions are used locally in e2e framework subpackages.
 - RunSSHCommandViaBastion
 - MakeNginxPod
 - LogPodTerminationMessages
 - CheckPodsCondition
 - SetNodeAffinityRequirement

This renames them to clarify them as local ones.

Ref: https://github.com/kubernetes/kubernetes/issues/81427

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
