### PR TITLE
set default value of KUBE_MASTER_URL to empty in e2e test

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -74,7 +74,11 @@ else
     prepare-e2e
 
     detect-master >/dev/null
-    KUBE_MASTER_URL="${KUBE_MASTER_URL:-https://${KUBE_MASTER_IP:-}}"
+
+    KUBE_MASTER_URL="${KUBE_MASTER_URL:-}"
+    if [[ -z "${KUBE_MASTER_URL:-}" && -n "${KUBE_MASTER_IP:-}" ]]; then
+      KUBE_MASTER_URL="https://${KUBE_MASTER_IP}"
+    fi
 
     auth_config=(
       "--kubeconfig=${KUBECONFIG:-$DEFAULT_KUBECONFIG}"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
kubeconfig is correctly set, but e2e test failed to create clientset

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/test-infra/issues/12661

**Special notes for your reviewer**:
`KUBE_MASTER_URL` is set to `https://` when `KUBE_MASTER_IP` is not set, kubeconfig configuration is then overrided with `https://` in the code below:

https://github.com/kubernetes/kubernetes/blob/9790262f128aa9d27733dac46619af1d18459439/test/e2e/framework/util.go#L918

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
