### PR TITLE
Expose filteredNodes to func PriorityMetadataProducer

### DIFF
--- a/pkg/scheduler/algorithm/priorities/metadata.go
+++ b/pkg/scheduler/algorithm/priorities/metadata.go
@@ -62,7 +62,7 @@ type priorityMetadata struct {
 }
 
 // PriorityMetadata is a PriorityMetadataProducer.  Node info can be nil.
-func (pmf *PriorityMetadataFactory) PriorityMetadata(pod *v1.Pod, sharedLister schedulerlisters.SharedLister) interface{} {
+func (pmf *PriorityMetadataFactory) PriorityMetadata(pod *v1.Pod, _ []*v1.Node, sharedLister schedulerlisters.SharedLister) interface{} {
 	// If we cannot compute metadata, just return nil
 	if pod == nil {
 		return nil

--- a/pkg/scheduler/algorithm/priorities/metadata_test.go
+++ b/pkg/scheduler/algorithm/priorities/metadata_test.go
@@ -173,7 +173,7 @@ func TestPriorityMetadata(t *testing.T) {
 	)
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ptData := metaDataProducer(test.pod, nil)
+			ptData := metaDataProducer(test.pod, nil, nil)
 			if !reflect.DeepEqual(test.expected, ptData) {
 				t.Errorf("expected %#v, got %#v", test.expected, ptData)
 			}

--- a/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -337,7 +337,8 @@ func TestSelectorSpreadPriority(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, makeNodeList(test.nodes))
+			nodes := makeNodeList(test.nodes)
+			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, nodes)
 			selectorSpread := SelectorSpread{
 				serviceLister:     fakelisters.ServiceLister(test.services),
 				controllerLister:  fakelisters.ControllerLister(test.rcs),
@@ -350,7 +351,7 @@ func TestSelectorSpreadPriority(t *testing.T) {
 				fakelisters.ControllerLister(test.rcs),
 				fakelisters.ReplicaSetLister(test.rss),
 				fakelisters.StatefulSetLister(test.sss))
-			metaData := metaDataProducer(test.pod, snapshot)
+			metaData := metaDataProducer(test.pod, nodes, snapshot)
 
 			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData)
 			list, err := ttp(test.pod, snapshot, makeNodeList(test.nodes))
@@ -573,7 +574,8 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, makeLabeledNodeList(labeledNodes))
+			nodes := makeLabeledNodeList(labeledNodes)
+			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, nodes)
 			selectorSpread := SelectorSpread{
 				serviceLister:     fakelisters.ServiceLister(test.services),
 				controllerLister:  fakelisters.ControllerLister(test.rcs),
@@ -586,7 +588,7 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 				fakelisters.ControllerLister(test.rcs),
 				fakelisters.ReplicaSetLister(test.rss),
 				fakelisters.StatefulSetLister(test.sss))
-			metaData := metaDataProducer(test.pod, snapshot)
+			metaData := metaDataProducer(test.pod, nodes, snapshot)
 			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData)
 			list, err := ttp(test.pod, snapshot, makeLabeledNodeList(labeledNodes))
 			if err != nil {
@@ -765,7 +767,8 @@ func TestZoneSpreadPriority(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, makeLabeledNodeList(test.nodes))
+			nodes := makeLabeledNodeList(labeledNodes)
+			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, nodes)
 			zoneSpread := ServiceAntiAffinity{podLister: snapshot.Pods(), serviceLister: fakelisters.ServiceLister(test.services), label: "zone"}
 
 			metaDataProducer := NewPriorityMetadataFactory(
@@ -773,7 +776,7 @@ func TestZoneSpreadPriority(t *testing.T) {
 				fakelisters.ControllerLister(rcs),
 				fakelisters.ReplicaSetLister(rss),
 				fakelisters.StatefulSetLister(sss))
-			metaData := metaDataProducer(test.pod, snapshot)
+			metaData := metaDataProducer(test.pod, nodes, snapshot)
 			ttp := priorityFunction(zoneSpread.CalculateAntiAffinityPriorityMap, zoneSpread.CalculateAntiAffinityPriorityReduce, metaData)
 			list, err := ttp(test.pod, snapshot, makeLabeledNodeList(test.nodes))
 			if err != nil {

--- a/pkg/scheduler/algorithm/priorities/types.go
+++ b/pkg/scheduler/algorithm/priorities/types.go
@@ -36,7 +36,7 @@ type PriorityReduceFunction func(pod *v1.Pod, meta interface{}, sharedLister sch
 
 // PriorityMetadataProducer is a function that computes metadata for a given pod. This
 // is now used for only for priority functions. For predicates please use PredicateMetadataProducer.
-type PriorityMetadataProducer func(pod *v1.Pod, sharedLister schedulerlisters.SharedLister) interface{}
+type PriorityMetadataProducer func(pod *v1.Pod, filteredNodes []*v1.Node, sharedLister schedulerlisters.SharedLister) interface{}
 
 // PriorityFunction is a function that computes scores for all nodes.
 // DEPRECATED
@@ -55,6 +55,6 @@ type PriorityConfig struct {
 }
 
 // EmptyPriorityMetadataProducer returns a no-op PriorityMetadataProducer type.
-func EmptyPriorityMetadataProducer(pod *v1.Pod, sharedLister schedulerlisters.SharedLister) interface{} {
+func EmptyPriorityMetadataProducer(pod *v1.Pod, filteredNodes []*v1.Node, sharedLister schedulerlisters.SharedLister) interface{} {
 	return nil
 }

--- a/pkg/scheduler/algorithm/priorities/types_test.go
+++ b/pkg/scheduler/algorithm/priorities/types_test.go
@@ -30,10 +30,11 @@ import (
 func TestEmptyPriorityMetadataProducer(t *testing.T) {
 	fakePod := st.MakePod().Name("p1").Node("node2").Obj()
 	fakeLabelSelector := labels.SelectorFromSet(labels.Set{"foo": "bar"})
+	fakeNodes := []*v1.Node{st.MakeNode().Name("node1").Obj(), st.MakeNode().Name("node-a").Obj()}
 
-	snapshot := nodeinfosnapshot.NewSnapshot([]*v1.Pod{fakePod}, []*v1.Node{st.MakeNode().Name("node1").Obj(), st.MakeNode().Name("node-a").Obj()})
+	snapshot := nodeinfosnapshot.NewSnapshot([]*v1.Pod{fakePod}, fakeNodes)
 	// Test EmptyPriorityMetadataProducer
-	metadata := EmptyPriorityMetadataProducer(fakePod, snapshot)
+	metadata := EmptyPriorityMetadataProducer(fakePod, fakeNodes, snapshot)
 	if metadata != nil {
 		t.Errorf("failed to produce empty metadata: got %v, expected nil", metadata)
 	}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -238,7 +238,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 		}, nil
 	}
 
-	metaPrioritiesInterface := g.priorityMetaProducer(pod, g.nodeInfoSnapshot)
+	metaPrioritiesInterface := g.priorityMetaProducer(pod, filteredNodes, g.nodeInfoSnapshot)
 	priorityList, err := PrioritizeNodes(ctx, pod, g.nodeInfoSnapshot, metaPrioritiesInterface, g.prioritizers, filteredNodes, g.extenders, g.framework, state)
 	if err != nil {
 		return result, err

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1008,7 +1008,7 @@ func TestZeroRequest(t *testing.T) {
 				informerFactory.Apps().V1().StatefulSets().Lister(),
 			)
 
-			metaData := metaDataProducer(test.pod, snapshot)
+			metaData := metaDataProducer(test.pod, test.nodes, snapshot)
 
 			list, err := PrioritizeNodes(
 				context.Background(),

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality_test.go
@@ -201,7 +201,7 @@ func TestImageLocalityPriority(t *testing.T) {
 			)
 
 			snapshot := nodeinfosnapshot.NewSnapshot(nil, test.nodes)
-			meta := metaDataProducer(test.pod, snapshot)
+			meta := metaDataProducer(test.pod, test.nodes, snapshot)
 
 			state := framework.NewCycleState()
 			state.Write(migration.PrioritiesStateKey, &migration.PrioritiesStateData{Reference: meta})


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Due to some historical reason, some Priorities are not written in the map-reduce style, in particular PodAffinity and EvenPodsSpread. To make sure they can refactored into map-reduce style, their specific internal helper data structure must be calculated in PriorityMetadataProducer, and unfortunately current PriorityMetadataProducer signature doesn't expose the `filteredNoded`, which is needed for those 2 Priorities. This PR adds the additional `filteredNoded` in PriorityMetadataProducer.

**Which issue(s) this PR fixes**:

The migration of PodAffinity and EvenPodsSpread Priority is dependent on this.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig scheduling
/assign @ahg-g 