### PR TITLE
Fix a double lock in test/utils

### DIFF
--- a/test/utils/audit_dynamic.go
+++ b/test/utils/audit_dynamic.go
@@ -95,8 +95,6 @@ func (a *AuditTestServer) WaitForEvents(expected []AuditEvent) ([]AuditEvent, er
 	var missing []AuditEvent
 	err := wait.PollImmediate(50*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
 		var err error
-		a.LockedEventList.RLock()
-		defer a.LockedEventList.RUnlock()
 		el := a.GetEventList()
 		if len(el.Items) < 1 {
 			return false, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There is a double lock bug in `*AuditTestServer.WaitForEvents`. `a.LockedEventList.RLock()` is called twice without `RUnlock()` between them. Note that double `RLock()` can also trigger deadlock bug, due to Go's implementation.

*First Call*
https://github.com/kubernetes/kubernetes/blob/b6c8f4916dc3a625e9decc2fd273e2a522e8b474/test/utils/audit_dynamic.go#L94-L100

*Second Call*
https://github.com/kubernetes/kubernetes/blob/b6c8f4916dc3a625e9decc2fd273e2a522e8b474/test/utils/audit_dynamic.go#L73-L77

**Special notes for your reviewer**:
There is only one concern that I want to discuss: I deleted the `RLock()` in `WaitForEvents()`. Do you think variable `el` needs protection? If so, I will move the `RLock()` lower, instead of removing it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```