### PR TITLE
Make e2eservice.CheckAffinity wait longer, to avoid flakes

### DIFF
--- a/test/e2e/framework/service/affinity_checker.go
+++ b/test/e2e/framework/service/affinity_checker.go
@@ -34,7 +34,7 @@ import (
 func CheckAffinity(execPod *v1.Pod, serviceIP string, servicePort int, shouldHold bool) bool {
 	serviceIPPort := net.JoinHostPort(serviceIP, strconv.Itoa(servicePort))
 	cmd := fmt.Sprintf(`curl -q -s --connect-timeout 2 http://%s/`, serviceIPPort)
-	timeout := TestTimeout
+	timeout := AffinityTimeout
 	if execPod == nil {
 		timeout = LoadBalancerPollTimeout
 	}

--- a/test/e2e/framework/service/const.go
+++ b/test/e2e/framework/service/const.go
@@ -72,6 +72,12 @@ const (
 	// TestTimeout is used for most polling/waiting activities
 	TestTimeout = 60 * time.Second
 
+	// AffinityTimeout is the maximum time that CheckAffinity is allowed to take; this
+	// needs to be more than long enough for AffinityConfirmCount HTTP requests to
+	// complete in a busy CI cluster, but shouldn't be too long since we will end up
+	// waiting the entire time in the tests where affinity is not expected.
+	AffinityTimeout = 2 * time.Minute
+
 	// AffinityConfirmCount is the number of needed continuous requests to confirm that
 	// affinity is enabled.
 	AffinityConfirmCount = 15


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
The session affinity tests have been flaky lately. I think it's just because the timeouts are too tight. See #83617 for some investigation.

Anyway, since we're still passing most of the time with a timeout of 1 minute, I just bumped it to 2 minutes.

**Which issue(s) this PR fixes**:
Fixes #83617

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority important-soon