### PR TITLE
Log the error before calling closeFn

### DIFF
--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -190,6 +190,8 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 	masterConfig.ExtraConfig.VersionedInformers = informers.NewSharedInformerFactory(clientset, masterConfig.GenericConfig.LoopbackClientConfig.Timeout)
 	m, err = masterConfig.Complete().New(genericapiserver.NewEmptyDelegate())
 	if err != nil {
+		// We log the error first so that even if closeFn crashes, the error is shown
+		klog.Errorf("error in bringing up the master: %v", err)
 		closeFn()
 		klog.Fatalf("error in bringing up the master: %v", err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I was running integration test and saw panic (without error)
```
I1015 13:33:16.314957   10815 feature_gate.go:216] feature gates: &{map[ServerSideApply:true]}
--- FAIL: TestApplyAlsoCreates (0.41s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x42cf596]

goroutine 192 [running]:
testing.tRunner.func1(0xc000395200)
        /usr/local/go/src/testing/testing.go:830 +0x392
panic(0x4925f20, 0xaf8ad20)
        /usr/local/go/src/runtime/panic.go:522 +0x1b5
k8s.io/kubernetes/test/integration/framework.startMasterOrDie.func2()
```
The closeFn() would access memory which might not have been setup yet (see 'error in bringing up the master: Error in registering group versions' below), leading to crash.

After the change:
```
E1015 13:37:06.909015   11119 master_utils.go:193] error in bringing up the master: Error in registering group versions: unable to get openapi models: cannot find model definition for k8s.io/api/admissionregistration/v1.MutatingWebhookConfiguration. If you added a new type, you may need to add +k8s:openapi-gen=true to the package or type and run code-gen again
I1015 13:37:06.909117   11119 feature_gate.go:216] feature gates: &{map[ServerSideApply:true]}
--- FAIL: TestApplyAlsoCreates (0.42s)
```

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
