### PR TITLE
replace grpc.WithDialer which is deprecated

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -11,11 +11,6 @@ pkg/controller/podgc
 pkg/controller/replicaset
 pkg/controller/resourcequota
 pkg/controller/statefulset
-pkg/kubelet/apis/podresources
-pkg/kubelet/cm/devicemanager
-pkg/kubelet/pluginmanager/operationexecutor
-pkg/kubelet/pluginmanager/pluginwatcher
-pkg/kubelet/remote
 pkg/probe/http
 pkg/registry/autoscaling/horizontalpodautoscaler/storage
 pkg/registry/core/namespace/storage

--- a/pkg/kubelet/apis/podresources/client.go
+++ b/pkg/kubelet/apis/podresources/client.go
@@ -36,7 +36,7 @@ func GetClient(socket string, connectionTimeout time.Duration, maxMsgSize int) (
 	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
 	defer cancel()
 
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithContextDialer(dialer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error dialing socket %s: %v", socket, err)
 	}

--- a/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
+++ b/pkg/kubelet/cm/devicemanager/device_plugin_stub.go
@@ -162,8 +162,8 @@ func (m *Stub) Register(kubeletEndpoint, resourceName string, pluginSockDir stri
 	defer cancel()
 
 	conn, err := grpc.DialContext(ctx, kubeletEndpoint, grpc.WithInsecure(), grpc.WithBlock(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 		}))
 	if err != nil {
 		return err

--- a/pkg/kubelet/cm/devicemanager/endpoint.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint.go
@@ -177,8 +177,8 @@ func dial(unixSocketPath string) (pluginapi.DevicePluginClient, *grpc.ClientConn
 	defer cancel()
 
 	c, err := grpc.DialContext(ctx, unixSocketPath, grpc.WithInsecure(), grpc.WithBlock(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 		}),
 	)
 

--- a/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
+++ b/pkg/kubelet/pluginmanager/operationexecutor/operation_generator.go
@@ -193,8 +193,8 @@ func dial(unixSocketPath string, timeout time.Duration) (registerapi.Registratio
 	defer cancel()
 
 	c, err := grpc.DialContext(ctx, unixSocketPath, grpc.WithInsecure(), grpc.WithBlock(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 		}),
 	)
 

--- a/pkg/kubelet/pluginmanager/pluginwatcher/example_handler.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/example_handler.go
@@ -156,8 +156,8 @@ func dial(unixSocketPath string, timeout time.Duration) (registerapi.Registratio
 	defer cancel()
 
 	c, err := grpc.DialContext(ctx, unixSocketPath, grpc.WithInsecure(), grpc.WithBlock(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, "unix", addr)
 		}),
 	)
 

--- a/pkg/kubelet/remote/remote_image.go
+++ b/pkg/kubelet/remote/remote_image.go
@@ -47,7 +47,7 @@ func NewRemoteImageService(endpoint string, connectionTimeout time.Duration) (in
 	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
 	defer cancel()
 
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithDialer(dailer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithContextDialer(dailer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
 		klog.Errorf("Connect remote image service %s failed: %v", addr, err)
 		return nil, err

--- a/pkg/kubelet/remote/remote_runtime.go
+++ b/pkg/kubelet/remote/remote_runtime.go
@@ -56,7 +56,7 @@ func NewRemoteRuntimeService(endpoint string, connectionTimeout time.Duration) (
 	ctx, cancel := context.WithTimeout(context.Background(), connectionTimeout)
 	defer cancel()
 
-	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithDialer(dailer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
+	conn, err := grpc.DialContext(ctx, addr, grpc.WithInsecure(), grpc.WithContextDialer(dailer), grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxMsgSize)))
 	if err != nil {
 		klog.Errorf("Connect remote runtime %s failed: %v", addr, err)
 		return nil, err

--- a/pkg/kubelet/util/util_unix.go
+++ b/pkg/kubelet/util/util_unix.go
@@ -19,13 +19,13 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
-	"time"
 
 	"golang.org/x/sys/unix"
 	"k8s.io/klog"
@@ -78,8 +78,8 @@ func CreateListener(endpoint string) (net.Listener, error) {
 	return l, nil
 }
 
-// GetAddressAndDialer returns the address parsed from the given endpoint and a dialer.
-func GetAddressAndDialer(endpoint string) (string, func(addr string, timeout time.Duration) (net.Conn, error), error) {
+// GetAddressAndDialer returns the address parsed from the given endpoint and a context dialer.
+func GetAddressAndDialer(endpoint string) (string, func(ctx context.Context, addr string) (net.Conn, error), error) {
 	protocol, addr, err := parseEndpointWithFallbackProtocol(endpoint, unixProtocol)
 	if err != nil {
 		return "", nil, err
@@ -91,8 +91,8 @@ func GetAddressAndDialer(endpoint string) (string, func(addr string, timeout tim
 	return addr, dial, nil
 }
 
-func dial(addr string, timeout time.Duration) (net.Conn, error) {
-	return net.DialTimeout(unixProtocol, addr, timeout)
+func dial(ctx context.Context, addr string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
 }
 
 func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (protocol string, addr string, err error) {

--- a/pkg/kubelet/util/util_unsupported.go
+++ b/pkg/kubelet/util/util_unsupported.go
@@ -19,6 +19,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -29,8 +30,8 @@ func CreateListener(endpoint string) (net.Listener, error) {
 	return nil, fmt.Errorf("CreateListener is unsupported in this build")
 }
 
-// GetAddressAndDialer returns the address parsed from the given endpoint and a dialer.
-func GetAddressAndDialer(endpoint string) (string, func(addr string, timeout time.Duration) (net.Conn, error), error) {
+// GetAddressAndDialer returns the address parsed from the given endpoint and a context dialer.
+func GetAddressAndDialer(endpoint string) (string, func(ctx context.Context, addr string) (net.Conn, error), error) {
 	return "", nil, fmt.Errorf("GetAddressAndDialer is unsupported in this build")
 }
 

--- a/pkg/kubelet/util/util_windows.go
+++ b/pkg/kubelet/util/util_windows.go
@@ -19,6 +19,7 @@ limitations under the License.
 package util
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/url"
@@ -53,8 +54,8 @@ func CreateListener(endpoint string) (net.Listener, error) {
 	}
 }
 
-// GetAddressAndDialer returns the address parsed from the given endpoint and a dialer.
-func GetAddressAndDialer(endpoint string) (string, func(addr string, timeout time.Duration) (net.Conn, error), error) {
+// GetAddressAndDialer returns the address parsed from the given endpoint and a context dialer.
+func GetAddressAndDialer(endpoint string) (string, func(ctx context.Context, addr string) (net.Conn, error), error) {
 	protocol, addr, err := parseEndpoint(endpoint)
 	if err != nil {
 		return "", nil, err
@@ -71,12 +72,12 @@ func GetAddressAndDialer(endpoint string) (string, func(addr string, timeout tim
 	return "", nil, fmt.Errorf("only support tcp and npipe endpoint")
 }
 
-func tcpDial(addr string, timeout time.Duration) (net.Conn, error) {
-	return net.DialTimeout(tcpProtocol, addr, timeout)
+func tcpDial(ctx context.Context, addr string) (net.Conn, error) {
+	return (&net.Dialer{}).DialContext(ctx, tcpProtocol, addr)
 }
 
-func npipeDial(addr string, timeout time.Duration) (net.Conn, error) {
-	return winio.DialPipe(addr, &timeout)
+func npipeDial(ctx context.Context, addr string) (net.Conn, error) {
+	return winio.DialPipeContext(ctx, addr)
 }
 
 func parseEndpoint(endpoint string) (string, string, error) {

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -496,8 +496,8 @@ func newGrpcConn(addr csiAddr) (*grpc.ClientConn, error) {
 	return grpc.Dial(
 		string(addr),
 		grpc.WithInsecure(),
-		grpc.WithDialer(func(target string, timeout time.Duration) (net.Conn, error) {
-			return net.Dial(network, target)
+		grpc.WithContextDialer(func(ctx context.Context, target string) (net.Conn, error) {
+			return (&net.Dialer{}).DialContext(ctx, network, target)
 		}),
 	)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/area apiserver

**What this PR does / why we need it**:

Now the grpc.WithDialer has deprecated, so use grpc.WithContextDialer instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

xref https://github.com/kubernetes/kubernetes/pull/83595 and https://github.com/kubernetes/kubernetes/pull/83003

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
