### PR TITLE
Fix a data race in registrytest

### DIFF
--- a/pkg/registry/registrytest/node.go
+++ b/pkg/registry/registrytest/node.go
@@ -114,5 +114,7 @@ func (r *NodeRegistry) DeleteNode(ctx context.Context, nodeID string) error {
 }
 
 func (r *NodeRegistry) WatchNodes(ctx context.Context, options *metainternalversion.ListOptions) (watch.Interface, error) {
+	r.Lock()
+	defer r.Unlock()
 	return nil, r.Err
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`*NodeRegistry.Err` is a field with type `error`. Among 8 read and 1 write operations of this field, all are protected, except the one in `*NodeRegistry.WatchNodes()`.

This can easily trigger a data race bug: if you call `r.WatchNodes()` in one goroutine, and call `r.SetError()` in another goroutine, the data race can happen. The code is shown below:

*Unprotected Read*
https://github.com/kubernetes/kubernetes/blob/b6c8f4916dc3a625e9decc2fd273e2a522e8b474/pkg/registry/registrytest/node.go#L116-L118

*Protected Write*
https://github.com/kubernetes/kubernetes/blob/b6c8f4916dc3a625e9decc2fd273e2a522e8b474/pkg/registry/registrytest/node.go#L57-L61

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```