### PR TITLE
use nginx1.13 for echoserver test image on s390x

### DIFF
--- a/test/images/echoserver/BASEIMAGE
+++ b/test/images/echoserver/BASEIMAGE
@@ -2,4 +2,4 @@ amd64=nginx:1.15-alpine
 arm=arm32v6/nginx:1.15-alpine
 arm64=arm64v8/nginx:1.15-alpine
 ppc64le=ppc64le/nginx:1.15-alpine
-s390x=s390x/nginx:1.15-alpine
+s390x=s390x/nginx:1.13-alpine


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
the docker image can not be built on s390x as the module of nginx-mod-http-lua and nginx-mod-http-lua-upstream was not available in repo v3.9.

@mkumatag @listx I need to change the s390 base image to use nginx:1.13-alpine as:

the nginx:1.13-alpine using v3.8 alpine apk repo and have the nginx lua module
the nginx:1.15-apline did not have nginx lua module in default alpine apk repo
the nginx lua module in v3.8 alpine apk repo have compatibility issues on nginx:1.15-alpine, after some test, only nginx:1.13-alpine can be used now.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/84269

**Special notes for your reviewer**:
@mkumatag

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
