### PR TITLE
Grab init containers logs in e2e tests

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1249,15 +1249,16 @@ func (f *Framework) MatchContainerOutput(
 
 	if podErr != nil {
 		// Pod failed. Dump all logs from all containers to see what's wrong
-		for _, container := range podStatus.Spec.Containers {
-			logs, err := e2epod.GetPodLogs(f.ClientSet, ns, podStatus.Name, container.Name)
+		_ = podutil.VisitContainers(&podStatus.Spec, func(c *v1.Container) bool {
+			logs, err := e2epod.GetPodLogs(f.ClientSet, ns, podStatus.Name, c.Name)
 			if err != nil {
 				Logf("Failed to get logs from node %q pod %q container %q: %v",
-					podStatus.Spec.NodeName, podStatus.Name, container.Name, err)
-				continue
+					podStatus.Spec.NodeName, podStatus.Name, c.Name, err)
+			} else {
+				Logf("Output of node %q pod %q container %q: %s", podStatus.Spec.NodeName, podStatus.Name, c.Name, logs)
 			}
-			Logf("Output of node %q pod %q container %q: %s", podStatus.Spec.NodeName, podStatus.Name, container.Name, logs)
-		}
+			return true
+		})
 		return fmt.Errorf("expected pod %q success: %v", createdPod.Name, podErr)
 	}
 


### PR DESCRIPTION
Storage tests use `initContainers` + `framework.TestContainerOutput` and they will benefit from logging their output in failed tests.

/kind cleanup

**What this PR does / why we need it**:
[This test](https://github.com/kubernetes/kubernetes/blob/23320c958edc85feb541db85edc43ec629288a7d/test/e2e/storage/testsuites/subpath.go#L350)  failed In a downstream test job and the test output did not contain logs from init containers used in the test, making the flake debugging impossible.

```release-note
NONE
```
