### PR TITLE
Prune inactive owners from test/e2e/framework/providers/vsphere/OWNERS.

### DIFF
--- a/test/e2e/framework/providers/vsphere/OWNERS
+++ b/test/e2e/framework/providers/vsphere/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - pmorie
 - saad-ali
 - thockin
-- matchstick
 - SandeepPissay
 - divyenpatel
 - BaluDontu
@@ -13,8 +12,9 @@ approvers:
 - frapposelli
 - dougm
 - sandeeppsunny
+emeritus_approvers:
+- matchstick
 reviewers:
-- abithap
 - abrarshivani
 - saad-ali
 - justinsb


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

OWNERS removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

Assigning several approvers for review

/assign imkin frapposelli dougm

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon