### PR TITLE
Hide metrics that have been deprecated 

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -40,9 +40,10 @@ var (
 	// deprecatedRequestLatency is deprecated, please use requestLatency.
 	deprecatedRequestLatency = k8smetrics.NewHistogramVec(
 		&k8smetrics.HistogramOpts{
-			Name:    "rest_client_request_latency_seconds",
-			Help:    "(Deprecated) Request latency in seconds. Broken down by verb and URL.",
-			Buckets: k8smetrics.ExponentialBuckets(0.001, 2, 10),
+			Name:              "rest_client_request_latency_seconds",
+			Help:              "Request latency in seconds. Broken down by verb and URL.",
+			Buckets:           k8smetrics.ExponentialBuckets(0.001, 2, 10),
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"verb", "url"},
 	)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Turn off metrics that have been deprecated in v1.14

Refer to https://github.com/kubernetes/enhancements/issues/1206:
>Kubernetes 1.17 will remove the in 1.14 marked as deprecated metrics. As a stretch goal, if the metrics stability framework is in place, then in Kubernetes 1.17 the metrics will only be turned off by default through the stability framework. Should this not be available, then the metrics will be removed.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/enhancements/issues/1206

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Deprecated metric `rest_client_request_latency_seconds` has been turned off.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/da4b7050ccae7a947e4d60f94ab28513e513a458/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
```