### PR TITLE
Revise SharedInformer godoc comments

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -106,7 +106,18 @@ import (
 // and index updates happen before such a prescribed notification.
 // For a given SharedInformer and client, the notifications are
 // delivered sequentially.  For a given SharedInformer, client, and
-// object ID, the notifications are delivered in order.
+// object ID, the notifications are delivered in order.  Because
+// `ObjectMeta.UID` has no role in identifying objects, if an object
+// O1 with ID (e.g. namespace and name) X and `ObjectMeta.UID` U1 in
+// the SharedInformer's local cache is deleted and shortly after
+// another relevant object O2 with ID X and `ObjectMeta.UID` U2 is
+// created a client has no guarantee of seeing O1's deletion and
+// O2's creation as two separate notifications, it might as well
+// receive a single update notification where the old object is O1
+// and the new object is O2. Clients that need to detect such cases
+// might do so by comparing the `ObjectMeta.UID` field of the old
+// and the new object in the code that handles update notifications
+// (i.e. `OnUpdate` method of ResourceEventHandler).
 //
 // A client must process each notification promptly; a SharedInformer
 // is not engineered to deal well with a large backlog of

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -70,7 +70,7 @@ import (
 // The local cache starts out empty, and gets populated and updated
 // during `Run()`.
 //
-// As a simple example, if a collection of objects is henceforeth
+// As a simple example, if a collection of objects is henceforth
 // unchanging, a SharedInformer is created that links to that
 // collection, and that SharedInformer is `Run()` then that
 // SharedInformer's cache eventually holds an exact copy of that
@@ -140,7 +140,7 @@ type SharedInformer interface {
 	AddEventHandler(handler ResourceEventHandler)
 	// AddEventHandlerWithResyncPeriod adds an event handler to the
 	// shared informer using the specified resync period.  The resync
-	// operation consists of delivering to the handler a create
+	// operation consists of delivering to the handler an update
 	// notification for every object in the informer's local cache; it
 	// does not add any interactions with the authoritative storage.
 	AddEventHandlerWithResyncPeriod(handler ResourceEventHandler, resyncPeriod time.Duration)

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer.go
@@ -107,17 +107,15 @@ import (
 // For a given SharedInformer and client, the notifications are
 // delivered sequentially.  For a given SharedInformer, client, and
 // object ID, the notifications are delivered in order.  Because
-// `ObjectMeta.UID` has no role in identifying objects, if an object
-// O1 with ID (e.g. namespace and name) X and `ObjectMeta.UID` U1 in
-// the SharedInformer's local cache is deleted and shortly after
-// another relevant object O2 with ID X and `ObjectMeta.UID` U2 is
-// created a client has no guarantee of seeing O1's deletion and
-// O2's creation as two separate notifications, it might as well
-// receive a single update notification where the old object is O1
-// and the new object is O2. Clients that need to detect such cases
-// might do so by comparing the `ObjectMeta.UID` field of the old
-// and the new object in the code that handles update notifications
-// (i.e. `OnUpdate` method of ResourceEventHandler).
+// `ObjectMeta.UID` has no role in identifying objects, it is possible
+// that when (1) object O1 with ID (e.g. namespace and name) X and
+// `ObjectMeta.UID` U1 in the SharedInformer's local cache is deleted
+// and later (2) another object O2 with ID X and ObjectMeta.UID U2 is
+// created the informer's clients are not notified of (1) and (2) but
+// rather are notified only of an update from O1 to O2. Clients that
+// need to detect such cases might do so by comparing the `ObjectMeta.UID`
+// field of the old and the new object in the code that handles update
+// notifications (i.e. `OnUpdate` method of ResourceEventHandler).
 //
 // A client must process each notification promptly; a SharedInformer
 // is not engineered to deal well with a large backlog of


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design

/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

(1) Periodic resyncs trigger update notifications (see notes to reviewer for proof), previous comments stated that create notifications are triggered, 3ae8c86 fixes that (and a minor typo as well). 

(2) The delete of an API object with identifier X followed by a create of a different API object with same identifier X can be seen as a single update notification by a ResourceEventHandler; 
ff543dd tries to explicitly state that in the comments on SharedInformer. In the previous comments there was all the needed information to derive that fact but at least one user still had doubts (see [this](https://kubernetes.slack.com/archives/C0EG7JC6T/p1571054208147900) thread). We can also drop this, but if we choose to keep it notice that there could be other places where this information might be added (e.g. godoc comments on [ResourceEventHandler](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/controller.go#L180))

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

If this gets approved let me know before you apply LGTM so that I can squash commits.

Appendix: "proof" that periodic resyncs cause update notifications as opposed to create notifications. When a [periodic resync is done](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/reflector.go#L267-L269), the reflector invokes its store Resync method. The store is a DeltaFIFO, its Resync method is [this](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go#L511). [Keys for all the objects in the SharedInformer's cache are retrieved](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go#L519) and for each one [syncKeyLocked is invoked](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go#L521), which [adds a Sync delta for the object](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go#L550) (there are minor exceptions, some deltas not enqueued but this is not relevant here). When the SharedInformer pops a Sync delta, it [queries its cache and delivers an update notification if the object in the delta is already in the cache](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/cache/shared_informer.go#L455-L462) ; this can only be true for deltas enqueued because of a period resync.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
