### PR TITLE
Upgrade all node pools for gke upgrade test.

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -230,28 +230,55 @@ func nodeUpgradeGCE(rawV, img string, enableKubeProxyDaemonSet bool) error {
 
 func nodeUpgradeGKE(v string, img string) error {
 	Logf("Upgrading nodes to version %q and image %q", v, img)
-	args := []string{
-		"container",
-		"clusters",
-		fmt.Sprintf("--project=%s", TestContext.CloudConfig.ProjectID),
-		locationParamGKE(),
-		"upgrade",
-		TestContext.CloudConfig.Cluster,
-		fmt.Sprintf("--cluster-version=%s", v),
-		"--quiet",
-	}
-	if len(img) > 0 {
-		args = append(args, fmt.Sprintf("--image-type=%s", img))
-	}
-	_, _, err := RunCmd("gcloud", appendContainerCommandGroupIfNeeded(args)...)
-
+	nps, err := nodePoolsGKE()
 	if err != nil {
 		return err
 	}
+	Logf("Found node pools %v", nps)
+	for _, np := range nps {
+		args := []string{
+			"container",
+			"clusters",
+			fmt.Sprintf("--project=%s", TestContext.CloudConfig.ProjectID),
+			locationParamGKE(),
+			"upgrade",
+			TestContext.CloudConfig.Cluster,
+			fmt.Sprintf("--node-pool=%s", np),
+			fmt.Sprintf("--cluster-version=%s", v),
+			"--quiet",
+		}
+		if len(img) > 0 {
+			args = append(args, fmt.Sprintf("--image-type=%s", img))
+		}
+		_, _, err = RunCmd("gcloud", appendContainerCommandGroupIfNeeded(args)...)
 
-	waitForSSHTunnels()
+		if err != nil {
+			return err
+		}
 
+		waitForSSHTunnels()
+	}
 	return nil
+}
+
+func nodePoolsGKE() ([]string, error) {
+	args := []string{
+		"container",
+		"node-pools",
+		fmt.Sprintf("--project=%s", TestContext.CloudConfig.ProjectID),
+		locationParamGKE(),
+		"list",
+		fmt.Sprintf("--cluster=%s", TestContext.CloudConfig.Cluster),
+		`--format="get(name)"`,
+	}
+	stdout, _, err := RunCmd("gcloud", appendContainerCommandGroupIfNeeded(args)...)
+	if err != nil {
+		return nil, err
+	}
+	if len(strings.TrimSpace(stdout)) == 0 {
+		return []string{}, nil
+	}
+	return strings.Fields(stdout), nil
 }
 
 // MigTemplate (GCE-only) returns the name of the MIG template that the


### PR DESCRIPTION
Upgrade all node pools for gke upgrade test.

This is useful for testing GKE clusters with multiple node pools.

/cc @fvoznika 
@kubernetes/sig-testing 

Signed-off-by: Lantao Liu <lantaol@google.com>

```docs
none
```
