### PR TITLE
Traverse OwnerReference maps more efficiently

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -409,6 +409,16 @@ func TestProcessEvent(t *testing.T) {
 	}
 }
 
+func BenchmarkReferencesDiffs(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+	for n := 0; n < t.N; n++ {
+		old := []metav1.OwnerReference{{UID: "1"}, {UID: "2"}}
+		new := []metav1.OwnerReference{{UID: "2"}, {UID: "3"}}
+		referencesDiffs(old, new)
+	}
+}
+
 // TestDependentsRace relies on golang's data race detector to check if there is
 // data race among in the dependents field.
 func TestDependentsRace(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently referencesDiffs traverses the old and new UID Set multiple times in order to form addition, deletion and changes slices.

This PR omits the newUIDSet and traverses the newUIDToRef and oldUIDSet only once.

With patch:
```
BenchmarkReferencesDiffs-12         1000000              1561 ns/op            1632 B/op         12 allocs/op
```
Without patch:
```
BenchmarkReferencesDiffs-12          500000              3162 ns/op            3520 B/op         26 allocs/op
```
Time spent is half prior to optimization.
Memory is half prior to optimization.

See this comment for results of more variations of the benchmark:
https://github.com/kubernetes/kubernetes/pull/84060#issuecomment-544205921

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
