### PR TITLE
Prune inactive owners from pkg/volume/* OWNERS files.

### DIFF
--- a/pkg/volume/configmap/OWNERS
+++ b/pkg/volume/configmap/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - pmorie
 - saad-ali
 - thockin
+emeritus_approvers:
 - matchstick
 reviewers:
 - ivan4th

--- a/pkg/volume/downwardapi/OWNERS
+++ b/pkg/volume/downwardapi/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - pmorie
 - saad-ali
 - thockin
+emeritus_approvers:
 - matchstick
 reviewers:
 - ivan4th

--- a/pkg/volume/emptydir/OWNERS
+++ b/pkg/volume/emptydir/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - pmorie
 - saad-ali
 - thockin
+emeritus_approvers:
 - matchstick
 reviewers:
 - ivan4th

--- a/pkg/volume/flexvolume/OWNERS
+++ b/pkg/volume/flexvolume/OWNERS
@@ -3,6 +3,7 @@
 approvers:
 - chakri-nelluri
 - saad-ali
+emeritus_approvers:
 - MikaelCluseau
 reviewers:
 - ivan4th
@@ -14,4 +15,3 @@ reviewers:
 - jingxu97
 - msau42
 - chakri-nelluri
-- MikaelCluseau

--- a/pkg/volume/flocker/OWNERS
+++ b/pkg/volume/flocker/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - rootfs
 - saad-ali
 reviewers:
-- agonzalezro
 - simonswine
 - saad-ali
 - jsafrane

--- a/pkg/volume/gcepd/OWNERS
+++ b/pkg/volume/gcepd/OWNERS
@@ -8,7 +8,6 @@ reviewers:
 - saad-ali
 - jsafrane
 - jingxu97
-- matchstick
 - gnufied
 - msau42
 - verult

--- a/pkg/volume/secret/OWNERS
+++ b/pkg/volume/secret/OWNERS
@@ -4,6 +4,7 @@ approvers:
 - pmorie
 - saad-ali
 - thockin
+emeritus_approvers:
 - matchstick
 reviewers:
 - ivan4th

--- a/pkg/volume/storageos/OWNERS
+++ b/pkg/volume/storageos/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-maintainers:
-- croomes
-- rusenask
-- chira001

--- a/pkg/volume/util/OWNERS
+++ b/pkg/volume/util/OWNERS
@@ -6,4 +6,3 @@ reviewers:
 - saad-ali
 - rootfs
 - jingxu97
-- screeley44

--- a/pkg/volume/vsphere_volume/OWNERS
+++ b/pkg/volume/vsphere_volume/OWNERS
@@ -4,13 +4,13 @@ approvers:
 - pmorie
 - saad-ali
 - thockin
-- matchstick
 - SandeepPissay
 - divyenpatel
 - BaluDontu
 - abrarshivani
+emeritus_approvers:
+- matchstick
 reviewers:
-- abithap
 - abrarshivani
 - saad-ali
 - justinsb


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

/assign saad-ali

As the only common approver across all OWNERS files for review.

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon