### PR TITLE
publishing: add rules for 1.17 and remove for 1.13

### DIFF
--- a/staging/publishing/rules-godeps.yaml
+++ b/staging/publishing/rules-godeps.yaml
@@ -8,11 +8,6 @@ rules:
 - destination: code-generator
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/code-generator
-    name: release-1.13
-    go: 1.11.5
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/code-generator
     name: release-1.14
@@ -21,11 +16,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/apimachinery
-    name: release-1.13
-    go: 1.11.5
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/apimachinery
     name: release-1.14
@@ -33,14 +23,6 @@ rules:
 - destination: api
   library: true
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/api
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/api
@@ -52,16 +34,6 @@ rules:
 - destination: client-go
   library: true
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/client-go
-    name: release-10.0
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/client-go
@@ -91,18 +63,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/apiserver
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/apiserver
     name: release-1.14
@@ -118,20 +78,6 @@ rules:
         branch: release-1.14
 - destination: kube-aggregator
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-aggregator
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiserver
-      branch: release-1.13
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-aggregator
@@ -150,24 +96,6 @@ rules:
         branch: release-1.14
 - destination: sample-apiserver
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/sample-apiserver
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiserver
-      branch: release-1.13
-    - repository: code-generator
-      branch: release-1.13
-    required-packages:
-    - k8s.io/code-generator
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/sample-apiserver
@@ -199,22 +127,6 @@ rules:
 - destination: sample-controller
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/sample-controller
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: code-generator
-      branch: release-1.13
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/sample-controller
     name: release-1.14
@@ -244,24 +156,6 @@ rules:
 - destination: apiextensions-apiserver
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/apiextensions-apiserver
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiserver
-      branch: release-1.13
-    - repository: code-generator
-      branch: release-1.13
-    required-packages:
-    - k8s.io/code-generator
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.14
@@ -285,18 +179,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/metrics
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/metrics
     name: release-1.14
@@ -311,20 +193,6 @@ rules:
 - destination: csi-api
   library: true
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/csi-api
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-    - repository: apiextensions-apiserver
-      branch: release-1.13
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/csi-api
@@ -343,18 +211,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/cli-runtime
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: api
-      branch: release-1.13
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.14
@@ -369,20 +225,6 @@ rules:
 - destination: sample-cli-plugin
   library: false
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/sample-cli-plugin
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: api
-      branch: release-1.13
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: cli-runtime
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/sample-cli-plugin
@@ -403,14 +245,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-proxy
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.14
@@ -423,16 +257,6 @@ rules:
 - destination: kubelet
   library: true
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kubelet
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/kubelet
@@ -449,16 +273,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-scheduler
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: apiserver
-      branch: release-1.13
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.14
@@ -473,16 +287,6 @@ rules:
 - destination: kube-controller-manager
   library: true
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/kube-controller-manager
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: apiserver
-      branch: release-1.13
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/kube-controller-manager
@@ -499,16 +303,6 @@ rules:
   library: true
   branches:
   - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/cluster-bootstrap
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: api
-      branch: release-1.13
-  - source:
       branch: release-1.14
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.14
@@ -521,18 +315,6 @@ rules:
 - destination: cloud-provider
   library: true
   branches:
-  - source:
-      branch: release-1.13
-      dir: staging/src/k8s.io/cloud-provider
-    name: release-1.13
-    go: 1.11.5
-    dependencies:
-    - repository: api
-      branch: release-1.13
-    - repository: apimachinery
-      branch: release-1.13
-    - repository: client-go
-      branch: release-10.0
   - source:
       branch: release-1.14
       dir: staging/src/k8s.io/cloud-provider

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -21,6 +21,11 @@ rules:
       dir: staging/src/k8s.io/code-generator
     name: release-1.16
     go: 1.12.7
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/code-generator
+    name: release-1.17
+    go: 1.12.12
 - destination: apimachinery
   library: true
   branches:
@@ -38,6 +43,11 @@ rules:
       dir: staging/src/k8s.io/apimachinery
     name: release-1.16
     go: 1.12.7
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/apimachinery
+    name: release-1.17
+    go: 1.12.12
 - destination: api
   library: true
   branches:
@@ -64,6 +74,14 @@ rules:
     dependencies:
       - repository: apimachinery
         branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/api
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.17
 - destination: client-go
   library: true
   branches:
@@ -96,6 +114,16 @@ rules:
         branch: release-1.16
       - repository: api
         branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/client-go
+    name: release-14.0
+    go: 1.12.12
+    dependencies:
+      - repository: apimachinery
+        branch: release-1.17
+      - repository: api
+        branch: release-1.17
   smoke-test: |
     # assumes GO111MODULE=on
     go build ./...
@@ -134,6 +162,18 @@ rules:
       branch: release-1.16
     - repository: client-go
       branch: release-13.0
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/component-base
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
 - destination: apiserver
   library: true
   branches:
@@ -178,6 +218,20 @@ rules:
       branch: release-13.0
     - repository: component-base
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/apiserver
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: component-base
+      branch: release-1.17
 - destination: kube-aggregator
   branches:
   - source:
@@ -233,6 +287,24 @@ rules:
       branch: release-1.16
     - repository: code-generator
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/kube-aggregator
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: apiserver
+      branch: release-1.17
+    - repository: component-base
+      branch: release-1.17
+    - repository: code-generator
+      branch: release-1.17
 - destination: sample-apiserver
   branches:
   - source:
@@ -294,6 +366,26 @@ rules:
       branch: release-1.16
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/sample-apiserver
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: apiserver
+      branch: release-1.17
+    - repository: code-generator
+      branch: release-1.17
+    - repository: component-base
+      branch: release-1.17
+    required-packages:
+    - k8s.io/code-generator
   smoke-test: |
     # assumes GO111MODULE=on
     go build .
@@ -344,6 +436,22 @@ rules:
       branch: release-13.0
     - repository: code-generator
       branch: release-1.16
+    required-packages:
+    - k8s.io/code-generator
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/sample-controller
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: code-generator
+      branch: release-1.17
     required-packages:
     - k8s.io/code-generator
   smoke-test: |
@@ -410,6 +518,26 @@ rules:
       branch: release-1.16
     required-packages:
     - k8s.io/code-generator
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/apiextensions-apiserver
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: apiserver
+      branch: release-1.17
+    - repository: code-generator
+      branch: release-1.17
+    - repository: component-base
+      branch: release-1.17
+    required-packages:
+    - k8s.io/code-generator
 - destination: metrics
   library: true
   branches:
@@ -454,6 +582,20 @@ rules:
       branch: release-13.0
     - repository: code-generator
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/metrics
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: code-generator
+      branch: release-1.17
 - destination: cli-runtime
   library: true
   branches:
@@ -492,6 +634,18 @@ rules:
       branch: release-1.16
     - repository: client-go
       branch: release-13.0
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/cli-runtime
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: api
+      branch: release-1.17
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
 - destination: sample-cli-plugin
   library: false
   branches:
@@ -536,6 +690,20 @@ rules:
       branch: release-1.16
     - repository: client-go
       branch: release-13.0
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/sample-cli-plugin
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: api
+      branch: release-1.17
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: cli-runtime
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
 - destination: kube-proxy
   library: true
   branches:
@@ -576,6 +744,20 @@ rules:
       branch: release-1.16
     - repository: client-go
       branch: release-13.0
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/kube-proxy
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.7
+    - repository: component-base
+      branch: release-1.17
+    - repository: api
+      branch: release-1.7
+    - repository: client-go
+      branch: release-14.0
 - destination: kubelet
   library: true
   branches:
@@ -608,6 +790,16 @@ rules:
       branch: release-1.16
     - repository: api
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/kubelet
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
 - destination: kube-scheduler
   library: true
   branches:
@@ -648,6 +840,20 @@ rules:
       branch: release-1.16
     - repository: client-go
       branch: release-13.0
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/kube-scheduler
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: component-base
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
 - destination: kube-controller-manager
   library: true
   branches:
@@ -688,6 +894,20 @@ rules:
       branch: release-1.16
     - repository: client-go
       branch: release-13.0
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/kube-controller-manager
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: component-base
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
 - destination: cluster-bootstrap
   library: true
   branches:
@@ -720,6 +940,16 @@ rules:
       branch: release-1.16
     - repository: api
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/cluster-bootstrap
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: api
+      branch: release-1.17
 - destination: cloud-provider
   library: true
   branches:
@@ -758,6 +988,18 @@ rules:
       branch: release-1.16
     - repository: client-go
       branch: release-13.0
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/cloud-provider
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: api
+      branch: release-1.17
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
 - destination: csi-translation-lib
   library: true
   branches:
@@ -802,6 +1044,20 @@ rules:
       branch: release-13.0
     - repository: cloud-provider
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/csi-translation-lib
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: api
+      branch: release-1.17
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: cloud-provider
+      branch: release-1.17
 - destination: legacy-cloud-providers
   library: true
   branches:
@@ -860,6 +1116,26 @@ rules:
       branch: release-1.16
     - repository: component-base
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/legacy-cloud-providers
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: api
+      branch: release-1.17
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: cloud-provider
+      branch: release-1.17
+    - repository: csi-translation-lib
+      branch: release-1.17
+    - repository: apiserver
+      branch: release-1.17
+    - repository: component-base
+      branch: release-1.17
 - destination: node-api
   library: true
   branches:
@@ -904,6 +1180,20 @@ rules:
       branch: release-13.0
     - repository: code-generator
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/node-api
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: api
+      branch: release-1.17
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: code-generator
+      branch: release-1.17
 - destination: cri-api
   library: true
   branches:
@@ -921,6 +1211,11 @@ rules:
       dir: staging/src/k8s.io/cri-api
     name: release-1.16
     go: 1.12.7
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/cri-api
+    name: release-1.17
+    go: 1.12.12
 - destination: kubectl
   library: true
   branches:
@@ -968,3 +1263,23 @@ rules:
       branch: release-1.16
     - repository: metrics
       branch: release-1.16
+  - source:
+      branch: release-1.17
+      dir: staging/src/k8s.io/kubectl
+    name: release-1.17
+    go: 1.12.12
+    dependencies:
+    - repository: api
+      branch: release-1.17
+    - repository: apimachinery
+      branch: release-1.17
+    - repository: cli-runtime
+      branch: release-1.17
+    - repository: client-go
+      branch: release-14.0
+    - repository: code-generator
+      branch: release-1.17
+    - repository: component-base
+      branch: release-1.17
+    - repository: metrics
+      branch: release-1.17


### PR DESCRIPTION
Ref: https://groups.google.com/forum/#!topic/kubernetes-dev/MDDmj5NQQzk
Closes: https://github.com/kubernetes/kubernetes/issues/84532

The `release-1.17` branch has been created. This PR adds rules for 1.17 and removes the 1.13 ones as it isn't supported anymore.

/hold
until it is confirmed that it is safe to remove the 1.13 rules

/assign @sttts @dims 
/cc @justaugustus @tpepper 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```