### PR TITLE
Errors from cgroup destroy are swallowed. Log error at warning level.

### DIFF
--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -187,7 +187,7 @@ func (m *podContainerManagerImpl) tryKillingCgroupProcesses(podCgroup CgroupName
 func (m *podContainerManagerImpl) Destroy(podCgroup CgroupName) error {
 	// Try killing all the processes attached to the pod cgroup
 	if err := m.tryKillingCgroupProcesses(podCgroup); err != nil {
-		klog.V(3).Infof("failed to kill all the processes attached to the %v cgroups", podCgroup)
+		klog.Warningf("failed to kill all the processes attached to the %v cgroups", podCgroup)
 		return fmt.Errorf("failed to kill all the processes attached to the %v cgroups : %v", podCgroup, err)
 	}
 
@@ -197,6 +197,7 @@ func (m *podContainerManagerImpl) Destroy(podCgroup CgroupName) error {
 		ResourceParameters: &ResourceConfig{},
 	}
 	if err := m.cgroupManager.Destroy(containerConfig); err != nil {
+		klog.Warningf("failed to delete cgroup paths for %v : %v", podCgroup, err)
 		return fmt.Errorf("failed to delete cgroup paths for %v : %v", podCgroup, err)
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Housekeeping sync loop finds an orphaned pod and tries to clean it up. The removal of the kubepod slice may fail. This leads to the docker scope timing out and entering a failed state. The returned error(s) from runc are swallowed making debugging difficult.

**Which issue(s) this PR fixes**:
Fixes #84595

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
```
