### PR TITLE
Restrict visibility of prometheus packages

### DIFF
--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -91,6 +91,13 @@ if [[ $ret != 0 && $ret != 3 ]]; then
   exit 1
 fi
 
+# restrict ./vendor/github.com/prometheus/* targets visibility
+# see comment above re: buildozer exit codes
+buildozer -quiet 'set visibility //staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list' '//vendor/github.com/prometheus/...:go_default_library' && ret=$? || ret=$?
+if [[ $ret != 0 && $ret != 3 ]]; then
+  exit 1
+fi
+
 # we need to set this because gazelle doesn't support pkg-config, which would set this link option
 # see comment above re: buildozer exit codes
 buildozer -quiet 'set clinkopts select({"@io_bazel_rules_go//go/platform:linux":["-lseccomp",],"//conditions:default":[],})' //vendor/github.com/seccomp/libseccomp-golang:go_default_library && ret=$? || ret=$?

--- a/staging/src/k8s.io/component-base/metrics/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/BUILD
@@ -81,3 +81,29 @@ filegroup(
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )
+
+# Packages allowed to import github.com/prometheus
+package_group(
+    name = "prometheus_import_allow_list",
+    packages = [
+        "//cluster/images/etcd-version-monitor",
+        "//pkg/controller/endpointslice",
+        "//pkg/controller/volume/attachdetach/metrics",
+        "//pkg/controller/volume/persistentvolume/metrics",
+        "//pkg/kubelet/metrics/collectors",
+        "//pkg/kubelet/pleg",
+        "//pkg/kubelet/pluginmanager/metrics",
+        "//pkg/kubelet/server",
+        "//pkg/kubelet/server/stats",
+        "//pkg/kubelet/volumemanager/metrics",
+        "//pkg/master",
+        "//pkg/scheduler/framework/v1alpha1",
+        "//pkg/volume/util/operationexecutor",
+        "//staging/src/k8s.io/apiserver/pkg/admission/metrics",
+        "//staging/src/k8s.io/component-base/metrics/...",
+        "//test/e2e",
+        "//test/e2e/storage",
+        "//test/e2e_node",
+        "//vendor/...",
+    ],
+)

--- a/vendor/github.com/prometheus/client_golang/prometheus/BUILD
+++ b/vendor/github.com/prometheus/client_golang/prometheus/BUILD
@@ -30,7 +30,7 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus",
     importpath = "github.com/prometheus/client_golang/prometheus",
-    visibility = ["//visibility:public"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
     deps = [
         "//vendor/github.com/beorn7/perks/quantile:go_default_library",
         "//vendor/github.com/golang/protobuf/proto:go_default_library",

--- a/vendor/github.com/prometheus/client_golang/prometheus/internal/BUILD
+++ b/vendor/github.com/prometheus/client_golang/prometheus/internal/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["metric.go"],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus/internal",
     importpath = "github.com/prometheus/client_golang/prometheus/internal",
-    visibility = ["//vendor/github.com/prometheus/client_golang/prometheus:__subpackages__"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
     deps = ["//vendor/github.com/prometheus/client_model/go:go_default_library"],
 )
 

--- a/vendor/github.com/prometheus/client_golang/prometheus/promhttp/BUILD
+++ b/vendor/github.com/prometheus/client_golang/prometheus/promhttp/BUILD
@@ -10,7 +10,7 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus/promhttp",
     importpath = "github.com/prometheus/client_golang/prometheus/promhttp",
-    visibility = ["//visibility:public"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
     deps = [
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/BUILD
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["testutil.go"],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/client_golang/prometheus/testutil",
     importpath = "github.com/prometheus/client_golang/prometheus/testutil",
-    visibility = ["//visibility:public"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
     deps = [
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/internal:go_default_library",

--- a/vendor/github.com/prometheus/client_model/go/BUILD
+++ b/vendor/github.com/prometheus/client_model/go/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["metrics.pb.go"],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/client_model/go",
     importpath = "github.com/prometheus/client_model/go",
-    visibility = ["//visibility:public"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
     deps = ["//vendor/github.com/golang/protobuf/proto:go_default_library"],
 )
 

--- a/vendor/github.com/prometheus/common/expfmt/BUILD
+++ b/vendor/github.com/prometheus/common/expfmt/BUILD
@@ -11,7 +11,7 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/common/expfmt",
     importpath = "github.com/prometheus/common/expfmt",
-    visibility = ["//visibility:public"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
     deps = [
         "//vendor/github.com/golang/protobuf/proto:go_default_library",
         "//vendor/github.com/matttproud/golang_protobuf_extensions/pbutil:go_default_library",

--- a/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/BUILD
+++ b/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["autoneg.go"],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
     importpath = "github.com/prometheus/common/internal/bitbucket.org/ww/goautoneg",
-    visibility = ["//vendor/github.com/prometheus/common:__subpackages__"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
 )
 
 filegroup(

--- a/vendor/github.com/prometheus/common/model/BUILD
+++ b/vendor/github.com/prometheus/common/model/BUILD
@@ -17,7 +17,7 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/common/model",
     importpath = "github.com/prometheus/common/model",
-    visibility = ["//visibility:public"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
 )
 
 filegroup(

--- a/vendor/github.com/prometheus/procfs/BUILD
+++ b/vendor/github.com/prometheus/procfs/BUILD
@@ -23,7 +23,7 @@ go_library(
     ],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/procfs",
     importpath = "github.com/prometheus/procfs",
-    visibility = ["//visibility:public"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
     deps = ["//vendor/github.com/prometheus/procfs/internal/fs:go_default_library"],
 )
 

--- a/vendor/github.com/prometheus/procfs/internal/fs/BUILD
+++ b/vendor/github.com/prometheus/procfs/internal/fs/BUILD
@@ -5,7 +5,7 @@ go_library(
     srcs = ["fs.go"],
     importmap = "k8s.io/kubernetes/vendor/github.com/prometheus/procfs/internal/fs",
     importpath = "github.com/prometheus/procfs/internal/fs",
-    visibility = ["//vendor/github.com/prometheus/procfs:__subpackages__"],
+    visibility = ["//staging/src/k8s.io/component-base/metrics:prometheus_import_allow_list"],
 )
 
 filegroup(


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This PR restricts visibility of prometheus packages which no longer should be directly imported.

**Which issue(s) this PR fixes**:
Refer kubernetes/enhancements#1238

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
/milestone v1.17
/priority important-soon
/assign RainbowMango