### PR TITLE
Added `kubectl get all` to `kubectl get --help`

### DIFF
--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -129,6 +129,9 @@ var (
 		# List all replication controllers and services together in ps output format.
 		kubectl get rc,services
 
+		# List all Kubernetes objects in ps output format.
+		kubectl get all
+
 		# List one or more resources by their type and names.
 		kubectl get rc/web service/frontend pods/web-pod-13je7`))
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Added `kubectl get all` to `kubectl get --help` to let users know how to get all objects in a namespace. `kubectl get all` command is extremely useful when trying to navigate the waters of Kubernetes and/or debugging things in the unknown namespace.

**Special notes for your reviewer**:

- This change may not need release notes - please confirm.
- Please let me know if this needs to be ported to previous versions of Kubernetes.

**Does this PR introduce a user-facing change?**:

```
Added helpful command example to `kubectl get --help` command response
```

