### PR TITLE
Default the --enable-cadvisor-endpoints flag to disabled

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -219,7 +219,7 @@ func NewKubeletFlags() *KubeletFlags {
 		SeccompProfileRoot:                  filepath.Join(defaultRootDir, "seccomp"),
 		// prior to the introduction of this flag, there was a hardcoded cap of 50 images
 		NodeStatusMaxImages:         50,
-		EnableCAdvisorJSONEndpoints: true,
+		EnableCAdvisorJSONEndpoints: false,
 	}
 }
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -339,6 +339,17 @@ func ProxyMode(f *Framework) (string, error) {
 	return stdout, nil
 }
 
+// SkipUnlessServerVersionLT skips if the server version is greater than or equal v.
+func SkipUnlessServerVersionLT(v *utilversion.Version, c discovery.ServerVersionInterface) {
+	gte, err := ServerVersionGTE(v, c)
+	if err != nil {
+		Failf("Failed to get server version: %v", err)
+	}
+	if gte {
+		skipInternalf(1, "The feature has been removed for server versions after %q", v)
+	}
+}
+
 // SkipUnlessServerVersionGTE skips if the server version is less than v.
 func SkipUnlessServerVersionGTE(v *utilversion.Version, c discovery.ServerVersionInterface) {
 	gte, err := ServerVersionGTE(v, c)

--- a/test/e2e/instrumentation/monitoring/BUILD
+++ b/test/e2e/instrumentation/monitoring/BUILD
@@ -27,6 +27,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/selection:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/discovery/cached/memory:go_default_library",

--- a/test/e2e/instrumentation/monitoring/cadvisor.go
+++ b/test/e2e/instrumentation/monitoring/cadvisor.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilversion "k8s.io/apimachinery/pkg/util/version"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
@@ -34,10 +35,15 @@ var cadvisor struct {
 	SleepDuration time.Duration `default:"10000ms"`
 }
 var _ = config.AddOptions(&cadvisor, "instrumentation.monitoring.cadvisor")
+var serverPrintVersion = utilversion.MustParseSemantic("v1.17.0")
 
 var _ = instrumentation.SIGDescribe("Cadvisor", func() {
 
 	f := framework.NewDefaultFramework("cadvisor")
+
+	ginkgo.BeforeEach(func() {
+		framework.SkipUnlessServerVersionLT(serverPrintVersion, f.ClientSet.Discovery())
+	})
 
 	ginkgo.It("should be healthy on every node.", func() {
 		CheckCadvisorHealthOnAllNodes(f.ClientSet, 5*time.Minute)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Default the --enable-cadvisor-endpoints flag to disabled

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68522

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubelet: default the --enable-cadvisor-endpoints flag to disabled
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
