### PR TITLE
add --resource-version flag to patch and replace operations

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch_test.go
@@ -61,6 +61,7 @@ func TestPatchObject(t *testing.T) {
 	cmd.Flags().Set("namespace", "test")
 	cmd.Flags().Set("patch", `{"spec":{"type":"NodePort"}}`)
 	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("resource-version", "1")
 	cmd.Run(cmd, []string{"services/frontend"})
 
 	// uses the name from the response

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace_test.go
@@ -78,6 +78,7 @@ func TestReplaceObject(t *testing.T) {
 	cmd.Flags().Set("force", "true")
 	cmd.Flags().Set("cascade", "false")
 	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("resource-version", "1")
 	cmd.Run(cmd, []string{})
 
 	if buf.String() != "replicationcontroller/redis-master\nreplicationcontroller/rc1\n" {


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Adds `--resource-version` flag to `patch` and `replace` operations.

kubectl's `annotate`, `label` and `scale` operations take `--resource-version`. This allows to prevent a change overwriting another change that happens between reading a resource and updating it. The same reasoning applies to all operations that update a resource, like `patch` and `replace`.

If `--resource-version` is specified and does not match the current resource version on server the command will fail.

e.g. 

patch:

```
kubectl patch node k8s-node-1 -p '{"spec":{"unschedulable":true}}' --resource-version=1
```

replace:

```
kubectl replace -f ./pod.json --resource-version=1
```

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/742

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
patch and replace operations now take an optional --release-version flag. If specified and does not match the current resource version on the server, the command will fail.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```