### PR TITLE
Stop register to prom registry

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -49,18 +49,12 @@ func Handler() http.Handler {
 // Register registers a collectable metric but uses the global registry
 func Register(c metrics.Registerable) error {
 	err := defaultRegistry.Register(c)
-	// sideload global prom registry as fallback
-	prometheus.Register(c)
 	return err
 }
 
 // MustRegister registers registerable metrics but uses the global registry.
 func MustRegister(cs ...metrics.Registerable) {
 	defaultRegistry.MustRegister(cs...)
-	// sideload global prom registry as fallback
-	for _, c := range cs {
-		prometheus.Register(c)
-	}
 }
 
 // RawMustRegister registers prometheus collectors but uses the global registry, this
@@ -69,10 +63,6 @@ func MustRegister(cs ...metrics.Registerable) {
 // Deprecated
 func RawMustRegister(cs ...prometheus.Collector) {
 	defaultRegistry.RawMustRegister(cs...)
-	// sideload global prom registry as fallback
-	for _, c := range cs {
-		prometheus.Register(c)
-	}
 }
 
 // RawRegister registers a prometheus collector but uses the global registry, this
@@ -81,7 +71,5 @@ func RawMustRegister(cs ...prometheus.Collector) {
 // Deprecated
 func RawRegister(c prometheus.Collector) error {
 	err := defaultRegistry.RawRegister(c)
-	// sideload global prom registry as fallback
-	prometheus.Register(c)
 	return err
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Stop register to Prometheus registry after migration.

**Which issue(s) this PR fixes**:
Fixes #83876

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: