### PR TITLE
Fix proto.Merge of IntOrString type

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -45,7 +45,7 @@ type IntOrString struct {
 }
 
 // Type represents the stored type of IntOrString.
-type Type int
+type Type int64
 
 const (
 	Int    Type = iota // The IntOrString holds an int.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The unsized int in the IntOrString type breaks proto.Merge. The proto serialization was already using int64, and json serialization used custom marshaling, so this doesn't change serialization at all.

**Which issue(s) this PR fixes**:
Fixes #83912

**Does this PR introduce a user-facing change?**:
```release-note
Switched intstr.Type to sized integer to follow API guidelines and improve compatibility with proto libraries
```

/sig api-machinery
/cc @smarterclayton 