### PR TITLE
Fix Windows perfcounters for non-English systems

### DIFF
--- a/pkg/kubelet/winstats/perfcounters.go
+++ b/pkg/kubelet/winstats/perfcounters.go
@@ -54,11 +54,6 @@ func newPerfCounter(counter string) (*perfCounter, error) {
 		return nil, errors.New("unable to open query through DLL call")
 	}
 
-	ret = win_pdh.PdhValidatePath(counter)
-	if ret != win_pdh.ERROR_SUCCESS {
-		return nil, fmt.Errorf("unable to valid path to counter. Error code is %x", ret)
-	}
-
 	ret = win_pdh.PdhAddEnglishCounter(queryHandle, counter, 0, &counterHandle)
 	if ret != win_pdh.ERROR_SUCCESS {
 		return nil, fmt.Errorf("unable to add process counter. Error code is %x", ret)


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
The `ValidatePath` syscall only operates in a localized language mode,
however `AddEnglishCounter` always works with English-localized counter
names. This means that on non-English systems, the counter will work but
will fail validation.

The only solution is to not validate the counter. There is no
corresponding `ValidateEnglishPath` syscall. `CollectQueryData` will
still error if the counter is invalid.

Reference: https://github.com/influxdata/telegraf/pull/2261

**Which issue(s) this PR fixes**:
Fixes #74173

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix kubelet metrics gathering on non-English Windows hosts
```

/sig windows