### PR TITLE
Prune inactive owners from pkg/* misc api-machinery related OWNERS files

### DIFF
--- a/pkg/master/OWNERS
+++ b/pkg/master/OWNERS
@@ -38,7 +38,6 @@ reviewers:
 - piosz
 - madhusudancs
 - hongchaodeng
-- jszczepkowski
 - enj
 labels:
 - sig/api-machinery

--- a/pkg/quota/v1/generic/OWNERS
+++ b/pkg/quota/v1/generic/OWNERS
@@ -4,4 +4,3 @@ reviewers:
 - smarterclayton
 - derekwaynecarr
 - david-mcmahon
-- goltermann

--- a/pkg/registry/registrytest/OWNERS
+++ b/pkg/registry/registrytest/OWNERS
@@ -20,7 +20,6 @@ reviewers:
 - dims
 - hongchaodeng
 - a-robinson
-- ddysher
 - mqliang
 - sdminonne
 - enj


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**Which issue(s) this PR fixes**:

This is part of a larger cleanup of inactive owners.

Owners removed had no activity from January 1st, 2018 to September 1st, 2019. 

For more information on this clean up, see the below links:
- Tracking Issue: https://github.com/kubernetes/kubernetes/issues/76269
- [Kubernetes-dev mailing list announcement](https://groups.google.com/d/msg/kubernetes-dev/4160VsBL7OI/BsBRZSqpCQAJ)


**Special notes for your reviewer**:

@deads2k I wasn't sure how best to group these ones, the main commonality is that you're an approver either in them or the next directory up -- if they should be broken apart for others to review, just let me know.

/assign @deads2k 

**Does this PR introduce a user-facing change?**: 

```release-note
NONE
```

/sig contributor-experience
/priority important-soon