### PR TITLE
Prune inactive members from cluster/* OWNERS files.

### DIFF
--- a/cluster/addons/calico-policy-controller/OWNERS
+++ b/cluster/addons/calico-policy-controller/OWNERS
@@ -3,10 +3,10 @@
 approvers:
 - bowei
 - caseydavenport
-- dnardo
 - fasaxc
+emeritus_approvers:
+- dnardo
 reviewers:
 - bowei
 - caseydavenport
-- dnardo
 - fasaxc

--- a/cluster/addons/ip-masq-agent/OWNERS
+++ b/cluster/addons/ip-masq-agent/OWNERS
@@ -2,7 +2,7 @@
 
 approvers:
 - bowei
+emeritus_approvers:
 - dnardo
 reviewers:
 - bowei
-- dnardo

--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -4,7 +4,6 @@ reviewers:
   - bowei
   - cjcullen
   - gmarek
-  - jszczepkowski
   - vishh
   - mwielgus
   - MaciekPytel
@@ -15,10 +14,11 @@ approvers:
   - bowei
   - cjcullen
   - gmarek
-  - jszczepkowski
   - vishh
   - mwielgus
   - MaciekPytel
   - jingax10
   - yujuhong
   - mtaufen
+emeritus_approvers:
+  - jszczepkowski


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

@bowei I probably should have combined this as a single PR with separate commits under https://github.com/kubernetes/kubernetes/pull/83862 as you're the only approver across the two groups again. Sorry about that =/ 

If you'd prefer me to do that let me know.

/assign @bowei 

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon