### PR TITLE
Prune inactive owners from pkg/kubelet/* network related OWNERS files.

### DIFF
--- a/pkg/kubelet/dockershim/network/OWNERS
+++ b/pkg/kubelet/dockershim/network/OWNERS
@@ -3,9 +3,10 @@
 approvers:
 - thockin
 - dchen1107
-- matchstick
 - freehan
 - dcbw
+emeritus_approvers:
+- matchstick
 reviewers:
 - sig-network-reviewers
 labels:

--- a/pkg/kubelet/network/OWNERS
+++ b/pkg/kubelet/network/OWNERS
@@ -3,8 +3,9 @@
 approvers:
 - thockin
 - dchen1107
-- matchstick
 - freehan
+emeritus_approvers:
+- matchstick
 reviewers:
 - sig-network-reviewers
 labels:


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

Assigning  to a subset of common approvers across all OWNERS files touched by this PR.

/assign @freehan @thockin 

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon