### PR TITLE
Handle error return if portString parsing has error

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -358,7 +358,11 @@ func (s componentStatusStorage) serversToValidate() map[string]*componentstatus.
 				klog.Errorf("Failed to split host/port: %s (%v)", etcdUrl.Host, err)
 				continue
 			}
-			port, _ = strconv.Atoi(portString)
+			port, err = strconv.Atoi(portString)
+			if err != nil {
+				klog.Errorf("Failed to parse port string %q : %v", portString, err)
+				continue
+			}
 		} else {
 			addr = etcdUrl.Host
 			port = 2379


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In componentStatusStorage#serversToValidate, the error return from strconv.Atoi is ignored.

When portString parsing has error, we should handle it.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
