### PR TITLE
Turn off apiserver deprecated metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -76,9 +76,10 @@ var (
 	)
 	deprecatedRequestCounter = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_request_count",
-			Help:           "(Deprecated) Counter of apiserver requests broken out for each verb, group, version, resource, scope, component, client, and HTTP response contentType and code.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "apiserver_request_count",
+			Help:              "Counter of apiserver requests broken out for each verb, group, version, resource, scope, component, client, and HTTP response contentType and code.",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component", "client", "contentType", "code"},
 	)
@@ -106,21 +107,23 @@ var (
 	deprecatedRequestLatencies = compbasemetrics.NewHistogramVec(
 		&compbasemetrics.HistogramOpts{
 			Name: "apiserver_request_latencies",
-			Help: "(Deprecated) Response latency distribution in microseconds for each verb, group, version, resource, subresource, scope and component.",
+			Help: "Response latency distribution in microseconds for each verb, group, version, resource, subresource, scope and component.",
 			// Use buckets ranging from 125 ms to 8 seconds.
-			Buckets:        compbasemetrics.ExponentialBuckets(125000, 2.0, 7),
-			StabilityLevel: compbasemetrics.ALPHA,
+			Buckets:           compbasemetrics.ExponentialBuckets(125000, 2.0, 7),
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
 	deprecatedRequestLatenciesSummary = compbasemetrics.NewSummaryVec(
 		&compbasemetrics.SummaryOpts{
 			Name: "apiserver_request_latencies_summary",
-			Help: "(Deprecated) Response latency summary in microseconds for each verb, group, version, resource, subresource, scope and component.",
+			Help: "Response latency summary in microseconds for each verb, group, version, resource, subresource, scope and component.",
 			// Make the sliding window of 5h.
 			// TODO: The value for this should be based on our SLI definition (medium term).
-			MaxAge:         5 * time.Hour,
-			StabilityLevel: compbasemetrics.ALPHA,
+			MaxAge:            5 * time.Hour,
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"verb", "group", "version", "resource", "subresource", "scope", "component"},
 	)
@@ -145,9 +148,10 @@ var (
 	)
 	DeprecatedDroppedRequests = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
-			Name:           "apiserver_dropped_requests",
-			Help:           "(Deprecated) Number of requests dropped with 'Try again later' response",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "apiserver_dropped_requests",
+			Help:              "Number of requests dropped with 'Try again later' response",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"requestKind"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -52,9 +52,10 @@ var (
 
 	deprecatedEtcdRequestLatenciesSummary = compbasemetrics.NewSummaryVec(
 		&compbasemetrics.SummaryOpts{
-			Name:           "etcd_request_latencies_summary",
-			Help:           "(Deprecated) Etcd request latency summary in microseconds for each operation and object type.",
-			StabilityLevel: compbasemetrics.ALPHA,
+			Name:              "etcd_request_latencies_summary",
+			Help:              "Etcd request latency summary in microseconds for each operation and object type.",
+			StabilityLevel:    compbasemetrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation", "type"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -81,11 +81,12 @@ var (
 
 	deprecatedTransformerFailuresTotal = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Namespace:      namespace,
-			Subsystem:      subsystem,
-			Name:           "transformation_failures_total",
-			Help:           "(Deprecated) Total number of failed transformation operations.",
-			StabilityLevel: metrics.ALPHA,
+			Namespace:         namespace,
+			Subsystem:         subsystem,
+			Name:              "transformation_failures_total",
+			Help:              "Total number of failed transformation operations.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.15.0",
 		},
 		[]string{"transformation_type"},
 	)

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics.go
@@ -58,11 +58,12 @@ var (
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "transformation_latencies_microseconds",
-			Help:      "(Deprecated) Latencies in microseconds of value transformation operations.",
+			Help:      "Latencies in microseconds of value transformation operations.",
 			// In-process transformations (ex. AES CBC) complete on the order of 20 microseconds. However, when
 			// external KMS is involved latencies may climb into milliseconds.
-			Buckets:        metrics.ExponentialBuckets(5, 2, 14),
-			StabilityLevel: metrics.ALPHA,
+			Buckets:           metrics.ExponentialBuckets(5, 2, 14),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"transformation_type"},
 	)
@@ -111,12 +112,13 @@ var (
 	)
 	deprecatedDataKeyGenerationLatencies = metrics.NewHistogram(
 		&metrics.HistogramOpts{
-			Namespace:      namespace,
-			Subsystem:      subsystem,
-			Name:           "data_key_generation_latencies_microseconds",
-			Help:           "(Deprecated) Latencies in microseconds of data encryption key(DEK) generation operations.",
-			Buckets:        metrics.ExponentialBuckets(5, 2, 14),
-			StabilityLevel: metrics.ALPHA,
+			Namespace:         namespace,
+			Subsystem:         subsystem,
+			Name:              "data_key_generation_latencies_microseconds",
+			Help:              "Latencies in microseconds of data encryption key(DEK) generation operations.",
+			Buckets:           metrics.ExponentialBuckets(5, 2, 14),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 	dataKeyGenerationFailuresTotal = metrics.NewCounter(

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/metrics_test.go
@@ -48,68 +48,52 @@ func TestTotals(t *testing.T) {
 			prefix: NewPrefixTransformers(nil, nonStatusErrTransformer),
 			metrics: []string{
 				"apiserver_storage_transformation_operations_total",
-				"apiserver_storage_transformation_failures_total",
 			},
 			want: `
-# HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
-# TYPE apiserver_storage_transformation_failures_total counter
-apiserver_storage_transformation_failures_total{transformation_type="from_storage"} 1
-apiserver_storage_transformation_failures_total{transformation_type="to_storage"} 1
-# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
-# TYPE apiserver_storage_transformation_operations_total counter
-apiserver_storage_transformation_operations_total{status="Unknown",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-apiserver_storage_transformation_operations_total{status="Unknown",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-`,
+				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+				# TYPE apiserver_storage_transformation_operations_total counter
+				apiserver_storage_transformation_operations_total{status="Unknown",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				apiserver_storage_transformation_operations_total{status="Unknown",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				`,
 		},
 		{
 			desc:   "ok",
 			prefix: NewPrefixTransformers(nil, okTransformer),
 			metrics: []string{
 				"apiserver_storage_transformation_operations_total",
-				"apiserver_storage_transformation_failures_total",
 			},
 			want: `
-# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
-# TYPE apiserver_storage_transformation_operations_total counter
-apiserver_storage_transformation_operations_total{status="OK",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-apiserver_storage_transformation_operations_total{status="OK",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-`,
+				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+				# TYPE apiserver_storage_transformation_operations_total counter
+				apiserver_storage_transformation_operations_total{status="OK",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				apiserver_storage_transformation_operations_total{status="OK",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				`,
 		},
 		{
 			desc:   "failed precondition",
 			prefix: NewPrefixTransformers(nil, failedPreconditionErrTransformer),
 			metrics: []string{
 				"apiserver_storage_transformation_operations_total",
-				"apiserver_storage_transformation_failures_total",
 			},
 			want: `
-# HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
-# TYPE apiserver_storage_transformation_failures_total counter
-apiserver_storage_transformation_failures_total{transformation_type="from_storage"} 1
-apiserver_storage_transformation_failures_total{transformation_type="to_storage"} 1
-# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
-# TYPE apiserver_storage_transformation_operations_total counter
-apiserver_storage_transformation_operations_total{status="FailedPrecondition",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-apiserver_storage_transformation_operations_total{status="FailedPrecondition",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-`,
+				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+				# TYPE apiserver_storage_transformation_operations_total counter
+				apiserver_storage_transformation_operations_total{status="FailedPrecondition",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				apiserver_storage_transformation_operations_total{status="FailedPrecondition",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				`,
 		},
 		{
 			desc:   "internal",
 			prefix: NewPrefixTransformers(nil, internalErrTransformer),
 			metrics: []string{
 				"apiserver_storage_transformation_operations_total",
-				"apiserver_storage_transformation_failures_total",
 			},
 			want: `
-# HELP apiserver_storage_transformation_failures_total [ALPHA] (Deprecated) Total number of failed transformation operations.
-# TYPE apiserver_storage_transformation_failures_total counter
-apiserver_storage_transformation_failures_total{transformation_type="from_storage"} 1
-apiserver_storage_transformation_failures_total{transformation_type="to_storage"} 1
-# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
-# TYPE apiserver_storage_transformation_operations_total counter
-apiserver_storage_transformation_operations_total{status="Internal",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-apiserver_storage_transformation_operations_total{status="Internal",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
-`,
+				# HELP apiserver_storage_transformation_operations_total [ALPHA] Total number of transformations.
+				# TYPE apiserver_storage_transformation_operations_total counter
+				apiserver_storage_transformation_operations_total{status="Internal",transformation_type="from_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				apiserver_storage_transformation_operations_total{status="Internal",transformation_type="to_storage",transformer_prefix="k8s:enc:kms:v1:"} 1
+				`,
 		},
 	}
 

--- a/test/e2e/framework/metrics/interesting_metrics.go
+++ b/test/e2e/framework/metrics/interesting_metrics.go
@@ -18,9 +18,7 @@ package metrics
 
 var interestingAPIServerMetrics = []string{
 	"apiserver_request_total",
-	// TODO(krzysied): apiserver_request_latencies_summary is a deprecated metric.
-	// It should be replaced with new metric.
-	"apiserver_request_latencies_summary",
+	"apiserver_request_latency_seconds",
 	"apiserver_init_events_total",
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Turn off metrics that have been deprecated.

Refer to https://github.com/kubernetes/enhancements/issues/1206:
>Kubernetes 1.17 will remove the in 1.14 marked as deprecated metrics. As a stretch goal, if the metrics stability framework is in place, then in Kubernetes 1.17 the metrics will only be turned off by default through the stability framework. Should this not be available, then the metrics will be removed.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/enhancements/issues/1206

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Following metrics have been turned off:
- apiserver_request_count
- apiserver_request_latencies
- apiserver_request_latencies_summary
- apiserver_dropped_requests
- etcd_request_latencies_summary
- apiserver_storage_transformation_latencies_microseconds
- apiserver_storage_data_key_generation_latencies_microseconds
- apiserver_storage_transformation_failures_total
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/da4b7050ccae7a947e4d60f94ab28513e513a458/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
```

