### PR TITLE
Fix bug in TopologyManager hint generation after kubelet restart

### DIFF
--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -229,6 +229,8 @@ func (m *manager) State() state.Reader {
 }
 
 func (m *manager) GetTopologyHints(pod v1.Pod, container v1.Container) map[string][]topologymanager.TopologyHint {
+	// Garbage collect any stranded resources before providing TopologyHints
+	m.removeStaleState()
 	// Delegate to active policy
 	return m.policy.GetTopologyHints(m.state, pod, container)
 }

--- a/pkg/kubelet/cm/cpumanager/cpu_manager.go
+++ b/pkg/kubelet/cm/cpumanager/cpu_manager.go
@@ -239,15 +239,68 @@ type reconciledContainer struct {
 	containerID   string
 }
 
-func (m *manager) reconcileState() (success []reconciledContainer, failure []reconciledContainer) {
+func (m *manager) removeStaleState() {
+	// Only once all sources are ready do we attempt to remove any stale state.
+	// This ensures that the call to `m.activePods()` below will succeed with
+	// the actual active pods list.
 	if !m.sourcesReady.AllReady() {
 		return
 	}
+
+	// We grab the lock to ensure that no new containers will grab CPUs while
+	// executing the code below. Without this lock, its possible that we end up
+	// removing state that is newly added by an asynchronous call to
+	// AddContainer() during the execution of this code.
+	m.Lock()
+	defer m.Unlock()
+
+	// We remove stale state very conservatively, only removing *any* state
+	// once we know for sure that we wont be accidentally removing state that
+	// is still valid. Since this function is called periodically, we will just
+	// try again next time this function is called.
+	activePods := m.activePods()
+	if len(activePods) == 0 {
+		// If there are no active pods, skip the removal of stale state.
+		return
+	}
+
+	// Build a list of containerIDs for all containers in all active Pods.
+	activeContainers := make(map[string]struct{})
+	for _, pod := range activePods {
+		pstatus, ok := m.podStatusProvider.GetPodStatus(pod.UID)
+		if !ok {
+			// If even one pod does not have it's status set, skip state removal.
+			return
+		}
+		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+			containerID, err := findContainerIDByName(&pstatus, container.Name)
+			if err != nil {
+				// If even one container does not have it's containerID set, skip state removal.
+				return
+			}
+			activeContainers[containerID] = struct{}{}
+		}
+	}
+
+	// Loop through the CPUManager state. Remove any state for containers not
+	// in the `activeContainers` list built above. The shortcircuits in place
+	// above ensure that no erroneous state will ever be removed.
+	for containerID := range m.state.GetCPUAssignments() {
+		if _, ok := activeContainers[containerID]; !ok {
+			klog.Errorf("[cpumanager] removeStaleState: removing container: %s)", containerID)
+			err := m.policy.RemoveContainer(m.state, containerID)
+			if err != nil {
+				klog.Errorf("[cpumanager] removeStaleState: failed to remove container %s, error: %v)", containerID, err)
+			}
+		}
+	}
+}
+
+func (m *manager) reconcileState() (success []reconciledContainer, failure []reconciledContainer) {
 	success = []reconciledContainer{}
 	failure = []reconciledContainer{}
 
-	activeContainers := make(map[string]*v1.Pod)
-
+	m.removeStaleState()
 	for _, pod := range m.activePods() {
 		allContainers := pod.Spec.InitContainers
 		allContainers = append(allContainers, pod.Spec.Containers...)
@@ -286,8 +339,6 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 				}
 			}
 
-			activeContainers[containerID] = pod
-
 			cset := m.state.GetCPUSetOrDefault(containerID)
 			if cset.IsEmpty() {
 				// NOTE: This should not happen outside of tests.
@@ -304,16 +355,6 @@ func (m *manager) reconcileState() (success []reconciledContainer, failure []rec
 				continue
 			}
 			success = append(success, reconciledContainer{pod.Name, container.Name, containerID})
-		}
-	}
-
-	for containerID := range m.state.GetCPUAssignments() {
-		if pod, ok := activeContainers[containerID]; !ok {
-			err := m.RemoveContainer(containerID)
-			if err != nil {
-				klog.Errorf("[cpumanager] reconcileState: failed to remove container (pod: %s, container id: %s, error: %v)", pod.Name, containerID, err)
-				failure = append(failure, reconciledContainer{pod.Name, "", containerID})
-			}
 		}
 	}
 	return success, failure

--- a/pkg/kubelet/cm/cpumanager/policy_static_test.go
+++ b/pkg/kubelet/cm/cpumanager/policy_static_test.go
@@ -214,6 +214,20 @@ func TestStaticPolicyAdd(t *testing.T) {
 			expCSet:         cpuset.NewCPUSet(1, 5),
 		},
 		{
+			description:     "GuPodMultipleCores, SingleSocketHT, ExpectSameAllocation",
+			topo:            topoSingleSocketHT,
+			numReservedCPUs: 1,
+			containerID:     "fakeID3",
+			stAssignments: state.ContainerCPUAssignments{
+				"fakeID3": cpuset.NewCPUSet(2, 3, 6, 7),
+			},
+			stDefaultCPUSet: cpuset.NewCPUSet(0, 1, 4, 5),
+			pod:             makePod("4000m", "4000m"),
+			expErr:          nil,
+			expCPUAlloc:     true,
+			expCSet:         cpuset.NewCPUSet(2, 3, 6, 7),
+		},
+		{
 			description:     "GuPodMultipleCores, DualSocketHT, ExpectAllocOneSocket",
 			topo:            topoDualSocketHT,
 			numReservedCPUs: 1,

--- a/pkg/kubelet/cm/cpumanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/cpumanager/topology_hints_test.go
@@ -23,6 +23,7 @@ import (
 
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/state"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager/topology"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
@@ -72,6 +73,7 @@ func TestGetTopologyHints(t *testing.T) {
 		name          string
 		pod           v1.Pod
 		container     v1.Container
+		assignments   state.ContainerCPUAssignments
 		defaultCPUSet cpuset.CPUSet
 		expectedHints []topologymanager.TopologyHint
 	}{
@@ -142,6 +144,86 @@ func TestGetTopologyHints(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:          "Request more CPUs than available",
+			pod:           *testPod2,
+			container:     *testContainer2,
+			defaultCPUSet: cpuset.NewCPUSet(0, 1, 2, 3),
+			expectedHints: nil,
+		},
+		{
+			name:      "Regenerate Single-Node NUMA Hints if already allocated 1/2",
+			pod:       *testPod1,
+			container: *testContainer1,
+			assignments: state.ContainerCPUAssignments{
+				"": cpuset.NewCPUSet(0, 6),
+			},
+			defaultCPUSet: cpuset.NewCPUSet(),
+			expectedHints: []topologymanager.TopologyHint{
+				{
+					NUMANodeAffinity: firstSocketMask,
+					Preferred:        true,
+				},
+				{
+					NUMANodeAffinity: crossSocketMask,
+					Preferred:        false,
+				},
+			},
+		},
+		{
+			name:      "Regenerate Single-Node NUMA Hints if already allocated 1/2",
+			pod:       *testPod1,
+			container: *testContainer1,
+			assignments: state.ContainerCPUAssignments{
+				"": cpuset.NewCPUSet(3, 9),
+			},
+			defaultCPUSet: cpuset.NewCPUSet(),
+			expectedHints: []topologymanager.TopologyHint{
+				{
+					NUMANodeAffinity: secondSocketMask,
+					Preferred:        true,
+				},
+				{
+					NUMANodeAffinity: crossSocketMask,
+					Preferred:        false,
+				},
+			},
+		},
+		{
+			name:      "Regenerate Cross-NUMA Hints if already allocated",
+			pod:       *testPod4,
+			container: *testContainer4,
+			assignments: state.ContainerCPUAssignments{
+				"": cpuset.NewCPUSet(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+			},
+			defaultCPUSet: cpuset.NewCPUSet(),
+			expectedHints: []topologymanager.TopologyHint{
+				{
+					NUMANodeAffinity: crossSocketMask,
+					Preferred:        true,
+				},
+			},
+		},
+		{
+			name:      "Requested less than already allocated",
+			pod:       *testPod1,
+			container: *testContainer1,
+			assignments: state.ContainerCPUAssignments{
+				"": cpuset.NewCPUSet(0, 6, 3, 9),
+			},
+			defaultCPUSet: cpuset.NewCPUSet(),
+			expectedHints: []topologymanager.TopologyHint{},
+		},
+		{
+			name:      "Requested more than already allocated",
+			pod:       *testPod4,
+			container: *testContainer4,
+			assignments: state.ContainerCPUAssignments{
+				"": cpuset.NewCPUSet(0, 6, 3, 9),
+			},
+			defaultCPUSet: cpuset.NewCPUSet(),
+			expectedHints: []topologymanager.TopologyHint{},
+		},
 	}
 	for _, tc := range tcases {
 		topology, _ := topology.Discover(&machineInfo, numaNodeInfo)
@@ -151,9 +233,13 @@ func TestGetTopologyHints(t *testing.T) {
 				topology: topology,
 			},
 			state: &mockState{
+				assignments:   tc.assignments,
 				defaultCPUSet: tc.defaultCPUSet,
 			},
-			topology: topology,
+			topology:          topology,
+			activePods:        func() []*v1.Pod { return nil },
+			podStatusProvider: mockPodStatusProvider{},
+			sourcesReady:      &sourcesReadyStub{},
 		}
 
 		hints := m.GetTopologyHints(tc.pod, tc.container)[string(v1.ResourceCPU)]

--- a/pkg/kubelet/cm/devicemanager/BUILD
+++ b/pkg/kubelet/cm/devicemanager/BUILD
@@ -60,6 +60,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Previously, the HintProviders for the CPUManager and devicemanager would
attempt to generate (new) hints for already running containers after a
kubelet restart.

This patch adds logic to both the CPUManager and the devicemanager to regenerate hints for containers that already have CPUs and/or devices allocated to them.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #84479 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```