### PR TITLE
Add conformance-behavior-approvers to OWNERS_ALIASES

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -473,3 +473,9 @@ aliases:
     - timothysc       # Cluster Lifecycle, Scheduling
     - wojtek-t        # Scalability
     - zehicle         # Cluster Ops
+
+  # conformance aliases https://git.k8s.io/enhancements/keps/sig-architecture/20190412-conformance-behaviors.md
+  conformance-behavior-approvers:
+    - bgrant0607
+    - smarterclayton
+    - johnbelamaric

--- a/test/conformance/testdata/OWNERS
+++ b/test/conformance/testdata/OWNERS
@@ -11,9 +11,7 @@ reviewers:
   - dims
   - johnbelamaric
 approvers:
-  - bgrant0607
-  - smarterclayton
-  - johnbelamaric
+  - conformance-behavior-approvers
 labels:
   - area/conformance
   - sig/architecture


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Creates a new alias for conformance approvers, which will be used for the current testdata directory as well as the behaviors directory that will be added for the KEP below.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

- [KEP](https://github.com/kubernetes/enhancements/blob/37c1f0266a6371ca0ccc53965cfb376a53821000/keps/sig-architecture/20190412-conformance-behaviors.md)
