### PR TITLE
check volume directories instead of mounts for cleanupOrphanedPodDirs

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -976,7 +976,7 @@ func (kl *Kubelet) PodResourcesAreReclaimed(pod *v1.Pod, status v1.PodStatus) bo
 		return false
 	}
 
-	if kl.podVolumesExist(pod.UID) && !kl.keepTerminatedPodVolumes {
+	if kl.podVolumePathsExistInCacheOrDisk(pod.UID) && !kl.keepTerminatedPodVolumes {
 		// We shouldn't delete pods whose volumes have not been cleaned up if we are not keeping terminated pod volumes
 		klog.V(3).Infof("Pod %q is terminated, but some volumes have not been cleaned up", format.Pod(pod))
 		return false
@@ -1962,7 +1962,7 @@ func (kl *Kubelet) cleanupOrphanedPodCgroups(pcm cm.PodContainerManager, cgroupP
 		// parent croup.  If the volumes still exist, reduce the cpu shares for any
 		// process in the cgroup to the minimum value while we wait.  if the kubelet
 		// is configured to keep terminated volumes, we will delete the cgroup and not block.
-		if podVolumesExist := kl.podVolumesExist(uid); podVolumesExist && !kl.keepTerminatedPodVolumes {
+		if podVolumesExist := kl.podVolumePathsExistInCacheOrDisk(uid); podVolumesExist && !kl.keepTerminatedPodVolumes {
 			klog.V(3).Infof("Orphaned pod %q found, but volumes not yet removed.  Reducing cpu to minimum", uid)
 			if err := pcm.ReduceCPULimits(val); err != nil {
 				klog.Warningf("Failed to reduce cpu time for pod %q pending volume cleanup due to %v", uid, err)

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -261,7 +261,7 @@ func TestPodVolumesExistWithMount(t *testing.T) {
 				}
 			}
 
-			exist := kubelet.podVolumesExist(poduid)
+			exist := kubelet.podMountedVolumesExistInCacheOrDisk(poduid)
 			if tc.expected != exist {
 				t.Errorf("%s failed: expected %t, got %t", name, tc.expected, exist)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig storage

**What this PR does / why we need it**:
Related comment; https://github.com/kubernetes/kubernetes/issues/72346#issuecomment-467330114

Change `podVolumesExist` to check volume directories instead of mounted volumes when it's called from `Kubelet.cleanupOrphanedPodDirs`. Because `getMountedVolumePathListFromDisk` does not always produce correct results for mounted volumes and `Kubelet.cleanupOrphanedPodDirs` already used `getPodVolumePathListFromDisk`.

**Which issue(s) this PR fixes**:
Related issue https://github.com/kubernetes/kubernetes/issues/72346

Related issue is quite evolved to fix all `podVolumesExist` method usage, but we may think this PR a fix for the issue https://github.com/kubernetes/kubernetes/issues/72346 and all `podVolumesExist` usage may be fixed within the scope of issue https://github.com/kubernetes/kubernetes/issues/72347

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
cc @msau42 @cofyc 
