### PR TITLE
Make PriorityQueue near FIFO for same priority Pods by leveraging Pod creation time

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -166,7 +166,7 @@ type Plugin interface {
 // the timestamp when it's added to the queue or recording per-pod metrics.
 type PodInfo struct {
 	Pod *v1.Pod
-	// The time pod added to the scheduling queue.
+	// The last time when the pod is tried to schedule.
 	Timestamp time.Time
 	// Number of schedule attempts before successfully scheduled.
 	// It's used to record the # attempts metric.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
See https://github.com/kubernetes/kubernetes/issues/83834 and https://github.com/kubernetes/kubernetes/issues/83826

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/83834
Fixes https://github.com/kubernetes/kubernetes/issues/83826
PartOfLongTermFinalSolutionFor https://github.com/microsoft/pai/issues/3704


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
yes
```release-note
Make PriorityQueue near FIFO for same priority Pods by leveraging Pod creation time
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
