### PR TITLE
WIP: Remove ephemeral container lists from API exceptions

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -132,7 +132,6 @@ API rule violation: list_type_missing,k8s.io/api/core/v1,EphemeralContainerCommo
 API rule violation: list_type_missing,k8s.io/api/core/v1,EphemeralContainerCommon,Ports
 API rule violation: list_type_missing,k8s.io/api/core/v1,EphemeralContainerCommon,VolumeDevices
 API rule violation: list_type_missing,k8s.io/api/core/v1,EphemeralContainerCommon,VolumeMounts
-API rule violation: list_type_missing,k8s.io/api/core/v1,EphemeralContainers,EphemeralContainers
 API rule violation: list_type_missing,k8s.io/api/core/v1,EventList,Items
 API rule violation: list_type_missing,k8s.io/api/core/v1,ExecAction,Command
 API rule violation: list_type_missing,k8s.io/api/core/v1,FCVolumeSource,TargetWWNs
@@ -182,7 +181,6 @@ API rule violation: list_type_missing,k8s.io/api/core/v1,PodPortForwardOptions,P
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSecurityContext,SupplementalGroups
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSecurityContext,Sysctls
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,Containers
-API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,EphemeralContainers
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,HostAliases
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,ImagePullSecrets
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,InitContainers
@@ -191,7 +189,6 @@ API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,Tolerations
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodSpec,Volumes
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodStatus,Conditions
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodStatus,ContainerStatuses
-API rule violation: list_type_missing,k8s.io/api/core/v1,PodStatus,EphemeralContainerStatuses
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodStatus,InitContainerStatuses
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodStatus,PodIPs
 API rule violation: list_type_missing,k8s.io/api/core/v1,PodTemplateList,Items

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -1344,6 +1344,8 @@ message EphemeralContainers {
   // or modified.
   // +patchMergeKey=name
   // +patchStrategy=merge
+  // +listType=map
+  // +listMapKey=name
   repeated EphemeralContainer ephemeralContainers = 2;
 }
 
@@ -3299,6 +3301,8 @@ message PodSpec {
   // +optional
   // +patchMergeKey=name
   // +patchStrategy=merge
+  // +listType=map
+  // +listMapKey=name
   repeated EphemeralContainer ephemeralContainers = 34;
 
   // Restart policy for all containers within the pod.
@@ -3604,6 +3608,7 @@ message PodStatus {
   // Status for any ephemeral containers that have run in this pod.
   // This field is alpha-level and is only populated by servers that enable the EphemeralContainers feature.
   // +optional
+  // +listType=atomic
   repeated ContainerStatus ephemeralContainerStatuses = 13;
 }
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2866,6 +2866,8 @@ type PodSpec struct {
 	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=name
 	EphemeralContainers []EphemeralContainer `json:"ephemeralContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,34,rep,name=ephemeralContainers"`
 	// Restart policy for all containers within the pod.
 	// One of Always, OnFailure, Never.
@@ -3481,6 +3483,7 @@ type PodStatus struct {
 	// Status for any ephemeral containers that have run in this pod.
 	// This field is alpha-level and is only populated by servers that enable the EphemeralContainers feature.
 	// +optional
+	// +listType=atomic
 	EphemeralContainerStatuses []ContainerStatus `json:"ephemeralContainerStatuses,omitempty" protobuf:"bytes,13,rep,name=ephemeralContainerStatuses"`
 }
 
@@ -4757,6 +4760,8 @@ type EphemeralContainers struct {
 	// or modified.
 	// +patchMergeKey=name
 	// +patchStrategy=merge
+	// +listType=map
+	// +listMapKey=name
 	EphemeralContainers []EphemeralContainer `json:"ephemeralContainers" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,2,rep,name=ephemeralContainers"`
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig node
/priority important-longterm

**What this PR does / why we need it**: This removes the API exceptions for the ephemeral container list types.

**Which issue(s) this PR fixes**:
WIP #27140 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
