### PR TITLE
add priority to favor nodes with least non ready pods

### DIFF
--- a/pkg/scheduler/algorithm/priorities/priorities.go
+++ b/pkg/scheduler/algorithm/priorities/priorities.go
@@ -54,4 +54,6 @@ const (
 	// EvenPodsSpreadPriority defines the name of prioritizer function that prioritizes nodes
 	// which have pods and labels matching the incoming pod's topologySpreadConstraints.
 	EvenPodsSpreadPriority = "EvenPodsSpreadPriority"
+	// ReadyPodPriority defines the name of prioritizer function that prioritizes nodes with lesser non ready pods.
+	ReadyPodPriority = "ReadyPodPriority"
 )

--- a/pkg/scheduler/algorithm/priorities/ready.go
+++ b/pkg/scheduler/algorithm/priorities/ready.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priorities
+
+import (
+	"k8s.io/api/core/v1"
+	"k8s.io/klog"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+	"math"
+)
+
+// ReadyPod contains information to calculate ready pod score.
+type ReadyPod struct {
+}
+
+// NewReadyPodPriority creates a ReadyPod.
+func NewReadyPodPriority() PriorityFunction {
+	readyPod := &ReadyPod{}
+	return readyPod.CalculateReadyPodPriority
+}
+func (r *ReadyPod) isPodReady(pod *v1.Pod) bool {
+	for _, cond := range pod.Status.Conditions {
+		if cond.Type == "Ready" && cond.Status == "True" {
+			return true
+		}
+	}
+	return false
+}
+
+// CalculateReadyPodPriority favors nodes with lesser count of non ready pods.
+// Calcuated on a scale of 0-10 where 10 is highest priority.
+func (r *ReadyPod) CalculateReadyPodPriority(pod *v1.Pod, nodeNameToInfo map[string]*schedulernodeinfo.NodeInfo, nodes []*v1.Node) (framework.NodeScoreList, error) {
+	totalPodsNotReady := 0
+	nodeToNonReadyPods := make(map[string]int)
+	// Get count of non ready pods for each node.
+	for _, node := range nodes {
+		nonReadyPods := 0
+		nodeinfo := nodeNameToInfo[node.Name]
+		pods := nodeinfo.Pods()
+		for _, p := range pods {
+			isPodReady := r.isPodReady(p)
+			klog.V(10).Infof("node: %v, pod: %v, ready: %v", node.Name, p.ObjectMeta.Name, isPodReady)
+			if !r.isPodReady(p) {
+				nonReadyPods++
+			}
+		}
+		klog.V(10).Infof("node: %v, non ready pods: %v", node.Name, nonReadyPods)
+		nodeToNonReadyPods[node.Name] = nonReadyPods
+		totalPodsNotReady += nonReadyPods
+	}
+	// Assign host priority to nodes with lesser count of non ready pods.
+	result := make(framework.NodeScoreList, 0, len(nodes))
+	for _, node := range nodes {
+		if totalPodsNotReady == 0 {
+			// all nodes have all pods in ready state
+			result = append(result, framework.NodeScore{Name: node.Name, Score: 10})
+		} else {
+			// prefer nodes nodes with least non ready pods and thus higher score
+			// formula: 10 - ( nonReadyPods / totalPodsNotReady ) * 10
+			score := math.Round(10 - (float64(nodeToNonReadyPods[node.Name])/float64(totalPodsNotReady))*10)
+			result = append(result, framework.NodeScore{Name: node.Name, Score: int64(score)})
+		}
+	}
+	klog.V(5).Infof("result: %v", result)
+	return result, nil
+}

--- a/pkg/scheduler/algorithm/priorities/ready_test.go
+++ b/pkg/scheduler/algorithm/priorities/ready_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package priorities
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
+	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
+)
+
+func TestReadyPodPriority(t *testing.T) {
+
+	tests := []struct {
+		pod          *v1.Pod
+		pods         []*v1.Pod
+		nodes        []*v1.Node
+		expectedList framework.NodeScoreList
+		name         string
+	}{
+		{
+			/*
+			   Test case: 3 of 3 nodes with equal non ready pods
+			   Total non ready pods across cluster: 3
+
+			   Node1 scores on 0-10 scale
+			   Node1 non ready pods: 1
+			   Node1 score: 10 - ( 1 / 3 ) * 10 = math.Round(6.67) = 7
+
+			   Node2 scores on 0-10 scale
+			   Node2 non ready pods: 1
+			   Node2 score: 10 - ( 1 / 3 ) * 10 = math.Round(6.67) = 7
+
+			   Node3 scores on 0-10 scale
+			   Node3 non ready pods: 1
+			   Node3 score: 10 - ( 1 / 3 ) * 10 = math.Round(6.67) = 7
+			*/
+			name: "3 of 3 nodes with equal non ready pods",
+			pod:  &v1.Pod{Spec: v1.PodSpec{NodeName: ""}},
+			pods: []*v1.Pod{
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node1"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node2"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node3"}},
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
+			},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 7}, {Name: "node2", Score: 7}, {Name: "node3", Score: 7}},
+		},
+		{
+			/*
+			   Test case: 3 of 3 nodes with zero non ready pods
+			   Total non ready pods across cluster: 0
+
+			   When all nodes are w/o non running pods, they are all scored with 10.
+			*/
+			name: "3 of 3 nodes with zero non ready pods",
+			pod:  &v1.Pod{Spec: v1.PodSpec{NodeName: ""}},
+			pods: []*v1.Pod{
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}, Spec: v1.PodSpec{NodeName: "node1"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}, Spec: v1.PodSpec{NodeName: "node2"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}, Spec: v1.PodSpec{NodeName: "node3"}},
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
+			},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 10}, {Name: "node2", Score: 10}, {Name: "node3", Score: 10}},
+		},
+		{
+			/*
+			   Test case: 3 nodes with varying non ready pods
+			   Total non ready pods across cluster: 5
+
+			   Node1 scores on 0-10 scale
+			   Node1 non ready pods: 0
+			   Node1 score: 10 - ( 0 / 5 ) * 10 = math.Round(10) = 10
+
+			   Node2 scores on 0-10 scale
+			   Node2 non ready pods: 1
+			   Node2 score: 10 - ( 1 / 5 ) * 10 = math.Round(8) = 8
+
+			   Node3 scores on 0-10 scale
+			   Node3 non ready pods: 4
+			   Node3 score: 10 - ( 4 / 5 ) * 10 = math.Round(2) = 2
+			*/
+			name: "3 nodes with varying non ready pods",
+			pod:  &v1.Pod{Spec: v1.PodSpec{NodeName: ""}},
+			pods: []*v1.Pod{
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}, Spec: v1.PodSpec{NodeName: "node1"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}, Spec: v1.PodSpec{NodeName: "node1"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}, Spec: v1.PodSpec{NodeName: "node2"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node2"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionTrue}}}, Spec: v1.PodSpec{NodeName: "node3"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node3"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node3"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node3"}},
+				{Status: v1.PodStatus{Conditions: []v1.PodCondition{{Type: v1.PodReady, Status: v1.ConditionFalse}}}, Spec: v1.PodSpec{NodeName: "node3"}},
+			},
+			nodes: []*v1.Node{
+				{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "node3"}},
+			},
+			expectedList: []framework.NodeScore{{Name: "node1", Score: 10}, {Name: "node2", Score: 8}, {Name: "node3", Score: 2}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nodeNameToInfo := schedulernodeinfo.CreateNodeNameToInfoMap(test.pods, test.nodes)
+			readyPod := ReadyPod{}
+			list, err := readyPod.CalculateReadyPodPriority(test.pod, nodeNameToInfo, test.nodes)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(test.expectedList, list) {
+				t.Errorf("expected \n\t%#v, \ngot \n\t%#v\n", test.expectedList, list)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -104,6 +104,7 @@ func defaultPriorities() sets.String {
 		priorities.NodeAffinityPriority,
 		priorities.TaintTolerationPriority,
 		priorities.ImageLocalityPriority,
+		priorities.ReadyPodPriority,
 	)
 }
 

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -75,6 +75,16 @@ func init() {
 			Weight: 1,
 		},
 	)
+	// Prioritize nodes with lesser count of non ready pods
+	scheduler.RegisterPriorityConfigFactory(
+		priorities.ReadyPodPriority,
+		scheduler.PriorityConfigFactory{
+			Function: func(args scheduler.PluginFactoryArgs) priorities.PriorityFunction {
+				return priorities.NewReadyPodPriority()
+			},
+			Weight: 1,
+		},
+	)
 
 	// Prioritize nodes by least requested utilization.
 	scheduler.RegisterPriorityMapReduceFunction(priorities.LeastRequestedPriority, priorities.LeastRequestedPriorityMap, nil, 1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

New scheduler priority ReadyPodPriority which adds a score to prefer nodes with least non ready pods.

In our environment we have pods that take a while to pass ready/liveness checks as these pods have caches which need to backfill to memory prior to being ready, during this time memory and cpu resources are spiked. By adding a score to favor nodes with less non ready pods, this helped us by preventing deployments to overload a node, especially a newly entered node which is idle, from getting overloaded.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

NONE

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add priority to default scheduler which favor nodes with least non ready pods.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
