### PR TITLE
cleanup duplicated MaxFileSize in e2e storage test

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -75,9 +75,8 @@ type hostpathCSIDriver struct {
 func initHostPathCSIDriver(name string, capabilities map[testsuites.Capability]bool, volumeAttributes []map[string]string, manifests ...string) testsuites.TestDriver {
 	return &hostpathCSIDriver{
 		driverInfo: testsuites.DriverInfo{
-			Name:        name,
-			FeatureTag:  "",
-			MaxFileSize: testpatterns.FileSizeMedium,
+			Name:       name,
+			FeatureTag: "",
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -250,9 +249,8 @@ func InitMockCSIDriver(driverOpts CSIMockDriverOpts) testsuites.TestDriver {
 
 	return &mockCSIDriver{
 		driverInfo: testsuites.DriverInfo{
-			Name:        "csi-mock",
-			FeatureTag:  "",
-			MaxFileSize: testpatterns.FileSizeMedium,
+			Name:       "csi-mock",
+			FeatureTag: "",
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -373,9 +371,8 @@ var _ testsuites.DynamicPVTestDriver = &gcePDCSIDriver{}
 func InitGcePDCSIDriver() testsuites.TestDriver {
 	return &gcePDCSIDriver{
 		driverInfo: testsuites.DriverInfo{
-			Name:        GCEPDCSIDriverName,
-			FeatureTag:  "[Serial]",
-			MaxFileSize: testpatterns.FileSizeMedium,
+			Name:       GCEPDCSIDriverName,
+			FeatureTag: "[Serial]",
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -91,7 +91,6 @@ func InitNFSDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "nfs",
 			InTreePluginName: "kubernetes.io/nfs",
-			MaxFileSize:      testpatterns.FileSizeLarge,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -233,7 +232,6 @@ func InitGlusterFSDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "gluster",
 			InTreePluginName: "kubernetes.io/glusterfs",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -356,7 +354,6 @@ func InitISCSIDriver() testsuites.TestDriver {
 			Name:             "iscsi",
 			InTreePluginName: "kubernetes.io/iscsi",
 			FeatureTag:       "[Feature:Volumes]",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 				"ext2",
@@ -470,7 +467,6 @@ func InitRbdDriver() testsuites.TestDriver {
 			Name:             "rbd",
 			InTreePluginName: "kubernetes.io/rbd",
 			FeatureTag:       "[Feature:Volumes][Serial]",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -602,7 +598,6 @@ func InitCephFSDriver() testsuites.TestDriver {
 			Name:             "ceph",
 			InTreePluginName: "kubernetes.io/cephfs",
 			FeatureTag:       "[Feature:Volumes][Serial]",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -705,7 +700,6 @@ func InitHostPathDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "hostPath",
 			InTreePluginName: "kubernetes.io/host-path",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -780,7 +774,6 @@ func InitHostPathSymlinkDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "hostPathSymlink",
 			InTreePluginName: "kubernetes.io/host-path",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -923,7 +916,6 @@ func InitEmptydirDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "emptydir",
 			InTreePluginName: "kubernetes.io/empty-dir",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedFsType: sets.NewString(
 				"", // Default fsType
 			),
@@ -990,7 +982,6 @@ func InitCinderDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "cinder",
 			InTreePluginName: "kubernetes.io/cinder",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -1162,7 +1153,6 @@ func InitGcePdDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "gcepd",
 			InTreePluginName: "kubernetes.io/gce-pd",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -1297,7 +1287,6 @@ func InitVSphereDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "vsphere",
 			InTreePluginName: "kubernetes.io/vsphere-volume",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -1419,7 +1408,6 @@ func InitAzureDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "azure",
 			InTreePluginName: "kubernetes.io/azure-file",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -1553,7 +1541,6 @@ func InitAwsDriver() testsuites.TestDriver {
 		driverInfo: testsuites.DriverInfo{
 			Name:             "aws",
 			InTreePluginName: "kubernetes.io/aws-ebs",
-			MaxFileSize:      testpatterns.FileSizeMedium,
 			SupportedSizeRange: volume.SizeRange{
 				Min: "5Gi",
 			},
@@ -1714,9 +1701,6 @@ var (
 			//"xfs", disabled see issue https://github.com/kubernetes/kubernetes/issues/74095
 		),
 	}
-	// max file size
-	defaultLocalVolumeMaxFileSize = testpatterns.FileSizeSmall
-	localVolumeMaxFileSizes       = map[utils.LocalVolumeType]int64{}
 )
 
 var _ testsuites.TestDriver = &localDriver{}
@@ -1725,10 +1709,6 @@ var _ testsuites.PreprovisionedPVTestDriver = &localDriver{}
 
 // InitLocalDriverWithVolumeType initializes the local driver based on the volume type.
 func InitLocalDriverWithVolumeType(volumeType utils.LocalVolumeType) func() testsuites.TestDriver {
-	maxFileSize := defaultLocalVolumeMaxFileSize
-	if maxFileSizeByVolType, ok := localVolumeMaxFileSizes[volumeType]; ok {
-		maxFileSize = maxFileSizeByVolType
-	}
 	supportedFsTypes := defaultLocalVolumeSupportedFsTypes
 	if supportedFsTypesByType, ok := localVolumeSupportedFsTypes[volumeType]; ok {
 		supportedFsTypes = supportedFsTypesByType
@@ -1749,7 +1729,6 @@ func InitLocalDriverWithVolumeType(volumeType utils.LocalVolumeType) func() test
 				Name:             "local",
 				InTreePluginName: "kubernetes.io/local-volume",
 				FeatureTag:       featureTag,
-				MaxFileSize:      maxFileSize,
 				SupportedFsType:  supportedFsTypes,
 				Capabilities:     capabilities,
 			},

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -166,8 +166,6 @@ type DriverInfo struct {
 	InTreePluginName string
 	FeatureTag       string // FeatureTag for the driver
 
-	// Max file size to be tested for this driver
-	MaxFileSize int64
 	// The range of size supported by this driver
 	SupportedSizeRange volume.SizeRange
 	// Map of string for supported fs type


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
Remove field MaxFileSize as it can be replaced by SizeRange.
MaxFileSize is duplicated since this PR merged [#78306](https://github.com/kubernetes/kubernetes/pull/78306)

maxFileSize is used only at :

https://github.com/kubernetes/kubernetes/blob/b8b7c376edb62ce8be42cef3728112c5c71d9fa4/test/e2e/storage/testsuites/volume_io.go#L145

So we can replaced it with SizeRange

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #83689

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
