### PR TITLE
Use DNS_SERVER_IP as --cluster-dns in all cases.

### DIFF
--- a/cluster/addons/dns/nodelocaldns/README.md
+++ b/cluster/addons/dns/nodelocaldns/README.md
@@ -14,6 +14,17 @@ The variables will be substituted by the configure scripts when the yaml is copi
 To create a GCE cluster with nodelocaldns enabled, use  the command:
 `KUBE_ENABLE_NODELOCAL_DNS=true go run hack/e2e.go -v --up`
 
+We have the following variables in the yaml:  
+`__PILLAR__DNS__SERVER__` - set to kube-dns service IP.   
+`__PILLAR__LOCAL__DNS__`  - set to the link-local IP(169.254.20.10 by default).    
+`__PILLAR__DNS__DOMAIN__` - set to the cluster domain(cluster.local by default).   
+
+The following variables will be set by the node-cache images - k8s.gcr.io/k8s-dns-node-cache:1.15.6 or later.
+The values will be determined by reading the kube-dns configMap for custom
+Upstream server configuration.  
+`__PILLAR__CLUSTER__DNS__` - Upstream server for in-cluster queries.   
+`__PILLAR__UPSTREAM__SERVERS__` - Upstream servers for external queries.  
+
 ### Network policy and DNS connectivity
 
 When running nodelocaldns addon on clusters using network policy, additional rules might be required to enable dns connectivity.

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -950,9 +950,6 @@ function print-common-kubelet-config {
   declare quoted_dns_server_ip
   declare quoted_dns_domain
   quoted_dns_server_ip=$(yaml-quote "${DNS_SERVER_IP}")
-  if [[ "${ENABLE_NODELOCAL_DNS:-}" == "true" ]]; then
-    quoted_dns_server_ip=$(yaml-quote "${LOCAL_DNS_IP}")
-  fi
   quoted_dns_domain=$(yaml-quote "${DNS_DOMAIN}")
   cat <<EOF
 kind: KubeletConfiguration


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
This PR sets the --cluster-dns flag value to kube-dns service IP whether or not NodeLocal DNSCache is enabled. NodeLocal DNSCache will listen on both the link-local as well as the service IP.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
