### PR TITLE
Optimize command  output `kubectl get pod -n xxx`

### DIFF
--- a/pkg/kubectl/cmd/get/BUILD
+++ b/pkg/kubectl/cmd/get/BUILD
@@ -40,6 +40,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",

--- a/pkg/kubectl/cmd/get/get.go
+++ b/pkg/kubectl/cmd/get/get.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/printers"
@@ -579,7 +580,11 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		// if we wrote no output, and had no errors, and are not ignoring NotFound, be sure we output something
 		if !o.AllNamespaces {
-			fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found in %s namespace.", o.Namespace))
+			if msgs := validation.IsDNS1123Label(o.Namespace); len(msgs) != 0 {
+				fmt.Fprintln(o.ErrOut, fmt.Sprintf("The Namespace %s is invalid.", o.Namespace))
+			} else {
+				fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found in %s namespace.", o.Namespace))
+			}
 		} else {
 			fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found"))
 		}


### PR DESCRIPTION
> **What this PR does / why we need it**:

```
# kubectl get pod -n qweewr~!

No resources found in qweewr~! namespace.

```
Should export，because "qweewr~!" is not a legal namespace name, Because it doesn't meet the DNS (RFC 1123) rules ，So its output should be like this.

```
The Namespace qweewr~! is invalid.
```

Only when the DNS (RFC 1123) rules are met, but there are no resources, the output should be this, which may be more reasonable.

```
No resources found in default namespace.
```
> **Which issue(s) this PR fixes** 

> Fixes #
/kind cleanup
/sig cli
> **Special notes for your reviewer**:
> 
> **Release note**:
> 
> ```
> NONE
> ```
