### PR TITLE
Add check against invalid owner reference

### DIFF
--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -568,7 +568,10 @@ func TestDeleteOwnerRefPatch(t *testing.T) {
 			},
 		},
 	}
-	patch := deleteOwnerRefStrategicMergePatch("100", "2", "3")
+	patch, err := deleteOwnerRefStrategicMergePatch("100", "2", "3")
+	if err != nil {
+		t.Fatal(err)
+	}
 	patched, err := strategicpatch.StrategicMergePatch(originalData, patch, v1.Pod{})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/controller/garbagecollector/patch.go
+++ b/pkg/controller/garbagecollector/patch.go
@@ -37,7 +37,7 @@ type objectMetaForMergePatch struct {
 	OwnerReferences []map[string]string `json:"ownerReferences"`
 }
 
-func deleteOwnerRefStrategicMergePatch(dependentUID types.UID, ownerUIDs ...types.UID) []byte {
+func deleteOwnerRefStrategicMergePatch(dependentUID types.UID, ownerUIDs ...types.UID) ([]byte, error) {
 	var pieces []map[string]string
 	for _, ownerUID := range ownerUIDs {
 		pieces = append(pieces, map[string]string{"$patch": "delete", "uid": string(ownerUID)})
@@ -50,9 +50,9 @@ func deleteOwnerRefStrategicMergePatch(dependentUID types.UID, ownerUIDs ...type
 	}
 	patchBytes, err := json.Marshal(&patch)
 	if err != nil {
-		return []byte{}
+		return []byte{}, err
 	}
-	return patchBytes
+	return patchBytes, nil
 }
 
 // getMetadata tries getting object metadata from local cache, and sends GET request to apiserver when


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds cross namespace check for owner reference in GarbageCollector#isDangling.

This handles the cases #c and #d @caesarxuchao mentioned.


```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
