### PR TITLE
Add crictl windows binaries to workspace

### DIFF
--- a/build/debs/BUILD
+++ b/build/debs/BUILD
@@ -148,7 +148,7 @@ genrule(
     name = "cri-tools-data-%s" % goarch,
     package_dir = "/usr/bin",
     tags = ["manual"],
-    deps = ["@cri_tools_%s//file" % goarch],
+    deps = ["@cri_tools_linux-%s//file" % goarch],
 ) for goarch in NODE_PLATFORMS["linux"]]
 
 [k8s_deb(

--- a/build/rpms/BUILD
+++ b/build/rpms/BUILD
@@ -106,7 +106,7 @@ genrule(
 [pkg_rpm_for_goarch(
     name = "cri-tools",
     data = [
-        "@cri_tools_{GOARCH}//file",
+        "@cri_tools_linux-{GOARCH}//file",
     ],
     goarch = arch,
     spec_file = "cri-tools.spec",

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -28,11 +28,14 @@ _CNI_TARBALL_ARCH_SHA256 = {
 
 CRI_TOOLS_VERSION = "1.16.1"
 _CRI_TARBALL_ARCH_SHA256 = {
-    "amd64": "19fed421710fccfe58f5573383bb137c19438a9056355556f1a15da8d23b3ad1",
-    "arm": "367826f3eb06c4d923f3174d23141ddacef9ffcb0c902502bd922dbad86d08dd",
-    "arm64": "62b60ab7046b788df892a1b746bd602c520a59c38232febc0580692c9805f641",
-    "ppc64le": "d6464188a5011242b8dad22cb1e55d8cb29d6873f3d1f3f3c32bb236d3fca64e",
-    "s390x": "f3d5e707810d7985f6a470ea439ca5989c0ee218a824795ed1726f4958281a2d",
+    "linux-386": "35b721a7a90a12cf9689fb1f4fe5b50f73520200130a52b552234bd798d2ae9f",
+    "linux-amd64": "19fed421710fccfe58f5573383bb137c19438a9056355556f1a15da8d23b3ad1",
+    "linux-arm": "367826f3eb06c4d923f3174d23141ddacef9ffcb0c902502bd922dbad86d08dd",
+    "linux-arm64": "62b60ab7046b788df892a1b746bd602c520a59c38232febc0580692c9805f641",
+    "linux-ppc64le": "d6464188a5011242b8dad22cb1e55d8cb29d6873f3d1f3f3c32bb236d3fca64e",
+    "linux-s390x": "f3d5e707810d7985f6a470ea439ca5989c0ee218a824795ed1726f4958281a2d",
+    "windows-386": "b7564675f69aa2a01b092874c9c9aeda084204384d711a6fb85c6d2328ca5c7d",
+    "windows-amd64": "7d092dcb3b1af2edf75477d5d049a70e8c0d1ac8242b1dff2de7e6aa084e3615",
 }
 
 ETCD_VERSION = "3.3.15"
@@ -65,7 +68,7 @@ def cri_tarballs():
             name = "cri_tools_%s" % arch,
             downloaded_file_path = "cri_tools.tgz",
             sha256 = sha,
-            urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-linux-%s.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION, arch)),
+            urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-%s.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION, arch)),
         )
 
 # Use go get -u github.com/estesp/manifest-tool to find these values


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
The Windows binaries for as well as the 32bit Linux binary was missing from the workspace, which has been added now.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/78134

**Special notes for your reviewer**:
It might be that I've missed some points regarding the release engineering. :innocent: 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added the `crictl` Windows binaries as well as the Linux 32bit binary to the release archives
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- crictl release archives: https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.16.1
```
