### PR TITLE
Update the event handler for deleting pods to reject the waiting pod

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -204,6 +204,7 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(obj interface{}) {
 		// Volume binder only wants to keep unassigned pods
 		sched.VolumeBinder.DeletePodBindings(pod)
 	}
+	sched.Framework.RejectWaitingPod(pod.UID)
 }
 
 func (sched *Scheduler) addPodToCache(obj interface{}) {

--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -62,6 +62,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_model/go:go_default_library",
     ],

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -627,6 +627,14 @@ func (f *framework) GetWaitingPod(uid types.UID) WaitingPod {
 	return f.waitingPods.get(uid)
 }
 
+// RejectWaitingPod rejects a WaitingPod given its UID.
+func (f *framework) RejectWaitingPod(uid types.UID) {
+	waitingPod := f.waitingPods.get(uid)
+	if waitingPod != nil {
+		waitingPod.Reject("removed")
+	}
+}
+
 // HasFilterPlugins returns true if at least one filter plugin is defined.
 func (f *framework) HasFilterPlugins() bool {
 	return len(f.filterPlugins) > 0

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -471,6 +471,9 @@ type FrameworkHandle interface {
 	// GetWaitingPod returns a waiting pod given its UID.
 	GetWaitingPod(uid types.UID) WaitingPod
 
+	// RejectWaitingPod rejects a waiting pod given its UID.
+	RejectWaitingPod(uid types.UID)
+
 	// ClientSet returns a kubernetes clientSet.
 	ClientSet() clientset.Interface
 

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -243,6 +243,9 @@ func (*fakeFramework) GetWaitingPod(uid types.UID) framework.WaitingPod {
 	return nil
 }
 
+func (*fakeFramework) RejectWaitingPod(uid types.UID) {
+}
+
 func (*fakeFramework) ClientSet() clientset.Interface {
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig scheduling
/priority important-soon

**What this PR does / why we need it**:
We need to take the initiative to delete the data in the waitingPodsMap and terminate the process in waiting state of permit plugin to ensure data accuracy, if the pod has been deleted.

**Which issue(s) this PR fixes**:
Fixes #84554

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @ahg-g