### PR TITLE
Continue killing containers in case of error

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -619,6 +619,27 @@ func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *ku
 	return changes
 }
 
+// We will continue killing containers in the case of error return from killContainer
+func (m *kubeGenericRuntimeManager) killAllContainersIgnoringFailures(pod *v1.Pod, podContainerChanges podActions, result kubecontainer.PodSyncResult) (int, bool) {
+	seenError := false
+	containersKillAttempted := 0
+	for containerID, containerInfo := range podContainerChanges.ContainersToKill {
+		if len(podContainerChanges.ContainersToKill) > 1 {
+			klog.V(3).Infof("Killing unwanted container %q(id=%q) for pod %q", containerInfo.name, containerID, format.Pod(pod))
+		}
+		klog.V(3).Infof("Killing unwanted container %q(id=%q) for pod %q", containerInfo.name, containerID, format.Pod(pod))
+		killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.name)
+		result.AddSyncResult(killContainerResult)
+		containersKillAttempted++
+		if err := m.killContainer(pod, containerID, containerInfo.name, containerInfo.message, nil); err != nil {
+			killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
+			klog.Errorf("killContainer %q(id=%q) for pod %q failed: %v", containerInfo.name, containerID, format.Pod(pod), err)
+			seenError = true
+		}
+	}
+	return containersKillAttempted, seenError
+}
+
 // SyncPod syncs the running pod into the desired pod by executing following steps:
 //
 //  1. Compute sandbox and container changes.
@@ -664,15 +685,8 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *v1.Pod, podStatus *kubecontaine
 		}
 	} else {
 		// Step 3: kill any running containers in this pod which are not to keep.
-		for containerID, containerInfo := range podContainerChanges.ContainersToKill {
-			klog.V(3).Infof("Killing unwanted container %q(id=%q) for pod %q", containerInfo.name, containerID, format.Pod(pod))
-			killContainerResult := kubecontainer.NewSyncResult(kubecontainer.KillContainer, containerInfo.name)
-			result.AddSyncResult(killContainerResult)
-			if err := m.killContainer(pod, containerID, containerInfo.name, containerInfo.message, nil); err != nil {
-				killContainerResult.Fail(kubecontainer.ErrKillContainer, err.Error())
-				klog.Errorf("killContainer %q(id=%q) for pod %q failed: %v", containerInfo.name, containerID, format.Pod(pod), err)
-				return
-			}
+		if _, errEncountered := m.killAllContainersIgnoringFailures(pod, podContainerChanges, result); errEncountered {
+			return
 		}
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -920,6 +920,26 @@ func TestComputePodActions(t *testing.T) {
 	}
 }
 
+func TestKillAllContainersIgnoringFailures(t *testing.T) {
+	_, _, m, err := createTestRuntimeManager()
+	require.NoError(t, err)
+
+	// Createing a pair reference pod and status for the test cases to refer
+	// the specific fields.
+	pod, status := makeBasePodAndStatus()
+	pod.Spec.RestartPolicy = v1.RestartPolicyNever
+	status.ContainerStatuses[1].State = kubecontainer.ContainerStateUnknown
+	actions := podActions{
+		SandboxID:         status.SandboxStatuses[0].Id,
+		ContainersToKill:  getKillMap(pod, status, []int{0, 1}),
+		ContainersToStart: []int{1},
+	}
+
+	count, seenErr := m.killAllContainersIgnoringFailures(pod, actions, kubecontainer.PodSyncResult{})
+	assert.Equal(t, 2, count, "2 container killings should be attempted")
+	assert.Equal(t, true, seenErr, "there should have been error killing container")
+}
+
 func getKillMap(pod *v1.Pod, status *kubecontainer.PodStatus, cIndexes []int) map[kubecontainer.ContainerID]containerToKillInfo {
 	m := map[kubecontainer.ContainerID]containerToKillInfo{}
 	for _, i := range cIndexes {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In kubeGenericRuntimeManager#SyncPod, when error is encountered killing container(s), we should continue killing the remaining running containers in this pod which are not to keep.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
