### PR TITLE
Make k8s.io/kubernetes dependency policy explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Try our [interactive tutorial].
 
 Take a free course on [Scalable Microservices with Kubernetes].
 
+To use Kubernetes code as a library in other applications, see the [list of published components](https://git.k8s.io/kubernetes/staging/README.md).
+Use of the `k8s.io/kubernetes` module or `k8s.io/kubernetes/...` packages as libraries is not supported.
+
 ## To start developing Kubernetes
 
 The [community repository] hosts all information about


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Makes the project policy around use of k8s.io/kubernetes as a library explicit.

This question comes up all the time, and the various threads/discussions where this is said and repeated are not very easy to find.

```release-note
NONE
```

/area code-organization
/sig architecture
/cc @dims @smarterclayton @sttts @lavalamp @thockin 