### PR TITLE
Change FuzzTime to FuzzTimeStrict for naming consistency

### DIFF
--- a/test/fuzz/yaml/yaml.go
+++ b/test/fuzz/yaml/yaml.go
@@ -81,10 +81,10 @@ func FuzzSigYaml(b []byte) int {
 	return out
 }
 
-// FuzzTime is a fuzz target for strict-unmarshaling Time defined in
+// FuzzTimeStrict is a fuzz target for strict-unmarshaling Time defined in
 // "k8s.io/apimachinery/pkg/apis/meta/v1". This target also checks that the
 // unmarshaled result can be marshaled back to the input.
-func FuzzTime(b []byte) int {
+func FuzzTimeStrict(b []byte) int {
 	var timeHolder struct {
 		T metav1.Time `json:"t"`
 	}


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Fixes a naming mistake from #84168. The other fuzz targets from that PR had a 'Strict' suffix in the target name, which was inadvertently omitted from the 'FuzzTime' target.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: