### PR TITLE
Adding new label to indicate what is managing an EndpointSlice

### DIFF
--- a/pkg/controller/endpointslice/endpointslice_controller.go
+++ b/pkg/controller/endpointslice/endpointslice_controller.go
@@ -54,6 +54,20 @@ const (
 	// 5ms, 10ms, 20ms, 40ms, 80ms, 160ms, 320ms, 640ms, 1.3s, 2.6s, 5.1s,
 	// 10.2s, 20.4s, 41s, 82s
 	maxRetries = 15
+	// controllerName is a unique value used with LabelManagedBy to indicated
+	// the component managing an EndpointSlice.
+	controllerName = "endpointslice-controller.k8s.io"
+	// managedBySetupAnnotation is set on a Service to indicate that
+	// EndpointSlices for the Service have already been configured with
+	// LabelManagedBy. If this annotation is not set, all related EndpointSlices
+	// will have LabelManagedBy set to reference this controller if the label
+	// is not already set. Once all EndpointSlices are labeled, the Controller
+	// will set this annotation on the Service.
+	managedBySetupAnnotation = "endpointslice.kubernetes.io/managed-by-setup"
+	// managedBySetupCompleteValue represents the value of the
+	// managedBySetupAnnotation that indicates that the setup process has been
+	// completed for a Service.
+	managedBySetupCompleteValue = "true"
 )
 
 // NewController creates and initializes a new Controller
@@ -286,7 +300,28 @@ func (c *Controller) syncService(key string) error {
 		return err
 	}
 
-	esLabelSelector := labels.Set(map[string]string{discovery.LabelServiceName: service.Name}).AsSelectorPreValidated()
+	// With the goal of different controllers being able to manage different
+	// subsets of EndpointSlices, LabelManagedBy has been added to indicate
+	// which controller or entity manages an EndpointSlice. As part of this
+	// v1.16->v1.17 change, EndpointSlices will initially be assumed to be
+	// managed by this controller unless a label is set to indicate otherwise.
+	// To ensure a seamless upgrade process, the managedBySetupAnnotation is
+	// used to indicate that LabelManagedBy has been set initially for related
+	// EndpointSlices. If it hasn't been set to the expected value here, we call
+	// ensureSetupManagedByAnnotation() to set up LabelManagedBy on each
+	// EndpointSlice.
+	// TODO(robscott): Remove this before v1.18.
+	err = c.ensureSetupManagedByAnnotation(service)
+	if err != nil {
+		c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToSetEndpointSliceManagedByLabel",
+			"Error adding managed-by Label to Endpoint Slices for Service %s/%s: %v", service.Namespace, service.Name, err)
+		return err
+	}
+
+	esLabelSelector := labels.Set(map[string]string{
+		discovery.LabelServiceName: service.Name,
+		discovery.LabelManagedBy:   controllerName,
+	}).AsSelectorPreValidated()
 	endpointSlices, err := c.endpointSliceLister.EndpointSlices(service.Namespace).List(esLabelSelector)
 
 	if err != nil {
@@ -335,6 +370,49 @@ func (c *Controller) onServiceDelete(obj interface{}) {
 
 	c.serviceSelectorCache.Delete(key)
 	c.queue.Add(key)
+}
+
+// ensureSetupManagedByAnnotation selects all EndpointSlices for a Service and
+// ensures they have LabelManagedBy set appropriately. This ensures that only
+// one controller or entity is trying to manage a given EndpointSlice. This
+// function provides backwards compatibility with the initial alpha release of
+// EndpointSlices that did not include these labels.
+// TODO(robscott): Remove this in time for v1.18.
+func (c *Controller) ensureSetupManagedByAnnotation(service *v1.Service) error {
+	if managedBySetup, ok := service.Annotations[managedBySetupAnnotation]; ok && managedBySetup == managedBySetupCompleteValue {
+		return nil
+	}
+
+	esLabelSelector := labels.Set(map[string]string{discovery.LabelServiceName: service.Name}).AsSelectorPreValidated()
+	endpointSlices, err := c.endpointSliceLister.EndpointSlices(service.Namespace).List(esLabelSelector)
+
+	if err != nil {
+		c.eventRecorder.Eventf(service, v1.EventTypeWarning, "FailedToListEndpointSlices",
+			"Error listing Endpoint Slices for Service %s/%s: %v", service.Namespace, service.Name, err)
+		return err
+	}
+
+	for _, endpointSlice := range endpointSlices {
+		if _, ok := endpointSlice.Labels[discovery.LabelManagedBy]; !ok {
+			if endpointSlice.Labels == nil {
+				endpointSlice.Labels = make(map[string]string)
+			}
+
+			endpointSlice.Labels[discovery.LabelManagedBy] = controllerName
+			_, err = c.client.DiscoveryV1alpha1().EndpointSlices(endpointSlice.Namespace).Update(endpointSlice)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if service.Annotations == nil {
+		service.Annotations = make(map[string]string)
+	}
+
+	service.Annotations[managedBySetupAnnotation] = managedBySetupCompleteValue
+	_, err = c.client.CoreV1().Services(service.Namespace).Update(service)
+	return err
 }
 
 func (c *Controller) addPod(obj interface{}) {

--- a/pkg/controller/endpointslice/utils.go
+++ b/pkg/controller/endpointslice/utils.go
@@ -162,7 +162,10 @@ func newEndpointSlice(service *corev1.Service, endpointMeta *endpointMeta) *disc
 	ownerRef := metav1.NewControllerRef(service, gvk)
 	return &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:          map[string]string{discovery.LabelServiceName: service.Name},
+			Labels: map[string]string{
+				discovery.LabelServiceName: service.Name,
+				discovery.LabelManagedBy:   controllerName,
+			},
 			GenerateName:    getEndpointSlicePrefix(service.Name),
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Namespace:       service.Namespace,

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -58,7 +58,10 @@ func TestNewEndpointSlice(t *testing.T) {
 
 	expectedSlice := discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels:          map[string]string{discovery.LabelServiceName: service.Name},
+			Labels: map[string]string{
+				discovery.LabelServiceName: service.Name,
+				discovery.LabelManagedBy:   controllerName,
+			},
 			GenerateName:    fmt.Sprintf("%s-", service.Name),
 			OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			Namespace:       service.Namespace,

--- a/staging/src/k8s.io/api/discovery/v1alpha1/well_known_labels.go
+++ b/staging/src/k8s.io/api/discovery/v1alpha1/well_known_labels.go
@@ -19,4 +19,10 @@ package v1alpha1
 const (
 	// LabelServiceName is used to indicate the name of a Kubernetes service.
 	LabelServiceName = "kubernetes.io/service-name"
+	// LabelManagedBy is used to indicate the controller or entity that manages
+	// an EndpointSlice. This label aims to enable different EndpointSlice
+	// objects to be managed by different controllers or entities within the
+	// same cluster. It is highly recommended to configure this label for all
+	// EndpointSlices.
+	LabelManagedBy = "endpointslice.kubernetes.io/managed-by"
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This adds a new Label to EndpointSlices that will ensure that multiple controllers or entities can manage subsets of EndpointSlices. This label provides a way to indicate the controller or entity responsible for managing an EndpointSlice.

To provide a seamless upgrade from the alpha release of EndpointSlices that did not support this label, a temporary annotation has been added on Services to indicate that this label has been initially set on EndpointSlices. That annotation will be set automatically by the EndpointSlice controller with this commit once appropriate Labels have been added on the corresponding EndpointSlices.

**Special notes for your reviewer**:
This is dependent on the associate [proposal PR](https://github.com/kubernetes/enhancements/pull/1286) getting approved.

**Does this PR introduce a user-facing change?**:
```release-note
Adds a new label to indicate what is managing an EndpointSlice.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752
- Enhancement PR: https://github.com/kubernetes/enhancements/pull/1286

/sig network
/priority important-longterm
/cc @freehan 
