### PR TITLE
fix golint warning

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/net/port_split.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/port_split.go
@@ -51,9 +51,9 @@ func SplitSchemeNamePort(id string) (scheme, name, port string, valid bool) {
 
 	if len(name) > 0 && validSchemes.Has(scheme) {
 		return scheme, name, port, true
-	} else {
-		return "", "", "", false
 	}
+	
+	return "", "", "", false
 }
 
 // JoinSchemeNamePort returns a string that specifies the scheme, name, and port:


### PR DESCRIPTION
**What type of PR is this?**

Uncomment only one /kind <> line, hit enter to put that in a new line, and remove leading whitespaces from that line:

> /kind cleanup

**What this PR does / why we need it**:
clean golint warning of kubernetes/staging/src/k8s.io/apimachinery/pkg/util/net/port_split.go

**Which issue(s) this PR fixes**:
Ref #68026

**Special notes for your reviewer**:
>
**Does this PR introduce a user-facing change?**:

>NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
>
