### PR TITLE
Turn off kubelet deprecated metrics

### DIFF
--- a/pkg/kubelet/dockershim/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/metrics/metrics.go
@@ -96,20 +96,22 @@ var (
 	// type.
 	DeprecatedDockerOperationsLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
-			Subsystem:      kubeletSubsystem,
-			Name:           DeprecatedDockerOperationsLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds of Docker operations. Broken down by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         kubeletSubsystem,
+			Name:              DeprecatedDockerOperationsLatencyKey,
+			Help:              "Latency in microseconds of Docker operations. Broken down by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
 	// DeprecatedDockerOperations collects operation counts by operation type.
 	DeprecatedDockerOperations = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem:      kubeletSubsystem,
-			Name:           DeprecatedDockerOperationsKey,
-			Help:           "(Deprecated) Cumulative number of Docker operations by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         kubeletSubsystem,
+			Name:              DeprecatedDockerOperationsKey,
+			Help:              "Cumulative number of Docker operations by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
@@ -117,20 +119,22 @@ var (
 	// type.
 	DeprecatedDockerOperationsErrors = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem:      kubeletSubsystem,
-			Name:           DeprecatedDockerOperationsErrorsKey,
-			Help:           "(Deprecated) Cumulative number of Docker operation errors by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         kubeletSubsystem,
+			Name:              DeprecatedDockerOperationsErrorsKey,
+			Help:              "Cumulative number of Docker operation errors by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
 	// DeprecatedDockerOperationsTimeout collects operation timeouts by operation type.
 	DeprecatedDockerOperationsTimeout = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem:      kubeletSubsystem,
-			Name:           DeprecatedDockerOperationsTimeoutKey,
-			Help:           "(Deprecated) Cumulative number of Docker operation timeout by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         kubeletSubsystem,
+			Name:              DeprecatedDockerOperationsTimeoutKey,
+			Help:              "Cumulative number of Docker operation timeout by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)

--- a/pkg/kubelet/dockershim/network/metrics/metrics.go
+++ b/pkg/kubelet/dockershim/network/metrics/metrics.go
@@ -54,10 +54,11 @@ var (
 	// type.
 	DeprecatedNetworkPluginOperationsLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
-			Subsystem:      kubeletSubsystem,
-			Name:           DeprecatedNetworkPluginOperationsLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds of network plugin operations. Broken down by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         kubeletSubsystem,
+			Name:              DeprecatedNetworkPluginOperationsLatencyKey,
+			Help:              "Latency in microseconds of network plugin operations. Broken down by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -283,10 +283,11 @@ var (
 	// Broken down by operation type. This metric is deprecated.
 	DeprecatedPodWorkerLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedPodWorkerLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds to sync a single pod. Broken down by operation type: create, update, or sync",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedPodWorkerLatencyKey,
+			Help:              "Latency in microseconds to sync a single pod. Broken down by operation type: create, update, or sync",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
@@ -294,20 +295,22 @@ var (
 	// This metric is deprecated.
 	DeprecatedPodStartLatency = metrics.NewSummary(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedPodStartLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds for a single pod to go from pending to running.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedPodStartLatencyKey,
+			Help:              "Latency in microseconds for a single pod to go from pending to running.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 	// DeprecatedCgroupManagerLatency is a Summary that tracks the latency (in microseconds) for cgroup manager operations to complete.
 	// Broken down by operation type. This metric is deprecated.
 	DeprecatedCgroupManagerLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedCgroupManagerOperationsKey,
-			Help:           "(Deprecated) Latency in microseconds for cgroup manager operations. Broken down by method.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedCgroupManagerOperationsKey,
+			Help:              "Latency in microseconds for cgroup manager operations. Broken down by method.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
@@ -315,40 +318,44 @@ var (
 	// This metric is deprecated.
 	DeprecatedPodWorkerStartLatency = metrics.NewSummary(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedPodWorkerStartLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds from seeing a pod to starting a worker.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedPodWorkerStartLatencyKey,
+			Help:              "Latency in microseconds from seeing a pod to starting a worker.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 	// DeprecatedPLEGRelistLatency is a Summary that tracks the latency (in microseconds) for relisting pods in PLEG.
 	// This metric is deprecated.
 	DeprecatedPLEGRelistLatency = metrics.NewSummary(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedPLEGRelistLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds for relisting pods in PLEG.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedPLEGRelistLatencyKey,
+			Help:              "Latency in microseconds for relisting pods in PLEG.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 	// DeprecatedPLEGRelistInterval is a Summary that tracks the interval (in microseconds) between relistings in PLEG.
 	// This metric is deprecated.
 	DeprecatedPLEGRelistInterval = metrics.NewSummary(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedPLEGRelistIntervalKey,
-			Help:           "(Deprecated) Interval in microseconds between relisting in PLEG.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedPLEGRelistIntervalKey,
+			Help:              "Interval in microseconds between relisting in PLEG.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 	)
 	// DeprecatedRuntimeOperations is a Counter that tracks the cumulative number of remote runtime operations.
 	// Broken down by operation type. This metric is deprecated.
 	DeprecatedRuntimeOperations = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedRuntimeOperationsKey,
-			Help:           "(Deprecated) Cumulative number of runtime operations by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedRuntimeOperationsKey,
+			Help:              "Cumulative number of runtime operations by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
@@ -356,10 +363,11 @@ var (
 	// to complete. Broken down by operation type. This metric is deprecated.
 	DeprecatedRuntimeOperationsLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedRuntimeOperationsLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds of runtime operations. Broken down by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedRuntimeOperationsLatencyKey,
+			Help:              "Latency in microseconds of runtime operations. Broken down by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
@@ -367,10 +375,11 @@ var (
 	// Broken down by operation type. This metric is deprecated.
 	DeprecatedRuntimeOperationsErrors = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedRuntimeOperationsErrorsKey,
-			Help:           "(Deprecated) Cumulative number of runtime operation errors by operation type.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedRuntimeOperationsErrorsKey,
+			Help:              "Cumulative number of runtime operation errors by operation type.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"operation_type"},
 	)
@@ -378,10 +387,11 @@ var (
 	// is evicted based on those stats. Broken down by eviction signal. This metric is deprecated.
 	DeprecatedEvictionStatsAge = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedEvictionStatsAgeKey,
-			Help:           "(Deprecated) Time between when stats are collected, and when pod is evicted based on those stats by eviction signal",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedEvictionStatsAgeKey,
+			Help:              "Time between when stats are collected, and when pod is evicted based on those stats by eviction signal",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"eviction_signal"},
 	)
@@ -389,10 +399,11 @@ var (
 	// Broken down by resource name. This metric is deprecated.
 	DeprecatedDevicePluginRegistrationCount = metrics.NewCounterVec(
 		&metrics.CounterOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedDevicePluginRegistrationCountKey,
-			Help:           "(Deprecated) Cumulative number of device plugin registrations. Broken down by resource name.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedDevicePluginRegistrationCountKey,
+			Help:              "Cumulative number of device plugin registrations. Broken down by resource name.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"resource_name"},
 	)
@@ -400,10 +411,11 @@ var (
 	// Broken down by resource name. This metric is deprecated.
 	DeprecatedDevicePluginAllocationLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
-			Subsystem:      KubeletSubsystem,
-			Name:           DeprecatedDevicePluginAllocationLatencyKey,
-			Help:           "(Deprecated) Latency in microseconds to serve a device plugin Allocation request. Broken down by resource name.",
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         KubeletSubsystem,
+			Name:              DeprecatedDevicePluginAllocationLatencyKey,
+			Help:              "Latency in microseconds to serve a device plugin Allocation request. Broken down by resource name.",
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.14.0",
 		},
 		[]string{"resource_name"},
 	)


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Turn off metrics that have been deprecated in v1.14.

Refer to https://github.com/kubernetes/enhancements/issues/1206:
>Kubernetes 1.17 will remove the in 1.14 marked as deprecated metrics. As a stretch goal, if the metrics stability framework is in place, then in Kubernetes 1.17 the metrics will only be turned off by default through the stability framework. Should this not be available, then the metrics will be removed.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/enhancements/issues/1206

**Special notes for your reviewer**:
Wrong metrics names(prefix `kubelet_` missed) in [1.14 release notes](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG-1.14.md#deprecated-metrics)
- `docker_operations` -> `docker_operations_total`. 
- `docker_operations_latency_microseconds` -> `docker_operations_latency_seconds`
- `docker_operations_errors` -> `docker_operations_errors_total`
- `docker_operations_timeout` -> `docker_operations_timeout_total`

If you want to do something about this, please let me know.

**Does this PR introduce a user-facing change?**:

```release-note
Following metrics have been turned off:
- kubelet_pod_worker_latency_microseconds
- kubelet_pod_start_latency_microseconds
- kubelet_cgroup_manager_latency_microseconds
- kubelet_pod_worker_start_latency_microseconds
- kubelet_pleg_relist_latency_microseconds
- kubelet_pleg_relist_interval_microseconds
- kubelet_eviction_stats_age_microseconds
- kubelet_runtime_operations
- kubelet_runtime_operations_latency_microseconds
- kubelet_runtime_operations_errors
- kubelet_device_plugin_registration_count
- kubelet_device_plugin_alloc_latency_microseconds
- kubelet_docker_operations
- kubelet_docker_operations_latency_microseconds
- kubelet_docker_operations_errors
- kubelet_docker_operations_timeout
- network_plugin_operations_latency_microseconds
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/da4b7050ccae7a947e4d60f94ab28513e513a458/keps/sig-instrumentation/20181106-kubernetes-metrics-overhaul.md
```