### PR TITLE
fix kubectl delete semantic error

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -820,7 +820,14 @@ func (b *Builder) visitorResult() *Result {
 	}
 
 	if len(b.resources) != 0 {
-		return &Result{err: fmt.Errorf("resource(s) were provided, but no name, label selector, or --all flag specified")}
+		for _, r := range b.resources {
+			_, err := b.mappingFor(r)
+			if err != nil {
+				return &Result{err: err}
+			} else {
+				return &Result{err: fmt.Errorf("resource(s) were provided, but no name, label selector, or --all flag specified")}
+			}
+		}
 	}
 	return &Result{err: missingResourceError}
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder_test.go
@@ -1228,7 +1228,18 @@ func TestFieldSelectorRequiresKnownTypes(t *testing.T) {
 		t.Errorf("unexpected non-error")
 	}
 }
+func TestNoSelectorUnknowResourceType(t *testing.T) {
+	b := newDefaultBuilder().
+		NamespaceParam("test").
+		ResourceTypeOrNameArgs(false, "unknown")
 
+	err := b.Do().Err()
+	if err != nil {
+		if !strings.Contains(err.Error(), "server doesn't have a resource type \"unknown\"") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+}
 func TestSingleResourceType(t *testing.T) {
 	b := newDefaultBuilder().
 		LabelSelectorParam("a=b").


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change?**:

Yes, it gives the right error message when using `kubectl delete` a wrong resource.

**What this PR does / why we need it**:

if we use:  
```
# kubeclt delete pods
```
It shows:
```
error: resource(s) were provided, but no name, label selector, or --all flag specified
``` 
Which is correct.
But if we use:
```
# kubectl delete unknown
```
It shows also:
```
error: resource(s) were provided, but no name, label selector, or --all flag specified
```
Which would lead semantic misunderstanding(see the https://github.com/kubernetes/kubernetes/issues/83721). The problem is caused beacause we didn't check the type of resource if `kubectl delete` has only one resource.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/83721

```release-note
Gives the right error message when using `kubectl delete` a wrong resource.
```