### PR TITLE
Comment out an e2eservice sanity check for now

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -420,11 +420,12 @@ func (j *TestJig) sanityCheckService(svc *v1.Service, svcType v1.ServiceType) (*
 		}
 	}
 
-	if svcType != v1.ServiceTypeLoadBalancer {
-		if len(svc.Status.LoadBalancer.Ingress) != 0 {
-			return nil, fmt.Errorf("unexpected Status.LoadBalancer.Ingress on non-LoadBalancer service")
-		}
-	}
+	// FIXME: this fails for tests that were changed from LoadBalancer to ClusterIP.
+	// if svcType != v1.ServiceTypeLoadBalancer {
+	// 	if len(svc.Status.LoadBalancer.Ingress) != 0 {
+	// 		return nil, fmt.Errorf("unexpected Status.LoadBalancer.Ingress on non-LoadBalancer service")
+	// 	}
+	// }
 
 	return svc, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Another followup to #83549.
#84159 fixed the case of not immediately checking that LoadBalancer services have Ingresses assigned, but I left the check that **non**-LoadBalancer services *didn't* have Ingresses assigned. But that fails in tests where a service is changed from LoadBalancer to non-LoadBalancer.

Long term, the fix is for `e2eservice.TestJig` to keep more track of what the test is doing, so that it can know that the service was formerly a LoadBalancer. For now I'm just commenting out that check to get the tests passing again.

**Which issue(s) this PR fixes**:
Definitely #84107, maybe #84149 too; it's unclear if that's already completely fixed yet or not.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/kind failing-test
/priority critical-urgent
/sig network
/assign @oomichi 