### PR TITLE
make sure filters are executed when no predicates configured

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -458,7 +458,7 @@ func (g *genericScheduler) findNodesThatFit(state *framework.CycleState, pod *v1
 	failedPredicateMap := FailedPredicateMap{}
 	filteredNodesStatuses := framework.NodeToStatusMap{}
 
-	if len(g.predicates) == 0 {
+	if len(g.predicates) == 0 && !g.framework.HasFilterPlugins() {
 		filtered = g.nodeInfoSnapshot.ListNodes()
 	} else {
 		allNodes := int32(g.cache.NodeTree().NumNodes())

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -599,6 +599,11 @@ func (f *framework) GetWaitingPod(uid types.UID) WaitingPod {
 	return f.waitingPods.get(uid)
 }
 
+// HasFilterPlugins returns true if at least one filter plugin is defined.
+func (f *framework) HasFilterPlugins() bool {
+	return len(f.filterPlugins) > 0
+}
+
 // ListPlugins returns a map of extension point name to plugin names configured at each extension
 // point. Returns nil if no plugins where configred.
 func (f *framework) ListPlugins() map[string][]config.Plugin {

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -435,6 +435,9 @@ type Framework interface {
 	// code=4("skip") status.
 	RunBindPlugins(state *CycleState, pod *v1.Pod, nodeName string) *Status
 
+	// HasFilterPlugins return true if at least one filter plugin is defined
+	HasFilterPlugins() bool
+
 	// ListPlugins returns a map of extension point name to list of configured Plugins.
 	ListPlugins() map[string][]config.Plugin
 }

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -172,6 +172,10 @@ func (*fakeFramework) QueueSortFunc() framework.LessFunc {
 	}
 }
 
+func (f *fakeFramework) HasFilterPlugins() bool {
+	return true
+}
+
 func (f *fakeFramework) ListPlugins() map[string][]config.Plugin {
 	return nil
 }


### PR DESCRIPTION

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Currently framework filters will not be executed if not predicates are configured, this shouldn't be the case.

```release-note
NONE
```

