### PR TITLE
Make all scheduler Node and Pod list/lookups from the snapshot 

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//pkg/scheduler/internal/queue:go_default_library",
         "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/metrics:go_default_library",
+        "//pkg/scheduler/nodeinfo/snapshot:go_default_library",
         "//pkg/scheduler/volumebinder:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",

--- a/pkg/scheduler/algorithm/predicates/metadata_test.go
+++ b/pkg/scheduler/algorithm/predicates/metadata_test.go
@@ -355,7 +355,7 @@ func TestPredicateMetadata_AddRemovePod(t *testing.T) {
 			// getMeta creates predicate meta data given the list of pods.
 			getMeta := func(lister fakelisters.PodLister) (*predicateMetadata, map[string]*schedulernodeinfo.NodeInfo) {
 				nodeInfoMap := schedulernodeinfo.CreateNodeNameToInfoMap(lister, test.nodes)
-				_, precompute := NewServiceAffinityPredicate(fakelisters.NodeLister(test.nodes), lister, fakelisters.ServiceLister(test.services), nil)
+				_, precompute := NewServiceAffinityPredicate(fakelisters.NewNodeInfoLister(test.nodes), lister, fakelisters.ServiceLister(test.services), nil)
 				RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", precompute)
 				meta := GetPredicateMetadata(test.pendingPod, nodeInfoMap)
 				return meta.(*predicateMetadata), nodeInfoMap

--- a/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -1858,7 +1858,7 @@ func TestServiceAffinity(t *testing.T) {
 				nodeInfo.SetNode(test.node)
 				nodeInfoMap := map[string]*schedulernodeinfo.NodeInfo{test.node.Name: nodeInfo}
 				// Reimplementing the logic that the scheduler implements: Any time it makes a predicate, it registers any precomputations.
-				predicate, precompute := NewServiceAffinityPredicate(fakelisters.NodeLister(nodes), fakelisters.PodLister(test.pods), fakelisters.ServiceLister(test.services), test.labels)
+				predicate, precompute := NewServiceAffinityPredicate(fakelisters.NewNodeInfoLister(nodes), fakelisters.PodLister(test.pods), fakelisters.ServiceLister(test.services), test.labels)
 				// Register a precomputation or Rewrite the precomputation to a no-op, depending on the state we want to test.
 				RegisterPredicateMetadataProducer("ServiceAffinityMetaProducer", func(pm *predicateMetadata) {
 					if !skipPrecompute {
@@ -2931,8 +2931,8 @@ func TestInterPodAffinity(t *testing.T) {
 			}
 
 			fit := PodAffinityChecker{
-				nodeLister: fakelisters.NodeLister([]*v1.Node{node}),
-				podLister:  fakelisters.PodLister(test.pods),
+				nodeInfoLister: fakelisters.NewNodeInfoLister([]*v1.Node{node}),
+				podLister:      fakelisters.PodLister(test.pods),
 			}
 			nodeInfo := schedulernodeinfo.NewNodeInfo(podsOnNode...)
 			nodeInfo.SetNode(test.node)
@@ -4044,8 +4044,8 @@ func TestInterPodAffinityWithMultipleNodes(t *testing.T) {
 
 			for indexNode, node := range test.nodes {
 				testFit := PodAffinityChecker{
-					nodeLister: fakelisters.NodeLister(test.nodes),
-					podLister:  fakelisters.PodLister(test.pods),
+					nodeInfoLister: fakelisters.NewNodeInfoLister(test.nodes),
+					podLister:      fakelisters.PodLister(test.pods),
 				}
 
 				var meta PredicateMetadata

--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -80,6 +80,7 @@ go_test(
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/listers/fake:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
+        "//pkg/scheduler/nodeinfo/snapshot:go_default_library",
         "//pkg/scheduler/testing:go_default_library",
         "//pkg/util/parsers:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",

--- a/pkg/scheduler/algorithm_factory.go
+++ b/pkg/scheduler/algorithm_factory.go
@@ -41,13 +41,13 @@ import (
 
 // PluginFactoryArgs are passed to all plugin factory functions.
 type PluginFactoryArgs struct {
+	NodeInfoLister                 schedulerlisters.NodeInfoLister
 	PodLister                      schedulerlisters.PodLister
 	ServiceLister                  corelisters.ServiceLister
 	ControllerLister               corelisters.ReplicationControllerLister
 	ReplicaSetLister               appslisters.ReplicaSetLister
 	StatefulSetLister              appslisters.StatefulSetLister
 	PDBLister                      policylisters.PodDisruptionBudgetLister
-	NodeLister                     schedulerlisters.NodeLister
 	CSINodeLister                  v1beta1storagelisters.CSINodeLister
 	PVLister                       corelisters.PersistentVolumeLister
 	PVCLister                      corelisters.PersistentVolumeClaimLister
@@ -270,7 +270,7 @@ func RegisterCustomFitPredicate(policy schedulerapi.PredicatePolicy) string {
 		if policy.Argument.ServiceAffinity != nil {
 			predicateFactory = func(args PluginFactoryArgs) predicates.FitPredicate {
 				predicate, precomputationFunction := predicates.NewServiceAffinityPredicate(
-					args.NodeLister,
+					args.NodeInfoLister,
 					args.PodLister,
 					args.ServiceLister,
 					policy.Argument.ServiceAffinity.Labels,

--- a/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
@@ -92,7 +92,7 @@ func init() {
 	scheduler.RegisterFitPredicateFactory(
 		predicates.MatchInterPodAffinityPred,
 		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
-			return predicates.NewPodAffinityPredicate(args.NodeLister, args.PodLister)
+			return predicates.NewPodAffinityPredicate(args.NodeInfoLister, args.PodLister)
 		},
 	)
 

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -70,7 +70,7 @@ func init() {
 		priorities.InterPodAffinityPriority,
 		scheduler.PriorityConfigFactory{
 			Function: func(args scheduler.PluginFactoryArgs) priorities.PriorityFunction {
-				return priorities.NewInterPodAffinityPriority(args.NodeLister, args.HardPodAffinitySymmetricWeight)
+				return priorities.NewInterPodAffinityPriority(args.NodeInfoLister, args.HardPodAffinitySymmetricWeight)
 			},
 			Weight: 1,
 		},

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1420,7 +1420,7 @@ func TestSelectNodesForPreemption(t *testing.T) {
 				nodes = append(nodes, node)
 			}
 			if test.addAffinityPredicate {
-				n := fakelisters.NodeLister([]*v1.Node{nodes[0]})
+				n := fakelisters.NewNodeInfoLister([]*v1.Node{nodes[0]})
 				p := fakelisters.PodLister(test.pods)
 				test.predicates[algorithmpredicates.MatchInterPodAffinityPred] = algorithmpredicates.NewPodAffinityPredicate(n, p)
 			}

--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//pkg/scheduler/framework/plugins/volumerestrictions:go_default_library",
         "//pkg/scheduler/framework/plugins/volumezone:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
-        "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/volumebinder:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],

--- a/pkg/scheduler/framework/plugins/default_registry.go
+++ b/pkg/scheduler/framework/plugins/default_registry.go
@@ -38,14 +38,12 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumerestrictions"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/volumezone"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
-	internalcache "k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	"k8s.io/kubernetes/pkg/scheduler/volumebinder"
 )
 
 // RegistryArgs arguments needed to create default plugin factories.
 type RegistryArgs struct {
-	SchedulerCache internalcache.Cache
-	VolumeBinder   *volumebinder.VolumeBinder
+	VolumeBinder *volumebinder.VolumeBinder
 }
 
 // NewDefaultRegistry builds a default registry with all the default plugins.
@@ -75,9 +73,7 @@ func NewDefaultRegistry(args *RegistryArgs) framework.Registry {
 		nodevolumelimits.GCEPDName:     nodevolumelimits.NewGCEPD,
 		nodevolumelimits.AzureDiskName: nodevolumelimits.NewAzureDisk,
 		nodevolumelimits.CinderName:    nodevolumelimits.NewCinder,
-		interpodaffinity.Name: func(_ *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
-			return interpodaffinity.New(args.SchedulerCache, args.SchedulerCache), nil
-		},
+		interpodaffinity.Name:          interpodaffinity.New,
 	}
 }
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/BUILD
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/BUILD
@@ -9,9 +9,9 @@ go_library(
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/framework/plugins/migration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
-        "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )
 
@@ -23,8 +23,7 @@ go_test(
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/framework/plugins/migration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
-        "//pkg/scheduler/listers/fake:go_default_library",
-        "//pkg/scheduler/nodeinfo:go_default_library",
+        "//pkg/scheduler/nodeinfo/snapshot:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/pkg/scheduler/framework/plugins/interpodaffinity/interpod_affinity.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/interpod_affinity.go
@@ -21,10 +21,10 @@ import (
 	"fmt"
 
 	"k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
-	schedulerlisters "k8s.io/kubernetes/pkg/scheduler/listers"
 	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
@@ -54,8 +54,8 @@ func (pl *InterPodAffinity) Filter(ctx context.Context, cycleState *framework.Cy
 }
 
 // New initializes a new plugin and returns it.
-func New(nodeLister schedulerlisters.NodeLister, podLister schedulerlisters.PodLister) framework.Plugin {
+func New(_ *runtime.Unknown, h framework.FrameworkHandle) (framework.Plugin, error) {
 	return &InterPodAffinity{
-		predicate: predicates.NewPodAffinityPredicate(nodeLister, podLister),
-	}
+		predicate: predicates.NewPodAffinityPredicate(h.SnapshotSharedLister().NodeInfos(), h.SnapshotSharedLister().Pods()),
+	}, nil
 }

--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/scheduler/apis/config:go_default_library",
+        "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/scheduler/nodeinfo/snapshot:go_default_library",

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/client-go/informers"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	schedulerlisters "k8s.io/kubernetes/pkg/scheduler/listers"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	nodeinfosnapshot "k8s.io/kubernetes/pkg/scheduler/nodeinfo/snapshot"
 )
@@ -452,6 +453,15 @@ type Framework interface {
 // passed to the plugin factories at the time of plugin initialization. Plugins
 // must store and use this handle to call framework functions.
 type FrameworkHandle interface {
+	// SnapshotSharedLister returns listers from the latest NodeInfo Snapshot. The snapshot
+	// is taken at the beginning of a scheduling cycle and remains unchanged until
+	// a pod finishes "Reserve" point. There is no guarantee that the information
+	// remains unchanged in the binding phase of scheduling, so plugins in the binding
+	// cycle(permit/pre-bind/bind/post-bind/un-reserve plugin) should not use it,
+	// otherwise a concurrent read/write error might occur, they should use scheduler
+	// cache instead.
+	SnapshotSharedLister() schedulerlisters.SharedLister
+
 	// NodeInfoSnapshot return the latest NodeInfo snapshot. The snapshot
 	// is taken at the beginning of a scheduling cycle and remains unchanged until
 	// a pod finishes "Reserve" point. There is no guarantee that the information

--- a/pkg/scheduler/internal/cache/cache_test.go
+++ b/pkg/scheduler/internal/cache/cache_test.go
@@ -1077,7 +1077,7 @@ func TestNodeOperators(t *testing.T) {
 		}
 
 		// Case 2: dump cached nodes successfully.
-		cachedNodes := nodeinfosnapshot.NewSnapshot()
+		cachedNodes := nodeinfosnapshot.NewEmptySnapshot()
 		cache.UpdateNodeInfoSnapshot(cachedNodes)
 		newNode, found := cachedNodes.NodeInfoMap[node.Name]
 		if !found || len(cachedNodes.NodeInfoMap) != 1 {
@@ -1333,7 +1333,7 @@ func TestSchedulerCache_UpdateNodeInfoSnapshot(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cache = newSchedulerCache(time.Second, time.Second, nil)
-			snapshot = nodeinfosnapshot.NewSnapshot()
+			snapshot = nodeinfosnapshot.NewEmptySnapshot()
 
 			for _, op := range test.operations {
 				op()
@@ -1382,7 +1382,7 @@ func BenchmarkUpdate1kNodes30kPods(b *testing.B) {
 	cache := setupCacheOf1kNodes30kPods(b)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		cachedNodes := nodeinfosnapshot.NewSnapshot()
+		cachedNodes := nodeinfosnapshot.NewEmptySnapshot()
 		cache.UpdateNodeInfoSnapshot(cachedNodes)
 	}
 }

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -102,9 +102,6 @@ type Cache interface {
 	// on this node.
 	UpdateNodeInfoSnapshot(nodeSnapshot *nodeinfosnapshot.Snapshot) error
 
-	// GetNodeInfo returns the node object with node string.
-	GetNodeInfo(nodeName string) (*v1.Node, error)
-
 	// Snapshot takes a snapshot on current cache
 	Snapshot() *Snapshot
 }

--- a/pkg/scheduler/internal/queue/BUILD
+++ b/pkg/scheduler/internal/queue/BUILD
@@ -37,6 +37,7 @@ go_test(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
+        "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/metrics:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/scheduler/nodeinfo/snapshot:go_default_library",

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -35,6 +35,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	schedulerlisters "k8s.io/kubernetes/pkg/scheduler/listers"
 	"k8s.io/kubernetes/pkg/scheduler/metrics"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	nodeinfosnapshot "k8s.io/kubernetes/pkg/scheduler/nodeinfo/snapshot"
@@ -243,6 +244,10 @@ func (*fakeFramework) ClientSet() clientset.Interface {
 }
 
 func (*fakeFramework) SharedInformerFactory() informers.SharedInformerFactory {
+	return nil
+}
+
+func (*fakeFramework) SnapshotSharedLister() schedulerlisters.SharedLister {
 	return nil
 }
 

--- a/pkg/scheduler/listers/BUILD
+++ b/pkg/scheduler/listers/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/listers",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],

--- a/pkg/scheduler/listers/fake/BUILD
+++ b/pkg/scheduler/listers/fake/BUILD
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/scheduler/listers:go_default_library",
+        "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",

--- a/pkg/scheduler/listers/listers.go
+++ b/pkg/scheduler/listers/listers.go
@@ -19,6 +19,7 @@ package listers
 import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 // PodFilter is a function to filter a pod. If pod passed return true else return false.
@@ -33,8 +34,16 @@ type PodLister interface {
 	FilteredList(podFilter PodFilter, selector labels.Selector) ([]*v1.Pod, error)
 }
 
-// NodeLister interface represents anything that can list/get node object from node name.
-type NodeLister interface {
-	// TODO(ahg-g): rename to Get and add a List interface.
-	GetNodeInfo(nodeName string) (*v1.Node, error)
+// NodeInfoLister interface represents anything that can list/get NodeInfo objects from node name.
+type NodeInfoLister interface {
+	// Returns the list of NodeInfos.
+	List() ([]*schedulernodeinfo.NodeInfo, error)
+	// Returns the NodeInfo of the given node name.
+	Get(nodeName string) (*schedulernodeinfo.NodeInfo, error)
+}
+
+// SharedLister groups scheduler-specific listers.
+type SharedLister interface {
+	Pods() PodLister
+	NodeInfos() NodeInfoLister
 }

--- a/pkg/scheduler/nodeinfo/snapshot/BUILD
+++ b/pkg/scheduler/nodeinfo/snapshot/BUILD
@@ -6,8 +6,10 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/nodeinfo/snapshot",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -277,8 +277,7 @@ func New(client clientset.Interface,
 	registry := options.frameworkDefaultRegistry
 	if registry == nil {
 		registry = frameworkplugins.NewDefaultRegistry(&frameworkplugins.RegistryArgs{
-			SchedulerCache: schedulerCache,
-			VolumeBinder:   volumeBinder,
+			VolumeBinder: volumeBinder,
 		})
 	}
 	registry.Merge(options.frameworkOutOfTreeRegistry)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature


**What this PR does / why we need it**:
Currently predicates/priorities list/lookup nodes/pods from the scheduler cache. This is not proper because the scheduler cache could change during the scheduling cycle of a pod, nodes/pods should be listed/lookedup from the nodeinfo snapshot.

Doing this allows lock free access to nodeinfo, here is an example benchmark result for interpod affinity where performance improved by 2x in some cases.

```
ahg@ahg1:~/go/src/k8s.io/kubernetes$ go test k8s.io/kubernetes/pkg/scheduler/algorithm/priorities -run=^$ -bench "BenchmarkInterPodAffinityPriority" 
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/algorithm/priorities
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_without_PodAffinity_and_existing_pods_without_PodAffinity-12               5000            263015 ns/op
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_with_PodAffinity_and_existing_pods_without_PodAffinity-12                   500           3877484 ns/op
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_without_PodAffinity_and_existing_pods_with_PodAffinity-12                   300           5311942 ns/op
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_with_PodAffinity_and_existing_pods_with_PodAffinity-12                      200           6979241 ns/op
PASS
ok      k8s.io/kubernetes/pkg/scheduler/algorithm/priorities    8.303s


ahg@ahg1:~/go/src/k8s.io/kubernetes$ git checkout ahg-shared
Switched to branch 'ahg-shared'
Your branch is up to date with 'origin/ahg-shared'.


ahg@ahg1:~/go/src/k8s.io/kubernetes$ go test k8s.io/kubernetes/pkg/scheduler/algorithm/priorities -run=^$ -bench "BenchmarkInterPodAffinityPriority" 
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/pkg/scheduler/algorithm/priorities
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_without_PodAffinity_and_existing_pods_without_PodAffinity-12               5000            257910 ns/op
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_with_PodAffinity_and_existing_pods_without_PodAffinity-12                  1000           1740313 ns/op
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_without_PodAffinity_and_existing_pods_with_PodAffinity-12                   500           3834182 ns/op
BenchmarkInterPodAffinityPriority/1000nodes/incoming_pod_with_PodAffinity_and_existing_pods_with_PodAffinity-12                      300           4923274 ns/op
PASS
ok      k8s.io/kubernetes/pkg/scheduler/algorithm/priorities    7.923s
```

**Which issue(s) this PR fixes**:
Fixes #83922

```release-note
NONE
```

