### PR TITLE
Building peer-finder Image on s390x

### DIFF
--- a/test/images/pets/peer-finder/BASEIMAGE
+++ b/test/images/pets/peer-finder/BASEIMAGE
@@ -2,3 +2,4 @@ amd64=k8s.gcr.io/debian-base-amd64:0.4.1
 arm=k8s.gcr.io/debian-base-arm:0.4.1
 arm64=k8s.gcr.io/debian-base-arm64:0.4.1
 ppc64le=k8s.gcr.io/debian-base-ppc64le:0.4.1
+s390x=k8s.gcr.io/debian-base-s390x:0.4.1


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
the peer-finder docker image can not be built on s390x. This PR supports building peer-finder on s390x.

**Which issue(s) this PR fixes**:
Fixes # https://github.com/kubernetes/kubernetes/issues/84369

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: