### PR TITLE
Prune inactive owners from pkg/controller/* network related OWNERS files

### DIFF
--- a/pkg/controller/endpoint/OWNERS
+++ b/pkg/controller/endpoint/OWNERS
@@ -4,11 +4,11 @@ approvers:
 - bowei
 - MrHohn
 - thockin
+emeritus_approvers:
 - matchstick
 reviewers:
 - bowei
 - MrHohn
 - thockin
-- matchstick
 labels:
 - sig/network

--- a/pkg/controller/nodeipam/ipam/OWNERS
+++ b/pkg/controller/nodeipam/ipam/OWNERS
@@ -2,8 +2,8 @@
 
 approvers:
 - bowei
+emeritus_approvers:
 - dnardo
 reviewers:
 - bowei
-- dnardo
 - freehan

--- a/pkg/controller/service/OWNERS
+++ b/pkg/controller/service/OWNERS
@@ -4,15 +4,15 @@ reviewers:
 - bowei
 - MrHohn
 - thockin
-- matchstick
 - andrewsykim
 - cheftako
 approvers:
 - bowei
 - MrHohn
 - thockin
-- matchstick
 - andrewsykim
 - cheftako
+emeritus_approvers:
+- matchstick
 labels:
 - sig/network


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

Assigning to @bowei as the common approvers across all OWNERS files touched by this PR.

/assign @bowei 

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon