### PR TITLE
add fuzzing targets for sig-yaml and yaml.v2

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -17,6 +17,7 @@ filegroup(
         "//test/e2e_kubeadm:all-srcs",
         "//test/e2e_node:all-srcs",
         "//test/fixtures:all-srcs",
+        "//test/fuzz/yaml:all-srcs",
         "//test/images:all-srcs",
         "//test/instrumentation:all-srcs",
         "//test/integration:all-srcs",

--- a/test/fuzz/yaml/BUILD
+++ b/test/fuzz/yaml/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["yaml.go"],
+    importpath = "k8s.io/kubernetes/test/fuzz/yaml",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/fuzz/yaml/yaml.go
+++ b/test/fuzz/yaml/yaml.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package yaml implements fuzzers for yaml deserialization routines in
+// Kubernetes. These targets are compatible with the github.com/dvyukov/go-fuzz
+// fuzzing framework.
+package yaml
+
+import (
+	"gopkg.in/yaml.v2"
+	sigyaml "sigs.k8s.io/yaml"
+)
+
+// FuzzSigYaml is a fuzz target for "sigs.k8s.io/yaml" unmarshaling.
+func FuzzSigYaml(b []byte) int {
+	t := struct{}{}
+	m := map[string]interface{}{}
+	var out int
+	if err := sigyaml.Unmarshal(b, &m); err == nil {
+		out = 1
+	}
+	if err := sigyaml.Unmarshal(b, &t); err == nil {
+		out = 1
+	}
+	return out
+}
+
+// FuzzYamlV2 is a fuzz target for "gopkg.in/yaml.v2" unmarshaling.
+func FuzzYamlV2(b []byte) int {
+	t := struct{}{}
+	m := map[string]interface{}{}
+	var out int
+	if err := yaml.Unmarshal(b, &m); err == nil {
+		out = 1
+	}
+	if err := yaml.Unmarshal(b, &t); err == nil {
+		out = 1
+	}
+	return out
+}


### PR DESCRIPTION
This is in prepration to add continous fuzzing of various targets via
https://github.com/google/oss-fuzz.

```release-note
NONE
```