### PR TITLE
Turn off proxy metrics that have been deprecated

### DIFF
--- a/pkg/proxy/metrics/metrics.go
+++ b/pkg/proxy/metrics/metrics.go
@@ -41,11 +41,12 @@ var (
 	// DeprecatedSyncProxyRulesLatency is the latency of one round of kube-proxy syncing proxy rules.
 	DeprecatedSyncProxyRulesLatency = metrics.NewHistogram(
 		&metrics.HistogramOpts{
-			Subsystem:      kubeProxySubsystem,
-			Name:           "sync_proxy_rules_latency_microseconds",
-			Help:           "(Deprecated) SyncProxyRules latency in microseconds",
-			Buckets:        metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         kubeProxySubsystem,
+			Name:              "sync_proxy_rules_latency_microseconds",
+			Help:              "SyncProxyRules latency in microseconds",
+			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 

--- a/pkg/proxy/winkernel/metrics.go
+++ b/pkg/proxy/winkernel/metrics.go
@@ -39,11 +39,12 @@ var (
 
 	DeprecatedSyncProxyRulesLatency = metrics.NewHistogram(
 		&metrics.HistogramOpts{
-			Subsystem:      kubeProxySubsystem,
-			Name:           "sync_proxy_rules_latency_microseconds",
-			Help:           "(Deprecated) SyncProxyRules latency in microseconds",
-			Buckets:        metrics.ExponentialBuckets(1000, 2, 15),
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         kubeProxySubsystem,
+			Name:              "sync_proxy_rules_latency_microseconds",
+			Help:              "SyncProxyRules latency in microseconds",
+			Buckets:           metrics.ExponentialBuckets(1000, 2, 15),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Turn off metrics that have been deprecated.

Refer to https://github.com/kubernetes/enhancements/issues/1206:
>Kubernetes 1.17 will remove the in 1.14 marked as deprecated metrics. As a stretch goal, if the metrics stability framework is in place, then in Kubernetes 1.17 the metrics will only be turned off by default through the stability framework. Should this not be available, then the metrics will be removed.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/enhancements/issues/1206

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Deprecated metric `kubeproxy_sync_proxy_rules_latency_microseconds` has been turned off.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/da4b7050ccae7a947e4d60f94ab28513e513a458/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
```

