### PR TITLE
Fixes crd per-version validation field path

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema/nonstructuralschema_controller.go
@@ -100,7 +100,7 @@ func calculateCondition(in *apiextensions.CustomResourceDefinition) *apiextensio
 		allErrs = append(allErrs, schema.ValidateStructural(pth, s)...)
 	}
 
-	for _, v := range in.Spec.Versions {
+	for i, v := range in.Spec.Versions {
 		if v.Schema == nil || v.Schema.OpenAPIV3Schema == nil {
 			continue
 		}
@@ -112,7 +112,7 @@ func calculateCondition(in *apiextensions.CustomResourceDefinition) *apiextensio
 			return cond
 		}
 
-		pth := field.NewPath("spec", "version").Key(v.Name).Child("schema", "openAPIV3Schema")
+		pth := field.NewPath("spec", "versions").Index(i).Child("schema", "openAPIV3Schema")
 
 		allErrs = append(allErrs, schema.ValidateStructural(pth, s)...)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -1233,8 +1233,8 @@ properties:
     type: string
 `,
 			expectedViolations: []string{
-				"spec.version[v1beta1].schema.openAPIV3Schema.properties[a].type: Required value: must not be empty for specified object fields",
-				"spec.version[v1beta1].schema.openAPIV3Schema.properties[b]: Required value: because it is defined in spec.version[v1beta1].schema.openAPIV3Schema.not.properties[b]",
+				"spec.versions[0].schema.openAPIV3Schema.properties[a].type: Required value: must not be empty for specified object fields",
+				"spec.versions[0].schema.openAPIV3Schema.properties[b]: Required value: because it is defined in spec.versions[0].schema.openAPIV3Schema.not.properties[b]",
 			},
 		},
 		{
@@ -1256,10 +1256,10 @@ not:
     d: {}
 `,
 			expectedViolations: []string{
-				"spec.version[v1beta1].schema.openAPIV3Schema.properties[a].type: Required value: must not be empty for specified object fields",
-				"spec.version[v1beta1].schema.openAPIV3Schema.properties[b]: Required value: because it is defined in spec.version[v1beta1].schema.openAPIV3Schema.not.properties[b]",
-				"spec.version[v1].schema.openAPIV3Schema.properties[c].type: Required value: must not be empty for specified object fields",
-				"spec.version[v1].schema.openAPIV3Schema.properties[d]: Required value: because it is defined in spec.version[v1].schema.openAPIV3Schema.not.properties[d]",
+				"spec.versions[0].schema.openAPIV3Schema.properties[a].type: Required value: must not be empty for specified object fields",
+				"spec.versions[0].schema.openAPIV3Schema.properties[b]: Required value: because it is defined in spec.versions[0].schema.openAPIV3Schema.not.properties[b]",
+				"spec.versions[1].schema.openAPIV3Schema.properties[c].type: Required value: must not be empty for specified object fields",
+				"spec.versions[1].schema.openAPIV3Schema.properties[d]: Required value: because it is defined in spec.versions[1].schema.openAPIV3Schema.not.properties[d]",
 			},
 		},
 		{


### PR DESCRIPTION
/sig api-machinery
/kind bug
/cc @sttts @liggitt @kubernetes/sig-api-machinery-misc 

found this when resolving CI failures for #84005 , i dont think there will be compatiblity issues if we reword it directly?

```release-note
NONE
```
