### PR TITLE
Fix a potential data race in ipvs

### DIFF
--- a/pkg/proxy/ipvs/graceful_termination.go
+++ b/pkg/proxy/ipvs/graceful_termination.go
@@ -82,8 +82,12 @@ func (q *graceTerminateRSList) remove(rs *listItem) bool {
 }
 
 func (q *graceTerminateRSList) flushList(handler func(rsToDelete *listItem) (bool, error)) bool {
+	q.lock.Lock()
+	list := q.list
+	q.lock.Unlock()
+	
 	success := true
-	for name, rs := range q.list {
+	for name, rs := range list {
 		deleted, err := handler(rs)
 		if err != nil {
 			klog.Errorf("Try delete rs %q err: %v", name, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`q.list` is a map, in the struct `graceTerminateRSList`. Among 4 read and 2 write operations to it, all are protected by `q.lock.Lock()`, except 1 read in `flushList()`. 

This patch adds a critical section in `flushList()`. I investigate the call-graph around this function, and make sure this patch won't introduce a double lock bug.

This bug is dangerous because data race of map will crash all running goroutines.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```