### PR TITLE
Fix fakeTimer.Reset while timer has been stopped or expired

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock.go
@@ -346,12 +346,15 @@ func (f *fakeTimer) Reset(d time.Duration) bool {
 	defer f.fakeClock.lock.Unlock()
 	waiters := f.fakeClock.waiters
 	seekChan := f.waiter.destChan
+	newTargetTime := f.fakeClock.time.Add(d)
+	f.waiter.targetTime = newTargetTime
 	for i := range waiters {
 		if waiters[i].destChan == seekChan {
-			waiters[i].targetTime = f.fakeClock.time.Add(d)
+			waiters[i].targetTime = newTargetTime
 			return true
 		}
 	}
+	f.fakeClock.waiters = append(f.fakeClock.waiters, f.waiter)
 	return false
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/clock/clock_test.go
@@ -237,9 +237,13 @@ func TestFakeTimer(t *testing.T) {
 	select {
 	case <-oneSec.C():
 		t.Errorf("unexpected channel read")
-	case <-twoSec.C():
-		t.Errorf("unexpected channel read")
 	default:
+	}
+	select {
+	case <-twoSec.C():
+		// Expected!
+	default:
+		t.Errorf("unexpected channel non-read")
 	}
 	select {
 	case <-treSec.C():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

A timer should always fire on Reset duration expiration
regardless of whether the timer has been stopped or expired before Reset.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #84130

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
