### PR TITLE
Check indexer before obtaining the lock

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_cache.go
@@ -117,11 +117,11 @@ func (c *mutationCache) GetByKey(key string) (interface{}, bool, error) {
 // ByIndex returns the newer objects that match the provided index and indexer key.
 // Will return an error if no indexer was provided.
 func (c *mutationCache) ByIndex(name string, indexKey string) ([]interface{}, error) {
-	c.lock.Lock()
-	defer c.lock.Unlock()
 	if c.indexer == nil {
 		return nil, fmt.Errorf("no indexer has been provided to the mutation cache")
 	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
 	keys, err := c.indexer.IndexKeys(name, indexKey)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In mutationCache#ByIndex, we should check whether indexer is nil before obtaining the lock since indexer doesn't change for mutationCache.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
