### PR TITLE
Update Calico to v3.8.3

### DIFF
--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
       terminationGracePeriodSeconds: 0
       initContainers:
         - name: install-cni
-          image: gcr.io/projectcalico-org/cni:v3.8.2
+          image: gcr.io/projectcalico-org/cni:v3.8.3
           command: ["/install-cni.sh"]
           env:
             - name: CNI_CONF_NAME
@@ -79,8 +79,10 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: gcr.io/projectcalico-org/node:v3.8.2
+          image: gcr.io/projectcalico-org/node:v3.8.3
           env:
+            - name: CALICO_MANAGE_CNI
+              value: "true"
             - name: CALICO_DISABLE_FILE_LOGGING
               value: "true"
             - name: CALICO_NETWORKING_BACKEND
@@ -132,6 +134,8 @@ spec:
               host: localhost
             periodSeconds: 10
           volumeMounts:
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
             - mountPath: /lib/modules
               name: lib-modules
               readOnly: true

--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       hostNetwork: true
       serviceAccountName: calico
       containers:
-      - image: gcr.io/projectcalico-org/typha:v3.8.2
+      - image: gcr.io/projectcalico-org/typha:v3.8.3
         name: calico-typha
         ports:
         - containerPort: 5473


### PR DESCRIPTION

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

This updates GCP scripts to use Calico v3.8.3, which includes support for token projection.

**Special notes for your reviewer**:

None