### PR TITLE
Implement support for setting hugepages limit on container cgroup sandbox.

### DIFF
--- a/pkg/apis/core/v1/helper/helpers.go
+++ b/pkg/apis/core/v1/helper/helpers.go
@@ -85,6 +85,24 @@ func HugePageSizeFromResourceName(name v1.ResourceName) (resource.Quantity, erro
 	return resource.ParseQuantity(pageSize)
 }
 
+// HugePageUnitSizeFromByteSize returns hugepage size has the format.
+// `size` must be guaranteed to divisible into the largest units that can be expressed.
+// <size><unit-prefix>B (1024 = "1KB", 1048576 = "1MB", etc).
+func HugePageUnitSizeFromByteSize(size int64) (string, error) {
+	// hugePageSizeUnitList is borrowed from opencontainers/runc/libcontainer/cgroups/utils.go
+	var hugePageSizeUnitList = []string{"B", "KB", "MB", "GB", "TB", "PB"}
+	idx := 0
+	len := len(hugePageSizeUnitList) - 1
+	for size%1024 == 0 && idx < len {
+		size /= 1024
+		idx++
+	}
+	if size > 1024 && idx < len {
+		return "", fmt.Errorf("size: %d%s must be guaranteed to divisible into the largest units", size, hugePageSizeUnitList[idx])
+	}
+	return fmt.Sprintf("%d%s", size, hugePageSizeUnitList[idx]), nil
+}
+
 // IsOvercommitAllowed returns true if the resource is in the default
 // namespace and is not hugepages.
 func IsOvercommitAllowed(name v1.ResourceName) bool {

--- a/pkg/apis/core/v1/helper/helpers_test.go
+++ b/pkg/apis/core/v1/helper/helpers_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1395,6 +1395,50 @@ func TestNodeSelectorRequirementKeyExistsInNodeSelectorTerms(t *testing.T) {
 		keyExists := NodeSelectorRequirementKeysExistInNodeSelectorTerms(test.reqs, test.terms)
 		if test.exists != keyExists {
 			t.Errorf("test %s failed. Expected %v but got %v", test.name, test.exists, keyExists)
+		}
+	}
+}
+
+func TestHugePageUnitSizeFromByteSize(t *testing.T) {
+	tests := []struct {
+		size     int64
+		expected string
+		wantErr  bool
+	}{
+		{
+			size:     1024,
+			expected: "1KB",
+			wantErr:  false,
+		},
+		{
+			size:     33554432,
+			expected: "32MB",
+			wantErr:  false,
+		},
+		{
+			size:     3221225472,
+			expected: "3GB",
+			wantErr:  false,
+		},
+		{
+			size:     1024 * 1024 * 1023 * 3,
+			expected: "3069MB",
+			wantErr:  true,
+		},
+	}
+	for _, test := range tests {
+		size := test.size
+		result, err := HugePageUnitSizeFromByteSize(size)
+		if err != nil {
+			if test.wantErr {
+				t.Logf("HugePageUnitSizeFromByteSize() expected error = %v", err)
+			} else {
+				t.Errorf("HugePageUnitSizeFromByteSize() error = %v, wantErr %v", err, test.wantErr)
+			}
+			continue
+		}
+		if test.expected != result {
+			t.Errorf("HugePageUnitSizeFromByteSize() expected %v but got %v", test.expected, result)
 		}
 	}
 }

--- a/pkg/kubelet/kuberuntime/BUILD
+++ b/pkg/kubelet/kuberuntime/BUILD
@@ -73,10 +73,14 @@ go_library(
         "//vendor/k8s.io/klog:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/apis/core/v1/helper:go_default_library",
             "//pkg/kubelet/qos:go_default_library",
+            "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/apis/core/v1/helper:go_default_library",
             "//pkg/kubelet/qos:go_default_library",
+            "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:windows": [
             "//pkg/kubelet/apis:go_default_library",
@@ -130,7 +134,17 @@ go_test(
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+            "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
+            "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(

--- a/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container_linux.go
@@ -21,9 +21,12 @@ package kuberuntime
 import (
 	"time"
 
-	"k8s.io/api/core/v1"
+	cgroupfs "github.com/opencontainers/runc/libcontainer/cgroups/fs"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/klog"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/qos"
 )
@@ -78,5 +81,48 @@ func (m *kubeGenericRuntimeManager) generateLinuxContainerConfig(container *v1.C
 		lc.Resources.CpuPeriod = cpuPeriod
 	}
 
+	lc.Resources.HugepageLimits = GetHugepageLimitsFromResources(container.Resources)
+
 	return lc
+}
+
+// GetHugepageLimitsFromResources returns limits of each hugepages from resources.
+func GetHugepageLimitsFromResources(resources v1.ResourceRequirements) []*runtimeapi.HugepageLimit {
+	var hugepageLimits []*runtimeapi.HugepageLimit
+
+	// For each page size, limit to 0.
+	for _, pageSize := range cgroupfs.HugePageSizes {
+		hugepageLimits = append(hugepageLimits, &runtimeapi.HugepageLimit{
+			PageSize: pageSize,
+			Limit:    uint64(0),
+		})
+	}
+
+	requiredHugepageLimits := map[string]uint64{}
+	for resourceObj, amountObj := range resources.Limits {
+		if !v1helper.IsHugePageResourceName(resourceObj) {
+			continue
+		}
+
+		pageSize, err := v1helper.HugePageSizeFromResourceName(resourceObj)
+		if err != nil {
+			klog.Warningf("Failed to get hugepage size from resource name: %v", err)
+			continue
+		}
+
+		sizeString, err := v1helper.HugePageUnitSizeFromByteSize(pageSize.Value())
+		if err != nil {
+			klog.Warningf("pageSize is invalid: %v", err)
+			continue
+		}
+		requiredHugepageLimits[sizeString] = uint64(amountObj.Value())
+	}
+
+	for _, hugepageLimit := range hugepageLimits {
+		if limit, exists := requiredHugepageLimits[hugepageLimit.PageSize]; exists {
+			hugepageLimit.Limit = limit
+		}
+	}
+
+	return hugepageLimits
 }


### PR DESCRIPTION
Signed-off-by: sewon.oh sewon.oh@samsung.com
CC @bg-chun @admanV
Wait for PR: https://github.com/kubernetes/kubernetes/pull/83353

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adding hugepage limits when creating container for container isolation of huge pages

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/80716

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
- [KEP]: [Update huge pages KEP for container isolation of huge pages](https://github.com/kubernetes/enhancements/pull/1199)
