### PR TITLE
avoid to evict pod created by daemonset controller

### DIFF
--- a/pkg/kubelet/eviction/eviction_manager.go
+++ b/pkg/kubelet/eviction/eviction_manager.go
@@ -550,6 +550,12 @@ func (m *managerImpl) evictPod(pod *v1.Pod, gracePeriodOverride int64, evictMsg 
 		klog.Errorf("eviction manager: cannot evict a critical pod %s", format.Pod(pod))
 		return false
 	}
+
+	if kubelettypes.IsPodOwnedByDaemonSet(pod) {
+		klog.Errorf("eviction manager: cannot evict a pod created by DaemonSet")
+		return false
+	}
+
 	status := v1.PodStatus{
 		Phase:   v1.PodFailed,
 		Message: evictMsg,

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -181,3 +181,14 @@ func Preemptable(preemptor, preemptee *v1.Pod) bool {
 func IsCriticalPodBasedOnPriority(priority int32) bool {
 	return priority >= scheduling.SystemCriticalPriority
 }
+
+// IsPodOwnedByDaemonSet checks if the given pod is owned by DaemonSet
+func IsPodOwnedByDaemonSet(pod *v1.Pod) bool {
+	for _, owner := range pod.OwnerReferences {
+		if *owner.Controller && owner.Kind == "DaemonSet" {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION

**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Quote from [eviction design doc](https://github.com/kubernetes/community/blob/master/contributors/design-proposals/node/kubelet-eviction.md#best-practices):

> It is never desired for a kubelet to evict a pod that was derived from a DaemonSet since the pod will immediately be recreated and rescheduled back to the same node.
>
> At the moment, the kubelet has no ability to distinguish a pod created from DaemonSet versus any other object. If/when that information is available, the kubelet could pro-actively filter those pods from the candidate set of pods provided to the eviction strategy.


As now we have an `OwnerReference` filed at ObjectMeta,  so we can judge a pod is created by `Daemonset` by `OwnerReference` filed.  
this PR achieve this, so pod created by DaemonSet will never be evicted by kubelet

@liggitt  could you please give some advice from api-machinery perspective?  is it reasonable and safe to judge a pod is created by `Daemonset` by `OwnerReference` filed ?


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```