### PR TITLE
framework: Fix a goroutine leak bug in resource_usage_gatherer.go

### DIFF
--- a/test/e2e/framework/resource_usage_gatherer.go
+++ b/test/e2e/framework/resource_usage_gatherer.go
@@ -345,7 +345,7 @@ func (g *ContainerResourceGatherer) StartGatheringData() {
 func (g *ContainerResourceGatherer) StopAndSummarize(percentiles []int, constraints map[string]ResourceConstraint) (*ResourceUsageSummary, error) {
 	close(g.stopCh)
 	Logf("Closed stop channel. Waiting for %v workers", len(g.workers))
-	finished := make(chan struct{})
+	finished := make(chan struct{}, 1)
 	go func() {
 		g.workerWg.Wait()
 		finished <- struct{}{}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There is a local unbuffered channel `finished` in [kubernetes/test/e2e/framework/resource_usage_gatherer.go, line 348](https://github.com/kubernetes/kubernetes/blob/master/test/e2e/framework/resource_usage_gatherer.go#L348). The send operation to `finished` will definitely be executed, but the receive operation may not, when the select chooses the timeout case. If timeout, there will be one goroutine leaked.
This PR gives the channel 1 buffer. This PR is quite safe, since the behavior of related goroutines won't change, except that when timeout, no goroutine will be leaked.

**Which issue(s) this PR fixes**:
This PR doesn't fix any issue. 

**Special notes for your reviewer**:
This PR is very similiar to #5316, where two unbuffered local channels were given 1 buffer, to prevent potential goroutine leak.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
