### PR TITLE
Improve histogram buckets for apiserver_request_duration_seconds

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -96,8 +96,8 @@ var (
 			Help: "Response latency distribution in seconds for each verb, dry run value, group, version, resource, subresource, scope and component.",
 			// This metric is used for verifying api call latencies SLO,
 			// as well as tracking regressions in this aspects.
-			// Thus we customize buckets significantly, to empower both usecases.
-			Buckets:        []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 10, 20, 40, 60},
+			// Thus we like to have good resolution between 0.1s and 1s.
+			Buckets:        []float64{0.05, 0.1, 0.2, 0.4, 0.6, 0.8, 1.0, 1.5, 2.0, 4.0, 10, 20, 40, 60},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"verb", "dry_run", "group", "version", "resource", "subresource", "scope", "component"},

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -97,8 +97,7 @@ var (
 			// This metric is used for verifying api call latencies SLO,
 			// as well as tracking regressions in this aspects.
 			// Thus we customize buckets significantly, to empower both usecases.
-			Buckets: []float64{0.05, 0.1, 0.15, 0.2, 0.25, 0.3, 0.35, 0.4, 0.45, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0,
-				1.25, 1.5, 1.75, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30, 40, 50, 60},
+			Buckets:        []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.0, 4.0, 10, 20, 40, 60},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"verb", "dry_run", "group", "version", "resource", "subresource", "scope", "component"},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

We don't need 38 buckets to get a decent idea of the distribution.
38 buckets x N api-servers x 7 verbs x M resources can easily lead to >100,000 timeseries.

```release-note
NONE
```
