### PR TITLE
Feature-gate RuntimeClass informer starts

### DIFF
--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -55,8 +55,6 @@ import (
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
 	mutatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/mutating"
 	validatingwebhook "k8s.io/apiserver/pkg/admission/plugin/webhook/validating"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 // AllOrderedPlugins is the list of all the plugins in order.
@@ -143,11 +141,8 @@ func DefaultOffAdmissionPlugins() sets.String {
 		storageobjectinuseprotection.PluginName, //StorageObjectInUseProtection
 		podpriority.PluginName,                  //PodPriority
 		nodetaint.PluginName,                    //TaintNodesByCondition
+		runtimeclass.PluginName,                 //RuntimeClass, gates internally on the feature
 	)
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) {
-		defaultOnPlugins.Insert(runtimeclass.PluginName) //RuntimeClass
-	}
 
 	return sets.NewString(AllOrderedPlugins...).Difference(defaultOnPlugins)
 }

--- a/plugin/pkg/admission/runtimeclass/admission.go
+++ b/plugin/pkg/admission/runtimeclass/admission.go
@@ -67,6 +67,9 @@ var _ genericadmissioninitailizer.WantsExternalKubeInformerFactory = &RuntimeCla
 
 // SetExternalKubeInformerFactory implements the WantsExternalKubeInformerFactory interface.
 func (r *RuntimeClass) SetExternalKubeInformerFactory(f informers.SharedInformerFactory) {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) {
+		return
+	}
 	runtimeClassInformer := f.Node().V1beta1().RuntimeClasses()
 	r.SetReadyFunc(runtimeClassInformer.Informer().HasSynced)
 	r.runtimeClassLister = runtimeClassInformer.Lister()
@@ -74,6 +77,9 @@ func (r *RuntimeClass) SetExternalKubeInformerFactory(f informers.SharedInformer
 
 // ValidateInitialization implements the WantsExternalKubeInformerFactory interface.
 func (r *RuntimeClass) ValidateInitialization() error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) {
+		return nil
+	}
 	if r.runtimeClassLister == nil {
 		return fmt.Errorf("missing RuntimeClass lister")
 	}
@@ -110,6 +116,10 @@ func (r *RuntimeClass) Admit(ctx context.Context, attributes admission.Attribute
 
 // Validate makes sure that pod adhere's to RuntimeClass's definition
 func (r *RuntimeClass) Validate(ctx context.Context, attributes admission.Attributes, o admission.ObjectInterfaces) error {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) {
+		return nil
+	}
+
 	// Ignore all calls to subresources or resources other than pods.
 	if shouldIgnore(attributes) {
 		return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind bug

**What this PR does / why we need it**:

Ensures that informers for beta RuntimeClass APIs are not started if the related feature gates are disabled. Otherwise the beta endpoints are perpetually listed and return 404s.

Discovered while working on https://github.com/kubernetes/enhancements/pull/1332 and trying to run all components with all beta features and APIs disabled.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig node
/cc @tallclair 