### PR TITLE
Microoptimization in SelectorFrom*Set

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -850,7 +850,7 @@ func SelectorFromSet(ls Set) Selector {
 	if ls == nil || len(ls) == 0 {
 		return internalSelector{}
 	}
-	var requirements internalSelector
+	requirements := make([]Requirement, 0, len(ls))
 	for label, value := range ls {
 		r, err := NewRequirement(label, selection.Equals, []string{value})
 		if err == nil {
@@ -862,7 +862,7 @@ func SelectorFromSet(ls Set) Selector {
 	}
 	// sort to have deterministic string representation
 	sort.Sort(ByKey(requirements))
-	return requirements
+	return internalSelector(requirements)
 }
 
 // SelectorFromValidatedSet returns a Selector which will match exactly the given Set.
@@ -872,13 +872,13 @@ func SelectorFromValidatedSet(ls Set) Selector {
 	if ls == nil || len(ls) == 0 {
 		return internalSelector{}
 	}
-	var requirements internalSelector
+	requirements := make([]Requirement, 0, len(ls))
 	for label, value := range ls {
 		requirements = append(requirements, Requirement{key: label, operator: selection.Equals, strValues: []string{value}})
 	}
 	// sort to have deterministic string representation
 	sort.Sort(ByKey(requirements))
-	return requirements
+	return internalSelector(requirements)
 }
 
 // ParseToRequirements takes a string representing a selector and returns a list of

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -617,3 +617,16 @@ func TestSafeSort(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkSelectorFromValidatedSet(b *testing.B) {
+	set := map[string]string{
+		"foo": "foo",
+		"bar": "bar",
+	}
+
+	for i := 0; i < b.N; i++ {
+		if SelectorFromValidatedSet(set).Empty() {
+			b.Errorf("Unexpected selector")
+		}
+	}
+}


### PR DESCRIPTION
Before this change:
```
pkg: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/labels
BenchmarkSelectorFromValidatedSet-12    	 3000000	       691 ns/op	     272 B/op	       6 allocs/op
```

With this change:
```
pkg: k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/labels
BenchmarkSelectorFromValidatedSet-12    	 3000000	       511 ns/op	     208 B/op	       5 allocs/op
```