### PR TITLE
Automated cherry pick of #84156: fix windows performance counter father information failed

### DIFF
--- a/pkg/kubelet/winstats/perfcounters.go
+++ b/pkg/kubelet/winstats/perfcounters.go
@@ -54,11 +54,6 @@ func newPerfCounter(counter string) (*perfCounter, error) {
 		return nil, errors.New("unable to open query through DLL call")
 	}
 
-	ret = win_pdh.PdhValidatePath(counter)
-	if ret != win_pdh.ERROR_SUCCESS {
-		return nil, fmt.Errorf("unable to valid path to counter. Error code is %x", ret)
-	}
-
 	ret = win_pdh.PdhAddEnglishCounter(queryHandle, counter, 0, &counterHandle)
 	if ret != win_pdh.ERROR_SUCCESS {
 		return nil, fmt.Errorf("unable to add process counter. Error code is %x", ret)


### PR DESCRIPTION
Cherry pick of #84156 on release-1.16.

#84156: fix windows performance counter father information failed on windows
This issue can cause the kubelet not to start properly and cannot provide services.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.