### PR TITLE
Automated cherry pick of #84038: Update Cluster Autoscaler version to 1.16.2

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Cherry pick of #84038 on release-1.16.

#84038: Update Cluster Autoscaler version to 1.16.2