### PR TITLE
Update logic in `CPUManager` `reconcileState()`

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -192,6 +192,8 @@ func (m *manager) Start(activePods ActivePodsFunc, sourcesReady config.SourcesRe
 	if m.policy.Name() == string(PolicyNone) {
 		return
 	}
+	// Periodically call m.reconcileState() to continue to keep the CPU sets of
+	// all pods in sync with and guaranteed CPUs handed out among them.
 	go wait.Until(func() { m.reconcileState() }, m.reconcilePeriod, wait.NeverStop)
 }
 
@@ -208,19 +210,24 @@ func (m *manager) AddContainer(p *v1.Pod, c *v1.Container, containerID string) e
 			}
 		}
 	}
+
+	// Call down into the policy to assign this container CPUs if required.
 	err := m.policyAddContainer(p, c, containerID)
 	if err != nil {
 		klog.Errorf("[cpumanager] AddContainer error: %v", err)
 		m.Unlock()
 		return err
 	}
+
+	// Get the CPUs just assigned to the container (or fall back to the default
+	// CPUSet if none were assigned).
 	cpus := m.state.GetCPUSetOrDefault(string(p.UID), c.Name)
 	m.Unlock()
 
 	if !cpus.IsEmpty() {
 		err = m.updateContainerCPUSet(containerID, cpus)
 		if err != nil {
-			klog.Errorf("[cpumanager] AddContainer error: %v", err)
+			klog.Errorf("[cpumanager] AddContainer error: error updating CPUSet for container (pod: %s, container: %s, container id: %s, err: %v)", p.Name, c.Name, containerID, err)
 			m.Lock()
 			err := m.policyRemoveContainerByID(containerID)
 			if err != nil {
@@ -376,7 +383,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 
 			if cstatus.State.Waiting != nil ||
 				(cstatus.State.Waiting == nil && cstatus.State.Running == nil && cstatus.State.Terminated == nil) {
-				klog.Warningf("[cpumanager] reconcileState: skipping container; container still in the waiting state (pod: %s, container: %s)", pod.Name, container.Name)
+				klog.Warningf("[cpumanager] reconcileState: skipping container; container still in the waiting state (pod: %s, container: %s, error: %v)", pod.Name, container.Name, err)
 				failure = append(failure, reconciledContainer{pod.Name, container.Name, ""})
 				continue
 			}
@@ -398,6 +405,9 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 				continue
 			}
 
+			// Once we make it here we know we have a running container.
+			// Idempotently add it to the containerMap incase it is missing.
+			// This can happen after a kubelet restart, for example.
 			m.containerMap.Add(string(pod.UID), container.Name, containerID)
 
 			cset := m.state.GetCPUSetOrDefault(string(pod.UID), container.Name)

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -367,25 +367,38 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 				continue
 			}
 
-			// Check whether container is present in state, there may be 3 reasons why it's not present:
-			// - policy does not want to track the container
-			// - kubelet has just been restarted - and there is no previous state file
-			// - container has been removed from state by RemoveContainer call (DeletionTimestamp is set)
-			if _, ok := m.state.GetCPUSet(string(pod.UID), container.Name); !ok {
-				if pstatus.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
-					klog.V(4).Infof("[cpumanager] reconcileState: container is not present in state - trying to add (pod: %s, container: %s, container id: %s)", pod.Name, container.Name, containerID)
-					err := m.AddContainer(pod, &container, containerID)
-					if err != nil {
-						klog.Errorf("[cpumanager] reconcileState: failed to add container (pod: %s, container: %s, container id: %s, error: %v)", pod.Name, container.Name, containerID, err)
-						failure = append(failure, reconciledContainer{pod.Name, container.Name, containerID})
-						continue
-					}
-				} else {
-					// if DeletionTimestamp is set, pod has already been removed from state
-					// skip the pod/container since it's not running and will be deleted soon
-					continue
-				}
+			cstatus, err := findContainerStatusByName(&pstatus, container.Name)
+			if err != nil {
+				klog.Warningf("[cpumanager] reconcileState: skipping container; container status not found in pod status (pod: %s, container: %s, error: %v)", pod.Name, container.Name, err)
+				failure = append(failure, reconciledContainer{pod.Name, container.Name, ""})
+				continue
 			}
+
+			if cstatus.State.Waiting != nil ||
+				(cstatus.State.Waiting == nil && cstatus.State.Running == nil && cstatus.State.Terminated == nil) {
+				klog.Warningf("[cpumanager] reconcileState: skipping container; container still in the waiting state (pod: %s, container: %s)", pod.Name, container.Name)
+				failure = append(failure, reconciledContainer{pod.Name, container.Name, ""})
+				continue
+			}
+
+			if cstatus.State.Terminated != nil {
+				// Since the container is terminated, we know it is safe to
+				// remove it without any reconciliation. Removing the container
+				// will also remove it from the `containerMap` so that this
+				// container will be skipped next time around the loop.
+				_, _, err := m.containerMap.GetContainerRef(containerID)
+				if err == nil {
+					klog.Warningf("[cpumanager] reconcileState: skipping container; already terminated (pod: %s, container id: %s)", pod.Name, containerID)
+					err := m.RemoveContainer(containerID)
+					if err != nil {
+						klog.Errorf("[cpumanager] reconcileState: failed to remove container (pod: %s, container id: %s, error: %v)", pod.Name, containerID, err)
+						failure = append(failure, reconciledContainer{pod.Name, container.Name, containerID})
+					}
+				}
+				continue
+			}
+
+			m.containerMap.Add(string(pod.UID), container.Name, containerID)
 
 			cset := m.state.GetCPUSetOrDefault(string(pod.UID), container.Name)
 			if cset.IsEmpty() {
@@ -422,6 +435,15 @@ func findContainerIDByName(status *v1.PodStatus, name string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("unable to find ID for container with name %v in pod status (it may not be running)", name)
+}
+
+func findContainerStatusByName(status *v1.PodStatus, name string) (*v1.ContainerStatus, error) {
+	for _, status := range append(status.InitContainerStatuses, status.ContainerStatuses...) {
+		if status.Name == name {
+			return &status, nil
+		}
+	}
+	return nil, fmt.Errorf("unable to find status for container with name %v in pod status (it may not be running)", name)
 }
 
 func (m *manager) updateContainerCPUSet(containerID string, cpus cpuset.CPUSet) error {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -350,19 +350,19 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 
 	m.removeStaleState()
 	for _, pod := range m.activePods() {
+		pstatus, ok := m.podStatusProvider.GetPodStatus(pod.UID)
+		if !ok {
+			klog.Warningf("[cpumanager] reconcileState: skipping pod; status not found (pod: %s)", pod.Name)
+			failure = append(failure, reconciledContainer{pod.Name, "", ""})
+			continue
+		}
+
 		allContainers := pod.Spec.InitContainers
 		allContainers = append(allContainers, pod.Spec.Containers...)
-		status, ok := m.podStatusProvider.GetPodStatus(pod.UID)
 		for _, container := range allContainers {
-			if !ok {
-				klog.Warningf("[cpumanager] reconcileState: skipping pod; status not found (pod: %s)", pod.Name)
-				failure = append(failure, reconciledContainer{pod.Name, container.Name, ""})
-				break
-			}
-
-			containerID, err := findContainerIDByName(&status, container.Name)
+			containerID, err := findContainerIDByName(&pstatus, container.Name)
 			if err != nil {
-				klog.Warningf("[cpumanager] reconcileState: skipping container; ID not found in status (pod: %s, container: %s, error: %v)", pod.Name, container.Name, err)
+				klog.Warningf("[cpumanager] reconcileState: skipping container; ID not found in pod status (pod: %s, container: %s, error: %v)", pod.Name, container.Name, err)
 				failure = append(failure, reconciledContainer{pod.Name, container.Name, ""})
 				continue
 			}
@@ -372,7 +372,7 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 			// - kubelet has just been restarted - and there is no previous state file
 			// - container has been removed from state by RemoveContainer call (DeletionTimestamp is set)
 			if _, ok := m.state.GetCPUSet(string(pod.UID), container.Name); !ok {
-				if status.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
+				if pstatus.Phase == v1.PodRunning && pod.DeletionTimestamp == nil {
 					klog.V(4).Infof("[cpumanager] reconcileState: container is not present in state - trying to add (pod: %s, container: %s, container id: %s)", pod.Name, container.Name, containerID)
 					err := m.AddContainer(pod, &container, containerID)
 					if err != nil {

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -701,6 +701,9 @@ func TestReconcileState(t *testing.T) {
 					{
 						Name:        "fakeContainerName",
 						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
 					},
 				},
 			},
@@ -737,6 +740,9 @@ func TestReconcileState(t *testing.T) {
 					{
 						Name:        "fakeContainerName",
 						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
 					},
 				},
 			},
@@ -752,7 +758,7 @@ func TestReconcileState(t *testing.T) {
 			expectFailedContainerName:    "",
 		},
 		{
-			description: "cpu manager reconclie - pod status not found",
+			description: "cpu manager reconcile - pod status not found",
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -777,7 +783,7 @@ func TestReconcileState(t *testing.T) {
 			expectFailedContainerName:    "",
 		},
 		{
-			description: "cpu manager reconclie - container id not found",
+			description: "cpu manager reconcile - container state not found",
 			activePods: []*v1.Pod{
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -830,6 +836,9 @@ func TestReconcileState(t *testing.T) {
 					{
 						Name:        "fakeContainerName",
 						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
 					},
 				},
 			},
@@ -866,6 +875,9 @@ func TestReconcileState(t *testing.T) {
 					{
 						Name:        "fakeContainerName",
 						ContainerID: "docker://fakeContainerID",
+						State: v1.ContainerState{
+							Running: &v1.ContainerStateRunning{},
+						},
 					},
 				},
 			},

--- a/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager_test.go
@@ -774,7 +774,7 @@ func TestReconcileState(t *testing.T) {
 			stDefaultCPUSet:              cpuset.NewCPUSet(),
 			updateErr:                    nil,
 			expectSucceededContainerName: "",
-			expectFailedContainerName:    "fakeContainerName",
+			expectFailedContainerName:    "",
 		},
 		{
 			description: "cpu manager reconclie - container id not found",


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR cleans up the logic for `reconcileState()` in the `CPUManager`.

As background.....

The `CPUManager` maintains state about the `CPUSet` that should be associated with any given  container on a node. For containers that require a *dedicated* set of CPUs, the `CPUManager` tracks a mapping of `(containerID)->(CPUSet)`, where this `CPUSet` contains the list of dedicated CPUs that the `CPUManager` has granted to the container. For containers that do not require a dedicated set of CPUs, no explicit state is maintained by the `CPUManager` about these containers. Instead, a `DefaultCPUSet` is maintained, which contains the set of all CPUs that are not part of any `(containerID)->(CPUSet)` mapping.

Once this state has been established, the actual `CPUSet` of a container can be updated via an `Update(CPUSet)` call on the specific `ContainerRuntime` in use. As each container is added to the system, a single `ContainerRuntime.Udate(CPUSet)` call is made with the appropriate `CPUSet` for the container.

As you can imagine, however, as containers come and go in the system the `DefaultCPUSet` can change quite frequently. Whenever it does, the containers at the mercy of the `DefaultCPUSet` need to have their `CPUSet`'s updated via a new call to `ContainerRuntime.Udate(DefaultCPUSet)`. However, at present, there is no easy path to synchronously update these containers whenever the `DefaultCPUSet` changes.

Instead, a function called `reconcileState()` is run in an asynchronous loop every `reconcilePeriod` seconds in order to accomplish this task. It looks at the set of *all* active containers on the node, and calls `ContainerRuntime.Update(CPUSet)` with the appropriate `CPUSet` for it. While this doesn't guarantee that all containers have the correct `CPUSet` associated with them at all times, it does guarantee that all containers converge to the correct value every `reconcilePeriod` seconds.

Unfortunately, the logic inside `reconcileState()` has become convoluted over time. While the basic idea behind `reconcileState()` is fairly straightforward, edge cases were found that caused the basic flow to diverge from its original intended purpose.

For example, there is currently a path inside `reconcileState()` that makes a call out to `AddContainer()` if an active container is found that has no `CPUSet` associated with it. Presumably, this was added to cover the case where `reconcileState()` began to execute asynchronous to the container in question actually being created. Since `AddContainer()` was designed to be idempotent, whoever got to the call first (either `reconcileState()` or the container creation path itself) would do the `AddContainer()` and everything could continue forward as expected

As we know, however, any containers that don't have dedicated CPUs, also don't have a `CPUSet` associated with them. This means that this `AddContainer()` call is erroneously being called on *all* containers that don't have any dedicated CPUs associated with them. This is OK because of the idempotency of the `AddContainer()` call, but it convolutes the logic significantly.

One of the reasons that this `AddContainer()` call is necessary inside `reconcileState()` is because there is currently no way "skip" a container that is not ready for further processing yet. All logic to decide if a container should be known by the `CPUManager` is gleaned from looking at the existence of the container in the `PodStatus` (regardless of that container's specific state).

This PR attempts to clean this up and make the logic inside `reconcileState()` a bit more sane. It does this through a combination of the `containerMap` introduced in https://github.com/kubernetes/kubernetes/pull/84196 and moving to a model that looks at the specific state of a given container inside the `PodStatus` rather than just looking for the existence of the container in the `PodStatus`.

The `containerMap` makes it so we know for sure whether the container has completed an `AddContainer()` call and should have its state reconciled. We should simply skip it if it has not. 

Using the state of the container let's us decide what to do, depending on whether it is currently `waiting`, `running`, or `terminated`.  When `waiting` we skip with a warning. When `terminated` we skip without warning and remove it so that it is never attempted again in the future. Only when `running` do we continue on to attempt a reconciliation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```