### PR TITLE
Do not list apiextensions.k8s.io/v1beta1 in discovery when disabled

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis_test.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/apiserver/handler_apis_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/cache"
 
 	apiregistration "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -37,21 +38,35 @@ import (
 func TestAPIs(t *testing.T) {
 	tests := []struct {
 		name        string
+		enabled     sets.String
 		apiservices []*apiregistration.APIService
 		expected    *metav1.APIGroupList
 	}{
 		{
 			name:        "empty",
+			enabled:     sets.NewString("v1", "v1beta1"),
 			apiservices: []*apiregistration.APIService{},
 			expected: &metav1.APIGroupList{
 				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
 				Groups: []metav1.APIGroup{
-					discoveryGroup,
+					discoveryGroup(sets.NewString("v1", "v1beta1")),
 				},
 			},
 		},
 		{
-			name: "simple add",
+			name:        "v1 only",
+			enabled:     sets.NewString("v1"),
+			apiservices: []*apiregistration.APIService{},
+			expected: &metav1.APIGroupList{
+				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
+				Groups: []metav1.APIGroup{
+					discoveryGroup(sets.NewString("v1")),
+				},
+			},
+		},
+		{
+			name:    "simple add",
+			enabled: sets.NewString("v1", "v1beta1"),
 			apiservices: []*apiregistration.APIService{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "v1.foo"},
@@ -91,7 +106,7 @@ func TestAPIs(t *testing.T) {
 			expected: &metav1.APIGroupList{
 				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
 				Groups: []metav1.APIGroup{
-					discoveryGroup,
+					discoveryGroup(sets.NewString("v1", "v1beta1")),
 					{
 						Name: "foo",
 						Versions: []metav1.GroupVersionForDiscovery{
@@ -122,7 +137,8 @@ func TestAPIs(t *testing.T) {
 			},
 		},
 		{
-			name: "sorting",
+			name:    "sorting",
+			enabled: sets.NewString("v1", "v1beta1"),
 			apiservices: []*apiregistration.APIService{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "v1.foo"},
@@ -198,7 +214,7 @@ func TestAPIs(t *testing.T) {
 			expected: &metav1.APIGroupList{
 				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
 				Groups: []metav1.APIGroup{
-					discoveryGroup,
+					discoveryGroup(sets.NewString("v1", "v1beta1")),
 					{
 						Name: "foo",
 						Versions: []metav1.GroupVersionForDiscovery{
@@ -237,7 +253,8 @@ func TestAPIs(t *testing.T) {
 			},
 		},
 		{
-			name: "unavailable service",
+			name:    "unavailable service",
+			enabled: sets.NewString("v1", "v1beta1"),
 			apiservices: []*apiregistration.APIService{
 				{
 					ObjectMeta: metav1.ObjectMeta{Name: "v1.foo"},
@@ -260,7 +277,7 @@ func TestAPIs(t *testing.T) {
 			expected: &metav1.APIGroupList{
 				TypeMeta: metav1.TypeMeta{Kind: "APIGroupList", APIVersion: "v1"},
 				Groups: []metav1.APIGroup{
-					discoveryGroup,
+					discoveryGroup(sets.NewString("v1", "v1beta1")),
 					{
 						Name: "foo",
 						Versions: []metav1.GroupVersionForDiscovery{
@@ -282,8 +299,9 @@ func TestAPIs(t *testing.T) {
 	for _, tc := range tests {
 		indexer := cache.NewIndexer(cache.MetaNamespaceKeyFunc, cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc})
 		handler := &apisHandler{
-			codecs: aggregatorscheme.Codecs,
-			lister: listers.NewAPIServiceLister(indexer),
+			codecs:         aggregatorscheme.Codecs,
+			lister:         listers.NewAPIServiceLister(indexer),
+			discoveryGroup: discoveryGroup(tc.enabled),
 		}
 		for _, o := range tc.apiservices {
 			indexer.Add(o)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind bug

**What this PR does / why we need it**:

Ensures that discovery documents published by the kube-aggregator are correct when the v1beta1 API is disabled. The controller-manager refuses to start if a version listed at /apis is unavailable at start.

Discovered while working on https://github.com/kubernetes/enhancements/pull/1332 and trying to run all components with all beta features and APIs disabled.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/cc @deads2k 