### PR TITLE
Adds initial unit tests for tablegenerator.go

### DIFF
--- a/pkg/printers/BUILD
+++ b/pkg/printers/BUILD
@@ -1,6 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -32,4 +32,16 @@ filegroup(
         "//pkg/printers/storage:all-srcs",
     ],
     tags = ["automanaged"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["tablegenerator_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+    ],
 )

--- a/pkg/printers/tablegenerator_test.go
+++ b/pkg/printers/tablegenerator_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package printers
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type TestPrintType struct {
+	Data string
+}
+
+func (obj *TestPrintType) GetObjectKind() schema.ObjectKind { return schema.EmptyObjectKind }
+func (obj *TestPrintType) DeepCopyObject() runtime.Object {
+	if obj == nil {
+		return nil
+	}
+	clone := *obj
+	return &clone
+}
+
+func PrintCustomType(obj *TestPrintType, options GenerateOptions) ([]metav1beta1.TableRow, error) {
+	return []metav1beta1.TableRow{{Cells: []interface{}{obj.Data}}}, nil
+}
+
+func ErrorPrintHandler(obj *TestPrintType, options GenerateOptions) ([]metav1beta1.TableRow, error) {
+	return nil, fmt.Errorf("ErrorPrintHandler error")
+}
+
+func TestCustomTypePrinting(t *testing.T) {
+	columns := []metav1beta1.TableColumnDefinition{{Name: "Data"}}
+	generator := NewTableGenerator()
+	generator.TableHandler(columns, PrintCustomType)
+
+	obj := TestPrintType{"test object"}
+	table, err := generator.GenerateTable(&obj, GenerateOptions{})
+	if err != nil {
+		t.Fatalf("An error occurred generating the table for custom type: %#v", err)
+	}
+
+	expectedTable := &metav1.Table{
+		ColumnDefinitions: []metav1.TableColumnDefinition{{Name: "Data"}},
+		Rows:              []metav1.TableRow{{Cells: []interface{}{"test object"}}},
+	}
+	if !reflect.DeepEqual(expectedTable, table) {
+		t.Errorf("Error generating table from custom type. Expected (%#v), got (%#v)", expectedTable, table)
+	}
+}
+
+func TestPrintHandlerError(t *testing.T) {
+	columns := []metav1beta1.TableColumnDefinition{{Name: "Data"}}
+	generator := NewTableGenerator()
+	generator.TableHandler(columns, ErrorPrintHandler)
+	obj := TestPrintType{"test object"}
+	_, err := generator.GenerateTable(&obj, GenerateOptions{})
+	if err == nil || err.Error() != "ErrorPrintHandler error" {
+		t.Errorf("Did not get the expected error: %#v", err)
+	}
+}


### PR DESCRIPTION
* Initial unit tests for `tablegenerator.go`
* Tests moved from `pkg/printers/internalversion`
* More tests will be added in future PR's

/kind cleanup
/sig cli
/area kubectl
/priority important-soon

```release-note
NONE
```