### PR TITLE
Remove CSINode from scheduler cache.

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -30,7 +30,6 @@ go_library(
         "//pkg/scheduler/volumebinder:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
-        "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",

--- a/pkg/scheduler/algorithm/predicates/BUILD
+++ b/pkg/scheduler/algorithm/predicates/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/listers/storage/v1:go_default_library",
+        "//staging/src/k8s.io/client-go/listers/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/util/workqueue:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume/helpers:go_default_library",
         "//staging/src/k8s.io/csi-translation-lib:go_default_library",

--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -24,7 +24,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
@@ -159,59 +158,11 @@ func (sched *Scheduler) deleteNodeFromCache(obj interface{}) {
 }
 
 func (sched *Scheduler) onCSINodeAdd(obj interface{}) {
-	csiNode, ok := obj.(*storagev1beta1.CSINode)
-	if !ok {
-		klog.Errorf("cannot convert to *storagev1beta1.CSINode: %v", obj)
-		return
-	}
-
-	if err := sched.SchedulerCache.AddCSINode(csiNode); err != nil {
-		klog.Errorf("scheduler cache AddCSINode failed: %v", err)
-	}
-
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(queue.CSINodeAdd)
 }
 
 func (sched *Scheduler) onCSINodeUpdate(oldObj, newObj interface{}) {
-	oldCSINode, ok := oldObj.(*storagev1beta1.CSINode)
-	if !ok {
-		klog.Errorf("cannot convert oldObj to *storagev1beta1.CSINode: %v", oldObj)
-		return
-	}
-
-	newCSINode, ok := newObj.(*storagev1beta1.CSINode)
-	if !ok {
-		klog.Errorf("cannot convert newObj to *storagev1beta1.CSINode: %v", newObj)
-		return
-	}
-
-	if err := sched.SchedulerCache.UpdateCSINode(oldCSINode, newCSINode); err != nil {
-		klog.Errorf("scheduler cache UpdateCSINode failed: %v", err)
-	}
-
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(queue.CSINodeUpdate)
-}
-
-func (sched *Scheduler) onCSINodeDelete(obj interface{}) {
-	var csiNode *storagev1beta1.CSINode
-	switch t := obj.(type) {
-	case *storagev1beta1.CSINode:
-		csiNode = t
-	case cache.DeletedFinalStateUnknown:
-		var ok bool
-		csiNode, ok = t.Obj.(*storagev1beta1.CSINode)
-		if !ok {
-			klog.Errorf("cannot convert to *storagev1beta1.CSINode: %v", t.Obj)
-			return
-		}
-	default:
-		klog.Errorf("cannot convert to *storagev1beta1.CSINode: %v", t)
-		return
-	}
-
-	if err := sched.SchedulerCache.RemoveCSINode(csiNode); err != nil {
-		klog.Errorf("scheduler cache RemoveCSINode failed: %v", err)
-	}
 }
 
 func (sched *Scheduler) addPodToSchedulingQueue(obj interface{}) {
@@ -450,7 +401,6 @@ func AddAllEventHandlers(
 			cache.ResourceEventHandlerFuncs{
 				AddFunc:    sched.onCSINodeAdd,
 				UpdateFunc: sched.onCSINodeUpdate,
-				DeleteFunc: sched.onCSINodeDelete,
 			},
 		)
 	}

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -594,7 +594,7 @@ func (c *Configurator) getAlgorithmArgs() (*PluginFactoryArgs, *plugins.ConfigPr
 		StatefulSetLister:              c.statefulSetLister,
 		PDBLister:                      c.pdbLister,
 		NodeInfo:                       c.schedulerCache,
-		CSINodeInfo:                    c.schedulerCache,
+		CSINodeInfo:                    &predicates.CachedCSINodeInfo{CSINodeLister: c.csiNodeLister},
 		PVInfo:                         &predicates.CachedPersistentVolumeInfo{PersistentVolumeLister: c.pVLister},
 		PVCInfo:                        &predicates.CachedPersistentVolumeClaimInfo{PersistentVolumeClaimLister: c.pVCLister},
 		StorageClassInfo:               &predicates.CachedStorageClassInfo{StorageClassLister: c.storageClassLister},

--- a/pkg/scheduler/framework/plugins/default_registry.go
+++ b/pkg/scheduler/framework/plugins/default_registry.go
@@ -63,7 +63,7 @@ func NewDefaultRegistry(args *RegistryArgs) framework.Registry {
 		},
 		volumerestrictions.Name: volumerestrictions.New,
 		volumezone.Name:         volumezone.New,
-		nodevolumelimits.Name:   nodevolumelimits.New(args.SchedulerCache),
+		nodevolumelimits.Name:   nodevolumelimits.New,
 		interpodaffinity.Name: func(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
 			return interpodaffinity.New(args.SchedulerCache, args.SchedulerCache), nil
 		},

--- a/pkg/scheduler/internal/cache/BUILD
+++ b/pkg/scheduler/internal/cache/BUILD
@@ -15,7 +15,6 @@ go_library(
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/pkg/scheduler/internal/cache/fake/BUILD
+++ b/pkg/scheduler/internal/cache/fake/BUILD
@@ -10,7 +10,6 @@ go_library(
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/storage/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],
 )

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -18,7 +18,6 @@ package fake
 
 import (
 	v1 "k8s.io/api/core/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
@@ -76,15 +75,6 @@ func (c *Cache) UpdateNode(oldNode, newNode *v1.Node) error { return nil }
 // RemoveNode is a fake method for testing.
 func (c *Cache) RemoveNode(node *v1.Node) error { return nil }
 
-// AddCSINode is a fake method for testing.
-func (c *Cache) AddCSINode(csiNode *storagev1beta1.CSINode) error { return nil }
-
-// UpdateCSINode is a fake method for testing.
-func (c *Cache) UpdateCSINode(oldCSINode, newCSINode *storagev1beta1.CSINode) error { return nil }
-
-// RemoveCSINode is a fake method for testing.
-func (c *Cache) RemoveCSINode(csiNode *storagev1beta1.CSINode) error { return nil }
-
 // UpdateNodeInfoSnapshot is a fake method for testing.
 func (c *Cache) UpdateNodeInfoSnapshot(nodeSnapshot *schedulernodeinfo.Snapshot) error {
 	return nil
@@ -111,14 +101,4 @@ func (c *Cache) GetNodeInfo(nodeName string) (*v1.Node, error) {
 // ListNodes is a fake method for testing.
 func (c *Cache) ListNodes() []*v1.Node {
 	return nil
-}
-
-// GetCSINodeInfo is a fake method for testing.
-func (c *Cache) GetCSINodeInfo(nodeName string) (*storagev1beta1.CSINode, error) {
-	return nil, nil
-}
-
-// NumNodes is a fake method for testing.
-func (c *Cache) NumNodes() int {
-	return 0
 }

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -18,7 +18,6 @@ package cache
 
 import (
 	v1 "k8s.io/api/core/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
@@ -102,20 +101,8 @@ type Cache interface {
 	// on this node.
 	UpdateNodeInfoSnapshot(nodeSnapshot *schedulernodeinfo.Snapshot) error
 
-	// AddCSINode adds overall CSI-related information about node.
-	AddCSINode(csiNode *storagev1beta1.CSINode) error
-
-	// UpdateCSINode updates overall CSI-related information about node.
-	UpdateCSINode(oldCSINode, newCSINode *storagev1beta1.CSINode) error
-
-	// RemoveCSINode removes overall CSI-related information about node.
-	RemoveCSINode(csiNode *storagev1beta1.CSINode) error
-
 	// GetNodeInfo returns the node object with node string.
 	GetNodeInfo(nodeName string) (*v1.Node, error)
-
-	// GetCSINodeInfo returns the csinode object with the given name.
-	GetCSINodeInfo(nodeName string) (*storagev1beta1.CSINode, error)
 
 	// Snapshot takes a snapshot on current cache
 	Snapshot() *Snapshot


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Remove CSINodeInfo from scheduler cache. CSINodeInfo should be read directly from informer cache. Having in the scheduler cache consumes memory and adds no value.

**Which issue(s) this PR fixes**:
Part of #83922

```release-note
NONE
```

/priority important-soon
/assign @liu-cong 