### PR TITLE
Move small test back to printers_test.go

### DIFF
--- a/pkg/printers/internalversion/additional_printers_test.go
+++ b/pkg/printers/internalversion/additional_printers_test.go
@@ -143,26 +143,6 @@ func TestJSONPrinter(t *testing.T) {
 	testPrinter(t, genericprinters.NewTypeSetter(legacyscheme.Scheme).ToPrinter(&genericprinters.JSONPrinter{}), json.Unmarshal)
 }
 
-// TODO(seans3): Move this test to cli-runtime/pkg/printers.
-func TestFormatResourceName(t *testing.T) {
-	tests := []struct {
-		kind schema.GroupKind
-		name string
-		want string
-	}{
-		{schema.GroupKind{}, "", ""},
-		{schema.GroupKind{}, "name", "name"},
-		{schema.GroupKind{Kind: "Kind"}, "", "kind/"}, // should not happen in practice
-		{schema.GroupKind{Kind: "Kind"}, "name", "kind/name"},
-		{schema.GroupKind{Group: "group", Kind: "Kind"}, "name", "kind.group/name"},
-	}
-	for _, tt := range tests {
-		if got := formatResourceName(tt.kind, tt.name, true); got != tt.want {
-			t.Errorf("formatResourceName(%q, %q) = %q, want %q", tt.kind, tt.name, got, tt.want)
-		}
-	}
-}
-
 func PrintCustomType(obj *TestPrintType, options printers.GenerateOptions) ([]metav1beta1.TableRow, error) {
 	return []metav1beta1.TableRow{{Cells: []interface{}{obj.Data}}}, nil
 }

--- a/pkg/printers/internalversion/printers_test.go
+++ b/pkg/printers/internalversion/printers_test.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/kubernetes/pkg/apis/apps"
@@ -42,6 +43,25 @@ import (
 	"k8s.io/kubernetes/pkg/printers"
 	utilpointer "k8s.io/utils/pointer"
 )
+
+func TestFormatResourceName(t *testing.T) {
+	tests := []struct {
+		kind schema.GroupKind
+		name string
+		want string
+	}{
+		{schema.GroupKind{}, "", ""},
+		{schema.GroupKind{}, "name", "name"},
+		{schema.GroupKind{Kind: "Kind"}, "", "kind/"}, // should not happen in practice
+		{schema.GroupKind{Kind: "Kind"}, "name", "kind/name"},
+		{schema.GroupKind{Group: "group", Kind: "Kind"}, "name", "kind.group/name"},
+	}
+	for _, tt := range tests {
+		if got := formatResourceName(tt.kind, tt.name, true); got != tt.want {
+			t.Errorf("formatResourceName(%q, %q) = %q, want %q", tt.kind, tt.name, got, tt.want)
+		}
+	}
+}
 
 type TestPrintHandler struct {
 	numCalls int


### PR DESCRIPTION
* Moves small test back to correct location in `printers_test.go`, since it tests functionality in `printers.go`

/kind cleanup
/sig cli
/area kubectl
/priority important-soon

```release-note
NONE
```