### PR TITLE
CSI: modify detach timeout to match attach timeout

### DIFF
--- a/pkg/volume/csi/csi_attacher.go
+++ b/pkg/volume/csi/csi_attacher.go
@@ -386,14 +386,13 @@ func (c *csiAttacher) Detach(volumeName string, nodeName types.NodeName) error {
 	}
 
 	klog.V(4).Info(log("detacher deleted ok VolumeAttachment.ID=%s", attachID))
-	err := c.waitForVolumeDetachment(volID, attachID)
+	err := c.waitForVolumeDetachment(volID, attachID, csiTimeout)
 	return err
 }
 
-func (c *csiAttacher) waitForVolumeDetachment(volumeHandle, attachID string) error {
+func (c *csiAttacher) waitForVolumeDetachment(volumeHandle, attachID string, timeout time.Duration) error {
 	klog.V(4).Info(log("probing for updates from CSI driver for [attachment.ID=%v]", attachID))
 
-	timeout := c.waitSleepTime * 10
 	timer := time.NewTimer(timeout) // TODO (vladimirvivien) investigate making this configurable
 	defer timer.Stop()
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This makes it so detach timeout matches that of attach timeout.

This was discovered in #84169 and alleviates the following challenge:
- if the attach-detach-reconcile-sync isn't disabled, it is possible to get enough volumeattachments in cluster, that it becomes impossible to detach volumes

#79529 changed csiTimeout from 15 seconds to 2 minutes, but missed making the same change for detach. Not all detach operations can complete in under 10 seconds, especially so if there is any api congestion. 

When the api is throttling the attach-detach controller, volume attachments are given 2 minutes, and detachments only 10 seconds, therefore it's possible to never get a detach to succeed.

**Which issue(s) this PR fixes**:
Fixes #

**Does this PR introduce a user-facing change?**:

```release-note
CSI detach timeout increased from 10 seconds to 2 minutes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
