### PR TITLE
:arrow_up: Update Apigroup extensions to apps

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-cpva-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/calico-cpva-clusterrole.yaml
@@ -9,6 +9,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list"]
-  - apiGroups: ["apps", "extensions"]
+  - apiGroups: ["apps"]
     resources: ["deployments", "daemonsets"]
     verbs: ["patch"]

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
@@ -10,6 +10,6 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get"]
-  - apiGroups: ["apps", "extensions"]
+  - apiGroups: ["apps"]
     resources: ["deployments/scale"]
     verbs: ["get", "update"]

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-clusterrole.yaml
@@ -9,6 +9,6 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["list"]
-  - apiGroups: ["apps", "extensions"]
+  - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["patch"]

--- a/cluster/addons/cluster-monitoring/heapster-rbac.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-rbac.yaml
@@ -30,7 +30,7 @@ rules:
   verbs:
   - get
 - apiGroups:
-  - "extensions"
+  - "apps"
   resources:
   - deployments
   verbs:

--- a/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
+++ b/cluster/addons/dns-horizontal-autoscaler/dns-horizontal-autoscaler.yaml
@@ -33,7 +33,7 @@ rules:
   - apiGroups: [""]
     resources: ["replicationcontrollers/scale"]
     verbs: ["get", "update"]
-  - apiGroups: ["extensions","apps"]
+  - apiGroups: ["apps"]
     resources: ["deployments/scale", "replicasets/scale"]
     verbs: ["get", "update"]
 # Remove the configmaps rule once below issue is fixed:

--- a/cluster/addons/fluentd-gcp/scaler-rbac.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-rbac.yaml
@@ -17,7 +17,7 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
 - apiGroups:
-  - "extensions"
+  - "apps"
   resources:
   - daemonsets
   verbs:

--- a/cluster/addons/prometheus/kube-state-metrics-rbac.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-rbac.yaml
@@ -30,7 +30,7 @@ rules:
   - namespaces
   - endpoints
   verbs: ["list", "watch"]
-- apiGroups: ["extensions"]
+- apiGroups: ["apps"]
   resources:
   - daemonsets
   - deployments
@@ -63,7 +63,7 @@ rules:
   resources:
   - pods
   verbs: ["get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["apps"]
   resources:
   - deployments
   resourceNames: ["kube-state-metrics"]

--- a/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
+++ b/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
@@ -27,7 +27,7 @@ rules:
   - apiGroups: [""]
     resources: ["services", "replicationcontrollers", "persistentvolumes", "persistentvolumeclaims"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["apps", "extensions"]
+  - apiGroups: ["apps"]
     resources: ["daemonsets", "replicasets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["apps"]


### PR DESCRIPTION
/release-note-none 
/kind cleanup

This PR updates API Group "Extensions" to "Apps" API Group following its deprecation
