### PR TITLE
Automated cherry pick of #83015: Bump metrics-server version to v0.3.5 #83907: bump metrics server version o v0.3.6

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,24 +23,24 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.3.5
+  name: metrics-server-v0.3.6
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.3.5
+    version: v0.3.6
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.3.5
+      version: v0.3.6
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.3.5
+        version: v0.3.6
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.5
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.6
         command:
         - /metrics-server
         - --metric-resolution=30s
@@ -90,7 +90,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.3.5
+          - --deployment=metrics-server-v0.3.6
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -23,24 +23,24 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: metrics-server-v0.3.4
+  name: metrics-server-v0.3.5
   namespace: kube-system
   labels:
     k8s-app: metrics-server
     kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
-    version: v0.3.4
+    version: v0.3.5
 spec:
   selector:
     matchLabels:
       k8s-app: metrics-server
-      version: v0.3.4
+      version: v0.3.5
   template:
     metadata:
       name: metrics-server
       labels:
         k8s-app: metrics-server
-        version: v0.3.4
+        version: v0.3.5
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
     spec:
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: metrics-server
       containers:
       - name: metrics-server
-        image: k8s.gcr.io/metrics-server-amd64:v0.3.4
+        image: k8s.gcr.io/metrics-server-amd64:v0.3.5
         command:
         - /metrics-server
         - --metric-resolution=30s
@@ -90,7 +90,7 @@ spec:
           - --memory={{ base_metrics_server_memory }}
           - --extra-memory={{ metrics_server_memory_per_node }}Mi
           - --threshold=5
-          - --deployment=metrics-server-v0.3.4
+          - --deployment=metrics-server-v0.3.5
           - --container=metrics-server
           - --poll-period=300000
           - --estimator=exponential


### PR DESCRIPTION
Cherry pick of #83015 #83907 on release-1.16.

#83015: Bump metrics-server version to v0.3.5
#83907: bump metrics server version o v0.3.6

This cherry-pick solves following issue with metrics-server:
https://github.com/kubernetes-incubator/metrics-server/issues/316
Duplicate pod should not break metric storage, making hpa and metrics-server fail

```release-note
Bumps metrics-server version to v0.3.6 for following bugfix:
* Don't break metric storage when duplicate pod metrics encountered causing hpa to fail
```