### PR TITLE
fix bug in fuc parseThresholdStatement

### DIFF
--- a/pkg/kubelet/eviction/helpers.go
+++ b/pkg/kubelet/eviction/helpers.go
@@ -197,21 +197,21 @@ func parseThresholdStatement(signal evictionapi.Signal, val string) (*evictionap
 		if val == "0%" || val == "100%" {
 			return nil, nil
 		}
-		percentage, err := parsePercentage(val)
+		percentageAsDecimal, err := parsePercentageAsDecimal(val)
 		if err != nil {
 			return nil, err
 		}
-		if percentage < 0 {
+		if percentageAsDecimal < 0 {
 			return nil, fmt.Errorf("eviction percentage threshold %v must be >= 0%%: %s", signal, val)
 		}
-		if percentage > 100 {
+		if percentageAsDecimal > 1 {
 			return nil, fmt.Errorf("eviction percentage threshold %v must be <= 100%%: %s", signal, val)
 		}
 		return &evictionapi.Threshold{
 			Signal:   signal,
 			Operator: operator,
 			Value: evictionapi.ThresholdValue{
-				Percentage: percentage,
+				Percentage: percentageAsDecimal,
 			},
 		}, nil
 	}
@@ -231,8 +231,8 @@ func parseThresholdStatement(signal evictionapi.Signal, val string) (*evictionap
 	}, nil
 }
 
-// parsePercentage parses a string representing a percentage value
-func parsePercentage(input string) (float32, error) {
+// parsePercentageAsDecimal parses a string representing a percentage to its decimal value
+func parsePercentageAsDecimal(input string) (float32, error) {
 	value, err := strconv.ParseFloat(strings.TrimRight(input, "%"), 32)
 	if err != nil {
 		return 0, err
@@ -275,15 +275,15 @@ func parseMinimumReclaims(statements map[string]string) (map[evictionapi.Signal]
 			return nil, fmt.Errorf(unsupportedEvictionSignal, signal)
 		}
 		if strings.HasSuffix(val, "%") {
-			percentage, err := parsePercentage(val)
+			percentageAsDecimal, err := parsePercentageAsDecimal(val)
 			if err != nil {
 				return nil, err
 			}
-			if percentage <= 0 {
+			if percentageAsDecimal <= 0 {
 				return nil, fmt.Errorf("eviction percentage minimum reclaim %v must be positive: %s", signal, val)
 			}
 			results[signal] = evictionapi.ThresholdValue{
-				Percentage: percentage,
+				Percentage: percentageAsDecimal,
 			}
 			continue
 		}

--- a/pkg/kubelet/eviction/helpers_test.go
+++ b/pkg/kubelet/eviction/helpers_test.go
@@ -1717,7 +1717,7 @@ func TestHasNodeConditions(t *testing.T) {
 	}
 }
 
-func TestParsePercentage(t *testing.T) {
+func TestParsePercentageAsDecimal(t *testing.T) {
 	testCases := map[string]struct {
 		hasError bool
 		value    float32
@@ -1736,7 +1736,7 @@ func TestParsePercentage(t *testing.T) {
 		},
 	}
 	for input, expected := range testCases {
-		value, err := parsePercentage(input)
+		value, err := parsePercentageAsDecimal(input)
 		if (err != nil) != expected.hasError {
 			t.Errorf("Test case: %s, expected: %v, actual: %v", input, expected.hasError, err != nil)
 		}


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
This PR fix a bug in eviction threshold statement parsing. Generally, eviction threshold can be represented in real value ("memory.available":  "100Mi") or in percentage ("memory.available":  "10%"). When parsing percentage thresholdValue, it should be guaranteed between 0% to 100%.  _Func parsePercentage_ is used to get the percentage value, when given "25.5%", the return value is 0.255. It's wrong to directly use the _Func parsePercentage_ return value to compare with 100 in _func parseThresholdStatement_.

**Which issue(s) this PR fixes**:
Fixes #

