### PR TITLE
Prune inactive owners from pkg/credentialprovider/* OWNERS files.

### DIFF
--- a/pkg/credentialprovider/OWNERS
+++ b/pkg/credentialprovider/OWNERS
@@ -23,7 +23,5 @@ reviewers:
 - david-mcmahon
 - mfojtik
 - therc
-- lixiaobing10051267
-- goltermann
 - andrewsykim
 - mcrute

--- a/pkg/credentialprovider/aws/OWNERS
+++ b/pkg/credentialprovider/aws/OWNERS
@@ -4,6 +4,4 @@ reviewers:
 - justinsb
 - david-mcmahon
 - therc
-- lixiaobing10051267
-- goltermann
 - chrislovecnm


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

Assigning a subset of the approvers from [pkg/credentialprovider/OWNERS](https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/OWNERS) for review.

/assign erictune  liggitt 

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon