### PR TITLE
when kubelet restarted, keep the readiness value intact until probed again

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1458,6 +1458,11 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		switch cs.State {
 		case kubecontainer.ContainerStateRunning:
 			status.State.Running = &v1.ContainerStateRunning{StartedAt: metav1.NewTime(cs.StartedAt)}
+			// Use the ready value from previousStatus so that we don't initialize it to false
+			// See https://github.com/kubernetes/kubernetes/issues/78733 for more details
+			if pc, found := podutil.GetContainerStatus(previousStatus, cs.Name); found && pc.ContainerID == cid {
+				status.Ready = pc.Ready
+			}
 		case kubecontainer.ContainerStateCreated:
 			// Treat containers in the "created" state as if they are exited.
 			// The pod workers are supposed start all containers it creates in

--- a/pkg/kubelet/prober/common_test.go
+++ b/pkg/kubelet/prober/common_test.go
@@ -58,6 +58,12 @@ func getTestRunningStatusWithStarted(started bool) v1.PodStatus {
 	return podStatus
 }
 
+func getTestRunningStatusWithReady(ready bool) v1.PodStatus {
+	status := getTestRunningStatusWithStarted(true)
+	status.ContainerStatuses[0].Ready = true
+	return status
+}
+
 func getTestPod() *v1.Pod {
 	container := v1.Container{
 		Name: testContainerName,

--- a/pkg/kubelet/prober/prober_manager.go
+++ b/pkg/kubelet/prober/prober_manager.go
@@ -241,6 +241,10 @@ func (m *manager) UpdatePodStatus(podUID types.UID, podStatus *v1.PodStatus) {
 			ready = false
 		} else if result, ok := m.readinessManager.Get(kubecontainer.ParseContainerID(c.ContainerID)); ok {
 			ready = result == results.Success
+		} else if c.Ready {
+			// Keep the container ready until we get a new result from readinessManager
+			// See https://github.com/kubernetes/kubernetes/issues/78733 for more details
+			ready = c.Ready
 		} else {
 			// The check whether there is a probe which hasn't run yet.
 			_, exists := m.getWorker(podUID, c.Name, readiness)

--- a/pkg/kubelet/prober/prober_manager_test.go
+++ b/pkg/kubelet/prober/prober_manager_test.go
@@ -235,6 +235,14 @@ func TestUpdatePodStatus(t *testing.T) {
 			Running: &v1.ContainerStateRunning{},
 		},
 	}
+	unprobedReady := v1.ContainerStatus{
+		Name:        "unprobed_ready_container",
+		ContainerID: "test://unprobed_ready_container_id",
+		State: v1.ContainerState{
+			Running: &v1.ContainerStateRunning{},
+		},
+		Ready: true,
+	}
 	probedReady := v1.ContainerStatus{
 		Name:        "probed_container_ready",
 		ContainerID: "test://probed_container_ready_id",
@@ -266,7 +274,7 @@ func TestUpdatePodStatus(t *testing.T) {
 	podStatus := v1.PodStatus{
 		Phase: v1.PodRunning,
 		ContainerStatuses: []v1.ContainerStatus{
-			unprobed, probedReady, probedPending, probedUnready, terminated,
+			unprobed, unprobedReady, probedReady, probedPending, probedUnready, terminated,
 		},
 	}
 
@@ -276,6 +284,7 @@ func TestUpdatePodStatus(t *testing.T) {
 	// Setup probe "workers" and cached results.
 	m.workers = map[probeKey]*worker{
 		{testPodUID, unprobed.Name, liveness}:       {},
+		{testPodUID, unprobedReady.Name, readiness}: {},
 		{testPodUID, probedReady.Name, readiness}:   {},
 		{testPodUID, probedPending.Name, readiness}: {},
 		{testPodUID, probedUnready.Name, readiness}: {},
@@ -289,6 +298,7 @@ func TestUpdatePodStatus(t *testing.T) {
 
 	expectedReadiness := map[probeKey]bool{
 		{testPodUID, unprobed.Name, readiness}:      true,
+		{testPodUID, unprobedReady.Name, readiness}: true,
 		{testPodUID, probedReady.Name, readiness}:   true,
 		{testPodUID, probedPending.Name, readiness}: false,
 		{testPodUID, probedUnready.Name, readiness}: false,

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -201,7 +201,10 @@ func (w *worker) doProbe() (keepGoing bool) {
 			w.resultsManager.Remove(w.containerID)
 		}
 		w.containerID = kubecontainer.ParseContainerID(c.ContainerID)
-		w.resultsManager.Set(w.containerID, w.initialValue, w.pod)
+		// Set initial value if and only if the container has just been created
+		if c.State.Running == nil || int32(time.Since(c.State.Running.StartedAt.Time).Seconds()) < w.spec.InitialDelaySeconds {
+			w.resultsManager.Set(w.containerID, w.initialValue, w.pod)
+		}
 		// We've got a new container; resume probing.
 		w.onHold = false
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
if the kubelet is restart, the status of the pod in the node will be set to failure, and then set to ready. the pod will be remove from ep and than add to ep. If the number of the service is 1, the result is that the service can't connect by other service at that duration, but the pod is work. if lots of kubelet is restart, it will affect more services

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #78733

**Special notes for your reviewer**:
tested on kubernetes v1.16.2

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

