### PR TITLE
Forbid label updates by nodes through pod/status

### DIFF
--- a/plugin/pkg/admission/noderestriction/BUILD
+++ b/plugin/pkg/admission/noderestriction/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Pod labels can no longer be updated through the pod/status updates by nodes.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/enhancements/issues/1314

**Special notes for your reviewer**:
Note that this change is NOT feature gated.

**Does this PR introduce a user-facing change?**:
```release-note
Pod labels can no longer be updated through the pod/status updates by nodes.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190916-noderestriction-pods.md
```

/sig auth
/sig node
/milestone v1.17
/priority important-longterm

/assign @liggitt @deads2k 