### PR TITLE
Log error from updateNetworkingCondition

### DIFF
--- a/pkg/controller/route/route_controller.go
+++ b/pkg/controller/route/route_controller.go
@@ -267,7 +267,9 @@ func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.R
 			go func(n *v1.Node) {
 				defer wg.Done()
 				klog.Infof("node %v has no routes assigned to it. NodeNetworkUnavailable will be set to true", n.Name)
-				rc.updateNetworkingCondition(n, false)
+				if err := rc.updateNetworkingCondition(n, false); err != nil {
+					klog.Errorf("encountered error when updating network condition for node %v : %v", n.Name, err)
+				}
 			}(node)
 			continue
 		}
@@ -281,7 +283,9 @@ func (rc *RouteController) reconcile(nodes []*v1.Node, routes []*cloudprovider.R
 		}
 		go func(n *v1.Node) {
 			defer wg.Done()
-			rc.updateNetworkingCondition(n, allRoutesCreated)
+			if err := rc.updateNetworkingCondition(n, allRoutesCreated); err != nil {
+				klog.Errorf("encountered error when updating network condition for node %v : %v", n.Name, err)
+			}
 		}(node)
 	}
 	wg.Wait()


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds log for the error return of updateNetworkingCondition.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
