### PR TITLE
vsphere: check if volume exists before create

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/vdm.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/vdm.go
@@ -39,11 +39,17 @@ func (diskManager virtualDiskManager) Create(ctx context.Context, datastore *vcl
 	if diskManager.volumeOptions.SCSIControllerType == "" {
 		diskManager.volumeOptions.SCSIControllerType = vclib.LSILogicControllerType
 	}
-	// Create virtual disk
-	diskFormat := vclib.DiskFormatValidType[diskManager.volumeOptions.DiskFormat]
-	// Create a virtual disk manager
-	vdm := object.NewVirtualDiskManager(datastore.Client())
+
+	// Check for existing VMDK before attempting create. Because a name collision
+	// is unlikely, "VMDK already exists" is likely from a previous attempt to
+	// create this volume.
+	if dsPath := vclib.GetPathFromVMDiskPath(diskManager.diskPath); datastore.Exists(ctx, dsPath) {
+		klog.V(2).Infof("Create: VirtualDisk already exists, returning success. Name=%q", diskManager.diskPath)
+		return diskManager.diskPath, nil
+	}
+
 	// Create specification for new virtual disk
+	diskFormat := vclib.DiskFormatValidType[diskManager.volumeOptions.DiskFormat]
 	vmDiskSpec := &types.FileBackedVirtualDiskSpec{
 		VirtualDiskSpec: types.VirtualDiskSpec{
 			AdapterType: diskManager.volumeOptions.SCSIControllerType,
@@ -51,6 +57,8 @@ func (diskManager virtualDiskManager) Create(ctx context.Context, datastore *vcl
 		},
 		CapacityKb: int64(diskManager.volumeOptions.CapacityKB),
 	}
+
+	vdm := object.NewVirtualDiskManager(datastore.Client())
 	requestTime := time.Now()
 	// Create virtual disk
 	task, err := vdm.CreateVirtualDisk(ctx, diskManager.diskPath, datastore.Datacenter.Datacenter, vmDiskSpec)


### PR DESCRIPTION
Sometimes, volume creation can succeed right as the request times out,
causing k8s to interpret it as a failure. When the request is retried,
we want it to succeed. When trying this in vSphere, the second create
request failed with "already exists" and it never recovered.

This adds a check to the in-tree vsphere storage plugin that checks if a
VMDK exists before trying to create it. The check is done BEFORE create.

Tested: manual only )-:

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/85238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
