### PR TITLE
Revert #84014

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -72,7 +72,7 @@ type schedulerCache struct {
 	// headNode points to the most recently updated NodeInfo in "nodes". It is the
 	// head of the linked list.
 	headNode *nodeInfoListItem
-	nodeTree *nodeTree
+	nodeTree *NodeTree
 	// A map from image name to its imageState.
 	imageStates map[string]*imageState
 }
@@ -233,17 +233,6 @@ func (cache *schedulerCache) UpdateNodeInfoSnapshot(nodeSnapshot *schedulernodei
 			if _, ok := cache.nodes[name]; !ok {
 				delete(nodeSnapshot.NodeInfoMap, name)
 			}
-		}
-	}
-
-	// Take a snapshot of the nodes order in the tree
-	nodeSnapshot.NodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
-	for i := 0; i < cache.nodeTree.numNodes; i++ {
-		nodeName := cache.nodeTree.next()
-		if n := nodeSnapshot.NodeInfoMap[nodeName]; n != nil {
-			nodeSnapshot.NodeInfoList = append(nodeSnapshot.NodeInfoList, n)
-		} else {
-			klog.Errorf("node %q exist in nodeTree but not in NodeInfoMap, this should not happen.", nodeName)
 		}
 	}
 	return nil
@@ -524,7 +513,7 @@ func (cache *schedulerCache) AddNode(node *v1.Node) error {
 	}
 	cache.moveNodeInfoToHead(node.Name)
 
-	cache.nodeTree.addNode(node)
+	cache.nodeTree.AddNode(node)
 	cache.addNodeImageStates(node, n.info)
 	return n.info.SetNode(node)
 }
@@ -542,7 +531,7 @@ func (cache *schedulerCache) UpdateNode(oldNode, newNode *v1.Node) error {
 	}
 	cache.moveNodeInfoToHead(newNode.Name)
 
-	cache.nodeTree.updateNode(oldNode, newNode)
+	cache.nodeTree.UpdateNode(oldNode, newNode)
 	cache.addNodeImageStates(newNode, n.info)
 	return n.info.SetNode(newNode)
 }
@@ -568,7 +557,7 @@ func (cache *schedulerCache) RemoveNode(node *v1.Node) error {
 		cache.moveNodeInfoToHead(node.Name)
 	}
 
-	if err := cache.nodeTree.removeNode(node); err != nil {
+	if err := cache.nodeTree.RemoveNode(node); err != nil {
 		return err
 	}
 	cache.removeNodeImageStates(node)
@@ -666,6 +655,10 @@ func (cache *schedulerCache) expirePod(key string, ps *podState) error {
 	delete(cache.assumedPods, key)
 	delete(cache.podStates, key)
 	return nil
+}
+
+func (cache *schedulerCache) NodeTree() *NodeTree {
+	return cache.nodeTree
 }
 
 // GetNodeInfo returns cached data for the node name.

--- a/pkg/scheduler/internal/cache/cache_test.go
+++ b/pkg/scheduler/internal/cache/cache_test.go
@@ -1066,7 +1066,7 @@ func TestNodeOperators(t *testing.T) {
 		if !found {
 			t.Errorf("Failed to find node %v in internalcache.", node.Name)
 		}
-		if cache.nodeTree.numNodes != 1 || cache.nodeTree.next() != node.Name {
+		if cache.nodeTree.NumNodes() != 1 || cache.nodeTree.Next() != node.Name {
 			t.Errorf("cache.nodeTree is not updated correctly after adding node: %v", node.Name)
 		}
 
@@ -1109,7 +1109,7 @@ func TestNodeOperators(t *testing.T) {
 			t.Errorf("Failed to update node in schedulernodeinfo:\n got: %+v \nexpected: %+v", got, expected)
 		}
 		// Check nodeTree after update
-		if cache.nodeTree.numNodes != 1 || cache.nodeTree.next() != node.Name {
+		if cache.nodeTree.NumNodes() != 1 || cache.nodeTree.Next() != node.Name {
 			t.Errorf("unexpected cache.nodeTree after updating node: %v", node.Name)
 		}
 
@@ -1120,7 +1120,7 @@ func TestNodeOperators(t *testing.T) {
 		}
 		// Check nodeTree after remove. The node should be removed from the nodeTree even if there are
 		// still pods on it.
-		if cache.nodeTree.numNodes != 0 || cache.nodeTree.next() != "" {
+		if cache.nodeTree.NumNodes() != 0 || cache.nodeTree.Next() != "" {
 			t.Errorf("unexpected cache.nodeTree after removing node: %v", node.Name)
 		}
 	}

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -93,6 +93,9 @@ func (c *Cache) Snapshot() *internalcache.Snapshot {
 	return &internalcache.Snapshot{}
 }
 
+// NodeTree is a fake method for testing.
+func (c *Cache) NodeTree() *internalcache.NodeTree { return nil }
+
 // GetNodeInfo is a fake method for testing.
 func (c *Cache) GetNodeInfo(nodeName string) (*v1.Node, error) {
 	return nil, nil

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -106,6 +106,9 @@ type Cache interface {
 
 	// Snapshot takes a snapshot on current cache
 	Snapshot() *Snapshot
+
+	// NodeTree returns a node tree structure
+	NodeTree() *NodeTree
 }
 
 // Snapshot is a snapshot of cache state

--- a/pkg/scheduler/internal/cache/node_tree_test.go
+++ b/pkg/scheduler/internal/cache/node_tree_test.go
@@ -110,23 +110,23 @@ var allNodes = []*v1.Node{
 		},
 	}}
 
-func verifyNodeTree(t *testing.T, nt *nodeTree, expectedTree map[string]*nodeArray) {
+func verifyNodeTree(t *testing.T, nt *NodeTree, expectedTree map[string]*nodeArray) {
 	expectedNumNodes := int(0)
 	for _, na := range expectedTree {
 		expectedNumNodes += len(na.nodes)
 	}
-	if numNodes := nt.numNodes; numNodes != expectedNumNodes {
-		t.Errorf("unexpected nodeTree.numNodes. Expected: %v, Got: %v", expectedNumNodes, numNodes)
+	if numNodes := nt.NumNodes(); numNodes != expectedNumNodes {
+		t.Errorf("unexpected NodeTree.numNodes. Expected: %v, Got: %v", expectedNumNodes, numNodes)
 	}
 	if !reflect.DeepEqual(nt.tree, expectedTree) {
 		t.Errorf("The node tree is not the same as expected. Expected: %v, Got: %v", expectedTree, nt.tree)
 	}
 	if len(nt.zones) != len(expectedTree) {
-		t.Errorf("Number of zones in nodeTree.zones is not expected. Expected: %v, Got: %v", len(expectedTree), len(nt.zones))
+		t.Errorf("Number of zones in NodeTree.zones is not expected. Expected: %v, Got: %v", len(expectedTree), len(nt.zones))
 	}
 	for _, z := range nt.zones {
 		if _, ok := expectedTree[z]; !ok {
-			t.Errorf("zone %v is not expected to exist in nodeTree.zones", z)
+			t.Errorf("zone %v is not expected to exist in NodeTree.zones", z)
 		}
 	}
 }
@@ -170,7 +170,7 @@ func TestNodeTree_AddNode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			nt := newNodeTree(nil)
 			for _, n := range test.nodesToAdd {
-				nt.addNode(n)
+				nt.AddNode(n)
 			}
 			verifyNodeTree(t, nt, test.expectedTree)
 		})
@@ -227,7 +227,7 @@ func TestNodeTree_RemoveNode(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			nt := newNodeTree(test.existingNodes)
 			for _, n := range test.nodesToRemove {
-				err := nt.removeNode(n)
+				err := nt.RemoveNode(n)
 				if test.expectError == (err == nil) {
 					t.Errorf("unexpected returned error value: %v", err)
 				}
@@ -312,7 +312,7 @@ func TestNodeTree_UpdateNode(t *testing.T) {
 			if oldNode == nil {
 				oldNode = &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "nonexisting-node"}}
 			}
-			nt.updateNode(oldNode, test.nodeToUpdate)
+			nt.UpdateNode(oldNode, test.nodeToUpdate)
 			verifyNodeTree(t, nt, test.expectedTree)
 		})
 	}
@@ -357,7 +357,7 @@ func TestNodeTree_Next(t *testing.T) {
 
 			var output []string
 			for i := 0; i < test.numRuns; i++ {
-				output = append(output, nt.next())
+				output = append(output, nt.Next())
 			}
 			if !reflect.DeepEqual(output, test.expectedOutput) {
 				t.Errorf("unexpected output. Expected: %v, Got: %v", test.expectedOutput, output)
@@ -423,18 +423,18 @@ func TestNodeTreeMultiOperations(t *testing.T) {
 					if addIndex >= len(test.nodesToAdd) {
 						t.Error("more add operations than nodesToAdd")
 					} else {
-						nt.addNode(test.nodesToAdd[addIndex])
+						nt.AddNode(test.nodesToAdd[addIndex])
 						addIndex++
 					}
 				case "remove":
 					if removeIndex >= len(test.nodesToRemove) {
 						t.Error("more remove operations than nodesToRemove")
 					} else {
-						nt.removeNode(test.nodesToRemove[removeIndex])
+						nt.RemoveNode(test.nodesToRemove[removeIndex])
 						removeIndex++
 					}
 				case "next":
-					output = append(output, nt.next())
+					output = append(output, nt.Next())
 				default:
 					t.Errorf("unknow operation: %v", op)
 				}

--- a/pkg/scheduler/nodeinfo/snapshot.go
+++ b/pkg/scheduler/nodeinfo/snapshot.go
@@ -20,14 +20,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-// Snapshot is a snapshot of cache NodeInfo and NodeTree order. The scheduler takes a
-// snapshot at the beginning of each scheduling cycle and uses it for its operations in that cycle.
+// Snapshot is a snapshot of cache NodeInfo. The scheduler takes a
+// snapshot at the beginning of each scheduling cycle and uses it for its
+// operations in that cycle.
 type Snapshot struct {
-	// NodeInfoMap a map of node name to a snapshot of its NodeInfo.
 	NodeInfoMap map[string]*NodeInfo
-	// NodeInfoList is the list of nodes as ordered in the cache's nodeTree.
-	NodeInfoList []*NodeInfo
-	Generation   int64
+	Generation  int64
 }
 
 // NewSnapshot initializes a Snapshot struct and returns it.
@@ -40,7 +38,7 @@ func NewSnapshot() *Snapshot {
 // ListNodes returns the list of nodes in the snapshot.
 func (s *Snapshot) ListNodes() []*v1.Node {
 	nodes := make([]*v1.Node, 0, len(s.NodeInfoMap))
-	for _, n := range s.NodeInfoList {
+	for _, n := range s.NodeInfoMap {
 		if n != nil && n.node != nil {
 			nodes = append(nodes, n.node)
 		}


### PR DESCRIPTION
This reverts commit 63d7733e988776355306e21947c43cb2f4fb8896.

Reverting: https://github.com/kubernetes/kubernetes/pull/84014

Reason for revert:

This broke scalability tests: https://github.com/kubernetes/kubernetes/issues/84151

TL;DR; this breaks spreading of pods in large clusters.

What exactly has happened:
1, in large enough clusters, we are using the features of finding only N feasible nodes and scoring only those:
https://github.com/kubernetes/kubernetes/blob/9d173852c14f0e8efb0d67db2c38b8dcfa45b31b/pkg/scheduler/core/generic_scheduler.go#L464

2. Before this change, we were looking for nodes starting at the point where we previously stopped (because Next() was done at the level of the original tree).
3. With this change, we're always starting from 0.

So assume, you have 5k nodes, all are feasible, and numFeasible is choosing 250.
- previously, you first chose nodes [1..250], then [251..500], ... [4751..5000], [1..250], ...
- with this change, we will chose [1..250], [1..250], [1..250], ... until one of those nodes become unfeasible and we will choose something different.

With this PR, next() is called only in UpdateNodeSnapshotInfo:
https://github.com/kubernetes/kubernetes/pull/84014/files#diff-f4a894ca5e905aa5f613269fc967fe2cR206
and if the set of nodes doesn't change, we will pretty much always be generating the same set of nodes.

This kind of breaks the fact that scheduler is scheduling in the whole cluster. While it's not documented feature per-se, I think this isn't the right thing to do.

I'm going to open a revert of this PR to to fix scalability tests (or the half of them, because we seem to have two different regressions), but will wait for your explicit approval.
We can discuss how to fix that later.


```release-note
NONE
```