### PR TITLE
Addon Manager: Fix bug in generate_prune_whitelist_flags

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -108,7 +108,11 @@ function log() {
 function generate_prune_whitelist_flags() {
   local -r resources=( "$@" )
   for resource in "${resources[@]}"; do
-    printf "%s" "--prune-whitelist ${resource} "
+    # Check if $resource isn't composed just of whitespaces by replacing ' '
+    # with '' and checking whether the resulting string is not empty.
+    if [[ -n "${resource// /}" ]]; then
+      printf "%s" "--prune-whitelist ${resource} "
+    fi
   done
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

It fixes a bug in addon manager related to generating prune_whitelist flags by not generating --prune_whitelist flags for empty resource variables.

The bug seems to be currently dormant but I managed to trigger it in some manual tests.
When the bug is triggered it appends empty --prune-whitelist without any value which in turn can capture the next flag and can cause addon-manager to fail.

E.g. when bug is not triggered the kubectl command looks like this

```
kubectl ... --prune-whitelist apps/v1/StatefulSet --prune-whitelist extensions/v1beta1/Ingress --recursive ...
```

When it's triggered it will be

```
kubectl ... --prune-whitelist apps/v1/StatefulSet --prune-whitelist --recursive ...
```
which will capture the --recursive flag and will make addon-manager to fail as there are no yamls in the top directory.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

