### PR TITLE
feat: mark node unschedulable as deprecated

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -3683,7 +3683,9 @@ type NodeSpec struct {
 	// +optional
 	ProviderID string
 
-	// Unschedulable controls node schedulability of new pods. By default node is schedulable.
+	// Deprecated. Unschedulable controls node schedulability of new pods. By default, node is schedulable.
+	// Remove field after 1.21.
+	// see: https://issues.k8s.io/69010
 	// +optional
 	Unschedulable bool
 

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -2325,8 +2325,9 @@ message NodeSpec {
   // +optional
   optional string providerID = 3;
 
-  // Unschedulable controls node schedulability of new pods. By default, node is schedulable.
-  // More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration
+  // Deprecated. Unschedulable controls node schedulability of new pods. By default, node is schedulable.
+  // Remove field after 1.21.
+  // see: https://issues.k8s.io/69010
   // +optional
   optional bool unschedulable = 4;
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -4217,8 +4217,9 @@ type NodeSpec struct {
 	// ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>
 	// +optional
 	ProviderID string `json:"providerID,omitempty" protobuf:"bytes,3,opt,name=providerID"`
-	// Unschedulable controls node schedulability of new pods. By default, node is schedulable.
-	// More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration
+	// Deprecated. Unschedulable controls node schedulability of new pods. By default, node is schedulable.
+	// Remove field after 1.21.
+	// see: https://issues.k8s.io/69010
 	// +optional
 	Unschedulable bool `json:"unschedulable,omitempty" protobuf:"varint,4,opt,name=unschedulable"`
 	// If specified, the node's taints.

--- a/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/core/v1/types_swagger_doc_generated.go
@@ -1175,7 +1175,7 @@ var map_NodeSpec = map[string]string{
 	"podCIDR":       "PodCIDR represents the pod IP range assigned to the node.",
 	"podCIDRs":      "podCIDRs represents the IP ranges assigned to the node for usage by Pods on that node. If this field is specified, the 0th entry must match the podCIDR field. It may contain at most 1 value for each of IPv4 and IPv6.",
 	"providerID":    "ID of the node assigned by the cloud provider in the format: <ProviderName>://<ProviderSpecificNodeID>",
-	"unschedulable": "Unschedulable controls node schedulability of new pods. By default, node is schedulable. More info: https://kubernetes.io/docs/concepts/nodes/node/#manual-node-administration",
+	"unschedulable": "Deprecated. Unschedulable controls node schedulability of new pods. By default, node is schedulable. Remove field after 1.21. see: https://issues.k8s.io/69010",
 	"taints":        "If specified, the node's taints.",
 	"configSource":  "If specified, the source to get node configuration from The DynamicKubeletConfig feature gate must be enabled for the Kubelet to use this field",
 	"externalID":    "Deprecated. Not all kubelets will set this field. Remove field after 1.13. see: https://issues.k8s.io/61966",


### PR DESCRIPTION
/kind cleanup
/sig node
/sig scheduling

**What this PR does / why we need it**:

TaintNodeByCondition has replaced the existing node condition. With this feature node conditions that affect the feasibility of nodes are reflected as taints on nodes. This feature is promoted to GA in https://github.com/kubernetes/kubernetes/pull/82703, we could announce the depracation of it now, and remove it after 4 releases (1.21).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref https://github.com/kubernetes/kubernetes/issues/69010

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Deprecate Node.Spec.Unschedulable, TaintNodesByCondition is used to replace this feature. The field will be removed in 1.21
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
