### PR TITLE
test/e2e/apps: Skip or scale LB test per node count

### DIFF
--- a/test/e2e/apps/BUILD
+++ b/test/e2e/apps/BUILD
@@ -82,6 +82,7 @@ go_library(
         "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/utils/integer:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/test/e2e/apps/deployment.go
+++ b/test/e2e/apps/deployment.go
@@ -48,6 +48,7 @@ import (
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	testutil "k8s.io/kubernetes/test/utils"
+	"k8s.io/utils/integer"
 	utilpointer "k8s.io/utils/pointer"
 )
 
@@ -127,6 +128,7 @@ var _ = SIGDescribe("Deployment", func() {
 		testProportionalScalingDeployment(f)
 	})
 	ginkgo.It("should not disrupt a cloud load-balancer's connectivity during rollout", func() {
+		e2eskipper.SkipUnlessNodeCountIsAtLeast(2)
 		e2eskipper.SkipUnlessProviderIs("aws", "azure", "gce", "gke")
 		testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f)
 	})
@@ -867,7 +869,7 @@ func testRollingUpdateDeploymentWithLocalTrafficLoadBalancer(f *framework.Framew
 	name := "test-rolling-update-with-lb"
 	framework.Logf("Creating Deployment %q", name)
 	podLabels := map[string]string{"name": name}
-	replicas := int32(3)
+	replicas := int32(integer.IntMin(5, framework.TestContext.CloudConfig.NumNodes))
 	d := e2edeployment.NewDeployment(name, replicas, podLabels, AgnhostImageName, AgnhostImage, appsv1.RollingUpdateDeploymentStrategyType)
 	// NewDeployment assigned the same value to both d.Spec.Selector and
 	// d.Spec.Template.Labels, so mutating the one would mutate the other.


### PR DESCRIPTION
Skip the "Deployment should not disrupt a cloud load-balancer's connectivity during rollout" test if the number of nodes is less than 2; otherwise, set the deployment's replicas equal to the lesser of 5 and the number of nodes.

The test would fail if there were fewer nodes than replicas, but the test needs at least 2 nodes, and the likelihood of failure absent the feature under test increases with the number of replicas, so it is desirable to set replicas to a higher value, within reason.

* `test/e2e/apps/deployment.go`: Skip the load-balancer connectivity test unless there are at least 2 nodes.
(`testRollingUpdateDeploymentWithLocalTrafficLoadBalancer`): Set `replicas` to the min of 5 and the number of nodes.

**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:

Ensure the "Deployment should not disrupt a cloud load-balancer's connectivity during rollout" test does not fail when the number of nodes is fewer than 3.

**Which issue(s) this PR fixes**:

None.

**Special notes for your reviewer**:

Follow-up to #80004.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
