### PR TITLE
Don't use hardcoded /go GOPATH in benchmark-dockerized.sh

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -49,7 +49,7 @@ export ARTIFACTS=${ARTIFACTS:-"${WORKSPACE}/artifacts"}
 export FULL_LOG="true"
 
 mkdir -p "${ARTIFACTS}"
-cd /go/src/k8s.io/kubernetes
+cd "${GOPATH}/src/k8s.io/kubernetes"
 
 ./hack/install-etcd.sh
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:

It starts using `$GOPATH` instead of hardcoded `/go` in hack/jenkins/benchmark-dockerized.s.
It will allow us to migrate some prow jobs to pod utilities where `GOPATH` is not `/go` but `/home/prow/go`.
I believe the script was written in the times when `bootstrap.py`was the only way to run prow-jobs.
This shouldn't break anything for prow jobs using bootstrap.py as the GOPATH is set by default to `/go` there.

Ref. https://github.com/kubernetes/kubernetes/issues/84186

```release-note
NONE
```


