### PR TITLE
modify error output in cniNetworkPlugin

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -191,7 +191,7 @@ func getDefaultCNINetwork(confDir string, binDirs []string) (*cniNetwork, error)
 			}
 		}
 		if len(confList.Plugins) == 0 {
-			klog.Warningf("CNI config list %s has no networks, skipping", confFile)
+			klog.Warningf("CNI config list %s has no networks, skipping", string(confList.Bytes))
 			continue
 		}
 
@@ -199,7 +199,7 @@ func getDefaultCNINetwork(confDir string, binDirs []string) (*cniNetwork, error)
 		// all plugins of this config exist on disk
 		caps, err := cniConfig.ValidateNetworkList(context.TODO(), confList)
 		if err != nil {
-			klog.Warningf("Error validating CNI config %v: %v", confList, err)
+			klog.Warningf("Error validating CNI config list %s: %v", string(confList.Bytes), err)
 			continue
 		}
 

--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -191,7 +191,7 @@ func getDefaultCNINetwork(confDir string, binDirs []string) (*cniNetwork, error)
 			}
 		}
 		if len(confList.Plugins) == 0 {
-			klog.Warningf("CNI config list %s has no networks, skipping", string(confList.Bytes))
+			klog.Warningf("CNI config list %s has no networks, skipping", string(confList.Bytes[:maxStringLengthInLog(len(confList.Bytes))]))
 			continue
 		}
 
@@ -199,7 +199,7 @@ func getDefaultCNINetwork(confDir string, binDirs []string) (*cniNetwork, error)
 		// all plugins of this config exist on disk
 		caps, err := cniConfig.ValidateNetworkList(context.TODO(), confList)
 		if err != nil {
-			klog.Warningf("Error validating CNI config list %s: %v", string(confList.Bytes), err)
+			klog.Warningf("Error validating CNI config list %s: %v", string(confList.Bytes[:maxStringLengthInLog(len(confList.Bytes))]), err)
 			continue
 		}
 
@@ -461,4 +461,14 @@ func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string
 	}
 
 	return rt, nil
+}
+
+func maxStringLengthInLog(length int) int {
+	// we allow no more than 4096-length strings to be logged
+	const maxStringLength = 4096
+
+	if length < maxStringLength {
+		return length
+	}
+	return maxStringLength
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

When cni validation fails, it will print error message like 
```
Sep 22 22:29:16 kubelet[5427]: W0922 22:29:16.598269    5427 cni.go:202] Error validating CNI config &{cbr0  false [0x8d20e40 0x8d20e80] [123 10 32 32 34 110 97 109 101 34 58 32 34 99 98 114 48 34 44 10 32 32 34 112 108 117 103 105 110 115 34 58 32 91 10 32 32 32 32 123 10 32 32 32 32 32 32 34 116 121 112 101 34 58 32 34 102 108 97 110 110 101 108 34 44 10 32 32 32 32 32 32 34 100 101 108 101 103 97 116 101 34 58 32 123 10 32 32 32 32 32 32 32 32 34 104 97 105 114 112 105 110 77 111 100 101 34 58 32 116 114 117 101 44 10 32 32 32 32 32 32 32 32 34 105 115 68 101 102 97 117 108 116 71 97 116 101 119 97 121 34 58 32 116 114 117 101 10 32 32 32 32 32 32 125 10 32 32 32 32 125 44 10 32 32 32 32 123 10 32 32 32 32 32 32 34 116 121 112 101 34 58 32 34 112 111 114 116 109 97 112 34 44 10 32 32 32 32 32 32 34 99 97 112 97 98 105 108 105 116 105 101 115 34 58 32 123 10 32 32 32 32 32 32 32 32 34 112 111 114 116 77 97 112 112 105 110 103 115 34 58 32 116 114 117 101 10 32 32 32 32 32 32 125 10 32 32 32 32 125 10 32 32 93 10 125 10]}: [plugin flannel does not support config version ""]
```
We can not get some valid information from it, this is because pointers and byte slice defined in `NetworkConfigList`,
```
type NetworkConfigList struct {
	Name         string
	CNIVersion   string
	DisableCheck bool
	Plugins      []*NetworkConfig
	Bytes        []byte
}
```
So we need to modify error output to what we expect, the raw string of config file.


```release-note
None
```