### PR TITLE
Check Phase equality directly without accessing map

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -96,7 +96,7 @@ var UpdateLabelBackoff = wait.Backoff{
 
 var (
 	KeyFunc           = cache.DeletionHandlingMetaNamespaceKeyFunc
-	podPhaseToOrdinal = map[v1.PodPhase]int{v1.PodPending: 0, v1.PodUnknown: 1, v1.PodRunning: 2}
+	podPhaseToOrdinal = map[v1.PodPhase]int{v1.PodPending: 0, v1.PodUnknown: 1, v1.PodRunning: 2, v1.PodFailed: 3, v1.PodSucceeded: 4}
 )
 
 type ResyncPeriodFunc func() time.Duration
@@ -748,7 +748,7 @@ func (s ActivePods) Less(i, j int) bool {
 		return len(s[i].Spec.NodeName) == 0
 	}
 	// 2. PodPending < PodUnknown < PodRunning
-	if podPhaseToOrdinal[s[i].Status.Phase] != podPhaseToOrdinal[s[j].Status.Phase] {
+	if s[i].Status.Phase != s[j].Status.Phase {
 		return podPhaseToOrdinal[s[i].Status.Phase] < podPhaseToOrdinal[s[j].Status.Phase]
 	}
 	// 3. Not ready < ready
@@ -832,7 +832,7 @@ func (s ActivePodsWithRanks) Less(i, j int) bool {
 		return len(s.Pods[i].Spec.NodeName) == 0
 	}
 	// 2. PodPending < PodUnknown < PodRunning
-	if podPhaseToOrdinal[s.Pods[i].Status.Phase] != podPhaseToOrdinal[s.Pods[j].Status.Phase] {
+	if s.Pods[i].Status.Phase != s.Pods[j].Status.Phase {
 		return podPhaseToOrdinal[s.Pods[i].Status.Phase] < podPhaseToOrdinal[s.Pods[j].Status.Phase]
 	}
 	// 3. Not ready < ready

--- a/staging/src/k8s.io/kubectl/pkg/util/podutils/podutils.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/podutils/podutils.go
@@ -95,8 +95,8 @@ func (s ByLogging) Less(i, j int) bool {
 		return len(s[i].Spec.NodeName) > 0
 	}
 	// 2. PodRunning < PodUnknown < PodPending
-	m := map[corev1.PodPhase]int{corev1.PodRunning: 0, corev1.PodUnknown: 1, corev1.PodPending: 2}
-	if m[s[i].Status.Phase] != m[s[j].Status.Phase] {
+	m := map[corev1.PodPhase]int{corev1.PodRunning: 0, corev1.PodUnknown: 1, corev1.PodPending: 2, corev1.PodFailed: 3, corev1.PodSucceeded: 4}
+	if s[i].Status.Phase != s[j].Status.Phase {
 		return m[s[i].Status.Phase] < m[s[j].Status.Phase]
 	}
 	// 3. ready < not ready
@@ -133,8 +133,8 @@ func (s ActivePods) Less(i, j int) bool {
 		return len(s[i].Spec.NodeName) == 0
 	}
 	// 2. PodPending < PodUnknown < PodRunning
-	m := map[corev1.PodPhase]int{corev1.PodPending: 0, corev1.PodUnknown: 1, corev1.PodRunning: 2}
-	if m[s[i].Status.Phase] != m[s[j].Status.Phase] {
+	m := map[corev1.PodPhase]int{corev1.PodPending: 0, corev1.PodUnknown: 1, corev1.PodRunning: 2, corev1.PodFailed: 3, corev1.PodSucceeded: 4}
+	if s[i].Status.Phase != s[j].Status.Phase {
 		return m[s[i].Status.Phase] < m[s[j].Status.Phase]
 	}
 	// 3. Not ready < ready


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR removes the unnecessary map access when checking equality of PodPhase.

Thanks to @Miciah who spotted the potential for this change over #84075

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
