### PR TITLE
Fix base image discrepancy when building kubemark images

### DIFF
--- a/build/root/WORKSPACE
+++ b/build/root/WORKSPACE
@@ -73,11 +73,11 @@ container_repositories()
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 container_pull(
-    name = "official_busybox",
-    digest = "sha256:5e8e0509e829bb8f990249135a36e81a3ecbe94294e7a185cc14616e5fad96bd",
+    name = "debian_jessie",
+    digest = "sha256:e25703ee6ab5b2fac31510323d959cdae31eebdf48e88891c549e55b25ad7e94",
     registry = "index.docker.io",
-    repository = "library/busybox",
-    tag = "latest",  # ignored, but kept here for documentation
+    repository = "library/debian",
+    tag = "jessie",  # ignored when digest provided, but kept here for documentation.
 )
 
 load("//build:workspace.bzl", "release_dependencies")

--- a/cluster/images/kubemark/BUILD
+++ b/cluster/images/kubemark/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_image", "cont
 
 container_image(
     name = "image",
-    base = "@official_busybox//image",
+    base = "@debian_jessie//image",
     entrypoint = ["/kubemark"],
     files = ["//cmd/kubemark"],
     stamp = True,

--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM debian:jessie
+# The line below points to debian:jessie as of 2019-10-23. The SHA should be
+# kept in sycn with debian_jessie definition in the WORKSPACE file.
+FROM debian@sha256:e25703ee6ab5b2fac31510323d959cdae31eebdf48e88891c549e55b25ad7e94
 
 COPY kubemark /kubemark


### PR DESCRIPTION
There are two ways of building kubemark: 1) via Dockerfile and 2) via bazel.

In CI/CD tests we use the 1) way and use the `debian:jessie` as the base image.
But if you build kubemark via 2) (bazel) it will use the discouraged `busybox` base image.

This PR fixes that by using debian:jessie everywhere.

In addition, it pins the exact SHA of debian:jessie to make the kubemark image hermetic.

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

