### PR TITLE
Added rest client metrics for client TTL and rot.

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
@@ -16,6 +16,7 @@ go_library(
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/metrics:go_default_library",
         "//staging/src/k8s.io/client-go/transport:go_default_library",
         "//staging/src/k8s.io/client-go/util/connrotation:go_default_library",
         "//vendor/github.com/davecgh/go-spew/spew:go_default_library",

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["exec.go"],
+    srcs = [
+        "exec.go",
+        "metrics.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/plugin/pkg/client/auth/exec",
     importpath = "k8s.io/client-go/plugin/pkg/client/auth/exec",
     visibility = ["//visibility:public"],
@@ -27,7 +30,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["exec_test.go"],
+    srcs = [
+        "exec_test.go",
+        "metrics_test.go",
+    ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [
@@ -35,6 +41,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/metrics:go_default_library",
         "//staging/src/k8s.io/client-go/transport:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -363,12 +363,12 @@ func (a *Authenticator) refreshCredsLocked(r *clientauthentication.Response) err
 	a.cachedCreds = newCreds
 	// Only close all connections when TLS cert rotates. Token rotation doesn't
 	// need the extra noise.
-	if len(a.onRotateList) > 0 && oldCreds != nil && !reflect.DeepEqual(oldCreds.cert, a.cachedCreds.cert) {
+	if oldCreds != nil && !reflect.DeepEqual(oldCreds.cert, a.cachedCreds.cert) {
+		metrics.ClientCertRotationAge.Observe(oldCreds.cert.Leaf.NotAfter.Sub(oldCreds.cert.Leaf.NotBefore))
 		for _, onRotate := range a.onRotateList {
 			onRotate()
 		}
 	}
-	metrics.ClientCertRotationAge.Observe(oldCreds.cert.Leaf.NotAfter.Sub(oldCreds.cert.Leaf.NotBefore))
 	metrics.ClientCertExpiration.Set(newCreds.cert.Leaf.NotAfter)
 	return nil
 }

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -364,7 +364,9 @@ func (a *Authenticator) refreshCredsLocked(r *clientauthentication.Response) err
 	// Only close all connections when TLS cert rotates. Token rotation doesn't
 	// need the extra noise.
 	if oldCreds != nil && !reflect.DeepEqual(oldCreds.cert, a.cachedCreds.cert) {
-		metrics.ClientCertRotationAge.Observe(oldCreds.cert.Leaf.NotAfter.Sub(oldCreds.cert.Leaf.NotBefore))
+		if oldCreds.cert != nil { // Can be nil if the exec auth plugin only returned token auth.
+			metrics.ClientCertRotationAge.Observe(time.Now().Sub(oldCreds.cert.Leaf.NotBefore))
+		}
 		for _, onRotate := range a.onRotateList {
 			onRotate()
 		}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -42,6 +42,7 @@ import (
 	"k8s.io/client-go/pkg/apis/clientauthentication/v1alpha1"
 	"k8s.io/client-go/pkg/apis/clientauthentication/v1beta1"
 	"k8s.io/client-go/tools/clientcmd/api"
+	"k8s.io/client-go/tools/metrics"
 	"k8s.io/client-go/transport"
 	"k8s.io/client-go/util/connrotation"
 	"k8s.io/klog"
@@ -367,5 +368,7 @@ func (a *Authenticator) refreshCredsLocked(r *clientauthentication.Response) err
 			onRotate()
 		}
 	}
+	metrics.ClientCertRotationAge.Observe(oldCreds.cert.Leaf.NotAfter.Sub(oldCreds.cert.Leaf.NotBefore))
+	metrics.ClientCertExpiration.Set(newCreds.cert.Leaf.NotAfter)
 	return nil
 }

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec_test.go
@@ -97,6 +97,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+	cert.Leaf, err = x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		panic(err)
+	}
 	validCert = &cert
 }
 
@@ -760,7 +764,7 @@ func TestConcurrentUpdateTransportConfig(t *testing.T) {
 }
 
 // genClientCert generates an x509 certificate for testing. Certificate and key
-// are returned in PEM encoding.
+// are returned in PEM encoding. The generated cert expires in 24 hours.
 func genClientCert(t *testing.T) ([]byte, []byte) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/client-go/tools/metrics"
+)
+
+type certificateExpirationTracker struct {
+	mu       sync.RWMutex
+	m        map[*Authenticator]time.Time
+	earliest time.Time
+}
+
+var expirationMetrics = &certificateExpirationTracker{m: map[*Authenticator]time.Time{}}
+
+// set stores the given expiration time and updates the updates earliest.
+func (c *certificateExpirationTracker) set(a *Authenticator, t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.m[a] = t
+
+	// update earliest
+	earliest := time.Time{}
+	for _, t := range c.m {
+		if t.IsZero() {
+			continue
+		}
+		if earliest.IsZero() || earliest.After(t) {
+			earliest = t
+		}
+	}
+	c.earliest = earliest
+}
+
+// report reports the ttl to the earliest reported expiration time.
+// If no Authenticators have reported a certificate expiration, this reports nil.
+func (c *certificateExpirationTracker) report(now func() time.Time) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if c.earliest.IsZero() {
+		metrics.ClientCertTTL.Set(nil)
+	} else {
+		ttl := c.earliest.Sub(now())
+		metrics.ClientCertTTL.Set(&ttl)
+	}
+}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/metrics_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package exec
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/client-go/tools/metrics"
+)
+
+type mockTTLGauge struct {
+	v *time.Duration
+}
+
+func (m *mockTTLGauge) Set(d *time.Duration) {
+	m.v = d
+}
+
+func ptr(d time.Duration) *time.Duration {
+	return &d
+}
+
+func TestCertificateExpirationTracker(t *testing.T) {
+	now := time.Now()
+	nowFn := func() time.Time { return now }
+	mockMetric := &mockTTLGauge{}
+	realMetric := metrics.ClientCertTTL
+	metrics.ClientCertTTL = mockMetric
+	defer func() {
+		metrics.ClientCertTTL = realMetric
+	}()
+
+	tracker := &certificateExpirationTracker{m: map[*Authenticator]time.Time{}}
+	tracker.report(nowFn)
+	if mockMetric.v != nil {
+		t.Error("empty tracker should record nil value")
+	}
+
+	firstAuthenticator := &Authenticator{}
+	secondAuthenticator := &Authenticator{}
+	for _, tc := range []struct {
+		desc string
+		auth *Authenticator
+		time time.Time
+		want *time.Duration
+	}{
+		{
+			desc: "ttl for one authenticator",
+			auth: firstAuthenticator,
+			time: now.Add(time.Minute * 10),
+			want: ptr(time.Minute * 10),
+		},
+		{
+			desc: "second authenticator shorter ttl",
+			auth: secondAuthenticator,
+			time: now.Add(time.Minute * 5),
+			want: ptr(time.Minute * 5),
+		},
+		{
+			desc: "update shorter to be longer",
+			auth: secondAuthenticator,
+			time: now.Add(time.Minute * 15),
+			want: ptr(time.Minute * 10),
+		},
+		{
+			desc: "update shorter to be zero time",
+			auth: firstAuthenticator,
+			time: time.Time{},
+			want: ptr(time.Minute * 15),
+		},
+		{
+			desc: "update last to be zero time records nil",
+			auth: secondAuthenticator,
+			time: time.Time{},
+			want: nil,
+		},
+	} {
+		// Must run in series as the tests build off each other.
+		t.Run(tc.desc, func(t *testing.T) {
+			tracker.set(tc.auth, tc.time)
+			tracker.report(nowFn)
+			if mockMetric.v != nil && tc.want != nil {
+				if mockMetric.v.Seconds() != tc.want.Seconds() {
+					t.Errorf("got: %v; want: %v", mockMetric.v, tc.want)
+				}
+			} else if mockMetric.v != tc.want {
+				t.Errorf("got: %v; want: %v", mockMetric.v, tc.want)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -57,7 +57,7 @@ var (
 	RequestResult ResultMetric = noopResult{}
 )
 
-// RegisterOpts is the foo bar
+// RegisterOpts contains all the metrics to register. Metrics may be nil.
 type RegisterOpts struct {
 	ClientCertExpiration  ExpirationMetric
 	ClientCertRotationAge DurationMetric
@@ -69,10 +69,18 @@ type RegisterOpts struct {
 // only be called once.
 func Register(opts RegisterOpts) {
 	registerMetrics.Do(func() {
-		ClientCertExpiration = opts.ClientCertExpiration
-		ClientCertRotationAge = opts.ClientCertRotationAge
-		RequestLatency = opts.RequestLatency
-		RequestResult = opts.RequestResult
+		if opts.ClientCertExpiration != nil {
+			ClientCertExpiration = opts.ClientCertExpiration
+		}
+		if opts.ClientCertRotationAge != nil {
+			ClientCertRotationAge = opts.ClientCertRotationAge
+		}
+		if opts.RequestLatency != nil {
+			RequestLatency = opts.RequestLatency
+		}
+		if opts.RequestResult != nil {
+			RequestResult = opts.RequestResult
+		}
 	})
 }
 

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -26,6 +26,16 @@ import (
 
 var registerMetrics sync.Once
 
+// DurationMetric is a measurement of some amount of time.
+type DurationMetric interface {
+	Observe(duration time.Duration)
+}
+
+// ExpirationMetric sets the time of an expiration.
+type ExpirationMetric interface {
+	Set(expiration time.Time)
+}
+
 // LatencyMetric observes client latency partitioned by verb and url.
 type LatencyMetric interface {
 	Observe(verb string, u url.URL, latency time.Duration)
@@ -37,20 +47,42 @@ type ResultMetric interface {
 }
 
 var (
+	// ClientCertExpiration is the lifetime of the client certificate. The value measured in seconds since January 1, 1970 UTC.
+	ClientCertExpiration ExpirationMetric = noopExpiration{}
+	// ClientCertRotationAge is the age of a certificate that has just been rotated.
+	ClientCertRotationAge DurationMetric = noopDuration{}
 	// RequestLatency is the latency metric that rest clients will update.
 	RequestLatency LatencyMetric = noopLatency{}
 	// RequestResult is the result metric that rest clients will update.
 	RequestResult ResultMetric = noopResult{}
 )
 
+// RegisterOpts is the foo bar
+type RegisterOpts struct {
+	ClientCertExpiration  ExpirationMetric
+	ClientCertRotationAge DurationMetric
+	RequestLatency        LatencyMetric
+	RequestResult         ResultMetric
+}
+
 // Register registers metrics for the rest client to use. This can
 // only be called once.
-func Register(lm LatencyMetric, rm ResultMetric) {
+func Register(opts RegisterOpts) {
 	registerMetrics.Do(func() {
-		RequestLatency = lm
-		RequestResult = rm
+		ClientCertExpiration = opts.ClientCertExpiration
+		ClientCertRotationAge = opts.ClientCertRotationAge
+		RequestLatency = opts.RequestLatency
+		RequestResult = opts.RequestResult
 	})
 }
+
+type noopDuration struct{}
+
+func (noopDuration) Observe(time.Duration) {}
+
+type noopExpiration struct{}
+
+func (noopExpiration) Set(time.Time) {}
 
 type noopLatency struct{}
 

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -31,9 +31,9 @@ type DurationMetric interface {
 	Observe(duration time.Duration)
 }
 
-// ExpirationMetric sets the time of an expiration.
-type ExpirationMetric interface {
-	Set(expiration time.Time)
+// TTLMetric sets the time to live of something.
+type TTLMetric interface {
+	Set(ttl *time.Duration)
 }
 
 // LatencyMetric observes client latency partitioned by verb and url.
@@ -47,8 +47,8 @@ type ResultMetric interface {
 }
 
 var (
-	// ClientCertExpiration is the lifetime of the client certificate. The value measured in seconds since January 1, 1970 UTC.
-	ClientCertExpiration ExpirationMetric = noopExpiration{}
+	// ClientCertTTL is the time to live of a client certificate
+	ClientCertTTL TTLMetric = noopTTL{}
 	// ClientCertRotationAge is the age of a certificate that has just been rotated.
 	ClientCertRotationAge DurationMetric = noopDuration{}
 	// RequestLatency is the latency metric that rest clients will update.
@@ -59,7 +59,7 @@ var (
 
 // RegisterOpts contains all the metrics to register. Metrics may be nil.
 type RegisterOpts struct {
-	ClientCertExpiration  ExpirationMetric
+	ClientCertTTL         TTLMetric
 	ClientCertRotationAge DurationMetric
 	RequestLatency        LatencyMetric
 	RequestResult         ResultMetric
@@ -69,8 +69,8 @@ type RegisterOpts struct {
 // only be called once.
 func Register(opts RegisterOpts) {
 	registerMetrics.Do(func() {
-		if opts.ClientCertExpiration != nil {
-			ClientCertExpiration = opts.ClientCertExpiration
+		if opts.ClientCertTTL != nil {
+			ClientCertTTL = opts.ClientCertTTL
 		}
 		if opts.ClientCertRotationAge != nil {
 			ClientCertRotationAge = opts.ClientCertRotationAge
@@ -88,9 +88,9 @@ type noopDuration struct{}
 
 func (noopDuration) Observe(time.Duration) {}
 
-type noopExpiration struct{}
+type noopTTL struct{}
 
-func (noopExpiration) Set(time.Time) {}
+func (noopTTL) Set(*time.Duration) {}
 
 type noopLatency struct{}
 

--- a/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/prometheus/restclient/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package restclient
 
 import (
+	"math"
 	"net/url"
 	"time"
 
@@ -56,32 +57,58 @@ var (
 		[]string{"code", "method", "host"},
 	)
 
-	certExpiration = k8smetrics.NewGauge(
+	execPluginCertTTL = k8smetrics.NewGauge(
 		&k8smetrics.GaugeOpts{
-			Name: "rest_client_certificate_expiration_seconds",
-			Help: "Gauge of the lifetime of the client certificate. The value is the date the certificate will expire in seconds since January 1, 1970 UTC.",
+			Name: "rest_client_exec_plugin_ttl_seconds",
+			Help: "Gauge of the shortest TTL (time-to-live) of the client " +
+				"certificate(s) managed by the auth exec plugin. The value " +
+				"is in seconds until certificate expiry. If auth exec " +
+				"plugins are unused or manage no TLS certificates, the " +
+				"value will be +INF.",
 		},
 	)
 
-	certRotation = k8smetrics.NewHistogram(
+	execPluginCertRotation = k8smetrics.NewHistogram(
 		&k8smetrics.HistogramOpts{
-			Name: "rest_client_certificate_rotation_age",
-			Help: "Count of the number of seconds the last client certificate lived before being rotated.",
-			// [1m, 1h, ... exponential x^4 ..., 7.5y]
-			Buckets: append([]float64{60}, k8smetrics.ExponentialBuckets(3600, 4, 9)...),
+			Name: "rest_client_exec_plugin_certificate_rotation_age",
+			Help: "Histogram of the number of seconds the last auth exec " +
+				"plugin client certificate lived before being rotated. " +
+				"If auth exec plugin client certificates are unused, " +
+				"histogram will contain no data.",
+			// There are three sets of ranges these buckets intend to capture:
+			//   - 10-60 minutes: captures a rotation cadence which is
+			//     happening too quickly.
+			//   - 4 hours - 1 month: captures an ideal rotation cadence.
+			//   - 3 months - 4 years: captures a rotation cadence which is
+			//     is probably too slow or much too slow.
+			Buckets: []float64{
+				600,       // 10 minutes
+				1800,      // 30 minutes
+				3600,      // 1  hour
+				14400,     // 4  hours
+				86400,     // 1  day
+				604800,    // 1  week
+				2592000,   // 1  month
+				7776000,   // 3  months
+				15552000,  // 6  months
+				31104000,  // 1  year
+				124416000, // 4  years
+			},
 		},
 	)
 )
 
 func init() {
+	execPluginCertTTL.Set(math.Inf(1)) // Initialize TTL to +INF
+
 	legacyregistry.MustRegister(requestLatency)
 	legacyregistry.MustRegister(deprecatedRequestLatency)
 	legacyregistry.MustRegister(requestResult)
-	legacyregistry.MustRegister(certExpiration)
-	legacyregistry.MustRegister(certRotation)
+	legacyregistry.MustRegister(execPluginCertTTL)
+	legacyregistry.MustRegister(execPluginCertRotation)
 	metrics.Register(metrics.RegisterOpts{
-		ClientCertExpiration:  &expirationAdapter{m: certExpiration},
-		ClientCertRotationAge: &rotationAdapter{m: certRotation},
+		ClientCertTTL:         &ttlAdapter{m: execPluginCertTTL},
+		ClientCertRotationAge: &rotationAdapter{m: execPluginCertRotation},
 		RequestLatency:        &latencyAdapter{m: requestLatency, dm: deprecatedRequestLatency},
 		RequestResult:         &resultAdapter{requestResult},
 	})
@@ -105,12 +132,16 @@ func (r *resultAdapter) Increment(code, method, host string) {
 	r.m.WithLabelValues(code, method, host).Inc()
 }
 
-type expirationAdapter struct {
+type ttlAdapter struct {
 	m *k8smetrics.Gauge
 }
 
-func (e *expirationAdapter) Set(t time.Time) {
-	e.m.Set(float64(t.Unix()))
+func (e *ttlAdapter) Set(ttl *time.Duration) {
+	if ttl == nil {
+		e.m.Set(math.Inf(1))
+	} else {
+		e.m.Set(float64(ttl.Seconds()))
+	}
 }
 
 type rotationAdapter struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

/sig auth
/sig instrumentation

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds prometheus metrics to the client-go rest transport to report the TTL and rotation cadence of the client TLS certificates. Improves monitoring capabilities into client certificates nearing expiry and/or issues with certificate refreshing. 


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added two client certificate metrics for exec auth:
    - `rest_client_certificate_expiration_seconds` a gauge reporting the lifetime of the current client certificate. Reports the time of expiry in seconds since January 1, 1970 UTC.
    - `rest_client_certificate_rotation_age` a histogram reporting the age of a just rotated client certificate in seconds.
```
