### PR TITLE
Prune inactive owners from staging/src/k8s.io/sample-controller/OWNERS.

### DIFF
--- a/staging/src/k8s.io/sample-controller/OWNERS
+++ b/staging/src/k8s.io/sample-controller/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - sttts
 - munnerz
 reviewers:
-- gregory-m
 - sttts
 - munnerz
 - nikhita


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

OWNERS removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

Assigning approvers for review

/assign munnerz sttts

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon