### PR TITLE
kubectl create: enforce namespace during dry run

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
@@ -96,7 +96,7 @@ type namespacedClientConfig struct {
 }
 
 func (c *namespacedClientConfig) Namespace() (string, bool, error) {
-	return c.namespace, false, nil
+	return c.namespace, true, nil
 }
 
 func (c *namespacedClientConfig) RawConfig() (clientcmdapi.Config, error) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -60,11 +60,12 @@ type CreateCronJobOptions struct {
 	Command  []string
 	Restart  string
 
-	Namespace string
-	Client    batchv1beta1client.BatchV1beta1Interface
-	DryRun    bool
-	Builder   *resource.Builder
-	Cmd       *cobra.Command
+	Namespace        string
+	EnforceNamespace bool
+	Client           batchv1beta1client.BatchV1beta1Interface
+	DryRun           bool
+	Builder          *resource.Builder
+	Cmd              *cobra.Command
 
 	genericclioptions.IOStreams
 }
@@ -126,7 +127,7 @@ func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 		return err
 	}
 
-	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
@@ -161,6 +162,10 @@ func (o *CreateCronJobOptions) Validate() error {
 func (o *CreateCronJobOptions) Run() error {
 	var cronjob *batchv1beta1.CronJob
 	cronjob = o.createCronJob()
+	if o.EnforceNamespace {
+		cronjob.Namespace = o.Namespace
+		cronjob.Spec.JobTemplate.Namespace = o.Namespace
+	}
 
 	if !o.DryRun {
 		var err error

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -150,12 +150,18 @@ func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 }
 
 func (o *CreateCronJobOptions) Validate() error {
+	if o.Name == "" {
+		return fmt.Errorf("name must be specified")
+	}
+
 	if len(o.Image) == 0 {
 		return fmt.Errorf("--image must be specified")
 	}
+
 	if len(o.Schedule) == 0 {
 		return fmt.Errorf("--schedule must be specified")
 	}
+
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
@@ -166,7 +166,7 @@ func TestValidateCreateCronJob(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			err := test.options.Validate()
 			if test.expectErr && err == nil {
-				t.Errorf("expected error but but validation passed.")
+				t.Errorf("expected error but validation passed")
 			}
 			if !test.expectErr && err != nil {
 				t.Errorf("unexpected error: %v", err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
@@ -127,9 +127,6 @@ func TestCreateCronJob(t *testing.T) {
 }
 
 func TestValidateCreateCronJob(t *testing.T) {
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
-	defer tf.Cleanup()
-
 	tests := map[string]struct {
 		options   *CreateCronJobOptions
 		expectErr bool

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package create
 
 import (
+	"reflect"
 	"testing"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -24,7 +25,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/rest/fake"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 )
 
 func TestCreateCronJob(t *testing.T) {
@@ -116,6 +121,279 @@ func TestCreateCronJob(t *testing.T) {
 			actual := o.createCronJob()
 			if !equality.Semantic.DeepEqual(tc.expected, actual) {
 				t.Errorf("%s", diff.ObjectReflectDiff(tc.expected, actual))
+			}
+		})
+	}
+}
+
+func TestValidateCreateCronJob(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	tests := map[string]struct {
+		options   *CreateCronJobOptions
+		expectErr bool
+	}{
+		"test-missing-name": {
+			options: &CreateCronJobOptions{
+				Image:    "busybox",
+				Schedule: "0/5 * * * ?",
+			},
+			expectErr: true,
+		},
+		"test-missing-image": {
+			options: &CreateCronJobOptions{
+				Name:     "my-cronjob",
+				Schedule: "0/5 * * * ?",
+			},
+			expectErr: true,
+		},
+		"test-missing-schedule": {
+			options: &CreateCronJobOptions{
+				Name:  "my-cronjob",
+				Image: "busybox",
+			},
+			expectErr: true,
+		},
+		"test-valid-case": {
+			options: &CreateCronJobOptions{
+				Name:     "my-conjob",
+				Image:    "busybox",
+				Schedule: "0/5 * * * ?",
+			},
+			expectErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.options.Validate()
+			if test.expectErr && err == nil {
+				t.Errorf("expected error but but validation passed.")
+			}
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestCompleteCreateCronJob(t *testing.T) {
+	// TODO: Test that CreateCronJobOptions.Command is properly set.
+	//       When setting .Command, CompleteCreateCronJob relies heavily
+	//       on Cobra, which makes testing difficult.
+
+	defaultTestName := "my-cronjob"
+	defaultTestDryRun := true
+	defaultTestRestart := "Never"
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	tf.Client = &fake.RESTClient{}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	tests := map[string]struct {
+		params    []string
+		dryRun    bool
+		options   *CreateCronJobOptions
+		expected  *CreateCronJobOptions
+		expectErr bool
+	}{
+		"test-missing-name": {
+			params:    []string{},
+			options:   &CreateCronJobOptions{},
+			expected:  &CreateCronJobOptions{},
+			expectErr: true,
+		},
+		"test-missing-restart": {
+			params: []string{defaultTestName},
+			options: &CreateCronJobOptions{
+				PrintFlags: genericclioptions.NewPrintFlags("created"),
+			},
+			expected: &CreateCronJobOptions{
+				Name:    defaultTestName,
+				Restart: "OnFailure",
+			},
+			expectErr: false,
+		},
+		"test-valid-complete-case": {
+			params: []string{defaultTestName},
+			dryRun: defaultTestDryRun,
+			options: &CreateCronJobOptions{
+				PrintFlags: genericclioptions.NewPrintFlags("created"),
+				Restart:    defaultTestRestart,
+			},
+			expected: &CreateCronJobOptions{
+				Name:    defaultTestName,
+				DryRun:  defaultTestDryRun,
+				Restart: defaultTestRestart,
+			},
+			expectErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cmd := NewCmdCreateRole(tf, genericclioptions.NewTestIOStreamsDiscard())
+
+			if test.dryRun {
+				cmd.Flags().Set("dry-run", "true")
+			}
+
+			err := test.options.Complete(tf, cmd, test.params)
+
+			if test.expectErr && err == nil {
+				t.Errorf("expected error but none was returned")
+			}
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			fields := map[string]struct {
+				expected, actual interface{}
+			}{
+				".Name": {
+					expected: test.expected.Name,
+					actual:   test.options.Name,
+				},
+				".DryRun": {
+					expected: test.expected.DryRun,
+					actual:   test.options.DryRun,
+				},
+				".Restart": {
+					expected: test.expected.Restart,
+					actual:   test.options.Restart,
+				},
+			}
+
+			for name, value := range fields {
+				if !reflect.DeepEqual(value.expected, value.actual) {
+					t.Errorf("mismatched field %q:\n%s", name, diff.ObjectReflectDiff(value.expected, value.actual))
+				}
+			}
+		})
+	}
+}
+
+func TestRunCreateCronJob(t *testing.T) {
+	defaultTestName := "my-cronjob"
+	defaultTestNamespace := "my-namespace"
+	defaultTestImage := "busybox"
+	defaultTestCommand := []string{"date"}
+	defaultTestSchedule := "0/5 * * * ?"
+	defaultTestRestart := "OnFailure"
+
+	defaultExpectedJobSpec := batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    defaultTestName,
+						Image:   defaultTestImage,
+						Command: defaultTestCommand,
+					},
+				},
+				RestartPolicy: corev1.RestartPolicyOnFailure,
+			},
+		},
+	}
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	tf.Client = &fake.RESTClient{}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	tests := map[string]struct {
+		options  *CreateCronJobOptions
+		expected *batchv1beta1.CronJob
+	}{
+		"test-valid-case": {
+			options: &CreateCronJobOptions{
+				Name:      defaultTestName,
+				Namespace: defaultTestNamespace,
+				DryRun:    true,
+				Image:     defaultTestImage,
+				Command:   defaultTestCommand,
+				Schedule:  defaultTestSchedule,
+				Restart:   defaultTestRestart,
+			},
+			expected: &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: batchv1beta1.SchemeGroupVersion.String(),
+					Kind:       "CronJob",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaultTestName,
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					Schedule: defaultTestSchedule,
+					JobTemplate: batchv1beta1.JobTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: defaultTestName,
+						},
+						Spec: defaultExpectedJobSpec,
+					},
+				},
+			},
+		},
+		"test-valid-case-enforce-namespace": {
+			options: &CreateCronJobOptions{
+				Name:             defaultTestName,
+				Namespace:        defaultTestNamespace,
+				EnforceNamespace: true,
+				DryRun:           true,
+				Image:            defaultTestImage,
+				Command:          defaultTestCommand,
+				Schedule:         defaultTestSchedule,
+				Restart:          defaultTestRestart,
+			},
+			expected: &batchv1beta1.CronJob{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: batchv1beta1.SchemeGroupVersion.String(),
+					Kind:       "CronJob",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      defaultTestName,
+					Namespace: defaultTestNamespace,
+				},
+				Spec: batchv1beta1.CronJobSpec{
+					Schedule: defaultTestSchedule,
+					JobTemplate: batchv1beta1.JobTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      defaultTestName,
+							Namespace: defaultTestNamespace,
+						},
+						Spec: defaultExpectedJobSpec,
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			var err error
+			clientset, err := tf.KubernetesClientSet()
+			if err != nil {
+				t.Fatal(err)
+			}
+			test.options.Client = clientset.BatchV1beta1()
+
+			var actual *batchv1beta1.CronJob
+			test.options.PrintObj = func(obj runtime.Object) error {
+				actual = obj.(*batchv1beta1.CronJob)
+				return nil
+			}
+
+			err = test.options.Run()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !equality.Semantic.DeepEqual(test.expected, actual) {
+				t.Errorf("%s", diff.ObjectReflectDiff(test.expected, actual))
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob_test.go
@@ -22,8 +22,9 @@ import (
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
 )
 
 func TestCreateCronJob(t *testing.T) {
@@ -112,9 +113,9 @@ func TestCreateCronJob(t *testing.T) {
 				Schedule: tc.schedule,
 				Restart:  tc.restart,
 			}
-			cronjob := o.createCronJob()
-			if !apiequality.Semantic.DeepEqual(cronjob, tc.expected) {
-				t.Errorf("expected:\n%#v\ngot:\n%#v", tc.expected, cronjob)
+			actual := o.createCronJob()
+			if !equality.Semantic.DeepEqual(tc.expected, actual) {
+				t.Errorf("%s", diff.ObjectReflectDiff(tc.expected, actual))
 			}
 		})
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -150,12 +150,18 @@ func (o *CreateJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args 
 
 // Validate makes sure provided values and valid Job options
 func (o *CreateJobOptions) Validate() error {
+	if len(o.Name) == 0 {
+		return fmt.Errorf("name must be specified")
+	}
+
 	if (len(o.Image) == 0 && len(o.From) == 0) || (len(o.Image) != 0 && len(o.From) != 0) {
 		return fmt.Errorf("either --image or --from must be specified")
 	}
+
 	if o.Command != nil && len(o.Command) != 0 && len(o.From) != 0 {
 		return fmt.Errorf("cannot specify --from and command")
 	}
+
 	return nil
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -28,6 +28,68 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func TestValidateCreateJob(t *testing.T) {
+	defaultTestName := "my-job"
+	defaultTestImage := "busybox"
+	defaultTestFrom := "cronjob/my-cronjob"
+	defaultTestCommand := []string{"my", "command"}
+
+	tests := map[string]struct {
+		options   *CreateJobOptions
+		expectErr bool
+	}{
+		"test-no-image-no-from": {
+			options: &CreateJobOptions{
+				Name: defaultTestName,
+			},
+			expectErr: true,
+		},
+		"test-both-image-and-from": {
+			options: &CreateJobOptions{
+				Name:  defaultTestName,
+				Image: defaultTestImage,
+				From:  defaultTestFrom,
+			},
+			expectErr: true,
+		},
+		"test-both-from-and-command": {
+			options: &CreateJobOptions{
+				Name:    defaultTestName,
+				From:    defaultTestFrom,
+				Command: defaultTestCommand,
+			},
+			expectErr: true,
+		},
+		"test-valid-case-with-image": {
+			options: &CreateJobOptions{
+				Name:    defaultTestName,
+				Image:   defaultTestImage,
+				Command: defaultTestCommand,
+			},
+			expectErr: false,
+		},
+		"test-valid-case-with-from": {
+			options: &CreateJobOptions{
+				Name: defaultTestName,
+				From: defaultTestFrom,
+			},
+			expectErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.options.Validate()
+			if test.expectErr && err == nil {
+				t.Errorf("expected error but validation passed")
+			}
+			if !test.expectErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestCreateJobValidation(t *testing.T) {
 	tests := map[string]struct {
 		image    string

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package create
 
 import (
-	"strings"
 	"testing"
 
 	apps "k8s.io/api/apps/v1"
@@ -84,44 +83,6 @@ func TestValidateCreateJob(t *testing.T) {
 				t.Errorf("expected error but validation passed")
 			}
 			if !test.expectErr && err != nil {
-				t.Errorf("unexpected error: %v", err)
-			}
-		})
-	}
-}
-
-func TestCreateJobValidation(t *testing.T) {
-	tests := map[string]struct {
-		image    string
-		command  []string
-		from     string
-		expected string
-	}{
-		"empty flags": {
-			expected: "--image or --from must be specified",
-		},
-		"both image and from specified": {
-			image:    "my-image",
-			from:     "cronjob/xyz",
-			expected: "--image or --from must be specified",
-		},
-		"from and command specified": {
-			from:     "cronjob/xyz",
-			command:  []string{"test", "command"},
-			expected: "cannot specify --from and command",
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			o := &CreateJobOptions{
-				Image:   tc.image,
-				From:    tc.from,
-				Command: tc.command,
-			}
-
-			err := o.Validate()
-			if err != nil && !strings.Contains(err.Error(), tc.expected) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -121,13 +121,13 @@ type CreateRoleOptions struct {
 	Resources     []ResourceOptions
 	ResourceNames []string
 
-	DryRun               bool
-	OutputFormat         string
-	Namespace            string
-	NamespaceOverwritten bool
-	Client               clientgorbacv1.RbacV1Interface
-	Mapper               meta.RESTMapper
-	PrintObj             func(obj runtime.Object) error
+	DryRun           bool
+	OutputFormat     string
+	Namespace        string
+	EnforceNamespace bool
+	Client           clientgorbacv1.RbacV1Interface
+	Mapper           meta.RESTMapper
+	PrintObj         func(obj runtime.Object) error
 
 	genericclioptions.IOStreams
 }
@@ -246,7 +246,7 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 		return printer.PrintObj(obj, o.Out)
 	}
 
-	o.Namespace, o.NamespaceOverwritten, err = f.ToRawKubeConfigLoader().Namespace()
+	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
@@ -330,7 +330,7 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 		TypeMeta: metav1.TypeMeta{APIVersion: rbacv1.SchemeGroupVersion.String(), Kind: "Role"},
 	}
 	role.Name = o.Name
-	if o.NamespaceOverwritten {
+	if o.EnforceNamespace {
 		role.Namespace = o.Namespace
 	}
 	rules, err := generateResourcePolicyRules(o.Mapper, o.Verbs, o.Resources, o.ResourceNames, []string{})

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -121,12 +121,13 @@ type CreateRoleOptions struct {
 	Resources     []ResourceOptions
 	ResourceNames []string
 
-	DryRun       bool
-	OutputFormat string
-	Namespace    string
-	Client       clientgorbacv1.RbacV1Interface
-	Mapper       meta.RESTMapper
-	PrintObj     func(obj runtime.Object) error
+	DryRun               bool
+	OutputFormat         string
+	Namespace            string
+	NamespaceOverwritten bool
+	Client               clientgorbacv1.RbacV1Interface
+	Mapper               meta.RESTMapper
+	PrintObj             func(obj runtime.Object) error
 
 	genericclioptions.IOStreams
 }
@@ -245,7 +246,7 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 		return printer.PrintObj(obj, o.Out)
 	}
 
-	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	o.Namespace, o.NamespaceOverwritten, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
@@ -329,6 +330,9 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 		TypeMeta: metav1.TypeMeta{APIVersion: rbacv1.SchemeGroupVersion.String(), Kind: "Role"},
 	}
 	role.Name = o.Name
+	if o.NamespaceOverwritten {
+		role.Namespace = o.Namespace
+	}
 	rules, err := generateResourcePolicyRules(o.Mapper, o.Verbs, o.Resources, o.ResourceNames, []string{})
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -155,7 +155,7 @@ func TestCreateRole(t *testing.T) {
 	}
 }
 
-func TestValidate(t *testing.T) {
+func TestValidateCreateRole(t *testing.T) {
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")
 	defer tf.Cleanup()
 
@@ -356,7 +356,7 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestComplete(t *testing.T) {
+func TestCompleteCreateRole(t *testing.T) {
 	roleName := "my-role"
 
 	tf := cmdtesting.NewTestFactory().WithNamespace("test")

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -33,8 +33,9 @@ import (
 
 func TestCreateRole(t *testing.T) {
 	roleName := "my-role"
+	roleNamespace := "my-namespace"
 
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	tf := cmdtesting.NewTestFactory().WithNamespace(roleNamespace)
 	defer tf.Cleanup()
 
 	tf.Client = &fake.RESTClient{}
@@ -52,7 +53,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: roleNamespace,
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -70,7 +72,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: roleNamespace,
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -88,7 +91,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: roleNamespace,
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -106,7 +110,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: roleNamespace,
 				},
 				Rules: []rbac.PolicyRule{
 					{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
@@ -79,7 +79,7 @@ func TestSetEnvLocal(t *testing.T) {
 }
 
 func TestSetEnvLocalNamespace(t *testing.T) {
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
 
 	tf.Client = &fake.RESTClient{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When creating a role with `kubectl create role`, any specified namespace is ignored if the command is a dry run. This is unexpected behavior.

For example, the following command yields the following output:

```bash
kubectl create role foo --verb=get --resource=pod --namespace=bar --output=yaml --dry-run
```

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  creationTimestamp: null
  name: foo
rules:
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - get
```

This pull-request fixes this issue. The command above now provides the expected output:

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  creationTimestamp: null
  name: foo
  namespace: bar
rules:
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - get
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/705

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The output of a dry run of creating a resource with kubectl now always takes into account the namespace specified in the command.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
