### PR TITLE
Fix metrics may be hidden in current minor release issue

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -101,7 +101,7 @@ func (r *lazyMetric) determineDeprecationStatus(version semver.Version) {
 			klog.Warningf("Hidden metrics have been manually overridden, showing this very deprecated metric.")
 			return
 		}
-		if selfVersion.LT(version) {
+		if shouldHide(&version, selfVersion) {
 			klog.Warningf("This metric has been deprecated for more than one release, hiding.")
 			r.isHidden = true
 		}

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"fmt"
 	"sync"
 	"sync/atomic"
 
@@ -32,6 +33,21 @@ var (
 	showHiddenOnce sync.Once
 	showHidden     atomic.Value
 )
+
+// shouldHide be used to check if a specific metric with deprecated version should be hidden
+// according to metrics deprecation lifecycle.
+func shouldHide(currentVersion *semver.Version, deprecatedVersion *semver.Version) bool {
+	guardVersion, err := semver.Make(fmt.Sprintf("%d.%d.0", currentVersion.Major, currentVersion.Minor))
+	if err != nil {
+		panic("failed to make version from current version")
+	}
+
+	if deprecatedVersion.LT(guardVersion) {
+		return true
+	}
+
+	return false
+}
 
 // SetShowHidden will enable showing hidden metrics. This will no-opt
 // after the initial call

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -60,6 +60,39 @@ var (
 	)
 )
 
+func TestShouldHide(t *testing.T) {
+	currentVersion := parseVersion(apimachineryversion.Info{
+		Major:      "1",
+		Minor:      "17",
+		GitVersion: "v1.17.1-alpha-1.12345",
+	})
+
+	var tests = []struct {
+		desc              string
+		deprecatedVersion string
+		shouldHide        bool
+	}{
+		{
+			desc:              "current minor release should not be hidden",
+			deprecatedVersion: "1.17.0",
+			shouldHide:        false,
+		},
+		{
+			desc:              "older minor release should be hidden",
+			deprecatedVersion: "1.16.0",
+			shouldHide:        true,
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.desc, func(t *testing.T) {
+			result := shouldHide(&currentVersion, parseSemver(tc.deprecatedVersion))
+			assert.Equalf(t, tc.shouldHide, result, "expected should hide %v, but got %v", tc.shouldHide, result)
+		})
+	}
+}
+
 func TestRegister(t *testing.T) {
 	var tests = []struct {
 		desc                    string


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
According to metrics deprecation lifecycle, only metric marked with deprecated version less than codebase `minor` release should be hidden.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
