### PR TITLE
Add note on the applicability of --grace-period flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -54,6 +54,7 @@ var (
 		hosting a pod is down or cannot reach the API server, termination may take significantly longer
 		than the grace period. To force delete a resource, you must pass a grace period of 0 and specify
 		the --force flag.
+		Note: only a subset of resources support graceful deletion. In absence of the support, --grace-period is ignored.
 
 		IMPORTANT: Force deleting pods does not wait for confirmation that the pod's processes have been
 		terminated, which can leave those processes running until the node detects the deletion and


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Recently there have been some queries on the usage of --grace-period flag. e.g. #84310

This PR adds note on the applicability of --grace-period flag .

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
