### PR TITLE
refactored counter_test to use assert statements and renamed variable…

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter_test.go
+++ b/staging/src/k8s.io/component-base/metrics/counter_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/blang/semver"
 	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 )
@@ -79,27 +80,19 @@ func TestCounter(t *testing.T) {
 				Minor:      "15",
 				GitVersion: "v1.15.0-alpha-1.12345",
 			})
+			// c is a pointer to a Counter
 			c := NewCounter(test.CounterOpts)
 			registry.MustRegister(c)
-
-			ms, err := registry.Gather()
+			// mfs is a pointer to a dto.MetricFamily slice
+			mfs, err := registry.Gather()
 			var buf bytes.Buffer
 			enc := expfmt.NewEncoder(&buf, "text/plain; version=0.0.4; charset=utf-8")
-
-			if len(ms) != test.expectedMetricCount {
-				t.Errorf("Got %v metrics, Want: %v metrics", len(ms), test.expectedMetricCount)
-			}
-			if err != nil {
-				t.Fatalf("Gather failed %v", err)
-			}
-			for _, metric := range ms {
+			assert.Equalf(t, test.expectedMetricCount, len(mfs), "Got %v metrics, Want: %v metrics", len(mfs), test.expectedMetricCount)
+			assert.Nil(t, err, "Gather failed %v", err)
+			for _, metric := range mfs {
 				err := enc.Encode(metric)
-				if err != nil {
-					t.Fatalf("Unexpected err %v in encoding the metric", err)
-				}
-				if metric.GetHelp() != test.expectedHelp {
-					t.Errorf("Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
-				}
+				assert.Nil(t, err, "Unexpected err %v in encoding the metric", err)
+				assert.Equalf(t, test.expectedHelp, metric.GetHelp(), "Got %s as help message, want %s", metric.GetHelp(), test.expectedHelp)
 			}
 
 			// increment the counter N number of times and verify that the metric retains the count correctly
@@ -107,15 +100,13 @@ func TestCounter(t *testing.T) {
 			for i := 0; i < numberOfTimesToIncrement; i++ {
 				c.Inc()
 			}
-			ms, err = registry.Gather()
-			if err != nil {
-				t.Fatalf("Gather failed %v", err)
-			}
-			for _, mf := range ms {
-				for _, m := range mf.GetMetric() {
-					if int(m.GetCounter().GetValue()) != numberOfTimesToIncrement {
-						t.Errorf("Got %v, wanted %v as the count", m.GetCounter().GetValue(), numberOfTimesToIncrement)
-					}
+			mfs, err = registry.Gather()
+			assert.Nil(t, err, "Gather failed %v", err)
+
+			for _, mf := range mfs {
+				mfMetric := mf.GetMetric()
+				for _, m := range mfMetric {
+					assert.Equalf(t, numberOfTimesToIncrement, int(m.GetCounter().GetValue()), "Got %v, wanted %v as the count", m.GetCounter().GetValue(), numberOfTimesToIncrement)
 				}
 			}
 		})
@@ -195,35 +186,24 @@ func TestCounterVec(t *testing.T) {
 			registry.MustRegister(c)
 			c.WithLabelValues("1", "2").Inc()
 			mfs, err := registry.Gather()
-			if len(mfs) != test.expectedMetricFamilyCount {
-				t.Errorf("Got %v metric families, Want: %v metric families", len(mfs), test.expectedMetricFamilyCount)
-			}
-			if err != nil {
-				t.Fatalf("Gather failed %v", err)
-			}
+			assert.Equalf(t, test.expectedMetricFamilyCount, len(mfs), "Got %v metric families, Want: %v metric families", len(mfs), test.expectedMetricFamilyCount)
+			assert.Nil(t, err, "Gather failed %v", err)
+
 			// this no-opts here when there are no metric families (i.e. when the metric is hidden)
 			for _, mf := range mfs {
-				if len(mf.GetMetric()) != 1 {
-					t.Errorf("Got %v metrics, wanted 1 as the count", len(mf.GetMetric()))
-				}
-				if mf.GetHelp() != test.expectedHelp {
-					t.Errorf("Got %s as help message, want %s", mf.GetHelp(), test.expectedHelp)
-				}
+				assert.Equalf(t, 1, len(mf.GetMetric()), "Got %v metrics, wanted 1 as the count", len(mf.GetMetric()))
+				assert.Equalf(t, test.expectedHelp, mf.GetHelp(), "Got %s as help message, want %s", mf.GetHelp(), test.expectedHelp)
 			}
 
 			// let's increment the counter and verify that the metric still works
 			c.WithLabelValues("1", "3").Inc()
 			c.WithLabelValues("2", "3").Inc()
 			mfs, err = registry.Gather()
-			if err != nil {
-				t.Fatalf("Gather failed %v", err)
-			}
+			assert.Nil(t, err, "Gather failed %v", err)
 
 			// this no-opts here when there are no metric families (i.e. when the metric is hidden)
 			for _, mf := range mfs {
-				if len(mf.GetMetric()) != 3 {
-					t.Errorf("Got %v metrics, wanted 3 as the count", len(mf.GetMetric()))
-				}
+				assert.Equalf(t, 3, len(mf.GetMetric()), "Got %v metrics, wanted 3 as the count", len(mf.GetMetric()))
 			}
 		})
 	}


### PR DESCRIPTION
…s for consistency

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/kind cleanup

**What this PR does / why we need it**:
The PR refactors a test to be more readable.  It is unnecessary but nice.

**Special notes for your reviewer**:
It is my first code change.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

