### PR TITLE
kubeadm-validators: bump the latest validated Docker version to 19.03

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -25,7 +25,7 @@ dependencies:
       match: const etcdImage
 
   - name: "docker"
-    version: 18.09
+    version: 19.03
     refPaths:
     - path: cmd/kubeadm/app/util/system/docker_validator.go
       match: latestValidatedDockerVersion

--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -46,7 +46,7 @@ func (d *DockerValidator) Name() string {
 
 const (
 	dockerConfigPrefix           = "DOCKER_"
-	latestValidatedDockerVersion = "18.09"
+	latestValidatedDockerVersion = "19.03"
 )
 
 // Validate is part of the system.Validator interface.

--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -28,7 +28,7 @@ func TestValidateDockerInfo(t *testing.T) {
 		Reporter: DefaultReporter,
 	}
 	spec := &DockerSpec{
-		Version:     []string{`1\.13\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`},
+		Version:     []string{`1\.13\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},
 		GraphDriver: []string{"driver_1", "driver_2"},
 	}
 	for _, test := range []struct {
@@ -86,8 +86,14 @@ func TestValidateDockerInfo(t *testing.T) {
 			warn: false,
 		},
 		{
-			name: "Docker version 19.01.0 is not in the list of validated versions",
-			info: dockerInfo{Driver: "driver_2", ServerVersion: "19.01.0"},
+			name: "valid Docker version 19.03.1-ce",
+			info: dockerInfo{Driver: "driver_2", ServerVersion: "19.03.1-ce"},
+			err:  false,
+			warn: false,
+		},
+		{
+			name: "Docker version 19.06.0 is not in the list of validated versions",
+			info: dockerInfo{Driver: "driver_2", ServerVersion: "19.06.0"},
 			err:  false,
 			warn: true,
 		},

--- a/cmd/kubeadm/app/util/system/types_unix.go
+++ b/cmd/kubeadm/app/util/system/types_unix.go
@@ -59,7 +59,7 @@ var DefaultSysSpec = SysSpec{
 	Cgroups: []string{"cpu", "cpuacct", "cpuset", "devices", "freezer", "memory"},
 	RuntimeSpec: RuntimeSpec{
 		DockerSpec: &DockerSpec{
-			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`},
+			Version:     []string{`1\.1[1-3]\..*`, `17\.0[3,6,9]\..*`, `18\.0[6,9]\..*`, `19\.03\..*`},
 			GraphDriver: []string{"aufs", "overlay", "overlay2", "devicemapper", "zfs"},
 		},
 	},


### PR DESCRIPTION
**What this PR does / why we need it**:

19.03 has been validated for a while, see:
https://github.com/kubernetes/kubernetes/issues/82326#issuecomment-546464495

also kubekins @ test-infra is already at 19*.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #82326
Fixes kubernetes/kubeadm#1821

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
update the latest validated version of Docker to 19.03
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @BenTheElder @yastij @timothysc 
/kind feature
/priority important-longterm
