### PR TITLE
test change `nslookup` to `nslookup -q=a service's full name`

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -888,7 +888,7 @@ func (j *TestJig) checkNodePortServiceReachability(svc *v1.Service, pod *v1.Pod)
 // FQDN of kubernetes is used as externalName(for air tight platforms).
 func (j *TestJig) checkExternalServiceReachability(svc *v1.Service, pod *v1.Pod) error {
 	// Service must resolve to IP
-	cmd := fmt.Sprintf("nslookup %s", svc.Name)
+	cmd := fmt.Sprintf("nslookup -q=a %s.%s.svc.cluster.local", svc.Name, svc.Namespace)
 	_, err := framework.RunHostCmd(pod.Namespace, pod.Name, cmd)
 	if err != nil {
 		return fmt.Errorf("ExternalName service %q must resolve to IP", pod.Namespace+"/"+pod.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind failing-test

**What this PR does / why we need it**:

The command `nslookup kubernetes.default.svc` will not return the correct address, I try `nslookup -q=a kubernetes.default.svc.cluster.local` and `nslookup -type=a kubernetes.default.svc.cluster.local` will get expected return

```shell
/ # nslookup kubernetes.default.svc
Server:		10.150.0.3
Address:	10.150.0.3:53

** server can't find kubernetes.default.svc: NXDOMAIN

*** Can't find kubernetes.default.svc: No answer

/ # nslookup kubernetes.default.svc.cluster.local
Server:		10.150.0.3
Address:	10.150.0.3:53

Name:	kubernetes.default.svc.cluster.local
Address: 10.150.0.1

*** Can't find kubernetes.default.svc.cluster.local: No answer

/ # nslookup -type=a kubernetes.default.svc
Server:		10.150.0.3
Address:	10.150.0.3:53

** server can't find kubernetes.default.svc: NXDOMAIN

/ # nslookup -type=a kubernetes.default.svc.cluster.local
Server:		10.150.0.3
Address:	10.150.0.3:53

Name:	kubernetes.default.svc.cluster.local
Address: 10.150.0.1

/ # nslookup -q=a kubernetes.default.svc.cluster.local
Server:		10.150.0.3
Address:	10.150.0.3:53

Name:	kubernetes.default.svc.cluster.local
Address: 10.150.0.1
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
