### PR TITLE
Let token create help with joining a master 

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -98,6 +98,7 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 
 	var cfgPath string
 	var printJoinCommand bool
+	var certificateKey string
 	bto := options.NewBootstrapTokenOptions()
 
 	createCmd := &cobra.Command{
@@ -132,13 +133,15 @@ func NewCmdToken(out io.Writer, errW io.Writer) *cobra.Command {
 				return err
 			}
 
-			return RunCreateToken(out, client, cfgPath, cfg, printJoinCommand, kubeConfigFile)
+			return RunCreateToken(out, client, cfgPath, cfg, printJoinCommand, certificateKey, kubeConfigFile)
 		},
 	}
 
 	options.AddConfigFlag(createCmd.Flags(), &cfgPath)
 	createCmd.Flags().BoolVar(&printJoinCommand,
 		"print-join-command", false, "Instead of printing only the token, print the full 'kubeadm join' flag needed to join the cluster using the token.")
+	createCmd.Flags().StringVar(&certificateKey,
+		options.CertificateKey, "", "When used together with '--print-join-command', print the full 'kubeadm join' flag needed to join the cluster as a control-plane. To create a new certificate key you must use 'kubeadm init phase upload-certs --upload-certs'.")
 	bto.AddTTLFlagWithName(createCmd.Flags(), "ttl")
 	bto.AddUsagesFlag(createCmd.Flags())
 	bto.AddGroupsFlag(createCmd.Flags())
@@ -226,7 +229,7 @@ func NewCmdTokenGenerate(out io.Writer) *cobra.Command {
 }
 
 // RunCreateToken generates a new bootstrap token and stores it as a secret on the server.
-func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, initCfg *kubeadmapiv1beta2.InitConfiguration, printJoinCommand bool, kubeConfigFile string) error {
+func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, initCfg *kubeadmapiv1beta2.InitConfiguration, printJoinCommand bool, certificateKey string, kubeConfigFile string) error {
 	// ClusterConfiguration is needed just for the call to LoadOrDefaultInitConfiguration
 	clusterCfg := &kubeadmapiv1beta2.ClusterConfiguration{
 		// KubernetesVersion is not used, but we set this explicitly to avoid
@@ -257,14 +260,28 @@ func RunCreateToken(out io.Writer, client clientset.Interface, cfgPath string, i
 	// otherwise, just print the token
 	if printJoinCommand {
 		skipTokenPrint := false
-		joinCommand, err := cmdutil.GetJoinWorkerCommand(kubeConfigFile, internalcfg.BootstrapTokens[0].Token.String(), skipTokenPrint)
-		if err != nil {
-			return errors.Wrap(err, "failed to get join command")
+		if certificateKey != "" {
+			skipCertificateKeyPrint := false
+			joinCommand, err := cmdutil.GetJoinControlPlaneCommand(kubeConfigFile, internalcfg.BootstrapTokens[0].Token.String(), certificateKey, skipTokenPrint, skipCertificateKeyPrint)
+			if err != nil {
+				return errors.Wrap(err, "failed to get join command")
+			}
+			joinCommand = strings.ReplaceAll(joinCommand, "\\\n", "")
+			joinCommand = strings.ReplaceAll(joinCommand, "\t", "")
+			fmt.Fprintln(out, joinCommand)
+		} else {
+			joinCommand, err := cmdutil.GetJoinWorkerCommand(kubeConfigFile, internalcfg.BootstrapTokens[0].Token.String(), skipTokenPrint)
+			if err != nil {
+				return errors.Wrap(err, "failed to get join command")
+			}
+			joinCommand = strings.ReplaceAll(joinCommand, "\\\n", "")
+			joinCommand = strings.ReplaceAll(joinCommand, "\t", "")
+			fmt.Fprintln(out, joinCommand)
 		}
-		joinCommand = strings.ReplaceAll(joinCommand, "\\\n", "")
-		joinCommand = strings.ReplaceAll(joinCommand, "\t", "")
-		fmt.Fprintln(out, joinCommand)
 	} else {
+		if certificateKey != "" {
+			return errors.Wrap(err, "cannot use --certificate-key without --print-join-command")
+		}
 		fmt.Fprintln(out, internalcfg.BootstrapTokens[0].Token.String())
 	}
 

--- a/cmd/kubeadm/app/cmd/token_test.go
+++ b/cmd/kubeadm/app/cmd/token_test.go
@@ -172,7 +172,7 @@ func TestRunCreateToken(t *testing.T) {
 				},
 			}
 
-			err = RunCreateToken(&buf, fakeClient, "", cfg, tc.printJoin, "")
+			err = RunCreateToken(&buf, fakeClient, "", cfg, tc.printJoin, "", "")
 			if tc.expectedError && err == nil {
 				t.Error("unexpected success")
 			} else if !tc.expectedError && err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
The `kubeadm token create --print-join-command` command is very helpful, but doesn't help with adding more masters to your cluster. This adds a `--for-master` flag which does setup and gives instructions for letting a master join.

**Special notes for your reviewer**:
This is the first time I am writing any Go code and I am still pretty new to Kubernetes, so this may be very ugly. I am also having trouble actually building Kubernetes on my device:
```
$ make WHAT=cmd/kubeadm
go/build: importGo k8s.io/kubernetes: exit status 1
can't load package: package k8s.io/kubernetes: cannot find module providing package k8s.io/kubernetes


+++ [1031 12:54:41] Building go targets for darwin/amd64:
    ./vendor/k8s.io/code-generator/cmd/deepcopy-gen
go: finding k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/deepcopy-gen latest
go: finding k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd latest
go: finding k8s.io/kubernetes/vendor/k8s.io/code-generator latest
go: finding k8s.io/kubernetes/vendor latest
go: finding k8s.io/kubernetes/vendor/k8s.io latest
can't load package: package k8s.io/kubernetes/vendor/k8s.io/code-generator/cmd/deepcopy-gen: no matching versions for query "latest"
!!! [1031 12:54:48] Call tree:
!!! [1031 12:54:48]  1: /Users/sylviavanos/kubernetes/hack/lib/golang.sh:713 kube::golang::build_some_binaries(...)
!!! [1031 12:54:48]  2: /Users/sylviavanos/kubernetes/hack/lib/golang.sh:852 kube::golang::build_binaries_for_platform(...)
!!! [1031 12:54:48]  3: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
!!! [1031 12:54:48] Call tree:
!!! [1031 12:54:48]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
!!! [1031 12:54:48] Call tree:
!!! [1031 12:54:48]  1: hack/make-rules/build.sh:27 kube::golang::build_binaries(...)
make[1]: *** [_output/bin/deepcopy-gen] Error 1
make: *** [generated_files] Error 2
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: the command "kubeadm token create" now has a "--certificate-key" flag that can be used for the formation of join commands for control-planes with automatic copy of certificates
``` 