### PR TITLE
Prune inactive owners from staging/src/k8s.io/client-go/* OWNERS files.

### DIFF
--- a/staging/src/k8s.io/client-go/rest/OWNERS
+++ b/staging/src/k8s.io/client-go/rest/OWNERS
@@ -20,7 +20,6 @@ reviewers:
 - resouer
 - cjcullen
 - rmmh
-- lixiaobing10051267
 - asalkeld
 - juanvallejo
 - lojies

--- a/staging/src/k8s.io/client-go/tools/cache/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/cache/OWNERS
@@ -33,8 +33,6 @@ reviewers:
 - madhusudancs
 - hongchaodeng
 - krousey
-- markturansky
-- fgrzadkowski
 - xiang90
 - mml
 - ingvagabund
@@ -42,10 +40,6 @@ reviewers:
 - jessfraz
 - david-mcmahon
 - mfojtik
-- '249043822'
-- lixiaobing10051267
-- ddysher
 - mqliang
-- feihujiang
 - sdminonne
 - ncdc

--- a/staging/src/k8s.io/client-go/tools/leaderelection/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/OWNERS
@@ -12,4 +12,3 @@ reviewers:
 - timothysc
 - ingvagabund
 - resouer
-- goltermann

--- a/staging/src/k8s.io/client-go/tools/metrics/OWNERS
+++ b/staging/src/k8s.io/client-go/tools/metrics/OWNERS
@@ -5,5 +5,3 @@ reviewers:
 - eparis
 - krousey
 - jayunit100
-- fgrzadkowski
-- tmrts


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

Assigning a subset of approvers from [staging/src/k8s.io/client-go/OWNERS](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/OWNERS) for review.

/assign smarterclayton caesarxuchao lavalamp

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon