### PR TITLE
Add SOCKS5 proxy support for kubectl exec

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -130,11 +130,10 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 		return s.dialWithoutProxy(req.Context(), req.URL)
 	}
 
-	if proxyURL.Scheme == "socks5" {
+	switch proxyURL.Scheme {
+	case "socks5":
 		return s.dialWithSocks5Proxy(req.URL, proxyURL)
-	}
-
-	if proxyURL.Scheme == "https" || "http" {
+	case "https", "http":
 		return s.dialWithHttpProxy(req.URL, proxyURL)
 	}
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -131,124 +131,14 @@ func (s *SpdyRoundTripper) dial(req *http.Request) (net.Conn, error) {
 	}
 
 	if proxyURL.Scheme == "socks5" {
-		return s.dialWithSocks5Proxy(proxyURL, req.Context(), req.URL)
+		return s.dialWithSocks5Proxy(req.URL, proxyURL)
 	}
 
-	// ensure we use a canonical host with proxyReq
-	targetHost := netutil.CanonicalAddr(req.URL)
-
-	// proxying logic adapted from http://blog.h6t.eu/post/74098062923/golang-websocket-with-http-proxy-support
-	proxyReq := http.Request{
-		Method: "CONNECT",
-		URL:    &url.URL{},
-		Host:   targetHost,
+	if proxyURL.Scheme == "https" || "http" {
+		return s.dialWithHttpProxy(req.URL, proxyURL)
 	}
 
-	if pa := s.proxyAuth(proxyURL); pa != "" {
-		proxyReq.Header = http.Header{}
-		proxyReq.Header.Set("Proxy-Authorization", pa)
-	}
-
-	proxyDialConn, err := s.dialWithoutProxy(req.Context(), proxyURL)
-	if err != nil {
-		return nil, err
-	}
-
-	proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
-	_, err = proxyClientConn.Do(&proxyReq)
-	if err != nil && err != httputil.ErrPersistEOF {
-		return nil, err
-	}
-
-	rwc, _ := proxyClientConn.Hijack()
-
-	if req.URL.Scheme != "https" {
-		return rwc, nil
-	}
-
-	host, _, err := net.SplitHostPort(targetHost)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConfig := s.tlsConfig
-	switch {
-	case tlsConfig == nil:
-		tlsConfig = &tls.Config{ServerName: host}
-	case len(tlsConfig.ServerName) == 0:
-		tlsConfig = tlsConfig.Clone()
-		tlsConfig.ServerName = host
-	}
-
-	tlsConn := tls.Client(rwc, tlsConfig)
-
-	// need to manually call Handshake() so we can call VerifyHostname() below
-	if err := tlsConn.Handshake(); err != nil {
-		return nil, err
-	}
-
-	// Return if we were configured to skip validation
-	if tlsConfig.InsecureSkipVerify {
-		return tlsConn, nil
-	}
-
-	if err := tlsConn.VerifyHostname(tlsConfig.ServerName); err != nil {
-		return nil, err
-	}
-
-	return tlsConn, nil
-}
-
-
-// dialWithoutProxy dials the host specified by url, using TLS if appropriate.
-func (s *SpdyRoundTripper) dialWithSocks5Proxy(ctx context.Context, requestUrl *url.URL, proxyURL *url.URL) (net.Conn, error) {
-	// ensure we use a canonical host with proxyReq
-	targetHost := netutil.CanonicalAddr(requestUrl)
-
-	proxyDialAddr := netutil.CanonicalAddr(proxyURL)
-	proxyDialer, err := proxy.SOCKS5("tcp", proxyDialAddr, nil, proxy.Direct)
-
-	proxyConn, err := proxyDialer.Dial("tcp", targetHost)
-
-	if err != nil {
-		return nil, err
-	}
-
-	proxyClientConn := httputil.NewProxyClientConn(proxyConn, nil)
-
-	rwc, _ := proxyClientConn.Hijack()
-
-	host, _, err := net.SplitHostPort(targetHost)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConfig := s.tlsConfig
-	switch {
-	case tlsConfig == nil:
-		tlsConfig = &tls.Config{ServerName: host}
-	case len(tlsConfig.ServerName) == 0:
-		tlsConfig = tlsConfig.Clone()
-		tlsConfig.ServerName = host
-	}
-
-	tlsConn := tls.Client(rwc, tlsConfig)
-
-	// need to manually call Handshake() so we can call VerifyHostname() below
-	if err := tlsConn.Handshake(); err != nil {
-		return nil, err
-	}
-
-	// Return if we were configured to skip validation
-	if tlsConfig.InsecureSkipVerify {
-		return tlsConn, nil
-	}
-
-	if err := tlsConn.VerifyHostname(tlsConfig.ServerName); err != nil {
-		return nil, err
-	}
-
-	return tlsConn, nil
+	return nil, fmt.Errorf("proxy URL scheme not supported: %s", proxyURL.Scheme)
 }
 
 // dialWithoutProxy dials the host specified by url, using TLS if appropriate.
@@ -296,7 +186,101 @@ func (s *SpdyRoundTripper) dialWithoutProxy(ctx context.Context, url *url.URL) (
 	return conn, nil
 }
 
-// proxyAuth returns, for a given proxy URL, the value to be used for the Proxy-Authorization header
+// dialWithoutProxy dials the host specified by url through an http or an https proxy.
+func (s *SpdyRoundTripper) dialWithHttpProxy(requestUrl *url.URL, proxyURL *url.URL) (net.Conn, error) {
+	// ensure we use a canonical host with proxyReq
+	targetHost := netutil.CanonicalAddr(req.URL)
+
+	// proxying logic adapted from http://blog.h6t.eu/post/74098062923/golang-websocket-with-http-proxy-support
+	proxyReq := http.Request{
+		Method: "CONNECT",
+		URL:    &url.URL{},
+		Host:   targetHost,
+	}
+
+	if pa := s.proxyAuth(proxyURL); pa != "" {
+		proxyReq.Header = http.Header{}
+		proxyReq.Header.Set("Proxy-Authorization", pa)
+	}
+
+	proxyDialConn, err := s.dialWithoutProxy(req.Context(), proxyURL)
+	if err != nil {
+		return nil, err
+	}
+
+	proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
+	_, err = proxyClientConn.Do(&proxyReq)
+	if err != nil && err != httputil.ErrPersistEOF {
+		return nil, err
+	}
+
+	rwc, _ := proxyClientConn.Hijack()
+
+	return s.tlsConn(req.URL, rwc, targetHost)
+}
+
+// dialWithoutProxy dials the host specified by url through a socks5 proxy.
+func (s *SpdyRoundTripper) dialWithSocks5Proxy(requestUrl *url.URL, proxyURL *url.URL) (net.Conn, error) {
+	// ensure we use a canonical host with proxyReq
+	targetHost := netutil.CanonicalAddr(requestUrl)
+
+	proxyDialAddr := netutil.CanonicalAddr(proxyURL)
+	proxyDialer, err := proxy.SOCKS5("tcp", proxyDialAddr, nil, proxy.Direct)
+
+	proxyConn, err := proxyDialer.Dial("tcp", targetHost)
+
+	if err != nil {
+		return nil, err
+	}
+
+	proxyClientConn := httputil.NewProxyClientConn(proxyConn, nil)
+
+	rwc, _ := proxyClientConn.Hijack()
+
+	return s.tlsConn(requestUrl, rwc, targetHost)
+}
+
+// tlsConn returns a TLS client side connection using rwc as the underlying transport.
+func (s *SpdyRoundTripper) tlsConn(requestUrl *url.URL, rwc net.Conn, targetHost string) (net.Conn, error) {
+
+	if requestUrl.Scheme != "https" {
+		return rwc, nil
+	}
+
+	host, _, err := net.SplitHostPort(targetHost)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := s.tlsConfig
+	switch {
+	case tlsConfig == nil:
+		tlsConfig = &tls.Config{ServerName: host}
+	case len(tlsConfig.ServerName) == 0:
+		tlsConfig = tlsConfig.Clone()
+		tlsConfig.ServerName = host
+	}
+
+	tlsConn := tls.Client(rwc, tlsConfig)
+
+	// need to manually call Handshake() so we can call VerifyHostname() below
+	if err := tlsConn.Handshake(); err != nil {
+		return nil, err
+	}
+
+	// Return if we were configured to skip validation
+	if tlsConfig.InsecureSkipVerify {
+		return tlsConn, nil
+	}
+
+	if err := tlsConn.VerifyHostname(tlsConfig.ServerName); err != nil {
+		return nil, err
+	}
+
+	return tlsConn, nil
+}
+
+// proxyAuth returns, for a given proxy URL, the value to be used for the Proxy-Authorization header.
 func (s *SpdyRoundTripper) proxyAuth(proxyURL *url.URL) string {
 	if proxyURL == nil || proxyURL.User == nil {
 		return ""

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -280,7 +280,7 @@ func (s *SpdyRoundTripper) tlsConn(requestUrl *url.URL, rwc net.Conn, targetHost
 	return tlsConn, nil
 }
 
-// proxyAuth returns, for a given proxy URL, the value to be used for the Proxy-Authorization header.
+// proxyAuth returns, for a given proxy URL, the value to be used for the Proxy-Authorization header
 func (s *SpdyRoundTripper) proxyAuth(proxyURL *url.URL) string {
 	if proxyURL == nil || proxyURL.User == nil {
 		return ""

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper.go
@@ -175,35 +175,35 @@ func (s *SpdyRoundTripper) dialWithHttpProxy(requestUrl *url.URL, proxyURL *url.
 
 // dialWithSocks5Proxy dials the host specified by url through a socks5 proxy.
 func (s *SpdyRoundTripper) dialWithSocks5Proxy(requestUrl *url.URL, proxyURL *url.URL) (net.Conn, error) {
-  // ensure we use a canonical host with proxyReq
-  targetHost := netutil.CanonicalAddr(requestUrl)
-  proxyDialAddr := netutil.CanonicalAddr(proxyURL)
+	// ensure we use a canonical host with proxyReq
+	targetHost := netutil.CanonicalAddr(requestUrl)
+	proxyDialAddr := netutil.CanonicalAddr(proxyURL)
 
-  var auth *proxy.Auth
-  if proxyURL.User != nil {
-  	pass, _ := proxyURL.User.Password()
-    auth = &proxy.Auth{
-      User: proxyURL.User.Username(),
-      Password: pass,
-    }
-  }
-  proxyDialer, err := proxy.SOCKS5("tcp", proxyDialAddr, auth, proxy.Direct)
+	var auth *proxy.Auth
+	if proxyURL.User != nil {
+		pass, _ := proxyURL.User.Password()
+		auth = &proxy.Auth{
+			User:     proxyURL.User.Username(),
+			Password: pass,
+		}
+	}
+	proxyDialer, err := proxy.SOCKS5("tcp", proxyDialAddr, auth, proxy.Direct)
 
-  if err != nil {
-    return nil, err
-  }
+	if err != nil {
+		return nil, err
+	}
 
-  proxyDialConn, err := proxyDialer.Dial("tcp", targetHost)
+	proxyDialConn, err := proxyDialer.Dial("tcp", targetHost)
 
-  if err != nil {
-    return nil, err
-  }
- 
-  proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
+	if err != nil {
+		return nil, err
+	}
 
-  rwc, _ := proxyClientConn.Hijack()
+	proxyClientConn := httputil.NewProxyClientConn(proxyDialConn, nil)
 
-  return s.tlsConn(requestUrl, rwc, targetHost)
+	rwc, _ := proxyClientConn.Hijack()
+
+	return s.tlsConn(requestUrl, rwc, targetHost)
 }
 
 // tlsConn returns a TLS client side connection using rwc as the underlying transport.

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/spdy/roundtripper_test.go
@@ -21,10 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
-	"github.com/armon/go-socks5"
-	"github.com/elazarl/goproxy"
 	"io"
-	"k8s.io/apimachinery/pkg/util/httpstream"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -34,6 +31,11 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/armon/go-socks5"
+	"github.com/elazarl/goproxy"
+
+	"k8s.io/apimachinery/pkg/util/httpstream"
 )
 
 // be sure to unset environment variable https_proxy (if exported) before testing, otherwise the testing will fail unexpectedly.


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The PR permits using kubectl commands like `kubectl exec` via a SOCKS5 proxy. The PR adds support for SOCKS5 proxies, but does not change HTTP or HTTPS behavior.

Test coverage provided for socks5 with [armon/go-socks5](https://github.com/armon/go-socks5) server.

**Does this PR introduce a user-facing change?**:

```release-note
The PR permits using kubectl commands like `kubectl exec` via a SOCKS5 proxy. 
The PR adds support for SOCKS5 proxies, but does not change HTTP or HTTPS behavior.
```
