### PR TITLE
apiserver: disable info level gRPC logging

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
@@ -82,6 +82,7 @@ go_library(
         "//vendor/go.etcd.io/etcd/clientv3:go_default_library",
         "//vendor/go.etcd.io/etcd/etcdserver/api/v3rpc/rpctypes:go_default_library",
         "//vendor/go.etcd.io/etcd/mvcc/mvccpb:go_default_library",
+        "//vendor/google.golang.org/grpc/grpclog:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/logger.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/logger.go
@@ -18,13 +18,19 @@ package etcd3
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 
 	"go.etcd.io/etcd/clientv3"
+	"google.golang.org/grpc/grpclog"
 	"k8s.io/klog"
 )
 
 func init() {
 	clientv3.SetLogger(klogWrapper{})
+
+	// overwrite gRPC logger, to discard all gRPC info-level logging
+	grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stderr, os.Stderr))
 }
 
 type klogWrapper struct{}


### PR DESCRIPTION
gRPC balancer wrapper has (non-leveled) info logging on "Notify" call.
Which maens we are logging every single endpoint resolution.
When the cluster scales up, the logging for apiserver can dramatically
increase.

Since etcd v3 client already provides all the relevant information,
let's disable gRPC info logging to reduce the log size.

Signed-off-by: Gyuho Lee <leegyuho@amazon.com>

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Disable gRPC info-level logging. We need it to reduce the logging size. We don't need these logs:

```
I1017 18:22:59.790791       6 asm_amd64.s:1337] balancerWrapper: got update addr from Notify: []
I1017 18:22:59.790877       6 controlbuf.go:382] transport: loopyWriter.run returning. connection error: desc = "transport is closing"
I1017 18:22:59.790986       6 asm_amd64.s:1337] balancerWrapper: got update addr from Notify: [{...:2379 <nil>}]
I1017 18:22:59.791038       6 asm_amd64.s:1337] balancerWrapper: got update addr from Notify: [{...:2379 <nil>}]
I1017 18:22:59.793949       6 asm_amd64.s:1337] balancerWrapper: got update addr from Notify: [{...:2379 <nil>}]
```

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/80741

**Does this PR introduce a user-facing change?**:

```release-note
Disable gRPC info level logging
```

