### PR TITLE
Automated cherry pick of #83924: release: lib: revert docker_registry to constant k8s.gcr.io

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -337,7 +337,10 @@ function kube::release::create_docker_images_for_server() {
     local images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
-    local -r docker_registry="${KUBE_DOCKER_REGISTRY}"
+    # k8s.gcr.io is the constant tag in the docker archives, this is also the default for config scripts in GKE.
+    # We can use KUBE_DOCKER_REGISTRY to include and extra registry in the docker archive.
+    # If we use KUBE_DOCKER_REGISTRY="k8s.gcr.io", then the extra tag (same) is ignored, see release_docker_image_tag below.
+    local -r docker_registry="k8s.gcr.io"
     # Docker tags cannot contain '+'
     local docker_tag="${KUBE_GIT_VERSION/+/_}"
     if [[ -z "${docker_tag}" ]]; then


### PR DESCRIPTION
Cherry pick of #83924 on release-1.16.

#83924: release: lib: revert docker_registry to constant k8s.gcr.io

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.