### PR TITLE
Automated cherry pick of #83822: set config.BindAddress to IPv4 address "127.0.0.1" if not

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -26,7 +26,7 @@ import (
 	"net"
 	"strings"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -142,7 +142,8 @@ func newProxyServer(
 	if nodeIP.IsUnspecified() {
 		nodeIP = utilnode.GetNodeIP(client, hostname)
 		if nodeIP == nil {
-			return nil, fmt.Errorf("unable to get node IP for hostname %s", hostname)
+			klog.V(0).Infof("can't determine this node's IP, assuming 127.0.0.1; if this is incorrect, please set the --bind-address flag")
+			nodeIP = net.ParseIP("127.0.0.1")
 		}
 	}
 	if proxyMode == proxyModeIPTables {

--- a/pkg/kubemark/hollow_proxy.go
+++ b/pkg/kubemark/hollow_proxy.go
@@ -18,6 +18,7 @@ package kubemark
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -77,6 +78,11 @@ func NewHollowProxyOrDie(
 	var err error
 
 	if useRealProxier {
+		nodeIP := utilnode.GetNodeIP(client, nodeName)
+		if nodeIP == nil {
+			klog.V(0).Infof("can't determine this node's IP, assuming 127.0.0.1")
+			nodeIP = net.ParseIP("127.0.0.1")
+		}
 		// Real proxier with fake iptables, sysctl, etc underneath it.
 		//var err error
 		proxier, err = iptables.NewProxier(
@@ -89,7 +95,7 @@ func NewHollowProxyOrDie(
 			0,
 			"10.0.0.0/8",
 			nodeName,
-			utilnode.GetNodeIP(client, nodeName),
+			nodeIP,
 			recorder,
 			nil,
 			[]string{},

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -32,7 +32,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	discovery "k8s.io/api/discovery/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -277,11 +277,6 @@ func NewProxier(ipt utiliptables.Interface,
 	// Generate the masquerade mark to use for SNAT rules.
 	masqueradeValue := 1 << uint(masqueradeBit)
 	masqueradeMark := fmt.Sprintf("%#08x/%#08x", masqueradeValue, masqueradeValue)
-
-	if nodeIP == nil {
-		klog.Warning("invalid nodeIP, initializing kube-proxy with 127.0.0.1 as nodeIP")
-		nodeIP = net.ParseIP("127.0.0.1")
-	}
 
 	if len(clusterCIDR) == 0 {
 		klog.Warning("clusterCIDR not specified, unable to distinguish between internal and external traffic")

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -401,11 +401,6 @@ func NewProxier(ipt utiliptables.Interface,
 	masqueradeValue := 1 << uint(masqueradeBit)
 	masqueradeMark := fmt.Sprintf("%#08x/%#08x", masqueradeValue, masqueradeValue)
 
-	if nodeIP == nil {
-		klog.Warningf("invalid nodeIP, initializing kube-proxy with 127.0.0.1 as nodeIP")
-		nodeIP = net.ParseIP("127.0.0.1")
-	}
-
 	isIPv6 := utilnet.IsIPv6(nodeIP)
 
 	klog.V(2).Infof("nodeIP: %v, isIPv6: %v", nodeIP, isIPv6)


### PR DESCRIPTION
Cherry pick of #83822 on release-1.16.

#83822: set config.BindAddress to IPv4 address "127.0.0.1" if not

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.
```release-note
Change kube-proxy's default node IP back to 127.0.0.1, if this is incorrect, please use --bind-address to set the correct address
```