### PR TITLE
Make node tree order part of the snapshot

### DIFF
--- a/pkg/scheduler/internal/cache/cache_test.go
+++ b/pkg/scheduler/internal/cache/cache_test.go
@@ -1066,7 +1066,7 @@ func TestNodeOperators(t *testing.T) {
 		if !found {
 			t.Errorf("Failed to find node %v in internalcache.", node.Name)
 		}
-		if cache.nodeTree.NumNodes() != 1 || cache.nodeTree.Next() != node.Name {
+		if cache.nodeTree.numNodes != 1 || cache.nodeTree.next() != node.Name {
 			t.Errorf("cache.nodeTree is not updated correctly after adding node: %v", node.Name)
 		}
 
@@ -1109,7 +1109,7 @@ func TestNodeOperators(t *testing.T) {
 			t.Errorf("Failed to update node in schedulernodeinfo:\n got: %+v \nexpected: %+v", got, expected)
 		}
 		// Check nodeTree after update
-		if cache.nodeTree.NumNodes() != 1 || cache.nodeTree.Next() != node.Name {
+		if cache.nodeTree.numNodes != 1 || cache.nodeTree.next() != node.Name {
 			t.Errorf("unexpected cache.nodeTree after updating node: %v", node.Name)
 		}
 
@@ -1120,7 +1120,7 @@ func TestNodeOperators(t *testing.T) {
 		}
 		// Check nodeTree after remove. The node should be removed from the nodeTree even if there are
 		// still pods on it.
-		if cache.nodeTree.NumNodes() != 0 || cache.nodeTree.Next() != "" {
+		if cache.nodeTree.numNodes != 0 || cache.nodeTree.next() != "" {
 			t.Errorf("unexpected cache.nodeTree after removing node: %v", node.Name)
 		}
 	}

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -103,9 +103,6 @@ func (c *Cache) Snapshot() *internalcache.Snapshot {
 	return &internalcache.Snapshot{}
 }
 
-// NodeTree is a fake method for testing.
-func (c *Cache) NodeTree() *internalcache.NodeTree { return nil }
-
 // GetNodeInfo is a fake method for testing.
 func (c *Cache) GetNodeInfo(nodeName string) (*v1.Node, error) {
 	return nil, nil
@@ -119,4 +116,9 @@ func (c *Cache) ListNodes() []*v1.Node {
 // GetCSINodeInfo is a fake method for testing.
 func (c *Cache) GetCSINodeInfo(nodeName string) (*storagev1beta1.CSINode, error) {
 	return nil, nil
+}
+
+// NumNodes is a fake method for testing.
+func (c *Cache) NumNodes() int {
+	return 0
 }

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -119,9 +119,6 @@ type Cache interface {
 
 	// Snapshot takes a snapshot on current cache
 	Snapshot() *Snapshot
-
-	// NodeTree returns a node tree structure
-	NodeTree() *NodeTree
 }
 
 // Snapshot is a snapshot of cache state

--- a/pkg/scheduler/internal/cache/node_tree_test.go
+++ b/pkg/scheduler/internal/cache/node_tree_test.go
@@ -110,23 +110,23 @@ var allNodes = []*v1.Node{
 		},
 	}}
 
-func verifyNodeTree(t *testing.T, nt *NodeTree, expectedTree map[string]*nodeArray) {
+func verifyNodeTree(t *testing.T, nt *nodeTree, expectedTree map[string]*nodeArray) {
 	expectedNumNodes := int(0)
 	for _, na := range expectedTree {
 		expectedNumNodes += len(na.nodes)
 	}
-	if numNodes := nt.NumNodes(); numNodes != expectedNumNodes {
-		t.Errorf("unexpected NodeTree.numNodes. Expected: %v, Got: %v", expectedNumNodes, numNodes)
+	if numNodes := nt.numNodes; numNodes != expectedNumNodes {
+		t.Errorf("unexpected nodeTree.numNodes. Expected: %v, Got: %v", expectedNumNodes, numNodes)
 	}
 	if !reflect.DeepEqual(nt.tree, expectedTree) {
 		t.Errorf("The node tree is not the same as expected. Expected: %v, Got: %v", expectedTree, nt.tree)
 	}
 	if len(nt.zones) != len(expectedTree) {
-		t.Errorf("Number of zones in NodeTree.zones is not expected. Expected: %v, Got: %v", len(expectedTree), len(nt.zones))
+		t.Errorf("Number of zones in nodeTree.zones is not expected. Expected: %v, Got: %v", len(expectedTree), len(nt.zones))
 	}
 	for _, z := range nt.zones {
 		if _, ok := expectedTree[z]; !ok {
-			t.Errorf("zone %v is not expected to exist in NodeTree.zones", z)
+			t.Errorf("zone %v is not expected to exist in nodeTree.zones", z)
 		}
 	}
 }
@@ -170,7 +170,7 @@ func TestNodeTree_AddNode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			nt := newNodeTree(nil)
 			for _, n := range test.nodesToAdd {
-				nt.AddNode(n)
+				nt.addNode(n)
 			}
 			verifyNodeTree(t, nt, test.expectedTree)
 		})
@@ -227,7 +227,7 @@ func TestNodeTree_RemoveNode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			nt := newNodeTree(test.existingNodes)
 			for _, n := range test.nodesToRemove {
-				err := nt.RemoveNode(n)
+				err := nt.removeNode(n)
 				if test.expectError == (err == nil) {
 					t.Errorf("unexpected returned error value: %v", err)
 				}
@@ -312,7 +312,7 @@ func TestNodeTree_UpdateNode(t *testing.T) {
 			if oldNode == nil {
 				oldNode = &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nonexisting-node"}}
 			}
-			nt.UpdateNode(oldNode, test.nodeToUpdate)
+			nt.updateNode(oldNode, test.nodeToUpdate)
 			verifyNodeTree(t, nt, test.expectedTree)
 		})
 	}
@@ -357,7 +357,7 @@ func TestNodeTree_Next(t *testing.T) {
 
 			var output []string
 			for i := 0; i < test.numRuns; i++ {
-				output = append(output, nt.Next())
+				output = append(output, nt.next())
 			}
 			if !reflect.DeepEqual(output, test.expectedOutput) {
 				t.Errorf("unexpected output. Expected: %v, Got: %v", test.expectedOutput, output)
@@ -423,18 +423,18 @@ func TestNodeTreeMultiOperations(t *testing.T) {
 					if addIndex >= len(test.nodesToAdd) {
 						t.Error("more add operations than nodesToAdd")
 					} else {
-						nt.AddNode(test.nodesToAdd[addIndex])
+						nt.addNode(test.nodesToAdd[addIndex])
 						addIndex++
 					}
 				case "remove":
 					if removeIndex >= len(test.nodesToRemove) {
 						t.Error("more remove operations than nodesToRemove")
 					} else {
-						nt.RemoveNode(test.nodesToRemove[removeIndex])
+						nt.removeNode(test.nodesToRemove[removeIndex])
 						removeIndex++
 					}
 				case "next":
-					output = append(output, nt.Next())
+					output = append(output, nt.next())
 				default:
 					t.Errorf("unknow operation: %v", op)
 				}

--- a/pkg/scheduler/nodeinfo/snapshot.go
+++ b/pkg/scheduler/nodeinfo/snapshot.go
@@ -20,12 +20,14 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// Snapshot is a snapshot of cache NodeInfo. The scheduler takes a
-// snapshot at the beginning of each scheduling cycle and uses it for its
-// operations in that cycle.
+// Snapshot is a snapshot of cache NodeInfo and NodeTree order. The scheduler takes a
+// snapshot at the beginning of each scheduling cycle and uses it for its operations in that cycle.
 type Snapshot struct {
+	// NodeInfoMap a map of node name to a snapshot of its NodeInfo.
 	NodeInfoMap map[string]*NodeInfo
-	Generation  int64
+	// NodeInfoList is the list of nodes as ordered in the cache's nodeTree.
+	NodeInfoList []*NodeInfo
+	Generation   int64
 }
 
 // NewSnapshot initializes a Snapshot struct and returns it.
@@ -38,7 +40,7 @@ func NewSnapshot() *Snapshot {
 // ListNodes returns the list of nodes in the snapshot.
 func (s *Snapshot) ListNodes() []*v1.Node {
 	nodes := make([]*v1.Node, 0, len(s.NodeInfoMap))
-	for _, n := range s.NodeInfoMap {
+	for _, n := range s.NodeInfoList {
 		if n != nil && n.node != nil {
 			nodes = append(nodes, n.node)
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Makes the scheduler's nodeTree object private to the cache and part of the snapshot. The purpose of NodeTree is decide on the iteration order of the nodes (force iterating across zones etc. when evaluating nodes), currently the scheduler iterates over the live tree instead of the snapshot, this has two drawbacks:

1) iterating over the scheduler cache nodeTree requires acquiring a lock, which causes contention (see #72408)
2) causes inconsistencies in clusters that bring up and shutdown nodes frequently (cluster autoscaling)

This PR make the order part of the snapshot, which improves performance (by about 3%) since we don't require locking, and removes the inconsistencies since the scheduler is now iterating over a static list of nodes.

**Which issue(s) this PR fixes**:
Part of #83922


**Does this PR introduce a user-facing change?**:
```release-note
NONE

```
