### PR TITLE
volume: add critical section to prevent potential data race

### DIFF
--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -787,6 +787,9 @@ func (pm *VolumePluginMgr) refreshProbedPlugins() {
 
 // ListVolumePluginWithLimits returns plugins that have volume limits on nodes
 func (pm *VolumePluginMgr) ListVolumePluginWithLimits() []VolumePluginWithAttachLimits {
+	pm.mutex.Lock()
+	defer pm.mutex.Unlock()
+
 	matchedPlugins := []VolumePluginWithAttachLimits{}
 	for _, v := range pm.plugins {
 		if plugin, ok := v.(VolumePluginWithAttachLimits); ok {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`pm.plugins` is a map. Among 7 usages of `pm.plugins`, 6 of them are protected by `pm.mutex.Lock()`, but the one in `pm.ListVolumePluginWithLimits()` is not protected. 

This patch adds a pair of lock and unlock to protect `pm.plugins`, following the same style as the other 6 usages.

This data race is quite *dangerous*, because data race of a map will crash all running goroutines.

I found below is the only place where `pm.ListVolumePluginWithLimits()` is invoked, so this patch will not introduce a double lock problem.
https://github.com/kubernetes/kubernetes/blob/7d13dfe3c34f44ff505afe397c7b05fe6e5414ed/pkg/kubelet/kubelet_node_status.go#L542-L544

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```