### PR TITLE
Fixing EndpointSlice port validation

### DIFF
--- a/pkg/apis/discovery/types.go
+++ b/pkg/apis/discovery/types.go
@@ -118,11 +118,10 @@ type EndpointPort struct {
 	// The name of this port. All ports in an EndpointSlice must have a unique
 	// name. If the EndpointSlice is dervied from a Kubernetes service, this
 	// corresponds to the Service.ports[].name.
-	// Name must either be an empty string or pass IANA_SVC_NAME validation:
-	// * must be no more than 15 characters long
-	// * may contain only [-a-z0-9]
-	// * must contain at least one letter [a-z]
-	// * it must not start or end with a hyphen, nor contain adjacent hyphens
+	// Name must either be an empty string or pass DNS_LABEL validation:
+	// * must be no more than 63 characters long.
+	// * must consist of lower case alphanumeric characters or '-'.
+	// * must start and end with an alphanumeric character.
 	Name *string
 	// The IP protocol for this port.
 	// Must be UDP, TCP, or SCTP.

--- a/pkg/apis/discovery/validation/validation.go
+++ b/pkg/apis/discovery/validation/validation.go
@@ -109,9 +109,7 @@ func validateEndpoints(endpoints []discovery.Endpoint, addrType discovery.Addres
 		allErrs = append(allErrs, metavalidation.ValidateLabels(endpoint.Topology, topologyPath)...)
 
 		if endpoint.Hostname != nil {
-			for _, msg := range validation.IsDNS1123Label(*endpoint.Hostname) {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("hostname"), *endpoint.Hostname, msg))
-			}
+			allErrs = append(allErrs, apivalidation.ValidateDNS1123Label(*endpoint.Hostname, idxPath.Child("hostname"))...)
 		}
 	}
 
@@ -131,9 +129,7 @@ func validatePorts(endpointPorts []discovery.EndpointPort, fldPath *field.Path) 
 		idxPath := fldPath.Index(i)
 
 		if len(*endpointPort.Name) > 0 {
-			for _, msg := range validation.IsValidPortName(*endpointPort.Name) {
-				allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), endpointPort.Name, msg))
-			}
+			allErrs = append(allErrs, apivalidation.ValidateDNS1123Label(*endpointPort.Name, idxPath.Child("name"))...)
 		}
 
 		if portNames.Has(*endpointPort.Name) {

--- a/pkg/apis/discovery/validation/validation_test.go
+++ b/pkg/apis/discovery/validation/validation_test.go
@@ -18,6 +18,7 @@ package validation
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -97,6 +98,20 @@ func TestValidateEndpointSlice(t *testing.T) {
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}, {
 					Name:     utilpointer.StringPtr("http"),
+					Protocol: protocolPtr(api.ProtocolTCP),
+				}},
+				Endpoints: []discovery.Endpoint{{
+					Addresses: generateIPAddresses(1),
+				}},
+			},
+		},
+		"long-port-name": {
+			expectedErrors: 0,
+			endpointSlice: &discovery.EndpointSlice{
+				ObjectMeta:  standardMeta,
+				AddressType: addressTypePtr(discovery.AddressTypeIP),
+				Ports: []discovery.EndpointPort{{
+					Name:     utilpointer.StringPtr(strings.Repeat("a", 63)),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{{
@@ -195,6 +210,18 @@ func TestValidateEndpointSlice(t *testing.T) {
 				AddressType: addressTypePtr(discovery.AddressTypeIP),
 				Ports: []discovery.EndpointPort{{
 					Name:     utilpointer.StringPtr("almost_valid"),
+					Protocol: protocolPtr(api.ProtocolTCP),
+				}},
+				Endpoints: []discovery.Endpoint{},
+			},
+		},
+		"bad-port-name-length": {
+			expectedErrors: 1,
+			endpointSlice: &discovery.EndpointSlice{
+				ObjectMeta:  standardMeta,
+				AddressType: addressTypePtr(discovery.AddressTypeIP),
+				Ports: []discovery.EndpointPort{{
+					Name:     utilpointer.StringPtr(strings.Repeat("a", 64)),
 					Protocol: protocolPtr(api.ProtocolTCP),
 				}},
 				Endpoints: []discovery.Endpoint{},

--- a/staging/src/k8s.io/api/discovery/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/discovery/v1alpha1/generated.proto
@@ -88,11 +88,10 @@ message EndpointPort {
   // The name of this port. All ports in an EndpointSlice must have a unique
   // name. If the EndpointSlice is dervied from a Kubernetes service, this
   // corresponds to the Service.ports[].name.
-  // Name must either be an empty string or pass IANA_SVC_NAME validation:
-  // * must be no more than 15 characters long
-  // * may contain only [-a-z0-9]
-  // * must contain at least one letter [a-z]
-  // * it must not start or end with a hyphen, nor contain adjacent hyphens
+  // Name must either be an empty string or pass DNS_LABEL validation:
+  // * must be no more than 63 characters long.
+  // * must consist of lower case alphanumeric characters or '-'.
+  // * must start and end with an alphanumeric character.
   // Default is empty string.
   optional string name = 1;
 

--- a/staging/src/k8s.io/api/discovery/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/discovery/v1alpha1/types.go
@@ -121,11 +121,10 @@ type EndpointPort struct {
 	// The name of this port. All ports in an EndpointSlice must have a unique
 	// name. If the EndpointSlice is dervied from a Kubernetes service, this
 	// corresponds to the Service.ports[].name.
-	// Name must either be an empty string or pass IANA_SVC_NAME validation:
-	// * must be no more than 15 characters long
-	// * may contain only [-a-z0-9]
-	// * must contain at least one letter [a-z]
-	// * it must not start or end with a hyphen, nor contain adjacent hyphens
+	// Name must either be an empty string or pass DNS_LABEL validation:
+	// * must be no more than 63 characters long.
+	// * must consist of lower case alphanumeric characters or '-'.
+	// * must start and end with an alphanumeric character.
 	// Default is empty string.
 	Name *string `json:"name,omitempty" protobuf:"bytes,1,name=name"`
 	// The IP protocol for this port.

--- a/staging/src/k8s.io/api/discovery/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/discovery/v1alpha1/types_swagger_doc_generated.go
@@ -51,7 +51,7 @@ func (EndpointConditions) SwaggerDoc() map[string]string {
 
 var map_EndpointPort = map[string]string{
 	"":         "EndpointPort represents a Port used by an EndpointSlice",
-	"name":     "The name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is dervied from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass IANA_SVC_NAME validation: * must be no more than 15 characters long * may contain only [-a-z0-9] * must contain at least one letter [a-z] * it must not start or end with a hyphen, nor contain adjacent hyphens Default is empty string.",
+	"name":     "The name of this port. All ports in an EndpointSlice must have a unique name. If the EndpointSlice is dervied from a Kubernetes service, this corresponds to the Service.ports[].name. Name must either be an empty string or pass DNS_LABEL validation: * must be no more than 63 characters long. * must consist of lower case alphanumeric characters or '-'. * must start and end with an alphanumeric character. Default is empty string.",
 	"protocol": "The IP protocol for this port. Must be UDP, TCP, or SCTP. Default is TCP.",
 	"port":     "The port number of the endpoint. If this is not specified, ports are not restricted and must be interpreted in the context of the specific consumer.",
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes EndpointSlice port validation to match the corresponding validation used by [Endpoints](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L5447) and [Services](https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L4102) (`validation.IsDNS1123Label()`). It was previously using `validation.IsValidPortName()` which is used in other places like NetworkPolicy and Service `intOrStr` ports, but unfortunately should not have been used here.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/84388

**Does this PR introduce a user-facing change?**:
```release-note
Fixed EndpointSlice port name validation to match Endpoint port name validation (allowing port names longer than 15 characters)
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752

/sig network
/priority important-soon
/cc @liggitt @howardjohn