### PR TITLE
Remove prom from metrics validation

### DIFF
--- a/test/instrumentation/BUILD
+++ b/test/instrumentation/BUILD
@@ -13,7 +13,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )
@@ -63,5 +62,5 @@ go_test(
     srcs = ["main_test.go"],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/prometheus/client_golang/prometheus:go_default_library"],
+    deps = ["//staging/src/k8s.io/component-base/metrics:go_default_library"],
 )

--- a/test/instrumentation/decode_metric.go
+++ b/test/instrumentation/decode_metric.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/component-base/metrics"
 )
 
@@ -209,7 +208,7 @@ func (c *metricDecoder) decodeBuckets(expr ast.Expr) ([]float64, error) {
 		variableName := v.Sel.String()
 		importName, ok := v.X.(*ast.Ident)
 		if ok && importName.String() == c.prometheusImportName && variableName == "DefBuckets" {
-			return prometheus.DefBuckets, nil
+			return metrics.DefBuckets, nil
 		}
 	case *ast.CallExpr:
 		se, ok := v.Fun.(*ast.SelectorExpr)
@@ -230,9 +229,9 @@ func (c *metricDecoder) decodeBuckets(expr ast.Expr) ([]float64, error) {
 		}
 		switch functionName {
 		case "LinearBuckets":
-			return prometheus.LinearBuckets(firstArg, secondArg, thirdArg), nil
+			return metrics.LinearBuckets(firstArg, secondArg, thirdArg), nil
 		case "ExponentialBuckets":
-			return prometheus.ExponentialBuckets(firstArg, secondArg, thirdArg), nil
+			return metrics.ExponentialBuckets(firstArg, secondArg, thirdArg), nil
 		}
 	}
 	return nil, newDecodeErrorf(expr, errBuckets)

--- a/test/instrumentation/main_test.go
+++ b/test/instrumentation/main_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics"
 )
 
 const fakeFilename = "testdata/metric.go"
@@ -304,7 +304,7 @@ var _ = custom.NewCounter(
 			metric: metric{
 				Name:           "histogram",
 				StabilityLevel: "STABLE",
-				Buckets:        prometheus.LinearBuckets(1, 1, 3),
+				Buckets:        metrics.LinearBuckets(1, 1, 3),
 				Type:           histogramMetricType,
 			},
 			src: `
@@ -324,7 +324,7 @@ var _ = metrics.NewHistogram(
 			metric: metric{
 				Name:           "histogram",
 				StabilityLevel: "STABLE",
-				Buckets:        prometheus.ExponentialBuckets(1, 2, 3),
+				Buckets:        metrics.ExponentialBuckets(1, 2, 3),
 				Type:           histogramMetricType,
 			},
 			src: `
@@ -344,7 +344,7 @@ var _ = metrics.NewHistogram(
 			metric: metric{
 				Name:           "histogram",
 				StabilityLevel: "STABLE",
-				Buckets:        prometheus.DefBuckets,
+				Buckets:        metrics.DefBuckets,
 				Type:           histogramMetricType,
 			},
 			src: `

--- a/test/instrumentation/metric.go
+++ b/test/instrumentation/metric.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics"
 )
 
 const (
@@ -39,7 +39,7 @@ type metric struct {
 }
 
 func (m metric) buildFQName() string {
-	return prometheus.BuildFQName(m.Namespace, m.Subsystem, m.Name)
+	return metrics.BuildFQName(m.Namespace, m.Subsystem, m.Name)
 }
 
 type byFQName []metric


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Remove prometheus reference from metrics validation framework.

**Which issue(s) this PR fixes**:
Ref https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
