### PR TITLE
Move scheduler cache ListNodes interface to snapshot

### DIFF
--- a/pkg/scheduler/algorithm/types.go
+++ b/pkg/scheduler/algorithm/types.go
@@ -30,13 +30,6 @@ var NodeFieldSelectorKeys = map[string]func(*v1.Node) string{
 	schedulerapi.NodeFieldSelectorKeyNodeName: func(n *v1.Node) string { return n.Name },
 }
 
-// NodeLister interface represents anything that can list nodes for a scheduler.
-type NodeLister interface {
-	// We explicitly return []*v1.Node, instead of v1.NodeList, to avoid
-	// performing expensive copies that are unneeded.
-	ListNodes() []*v1.Node
-}
-
 // PodFilter is a function to filter a pod. If pod passed return true else return false.
 type PodFilter func(*v1.Pod) bool
 

--- a/pkg/scheduler/algorithm_factory.go
+++ b/pkg/scheduler/algorithm_factory.go
@@ -41,7 +41,6 @@ type PluginFactoryArgs struct {
 	ControllerLister               algorithm.ControllerLister
 	ReplicaSetLister               algorithm.ReplicaSetLister
 	StatefulSetLister              algorithm.StatefulSetLister
-	NodeLister                     algorithm.NodeLister
 	PDBLister                      algorithm.PDBLister
 	NodeInfo                       predicates.NodeInfo
 	CSINodeInfo                    predicates.CSINodeInfo

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -999,7 +999,7 @@ func TestZeroRequest(t *testing.T) {
 
 			list, err := PrioritizeNodes(
 				test.pod, nodeNameToInfo, metaData, priorityConfigs,
-				schedulertesting.FakeNodeLister(test.nodes), []algorithm.SchedulerExtender{}, emptyFramework, framework.NewCycleState())
+				test.nodes, []algorithm.SchedulerExtender{}, emptyFramework, framework.NewCycleState())
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -1795,7 +1795,7 @@ func TestNodesWherePreemptionMightHelp(t *testing.T) {
 				FailedPredicates:      test.failedPredMap,
 				FilteredNodesStatuses: test.nodesStatuses,
 			}
-			nodes := nodesWherePreemptionMightHelp(makeNodeList(nodeNames), &fitErr)
+			nodes := nodesWherePreemptionMightHelp(schedulernodeinfo.CreateNodeNameToInfoMap(nil, makeNodeList(nodeNames)), &fitErr)
 			if len(test.expected) != len(nodes) {
 				t.Errorf("number of nodes is not the same as expected. exptectd: %d, got: %d. Nodes: %v", len(test.expected), len(nodes), nodes)
 			}

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -592,7 +592,6 @@ func (c *Configurator) getAlgorithmArgs() (*PluginFactoryArgs, *plugins.ConfigPr
 		ControllerLister:               c.controllerLister,
 		ReplicaSetLister:               c.replicaSetLister,
 		StatefulSetLister:              c.statefulSetLister,
-		NodeLister:                     c.schedulerCache,
 		PDBLister:                      c.pdbLister,
 		NodeInfo:                       c.schedulerCache,
 		CSINodeInfo:                    c.schedulerCache,

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -705,22 +705,6 @@ func (cache *schedulerCache) GetNodeInfo(nodeName string) (*v1.Node, error) {
 	return n.info.Node(), nil
 }
 
-// ListNodes returns the cached list of nodes.
-func (cache *schedulerCache) ListNodes() []*v1.Node {
-	cache.mu.RLock()
-	defer cache.mu.RUnlock()
-
-	nodes := make([]*v1.Node, 0, len(cache.nodes))
-	for _, node := range cache.nodes {
-		// Node info is sometimes not removed immediately. See schedulerCache.RemoveNode.
-		n := node.info.Node()
-		if n != nil {
-			nodes = append(nodes, n)
-		}
-	}
-	return nodes
-}
-
 func (cache *schedulerCache) GetCSINodeInfo(nodeName string) (*storagev1beta1.CSINode, error) {
 	cache.mu.RLock()
 	defer cache.mu.RUnlock()

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -59,7 +59,6 @@ import (
 //   a pod might have changed its state (e.g. added and deleted) without delivering notification to the cache.
 type Cache interface {
 	algorithm.PodLister
-	algorithm.NodeLister
 
 	// AssumePod assumes a pod scheduled and aggregates the pod's information into its node.
 	// The implementation also decides the policy to expire pod before being confirmed (receiving Add event).

--- a/pkg/scheduler/nodeinfo/snapshot.go
+++ b/pkg/scheduler/nodeinfo/snapshot.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package nodeinfo
 
+import (
+	v1 "k8s.io/api/core/v1"
+)
+
 // Snapshot is a snapshot of cache NodeInfo. The scheduler takes a
 // snapshot at the beginning of each scheduling cycle and uses it for its
 // operations in that cycle.
@@ -29,4 +33,15 @@ func NewSnapshot() *Snapshot {
 	return &Snapshot{
 		NodeInfoMap: make(map[string]*NodeInfo),
 	}
+}
+
+// ListNodes returns the list of nodes in the snapshot.
+func (s *Snapshot) ListNodes() []*v1.Node {
+	nodes := make([]*v1.Node, 0, len(s.NodeInfoMap))
+	for _, n := range s.NodeInfoMap {
+		if n != nil && n.node != nil {
+			nodes = append(nodes, n.node)
+		}
+	}
+	return nodes
 }

--- a/pkg/scheduler/testing/fake_lister.go
+++ b/pkg/scheduler/testing/fake_lister.go
@@ -28,16 +28,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 )
 
-var _ algorithm.NodeLister = &FakeNodeLister{}
-
-// FakeNodeLister implements NodeLister on a []string for test purposes.
-type FakeNodeLister []*v1.Node
-
-// ListNodes returns nodes as a []*v1.Node.
-func (f FakeNodeLister) ListNodes() []*v1.Node {
-	return f
-}
-
 var _ algorithm.PodLister = &FakePodLister{}
 
 // FakePodLister implements PodLister on an []v1.Pods for test purposes.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Forces scheduler logic to list nodes from the snapshot rather than the cache.

**Which issue(s) this PR fixes**:
Part of #83922

```release-note
NONE
```

