### PR TITLE
Automated cherry pick of #83208: Only detecting stale connections for UDP ports in kube-proxy. #83206: Reworking kube-proxy to only compute endpointChanges on #83035: Updating EndpointSliceCache sort function to be significantly

### DIFF
--- a/pkg/proxy/endpoints.go
+++ b/pkg/proxy/endpoints.go
@@ -92,7 +92,7 @@ type EndpointChangeTracker struct {
 	items map[types.NamespacedName]*endpointsChange
 	// makeEndpointInfo allows proxier to inject customized information when processing endpoint.
 	makeEndpointInfo makeEndpointFunc
-	// endpointSliceCache holds a simplified version of endpoint slices
+	// endpointSliceCache holds a simplified version of endpoint slices.
 	endpointSliceCache *EndpointSliceCache
 	// isIPv6Mode indicates if change tracker is under IPv6/IPv4 mode. Nil means not applicable.
 	isIPv6Mode *bool
@@ -190,39 +190,54 @@ func (ect *EndpointChangeTracker) EndpointSliceUpdate(endpointSlice *discovery.E
 	ect.lock.Lock()
 	defer ect.lock.Unlock()
 
-	change, ok := ect.items[namespacedName]
-	if !ok {
-		change = &endpointsChange{}
-		change.previous = ect.endpointSliceCache.EndpointsMap(namespacedName)
-		ect.items[namespacedName] = change
+	changeNeeded := ect.endpointSliceCache.updatePending(endpointSlice, removeSlice)
+
+	if changeNeeded {
+		metrics.EndpointChangesPending.Inc()
+		if t := getLastChangeTriggerTime(endpointSlice.Annotations); !t.IsZero() {
+			ect.lastChangeTriggerTimes[namespacedName] =
+				append(ect.lastChangeTriggerTimes[namespacedName], t)
+		}
 	}
 
-	if removeSlice {
-		ect.endpointSliceCache.Delete(endpointSlice)
-	} else {
-		ect.endpointSliceCache.Update(endpointSlice)
+	return changeNeeded
+}
+
+// checkoutChanges returns a list of pending endpointsChanges and marks them as
+// applied.
+func (ect *EndpointChangeTracker) checkoutChanges() []*endpointsChange {
+	ect.lock.Lock()
+	defer ect.lock.Unlock()
+
+	metrics.EndpointChangesPending.Set(0)
+
+	if ect.endpointSliceCache != nil {
+		return ect.endpointSliceCache.checkoutChanges()
 	}
 
-	if t := getLastChangeTriggerTime(endpointSlice.Annotations); !t.IsZero() {
-		ect.lastChangeTriggerTimes[namespacedName] =
-			append(ect.lastChangeTriggerTimes[namespacedName], t)
+	changes := []*endpointsChange{}
+	for _, change := range ect.items {
+		changes = append(changes, change)
 	}
+	ect.items = make(map[types.NamespacedName]*endpointsChange)
+	return changes
+}
 
-	change.current = ect.endpointSliceCache.EndpointsMap(namespacedName)
-	// if change.previous equal to change.current, it means no change
-	if reflect.DeepEqual(change.previous, change.current) {
-		delete(ect.items, namespacedName)
-		// Reset the lastChangeTriggerTimes for this service. Given that the network programming
-		// SLI is defined as the duration between a time of an event and a time when the network was
-		// programmed to incorporate that event, if there are events that happened between two
-		// consecutive syncs and that canceled each other out, e.g. pod A added -> pod A deleted,
-		// there will be no network programming for them and thus no network programming latency metric
-		// should be exported.
-		delete(ect.lastChangeTriggerTimes, namespacedName)
+// checkoutTriggerTimes applies the locally cached trigger times to a map of
+// trigger times that have been passed in and empties the local cache.
+func (ect *EndpointChangeTracker) checkoutTriggerTimes(lastChangeTriggerTimes *map[types.NamespacedName][]time.Time) {
+	ect.lock.Lock()
+	defer ect.lock.Unlock()
+
+	for k, v := range ect.lastChangeTriggerTimes {
+		prev, ok := (*lastChangeTriggerTimes)[k]
+		if !ok {
+			(*lastChangeTriggerTimes)[k] = v
+		} else {
+			(*lastChangeTriggerTimes)[k] = append(prev, v...)
+		}
 	}
-
-	metrics.EndpointChangesPending.Set(float64(len(ect.items)))
-	return len(ect.items) > 0
+	ect.lastChangeTriggerTimes = make(map[types.NamespacedName][]time.Time)
 }
 
 // getLastChangeTriggerTime returns the time.Time value of the
@@ -351,29 +366,19 @@ func (ect *EndpointChangeTracker) endpointsToEndpointsMap(endpoints *v1.Endpoint
 // The changes map is cleared after applying them.
 // In addition it returns (via argument) and resets the lastChangeTriggerTimes for all endpoints
 // that were changed and will result in syncing the proxy rules.
-func (em EndpointsMap) apply(changes *EndpointChangeTracker, staleEndpoints *[]ServiceEndpoint,
+func (em EndpointsMap) apply(ect *EndpointChangeTracker, staleEndpoints *[]ServiceEndpoint,
 	staleServiceNames *[]ServicePortName, lastChangeTriggerTimes *map[types.NamespacedName][]time.Time) {
-	if changes == nil {
+	if ect == nil {
 		return
 	}
-	changes.lock.Lock()
-	defer changes.lock.Unlock()
-	for _, change := range changes.items {
+
+	changes := ect.checkoutChanges()
+	for _, change := range changes {
 		em.unmerge(change.previous)
 		em.merge(change.current)
 		detectStaleConnections(change.previous, change.current, staleEndpoints, staleServiceNames)
 	}
-	changes.items = make(map[types.NamespacedName]*endpointsChange)
-	metrics.EndpointChangesPending.Set(0)
-	for k, v := range changes.lastChangeTriggerTimes {
-		prev, ok := (*lastChangeTriggerTimes)[k]
-		if !ok {
-			(*lastChangeTriggerTimes)[k] = v
-		} else {
-			(*lastChangeTriggerTimes)[k] = append(prev, v...)
-		}
-	}
-	changes.lastChangeTriggerTimes = make(map[types.NamespacedName][]time.Time)
+	ect.checkoutTriggerTimes(lastChangeTriggerTimes)
 }
 
 // Merge ensures that the current EndpointsMap contains all <service, endpoints> pairs from the EndpointsMap passed in.

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -1630,27 +1630,147 @@ func TestEndpointSliceUpdate(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		for _, startingSlice := range tc.startingSlices {
-			tc.endpointChangeTracker.endpointSliceCache.Update(startingSlice)
-		}
+		t.Run(name, func(t *testing.T) {
+			initializeCache(tc.endpointChangeTracker.endpointSliceCache, tc.startingSlices)
 
-		got := tc.endpointChangeTracker.EndpointSliceUpdate(tc.paramEndpointSlice, tc.paramRemoveSlice)
-		if !reflect.DeepEqual(got, tc.expectedReturnVal) {
-			t.Errorf("[%s] EndpointSliceUpdate return value got: %v, want %v", name, got, tc.expectedReturnVal)
-		}
-		if tc.endpointChangeTracker.items == nil {
-			t.Errorf("[%s] Expected ect.items to not be nil", name)
-		}
-		if tc.expectedCurrentChange == nil {
-			if tc.endpointChangeTracker.items[tc.namespacedName] != nil {
-				t.Errorf("[%s] Expected ect.items[%s] to be nil", name, tc.namespacedName)
+			got := tc.endpointChangeTracker.EndpointSliceUpdate(tc.paramEndpointSlice, tc.paramRemoveSlice)
+			if !reflect.DeepEqual(got, tc.expectedReturnVal) {
+				t.Errorf("EndpointSliceUpdate return value got: %v, want %v", got, tc.expectedReturnVal)
 			}
-		} else {
-			if tc.endpointChangeTracker.items[tc.namespacedName] == nil {
-				t.Errorf("[%s] Expected ect.items[%s] to not be nil", name, tc.namespacedName)
+			if tc.endpointChangeTracker.items == nil {
+				t.Errorf("Expected ect.items to not be nil")
 			}
-			compareEndpointsMapsStr(t, tc.endpointChangeTracker.items[tc.namespacedName].current, tc.expectedCurrentChange)
-		}
+			changes := tc.endpointChangeTracker.checkoutChanges()
+			if tc.expectedCurrentChange == nil {
+				if len(changes) != 0 {
+					t.Errorf("Expected %s to have no changes", tc.namespacedName)
+				}
+			} else {
+				if len(changes) == 0 || changes[0] == nil {
+					t.Fatalf("Expected %s to have changes", tc.namespacedName)
+				}
+				compareEndpointsMapsStr(t, changes[0].current, tc.expectedCurrentChange)
+			}
+		})
+	}
+}
+
+func TestCheckoutChanges(t *testing.T) {
+	svcPortName0 := ServicePortName{types.NamespacedName{Namespace: "ns1", Name: "svc1"}, "port-0", v1.ProtocolTCP}
+	svcPortName1 := ServicePortName{types.NamespacedName{Namespace: "ns1", Name: "svc1"}, "port-1", v1.ProtocolTCP}
+
+	testCases := map[string]struct {
+		endpointChangeTracker *EndpointChangeTracker
+		expectedChanges       []*endpointsChange
+		useEndpointSlices     bool
+		items                 map[types.NamespacedName]*endpointsChange
+		appliedSlices         []*discovery.EndpointSlice
+		pendingSlices         []*discovery.EndpointSlice
+	}{
+		"empty slices": {
+			endpointChangeTracker: NewEndpointChangeTracker("", nil, nil, nil, true),
+			expectedChanges:       []*endpointsChange{},
+			useEndpointSlices:     true,
+			appliedSlices:         []*discovery.EndpointSlice{},
+			pendingSlices:         []*discovery.EndpointSlice{},
+		},
+		"without slices, empty items": {
+			endpointChangeTracker: NewEndpointChangeTracker("", nil, nil, nil, false),
+			expectedChanges:       []*endpointsChange{},
+			items:                 map[types.NamespacedName]*endpointsChange{},
+			useEndpointSlices:     false,
+		},
+		"without slices, simple items": {
+			endpointChangeTracker: NewEndpointChangeTracker("", nil, nil, nil, false),
+			expectedChanges: []*endpointsChange{{
+				previous: EndpointsMap{
+					svcPortName0: []Endpoint{newTestEp("10.0.1.1:80"), newTestEp("10.0.1.2:80")},
+					svcPortName1: []Endpoint{newTestEp("10.0.1.1:443"), newTestEp("10.0.1.2:443")},
+				},
+				current: EndpointsMap{
+					svcPortName0: []Endpoint{newTestEp("10.0.1.1:80"), newTestEp("10.0.1.2:80")},
+				},
+			}},
+			items: map[types.NamespacedName]*endpointsChange{
+				{Namespace: "ns1", Name: "svc1"}: {
+					previous: EndpointsMap{
+						svcPortName0: []Endpoint{newTestEp("10.0.1.1:80"), newTestEp("10.0.1.2:80")},
+						svcPortName1: []Endpoint{newTestEp("10.0.1.1:443"), newTestEp("10.0.1.2:443")},
+					},
+					current: EndpointsMap{
+						svcPortName0: []Endpoint{newTestEp("10.0.1.1:80"), newTestEp("10.0.1.2:80")},
+					},
+				},
+			},
+			useEndpointSlices: false,
+		},
+		"adding initial slice": {
+			endpointChangeTracker: NewEndpointChangeTracker("", nil, nil, nil, true),
+			expectedChanges: []*endpointsChange{{
+				previous: EndpointsMap{},
+				current: EndpointsMap{
+					svcPortName0: []Endpoint{newTestEp("10.0.1.1:80"), newTestEp("10.0.1.2:80")},
+				},
+			}},
+			useEndpointSlices: true,
+			appliedSlices:     []*discovery.EndpointSlice{},
+			pendingSlices: []*discovery.EndpointSlice{
+				generateEndpointSlice("svc1", "ns1", 1, 3, 3, []string{"host1"}, []*int32{utilpointer.Int32Ptr(80)}),
+			},
+		},
+		"removing port in update": {
+			endpointChangeTracker: NewEndpointChangeTracker("", nil, nil, nil, true),
+			expectedChanges: []*endpointsChange{{
+				previous: EndpointsMap{
+					svcPortName0: []Endpoint{newTestEp("10.0.1.1:80"), newTestEp("10.0.1.2:80")},
+					svcPortName1: []Endpoint{newTestEp("10.0.1.1:443"), newTestEp("10.0.1.2:443")},
+				},
+				current: EndpointsMap{
+					svcPortName0: []Endpoint{newTestEp("10.0.1.1:80"), newTestEp("10.0.1.2:80")},
+				},
+			}},
+			useEndpointSlices: true,
+			appliedSlices: []*discovery.EndpointSlice{
+				generateEndpointSlice("svc1", "ns1", 1, 3, 3, []string{"host1"}, []*int32{utilpointer.Int32Ptr(80), utilpointer.Int32Ptr(443)}),
+			},
+			pendingSlices: []*discovery.EndpointSlice{
+				generateEndpointSlice("svc1", "ns1", 1, 3, 3, []string{"host1"}, []*int32{utilpointer.Int32Ptr(80)}),
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			if tc.useEndpointSlices {
+				for _, slice := range tc.appliedSlices {
+					tc.endpointChangeTracker.EndpointSliceUpdate(slice, false)
+				}
+				tc.endpointChangeTracker.checkoutChanges()
+				for _, slice := range tc.pendingSlices {
+					tc.endpointChangeTracker.EndpointSliceUpdate(slice, false)
+				}
+			} else {
+				tc.endpointChangeTracker.items = tc.items
+			}
+
+			changes := tc.endpointChangeTracker.checkoutChanges()
+
+			if len(tc.expectedChanges) != len(changes) {
+				t.Fatalf("Expected %d changes, got %d", len(tc.expectedChanges), len(changes))
+			}
+
+			for i, change := range changes {
+				expectedChange := tc.expectedChanges[i]
+
+				if !reflect.DeepEqual(change.previous, expectedChange.previous) {
+					t.Errorf("[%d] Expected change.previous: %+v, got: %+v", i, expectedChange.previous, change.previous)
+				}
+
+				if !reflect.DeepEqual(change.current, expectedChange.current) {
+					t.Errorf("[%d] Expected change.current: %+v, got: %+v", i, expectedChange.current, change.current)
+				}
+			}
+		})
 	}
 }
 
@@ -1677,5 +1797,20 @@ func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap, expected map[Ser
 				}
 			}
 		}
+	}
+}
+
+func newTestEp(ep string) *BaseEndpointInfo {
+	return &BaseEndpointInfo{Endpoint: ep}
+}
+
+func initializeCache(endpointSliceCache *EndpointSliceCache, endpointSlices []*discovery.EndpointSlice) {
+	for _, endpointSlice := range endpointSlices {
+		endpointSliceCache.updatePending(endpointSlice, false)
+	}
+
+	for _, tracker := range endpointSliceCache.trackerByServiceMap {
+		tracker.applied = tracker.pending
+		tracker.pending = endpointSliceInfoByName{}
 	}
 }

--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -54,7 +54,7 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 	}, {
 		// Case[1]: unnamed port
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", ""): []Endpoint{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
@@ -62,7 +62,7 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 	}, {
 		// Case[2]: unnamed port local
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", ""): []Endpoint{
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
@@ -72,11 +72,11 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 	}, {
 		// Case[3]: named local and non-local ports for the same IP.
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 				&BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): []Endpoint{
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false},
 				&BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
@@ -87,21 +87,21 @@ func TestGetLocalEndpointIPs(t *testing.T) {
 	}, {
 		// Case[4]: named local and non-local ports for different IPs.
 		endpointsMap: EndpointsMap{
-			makeServicePortName("ns1", "ep1", "p11"): []Endpoint{
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): []Endpoint{
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true},
 				&BaseEndpointInfo{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): []Endpoint{
+			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): []Endpoint{
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true},
 				&BaseEndpointInfo{Endpoint: "4.4.4.5:44", IsLocal: false},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): []Endpoint{
+			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolTCP): []Endpoint{
 				&BaseEndpointInfo{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
@@ -160,14 +160,15 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "1.1.1.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "",
-							Port: 11,
+							Name:     "",
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", ""): {
+				makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -181,14 +182,15 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "1.1.1.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "port",
-							Port: 11,
+							Name:     "port",
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "port"): {
+				makeServicePortName("ns1", "ep1", "port", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -202,13 +204,14 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "1.1.1.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Port: 11,
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", ""): {
+				makeServicePortName("ns1", "ep1", "", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -229,21 +232,23 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "2.2.2.2",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p1",
-							Port: 11,
+							Name:     "p1",
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}, {
-							Name: "p2",
-							Port: 22,
+							Name:     "p2",
+							Port:     22,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("ns1", "ep1", "p1", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 					{Endpoint: "2.2.2.2:11", IsLocal: false},
 				},
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("ns1", "ep1", "p2", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:22", IsLocal: false},
 					{Endpoint: "2.2.2.2:22", IsLocal: false},
 				},
@@ -258,14 +263,15 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "1.1.1.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p1",
-							Port: 11,
+							Name:     "p1",
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("ns1", "ep1", "p1", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -279,14 +285,15 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "1.1.1.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p2",
-							Port: 11,
+							Name:     "p2",
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("ns1", "ep1", "p2", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
 			},
@@ -300,14 +307,15 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "1.1.1.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p1",
-							Port: 22,
+							Name:     "p1",
+							Port:     22,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("ns1", "ep1", "p1", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:22", IsLocal: false},
 				},
 			},
@@ -323,20 +331,22 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "2001:db8:85a3:0:0:8a2e:370:7334",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p1",
-							Port: 11,
+							Name:     "p1",
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}, {
-							Name: "p2",
-							Port: 22,
+							Name:     "p2",
+							Port:     22,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("ns1", "ep1", "p1", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:11", IsLocal: false},
 				},
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("ns1", "ep1", "p2", v1.ProtocolTCP): {
 					{Endpoint: "1.1.1.1:22", IsLocal: false},
 				},
 			},
@@ -353,20 +363,22 @@ func TestEndpointsToEndpointsMap(t *testing.T) {
 							IP: "2001:db8:85a3:0:0:8a2e:370:7334",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p1",
-							Port: 11,
+							Name:     "p1",
+							Port:     11,
+							Protocol: v1.ProtocolTCP,
 						}, {
-							Name: "p2",
-							Port: 22,
+							Name:     "p2",
+							Port:     22,
+							Protocol: v1.ProtocolTCP,
 						}},
 					},
 				}
 			}),
 			expected: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "ep1", "p1"): {
+				makeServicePortName("ns1", "ep1", "p1", v1.ProtocolTCP): {
 					{Endpoint: "[2001:db8:85a3:0:0:8a2e:370:7334]:11", IsLocal: false},
 				},
-				makeServicePortName("ns1", "ep1", "p2"): {
+				makeServicePortName("ns1", "ep1", "p2", v1.ProtocolTCP): {
 					{Endpoint: "[2001:db8:85a3:0:0:8a2e:370:7334]:22", IsLocal: false},
 				},
 			},
@@ -409,7 +421,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Port: 11,
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -420,7 +433,8 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Port: 11,
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -431,8 +445,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -442,8 +457,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -453,8 +469,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11-2",
-				Port: 11,
+				Name:     "p11-2",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -464,8 +481,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 22,
+				Name:     "p11",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -478,11 +496,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -492,16 +512,18 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.2",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -511,8 +533,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -520,8 +543,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -532,19 +556,22 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.3",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p13",
-				Port: 13,
+				Name:     "p13",
+				Port:     13,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -557,11 +584,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -571,11 +600,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p13",
-				Port: 13,
+				Name:     "p13",
+				Port:     13,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p14",
-				Port: 14,
+				Name:     "p14",
+				Port:     14,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -588,11 +619,13 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p21",
-				Port: 21,
+				Name:     "p21",
+				Port:     21,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p22",
-				Port: 22,
+				Name:     "p22",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -602,8 +635,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -617,8 +651,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p22",
-				Port: 22,
+				Name:     "p22",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -626,8 +661,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p23",
-				Port: 23,
+				Name:     "p23",
+				Port:     23,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -641,8 +677,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p44",
-				Port: 44,
+				Name:     "p44",
+				Port:     44,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -650,8 +687,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p45",
-				Port: 45,
+				Name:     "p45",
+				Port:     45,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -663,19 +701,22 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.11",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.2",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p122",
-				Port: 122,
+				Name:     "p122",
+				Port:     122,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -685,8 +726,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				IP: "3.3.3.3",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p33",
-				Port: 33,
+				Name:     "p33",
+				Port:     33,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -697,8 +739,9 @@ func TestUpdateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p44",
-				Port: 44,
+				Name:     "p44",
+				Port:     44,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -707,6 +750,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		// previousEndpoints and currentEndpoints are used to call appropriate
 		// handlers OnEndpoints* (based on whether corresponding values are nil
 		// or non-nil) and must be of equal length.
+		name                      string
 		previousEndpoints         []*v1.Endpoints
 		currentEndpoints          []*v1.Endpoints
 		oldEndpoints              map[ServicePortName][]*BaseEndpointInfo
@@ -715,14 +759,14 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleServiceNames map[ServicePortName]bool
 		expectedHealthchecks      map[types.NamespacedName]int
 	}{{
-		// Case[0]: nothing
+		name:                      "empty",
 		oldEndpoints:              map[ServicePortName][]*BaseEndpointInfo{},
 		expectedResult:            map[ServicePortName][]*BaseEndpointInfo{},
 		expectedStaleEndpoints:    []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
-		// Case[1]: no change, unnamed port
+		name: "no change, unnamed port",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
@@ -730,12 +774,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
@@ -743,7 +787,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
-		// Case[2]: no change, named port, local
+		name: "no change, named port, local",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
@@ -751,12 +795,12 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
@@ -766,7 +810,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeNSN("ns1", "ep1"): 1,
 		},
 	}, {
-		// Case[3]: no change, multiple subsets
+		name: "no change, multiple subsets",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
@@ -774,18 +818,18 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
@@ -793,7 +837,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
-		// Case[4]: no change, multiple subsets, multiple ports, local
+		name: "no change, multiple subsets, multiple ports, local",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
@@ -801,24 +845,24 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
@@ -828,7 +872,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeNSN("ns1", "ep1"): 1,
 		},
 	}, {
-		// Case[5]: no change, multiple endpoints, subsets, IPs, and ports
+		name: "no change, multiple endpoints, subsets, IPs, and ports",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsIPsPorts1),
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
@@ -838,53 +882,53 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("ns1", "ep1", "p14", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("ns2", "ep2", "p21", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("ns1", "ep1", "p14", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("ns2", "ep2", "p21", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
@@ -896,7 +940,7 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeNSN("ns2", "ep2"): 1,
 		},
 	}, {
-		// Case[6]: add an Endpoints
+		name: "add an Endpoints",
 		previousEndpoints: []*v1.Endpoints{
 			nil,
 		},
@@ -905,19 +949,19 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
 	}, {
-		// Case[7]: remove an Endpoints
+		name: "remove an Endpoints",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", unnamedPortLocal),
 		},
@@ -925,19 +969,19 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", ""),
+			ServicePortName: makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
-		// Case[8]: add an IP and port
+		name: "add an IP and port",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -945,29 +989,29 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
 	}, {
-		// Case[9]: remove an IP and port
+		name: "remove an IP and port",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
@@ -975,34 +1019,34 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
-		// Case[10]: add a subset
+		name: "add a subset",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -1010,27 +1054,27 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
 		},
 	}, {
-		// Case[11]: remove a subset
+		name: "remove a subset",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
@@ -1038,26 +1082,26 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
-		// Case[12]: rename a port
+		name: "rename a port",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -1065,25 +1109,25 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11-2"): {
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2"): true,
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	}, {
-		// Case[13]: renumber a port
+		name: "renumber a port",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
@@ -1091,23 +1135,23 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:22", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
 	}, {
-		// Case[14]: complex add and remove
+		name: "complex add and remove",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", complexBefore1),
 			makeTestEndpoints("ns2", "ep2", complexBefore2),
@@ -1121,68 +1165,68 @@ func TestUpdateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 				{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): {
+			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 				{Endpoint: "4.4.4.5:44", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): {
+			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP): {
 				{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.11:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p122"): {
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:122", IsLocal: false},
 			},
-			makeServicePortName("ns3", "ep3", "p33"): {
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP): {
 				{Endpoint: "3.3.3.3:33", IsLocal: false},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{{
 			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44"),
+			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45"),
+			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"):  true,
-			makeServicePortName("ns1", "ep1", "p122"): true,
-			makeServicePortName("ns3", "ep3", "p33"):  true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
 		},
 	}, {
-		// Case[15]: change from 0 endpoint address to 1 unnamed port
+		name: "change from 0 endpoint address to 1 unnamed port",
 		previousEndpoints: []*v1.Endpoints{
 			makeTestEndpoints("ns1", "ep1", emptyEndpoint),
 		},
@@ -1191,84 +1235,86 @@ func TestUpdateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[ServicePortName][]*BaseEndpointInfo{},
 		expectedResult: map[ServicePortName][]*BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []ServiceEndpoint{},
 		expectedStaleServiceNames: map[ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	},
 	}
 
 	for tci, tc := range testCases {
-		fp := newFakeProxier()
-		fp.hostname = nodeName
+		t.Run(tc.name, func(t *testing.T) {
+			fp := newFakeProxier()
+			fp.hostname = nodeName
 
-		// First check that after adding all previous versions of endpoints,
-		// the fp.oldEndpoints is as we expect.
-		for i := range tc.previousEndpoints {
-			if tc.previousEndpoints[i] != nil {
-				fp.addEndpoints(tc.previousEndpoints[i])
-			}
-		}
-		fp.endpointsMap.Update(fp.endpointsChanges)
-		compareEndpointsMaps(t, tci, fp.endpointsMap, tc.oldEndpoints)
-
-		// Now let's call appropriate handlers to get to state we want to be.
-		if len(tc.previousEndpoints) != len(tc.currentEndpoints) {
-			t.Fatalf("[%d] different lengths of previous and current endpoints", tci)
-			continue
-		}
-
-		for i := range tc.previousEndpoints {
-			prev, curr := tc.previousEndpoints[i], tc.currentEndpoints[i]
-			switch {
-			case prev == nil:
-				fp.addEndpoints(curr)
-			case curr == nil:
-				fp.deleteEndpoints(prev)
-			default:
-				fp.updateEndpoints(prev, curr)
-			}
-		}
-		result := fp.endpointsMap.Update(fp.endpointsChanges)
-		newMap := fp.endpointsMap
-		compareEndpointsMaps(t, tci, newMap, tc.expectedResult)
-		if len(result.StaleEndpoints) != len(tc.expectedStaleEndpoints) {
-			t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedStaleEndpoints), len(result.StaleEndpoints), result.StaleEndpoints)
-		}
-		for _, x := range tc.expectedStaleEndpoints {
-			found := false
-			for _, stale := range result.StaleEndpoints {
-				if stale == x {
-					found = true
-					break
+			// First check that after adding all previous versions of endpoints,
+			// the fp.oldEndpoints is as we expect.
+			for i := range tc.previousEndpoints {
+				if tc.previousEndpoints[i] != nil {
+					fp.addEndpoints(tc.previousEndpoints[i])
 				}
 			}
-			if !found {
-				t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.StaleEndpoints)
+			fp.endpointsMap.Update(fp.endpointsChanges)
+			compareEndpointsMapsStr(t, fp.endpointsMap, tc.oldEndpoints)
+
+			// Now let's call appropriate handlers to get to state we want to be.
+			if len(tc.previousEndpoints) != len(tc.currentEndpoints) {
+				t.Fatalf("[%d] different lengths of previous and current endpoints", tci)
+				return
 			}
-		}
-		if len(result.StaleServiceNames) != len(tc.expectedStaleServiceNames) {
-			t.Errorf("[%d] expected %d staleServiceNames, got %d: %v", tci, len(tc.expectedStaleServiceNames), len(result.StaleServiceNames), result.StaleServiceNames)
-		}
-		for svcName := range tc.expectedStaleServiceNames {
-			found := false
-			for _, stale := range result.StaleServiceNames {
-				if stale == svcName {
-					found = true
+
+			for i := range tc.previousEndpoints {
+				prev, curr := tc.previousEndpoints[i], tc.currentEndpoints[i]
+				switch {
+				case prev == nil:
+					fp.addEndpoints(curr)
+				case curr == nil:
+					fp.deleteEndpoints(prev)
+				default:
+					fp.updateEndpoints(prev, curr)
 				}
 			}
-			if !found {
-				t.Errorf("[%d] expected staleServiceNames[%v], but didn't find it: %v", tci, svcName, result.StaleServiceNames)
+			result := fp.endpointsMap.Update(fp.endpointsChanges)
+			newMap := fp.endpointsMap
+			compareEndpointsMapsStr(t, newMap, tc.expectedResult)
+			if len(result.StaleEndpoints) != len(tc.expectedStaleEndpoints) {
+				t.Errorf("[%d] expected %d staleEndpoints, got %d: %v", tci, len(tc.expectedStaleEndpoints), len(result.StaleEndpoints), result.StaleEndpoints)
 			}
-		}
-		if !reflect.DeepEqual(result.HCEndpointsLocalIPSize, tc.expectedHealthchecks) {
-			t.Errorf("[%d] expected healthchecks %v, got %v", tci, tc.expectedHealthchecks, result.HCEndpointsLocalIPSize)
-		}
+			for _, x := range tc.expectedStaleEndpoints {
+				found := false
+				for _, stale := range result.StaleEndpoints {
+					if stale == x {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected staleEndpoints[%v], but didn't find it: %v", tci, x, result.StaleEndpoints)
+				}
+			}
+			if len(result.StaleServiceNames) != len(tc.expectedStaleServiceNames) {
+				t.Errorf("[%d] expected %d staleServiceNames, got %d: %v", tci, len(tc.expectedStaleServiceNames), len(result.StaleServiceNames), result.StaleServiceNames)
+			}
+			for svcName := range tc.expectedStaleServiceNames {
+				found := false
+				for _, stale := range result.StaleServiceNames {
+					if stale == svcName {
+						found = true
+					}
+				}
+				if !found {
+					t.Errorf("[%d] expected staleServiceNames[%v], but didn't find it: %v", tci, svcName, result.StaleServiceNames)
+				}
+			}
+			if !reflect.DeepEqual(result.HCEndpointsLocalIPSize, tc.expectedHealthchecks) {
+				t.Errorf("[%d] expected healthchecks %v, got %v", tci, tc.expectedHealthchecks, result.HCEndpointsLocalIPSize)
+			}
+		})
 	}
 }
 
@@ -1403,12 +1449,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			paramRemoveSlice:      false,
 			expectedReturnVal:     true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80"},
 				},
-				makeServicePortName("ns1", "svc1", "port-1"): {
+				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:443"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443"},
@@ -1439,7 +1485,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			paramRemoveSlice:      false,
 			expectedReturnVal:     true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80", IsLocal: true},
@@ -1448,7 +1494,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:80", IsLocal: true},
 				},
-				makeServicePortName("ns1", "svc1", "port-1"): {
+				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443", IsLocal: true},
@@ -1471,7 +1517,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			paramRemoveSlice:      false,
 			expectedReturnVal:     true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80", IsLocal: true},
@@ -1480,7 +1526,7 @@ func TestEndpointSliceUpdate(t *testing.T) {
 					&BaseEndpointInfo{Endpoint: "10.0.2.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:80", IsLocal: true},
 				},
-				makeServicePortName("ns1", "svc1", "port-1"): {
+				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:443"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443"},
@@ -1501,11 +1547,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			paramRemoveSlice:      true,
 			expectedReturnVal:     true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.2.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:80", IsLocal: true},
 				},
-				makeServicePortName("ns1", "svc1", "port-1"): {
+				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.2.1:443"},
 					&BaseEndpointInfo{Endpoint: "10.0.2.2:443", IsLocal: true},
 				},
@@ -1547,11 +1593,11 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			paramRemoveSlice:      false,
 			expectedReturnVal:     true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
 				},
-				makeServicePortName("ns1", "svc1", "port-1"): {
+				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true},
 				},
@@ -1569,12 +1615,12 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			paramRemoveSlice:      false,
 			expectedReturnVal:     true,
 			expectedCurrentChange: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.2.1:80", IsLocal: true},
 				},
-				makeServicePortName("ns1", "svc1", "port-1"): {
+				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.2.1:443", IsLocal: true},
@@ -1603,26 +1649,21 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			if tc.endpointChangeTracker.items[tc.namespacedName] == nil {
 				t.Errorf("[%s] Expected ect.items[%s] to not be nil", name, tc.namespacedName)
 			}
-			compareEndpointsMapsStr(t, name, tc.endpointChangeTracker.items[tc.namespacedName].current, tc.expectedCurrentChange)
+			compareEndpointsMapsStr(t, tc.endpointChangeTracker.items[tc.namespacedName].current, tc.expectedCurrentChange)
 		}
 	}
 }
 
 // Test helpers
 
-func compareEndpointsMaps(t *testing.T, tci int, newMap EndpointsMap, expected map[ServicePortName][]*BaseEndpointInfo) {
-	t.Helper()
-	compareEndpointsMapsStr(t, string(tci), newMap, expected)
-}
-
-func compareEndpointsMapsStr(t *testing.T, testName string, newMap EndpointsMap, expected map[ServicePortName][]*BaseEndpointInfo) {
+func compareEndpointsMapsStr(t *testing.T, newMap EndpointsMap, expected map[ServicePortName][]*BaseEndpointInfo) {
 	t.Helper()
 	if len(newMap) != len(expected) {
-		t.Errorf("[%s] expected %d results, got %d: %v", testName, len(expected), len(newMap), newMap)
+		t.Errorf("expected %d results, got %d: %v", len(expected), len(newMap), newMap)
 	}
 	for x := range expected {
 		if len(newMap[x]) != len(expected[x]) {
-			t.Errorf("[%s] expected %d endpoints for %v, got %d", testName, len(expected[x]), x, len(newMap[x]))
+			t.Errorf("expected %d endpoints for %v, got %d", len(expected[x]), x, len(newMap[x]))
 			t.Logf("Endpoints %+v", newMap[x])
 		} else {
 			for i := range expected[x] {
@@ -1632,7 +1673,7 @@ func compareEndpointsMapsStr(t *testing.T, testName string, newMap EndpointsMap,
 					continue
 				}
 				if *newEp != *(expected[x][i]) {
-					t.Errorf("[%s] expected new[%v][%d] to be %v, got %v (IsLocal expected %v, got %v)", testName, x, i, expected[x][i], newEp, expected[x][i].IsLocal, newEp.IsLocal)
+					t.Errorf("expected new[%v][%d] to be %v, got %v (IsLocal expected %v, got %v)", x, i, expected[x][i], newEp, expected[x][i].IsLocal, newEp.IsLocal)
 				}
 			}
 		}

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -145,8 +145,11 @@ func (cache *EndpointSliceCache) endpointInfoByServicePort(serviceNN types.Names
 				continue
 			}
 
-			svcPortName := ServicePortName{NamespacedName: serviceNN}
-			svcPortName.Port = *port.Name
+			svcPortName := ServicePortName{
+				NamespacedName: serviceNN,
+				Port:           *port.Name,
+				Protocol:       *port.Protocol,
+			}
 
 			endpointInfoBySP[svcPortName] = cache.addEndpointsByIP(serviceNN, int(*port.Port), endpointInfoBySP[svcPortName], sliceInfo.Endpoints)
 		}

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -18,7 +18,10 @@ package proxy
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
+	"strings"
+	"sync"
 
 	"k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1alpha1"
@@ -31,24 +34,41 @@ import (
 
 // EndpointSliceCache is used as a cache of EndpointSlice information.
 type EndpointSliceCache struct {
-	// sliceByServiceMap is the basis of this cache. It contains endpoint slice
-	// info grouped by service name and endpoint slice name. The first key
-	// represents a namespaced service name while the second key represents
+	// lock protects trackerByServiceMap.
+	lock sync.Mutex
+
+	// trackerByServiceMap is the basis of this cache. It contains endpoint
+	// slice trackers grouped by service name and endpoint slice name. The first
+	// key represents a namespaced service name while the second key represents
 	// an endpoint slice name. Since endpoints can move between slices, we
 	// require slice specific caching to prevent endpoints being removed from
 	// the cache when they may have just moved to a different slice.
-	sliceByServiceMap map[types.NamespacedName]map[string]*endpointSliceInfo
-	makeEndpointInfo  makeEndpointFunc
-	hostname          string
-	isIPv6Mode        *bool
-	recorder          record.EventRecorder
+	trackerByServiceMap map[types.NamespacedName]*endpointSliceTracker
+
+	makeEndpointInfo makeEndpointFunc
+	hostname         string
+	isIPv6Mode       *bool
+	recorder         record.EventRecorder
 }
+
+// endpointSliceTracker keeps track of EndpointSlices as they have been applied
+// by a proxier along with any pending EndpointSlices that have been updated
+// in this cache but not yet applied by a proxier.
+type endpointSliceTracker struct {
+	applied endpointSliceInfoByName
+	pending endpointSliceInfoByName
+}
+
+// endpointSliceInfoByName groups endpointSliceInfo by the names of the
+// corresponding EndpointSlices.
+type endpointSliceInfoByName map[string]*endpointSliceInfo
 
 // endpointSliceInfo contains just the attributes kube-proxy cares about.
 // Used for caching. Intentionally small to limit memory util.
 type endpointSliceInfo struct {
 	Ports     []discovery.EndpointPort
 	Endpoints []*endpointInfo
+	Remove    bool
 }
 
 // endpointInfo contains just the attributes kube-proxy cares about.
@@ -69,12 +89,46 @@ func NewEndpointSliceCache(hostname string, isIPv6Mode *bool, recorder record.Ev
 		makeEndpointInfo = standardEndpointInfo
 	}
 	return &EndpointSliceCache{
-		sliceByServiceMap: map[types.NamespacedName]map[string]*endpointSliceInfo{},
-		hostname:          hostname,
-		isIPv6Mode:        isIPv6Mode,
-		makeEndpointInfo:  makeEndpointInfo,
-		recorder:          recorder,
+		trackerByServiceMap: map[types.NamespacedName]*endpointSliceTracker{},
+		hostname:            hostname,
+		isIPv6Mode:          isIPv6Mode,
+		makeEndpointInfo:    makeEndpointInfo,
+		recorder:            recorder,
 	}
+}
+
+// newEndpointSliceTracker initializes an endpointSliceTracker.
+func newEndpointSliceTracker() *endpointSliceTracker {
+	return &endpointSliceTracker{
+		applied: endpointSliceInfoByName{},
+		pending: endpointSliceInfoByName{},
+	}
+}
+
+// newEndpointSliceInfo generates endpointSliceInfo from an EndpointSlice.
+func newEndpointSliceInfo(endpointSlice *discovery.EndpointSlice, remove bool) *endpointSliceInfo {
+	esInfo := &endpointSliceInfo{
+		Ports:     endpointSlice.Ports,
+		Endpoints: []*endpointInfo{},
+		Remove:    remove,
+	}
+
+	sort.Sort(byPort(esInfo.Ports))
+
+	if !remove {
+		for _, endpoint := range endpointSlice.Endpoints {
+			if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready == true {
+				esInfo.Endpoints = append(esInfo.Endpoints, &endpointInfo{
+					Addresses: endpoint.Addresses,
+					Topology:  endpoint.Topology,
+				})
+			}
+		}
+
+		sort.Sort(byAddress(esInfo.Endpoints))
+	}
+
+	return esInfo
 }
 
 // standardEndpointInfo is the default makeEndpointFunc.
@@ -82,56 +136,75 @@ func standardEndpointInfo(ep *BaseEndpointInfo) Endpoint {
 	return ep
 }
 
-// Update a slice in the cache.
-func (cache *EndpointSliceCache) Update(endpointSlice *discovery.EndpointSlice) {
+// updatePending updates a pending slice in the cache.
+func (cache *EndpointSliceCache) updatePending(endpointSlice *discovery.EndpointSlice, remove bool) bool {
 	serviceKey, sliceKey, err := endpointSliceCacheKeys(endpointSlice)
 	if err != nil {
 		klog.Warningf("Error getting endpoint slice cache keys: %v", err)
-		return
+		return false
 	}
 
-	esInfo := &endpointSliceInfo{
-		Ports:     endpointSlice.Ports,
-		Endpoints: []*endpointInfo{},
+	esInfo := newEndpointSliceInfo(endpointSlice, remove)
+
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	if _, ok := cache.trackerByServiceMap[serviceKey]; !ok {
+		cache.trackerByServiceMap[serviceKey] = newEndpointSliceTracker()
 	}
-	for _, endpoint := range endpointSlice.Endpoints {
-		if endpoint.Conditions.Ready == nil || *endpoint.Conditions.Ready == true {
-			esInfo.Endpoints = append(esInfo.Endpoints, &endpointInfo{
-				Addresses: endpoint.Addresses,
-				Topology:  endpoint.Topology,
-			})
+
+	changed := cache.esInfoChanged(serviceKey, sliceKey, esInfo)
+
+	if changed {
+		cache.trackerByServiceMap[serviceKey].pending[sliceKey] = esInfo
+	}
+
+	return changed
+}
+
+// checkoutChanges returns a list of all endpointsChanges that are
+// pending and then marks them as applied.
+func (cache *EndpointSliceCache) checkoutChanges() []*endpointsChange {
+	changes := []*endpointsChange{}
+
+	cache.lock.Lock()
+	defer cache.lock.Unlock()
+
+	for serviceNN, esTracker := range cache.trackerByServiceMap {
+		if len(esTracker.pending) == 0 {
+			continue
 		}
+
+		change := &endpointsChange{}
+
+		change.previous = cache.getEndpointsMap(serviceNN, esTracker.applied)
+
+		for name, sliceInfo := range esTracker.pending {
+			if sliceInfo.Remove {
+				delete(esTracker.applied, name)
+			} else {
+				esTracker.applied[name] = sliceInfo
+			}
+
+			delete(esTracker.pending, name)
+		}
+
+		change.current = cache.getEndpointsMap(serviceNN, esTracker.applied)
+		changes = append(changes, change)
 	}
-	if _, exists := cache.sliceByServiceMap[serviceKey]; !exists {
-		cache.sliceByServiceMap[serviceKey] = map[string]*endpointSliceInfo{}
-	}
-	cache.sliceByServiceMap[serviceKey][sliceKey] = esInfo
+
+	return changes
 }
 
-// Delete a slice from the cache.
-func (cache *EndpointSliceCache) Delete(endpointSlice *discovery.EndpointSlice) {
-	serviceKey, sliceKey, err := endpointSliceCacheKeys(endpointSlice)
-	if err != nil {
-		klog.Warningf("Error getting endpoint slice cache keys: %v", err)
-		return
-	}
-	delete(cache.sliceByServiceMap[serviceKey], sliceKey)
-}
-
-// EndpointsMap computes an EndpointsMap for a given service.
-func (cache *EndpointSliceCache) EndpointsMap(serviceNN types.NamespacedName) EndpointsMap {
-	endpointInfoBySP := cache.endpointInfoByServicePort(serviceNN)
+// getEndpointsMap computes an EndpointsMap for a given set of EndpointSlices.
+func (cache *EndpointSliceCache) getEndpointsMap(serviceNN types.NamespacedName, sliceInfoByName endpointSliceInfoByName) EndpointsMap {
+	endpointInfoBySP := cache.endpointInfoByServicePort(serviceNN, sliceInfoByName)
 	return endpointsMapFromEndpointInfo(endpointInfoBySP)
 }
 
 // endpointInfoByServicePort groups endpoint info by service port name and address.
-func (cache *EndpointSliceCache) endpointInfoByServicePort(serviceNN types.NamespacedName) spToEndpointMap {
+func (cache *EndpointSliceCache) endpointInfoByServicePort(serviceNN types.NamespacedName, sliceInfoByName endpointSliceInfoByName) spToEndpointMap {
 	endpointInfoBySP := spToEndpointMap{}
-	sliceInfoByName, ok := cache.sliceByServiceMap[serviceNN]
-
-	if !ok {
-		return endpointInfoBySP
-	}
 
 	for _, sliceInfo := range sliceInfoByName {
 		for _, port := range sliceInfo.Ports {
@@ -198,6 +271,36 @@ func (cache *EndpointSliceCache) isLocal(hostname string) bool {
 	return len(cache.hostname) > 0 && hostname == cache.hostname
 }
 
+// esInfoChanged returns true if the esInfo parameter should be set as a new
+// pending value in the cache.
+func (cache *EndpointSliceCache) esInfoChanged(serviceKey types.NamespacedName, sliceKey string, esInfo *endpointSliceInfo) bool {
+	if _, ok := cache.trackerByServiceMap[serviceKey]; ok {
+		appliedInfo, appliedOk := cache.trackerByServiceMap[serviceKey].applied[sliceKey]
+		pendingInfo, pendingOk := cache.trackerByServiceMap[serviceKey].pending[sliceKey]
+
+		// If there's already a pending value, return whether or not this would
+		// change that.
+		if pendingOk {
+			return !reflect.DeepEqual(esInfo, pendingInfo)
+		}
+
+		// If there's already an applied value, return whether or not this would
+		// change that.
+		if appliedOk {
+			return !reflect.DeepEqual(esInfo, appliedInfo)
+		}
+	}
+
+	// If this is marked for removal and does not exist in the cache, no changes
+	// are necessary.
+	if esInfo.Remove {
+		return false
+	}
+
+	// If not in the cache, and not marked for removal, it should be added.
+	return true
+}
+
 // endpointsMapFromEndpointInfo computes an endpointsMap from endpointInfo that
 // has been grouped by service port and IP.
 func endpointsMapFromEndpointInfo(endpointInfoBySP map[ServicePortName]map[string]Endpoint) EndpointsMap {
@@ -242,6 +345,19 @@ func endpointSliceCacheKeys(endpointSlice *discovery.EndpointSlice) (types.Names
 	return types.NamespacedName{Namespace: endpointSlice.Namespace, Name: serviceName}, endpointSlice.Name, err
 }
 
+// byAddress helps sort endpointInfo
+type byAddress []*endpointInfo
+
+func (e byAddress) Len() int {
+	return len(e)
+}
+func (e byAddress) Swap(i, j int) {
+	e[i], e[j] = e[j], e[i]
+}
+func (e byAddress) Less(i, j int) bool {
+	return strings.Join(e[i].Addresses, ",") < strings.Join(e[j].Addresses, ",")
+}
+
 // byIP helps sort endpoints by IP
 type byIP []Endpoint
 
@@ -253,4 +369,17 @@ func (e byIP) Swap(i, j int) {
 }
 func (e byIP) Less(i, j int) bool {
 	return e[i].IP() < e[j].IP()
+}
+
+// byPort helps sort EndpointSlice ports by port number
+type byPort []discovery.EndpointPort
+
+func (p byPort) Len() int {
+	return len(p)
+}
+func (p byPort) Swap(i, j int) {
+	p[i], p[j] = p[j], p[i]
+}
+func (p byPort) Less(i, j int) bool {
+	return *p[i].Port < *p[j].Port
 }

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -368,7 +368,7 @@ func (e byIP) Swap(i, j int) {
 	e[i], e[j] = e[j], e[i]
 }
 func (e byIP) Less(i, j int) bool {
-	return e[i].IP() < e[j].IP()
+	return e[i].String() < e[j].String()
 }
 
 // byPort helps sort EndpointSlice ports by port number

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"testing"
 
+	"k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,12 +42,12 @@ func TestEndpointsMapFromESC(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(80), utilpointer.Int32Ptr(443)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: false},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80", IsLocal: false},
 				},
-				makeServicePortName("ns1", "svc1", "port-1"): {
+				makeServicePortName("ns1", "svc1", "port-1", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:443", IsLocal: false},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:443", IsLocal: true},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:443", IsLocal: false},
@@ -60,7 +61,7 @@ func TestEndpointsMapFromESC(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 2, 3, 999, []string{}, []*int32{utilpointer.Int32Ptr(80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80"},
@@ -79,7 +80,7 @@ func TestEndpointsMapFromESC(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 4, 999, []string{}, []*int32{utilpointer.Int32Ptr(80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80"},
@@ -98,7 +99,7 @@ func TestEndpointsMapFromESC(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 10, 6, []string{}, []*int32{utilpointer.Int32Ptr(80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.10:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80"},
@@ -127,7 +128,7 @@ func TestEndpointsMapFromESC(t *testing.T) {
 				generateEndpointSlice("svc1", "ns2", 3, 3, 999, []string{}, []*int32{utilpointer.Int32Ptr(80)}),
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
-				makeServicePortName("ns1", "svc1", "port-0"): {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80"},
@@ -148,13 +149,15 @@ func TestEndpointsMapFromESC(t *testing.T) {
 	}
 
 	for name, tc := range testCases {
-		esCache := NewEndpointSliceCache(tc.hostname, nil, nil, nil)
+		t.Run(name, func(t *testing.T) {
+			esCache := NewEndpointSliceCache(tc.hostname, nil, nil, nil)
 
-		for _, endpointSlice := range tc.endpointSlices {
-			esCache.Update(endpointSlice)
-		}
+			for _, endpointSlice := range tc.endpointSlices {
+				esCache.Update(endpointSlice)
+			}
 
-		compareEndpointsMapsStr(t, name, esCache.EndpointsMap(tc.namespacedName), tc.expectedMap)
+			compareEndpointsMapsStr(t, esCache.EndpointsMap(tc.namespacedName), tc.expectedMap)
+		})
 	}
 }
 
@@ -172,7 +175,7 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 				generateEndpointSlice("svc1", "ns1", 1, 3, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(80)}),
 			},
 			expectedMap: spToEndpointMap{
-				{NamespacedName: types.NamespacedName{Name: "svc1", Namespace: "ns1"}, Port: "port-0"}: {
+				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
 					"10.0.1.1": &BaseEndpointInfo{Endpoint: "10.0.1.1:80", IsLocal: false},
 					"10.0.1.2": &BaseEndpointInfo{Endpoint: "10.0.1.2:80", IsLocal: true},
 					"10.0.1.3": &BaseEndpointInfo{Endpoint: "10.0.1.3:80", IsLocal: false},
@@ -198,6 +201,8 @@ func TestEndpointInfoByServicePort(t *testing.T) {
 
 func generateEndpointSliceWithOffset(serviceName, namespace string, sliceNum, offset, numEndpoints, unreadyMod int, hosts []string, portNums []*int32) *discovery.EndpointSlice {
 	ipAddressType := discovery.AddressTypeIP
+	tcpProtocol := v1.ProtocolTCP
+
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-%d", serviceName, sliceNum),
@@ -211,8 +216,9 @@ func generateEndpointSliceWithOffset(serviceName, namespace string, sliceNum, of
 
 	for i, portNum := range portNums {
 		endpointSlice.Ports = append(endpointSlice.Ports, discovery.EndpointPort{
-			Name: utilpointer.StringPtr(fmt.Sprintf("port-%d", i)),
-			Port: portNum,
+			Name:     utilpointer.StringPtr(fmt.Sprintf("port-%d", i)),
+			Port:     portNum,
+			Protocol: &tcpProtocol,
 		})
 	}
 

--- a/pkg/proxy/endpointslicecache_test.go
+++ b/pkg/proxy/endpointslicecache_test.go
@@ -100,8 +100,8 @@ func TestEndpointsMapFromESC(t *testing.T) {
 			},
 			expectedMap: map[ServicePortName][]*BaseEndpointInfo{
 				makeServicePortName("ns1", "svc1", "port-0", v1.ProtocolTCP): {
-					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.10:80"},
+					&BaseEndpointInfo{Endpoint: "10.0.1.1:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.2:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.3:80"},
 					&BaseEndpointInfo{Endpoint: "10.0.1.4:80"},

--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -279,6 +279,7 @@ func TestDeleteEndpointConnections(t *testing.T) {
 		svc := proxy.ServicePortName{
 			NamespacedName: types.NamespacedName{Namespace: "ns1", Name: tc.svcName},
 			Port:           "p80",
+			Protocol:       tc.protocol,
 		}
 		input := []proxy.ServiceEndpoint{
 			{
@@ -627,6 +628,7 @@ func TestClusterIPEndpointsJump(t *testing.T) {
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
 	}
 
 	makeServiceMap(fp,
@@ -648,8 +650,9 @@ func TestClusterIPEndpointsJump(t *testing.T) {
 					IP: epIP,
 				}},
 				Ports: []v1.EndpointPort{{
-					Name: svcPortName.Port,
-					Port: int32(svcPort),
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: v1.ProtocolTCP,
 				}},
 			}}
 		}),
@@ -686,6 +689,7 @@ func TestLoadBalancer(t *testing.T) {
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
 	}
 
 	makeServiceMap(fp,
@@ -712,8 +716,9 @@ func TestLoadBalancer(t *testing.T) {
 					IP: epIP,
 				}},
 				Ports: []v1.EndpointPort{{
-					Name: svcPortName.Port,
-					Port: int32(svcPort),
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: v1.ProtocolTCP,
 				}},
 			}}
 		}),
@@ -745,6 +750,7 @@ func TestNodePort(t *testing.T) {
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
 	}
 
 	makeServiceMap(fp,
@@ -768,8 +774,9 @@ func TestNodePort(t *testing.T) {
 					IP: epIP,
 				}},
 				Ports: []v1.EndpointPort{{
-					Name: svcPortName.Port,
-					Port: int32(svcPort),
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: v1.ProtocolTCP,
 				}},
 			}}
 		}),
@@ -890,6 +897,7 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
 	}
 	svcSessionAffinityTimeout := int32(10800)
 
@@ -929,8 +937,9 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 					NodeName: utilpointer.StringPtr(testHostname),
 				}},
 				Ports: []v1.EndpointPort{{
-					Name: svcPortName.Port,
-					Port: int32(svcPort),
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: v1.ProtocolTCP,
 				}},
 			}}
 		}),
@@ -991,6 +1000,7 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 	svcPortName := proxy.ServicePortName{
 		NamespacedName: makeNSN("ns1", "svc1"),
 		Port:           "p80",
+		Protocol:       v1.ProtocolTCP,
 	}
 
 	makeServiceMap(fp,
@@ -1022,8 +1032,9 @@ func onlyLocalNodePorts(t *testing.T, fp *Proxier, ipt *iptablestest.FakeIPTable
 					NodeName: utilpointer.StringPtr(testHostname),
 				}},
 				Ports: []v1.EndpointPort{{
-					Name: svcPortName.Port,
-					Port: int32(svcPort),
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: v1.ProtocolTCP,
 				}},
 			}}
 		}),
@@ -1363,10 +1374,11 @@ func makeNSN(namespace, name string) types.NamespacedName {
 	return types.NamespacedName{Namespace: namespace, Name: name}
 }
 
-func makeServicePortName(ns, name, port string) proxy.ServicePortName {
+func makeServicePortName(ns, name, port string, protocol v1.Protocol) proxy.ServicePortName {
 	return proxy.ServicePortName{
 		NamespacedName: makeNSN(ns, name),
 		Port:           port,
+		Protocol:       protocol,
 	}
 }
 
@@ -1417,7 +1429,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Port: 11,
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1428,7 +1441,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Port: 11,
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1439,8 +1453,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1450,8 +1465,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1461,8 +1477,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11-2",
-				Port: 11,
+				Name:     "p11-2",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1472,8 +1489,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 22,
+				Name:     "p11",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1486,11 +1504,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1500,16 +1520,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.2",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1519,8 +1541,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -1528,8 +1551,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1540,19 +1564,22 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.3",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p13",
-				Port: 13,
+				Name:     "p13",
+				Port:     13,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1565,11 +1592,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -1579,11 +1608,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p13",
-				Port: 13,
+				Name:     "p13",
+				Port:     13,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p14",
-				Port: 14,
+				Name:     "p14",
+				Port:     14,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1596,11 +1627,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p21",
-				Port: 21,
+				Name:     "p21",
+				Port:     21,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p22",
-				Port: 22,
+				Name:     "p22",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1610,8 +1643,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1625,8 +1659,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p22",
-				Port: 22,
+				Name:     "p22",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -1634,8 +1669,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p23",
-				Port: 23,
+				Name:     "p23",
+				Port:     23,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1649,8 +1685,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p44",
-				Port: 44,
+				Name:     "p44",
+				Port:     44,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -1658,8 +1695,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p45",
-				Port: 45,
+				Name:     "p45",
+				Port:     45,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1671,19 +1709,22 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.11",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.2",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p122",
-				Port: 122,
+				Name:     "p122",
+				Port:     122,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1693,8 +1734,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "3.3.3.3",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p33",
-				Port: 33,
+				Name:     "p33",
+				Port:     33,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1705,8 +1747,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p44",
-				Port: 44,
+				Name:     "p44",
+				Port:     44,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -1738,12 +1781,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
@@ -1759,12 +1802,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
@@ -1782,18 +1825,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
@@ -1809,24 +1852,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 			},
 		},
@@ -1846,53 +1889,53 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:13", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("ns1", "ep1", "p14", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:14", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:14", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("ns2", "ep2", "p21", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:21", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:21", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:22", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:13", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:13", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("ns1", "ep1", "p14", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.3:14", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.4:14", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("ns2", "ep2", "p21", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:21", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:21", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.1:22", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true}},
 			},
@@ -1913,13 +1956,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
@@ -1933,14 +1976,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", ""),
+			ServicePortName: makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -1953,23 +1996,23 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
@@ -1983,29 +2026,29 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:11", IsLocal: true}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:12", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -2018,21 +2061,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
@@ -2046,21 +2089,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -2073,21 +2116,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11-2"): {
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2"): true,
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	}, {
@@ -2099,18 +2142,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:22", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -2129,62 +2172,62 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.2:22", IsLocal: true}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.22:22", IsLocal: true}},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): {
+			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "2.2.2.3:23", IsLocal: true}},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.5:44", IsLocal: true}},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): {
+			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.6:45", IsLocal: true}},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.11:11", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:12", IsLocal: false}},
 			},
-			makeServicePortName("ns1", "ep1", "p122"): {
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.2:122", IsLocal: false}},
 			},
-			makeServicePortName("ns3", "ep3", "p33"): {
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "3.3.3.3:33", IsLocal: false}},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "4.4.4.4:44", IsLocal: true}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44"),
+			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45"),
+			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"):  true,
-			makeServicePortName("ns1", "ep1", "p122"): true,
-			makeServicePortName("ns3", "ep3", "p33"):  true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
@@ -2199,13 +2242,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*endpointsInfo{},
 		expectedResult: map[proxy.ServicePortName][]*endpointsInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{BaseEndpointInfo: &proxy.BaseEndpointInfo{Endpoint: "1.1.1.1:11", IsLocal: false}},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	},
@@ -2285,29 +2328,6 @@ func Test_updateEndpointsMap(t *testing.T) {
 // the shared EndpointChangeTracker and EndpointSliceCache. This test ensures that the
 // iptables proxier supports translating EndpointSlices to iptables output.
 func TestEndpointSliceE2E(t *testing.T) {
-	expectedIPTablesWithoutSlice := `*filter
-:KUBE-SERVICES - [0:0]
-:KUBE-EXTERNAL-SERVICES - [0:0]
-:KUBE-FORWARD - [0:0]
--A KUBE-SERVICES -m comment --comment "ns1/svc1: has no endpoints" -m  -p  -d 172.20.1.1/32 --dport 0 -j REJECT
--A KUBE-FORWARD -m conntrack --ctstate INVALID -j DROP
--A KUBE-FORWARD -m comment --comment "kubernetes forwarding rules" -m mark --mark  -j ACCEPT
--A KUBE-FORWARD -s 10.0.0.0/24 -m comment --comment "kubernetes forwarding conntrack pod source rule" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
--A KUBE-FORWARD -m comment --comment "kubernetes forwarding conntrack pod destination rule" -d 10.0.0.0/24 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-COMMIT
-*nat
-:KUBE-SERVICES - [0:0]
-:KUBE-NODEPORTS - [0:0]
-:KUBE-POSTROUTING - [0:0]
-:KUBE-MARK-MASQ - [0:0]
-:KUBE-SVC-3WUAALNGPYZZAWAD - [0:0]
--A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -m mark --mark  -j MASQUERADE
--A KUBE-MARK-MASQ -j MARK --set-xmark 
--X KUBE-SVC-3WUAALNGPYZZAWAD
--A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
-COMMIT
-`
-
 	expectedIPTablesWithSlice := `*filter
 :KUBE-SERVICES - [0:0]
 :KUBE-EXTERNAL-SERVICES - [0:0]
@@ -2322,23 +2342,23 @@ COMMIT
 :KUBE-NODEPORTS - [0:0]
 :KUBE-POSTROUTING - [0:0]
 :KUBE-MARK-MASQ - [0:0]
-:KUBE-SVC-3WUAALNGPYZZAWAD - [0:0]
-: - [0:0]
-: - [0:0]
-: - [0:0]
+:KUBE-SVC-AHZNAGK3SCETOS2T - [0:0]
+:KUBE-SEP-PXD6POUVGD2I37UY - [0:0]
+:KUBE-SEP-SOKZUIT7SCEVIP33 - [0:0]
+:KUBE-SEP-WVE3FAB34S7NZGDJ - [0:0]
 -A KUBE-POSTROUTING -m comment --comment "kubernetes service traffic requiring SNAT" -m mark --mark  -j MASQUERADE
 -A KUBE-MARK-MASQ -j MARK --set-xmark 
--A KUBE-SERVICES -m comment --comment "ns1/svc1: cluster IP" -m  -p  -d 172.20.1.1/32 --dport 0 ! -s 10.0.0.0/24 -j KUBE-MARK-MASQ
--A KUBE-SERVICES -m comment --comment "ns1/svc1: cluster IP" -m  -p  -d 172.20.1.1/32 --dport 0 -j KUBE-SVC-3WUAALNGPYZZAWAD
--A KUBE-SVC-3WUAALNGPYZZAWAD -m statistic --mode random --probability 0.33333 -j 
--A  -s 10.0.1.1/32 -j KUBE-MARK-MASQ
--A  -m  -p  -j DNAT --to-destination 10.0.1.1:80
--A KUBE-SVC-3WUAALNGPYZZAWAD -m statistic --mode random --probability 0.50000 -j 
--A  -s 10.0.1.2/32 -j KUBE-MARK-MASQ
--A  -m  -p  -j DNAT --to-destination 10.0.1.2:80
--A KUBE-SVC-3WUAALNGPYZZAWAD -j 
--A  -s 10.0.1.3/32 -j KUBE-MARK-MASQ
--A  -m  -p  -j DNAT --to-destination 10.0.1.3:80
+-A KUBE-SERVICES -m comment --comment "ns1/svc1: cluster IP" -m tcp -p tcp -d 172.20.1.1/32 --dport 0 ! -s 10.0.0.0/24 -j KUBE-MARK-MASQ
+-A KUBE-SERVICES -m comment --comment "ns1/svc1: cluster IP" -m tcp -p tcp -d 172.20.1.1/32 --dport 0 -j KUBE-SVC-AHZNAGK3SCETOS2T
+-A KUBE-SVC-AHZNAGK3SCETOS2T -m statistic --mode random --probability 0.33333 -j KUBE-SEP-PXD6POUVGD2I37UY
+-A KUBE-SEP-PXD6POUVGD2I37UY -s 10.0.1.1/32 -j KUBE-MARK-MASQ
+-A KUBE-SEP-PXD6POUVGD2I37UY -m tcp -p tcp -j DNAT --to-destination 10.0.1.1:80
+-A KUBE-SVC-AHZNAGK3SCETOS2T -m statistic --mode random --probability 0.50000 -j KUBE-SEP-SOKZUIT7SCEVIP33
+-A KUBE-SEP-SOKZUIT7SCEVIP33 -s 10.0.1.2/32 -j KUBE-MARK-MASQ
+-A KUBE-SEP-SOKZUIT7SCEVIP33 -m tcp -p tcp -j DNAT --to-destination 10.0.1.2:80
+-A KUBE-SVC-AHZNAGK3SCETOS2T -j KUBE-SEP-WVE3FAB34S7NZGDJ
+-A KUBE-SEP-WVE3FAB34S7NZGDJ -s 10.0.1.3/32 -j KUBE-MARK-MASQ
+-A KUBE-SEP-WVE3FAB34S7NZGDJ -m tcp -p tcp -j DNAT --to-destination 10.0.1.3:80
 -A KUBE-SERVICES -m comment --comment "kubernetes service nodeports; NOTE: this must be the last rule in this chain" -m addrtype --dst-type LOCAL -j KUBE-NODEPORTS
 COMMIT
 `
@@ -2357,11 +2377,12 @@ COMMIT
 		Spec: v1.ServiceSpec{
 			ClusterIP: "172.20.1.1",
 			Selector:  map[string]string{"foo": "bar"},
-			Ports:     []v1.ServicePort{{Name: "", TargetPort: intstr.FromInt(80)}},
+			Ports:     []v1.ServicePort{{Name: "", TargetPort: intstr.FromInt(80), Protocol: v1.ProtocolTCP}},
 		},
 	})
 
 	ipAddressType := discovery.AddressTypeIP
+	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -2369,8 +2390,9 @@ COMMIT
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name: utilpointer.StringPtr(""),
-			Port: utilpointer.Int32Ptr(80),
+			Name:     utilpointer.StringPtr(""),
+			Port:     utilpointer.Int32Ptr(80),
+			Protocol: &tcpProtocol,
 		}},
 		AddressType: &ipAddressType,
 		Endpoints: []discovery.Endpoint{{
@@ -2394,7 +2416,7 @@ COMMIT
 
 	fp.OnEndpointSliceDelete(endpointSlice)
 	fp.syncProxyRules()
-	assert.Equal(t, expectedIPTablesWithoutSlice, fp.iptablesData.String())
+	assert.NotEqual(t, expectedIPTablesWithSlice, fp.iptablesData.String())
 }
 
 // TODO(thockin): add *more* tests for syncProxyRules() or break it down further and test the pieces.

--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -458,8 +458,9 @@ func TestNodePort(t *testing.T) {
 							IP: "1002:ab8::2:10",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p80",
-							Port: int32(80),
+							Name:     "p80",
+							Port:     int32(80),
+							Protocol: v1.ProtocolTCP,
 						}},
 					}}
 				}),
@@ -575,8 +576,9 @@ func TestNodePort(t *testing.T) {
 							IP: "10.180.0.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p80",
-							Port: int32(80),
+							Name:     "p80",
+							Port:     int32(80),
+							Protocol: v1.ProtocolUDP,
 						}},
 					}}
 				}),
@@ -726,8 +728,9 @@ func TestNodePort(t *testing.T) {
 							IP: "10.180.0.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p80",
-							Port: int32(80),
+							Name:     "p80",
+							Port:     int32(80),
+							Protocol: v1.ProtocolSCTP,
 						}},
 					}}
 				}),
@@ -1001,8 +1004,9 @@ func TestClusterIP(t *testing.T) {
 							IP: "10.180.0.1",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p80",
-							Port: int32(80),
+							Name:     "p80",
+							Port:     int32(80),
+							Protocol: v1.ProtocolTCP,
 						}},
 					}}
 				}),
@@ -1012,8 +1016,9 @@ func TestClusterIP(t *testing.T) {
 							IP: "1009:ab8::5:6",
 						}},
 						Ports: []v1.EndpointPort{{
-							Name: "p8080",
-							Port: int32(8080),
+							Name:     "p8080",
+							Port:     int32(8080),
+							Protocol: v1.ProtocolTCP,
 						}},
 					}}
 				}),
@@ -1386,8 +1391,9 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 						NodeName: &thisHostname,
 					}},
 					Ports: []v1.EndpointPort{{
-						Name: svcPortName.Port,
-						Port: int32(svcPort),
+						Name:     svcPortName.Port,
+						Port:     int32(svcPort),
+						Protocol: v1.ProtocolTCP,
 					}}},
 				{ // **remote** endpoint address, should not be added as RS
 					Addresses: []v1.EndpointAddress{{
@@ -1395,8 +1401,9 @@ func TestOnlyLocalNodePorts(t *testing.T) {
 						NodeName: &otherHostname,
 					}},
 					Ports: []v1.EndpointPort{{
-						Name: svcPortName.Port,
-						Port: int32(svcPort),
+						Name:     svcPortName.Port,
+						Port:     int32(svcPort),
+						Protocol: v1.ProtocolTCP,
 					}},
 				}}
 		}),
@@ -1483,8 +1490,9 @@ func TestLoadBalanceSourceRanges(t *testing.T) {
 					NodeName: nil,
 				}},
 				Ports: []v1.EndpointPort{{
-					Name: svcPortName.Port,
-					Port: int32(svcPort),
+					Name:     svcPortName.Port,
+					Port:     int32(svcPort),
+					Protocol: v1.ProtocolTCP,
 				}},
 			}}
 		}),
@@ -1651,8 +1659,9 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 						NodeName: &thisHostname,
 					}},
 					Ports: []v1.EndpointPort{{
-						Name: svcPortName.Port,
-						Port: int32(svcPort),
+						Name:     svcPortName.Port,
+						Port:     int32(svcPort),
+						Protocol: v1.ProtocolTCP,
 					}}},
 				{ // **remote** endpoint address, should not be added as RS
 					Addresses: []v1.EndpointAddress{{
@@ -1660,8 +1669,9 @@ func TestOnlyLocalLoadBalancing(t *testing.T) {
 						NodeName: &otherHostname,
 					}},
 					Ports: []v1.EndpointPort{{
-						Name: svcPortName.Port,
-						Port: int32(svcPort),
+						Name:     svcPortName.Port,
+						Port:     int32(svcPort),
+						Protocol: v1.ProtocolTCP,
 					}},
 				}}
 		}),
@@ -2030,10 +2040,11 @@ func TestSessionAffinity(t *testing.T) {
 	}
 }
 
-func makeServicePortName(ns, name, port string) proxy.ServicePortName {
+func makeServicePortName(ns, name, port string, protocol v1.Protocol) proxy.ServicePortName {
 	return proxy.ServicePortName{
 		NamespacedName: makeNSN(ns, name),
 		Port:           port,
+		Protocol:       protocol,
 	}
 }
 
@@ -2049,7 +2060,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Port: 11,
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2060,7 +2072,8 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Port: 11,
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2071,8 +2084,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2082,8 +2096,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2093,8 +2108,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11-2",
-				Port: 11,
+				Name:     "p11-2",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2104,8 +2120,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 22,
+				Name:     "p11",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2118,11 +2135,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2132,16 +2151,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.2",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2151,8 +2172,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -2160,8 +2182,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2172,19 +2195,22 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.3",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p13",
-				Port: 13,
+				Name:     "p13",
+				Port:     13,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2197,11 +2223,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -2211,11 +2239,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p13",
-				Port: 13,
+				Name:     "p13",
+				Port:     13,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p14",
-				Port: 14,
+				Name:     "p14",
+				Port:     14,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2228,11 +2258,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p21",
-				Port: 21,
+				Name:     "p21",
+				Port:     21,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p22",
-				Port: 22,
+				Name:     "p22",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2242,8 +2274,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.1",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2257,8 +2290,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p22",
-				Port: 22,
+				Name:     "p22",
+				Port:     22,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -2266,8 +2300,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p23",
-				Port: 23,
+				Name:     "p23",
+				Port:     23,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2281,8 +2316,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p44",
-				Port: 44,
+				Name:     "p44",
+				Port:     44,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
@@ -2290,8 +2326,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p45",
-				Port: 45,
+				Name:     "p45",
+				Port:     45,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2303,19 +2340,22 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "1.1.1.11",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p11",
-				Port: 11,
+				Name:     "p11",
+				Port:     11,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}, {
 			Addresses: []v1.EndpointAddress{{
 				IP: "1.1.1.2",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p12",
-				Port: 12,
+				Name:     "p12",
+				Port:     12,
+				Protocol: v1.ProtocolUDP,
 			}, {
-				Name: "p122",
-				Port: 122,
+				Name:     "p122",
+				Port:     122,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2325,8 +2365,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				IP: "3.3.3.3",
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p33",
-				Port: 33,
+				Name:     "p33",
+				Port:     33,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2337,8 +2378,9 @@ func Test_updateEndpointsMap(t *testing.T) {
 				NodeName: &nodeName,
 			}},
 			Ports: []v1.EndpointPort{{
-				Name: "p44",
-				Port: 44,
+				Name:     "p44",
+				Port:     44,
+				Protocol: v1.ProtocolUDP,
 			}},
 		}}
 	}
@@ -2370,12 +2412,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", unnamedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
@@ -2391,12 +2433,12 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
@@ -2414,18 +2456,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsets),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
@@ -2441,24 +2483,24 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsMultiplePortsLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 			},
 		},
@@ -2478,53 +2520,53 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns2", "ep2", multipleSubsetsIPsPorts2),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("ns1", "ep1", "p14", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("ns2", "ep2", "p21", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p13"): {
+			makeServicePortName("ns1", "ep1", "p13", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:13", IsLocal: false},
 				{Endpoint: "1.1.1.4:13", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p14"): {
+			makeServicePortName("ns1", "ep1", "p14", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.3:14", IsLocal: false},
 				{Endpoint: "1.1.1.4:14", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p21"): {
+			makeServicePortName("ns2", "ep2", "p21", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:21", IsLocal: false},
 				{Endpoint: "2.2.2.2:21", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.1:22", IsLocal: false},
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 			},
@@ -2545,13 +2587,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
@@ -2565,14 +2607,14 @@ func Test_updateEndpointsMap(t *testing.T) {
 			nil,
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", ""),
+			ServicePortName: makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -2585,23 +2627,23 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortsLocalNoLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
@@ -2615,29 +2657,29 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.2:11", IsLocal: true},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:12", IsLocal: false},
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "1.1.1.1:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -2650,21 +2692,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", multipleSubsetsWithLocal),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"): true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns1", "ep1"): 1,
@@ -2678,21 +2720,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPort),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.2:12",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p12"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -2705,21 +2747,21 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenamed),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11-2"): {
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p11-2"): true,
+			makeServicePortName("ns1", "ep1", "p11-2", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	}, {
@@ -2731,18 +2773,18 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns1", "ep1", namedPortRenumbered),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:22", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "1.1.1.1:11",
-			ServicePortName: makeServicePortName("ns1", "ep1", "p11"),
+			ServicePortName: makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{},
 		expectedHealthchecks:      map[types.NamespacedName]int{},
@@ -2761,62 +2803,62 @@ func Test_updateEndpointsMap(t *testing.T) {
 			makeTestEndpoints("ns4", "ep4", complexAfter4),
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
-			makeServicePortName("ns2", "ep2", "p22"): {
+			makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.2:22", IsLocal: true},
 				{Endpoint: "2.2.2.22:22", IsLocal: true},
 			},
-			makeServicePortName("ns2", "ep2", "p23"): {
+			makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP): {
 				{Endpoint: "2.2.2.3:23", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 				{Endpoint: "4.4.4.5:44", IsLocal: true},
 			},
-			makeServicePortName("ns4", "ep4", "p45"): {
+			makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP): {
 				{Endpoint: "4.4.4.6:45", IsLocal: true},
 			},
 		},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", "p11"): {
+			makeServicePortName("ns1", "ep1", "p11", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 				{Endpoint: "1.1.1.11:11", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p12"): {
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:12", IsLocal: false},
 			},
-			makeServicePortName("ns1", "ep1", "p122"): {
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.2:122", IsLocal: false},
 			},
-			makeServicePortName("ns3", "ep3", "p33"): {
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP): {
 				{Endpoint: "3.3.3.3:33", IsLocal: false},
 			},
-			makeServicePortName("ns4", "ep4", "p44"): {
+			makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP): {
 				{Endpoint: "4.4.4.4:44", IsLocal: true},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{{
 			Endpoint:        "2.2.2.2:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "2.2.2.22:22",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p22"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p22", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "2.2.2.3:23",
-			ServicePortName: makeServicePortName("ns2", "ep2", "p23"),
+			ServicePortName: makeServicePortName("ns2", "ep2", "p23", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "4.4.4.5:44",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p44"),
+			ServicePortName: makeServicePortName("ns4", "ep4", "p44", v1.ProtocolUDP),
 		}, {
 			Endpoint:        "4.4.4.6:45",
-			ServicePortName: makeServicePortName("ns4", "ep4", "p45"),
+			ServicePortName: makeServicePortName("ns4", "ep4", "p45", v1.ProtocolUDP),
 		}},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", "p12"):  true,
-			makeServicePortName("ns1", "ep1", "p122"): true,
-			makeServicePortName("ns3", "ep3", "p33"):  true,
+			makeServicePortName("ns1", "ep1", "p12", v1.ProtocolUDP):  true,
+			makeServicePortName("ns1", "ep1", "p122", v1.ProtocolUDP): true,
+			makeServicePortName("ns3", "ep3", "p33", v1.ProtocolUDP):  true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{
 			makeNSN("ns4", "ep4"): 1,
@@ -2831,13 +2873,13 @@ func Test_updateEndpointsMap(t *testing.T) {
 		},
 		oldEndpoints: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{},
 		expectedResult: map[proxy.ServicePortName][]*proxy.BaseEndpointInfo{
-			makeServicePortName("ns1", "ep1", ""): {
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): {
 				{Endpoint: "1.1.1.1:11", IsLocal: false},
 			},
 		},
 		expectedStaleEndpoints: []proxy.ServiceEndpoint{},
 		expectedStaleServiceNames: map[proxy.ServicePortName]bool{
-			makeServicePortName("ns1", "ep1", ""): true,
+			makeServicePortName("ns1", "ep1", "", v1.ProtocolUDP): true,
 		},
 		expectedHealthchecks: map[types.NamespacedName]int{},
 	},
@@ -3687,12 +3729,13 @@ func TestEndpointSliceE2E(t *testing.T) {
 		Spec: v1.ServiceSpec{
 			ClusterIP: "172.20.1.1",
 			Selector:  map[string]string{"foo": "bar"},
-			Ports:     []v1.ServicePort{{Name: "", TargetPort: intstr.FromInt(80)}},
+			Ports:     []v1.ServicePort{{Name: "", TargetPort: intstr.FromInt(80), Protocol: v1.ProtocolTCP}},
 		},
 	})
 
 	// Add initial endpoint slice
 	ipAddressType := discovery.AddressTypeIP
+	tcpProtocol := v1.ProtocolTCP
 	endpointSlice := &discovery.EndpointSlice{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s-1", serviceName),
@@ -3700,8 +3743,9 @@ func TestEndpointSliceE2E(t *testing.T) {
 			Labels:    map[string]string{discovery.LabelServiceName: serviceName},
 		},
 		Ports: []discovery.EndpointPort{{
-			Name: utilpointer.StringPtr(""),
-			Port: utilpointer.Int32Ptr(80),
+			Name:     utilpointer.StringPtr(""),
+			Port:     utilpointer.Int32Ptr(80),
+			Protocol: &tcpProtocol,
 		}},
 		AddressType: &ipAddressType,
 		Endpoints: []discovery.Endpoint{{

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -299,7 +299,7 @@ func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) Servic
 	serviceMap := make(ServiceMap)
 	for i := range service.Spec.Ports {
 		servicePort := &service.Spec.Ports[i]
-		svcPortName := ServicePortName{NamespacedName: svcName, Port: servicePort.Name}
+		svcPortName := ServicePortName{NamespacedName: svcName, Port: servicePort.Name, Protocol: servicePort.Protocol}
 		baseSvcInfo := sct.newBaseServiceInfo(servicePort, service)
 		if sct.makeServiceInfo != nil {
 			serviceMap[svcPortName] = sct.makeServiceInfo(servicePort, service, baseSvcInfo)

--- a/pkg/proxy/types.go
+++ b/pkg/proxy/types.go
@@ -43,7 +43,8 @@ type Provider interface {
 // identifier for a load-balanced service.
 type ServicePortName struct {
 	types.NamespacedName
-	Port string
+	Port     string
+	Protocol v1.Protocol
 }
 
 func (spn ServicePortName) String() string {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR is a cherry pick of 3 performance related PRs on release-1.16. This can result in a 5x performance improvement for kube-proxy, and more than 40x improvement when EndpointSlices (alpha in 1.16) are enabled. These results were presented at the most recent sig-network meeting ([presentation here](https://docs.google.com/presentation/d/1Wwqq1xpzC3l-1qxId-O5pr3X4RM3OUUTQn7af2esT1Y/edit?usp=sharing)), and given the huge performance improvements, a cherry-pick PR was recommended. 

#83208: Only detecting stale connections for UDP ports in kube-proxy.
#83206: Reworking kube-proxy to only compute endpointChanges on apply.
#83035: Updating EndpointSliceCache sort function to be significantly faster.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Does this PR introduce a user-facing change?**:
```release-note
Significant kube-proxy performance improvements. 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752

/sig network