### PR TITLE
Fix validation for metav1 fuzz targets.

### DIFF
--- a/test/fuzz/yaml/yaml.go
+++ b/test/fuzz/yaml/yaml.go
@@ -20,7 +20,8 @@ limitations under the License.
 package yaml
 
 import (
-	"bytes"
+	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -41,8 +42,12 @@ func FuzzDurationStrict(b []byte) int {
 	if err != nil {
 		panic(err)
 	}
-	if !bytes.Equal(result, b) {
-		panic("result != input")
+	// Result is in the format "d: <duration>\n", so strip off the trailing
+	// newline and convert durationHolder.D to the expected format.
+	resultStr := strings.TrimSpace(string(result[:]))
+	inputStr := fmt.Sprintf("d: %s", durationHolder.D.Duration)
+	if resultStr != inputStr {
+		panic(fmt.Sprintf("result(%v) != input(%v)", resultStr, inputStr))
 	}
 	return 1
 }
@@ -61,8 +66,18 @@ func FuzzMicroTimeStrict(b []byte) int {
 	if err != nil {
 		panic(err)
 	}
-	if !bytes.Equal(result, b) {
-		panic("result != input")
+	// Result is in the format "t: <time>\n", so strip off the trailing
+	// newline and convert microTimeHolder.T to the expected format. If
+	// time is zero, the value is marshaled to "null".
+	resultStr := strings.TrimSpace(string(result[:]))
+	var inputStr string
+	if microTimeHolder.T.Time.IsZero() {
+		inputStr = "t: null"
+	} else {
+		inputStr = fmt.Sprintf("t: %s", microTimeHolder.T.Time)
+	}
+	if resultStr != inputStr {
+		panic(fmt.Sprintf("result(%v) != input(%v)", resultStr, inputStr))
 	}
 	return 1
 }
@@ -95,8 +110,18 @@ func FuzzTimeStrict(b []byte) int {
 	if err != nil {
 		panic(err)
 	}
-	if !bytes.Equal(result, b) {
-		panic("result != input")
+	// Result is in the format "t: <time>\n", so strip off the trailing
+	// newline and convert timeHolder.T to the expected format. If time is
+	// zero, the value is marshaled to "null".
+	resultStr := strings.TrimSpace(string(result[:]))
+	var inputStr string
+	if timeHolder.T.Time.IsZero() {
+		inputStr = "t: null"
+	} else {
+		inputStr = fmt.Sprintf("t: %s", timeHolder.T.Time)
+	}
+	if resultStr != inputStr {
+		panic(fmt.Sprintf("result(%v) != input(%v)", resultStr, inputStr))
 	}
 	return 1
 }


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
The current validation logic doesn't work since the marshaled format contains the prefix specified in the json tag.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Tested locally by running oss-fuzz pointed to my kubernetes fork:

```
$ python infra/helper.py check_build --sanitizer address --engine libfuzzer kubernetes             
Running: docker run --rm -i --privileged -e FUZZING_ENGINE=libfuzzer -e SANITIZER=address -e ARCHITECTURE=x86_64 -v /usr/local/google/home/brendanschang/oss-fuzz/build/out/kubernetes:/out -t gcr.io/oss-fuzz-base/base-runner test_all                                               
INFO: performing bad build checks for /out/yaml_FuzzMicroTimeStrict.
INFO: performing bad build checks for /out/yaml_FuzzTimeStrict.
INFO: performing bad build checks for /out/json_FuzzStrictDecode.
INFO: performing bad build checks for /out/yaml_FuzzYamlV2.
INFO: performing bad build checks for /out/json_FuzzNonStrictDecode.
INFO: performing bad build checks for /out/yaml_FuzzDurationStrict.
INFO: performing bad build checks for /out/yaml_FuzzSigYaml.
7 fuzzers total, 0 seem to be broken (0%).
Check build passed.
```

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: