### PR TITLE
Prefer CRD v1 for internal clients

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/install.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install/install.go
@@ -29,5 +29,5 @@ func Install(scheme *runtime.Scheme) {
 	utilruntime.Must(apiextensions.AddToScheme(scheme))
 	utilruntime.Must(v1beta1.AddToScheme(scheme))
 	utilruntime.Must(v1.AddToScheme(scheme))
-	utilruntime.Must(scheme.SetVersionPriority(v1beta1.SchemeGroupVersion, v1.SchemeGroupVersion))
+	utilruntime.Must(scheme.SetVersionPriority(v1.SchemeGroupVersion, v1beta1.SchemeGroupVersion))
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind bug

**What this PR does / why we need it**:

Ensures that the internal client used by the CRD API server prefers v1 over v1beta1. Otherwise the loopback client fails if the v1beta1 CRD version is disabled.

Discovered while working on https://github.com/kubernetes/enhancements/pull/1332 and trying to run all components with all beta features and APIs disabled.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/cc @sttts 