### PR TITLE
Relocate tableprinter tests

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -53,6 +53,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
     ],

--- a/pkg/printers/internalversion/additional_printers_test.go
+++ b/pkg/printers/internalversion/additional_printers_test.go
@@ -81,17 +81,6 @@ func (obj *TestPrintType) DeepCopyObject() runtime.Object {
 	return &clone
 }
 
-type TestUnknownType struct{}
-
-func (obj *TestUnknownType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
-func (obj *TestUnknownType) DeepCopyObject() runtime.Object {
-	if obj == nil {
-		return nil
-	}
-	clone := *obj
-	return &clone
-}
-
 // TODO(seans3): Move this test to cli-runtime/pkg/printers.
 func testPrinter(t *testing.T, printer printers.ResourcePrinter, unmarshalFunc func(data []byte, v interface{}) error) {
 	buf := bytes.NewBuffer([]byte{})
@@ -214,15 +203,6 @@ func TestPrintHandlerError(t *testing.T) {
 	_, err := generator.GenerateTable(&obj, printers.GenerateOptions{})
 	if err == nil || err.Error() != "ErrorPrintHandler error" {
 		t.Errorf("Did not get the expected error: %#v", err)
-	}
-}
-
-func TestUnknownTypePrinting(t *testing.T) {
-	printer := printers.NewTablePrinter(printers.PrintOptions{})
-	buffer := &bytes.Buffer{}
-	err := printer.PrintObj(&TestUnknownType{}, buffer)
-	if err == nil {
-		t.Errorf("An error was expected from printing unknown type")
 	}
 }
 

--- a/pkg/printers/internalversion/additional_printers_test.go
+++ b/pkg/printers/internalversion/additional_printers_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"regexp"
 	"testing"
 
 	yaml "gopkg.in/yaml.v2"
@@ -67,113 +66,6 @@ type TestStruct struct {
 
 func (in *TestStruct) DeepCopyObject() runtime.Object {
 	panic("never called")
-}
-
-// TODO(seans3): Move this test to tableprinter_test.go
-func TestPrintUnstructuredObject(t *testing.T) {
-	obj := &unstructured.Unstructured{
-		Object: map[string]interface{}{
-			"apiVersion": "v1",
-			"kind":       "Test",
-			"dummy1":     "present",
-			"dummy2":     "present",
-			"metadata": map[string]interface{}{
-				"name":              "MyName",
-				"namespace":         "MyNamespace",
-				"creationTimestamp": "2017-04-01T00:00:00Z",
-				"resourceVersion":   123,
-				"uid":               "00000000-0000-0000-0000-000000000001",
-				"dummy3":            "present",
-				"labels":            map[string]interface{}{"test": "other"},
-			},
-			/*"items": []interface{}{
-				map[string]interface{}{
-					"itemBool": true,
-					"itemInt":  42,
-				},
-			},*/
-			"url":    "http://localhost",
-			"status": "ok",
-		},
-	}
-
-	tests := []struct {
-		expected string
-		options  printers.PrintOptions
-		object   runtime.Object
-	}{
-		{
-			expected: "NAME\\s+AGE\nMyName\\s+\\d+",
-			object:   obj,
-		},
-		{
-			options: printers.PrintOptions{
-				WithNamespace: true,
-			},
-			expected: "NAMESPACE\\s+NAME\\s+AGE\nMyNamespace\\s+MyName\\s+\\d+",
-			object:   obj,
-		},
-		{
-			options: printers.PrintOptions{
-				ShowLabels:    true,
-				WithNamespace: true,
-			},
-			expected: "NAMESPACE\\s+NAME\\s+AGE\\s+LABELS\nMyNamespace\\s+MyName\\s+\\d+\\w+\\s+test\\=other",
-			object:   obj,
-		},
-		{
-			expected: "NAME\\s+AGE\nMyName\\s+\\d+\\w+\nMyName2\\s+\\d+",
-			object: &unstructured.Unstructured{
-				Object: map[string]interface{}{
-					"apiVersion": "v1",
-					"kind":       "Test",
-					"dummy1":     "present",
-					"dummy2":     "present",
-					"items": []interface{}{
-						map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"name":              "MyName",
-								"namespace":         "MyNamespace",
-								"creationTimestamp": "2017-04-01T00:00:00Z",
-								"resourceVersion":   123,
-								"uid":               "00000000-0000-0000-0000-000000000001",
-								"dummy3":            "present",
-								"labels":            map[string]interface{}{"test": "other"},
-							},
-						},
-						map[string]interface{}{
-							"metadata": map[string]interface{}{
-								"name":              "MyName2",
-								"namespace":         "MyNamespace",
-								"creationTimestamp": "2017-04-01T00:00:00Z",
-								"resourceVersion":   123,
-								"uid":               "00000000-0000-0000-0000-000000000001",
-								"dummy3":            "present",
-								"labels":            "badlabel",
-							},
-						},
-					},
-					"url":    "http://localhost",
-					"status": "ok",
-				},
-			},
-		},
-	}
-	out := bytes.NewBuffer([]byte{})
-
-	for _, test := range tests {
-		out.Reset()
-		printer := printers.NewTablePrinter(test.options)
-		printer.PrintObj(test.object, out)
-
-		matches, err := regexp.MatchString(test.expected, out.String())
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if !matches {
-			t.Errorf("wanted:\n%s\ngot:\n%s", test.expected, out)
-		}
-	}
 }
 
 type TestPrintType struct {

--- a/pkg/printers/internalversion/additional_printers_test.go
+++ b/pkg/printers/internalversion/additional_printers_test.go
@@ -182,16 +182,12 @@ func TestCustomTypePrinting(t *testing.T) {
 		t.Fatalf("An error occurred generating the table for custom type: %#v", err)
 	}
 
-	printer := printers.NewTablePrinter(printers.PrintOptions{})
-	buffer := &bytes.Buffer{}
-	err = printer.PrintObj(table, buffer)
-	if err != nil {
-		t.Fatalf("An error occurred printing the Table: %#v", err)
+	expectedTable := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{{Name: "Data"}},
+		Rows:              []metav1.TableRow{{Cells: []interface{}{"test object"}}},
 	}
-
-	expectedOutput := "DATA\ntest object\n"
-	if buffer.String() != expectedOutput {
-		t.Errorf("The data was not printed as expected. Expected:\n%s\nGot:\n%s", expectedOutput, buffer.String())
+	if !reflect.DeepEqual(expectedTable, table) {
+		t.Errorf("Error generating table from custom type. Expected (%#v), got (%#v)", expectedTable, table)
 	}
 }
 

--- a/pkg/printers/tableprinter_test.go
+++ b/pkg/printers/tableprinter_test.go
@@ -702,3 +702,23 @@ func TestPrintUnstructuredObject(t *testing.T) {
 		}
 	}
 }
+
+type TestUnknownType struct{}
+
+func (obj *TestUnknownType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (obj *TestUnknownType) DeepCopyObject() runtime.Object {
+	if obj == nil {
+		return nil
+	}
+	clone := *obj
+	return &clone
+}
+
+func TestUnknownTypePrinting(t *testing.T) {
+	printer := NewTablePrinter(PrintOptions{})
+	buffer := &bytes.Buffer{}
+	err := printer.PrintObj(&TestUnknownType{}, buffer)
+	if err == nil {
+		t.Errorf("An error was expected from printing unknown type")
+	}
+}

--- a/pkg/printers/tableprinter_test.go
+++ b/pkg/printers/tableprinter_test.go
@@ -18,10 +18,12 @@ package printers
 
 import (
 	"bytes"
+	"regexp"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -591,6 +593,112 @@ Added   test1   1/1     podPhase   5         20h
 		// Validate the expected output matches the printed table.
 		if test.expected != out.String() {
 			t.Errorf("Event/Table printing error: expected (%s), got (%s)", test.expected, out.String())
+		}
+	}
+}
+
+func TestPrintUnstructuredObject(t *testing.T) {
+	obj := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "Test",
+			"dummy1":     "present",
+			"dummy2":     "present",
+			"metadata": map[string]interface{}{
+				"name":              "MyName",
+				"namespace":         "MyNamespace",
+				"creationTimestamp": "2017-04-01T00:00:00Z",
+				"resourceVersion":   123,
+				"uid":               "00000000-0000-0000-0000-000000000001",
+				"dummy3":            "present",
+				"labels":            map[string]interface{}{"test": "other"},
+			},
+			/*"items": []interface{}{
+				map[string]interface{}{
+					"itemBool": true,
+					"itemInt":  42,
+				},
+			},*/
+			"url":    "http://localhost",
+			"status": "ok",
+		},
+	}
+
+	tests := []struct {
+		expected string
+		options  PrintOptions
+		object   runtime.Object
+	}{
+		{
+			expected: "NAME\\s+AGE\nMyName\\s+\\d+",
+			object:   obj,
+		},
+		{
+			options: PrintOptions{
+				WithNamespace: true,
+			},
+			expected: "NAMESPACE\\s+NAME\\s+AGE\nMyNamespace\\s+MyName\\s+\\d+",
+			object:   obj,
+		},
+		{
+			options: PrintOptions{
+				ShowLabels:    true,
+				WithNamespace: true,
+			},
+			expected: "NAMESPACE\\s+NAME\\s+AGE\\s+LABELS\nMyNamespace\\s+MyName\\s+\\d+\\w+\\s+test\\=other",
+			object:   obj,
+		},
+		{
+			expected: "NAME\\s+AGE\nMyName\\s+\\d+\\w+\nMyName2\\s+\\d+",
+			object: &unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"apiVersion": "v1",
+					"kind":       "Test",
+					"dummy1":     "present",
+					"dummy2":     "present",
+					"items": []interface{}{
+						map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name":              "MyName",
+								"namespace":         "MyNamespace",
+								"creationTimestamp": "2017-04-01T00:00:00Z",
+								"resourceVersion":   123,
+								"uid":               "00000000-0000-0000-0000-000000000001",
+								"dummy3":            "present",
+								"labels":            map[string]interface{}{"test": "other"},
+							},
+						},
+						map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"name":              "MyName2",
+								"namespace":         "MyNamespace",
+								"creationTimestamp": "2017-04-01T00:00:00Z",
+								"resourceVersion":   123,
+								"uid":               "00000000-0000-0000-0000-000000000001",
+								"dummy3":            "present",
+								"labels":            "badlabel",
+							},
+						},
+					},
+					"url":    "http://localhost",
+					"status": "ok",
+				},
+			},
+		},
+	}
+	out := bytes.NewBuffer([]byte{})
+
+	for _, test := range tests {
+		out.Reset()
+		printer := NewTablePrinter(test.options)
+		printer.PrintObj(test.object, out)
+
+		matches, err := regexp.MatchString(test.expected, out.String())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !matches {
+			t.Errorf("wanted:\n%s\ngot:\n%s", test.expected, out)
 		}
 	}
 }


### PR DESCRIPTION
* Moves TablePrinter tests to correct location of `tableprinter_test.go`

/kind cleanup
/sig cli
/area kubectl
/priority important-soon

```release-note
NONE
```
