### PR TITLE
Switch storage version to use v1.CSINode in 1.18

### DIFF
--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -55,8 +55,6 @@ func NewStorageFactoryConfig() *StorageFactoryConfig {
 	resources := []schema.GroupVersionResource{
 		batch.Resource("cronjobs").WithVersion("v1beta1"),
 		networking.Resource("ingresses").WithVersion("v1beta1"),
-		// TODO #83513 csinodes override can be removed in 1.18
-		apisstorage.Resource("csinodes").WithVersion("v1beta1"),
 		apisstorage.Resource("csidrivers").WithVersion("v1beta1"),
 	}
 

--- a/test/integration/etcd/data.go
+++ b/test/integration/etcd/data.go
@@ -550,13 +550,13 @@ func GetEtcdStorageDataForNamespace(namespace string) map[schema.GroupVersionRes
 		etcdStorageData[gvr("storage.k8s.io", "v1beta1", "csinodes")] = StorageData{
 			Stub:             `{"metadata": {"name": "csini1"}, "spec": {"drivers": [{"name": "test-driver", "nodeID": "localhost", "topologyKeys": ["company.com/zone1", "company.com/zone2"]}]}}`,
 			ExpectedEtcdPath: "/registry/csinodes/csini1",
+			ExpectedGVK:      gvkP("storage.k8s.io", "v1", "CSINode"),
 		}
 
 		// k8s.io/kubernetes/pkg/apis/storage/v1
 		etcdStorageData[gvr("storage.k8s.io", "v1", "csinodes")] = StorageData{
 			Stub:             `{"metadata": {"name": "csini2"}, "spec": {"drivers": [{"name": "test-driver", "nodeID": "localhost", "topologyKeys": ["company.com/zone1", "company.com/zone2"]}]}}`,
 			ExpectedEtcdPath: "/registry/csinodes/csini2",
-			ExpectedGVK:      gvkP("storage.k8s.io", "v1beta1", "CSINode"),
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #83513

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
