### PR TITLE
rename scheduler fake listers

### DIFF
--- a/pkg/scheduler/algorithm/predicates/csi_volume_predicate_test.go
+++ b/pkg/scheduler/algorithm/predicates/csi_volume_predicate_test.go
@@ -453,10 +453,10 @@ func TestCSIVolumeCountPredicate(t *testing.T) {
 				expectedFailureReasons = []PredicateFailureReason{test.expectedFailureReason}
 			}
 
-			pred := NewCSIMaxVolumeLimitPredicate(getFakeCSINodeInfo(csiNode),
-				getFakeCSIPVInfo(test.filterName, test.driverNames...),
-				getFakeCSIPVCInfo(test.filterName, "csi-sc", test.driverNames...),
-				getFakeCSIStorageClassInfo("csi-sc", test.driverNames[0]))
+			pred := NewCSIMaxVolumeLimitPredicate(getFakeCSINodeLister(csiNode),
+				getFakeCSIPVLister(test.filterName, test.driverNames...),
+				getFakeCSIPVCLister(test.filterName, "csi-sc", test.driverNames...),
+				getFakeCSIStorageClassLister("csi-sc", test.driverNames[0]))
 
 			fits, reasons, err := pred(test.newPod, GetPredicateMetadata(test.newPod, nil), node)
 			if err != nil {
@@ -472,8 +472,8 @@ func TestCSIVolumeCountPredicate(t *testing.T) {
 	}
 }
 
-func getFakeCSIPVInfo(volumeName string, driverNames ...string) fakelisters.PersistentVolumeInfo {
-	pvInfos := fakelisters.PersistentVolumeInfo{}
+func getFakeCSIPVLister(volumeName string, driverNames ...string) fakelisters.PersistentVolumeLister {
+	pvLister := fakelisters.PersistentVolumeLister{}
 	for _, driver := range driverNames {
 		for j := 0; j < 4; j++ {
 			volumeHandle := fmt.Sprintf("%s-%s-%d", volumeName, driver, j)
@@ -510,15 +510,15 @@ func getFakeCSIPVInfo(volumeName string, driverNames ...string) fakelisters.Pers
 					},
 				}
 			}
-			pvInfos = append(pvInfos, pv)
+			pvLister = append(pvLister, pv)
 		}
 
 	}
-	return pvInfos
+	return pvLister
 }
 
-func getFakeCSIPVCInfo(volumeName, scName string, driverNames ...string) fakelisters.PersistentVolumeClaimInfo {
-	pvcInfos := fakelisters.PersistentVolumeClaimInfo{}
+func getFakeCSIPVCLister(volumeName, scName string, driverNames ...string) fakelisters.PersistentVolumeClaimLister {
+	pvcLister := fakelisters.PersistentVolumeClaimLister{}
 	for _, driver := range driverNames {
 		for j := 0; j < 4; j++ {
 			v := fmt.Sprintf("%s-%s-%d", volumeName, driver, j)
@@ -526,24 +526,24 @@ func getFakeCSIPVCInfo(volumeName, scName string, driverNames ...string) fakelis
 				ObjectMeta: metav1.ObjectMeta{Name: v},
 				Spec:       v1.PersistentVolumeClaimSpec{VolumeName: v},
 			}
-			pvcInfos = append(pvcInfos, pvc)
+			pvcLister = append(pvcLister, pvc)
 		}
 	}
 
-	pvcInfos = append(pvcInfos, v1.PersistentVolumeClaim{
+	pvcLister = append(pvcLister, v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: volumeName + "-4"},
 		Spec:       v1.PersistentVolumeClaimSpec{StorageClassName: &scName},
 	})
-	pvcInfos = append(pvcInfos, v1.PersistentVolumeClaim{
+	pvcLister = append(pvcLister, v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: volumeName + "-5"},
 		Spec:       v1.PersistentVolumeClaimSpec{},
 	})
 	// a pvc with missing PV but available storageclass.
-	pvcInfos = append(pvcInfos, v1.PersistentVolumeClaim{
+	pvcLister = append(pvcLister, v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{Name: volumeName + "-6"},
 		Spec:       v1.PersistentVolumeClaimSpec{StorageClassName: &scName, VolumeName: "missing-in-action"},
 	})
-	return pvcInfos
+	return pvcLister
 }
 
 func enableMigrationOnNode(csiNode *storagev1beta1.CSINode, pluginName string) {
@@ -560,8 +560,8 @@ func enableMigrationOnNode(csiNode *storagev1beta1.CSINode, pluginName string) {
 	csiNode.Annotations = nodeInfoAnnotations
 }
 
-func getFakeCSIStorageClassInfo(scName, provisionerName string) fakelisters.StorageClassInfo {
-	return fakelisters.StorageClassInfo{
+func getFakeCSIStorageClassLister(scName, provisionerName string) fakelisters.StorageClassLister {
+	return fakelisters.StorageClassLister{
 		{
 			ObjectMeta:  metav1.ObjectMeta{Name: scName},
 			Provisioner: provisionerName,
@@ -569,9 +569,9 @@ func getFakeCSIStorageClassInfo(scName, provisionerName string) fakelisters.Stor
 	}
 }
 
-func getFakeCSINodeInfo(csiNode *storagev1beta1.CSINode) fakelisters.CSINodeInfo {
+func getFakeCSINodeLister(csiNode *storagev1beta1.CSINode) fakelisters.CSINodeLister {
 	if csiNode != nil {
-		return fakelisters.CSINodeInfo(*csiNode)
+		return fakelisters.CSINodeLister(*csiNode)
 	}
-	return fakelisters.CSINodeInfo{}
+	return fakelisters.CSINodeLister{}
 }

--- a/pkg/scheduler/algorithm/predicates/max_attachable_volume_predicate_test.go
+++ b/pkg/scheduler/algorithm/predicates/max_attachable_volume_predicate_test.go
@@ -853,10 +853,10 @@ func TestVolumeCountConflicts(t *testing.T) {
 		os.Setenv(KubeMaxPDVols, strconv.Itoa(test.maxVols))
 		node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
 		pred := NewMaxPDVolumeCountPredicate(test.filterName,
-			getFakeCSINodeInfo(csiNode),
-			getFakeStorageClassInfo(test.filterName),
-			getFakePVInfo(test.filterName),
-			getFakePVCInfo(test.filterName))
+			getFakeCSINodeLister(csiNode),
+			getFakeStorageClassLister(test.filterName),
+			getFakePVLister(test.filterName),
+			getFakePVCLister(test.filterName))
 
 		fits, reasons, err := pred(test.newPod, GetPredicateMetadata(test.newPod, nil), node)
 		if err != nil {
@@ -876,10 +876,10 @@ func TestVolumeCountConflicts(t *testing.T) {
 	for _, test := range tests {
 		node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
 		pred := NewMaxPDVolumeCountPredicate(test.filterName,
-			getFakeCSINodeInfo(csiNode),
-			getFakeStorageClassInfo(test.filterName),
-			getFakePVInfo(test.filterName),
-			getFakePVCInfo(test.filterName))
+			getFakeCSINodeLister(csiNode),
+			getFakeStorageClassLister(test.filterName),
+			getFakePVLister(test.filterName),
+			getFakePVCLister(test.filterName))
 		fits, reasons, err := pred(test.newPod, GetPredicateMetadata(test.newPod, nil), node)
 		if err != nil {
 			t.Errorf("Using allocatable [%s]%s: unexpected error: %v", test.filterName, test.test, err)
@@ -893,7 +893,7 @@ func TestVolumeCountConflicts(t *testing.T) {
 	}
 }
 
-func getFakeStorageClassInfo(sc string) fakelisters.StorageClassInfo {
+func getFakeStorageClassLister(sc string) fakelisters.StorageClassLister {
 	var provisioner string
 	switch sc {
 	case EBSVolumeFilterType:
@@ -905,9 +905,9 @@ func getFakeStorageClassInfo(sc string) fakelisters.StorageClassInfo {
 	case CinderVolumeFilterType:
 		provisioner = csilibplugins.CinderInTreePluginName
 	default:
-		return fakelisters.StorageClassInfo{}
+		return fakelisters.StorageClassLister{}
 	}
-	return fakelisters.StorageClassInfo{
+	return fakelisters.StorageClassLister{
 		{
 			ObjectMeta:  metav1.ObjectMeta{Name: sc},
 			Provisioner: provisioner,
@@ -919,8 +919,8 @@ func getFakeStorageClassInfo(sc string) fakelisters.StorageClassInfo {
 	}
 }
 
-func getFakePVInfo(filterName string) fakelisters.PersistentVolumeInfo {
-	return fakelisters.PersistentVolumeInfo{
+func getFakePVLister(filterName string) fakelisters.PersistentVolumeLister {
+	return fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "some" + filterName + "Vol"},
 			Spec: v1.PersistentVolumeSpec{
@@ -938,8 +938,8 @@ func getFakePVInfo(filterName string) fakelisters.PersistentVolumeInfo {
 	}
 }
 
-func getFakePVCInfo(filterName string) fakelisters.PersistentVolumeClaimInfo {
-	return fakelisters.PersistentVolumeClaimInfo{
+func getFakePVCLister(filterName string) fakelisters.PersistentVolumeClaimLister {
+	return fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "some" + filterName + "Vol"},
 			Spec: v1.PersistentVolumeClaimSpec{

--- a/pkg/scheduler/algorithm/predicates/predicates_test.go
+++ b/pkg/scheduler/algorithm/predicates/predicates_test.go
@@ -4302,7 +4302,7 @@ func createPodWithVolume(pod, pv, pvc string) *v1.Pod {
 }
 
 func TestVolumeZonePredicate(t *testing.T) {
-	pvInfo := fakelisters.PersistentVolumeInfo{
+	pvLister := fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_1", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-a"}},
 		},
@@ -4314,7 +4314,7 @@ func TestVolumeZonePredicate(t *testing.T) {
 		},
 	}
 
-	pvcInfo := fakelisters.PersistentVolumeClaimInfo{
+	pvcLister := fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_1", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_1"},
@@ -4412,7 +4412,7 @@ func TestVolumeZonePredicate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fit := NewVolumeZonePredicate(pvInfo, pvcInfo, nil)
+			fit := NewVolumeZonePredicate(pvLister, pvcLister, nil)
 			node := &schedulernodeinfo.NodeInfo{}
 			node.SetNode(test.Node)
 
@@ -4431,7 +4431,7 @@ func TestVolumeZonePredicate(t *testing.T) {
 }
 
 func TestVolumeZonePredicateMultiZone(t *testing.T) {
-	pvInfo := fakelisters.PersistentVolumeInfo{
+	pvLister := fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_1", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-a"}},
 		},
@@ -4443,7 +4443,7 @@ func TestVolumeZonePredicateMultiZone(t *testing.T) {
 		},
 	}
 
-	pvcInfo := fakelisters.PersistentVolumeClaimInfo{
+	pvcLister := fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_1", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_1"},
@@ -4506,7 +4506,7 @@ func TestVolumeZonePredicateMultiZone(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fit := NewVolumeZonePredicate(pvInfo, pvcInfo, nil)
+			fit := NewVolumeZonePredicate(pvLister, pvcLister, nil)
 			node := &schedulernodeinfo.NodeInfo{}
 			node.SetNode(test.Node)
 
@@ -4533,7 +4533,7 @@ func TestVolumeZonePredicateWithVolumeBinding(t *testing.T) {
 		classImmediate = "Class_Immediate"
 	)
 
-	classInfo := fakelisters.StorageClassInfo{
+	scLister := fakelisters.StorageClassLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: classImmediate},
 		},
@@ -4543,13 +4543,13 @@ func TestVolumeZonePredicateWithVolumeBinding(t *testing.T) {
 		},
 	}
 
-	pvInfo := fakelisters.PersistentVolumeInfo{
+	pvLister := fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_1", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-a"}},
 		},
 	}
 
-	pvcInfo := fakelisters.PersistentVolumeClaimInfo{
+	pvcLister := fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_1", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_1"},
@@ -4622,7 +4622,7 @@ func TestVolumeZonePredicateWithVolumeBinding(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fit := NewVolumeZonePredicate(pvInfo, pvcInfo, classInfo)
+			fit := NewVolumeZonePredicate(pvLister, pvcLister, scLister)
 			node := &schedulernodeinfo.NodeInfo{}
 			node.SetNode(test.Node)
 

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -282,7 +282,7 @@ func TestGenericScheduler(t *testing.T) {
 		prioritizers                  []priorities.PriorityConfig
 		alwaysCheckAllPredicates      bool
 		nodes                         []string
-		pvcs                          []*v1.PersistentVolumeClaim
+		pvcs                          []v1.PersistentVolumeClaim
 		pod                           *v1.Pod
 		pods                          []*v1.Pod
 		buildPredMeta                 bool // build predicates metadata or not
@@ -404,7 +404,7 @@ func TestGenericScheduler(t *testing.T) {
 			predicates:   map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
 			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
 			nodes:        []string{"machine1", "machine2"},
-			pvcs:         []*v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC"}}},
+			pvcs:         []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC"}}},
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "ignore", UID: types.UID("ignore")},
 				Spec: v1.PodSpec{
@@ -450,7 +450,7 @@ func TestGenericScheduler(t *testing.T) {
 			predicates:   map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
 			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
 			nodes:        []string{"machine1", "machine2"},
-			pvcs:         []*v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC", DeletionTimestamp: &metav1.Time{}}}},
+			pvcs:         []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC", DeletionTimestamp: &metav1.Time{}}}},
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "ignore", UID: types.UID("ignore")},
 				Spec: v1.PodSpec{
@@ -654,7 +654,7 @@ func TestGenericScheduler(t *testing.T) {
 			for _, name := range test.nodes {
 				cache.AddNode(&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, Labels: map[string]string{"hostname": name}}})
 			}
-			pvcs := []*v1.PersistentVolumeClaim{}
+			pvcs := []v1.PersistentVolumeClaim{}
 			pvcs = append(pvcs, test.pvcs...)
 
 			pvcLister := fakelisters.PersistentVolumeClaimLister(pvcs)

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/azure_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/azure_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
@@ -361,7 +361,7 @@ func TestAzureDiskLimits(t *testing.T) {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
 			p := &AzureDiskLimits{
-				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeInfo(csiNode), getFakeCSIStorageClassInfo(test.filterName, test.driverName), getFakePVInfo(test.filterName), getFakePVCInfo(test.filterName)),
+				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/cinder_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/cinder_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
@@ -90,7 +90,7 @@ func TestCinderLimits(t *testing.T) {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
 			p := &CinderLimits{
-				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeInfo(csiNode), getFakeCSIStorageClassInfo(test.filterName, test.driverName), getFakePVInfo(test.filterName), getFakePVCInfo(test.filterName)),
+				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/ebs_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/ebs_test.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
@@ -475,7 +475,7 @@ func TestEBSLimits(t *testing.T) {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
 			p := &EBSLimits{
-				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeInfo(csiNode), getFakeCSIStorageClassInfo(test.filterName, test.driverName), getFakePVInfo(test.filterName), getFakePVCInfo(test.filterName)),
+				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
@@ -485,8 +485,8 @@ func TestEBSLimits(t *testing.T) {
 	}
 }
 
-func getFakePVCInfo(filterName string) fakelisters.PersistentVolumeClaimInfo {
-	return fakelisters.PersistentVolumeClaimInfo{
+func getFakePVCLister(filterName string) fakelisters.PersistentVolumeClaimLister {
+	return fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "some" + filterName + "Vol"},
 			Spec: v1.PersistentVolumeClaimSpec{
@@ -546,8 +546,8 @@ func getFakePVCInfo(filterName string) fakelisters.PersistentVolumeClaimInfo {
 	}
 }
 
-func getFakePVInfo(filterName string) fakelisters.PersistentVolumeInfo {
-	return fakelisters.PersistentVolumeInfo{
+func getFakePVLister(filterName string) fakelisters.PersistentVolumeLister {
+	return fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "some" + filterName + "Vol"},
 			Spec: v1.PersistentVolumeSpec{

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/gce_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/gce_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/features"
@@ -361,7 +361,7 @@ func TestGCEPDLimits(t *testing.T) {
 		t.Run(test.test, func(t *testing.T) {
 			node, csiNode := getNodeWithPodAndVolumeLimits("node", test.existingPods, int64(test.maxVols), test.filterName)
 			p := &GCEPDLimits{
-				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeInfo(csiNode), getFakeCSIStorageClassInfo(test.filterName, test.driverName), getFakePVInfo(test.filterName), getFakePVCInfo(test.filterName)),
+				predicate: predicates.NewMaxPDVolumeCountPredicate(test.filterName, getFakeCSINodeLister(csiNode), getFakeCSIStorageClassLister(test.filterName, test.driverName), getFakePVLister(test.filterName), getFakePVCLister(test.filterName)),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.newPod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -49,7 +49,7 @@ func createPodWithVolume(pod, pv, pvc string) *v1.Pod {
 }
 
 func TestSingleZone(t *testing.T) {
-	pvInfo := fakelisters.PersistentVolumeInfo{
+	pvLister := fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_1", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-a"}},
 		},
@@ -61,7 +61,7 @@ func TestSingleZone(t *testing.T) {
 		},
 	}
 
-	pvcInfo := fakelisters.PersistentVolumeClaimInfo{
+	pvcLister := fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_1", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_1"},
@@ -156,7 +156,7 @@ func TestSingleZone(t *testing.T) {
 			node := &schedulernodeinfo.NodeInfo{}
 			node.SetNode(test.Node)
 			p := &VolumeZone{
-				predicate: predicates.NewVolumeZonePredicate(pvInfo, pvcInfo, nil),
+				predicate: predicates.NewVolumeZonePredicate(pvLister, pvcLister, nil),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.Pod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
@@ -167,7 +167,7 @@ func TestSingleZone(t *testing.T) {
 }
 
 func TestMultiZone(t *testing.T) {
-	pvInfo := fakelisters.PersistentVolumeInfo{
+	pvLister := fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_1", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-a"}},
 		},
@@ -179,7 +179,7 @@ func TestMultiZone(t *testing.T) {
 		},
 	}
 
-	pvcInfo := fakelisters.PersistentVolumeClaimInfo{
+	pvcLister := fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_1", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_1"},
@@ -241,7 +241,7 @@ func TestMultiZone(t *testing.T) {
 			node := &schedulernodeinfo.NodeInfo{}
 			node.SetNode(test.Node)
 			p := &VolumeZone{
-				predicate: predicates.NewVolumeZonePredicate(pvInfo, pvcInfo, nil),
+				predicate: predicates.NewVolumeZonePredicate(pvLister, pvcLister, nil),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.Pod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {
@@ -260,7 +260,7 @@ func TestWithBinding(t *testing.T) {
 		classImmediate = "Class_Immediate"
 	)
 
-	classInfo := fakelisters.StorageClassInfo{
+	scLister := fakelisters.StorageClassLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: classImmediate},
 		},
@@ -270,13 +270,13 @@ func TestWithBinding(t *testing.T) {
 		},
 	}
 
-	pvInfo := fakelisters.PersistentVolumeInfo{
+	pvLister := fakelisters.PersistentVolumeLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_1", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-a"}},
 		},
 	}
 
-	pvcInfo := fakelisters.PersistentVolumeClaimInfo{
+	pvcLister := fakelisters.PersistentVolumeClaimLister{
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_1", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_1"},
@@ -346,7 +346,7 @@ func TestWithBinding(t *testing.T) {
 			node := &schedulernodeinfo.NodeInfo{}
 			node.SetNode(test.Node)
 			p := &VolumeZone{
-				predicate: predicates.NewVolumeZonePredicate(pvInfo, pvcInfo, classInfo),
+				predicate: predicates.NewVolumeZonePredicate(pvLister, pvcLister, scLister),
 			}
 			gotStatus := p.Filter(context.Background(), nil, test.Pod, node)
 			if !reflect.DeepEqual(gotStatus, test.wantStatus) {

--- a/pkg/scheduler/listers/fake/listers.go
+++ b/pkg/scheduler/listers/fake/listers.go
@@ -202,24 +202,6 @@ func (f StatefulSetLister) StatefulSets(namespace string) appslisters.StatefulSe
 	return nil
 }
 
-// PersistentVolumeClaimLister implements PersistentVolumeClaimLister on []*v1.PersistentVolumeClaim for test purposes.
-type PersistentVolumeClaimLister []*v1.PersistentVolumeClaim
-
-var _ corelisters.PersistentVolumeClaimLister = PersistentVolumeClaimLister{}
-
-// List lists all PersistentVolumeClaims in the indexer.
-func (f PersistentVolumeClaimLister) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-// PersistentVolumeClaims returns a fake PersistentVolumeClaimLister object.
-func (f PersistentVolumeClaimLister) PersistentVolumeClaims(namespace string) corelisters.PersistentVolumeClaimNamespaceLister {
-	return &persistentVolumeClaimNamespaceLister{
-		pvcs:      f,
-		namespace: namespace,
-	}
-}
-
 // persistentVolumeClaimNamespaceLister is implementation of PersistentVolumeClaimNamespaceLister returned by List() above.
 type persistentVolumeClaimNamespaceLister struct {
 	pvcs      []*v1.PersistentVolumeClaim
@@ -239,28 +221,18 @@ func (f persistentVolumeClaimNamespaceLister) List(selector labels.Selector) (re
 	return nil, fmt.Errorf("not implemented")
 }
 
-// PersistentVolumeClaimInfo declares a []v1.PersistentVolumeClaim type for testing.
-type PersistentVolumeClaimInfo []v1.PersistentVolumeClaim
+// PersistentVolumeClaimLister declares a []v1.PersistentVolumeClaim type for testing.
+type PersistentVolumeClaimLister []v1.PersistentVolumeClaim
 
-var _ corelisters.PersistentVolumeClaimLister = PersistentVolumeClaimInfo{}
-
-// GetPersistentVolumeClaimInfo gets PVC matching the namespace and PVC ID.
-func (pvcs PersistentVolumeClaimInfo) GetPersistentVolumeClaimInfo(namespace string, pvcID string) (*v1.PersistentVolumeClaim, error) {
-	for _, pvc := range pvcs {
-		if pvc.Name == pvcID && pvc.Namespace == namespace {
-			return &pvc, nil
-		}
-	}
-	return nil, fmt.Errorf("Unable to find persistent volume claim: %s/%s", namespace, pvcID)
-}
+var _ corelisters.PersistentVolumeClaimLister = PersistentVolumeClaimLister{}
 
 // List gets PVC matching the namespace and PVC ID.
-func (pvcs PersistentVolumeClaimInfo) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
+func (pvcs PersistentVolumeClaimLister) List(selector labels.Selector) (ret []*v1.PersistentVolumeClaim, err error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
 // PersistentVolumeClaims returns a fake PersistentVolumeClaimLister object.
-func (pvcs PersistentVolumeClaimInfo) PersistentVolumeClaims(namespace string) corelisters.PersistentVolumeClaimNamespaceLister {
+func (pvcs PersistentVolumeClaimLister) PersistentVolumeClaims(namespace string) corelisters.PersistentVolumeClaimNamespaceLister {
 	ps := make([]*v1.PersistentVolumeClaim, len(pvcs))
 	for i := range pvcs {
 		ps[i] = &pvcs[i]
@@ -284,45 +256,29 @@ func (nodes NodeLister) GetNodeInfo(nodeName string) (*v1.Node, error) {
 	return nil, fmt.Errorf("Unable to find node: %s", nodeName)
 }
 
-var _ v1beta1storagelisters.CSINodeLister = CSINodeInfo{}
+var _ v1beta1storagelisters.CSINodeLister = CSINodeLister{}
 
-// CSINodeInfo declares a storagev1beta1.CSINode type for testing.
-type CSINodeInfo storagev1beta1.CSINode
-
-// GetCSINodeInfo returns a fake CSINode object.
-func (n CSINodeInfo) GetCSINodeInfo(name string) (*storagev1beta1.CSINode, error) {
-	csiNode := storagev1beta1.CSINode(n)
-	return &csiNode, nil
-}
+// CSINodeLister declares a storagev1beta1.CSINode type for testing.
+type CSINodeLister storagev1beta1.CSINode
 
 // Get returns a fake CSINode object.
-func (n CSINodeInfo) Get(name string) (*storagev1beta1.CSINode, error) {
+func (n CSINodeLister) Get(name string) (*storagev1beta1.CSINode, error) {
 	csiNode := storagev1beta1.CSINode(n)
 	return &csiNode, nil
 }
 
 // List lists all CSINodes in the indexer.
-func (n CSINodeInfo) List(selector labels.Selector) (ret []*storagev1beta1.CSINode, err error) {
+func (n CSINodeLister) List(selector labels.Selector) (ret []*storagev1beta1.CSINode, err error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-// PersistentVolumeInfo declares a []v1.PersistentVolume type for testing.
-type PersistentVolumeInfo []v1.PersistentVolume
+// PersistentVolumeLister declares a []v1.PersistentVolume type for testing.
+type PersistentVolumeLister []v1.PersistentVolume
 
-var _ corelisters.PersistentVolumeLister = PersistentVolumeInfo{}
-
-// GetPersistentVolumeInfo returns a fake PV object in the fake PVs by PV ID.
-func (pvs PersistentVolumeInfo) GetPersistentVolumeInfo(pvID string) (*v1.PersistentVolume, error) {
-	for _, pv := range pvs {
-		if pv.Name == pvID {
-			return &pv, nil
-		}
-	}
-	return nil, fmt.Errorf("Unable to find persistent volume: %s", pvID)
-}
+var _ corelisters.PersistentVolumeLister = PersistentVolumeLister{}
 
 // Get returns a fake PV object in the fake PVs by PV ID.
-func (pvs PersistentVolumeInfo) Get(pvID string) (*v1.PersistentVolume, error) {
+func (pvs PersistentVolumeLister) Get(pvID string) (*v1.PersistentVolume, error) {
 	for _, pv := range pvs {
 		if pv.Name == pvID {
 			return &pv, nil
@@ -332,27 +288,17 @@ func (pvs PersistentVolumeInfo) Get(pvID string) (*v1.PersistentVolume, error) {
 }
 
 // List lists all PersistentVolumes in the indexer.
-func (pvs PersistentVolumeInfo) List(selector labels.Selector) ([]*v1.PersistentVolume, error) {
+func (pvs PersistentVolumeLister) List(selector labels.Selector) ([]*v1.PersistentVolume, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-// StorageClassInfo declares a []storagev1.StorageClass type for testing.
-type StorageClassInfo []storagev1.StorageClass
+// StorageClassLister declares a []storagev1.StorageClass type for testing.
+type StorageClassLister []storagev1.StorageClass
 
-var _ storagelisters.StorageClassLister = StorageClassInfo{}
-
-// GetStorageClassInfo returns a fake storage class object in the fake storage classes by name.
-func (classes StorageClassInfo) GetStorageClassInfo(name string) (*storagev1.StorageClass, error) {
-	for _, sc := range classes {
-		if sc.Name == name {
-			return &sc, nil
-		}
-	}
-	return nil, fmt.Errorf("Unable to find storage class: %s", name)
-}
+var _ storagelisters.StorageClassLister = StorageClassLister{}
 
 // Get returns a fake storage class object in the fake storage classes by name.
-func (classes StorageClassInfo) Get(name string) (*storagev1.StorageClass, error) {
+func (classes StorageClassLister) Get(name string) (*storagev1.StorageClass, error) {
 	for _, sc := range classes {
 		if sc.Name == name {
 			return &sc, nil
@@ -362,6 +308,6 @@ func (classes StorageClassInfo) Get(name string) (*storagev1.StorageClass, error
 }
 
 // List lists all StorageClass in the indexer.
-func (classes StorageClassInfo) List(selector labels.Selector) ([]*storagev1.StorageClass, error) {
+func (classes StorageClassLister) List(selector labels.Selector) ([]*storagev1.StorageClass, error) {
 	return nil, fmt.Errorf("not implemented")
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
rename fake listers  names：

- PersistentVolumeClaimInfo to PersistentVolumeClaimLister
- CSINodeInfo to CSINodeLister
- PersistentVolumeInfo to PersistentVolumeLister
- StorageClassInfo to StorageClassLister

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
xref: https://github.com/kubernetes/kubernetes/pull/84192

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
