### PR TITLE
Feature-gate PDB informer starts

### DIFF
--- a/cmd/kube-controller-manager/app/policy.go
+++ b/cmd/kube-controller-manager/app/policy.go
@@ -21,14 +21,16 @@ limitations under the License.
 package app
 
 import (
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/scale"
-	"k8s.io/kubernetes/pkg/controller/disruption"
-
 	"net/http"
 
 	"k8s.io/klog"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/scale"
+	"k8s.io/kubernetes/pkg/controller/disruption"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 )
 
 func startDisruptionController(ctx ControllerContext) (http.Handler, bool, error) {
@@ -40,6 +42,10 @@ func startDisruptionController(ctx ControllerContext) (http.Handler, bool, error
 		klog.Infof(
 			"Refusing to start disruption because resource %q in group %q is not available.",
 			resource, group+"/"+version)
+		return nil, false, nil
+	}
+	if !utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodDisruptionBudget) {
+		klog.Infof("Refusing to start disruption because the PodDisruptionBudget feature is disabled")
 		return nil, false, nil
 	}
 

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -492,6 +492,13 @@ const (
 	//
 	// Enables the users to skip TLS verification of kubelets on pod logs requests
 	AllowInsecureBackendProxy featuregate.Feature = "AllowInsecureBackendProxy"
+
+	// owner: @mortent
+	// alpha: v1.3
+	// beta:  v1.5
+	//
+	// Enable all logic related to the PodDisruptionBudget API object in policy
+	PodDisruptionBudget featuregate.Feature = "PodDisruptionBudget"
 )
 
 func init() {
@@ -572,6 +579,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	EvenPodsSpread:                                 {Default: false, PreRelease: featuregate.Alpha},
 	StartupProbe:                                   {Default: false, PreRelease: featuregate.Alpha},
 	AllowInsecureBackendProxy:                      {Default: true, PreRelease: featuregate.Beta},
+	PodDisruptionBudget:                            {Default: true, PreRelease: featuregate.Beta},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -332,9 +332,15 @@ func (g *genericScheduler) Preempt(ctx context.Context, state *framework.CycleSt
 		// In this case, we should clean-up any existing nominated node name of the pod.
 		return nil, nil, []*v1.Pod{pod}, nil
 	}
-	pdbs, err := g.pdbLister.List(labels.Everything())
-	if err != nil {
-		return nil, nil, nil, err
+	var (
+		pdbs []*policy.PodDisruptionBudget
+		err  error
+	)
+	if g.pdbLister != nil {
+		pdbs, err = g.pdbLister.List(labels.Everything())
+		if err != nil {
+			return nil, nil, nil, err
+		}
 	}
 	nodeToVictims, err := g.selectNodesForPreemption(ctx, state, pod, potentialNodes, pdbs)
 	if err != nil {

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -232,6 +232,11 @@ func NewConfigFactory(args *ConfigFactoryArgs) *Configurator {
 		csiNodeLister = args.CSINodeInformer.Lister()
 	}
 
+	var pdbLister policylisters.PodDisruptionBudgetLister
+	if args.PdbInformer != nil {
+		pdbLister = args.PdbInformer.Lister()
+	}
+
 	c := &Configurator{
 		client:                         args.Client,
 		informerFactory:                args.InformerFactory,
@@ -241,7 +246,7 @@ func NewConfigFactory(args *ConfigFactoryArgs) *Configurator {
 		controllerLister:               args.ReplicationControllerInformer.Lister(),
 		replicaSetLister:               args.ReplicaSetInformer.Lister(),
 		statefulSetLister:              args.StatefulSetInformer.Lister(),
-		pdbLister:                      args.PdbInformer.Lister(),
+		pdbLister:                      pdbLister,
 		nodeLister:                     args.NodeInformer.Lister(),
 		podLister:                      args.PodInformer.Lister(),
 		storageClassLister:             storageClassLister,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -29,11 +29,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	coreinformers "k8s.io/client-go/informers/core/v1"
+	policyv1beta1informers "k8s.io/client-go/informers/policy/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/events"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	kubefeatures "k8s.io/kubernetes/pkg/features"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	latestschedulerapi "k8s.io/kubernetes/pkg/scheduler/api/latest"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
@@ -280,6 +283,11 @@ func New(client clientset.Interface,
 	}
 	registry.Merge(options.frameworkOutOfTreeRegistry)
 
+	var pdbInformer policyv1beta1informers.PodDisruptionBudgetInformer
+	if utilfeature.DefaultFeatureGate.Enabled(kubefeatures.PodDisruptionBudget) {
+		pdbInformer = informerFactory.Policy().V1beta1().PodDisruptionBudgets()
+	}
+
 	// Set up the configurator which can create schedulers from configs.
 	configurator := NewConfigFactory(&ConfigFactoryArgs{
 		Client:                         client,
@@ -292,7 +300,7 @@ func New(client clientset.Interface,
 		ReplicaSetInformer:             informerFactory.Apps().V1().ReplicaSets(),
 		StatefulSetInformer:            informerFactory.Apps().V1().StatefulSets(),
 		ServiceInformer:                informerFactory.Core().V1().Services(),
-		PdbInformer:                    informerFactory.Policy().V1beta1().PodDisruptionBudgets(),
+		PdbInformer:                    pdbInformer,
 		StorageClassInformer:           informerFactory.Storage().V1().StorageClasses(),
 		CSINodeInformer:                informerFactory.Storage().V1beta1().CSINodes(),
 		VolumeBinder:                   volumeBinder,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind bug

**What this PR does / why we need it**:

Ensures that informers for beta PDB APIs are not started if the related feature gates are disabled. Otherwise the beta endpoints are perpetually listed and return 404s.

Discovered while working on https://github.com/kubernetes/enhancements/pull/1332 and trying to run all components with all beta features and APIs disabled.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig scheduling
/cc @mortent 