### PR TITLE
e2e: share /dev with host in hostpath driver deployment

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -101,6 +101,8 @@ spec:
               name: plugins-dir
             - mountPath: /csi-data-dir
               name: csi-data-dir
+            - mountPath: /dev
+              name: dev-dir
 
         - name: liveness-probe
           volumeMounts:
@@ -135,3 +137,7 @@ spec:
             path: /var/lib/csi-hostpath-data/
             type: DirectoryOrCreate
           name: csi-data-dir
+        - hostPath:
+            path: /dev
+            type: Directory
+          name: dev-dir


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:

This is needed for raw block volumes.

Raw block volumes use loop devices under the hood. "losetup --find
--show" uses LOOP_CTL_GET_FREE to get a free loop device. It then
expects to have the corresponding /dev/loopX already available. When
/dev inside the container is a static tmpfs which doesn't already have
those /dev/loop* devices (*) the new device fails to show up,
resulting in:

I1028 13:25:19.937846       1 server.go:117] GRPC call: /csi.v1.Controller/CreateVolume
I1028 13:25:19.938083       1 server.go:118] GRPC request: {"accessibility_requirements":{"preferred":[{"segments":{"topology.hostpath.csi/node":"pmem-csi-pmem-govm-worker3"}}],"requisite":[{"segments":{"topology.hostpath.csi/node":"pmem-csi-pmem-govm-worker3"}}]},"capacity_range":{"required_bytes":5368709120},"name":"pvc-24985a49-5638-4bf6-b789-bb99a28d1073","volume_capabilities":[{"AccessType":{"Block":{}},"access_mode":{"mode":1}}]}
I1028 13:25:19.961124       1 volume_path_handler_linux.go:41] Creating device for path: /csi-data-dir/635c6569-f986-11e9-baa6-0242ac110004
I1028 13:25:20.391472       1 volume_path_handler_linux.go:75] Failed device create command for path: /csi-data-dir/635c6569-f986-11e9-baa6-0242ac110004 exit status 1 losetup: /csi-data-dir/635c6569-f986-11e9-baa6-0242ac110004: failed to set up loop device: No such file or directory
E1028 13:25:20.392916       1 server.go:121] GRPC error: rpc error: code = Internal desc = failed to create volume 635c6569-f986-11e9-baa6-0242ac110004: failed to attach device /csi-data-dir/635c6569-f986-11e9-baa6-0242ac110004: exit status 1

(*) It seems that the static tmpfs gets populated by Docker based on
what's currently on the host when the container starts. That would
explain why it worked in the Kubernetes Prow testing - the host must
have had enough loop devices already defined.

**Special notes for your reviewer**:

The same change was already made upstream in https://github.com/kubernetes-csi/csi-driver-host-path/pull/109

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
