### PR TITLE
Prevent 2 goroutines in test from being leaked if proxy hangs

### DIFF
--- a/test/e2e/framework/kubelet/stats.go
+++ b/test/e2e/framework/kubelet/stats.go
@@ -89,10 +89,9 @@ type RuntimeOperationErrorRate struct {
 
 // ProxyRequest performs a get on a node proxy endpoint given the nodename and rest client.
 func ProxyRequest(c clientset.Interface, node, endpoint string, port int) (restclient.Result, error) {
-	// proxy tends to hang in some cases when Node is not ready. Add an artificial timeout for this call.
-	// This will leak a goroutine if proxy hangs. #22165
+	// proxy tends to hang in some cases when Node is not ready. Add an artificial timeout for this call. #22165
 	var result restclient.Result
-	finished := make(chan struct{})
+	finished := make(chan struct{}, 1)
 	go func() {
 		result = c.CoreV1().RESTClient().Get().
 			Resource("nodes").

--- a/test/e2e/framework/metrics/kubelet_metrics.go
+++ b/test/e2e/framework/metrics/kubelet_metrics.go
@@ -76,8 +76,7 @@ func parseKubeletMetrics(data string) (KubeletMetrics, error) {
 
 func (g *Grabber) getMetricsFromNode(nodeName string, kubeletPort int) (string, error) {
 	// There's a problem with timing out during proxy. Wrapping this in a goroutine to prevent deadlock.
-	// Hanging goroutine will be leaked.
-	finished := make(chan struct{})
+	finished := make(chan struct{}, 1)
 	var err error
 	var rawOutput []byte
 	go func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In function `ProxyRequest` and `getMetricsFromNode`, developers noted that when proxy hangs, two goroutines will be leaked. Leaked goroutines will occupy the memory during other tests. This can be safely and easily fixed, by adding 1 buffer.

**Special notes for your reviewer**:
This patch is the same as #5316 and #83925
This patch is quite safe, without any side effects. The only effect is that no goroutines will be leaked.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```