### PR TITLE
release: lib: revert docker_registry to constant k8s.gcr.io

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -309,7 +309,10 @@ function kube::release::create_docker_images_for_server() {
     local images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
-    local -r docker_registry="${KUBE_DOCKER_REGISTRY}"
+    # k8s.gcr.io is the constant tag in the docker archives, this is also the default for config scripts in GKE.
+    # We can use KUBE_DOCKER_REGISTRY to include and extra registry in the docker archive.
+    # If we use KUBE_DOCKER_REGISTRY="k8s.gcr.io", then the extra tag (same) is ignored, see release_docker_image_tag below.
+    local -r docker_registry="k8s.gcr.io"
     # Docker tags cannot contain '+'
     local docker_tag="${KUBE_GIT_VERSION/+/_}"
     if [[ -z "${docker_tag}" ]]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Due to https://github.com/kubernetes/kubernetes/pull/80525 the behavior in the release lib code that generate the docker archives changed.
Since `release_docker_image_tag` is using `KUBE_DOCKER_REGISTRY` and `docker_registry` is too, they both will have the exact same value, which means we only include one tag in the archive.

In the past "k8s.gcr.io" was the constant name in the archives and "KUBE_DOCKER_REGISTRY" was used to add an "extra" tag in the archive.

**Special notes for your reviewer**:
Current output:
KUBE_DOCKER_REGISTRY=gke.gcr.io make quick-release
"RepoTags":["gke.gcr.io/kube-apiserver-amd64:v1.16.2-beta.0.21_c97fe5036ef3df"]

Expected:
KUBE_DOCKER_REGISTRY=gke.gcr.io make quick-release
"RepoTags":["k8s.gcr.io/kube-apiserver-amd64:v1.16.2-beta.0.21_c97fe5036ef3df", "gke.gcr.io/kube-apiserver-amd64:v1.16.2-beta.0.21_c97fe5036ef3df"]

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```