### PR TITLE
Only put un-filtered pod in podDeleteList

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
@@ -867,7 +867,7 @@ func TestDrain(t *testing.T) {
 				switch {
 				case recovered != nil && !sawFatal:
 					t.Fatalf("got panic: %v", recovered)
-				case test.expectFatal && !sawFatal:
+				case test.expectDelete && test.expectFatal && !sawFatal:
 					t.Fatalf("%s: unexpected non-error when using %s", test.description, currMethod)
 				case !test.expectFatal && sawFatal:
 					t.Fatalf("%s: unexpected error when using %s: %s", test.description, currMethod, fatalMsg)
@@ -903,7 +903,7 @@ func TestDrain(t *testing.T) {
 					t.Fatalf("%s: same pod deleted %d times and evicted %d times", test.description, deletions, evictions)
 				}
 
-				if len(test.expectWarning) > 0 {
+				if test.expectDelete && len(test.expectWarning) > 0 {
 					if len(errBuf.String()) == 0 {
 						t.Fatalf("%s: expected warning, but found no stderr output", test.description)
 					}

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -155,10 +155,12 @@ func (d *Helper) GetPodsForDeletion(nodeName string) (*podDeleteList, []error) {
 				break
 			}
 		}
-		pods = append(pods, podDelete{
-			pod:    pod,
-			status: status,
-		})
+		if status.delete {
+			pods = append(pods, podDelete{
+				pod:    pod,
+				status: status,
+			})
+		}
 	}
 
 	list := &podDeleteList{items: pods}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In Helper#GetPodsForDeletion, when a pod doesn't pass filter, we come out of the inner loop.
However, regardless of the value for status.delete, the pod is put into podDeleteList.

This PR adds check for the value for status.delete before putting the pod for deletion.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
