### PR TITLE
Move TranslateIPv4ToIPv6() to e2e scheduling test

### DIFF
--- a/test/e2e/framework/networking_utils.go
+++ b/test/e2e/framework/networking_utils.go
@@ -40,7 +40,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	k8utilnet "k8s.io/utils/net"
 )
 
 const (
@@ -75,16 +74,6 @@ const (
 
 // NetexecImageName is the image name for agnhost.
 var NetexecImageName = imageutils.GetE2EImage(imageutils.Agnhost)
-
-// TranslateIPv4ToIPv6 maps an IPv4 address into a valid IPv6 address
-// adding the well known prefix "0::ffff:" https://tools.ietf.org/html/rfc2765
-// if the ip is IPv4 and the cluster IPFamily is IPv6, otherwise returns the same ip
-func TranslateIPv4ToIPv6(ip string) string {
-	if TestContext.IPFamily == "ipv6" && !k8utilnet.IsIPv6String(ip) && ip != "" {
-		ip = "0::ffff:" + ip
-	}
-	return ip
-}
 
 // NewNetworkingTestConfig creates and sets up a new test config helper.
 func NewNetworkingTestConfig(f *Framework) *NetworkingTestConfig {

--- a/test/e2e/scheduling/BUILD
+++ b/test/e2e/scheduling/BUILD
@@ -55,6 +55,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/google.golang.org/api/compute/v1:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

TranslateIPv4ToIPv6() is used at e2e scheduling test only, so this moves the function to the place.

**Special notes for your reviewer**:

I am trying to make networking_utils of e2e core framework small as possible for reducing
invalid dependency to e2elog subpackage as a part of https://github.com/kubernetes/kubernetes/issues/81427
This is a small step but stable step I believe.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
