### PR TITLE
UpdateStrategy.RollingUpdate.Partition is lost when UpdateStrategy.Type is not set

### DIFF
--- a/pkg/apis/apps/v1/defaults.go
+++ b/pkg/apis/apps/v1/defaults.go
@@ -99,8 +99,10 @@ func SetDefaults_StatefulSet(obj *appsv1.StatefulSet) {
 	if obj.Spec.UpdateStrategy.Type == "" {
 		obj.Spec.UpdateStrategy.Type = appsv1.RollingUpdateStatefulSetStrategyType
 
-		// UpdateStrategy.RollingUpdate will take default values below.
-		obj.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{}
+		if obj.Spec.UpdateStrategy.RollingUpdate == nil {
+			// UpdateStrategy.RollingUpdate will take default values below.
+			obj.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateStatefulSetStrategy{}
+		}
 	}
 
 	if obj.Spec.UpdateStrategy.Type == appsv1.RollingUpdateStatefulSetStrategyType &&

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -173,6 +173,7 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 	defaultLabels := map[string]string{"foo": "bar"}
 	var defaultPartition int32 = 0
 	var defaultReplicas int32 = 1
+	var notTheDefaultPartition int32 = 42
 
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
@@ -259,6 +260,35 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,
 						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
 							Partition: &defaultPartition,
+						},
+					},
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
+				},
+			},
+		},
+		{ // UpdateStrategy.RollingUpdate.Partition is not lost when UpdateStrategy.Type is not set
+			original: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: defaultTemplate,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+							Partition: &notTheDefaultPartition,
+						},
+					},
+				},
+			},
+			expected: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: defaultLabels,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas:            &defaultReplicas,
+					Template:            defaultTemplate,
+					PodManagementPolicy: appsv1.OrderedReadyPodManagement,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+							Partition: &notTheDefaultPartition,
 						},
 					},
 					RevisionHistoryLimit: utilpointer.Int32Ptr(10),


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When updating or creating a `StatefulSet` the value of `UpdateStrategy.RollingUpdate.Partition` is overwritten with the default value (`0`) when `UpdateStrategy.Type` is not set.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
