### PR TITLE
Traverse resources before giving no name error

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -824,10 +824,9 @@ func (b *Builder) visitorResult() *Result {
 			_, err := b.mappingFor(r)
 			if err != nil {
 				return &Result{err: err}
-			} else {
-				return &Result{err: fmt.Errorf("resource(s) were provided, but no name, label selector, or --all flag specified")}
 			}
 		}
+		return &Result{err: fmt.Errorf("resource(s) were provided, but no name, label selector, or --all flag specified")}
 	}
 	return &Result{err: missingResourceError}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is follow on to #83825.
We should traverse b.resources and see if any error is returned from mappingFor() before emitting 'no name' message.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
