### PR TITLE
Simplify expression involving matched

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/selection_predicate.go
@@ -93,7 +93,7 @@ func (s *SelectionPredicate) Matches(obj runtime.Object) (bool, error) {
 	}
 	matched := s.Label.Matches(labels)
 	if matched && s.Field != nil {
-		matched = matched && s.Field.Matches(fields)
+		matched = s.Field.Matches(fields)
 	}
 	return matched, nil
 }
@@ -106,7 +106,7 @@ func (s *SelectionPredicate) MatchesObjectAttributes(l labels.Set, f fields.Set)
 	}
 	matched := s.Label.Matches(l)
 	if matched && s.Field != nil {
-		matched = (matched && s.Field.Matches(f))
+		matched = s.Field.Matches(f)
 	}
 	return matched
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Two func's of SelectionPredicate have the following code:
```
	matched := s.Label.Matches(l)
	if matched && s.Field != nil {
		matched = (matched && s.Field.Matches(f))
```
Since the body of if would only be executed when matched is true, the assignment can be simplified.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
