### PR TITLE
Move json/yaml printer tests to correct location

### DIFF
--- a/pkg/printers/internalversion/BUILD
+++ b/pkg/printers/internalversion/BUILD
@@ -16,7 +16,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
-        "//pkg/api/testapi:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/autoscaling:go_default_library",
         "//pkg/apis/batch:go_default_library",
@@ -38,13 +37,11 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer/yaml:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",
-        "//vendor/gopkg.in/yaml.v2:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/BUILD
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/BUILD
@@ -38,6 +38,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "json_test.go",
         "sourcechecker_test.go",
         "tableprinter_test.go",
         "template_test.go",
@@ -49,6 +50,10 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/cli-runtime/pkg/printers/json_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/printers/json_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/json"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/yaml"
+)
+
+var testData = TestStruct{
+	TypeMeta:   metav1.TypeMeta{APIVersion: "foo/bar", Kind: "TestStruct"},
+	Key:        "testValue",
+	Map:        map[string]int{"TestSubkey": 1},
+	StringList: []string{"a", "b", "c"},
+	IntList:    []int{1, 2, 3},
+}
+
+type TestStruct struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+	Key               string         `json:"Key"`
+	Map               map[string]int `json:"Map"`
+	StringList        []string       `json:"StringList"`
+	IntList           []int          `json:"IntList"`
+}
+
+func (in *TestStruct) DeepCopyObject() runtime.Object {
+	panic("never called")
+}
+
+func TestYAMLPrinter(t *testing.T) {
+	testPrinter(t, NewTypeSetter(scheme.Scheme).ToPrinter(&YAMLPrinter{}), yamlUnmarshal)
+}
+
+func TestJSONPrinter(t *testing.T) {
+	testPrinter(t, NewTypeSetter(scheme.Scheme).ToPrinter(&JSONPrinter{}), json.Unmarshal)
+}
+
+func testPrinter(t *testing.T, printer ResourcePrinter, unmarshalFunc func(data []byte, v interface{}) error) {
+	buf := bytes.NewBuffer([]byte{})
+
+	err := printer.PrintObj(&testData, buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var poutput TestStruct
+	// Verify that given function runs without error.
+	err = unmarshalFunc(buf.Bytes(), &poutput)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Use real decode function to undo the versioning process.
+	poutput = TestStruct{}
+	s := scheme.Codecs.UniversalDecoder(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+	if err := runtime.DecodeInto(s, buf.Bytes(), &poutput); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(testData, poutput) {
+		t.Errorf("Test data and unmarshaled data are not equal: %v", diff.ObjectDiff(poutput, testData))
+	}
+
+	obj := &v1.Pod{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "v1", Kind: "Pod"},
+		ObjectMeta: metav1.ObjectMeta{Name: "foo"},
+	}
+	// our decoder defaults, so we should default our expected object as well
+	scheme.Scheme.Default(obj)
+	buf.Reset()
+	printer.PrintObj(obj, buf)
+	var objOut v1.Pod
+	// Verify that given function runs without error.
+	err = unmarshalFunc(buf.Bytes(), &objOut)
+	if err != nil {
+		t.Fatalf("unexpected error: %#v", err)
+	}
+	// Use real decode function to undo the versioning process.
+	objOut = v1.Pod{}
+	if err := runtime.DecodeInto(s, buf.Bytes(), &objOut); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(obj, &objOut) {
+		t.Errorf("Unexpected inequality:\n%v", diff.ObjectDiff(obj, &objOut))
+	}
+}
+
+func yamlUnmarshal(data []byte, v interface{}) error {
+	return yaml.Unmarshal(data, v)
+}


### PR DESCRIPTION
* Moves json/yaml printers tests to the correct location in `cli-runtime/pkg/printers`.

/kind cleanup
/sig cli
/area kubectl
/priority important-soon

```release-note
NONE
```