### PR TITLE
Prune inactive owners from autoscaling related OWNERS files.

### DIFF
--- a/pkg/controller/podautoscaler/OWNERS
+++ b/pkg/controller/podautoscaler/OWNERS
@@ -1,17 +1,16 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-- fgrzadkowski
 - josephburnett
-- jszczepkowski
 - MaciekPytel
 - mwielgus
 - piosz
 approvers:
 - josephburnett
-- jszczepkowski
 - MaciekPytel
 - mwielgus
 - piosz
+emeritus_approvers:
+- jszczepkowski
 labels:
 - sig/autoscaling

--- a/test/e2e/autoscaling/OWNERS
+++ b/test/e2e/autoscaling/OWNERS
@@ -1,12 +1,11 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 reviewers:
-  - jszczepkowski
   - sig-autoscaling-maintainers
-  - wasylkowski
 approvers:
-  - jszczepkowski
   - sig-autoscaling-maintainers
+emeritus_approvers:
+  - jszczepkowski
   - wasylkowski
 labels:
 - sig/autoscaling


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

Assigning common approvers across all OWNERS files touched by this PR.

/assign mwielgus MaciekPytel

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon