### PR TITLE
Fix service sanity check after jig.ChangeServiceType

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -526,7 +526,7 @@ func (j *TestJig) WaitForLoadBalancerDestroy(ip string, port int, timeout time.D
 	if err != nil {
 		return nil, err
 	}
-	return j.sanityCheckService(service, v1.ServiceTypeLoadBalancer)
+	return j.sanityCheckService(service, service.Spec.Type)
 }
 
 func (j *TestJig) waitForCondition(timeout time.Duration, message string, conditionFn func(*v1.Service) bool) (*v1.Service, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Another followup to #83549 and #84188. Sigh. When changing a service from LoadBalancer to non-LoadBalancer, the code called `jig.WaitForLoadBalancerDestroy`, which was unconditionally passing `v1.ServiceTypeLoadBalancer` to `jig.sanityCheckService`, but that's incorrect in this case.

**Which issue(s) this PR fixes**:
#84107, #84149

**Special notes for your reviewer**:
I believe I've untagged all of the still-failing `[Slow]` tests so they should get run as part of e2e-gce here to make sure this is the last fix...

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority critical-urgent
/assign @wojtek-t 