### PR TITLE
add metrics for watchers of storage/cacher and storage/etcd3

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
@@ -78,6 +78,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/value:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//vendor/github.com/coreos/etcd/clientv3:go_default_library",
         "//vendor/github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes:go_default_library",
         "//vendor/github.com/coreos/etcd/mvcc/mvccpb:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -59,13 +59,6 @@ var (
 		[]string{"operation", "type"},
 	)
 
-	etcdWatcherChannelLength = compbasemetrics.NewGaugeVec(
-		&compbasemetrics.GaugeOpts{
-			Name: "etcd_watcher_channel_length",
-			Help: "Channel length of etcd watchers broken by resource key and channel name",
-		},
-		[]string{"key", "channel"},
-	)
 	etcdEventsCounter = compbasemetrics.NewCounterVec(
 		&compbasemetrics.CounterOpts{
 			Name: "etcd_watcher_received_events",
@@ -91,7 +84,6 @@ func Register() {
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(etcdRequestLatency)
 		legacyregistry.MustRegister(objectCounts)
-		legacyregistry.MustRegister(etcdWatcherChannelLength)
 		legacyregistry.MustRegister(etcdEventsCounter)
 		legacyregistry.MustRegister(etcdEventsSentLatency)
 
@@ -128,17 +120,12 @@ func sinceInSeconds(start time.Time) float64 {
 	return time.Since(start).Seconds()
 }
 
-// RecordEtcdWatcherChannelLength sets the length of a watcher channel.
-func RecordEtcdWatcherChannelLength(key, name string, length int) {
-	etcdWatcherChannelLength.WithLabelValues(key, name).Set(float64(length))
+// NewEtcdWatcherEventCountMetric creates a metric to count events.
+func NewEtcdWatcherEventCountMetric(key string) compbasemetrics.CounterMetric {
+	return etcdEventsCounter.WithLabelValues(key)
 }
 
-// RecordEtcdWatcherEventCount adds event count to the event counter.
-func RecordEtcdWatcherEventCount(key string, count int) {
-	etcdEventsCounter.WithLabelValues(key).Add(float64(count))
-}
-
-// RecordEtcdWatcherEventLatency adds a duration to the latency bucket.
-func RecordEtcdWatcherEventLatency(key string, duration time.Duration) {
-	etcdEventsSentLatency.WithLabelValues(key).Observe(float64(duration/time.Microsecond) / 1000)
+// NewEtcdWatcherEventLatencyMetric creates a metric to generate latency histogram.
+func NewEtcdWatcherEventLatencyMetric(key string) compbasemetrics.ObserverMetric {
+	return etcdEventsSentLatency.WithLabelValues(key)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Add metrics for watch-cache of `storage/cacher` and `storage/etcd3`. It's very useful for us to judge how many events a controller will receive. Then we can tweak the cache size for a specific resource via `--watch-cache-sizes`.

We have an experience formula for a resource:
```
WatchCacheSize = EventCountPerMinute / 60 * (TimeToListAllObjects + TimeToUnmarshalAllObjects) * 1.5
```

Ex.
![image](https://user-images.githubusercontent.com/13895988/66728614-823c8000-ee78-11e9-95d4-2a33425aacdb.png)


In this case, the max event count is 6k, and if we takes 40s to list and unmarshal objects:

```
WatchCacheSize = 6000 / 60 * 40 * 1.5 = 6000
``` 

```release-note
NONE
```
