### PR TITLE
Tests/agnhost guestbook replacement

### DIFF
--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -52,8 +52,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 	ginkgo.It("should serve a basic image on each replica with a private image", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
-		privateimage := imageutils.GetConfig(imageutils.Agnhost)
-		privateimage.SetRegistry(imageutils.PrivateRegistry)
+		privateimage := imageutils.GetConfig(imageutils.AgnhostPrivate)
 		TestReplicationControllerServeImageOrFail(f, "private", privateimage.GetE2EImage())
 	})
 

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -96,8 +96,7 @@ var _ = SIGDescribe("ReplicaSet", func() {
 	ginkgo.It("should serve a basic image on each replica with a private image", func() {
 		// requires private images
 		framework.SkipUnlessProviderIs("gce", "gke")
-		privateimage := imageutils.GetConfig(imageutils.Agnhost)
-		privateimage.SetRegistry(imageutils.PrivateRegistry)
+		privateimage := imageutils.GetConfig(imageutils.AgnhostPrivate)
 		testReplicaSetServeImageOrFail(f, "private", privateimage.GetE2EImage())
 	})
 

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -66,18 +66,17 @@ var CommonImageWhiteList = sets.NewString(
 )
 
 type testImagesStruct struct {
-	AgnhostImage    string
-	BusyBoxImage    string
-	GBFrontendImage string
-	KittenImage     string
-	MounttestImage  string
-	NautilusImage   string
-	NginxImage      string
-	NginxNewImage   string
-	HttpdImage      string
-	HttpdNewImage   string
-	PauseImage      string
-	RedisImage      string
+	AgnhostImage   string
+	BusyBoxImage   string
+	KittenImage    string
+	MounttestImage string
+	NautilusImage  string
+	NginxImage     string
+	NginxNewImage  string
+	HttpdImage     string
+	HttpdNewImage  string
+	PauseImage     string
+	RedisImage     string
 }
 
 var testImages testImagesStruct
@@ -86,7 +85,6 @@ func init() {
 	testImages = testImagesStruct{
 		imageutils.GetE2EImage(imageutils.Agnhost),
 		imageutils.GetE2EImage(imageutils.BusyBox),
-		imageutils.GetE2EImage(imageutils.GBFrontend),
 		imageutils.GetE2EImage(imageutils.Kitten),
 		imageutils.GetE2EImage(imageutils.Mounttest),
 		imageutils.GetE2EImage(imageutils.Nautilus),

--- a/test/e2e/testing-manifests/guestbook/agnhost-master-deployment.yaml.in
+++ b/test/e2e/testing-manifests/guestbook/agnhost-master-deployment.yaml.in
@@ -1,26 +1,28 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: frontend
+  name: agnhost-master
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
-      app: guestbook
-      tier: frontend
+      app: agnhost
+      role: master
+      tier: backend
   template:
     metadata:
       labels:
-        app: guestbook
-        tier: frontend
+        app: agnhost
+        role: master
+        tier: backend
     spec:
       containers:
-      - name: guestbook-frontend
+      - name: master
         image: {{.AgnhostImage}}
-        args: [ "guestbook", "--backend-port", "6379" ]
+        args: [ "guestbook", "--http-port", "6379" ]
         resources:
           requests:
             cpu: 100m
             memory: 100Mi
         ports:
-        - containerPort: 80
+        - containerPort: 6379

--- a/test/e2e/testing-manifests/guestbook/agnhost-master-service.yaml
+++ b/test/e2e/testing-manifests/guestbook/agnhost-master-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agnhost-master
+  labels:
+    app: agnhost
+    role: master
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: agnhost
+    role: master
+    tier: backend

--- a/test/e2e/testing-manifests/guestbook/agnhost-slave-deployment.yaml.in
+++ b/test/e2e/testing-manifests/guestbook/agnhost-slave-deployment.yaml.in
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agnhost-slave
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: agnhost
+      role: slave
+      tier: backend
+  template:
+    metadata:
+      labels:
+        app: agnhost
+        role: slave
+        tier: backend
+    spec:
+      containers:
+      - name: slave
+        image: {{.AgnhostImage}}
+        args: [ "guestbook", "--slaveof", "agnhost-master", "--http-port", "6379" ]
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379

--- a/test/e2e/testing-manifests/guestbook/agnhost-slave-service.yaml
+++ b/test/e2e/testing-manifests/guestbook/agnhost-slave-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agnhost-slave
+  labels:
+    app: agnhost
+    role: slave
+    tier: backend
+spec:
+  ports:
+  - port: 6379
+  selector:
+    app: agnhost
+    role: slave
+    tier: backend

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -118,6 +118,8 @@ var (
 const (
 	// Agnhost image
 	Agnhost = iota
+	// AgnhostPrivate image
+	AgnhostPrivate
 	// APIServer image
 	APIServer
 	// AppArmorLoader image
@@ -140,8 +142,6 @@ const (
 	EchoServer
 	// Etcd image
 	Etcd
-	// GBFrontend image
-	GBFrontend
 	// GlusterDynamicProvisioner image
 	GlusterDynamicProvisioner
 	// Httpd image
@@ -207,7 +207,8 @@ const (
 
 func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.6"}
+	configs[Agnhost] = Config{e2eRegistry, "agnhost", "2.8"}
+	configs[AgnhostPrivate] = Config{PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}
 	configs[APIServer] = Config{e2eRegistry, "sample-apiserver", "1.10"}
@@ -219,7 +220,6 @@ func initImageConfigs() map[int]Config {
 	configs[Dnsutils] = Config{e2eRegistry, "dnsutils", "1.1"}
 	configs[EchoServer] = Config{e2eRegistry, "echoserver", "2.2"}
 	configs[Etcd] = Config{gcRegistry, "etcd", "3.4.3"}
-	configs[GBFrontend] = Config{sampleRegistry, "gb-frontend", "v6"}
 	configs[GlusterDynamicProvisioner] = Config{dockerGluster, "glusterdynamic-provisioner", "v1.0"}
 	configs[Httpd] = Config{dockerLibraryRegistry, "httpd", "2.4.38-alpine"}
 	configs[HttpdNew] = Config{dockerLibraryRegistry, "httpd", "2.4.39-alpine"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig windows
/sig testing

/area conformance

**What this PR does / why we need it**:

The redis version has been bumped to version 5.0.5, but the maximum version supported on Windows is 3.2. This can lead to failing tests, the output and behaviour can be different (see #80516). In order to prevent such failures, the amount of times the Redis image is used can be reduced.

This commit uses the previously added agnhost guestbook subcommand as a replacement for the     Guestbook application created by the test ``should create and stop a working application``.

Adds ``AgnhostPrivate`` to ``test/utils/image/manifest``. Some tests are trying to pull the agnhost image from the private registry, meaning that we would need to always build and push the agnhost image to both e2e and private registry whenever we bump its version. Decoupling them would mean that we only need to push the image to the e2e registry.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #80534
Depends On: #83055

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
