### PR TITLE
kubeadm: remove ObjectMeta from output.BootstrapTooken

### DIFF
--- a/cmd/kubeadm/app/apis/output/fuzzer/fuzzer.go
+++ b/cmd/kubeadm/app/apis/output/fuzzer/fuzzer.go
@@ -36,7 +36,6 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 func fuzzBootstrapToken(obj *output.BootstrapToken, c fuzz.Continue) {
 	c.FuzzNoCustom(obj)
 
-	obj.ObjectMeta = metav1.ObjectMeta{}
 	obj.Token = &kubeadmapiv1beta2.BootstrapTokenString{ID: "uvxdac", Secret: "fq35fuyue3kd4gda"}
 	obj.Description = ""
 	obj.TTL = &metav1.Duration{Duration: time.Hour * 24}

--- a/cmd/kubeadm/app/apis/output/types.go
+++ b/cmd/kubeadm/app/apis/output/types.go
@@ -28,7 +28,6 @@ import (
 // metav1.TypeMeta and metav1.ObjectMeta
 type BootstrapToken struct {
 	metav1.TypeMeta
-	metav1.ObjectMeta
 
 	kubeadmapiv1beta2.BootstrapToken
 }

--- a/cmd/kubeadm/app/apis/output/v1alpha1/types.go
+++ b/cmd/kubeadm/app/apis/output/v1alpha1/types.go
@@ -27,8 +27,7 @@ import (
 // This is a copy of BoostrapToken struct from ../kubeadm/types.go with 2 additions:
 // metav1.TypeMeta and metav1.ObjectMeta
 type BootstrapToken struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:",inline"`
+	metav1.TypeMeta `json:",inline"`
 
 	kubeadmapiv1beta2.BootstrapToken
 }

--- a/cmd/kubeadm/app/apis/output/v1alpha1/zz_generated.conversion.go
+++ b/cmd/kubeadm/app/apis/output/v1alpha1/zz_generated.conversion.go
@@ -47,7 +47,6 @@ func RegisterConversions(s *runtime.Scheme) error {
 }
 
 func autoConvert_v1alpha1_BootstrapToken_To_output_BootstrapToken(in *BootstrapToken, out *output.BootstrapToken, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
 	out.BootstrapToken = in.BootstrapToken
 	return nil
 }
@@ -58,7 +57,6 @@ func Convert_v1alpha1_BootstrapToken_To_output_BootstrapToken(in *BootstrapToken
 }
 
 func autoConvert_output_BootstrapToken_To_v1alpha1_BootstrapToken(in *output.BootstrapToken, out *BootstrapToken, s conversion.Scope) error {
-	out.ObjectMeta = in.ObjectMeta
 	out.BootstrapToken = in.BootstrapToken
 	return nil
 }

--- a/cmd/kubeadm/app/apis/output/v1alpha1/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/output/v1alpha1/zz_generated.deepcopy.go
@@ -28,7 +28,6 @@ import (
 func (in *BootstrapToken) DeepCopyInto(out *BootstrapToken) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.BootstrapToken.DeepCopyInto(&out.BootstrapToken)
 	return
 }

--- a/cmd/kubeadm/app/apis/output/zz_generated.deepcopy.go
+++ b/cmd/kubeadm/app/apis/output/zz_generated.deepcopy.go
@@ -28,7 +28,6 @@ import (
 func (in *BootstrapToken) DeepCopyInto(out *BootstrapToken) {
 	*out = *in
 	out.TypeMeta = in.TypeMeta
-	in.ObjectMeta.DeepCopyInto(&out.ObjectMeta)
 	in.BootstrapToken.DeepCopyInto(&out.BootstrapToken)
 	return
 }

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -358,7 +358,6 @@ func TestTokenOutput(t *testing.T) {
 			expected: `{
     "kind": "BootstrapToken",
     "apiVersion": "output.kubeadm.k8s.io/v1alpha1",
-    "creationTimestamp": null,
     "token": "abcdef.1234567890123456",
     "description": "valid bootstrap tooken",
     "usages": [
@@ -380,7 +379,6 @@ func TestTokenOutput(t *testing.T) {
 			extraGroups:  []string{"system:bootstrappers:kubeadm:default-node-token"},
 			outputFormat: "yaml",
 			expected: `apiVersion: output.kubeadm.k8s.io/v1alpha1
-creationTimestamp: null
 description: valid bootstrap tooken
 groups:
 - system:bootstrappers:kubeadm:default-node-token


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

metav1.TypeMeta is what needed to make a runtime object.
ObjectMeta is not needed and can be safely removed.

```release-note
NONE
```
