### PR TITLE
Update etcd-version-monitor readme and yaml file.

### DIFF
--- a/cluster/images/etcd-version-monitor/README.md
+++ b/cluster/images/etcd-version-monitor/README.md
@@ -18,7 +18,7 @@ latency metrics (`etcd_grpc_unary_requests_duration_seconds`) to be exposed.
 
 To run this tool as a docker container:
 - make build
-- docker run --net=host -i -t k8s.gcr.io/etcd-version-monitor:test /etcd-version-monitor --logtostderr
+- docker run --net=host -i -t staging-k8s.gcr.io/etcd-version-monitor:0.1.3 /etcd-version-monitor
 
 To run this as a pod on the kubernetes cluster:
 - Place the 'etcd-version-monitor.yaml' in the manifests directory of

--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.yaml
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.yaml
@@ -10,4 +10,3 @@ spec:
     image: k8s.gcr.io/etcd-version-monitor:0.1.3
     command:
     - /etcd-version-monitor
-    - --logtostderr


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Update outdated information in readme and yaml.

1. Default registry, `k8s.gcr.io` --> `staging-k8s.gcr.io`
2. Default image tag, `test`-->`0.1.3`
3. Remove non-exist parameter `logtostderr`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: