### PR TITLE
Support local volume block mode reconstruction

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler.go
@@ -586,24 +586,19 @@ func (rc *reconciler) updateDevicePath(volumesNeedUpdate map[v1.UniqueVolumeName
 }
 
 func getDeviceMountPath(volume *reconstructedVolume) (string, error) {
-	volumeAttacher, err := volume.attachablePlugin.NewAttacher()
-	if volumeAttacher == nil || err != nil {
-		return "", err
-	}
-	deviceMountPath, err :=
-		volumeAttacher.GetDeviceMountPath(volume.volumeSpec)
-	if err != nil {
-		return "", err
-	}
-
 	if volume.blockVolumeMapper != nil {
-		deviceMountPath, err =
-			volume.blockVolumeMapper.GetGlobalMapPath(volume.volumeSpec)
-		if err != nil {
+		// for block volume, we return its global map path
+		return volume.blockVolumeMapper.GetGlobalMapPath(volume.volumeSpec)
+	} else if volume.attachablePlugin != nil {
+		// for filesystem volume, we return its device mount path if the plugin implements AttachableVolumePlugin
+		volumeAttacher, err := volume.attachablePlugin.NewAttacher()
+		if volumeAttacher == nil || err != nil {
 			return "", err
 		}
+		return volumeAttacher.GetDeviceMountPath(volume.volumeSpec)
+	} else {
+		return "", fmt.Errorf("blockVolumeMapper or attachablePlugin required")
 	}
-	return deviceMountPath, nil
 }
 
 func (rc *reconciler) updateStates(volumesNeedUpdate map[v1.UniqueVolumeName]*reconstructedVolume) error {
@@ -632,7 +627,8 @@ func (rc *reconciler) updateStates(volumesNeedUpdate map[v1.UniqueVolumeName]*re
 			continue
 		}
 		klog.V(4).Infof("Volume: %s (pod UID %s) is marked as mounted and added into the actual state", volume.volumeName, volume.podName)
-		if volume.attachablePlugin != nil {
+		// If the volume has device to mount, we mark its device as mounted.
+		if volume.attachablePlugin != nil || volume.blockVolumeMapper != nil {
 			deviceMountPath, err := getDeviceMountPath(volume)
 			if err != nil {
 				klog.Errorf("Could not find device mount path for volume %s", volume.volumeName)

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -218,6 +218,7 @@ func (plugin *localVolumePlugin) ConstructBlockVolumeSpec(podUID types.UID, volu
 		Spec: v1.PersistentVolumeSpec{
 			PersistentVolumeSource: v1.PersistentVolumeSource{
 				Local: &v1.LocalVolumeSource{
+					// Not needed because we don't need to detach local device from the host.
 					Path: "",
 				},
 			},

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -50,7 +50,6 @@ func InitDisruptiveTestSuite() TestSuite {
 		},
 	}
 }
-
 func (s *disruptiveTestSuite) getTestSuiteInfo() TestSuiteInfo {
 	return s.tsInfo
 }
@@ -145,12 +144,6 @@ func (s *disruptiveTestSuite) defineTests(driver TestDriver, pattern testpattern
 			if (pattern.VolMode == v1.PersistentVolumeBlock && t.runTestBlock != nil) ||
 				(pattern.VolMode == v1.PersistentVolumeFilesystem && t.runTestFile != nil) {
 				ginkgo.It(t.testItStmt, func() {
-
-					if pattern.VolMode == v1.PersistentVolumeBlock && driver.GetDriverInfo().InTreePluginName == "kubernetes.io/local-volume" {
-						// TODO: https://github.com/kubernetes/kubernetes/issues/74552
-						framework.Skipf("Local volume volume plugin does not support block volume reconstruction (#74552)")
-					}
-
 					init()
 					defer cleanup()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Support local volume block mode reconstruction.

The failing test in #83693 is reverted and fixed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #83693

**Special notes for your reviewer**:

Overview of local volume reconstruction:

- .spec.path is a directory and .spec.volumeMode == "Filesystem" (no need to support reconstruction) 
  - the local volume is a directory and bind-mounted into container directly, no mount point or device symbolic link to clean
- .spec.path is a block and .spec.volumeMode == "Filesystem" (#74552 and #74923, will be addressed in a separate PR)
  - the block device is mounted at global mount path: `/var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/spec.Name()` (DeviceMounter.GetDeviceMountPath()) and should be cleaned
- .spec.path is a block and .spec.volumeMode == "Block" (supported in this PR)
  - node map path is symbolic linked at `/var/lib/kubelet/plugins/kubernetes.io~local-volume/volumeDevices/spec.Name()/{podUid} ` (symlink to device, e.g. /dev/sdb) and should be cleaned
  - pod map path is symbolic linked at `/var/lib/kubelet/pods/{podUid}/volumeDevices/kubernetes.io~local-volume/spec.Name()` (symlink to device, e.g. /dev/sdb) and should be cleaned

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
local: support local volume block mode reconstruction
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
