### PR TITLE
WIP: kubeadm: don't manually create the Node object during init

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/phases/workflow"
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
+	nodebootstraptokenphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/bootstraptoken/node"
 	markcontrolplanephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/markcontrolplane"
 )
 
@@ -57,6 +58,12 @@ func runMarkControlPlane(c workflow.RunData) error {
 
 	client, err := data.Client()
 	if err != nil {
+		return err
+	}
+
+	// Create/update RBAC rules that makes the nodes to rotate certificates and get their CSRs approved automatically
+	// Adding these RBAC rules ensures that the Node object is created during init before patching the Node object.
+	if err := nodebootstraptokenphase.AutoApproveNodeCertificateRotation(client); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/phases/markcontrolplane/BUILD
+++ b/cmd/kubeadm/app/phases/markcontrolplane/BUILD
@@ -29,7 +29,6 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
@@ -21,19 +21,12 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	"k8s.io/klog"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	"k8s.io/kubernetes/cmd/kubeadm/app/util/apiclient"
 )
 
 // MarkControlPlane taints the control-plane and sets the control-plane label
 func MarkControlPlane(client clientset.Interface, controlPlaneName string, taints []v1.Taint) error {
-	klog.V(1).Infof("[patchnode] Creating the Node API object %q if missing", controlPlaneName)
-	// See the comments for this function
-	if err := apiclient.EnsureNodeObject(client, controlPlaneName); err != nil {
-		return err
-	}
-
 	fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the label \"%s=''\"\n", controlPlaneName, constants.LabelNodeRoleMaster)
 
 	if len(taints) > 0 {

--- a/cmd/kubeadm/app/phases/patchnode/patchnode.go
+++ b/cmd/kubeadm/app/phases/patchnode/patchnode.go
@@ -26,11 +26,6 @@ import (
 
 // AnnotateCRISocket annotates the node with the given crisocket
 func AnnotateCRISocket(client clientset.Interface, nodeName string, criSocket string) error {
-	klog.V(1).Infof("[patchnode] Creating the Node API object %q if missing", nodeName)
-	// See the comments for this function
-	if err := apiclient.EnsureNodeObject(client, nodeName); err != nil {
-		return err
-	}
 	klog.V(1).Infof("[patchnode] Uploading the CRI Socket information %q to the Node API object %q as an annotation", criSocket, nodeName)
 	return apiclient.PatchNode(client, nodeName, func(n *v1.Node) {
 		annotateNodeWithCRISocket(n, criSocket)

--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -285,29 +285,6 @@ func PatchNodeOnce(client clientset.Interface, nodeName string, patchFn func(*v1
 	}
 }
 
-// EnsureNodeObject creates a Node with the given name if the Node doesn't exist.
-// Adding a placeholder v1.LabelHostname label makes the object suitable for patching using PatchNodeOnce.
-//
-// Currently this function is used to make sure a Node object exists before patching it
-// during the "kubeadm init" phases. The creation of the Node object is delayed due to TLS boostrap
-// and instead of waiting for the object, we create it as a placeholder and patch it right away.
-// Later the same Node object is populated with dynamic values by the kubelet.
-func EnsureNodeObject(client clientset.Interface, nodeName string) error {
-	node := &v1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   nodeName,
-			Labels: map[string]string{v1.LabelHostname: ""},
-		},
-	}
-	if _, err := client.CoreV1().Nodes().Create(node); err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			return nil
-		}
-		return errors.Wrapf(err, "error creating Node %q", nodeName)
-	}
-	return nil
-}
-
 // PatchNode tries to patch a node using patchFn for the actual mutating logic.
 // Retries are provided by the wait package.
 func PatchNode(client clientset.Interface, nodeName string, patchFn func(*v1.Node)) error {

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netutil "k8s.io/apimachinery/pkg/util/net"
@@ -135,7 +135,6 @@ func (w *KubeWaiter) WaitForPodToDisappear(podName string) error {
 // WaitForHealthyKubelet blocks until the kubelet /healthz endpoint returns 'ok'
 func (w *KubeWaiter) WaitForHealthyKubelet(initalTimeout time.Duration, healthzEndpoint string) error {
 	time.Sleep(initalTimeout)
-	fmt.Printf("[kubelet-check] Initial timeout of %v passed.\n", initalTimeout)
 	return TryRunCommand(func() error {
 		client := &http.Client{Transport: netutil.SetOldTransportDefaults(&http.Transport{})}
 		resp, err := client.Get(healthzEndpoint)


### PR DESCRIPTION
**What this PR does / why we need it**:

xref https://github.com/kubernetes/kubernetes/pull/83339

> don't manually create the Node object during init

This proved to be problematic if the kubelet is running within a
cloud-provider. The problem is that the kubeadm created Node object
does not trigger an update in the providerID field under the Node spec.
The reason for that is unclear, yet it hinted that this manual Node
creation is not ideal.

To solve the problem without touching the phase orders:
- Remove the manual node creation (EnsureNodeObject()) and it's calls
in app/phases/* code
- In the cmd/phases/iinit markcontrolplane and uploadconfig phases
before patching the Node object make sure that the "system:nodes" group
is granted the
"system:certificates.k8s.io:certificatesigningrequests:selfnodeclient"
ClusterRole which will allow the kubelet to renew it's own client
certificate and create the Node object.
The same CRB is later created by the boostraptoken init phase, but
the operation will not error out and act as transparent update.

Ideally:
- The bootstraptoken phase should have been before all phases the
patch Nodes.
- The uploadconfig should have not include patching node actions
and this should have been a separate phase.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref  https://github.com/kubernetes/kubernetes/issues/83923
xref https://github.com/kubernetes/kubernetes/pull/83339

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind bug
/priority important-soon
/assign @fabriziopandini 
cc @dims 
