### PR TITLE
Define workloads specs by YAML

### DIFF
--- a/test/integration/scheduler_perf/BUILD
+++ b/test/integration/scheduler_perf/BUILD
@@ -50,6 +50,7 @@ go_test(
         "//test/integration/framework:go_default_library",
         "//test/utils:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/test/integration/scheduler_perf/benchmark-config.yml
+++ b/test/integration/scheduler_perf/benchmark-config.yml
@@ -1,0 +1,107 @@
+benchmarkScheduling:
+  - nodes: 100
+    existingPods: 0
+    minPods: 100
+  - nodes: 100
+    existingPods: 1000
+    minPods: 100
+  - nodes: 1000
+    existingPods: 0
+    minPods: 100
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 100
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000
+benchmarkSchedulingPodAntiAffinity:
+  - nodes: 500
+    existingPods: 250
+    minPods: 250
+  - nodes: 500
+    existingPods: 5000
+    minPods: 250
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 500
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000
+benchmarkSchedulingSecrets:
+  - nodes: 500
+    existingPods: 250
+    minPods: 250
+  - nodes: 500
+    existingPods: 5000
+    minPods: 250
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 500
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000
+benchmarkSchedulingInTreePVs:
+  - nodes: 500
+    existingPods: 250
+    minPods: 250
+  - nodes: 500
+    existingPods: 5000
+    minPods: 250
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 500
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000
+benchmarkSchedulingMigratedInTreePVs:
+  - nodes: 500
+    existingPods: 250
+    minPods: 250
+  - nodes: 500
+    existingPods: 5000
+    minPods: 250
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 500
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000
+benchmarkSchedulingCSIPVs:
+  - nodes: 500
+    existingPods: 250
+    minPods: 250
+  - nodes: 500
+    existingPods: 5000
+    minPods: 250
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 500
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000
+benchmarkSchedulingPodAffinity:
+  - nodes: 500
+    existingPods: 250
+    minPods: 250
+  - nodes: 500
+    existingPods: 5000
+    minPods: 250
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 500
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000
+benchmarkSchedulingNodeAffinity:
+  - nodes: 500
+    existingPods: 250
+    minPods: 250
+  - nodes: 500
+    existingPods: 5000
+    minPods: 250
+  - nodes: 1000
+    existingPods: 1000
+    minPods: 500
+  - nodes: 5000
+    existingPods: 1000
+    minPods: 1000


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Current benchmark tests are hardcoded to be a certain kind of workloads. We can use YAML to define the workloads spec, so that users can leverage the benchmark utilities while composing their own workloads to benchmark.

**Which issue(s) this PR fixes**:

Fixes #84307

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
