### PR TITLE
Add node label to cAdvisor prometheus metrics

### DIFF
--- a/pkg/kubelet/kuberuntime/labels.go
+++ b/pkg/kubelet/kuberuntime/labels.go
@@ -47,6 +47,7 @@ type labeledPodSandboxInfo struct {
 	PodName      string
 	PodNamespace string
 	PodUID       kubetypes.UID
+	NodeName     string
 }
 
 type annotatedPodSandboxInfo struct {
@@ -84,6 +85,7 @@ func newPodLabels(pod *v1.Pod) map[string]string {
 	labels[types.KubernetesPodNameLabel] = pod.Name
 	labels[types.KubernetesPodNamespaceLabel] = pod.Namespace
 	labels[types.KubernetesPodUIDLabel] = string(pod.UID)
+	labels[types.KubernetesNodeNameLabel] = pod.Spec.NodeName
 
 	return labels
 }
@@ -100,6 +102,7 @@ func newContainerLabels(container *v1.Container, pod *v1.Pod) map[string]string 
 	labels[types.KubernetesPodNamespaceLabel] = pod.Namespace
 	labels[types.KubernetesPodUIDLabel] = string(pod.UID)
 	labels[types.KubernetesContainerNameLabel] = container.Name
+	labels[types.KubernetesNodeNameLabel] = pod.Spec.NodeName
 
 	return labels
 }
@@ -154,11 +157,12 @@ func getPodSandboxInfoFromLabels(labels map[string]string) *labeledPodSandboxInf
 		PodName:      getStringValueFromLabel(labels, types.KubernetesPodNameLabel),
 		PodNamespace: getStringValueFromLabel(labels, types.KubernetesPodNamespaceLabel),
 		PodUID:       kubetypes.UID(getStringValueFromLabel(labels, types.KubernetesPodUIDLabel)),
+		NodeName:     getStringValueFromLabel(labels, types.KubernetesNodeNameLabel),
 	}
 
 	// Remain only labels from v1.Pod
 	for k, v := range labels {
-		if k != types.KubernetesPodNameLabel && k != types.KubernetesPodNamespaceLabel && k != types.KubernetesPodUIDLabel {
+		if k != types.KubernetesPodNameLabel && k != types.KubernetesPodNamespaceLabel && k != types.KubernetesPodUIDLabel && k != types.KubernetesNodeNameLabel {
 			podSandboxInfo.Labels[k] = v
 		}
 	}

--- a/pkg/kubelet/kuberuntime/labels_test.go
+++ b/pkg/kubelet/kuberuntime/labels_test.go
@@ -197,6 +197,7 @@ func TestPodLabels(t *testing.T) {
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{},
+			NodeName:   "test_node",
 		},
 	}
 	expected := &labeledPodSandboxInfo{
@@ -204,6 +205,7 @@ func TestPodLabels(t *testing.T) {
 		PodName:      pod.Name,
 		PodNamespace: pod.Namespace,
 		PodUID:       pod.UID,
+		NodeName:     pod.Spec.NodeName,
 	}
 
 	// Test whether we can get right information from label

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -895,7 +895,7 @@ func containerPrometheusLabelsFunc(s stats.Provider) metrics.ContainerLabelsFunc
 	return func(c *cadvisorapi.ContainerInfo) map[string]string {
 		// Prometheus requires that all metrics in the same family have the same labels,
 		// so we arrange to supply blank strings for missing labels
-		var name, image, podName, namespace, containerName string
+		var name, image, podName, namespace, containerName, nodeName string
 		if len(c.Aliases) > 0 {
 			name = c.Aliases[0]
 		}
@@ -908,6 +908,9 @@ func containerPrometheusLabelsFunc(s stats.Provider) metrics.ContainerLabelsFunc
 		}
 		if v, ok := c.Spec.Labels[kubelettypes.KubernetesContainerNameLabel]; ok {
 			containerName = v
+		}
+		if v, ok := c.Spec.Labels[kubelettypes.KubernetesNodeNameLabel]; ok {
+			nodeName = v
 		}
 		// Associate pod cgroup with pod so we have an accurate accounting of sandbox
 		if podName == "" && namespace == "" {
@@ -923,6 +926,7 @@ func containerPrometheusLabelsFunc(s stats.Provider) metrics.ContainerLabelsFunc
 			"pod":              podName,
 			"namespace":        namespace,
 			"container":        containerName,
+			"node":             nodeName,
 		}
 		return set
 	}

--- a/pkg/kubelet/types/labels.go
+++ b/pkg/kubelet/types/labels.go
@@ -21,6 +21,7 @@ const (
 	KubernetesPodNamespaceLabel  = "io.kubernetes.pod.namespace"
 	KubernetesPodUIDLabel        = "io.kubernetes.pod.uid"
 	KubernetesContainerNameLabel = "io.kubernetes.container.name"
+	KubernetesNodeNameLabel      = "io.kubernetes.node.name"
 )
 
 func GetContainerName(labels map[string]string) string {
@@ -37,4 +38,8 @@ func GetPodUID(labels map[string]string) string {
 
 func GetPodNamespace(labels map[string]string) string {
 	return labels[KubernetesPodNamespaceLabel]
+}
+
+func GetNodeName(labels map[string]string) string {
+	return labels[KubernetesNodeNameLabel]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
/kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Add node label to cAdvisor prometheus metrics
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add node label to cAdvisor prometheus metrics
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
