### PR TITLE
Ensure script saves results even when tests fail

### DIFF
--- a/cluster/images/conformance/run_e2e.sh
+++ b/cluster/images/conformance/run_e2e.sh
@@ -40,8 +40,8 @@ saveResults() {
 # Entry provided via env var to simplify invocation. 
 if [[ -n ${E2E_USE_GO_RUNNER:-} ]]; then
     set -x
-    /gorunner
-    exit $?
+    /gorunner && ret=0 || ret=$?
+    exit ${ret}
 fi
 
 # We get the TERM from kubernetes and handle it gracefully
@@ -67,8 +67,7 @@ ginkgo_args+=(
 )
 
 set -x
-/usr/local/bin/ginkgo "${ginkgo_args[@]}" /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" -v="${E2E_VERBOSITY}" > >(tee "${RESULTS_DIR}"/e2e.log)
-ret=$?
+/usr/local/bin/ginkgo "${ginkgo_args[@]}" /usr/local/bin/e2e.test -- --disable-log-dump --repo-root=/kubernetes --provider="${E2E_PROVIDER}" --report-dir="${RESULTS_DIR}" --kubeconfig="${KUBECONFIG}" -v="${E2E_VERBOSITY}" > >(tee "${RESULTS_DIR}"/e2e.log) && ret=0 || ret=$?
 set +x
 saveResults
 exit ${ret}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When we run commands that may exit non-zero during normal operation
we need to ensure the script does not exit early and avoid
saving the results.

**Which issue(s) this PR fixes**:
Fixes #83272

**Special notes for your reviewer**:
To test this you can do it manually with an image I made that took the v1.16 conformance but swapped this script.

This command shows the new behavior:
```
sonobuoy gen --kube-conformance-image=schnake/custom-conformance:v0 --plugin-env e2e.E2E_USE_GO_RUNNER|sed 's/value: \\\[Conformance\\\]/value: "\*"/'|sonobuoy run -f -
```

It:
 - uses my custom image
 - disables use of the go runner so we use the bash one (which is what we're fixing)
 - changes the focus of the tests to be a regexp that will not parse and cause ginkgo to exit non-zero

You'll see:
 - the plugin now reports results to sonobuoy; since none of them are xml it will come up as an 'unknown' status instead of failed though since there wasnt a 'test case' that failed.

FYI this should be cherry-picked into the v1.16.x branches.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
