### PR TITLE
stop removing cni directories as they aren't installed by kubeadm

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
+++ b/cmd/kubeadm/app/cmd/phases/reset/cleanupnode.go
@@ -81,7 +81,7 @@ func runCleanupNode(c workflow.RunData) error {
 		klog.Warningf("[reset] Failed to remove containers: %v\n", err)
 	}
 
-	r.AddDirsToClean("/etc/cni/net.d", "/var/lib/dockershim", "/var/run/kubernetes", "/var/lib/cni")
+	r.AddDirsToClean("/var/lib/dockershim", "/var/run/kubernetes", "/var/lib/cni")
 
 	// Remove contents from the config and pki directories
 	klog.V(1).Infoln("[reset] Removing contents from the config and pki directories")

--- a/cmd/kubeadm/app/cmd/reset.go
+++ b/cmd/kubeadm/app/cmd/reset.go
@@ -49,6 +49,10 @@ var (
 		The reset process does not clean your kubeconfig files and you must remove them manually.
 		Please, check the contents of the $HOME/.kube/config file.
 	`)
+
+	cniCleanupInstructions = dedent.Dedent(`
+		The reset process does not clean CNI configuration. To do so, you must remove /etc/cni/net.d
+	`)
 )
 
 // resetOptions defines all the options exposed via flags by kubeadm reset.
@@ -179,6 +183,8 @@ func NewCmdReset(in io.Reader, out io.Writer, resetOptions *resetOptions) *cobra
 			data := c.(*resetData)
 			cleanDirs(data)
 
+			// output help text instructing user how to remove cni folders
+			fmt.Print(cniCleanupInstructions)
 			// Output help text instructing user how to remove iptables rules
 			fmt.Print(iptablesCleanupInstructions)
 			return nil


### PR DESCRIPTION
Signed-off-by: Yassine TIJANI <ytijani@vmware.com>


**What type of PR is this?**

/kind bug
/priority backlog

**What this PR does / why we need it**: This PR stops removing `/etc/cni/net.d` as its removal might break tools that install configuration under this directory. Also, this isn't created by kubeadm. Added a message when using `reset` like we do for iptables/ipvs

**Which issue(s) this PR fixes**: Fixes https://github.com/kubernetes/kubeadm/issues/1822

**Special notes for your reviewer**:

/assign @neolit123 

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm no longer removes /etc/cni/net.d as it does not install it. Users should remove files from it manually or rely on the component that created them
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
