### PR TITLE
Add labels to leaderelection resources

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -73,6 +73,9 @@ func (cml *ConfigMapLock) Create(ler LeaderElectionRecord) error {
 			Annotations: map[string]string{
 				LeaderElectionRecordAnnotationKey: string(recordBytes),
 			},
+			Labels: map[string]string{
+				LeaderElectionKindLabelKey: LeaderElectionKindLabelValue,
+			},
 		},
 	})
 	return err

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/endpointslock.go
@@ -68,6 +68,9 @@ func (el *EndpointsLock) Create(ler LeaderElectionRecord) error {
 			Annotations: map[string]string{
 				LeaderElectionRecordAnnotationKey: string(recordBytes),
 			},
+			Labels: map[string]string{
+				LeaderElectionKindLabelKey: LeaderElectionKindLabelValue,
+			},
 		},
 	})
 	return err

--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/interface.go
@@ -27,6 +27,8 @@ import (
 
 const (
 	LeaderElectionRecordAnnotationKey = "control-plane.alpha.kubernetes.io/leader"
+	LeaderElectionKindLabelKey        = "app.kubernetes.io/component"
+	LeaderElectionKindLabelValue      = "leaderelection"
 	EndpointsResourceLock             = "endpoints"
 	ConfigMapsResourceLock            = "configmaps"
 	LeasesResourceLock                = "leases"


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
For cleanup purposes it's sometimes neccessary to remove leftover Endpoints/ConfigMaps from leaderelections. Right now it's hard to find these resources, so a label would be nice to have.

This PR adds a label to the resources created by the `resourcelock` package. Both label key and value are subject to debate, I could not find many other examples for labels in client-go.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
