### PR TITLE
[WIP] use alpine image for kube-proxy iptables

### DIFF
--- a/build/alpine-iptables/Dockerfile
+++ b/build/alpine-iptables/Dockerfile
@@ -1,0 +1,37 @@
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM BASEIMAGE
+
+RUN apk add -U --no-cache \
+    ebtables \
+    iptables \
+    ip6tables \
+    conntrack-tools \
+    ipset \
+    kmod \
+    iproute2
+
+# Install iptables wrapper scripts to detect the correct iptables mode
+# the first time any of them is run
+# Alpine PATH is PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# and iptables binaries are installed in /sbin by default
+COPY iptables-wrapper /usr/sbin/iptables-wrapper
+
+RUN ln -s /usr/sbin/iptables-wrapper /usr/sbin/iptables \
+    && ln -s /usr/sbin/iptables-wrapper /usr/sbin/ip6tables \
+    && ln -s /usr/sbin/iptables-wrapper /usr/sbin/iptables-restore \
+    && ln -s /usr/sbin/iptables-wrapper /usr/sbin/ip6tables-restore \
+    && ln -s /usr/sbin/iptables-wrapper /usr/sbin/iptables-save \
+    && ln -s /usr/sbin/iptables-wrapper /usr/sbin/ip6tables-save

--- a/build/alpine-iptables/Makefile
+++ b/build/alpine-iptables/Makefile
@@ -1,0 +1,62 @@
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY:	build push all all-build all-push-images all-push push-manifest
+
+REGISTRY?="staging-k8s.gcr.io"
+IMAGE=$(REGISTRY)/alpine-iptables
+TAG?=v12.0.0
+ARCH?=amd64
+ALL_ARCH = amd64 arm arm64 ppc64le s390x
+TEMP_DIR:=$(shell mktemp -d)
+
+BASEIMAGE?=docker.io/alpine:3
+
+# This option is for running docker manifest command
+export DOCKER_CLI_EXPERIMENTAL := enabled
+
+SUDO=$(if $(filter 0,$(shell id -u)),,sudo)
+
+build:
+	cp ./* $(TEMP_DIR)
+	cd $(TEMP_DIR) && sed -i "s|BASEIMAGE|$(BASEIMAGE)|g" Dockerfile
+
+ifneq ($(ARCH),amd64)
+	# Register /usr/bin/qemu-ARCH-static as the handler for non-x86 binaries in the kernel
+	$(SUDO) ../../third_party/multiarch/qemu-user-static/register/register.sh --reset
+endif
+
+	docker build --pull -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+
+push: build
+	docker push $(IMAGE)-$(ARCH):$(TAG)
+
+sub-build-%:
+	$(MAKE) ARCH=$* build
+
+all-build: $(addprefix sub-build-,$(ALL_ARCH))
+
+sub-push-image-%:
+	$(MAKE) ARCH=$* push
+
+all-push-images: $(addprefix sub-push-image-,$(ALL_ARCH))
+
+all-push: all-push-images push-manifest
+
+push-manifest:
+	docker manifest create --amend $(IMAGE):$(TAG) $(shell echo $(ALL_ARCH) | sed -e "s~[^ ]*~$(IMAGE)\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCH); do docker manifest annotate --arch $${arch} ${IMAGE}:${TAG} ${IMAGE}-$${arch}:${TAG}; done
+	docker manifest push --purge ${IMAGE}:${TAG}
+
+all: all-push

--- a/build/alpine-iptables/OWNERS
+++ b/build/alpine-iptables/OWNERS
@@ -1,0 +1,18 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - BenTheElder
+  - bowei
+  - freehan
+  - jingax10
+  - mkumatag
+  - mrhohn
+  - tallclair
+approvers:
+  - BenTheElder
+  - bowei
+  - freehan
+  - jingax10
+  - mkumatag
+  - mrhohn
+  - tallclair

--- a/build/alpine-iptables/README.md
+++ b/build/alpine-iptables/README.md
@@ -1,0 +1,24 @@
+### alpine-iptables
+
+Serves as the base image for `k8s.gcr.io/kube-proxy-${ARCH}`
+
+This image is compiled for multiple architectures.
+
+#### How to release
+
+If you're editing the Dockerfile or some other thing, please bump the `TAG` in the Makefile.
+
+```console
+Build and  push images for all the architectures
+$ make all-push
+# ---> staging-k8s.gcr.io/alpine-iptables-amd64:TAG
+# ---> staging-k8s.gcr.io/alpine-iptables-arm:TAG
+# ---> staging-k8s.gcr.io/alpine-iptables-arm64:TAG
+# ---> staging-k8s.gcr.io/alpine-iptables-ppc64le:TAG
+# ---> staging-k8s.gcr.io/alpine-iptables-s390x:TAG
+```
+
+If you don't want to push the images, run `make build ARCH={target_arch}` or `make all-build` instead
+
+
+[![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/build/alpine-iptables/README.md?pixel)]()

--- a/build/alpine-iptables/iptables-wrapper
+++ b/build/alpine-iptables/iptables-wrapper
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+# Detect whether the base system is using iptables-legacy or
+# iptables-nft. This assumes that some non-containerized process (eg
+# kubelet) has already created some iptables rules.
+num_legacy_lines=$( (iptables-legacy-save || true; ip6tables-legacy-save || true) 2>/dev/null | grep '^-' | wc -l)
+num_nft_lines=$( (iptables-nft-save || true; ip6tables-nft-save || true) 2>/dev/null | grep '^-' | wc -l)
+if [ "${num_legacy_lines}" -ge "${num_nft_lines}" ]; then
+    mode=legacy
+else
+    mode=nft
+fi
+
+ln -sf /sbin/iptables-${mode} /usr/sbin/iptables > /dev/null
+ln -sf /sbin/ip6tables-${mode} /usr/sbin/ip6tables > /dev/null
+ln -sf /sbin/iptables-${mode}-restore /usr/sbin/iptables-restore > /dev/null
+ln -sf /sbin/ip6tables-${mode}-restore /usr/sbin/ip6tables-restore > /dev/null
+ln -sf /sbin/iptables-${mode}-save /usr/sbin/iptables-save > /dev/null
+ln -sf /sbin/ip6tables-${mode}-save /usr/sbin/ip6tables-save > /dev/null
+
+# Now re-exec the original command with the newly-selected alternative
+exec "$0" "$@"

--- a/build/common.sh
+++ b/build/common.sh
@@ -94,13 +94,14 @@ kube::build::get_docker_wrapped_binaries() {
   local arch=$1
   local debian_base_version=v1.0.0
   local debian_iptables_version=v11.0.2
+  local alpine_iptables_version=v12.0.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(
     kube-apiserver,"${KUBE_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
     kube-controller-manager,"${KUBE_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
     kube-scheduler,"${KUBE_BASE_IMAGE_REGISTRY}/debian-base-${arch}:${debian_base_version}"
-    kube-proxy,"${KUBE_BASE_IMAGE_REGISTRY}/debian-iptables-${arch}:${debian_iptables_version}"
+    kube-proxy,"docker.io/aojea/alpine-iptables-${arch}:${alpine_iptables_version}"
   )
 
   echo "${targets[@]}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
/kind cleanup

> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

The maintenance and generation of current images based in debian is not clear and adds an overhead that we can avoid leveraging well-known and maintained container images. It also complicates in excess dealing with security patches and/or adding new features.
Alpine images are well known, small-sized and widely used that make them a perfect fit for using with kube-proxy, which only requires access to the iptables binaries.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71305
Fixes #81729

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The official kube-proxy image (used by kubeadm, among other things) is now
based in alpine and compatible with systems running iptables 1.8 in "nft" mode, 
and will autodetect which mode it should use.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
