### PR TITLE
avoid unexpected keyword error by using positional parameters

### DIFF
--- a/build/code_generation.bzl
+++ b/build/code_generation.bzl
@@ -41,7 +41,7 @@ def go_pkg(pkg):
         ...
     )
     """
-    return go_prefix + "/" + pkg.replace("staging/src/", "vendor/", maxsplit = 1)
+    return go_prefix + "/" + pkg.replace("staging/src/", "vendor/", 1)
 
 def openapi_deps():
     deps = [


### PR DESCRIPTION
This avoids the following error, when building with bazel 1.0:

	File "/home/user/kubernetes/build/code_generation.bzl", line 44, in go_pkg
		pkg.replace("staging/src/", "vendor/", maxsplit ...)
unexpected keyword 'maxsplit', for call to method replace(old, new, maxsplit = None) of 'string'

/kind bug