### PR TITLE
Move funcs of node_util to cloud/gcp.

### DIFF
--- a/test/e2e/cloud/BUILD
+++ b/test/e2e/cloud/BUILD
@@ -9,6 +9,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/cloud",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/test/e2e/cloud/nodes.go
+++ b/test/e2e/cloud/nodes.go
@@ -19,6 +19,7 @@ package cloud
 import (
 	"time"
 
+	v1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -55,7 +56,7 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 
 		framework.Logf("Original number of ready nodes: %d", len(origNodes.Items))
 
-		err = framework.DeleteNodeOnCloudProvider(nodeToDelete)
+		err = deleteNodeOnCloudProvider(nodeToDelete)
 		if err != nil {
 			framework.Failf("failed to delete node %q, err: %q", nodeToDelete.Name, err)
 		}
@@ -73,3 +74,8 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 
 	})
 })
+
+// DeleteNodeOnCloudProvider deletes the specified node.
+func deleteNodeOnCloudProvider(node *v1.Node) error {
+	return framework.TestContext.CloudConfig.Provider.DeleteNode(node)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

ref: https://github.com/kubernetes/kubernetes/issues/84380

Move functions in `node_util.go` to module `cloud/gcp`.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```

/assigin @oomichi 