### PR TITLE
Kubectl certificate signing: fix certificate deny message

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -68,6 +68,14 @@ type CertificateOptions struct {
 	genericclioptions.IOStreams
 }
 
+// NewCertificateOptions creates the options for certificate
+func NewCertificateOptions(ioStreams genericclioptions.IOStreams, operation string) *CertificateOptions {
+	return &CertificateOptions{
+		PrintFlags: genericclioptions.NewPrintFlags(operation).WithTypeSetter(scheme.Scheme),
+		IOStreams:  ioStreams,
+	}
+}
+
 func (o *CertificateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.csrNames = args
 	o.outputStyle = cmdutil.GetFlagString(cmd, "output")
@@ -103,10 +111,7 @@ func (o *CertificateOptions) Validate() error {
 }
 
 func NewCmdCertificateApprove(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	o := &CertificateOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("approved").WithTypeSetter(scheme.Scheme),
-		IOStreams:  ioStreams,
-	}
+	o := NewCertificateOptions(ioStreams, "approved")
 
 	cmd := &cobra.Command{
 		Use:                   "approve (-f FILENAME | NAME)",
@@ -161,10 +166,7 @@ func (o *CertificateOptions) RunCertificateApprove(force bool) error {
 }
 
 func NewCmdCertificateDeny(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	o := &CertificateOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("denied").WithTypeSetter(scheme.Scheme),
-		IOStreams:  ioStreams,
-	}
+	o := NewCertificateOptions(ioStreams, "denied")
 
 	cmd := &cobra.Command{
 		Use:                   "deny (-f FILENAME | NAME)",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -68,14 +68,6 @@ type CertificateOptions struct {
 	genericclioptions.IOStreams
 }
 
-// NewCertificateOptions creates the options for certificate
-func NewCertificateOptions(ioStreams genericclioptions.IOStreams) *CertificateOptions {
-	return &CertificateOptions{
-		PrintFlags: genericclioptions.NewPrintFlags("approved").WithTypeSetter(scheme.Scheme),
-		IOStreams:  ioStreams,
-	}
-}
-
 func (o *CertificateOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.csrNames = args
 	o.outputStyle = cmdutil.GetFlagString(cmd, "output")
@@ -111,7 +103,10 @@ func (o *CertificateOptions) Validate() error {
 }
 
 func NewCmdCertificateApprove(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	o := NewCertificateOptions(ioStreams)
+	o := &CertificateOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("approved").WithTypeSetter(scheme.Scheme),
+		IOStreams:  ioStreams,
+	}
 
 	cmd := &cobra.Command{
 		Use:                   "approve (-f FILENAME | NAME)",
@@ -166,7 +161,10 @@ func (o *CertificateOptions) RunCertificateApprove(force bool) error {
 }
 
 func NewCmdCertificateDeny(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	o := NewCertificateOptions(ioStreams)
+	o := &CertificateOptions{
+		PrintFlags: genericclioptions.NewPrintFlags("denied").WithTypeSetter(scheme.Scheme),
+		IOStreams:  ioStreams,
+	}
 
 	cmd := &cobra.Command{
 		Use:                   "deny (-f FILENAME | NAME)",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes an incorrect message when manually denying a certificate signing request
Currently, denied CSRs are getting an **approved** message
```bash
$ kubectl certificate deny mycert
certificatesigningrequest.certificates.k8s.io/mycert approved
```

**Which issue(s) this PR fixes**:
Fixes #84398

**Special notes for your reviewer**:

Find at the lined issue instructions for reproducing the issue 

```release-note
NONE
```
