### PR TITLE
[WIP] (Refactor) Separate staging/publish and unstaging/unpublish logics for block

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -108,19 +108,18 @@ func (kl *Kubelet) makeBlockVolumes(pod *v1.Pod, container *v1.Container, podVol
 			klog.Errorf("Block volume cannot be satisfied for container %q, because the volume is missing or the volume mapper is nil: %+v", container.Name, device)
 			return nil, fmt.Errorf("cannot find volume %q to pass into container %q", device.Name, container.Name)
 		}
-		// Get a symbolic link associated to a block device under pod device path
 		dirPath, volName := vol.BlockVolumeMapper.GetPodDeviceMapPath()
-		symlinkPath := path.Join(dirPath, volName)
-		if islinkExist, checkErr := blkutil.IsSymlinkExist(symlinkPath); checkErr != nil {
+		volPath := path.Join(dirPath, volName)
+		if isFileExist, checkErr := blkutil.IsFileExist(volPath); checkErr != nil {
 			return nil, checkErr
-		} else if islinkExist {
+		} else if isFileExist {
 			// Check readOnly in PVCVolumeSource and set read only permission if it's true.
 			permission := "mrw"
 			if vol.ReadOnly {
 				permission = "r"
 			}
-			klog.V(4).Infof("Device will be attached to container %q. Path on host: %v", container.Name, symlinkPath)
-			devices = append(devices, kubecontainer.DeviceInfo{PathOnHost: symlinkPath, PathInContainer: device.DevicePath, Permissions: permission})
+			klog.V(4).Infof("Device will be attached to container %q. Path on host: %v", container.Name, volPath)
+			devices = append(devices, kubecontainer.DeviceInfo{PathOnHost: volPath, PathInContainer: device.DevicePath, Permissions: permission})
 		}
 	}
 

--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -555,10 +555,14 @@ func (f *stubBlockVolume) SetUpDevice() (string, error) {
 	return "", nil
 }
 
-func (f stubBlockVolume) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
+func (f stubBlockVolume) MapPodDevice() error {
 	return nil
 }
 
 func (f *stubBlockVolume) TearDownDevice(mapPath string, devicePath string) error {
+	return nil
+}
+
+func (f *stubBlockVolume) UnmapPodDevice() error {
 	return nil
 }

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -527,7 +527,7 @@ func Test_Run_Positive_VolumeAttachAndMap(t *testing.T) {
 		1 /* expectedAttachCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))
@@ -631,7 +631,7 @@ func Test_Run_Positive_BlockVolumeMapControllerAttachEnabled(t *testing.T) {
 	assert.NoError(t, volumetesting.VerifyZeroAttachCalls(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))
@@ -731,7 +731,7 @@ func Test_Run_Positive_BlockVolumeAttachMapUnmapDetach(t *testing.T) {
 		1 /* expectedAttachCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))
@@ -847,7 +847,7 @@ func Test_Run_Positive_VolumeUnmapControllerAttachEnabled(t *testing.T) {
 	assert.NoError(t, volumetesting.VerifyZeroAttachCalls(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))

--- a/pkg/volume/awsebs/aws_ebs_block.go
+++ b/pkg/volume/awsebs/aws_ebs_block.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
-	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
 	"k8s.io/legacy-cloud-providers/aws"
 	utilstrings "k8s.io/utils/strings"
@@ -126,10 +125,6 @@ func (plugin *awsElasticBlockStorePlugin) newUnmapperInternal(volName string, po
 		}}, nil
 }
 
-func (c *awsElasticBlockStoreUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type awsElasticBlockStoreUnmapper struct {
 	*awsElasticBlockStore
 }
@@ -142,14 +137,6 @@ type awsElasticBlockStoreMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &awsElasticBlockStoreMapper{}
-
-func (b *awsElasticBlockStoreMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *awsElasticBlockStoreMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return util.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/volumeID

--- a/pkg/volume/azure_dd/azure_dd_block.go
+++ b/pkg/volume/azure_dd/azure_dd_block.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
-	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
 	utilstrings "k8s.io/utils/strings"
 )
@@ -119,10 +118,6 @@ func (plugin *azureDataDiskPlugin) newUnmapperInternal(volName string, podUID ty
 	return &azureDataDiskUnmapper{dataDisk: disk}, nil
 }
 
-func (c *azureDataDiskUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type azureDataDiskUnmapper struct {
 	*dataDisk
 }
@@ -135,14 +130,6 @@ type azureDataDiskMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &azureDataDiskMapper{}
-
-func (b *azureDataDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *azureDataDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return util.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/volumeID

--- a/pkg/volume/cinder/cinder_block.go
+++ b/pkg/volume/cinder/cinder_block.go
@@ -28,7 +28,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
-	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
 	utilstrings "k8s.io/utils/strings"
 )
@@ -129,10 +128,6 @@ func (plugin *cinderPlugin) newUnmapperInternal(volName string, podUID types.UID
 		}}, nil
 }
 
-func (c *cinderPluginUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type cinderPluginUnmapper struct {
 	*cinderVolume
 }
@@ -145,14 +140,6 @@ type cinderVolumeMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &cinderVolumeMapper{}
-
-func (b *cinderVolumeMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *cinderVolumeMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return util.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/volumeID

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/volume"
-	ioutil "k8s.io/kubernetes/pkg/volume/util"
 	utilstrings "k8s.io/utils/strings"
 )
 
@@ -49,6 +48,8 @@ type csiBlockMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &csiBlockMapper{}
+var _ volume.BlockVolumeStager = &csiBlockMapper{}
+var _ volume.BlockVolumePublisher = &csiBlockMapper{}
 
 // GetGlobalMapPath returns a global map path (on the node) to a device file which will be symlinked to
 // Example: plugins/kubernetes.io/csi/volumeDevices/{pvname}/dev
@@ -204,26 +205,26 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 }
 
 // SetUpDevice ensures the device is attached returns path where the device is located.
-func (m *csiBlockMapper) SetUpDevice() (string, error) {
+func (m *csiBlockMapper) SetUpDevice() error {
 	if !m.plugin.blockEnabled {
-		return "", errors.New("CSIBlockVolume feature not enabled")
+		return errors.New("CSIBlockVolume feature not enabled")
 	}
 	klog.V(4).Infof(log("blockMapper.SetUpDevice called"))
 
 	// Get csiSource from spec
 	if m.spec == nil {
-		return "", errors.New(log("blockMapper.SetUpDevice spec is nil"))
+		return errors.New(log("blockMapper.SetUpDevice spec is nil"))
 	}
 
 	csiSource, err := getCSISourceFromSpec(m.spec)
 	if err != nil {
-		return "", errors.New(log("blockMapper.SetUpDevice failed to get CSI persistent source: %v", err))
+		return errors.New(log("blockMapper.SetUpDevice failed to get CSI persistent source: %v", err))
 	}
 
 	driverName := csiSource.Driver
 	skip, err := m.plugin.skipAttach(driverName)
 	if err != nil {
-		return "", errors.New(log("blockMapper.SetupDevice failed to check CSIDriver for %s: %v", driverName, err))
+		return errors.New(log("blockMapper.SetupDevice failed to check CSIDriver for %s: %v", driverName, err))
 	}
 
 	var attachment *storage.VolumeAttachment
@@ -233,7 +234,7 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 		attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
 		attachment, err = m.k8s.StorageV1().VolumeAttachments().Get(attachID, meta.GetOptions{})
 		if err != nil {
-			return "", errors.New(log("blockMapper.SetupDevice failed to get volume attachment [id=%v]: %v", attachID, err))
+			return errors.New(log("blockMapper.SetupDevice failed to get volume attachment [id=%v]: %v", attachID, err))
 		}
 	}
 
@@ -248,29 +249,31 @@ func (m *csiBlockMapper) SetUpDevice() (string, error) {
 
 	csiClient, err := m.csiClientGetter.Get()
 	if err != nil {
-		return "", errors.New(log("blockMapper.SetUpDevice failed to get CSI client: %v", err))
+		return errors.New(log("blockMapper.SetUpDevice failed to get CSI client: %v", err))
 	}
 
 	// Call NodeStageVolume
 	stagingPath, err := m.stageVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	// Call NodePublishVolume
-	publishPath, err := m.publishVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment, stagingPath)
+	_, err = m.publishVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment, stagingPath)
 	if err != nil {
-		return "", err
+		return err
 	}
 
-	return publishPath, nil
+	return nil
 }
 
-func (m *csiBlockMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return ioutil.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
+func (m *csiBlockMapper) MapPodDevice() (string, error) {
+	return m.getPublishPath(), nil
 }
 
 var _ volume.BlockVolumeUnmapper = &csiBlockMapper{}
+var _ volume.BlockVolumeUnstager = &csiBlockMapper{}
+var _ volume.BlockVolumeUnpublisher = &csiBlockMapper{}
 
 // unpublishVolumeForBlock unpublishes a block volume from publishPath
 func (m *csiBlockMapper) unpublishVolumeForBlock(ctx context.Context, csi csiClient, publishPath string) error {
@@ -361,5 +364,10 @@ func (m *csiBlockMapper) TearDownDevice(globalMapPath, devicePath string) error 
 		}
 	}
 
+	return nil
+}
+
+// UnmapPodDevice unmaps the block device path.
+func (m *csiBlockMapper) UnmapPodDevice() error {
 	return nil
 }

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -58,9 +58,8 @@ After successful MountVolume for block volume, directory structure will be like 
   /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/{specName}/dev/ ... Global map path
   /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/{specName}/dev/{podUID} ... MapFile(Bind mount to publish Path)
   /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/{specName} ... Staging path
-  /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/{specName}/{podUID} ... Publish path
   /var/lib/kubelet/pods/{podUID}/volumeDevices/kubernetes.io~csi/ ... Pod device map path
-  /var/lib/kubelet/pods/{podUID}/volumeDevices/kubernetes.io~csi/{specName} ... MapFile(Symlink to publish path)
+  /var/lib/kubelet/pods/{podUID}/volumeDevices/kubernetes.io~csi/{specName} ... MapFile == Publish path
 */
 
 package csi
@@ -115,9 +114,12 @@ func (m *csiBlockMapper) getStagingPath() string {
 }
 
 // getPublishPath returns a publish path for a file (on the node) that should be used on NodePublishVolume/NodeUnpublishVolume
+// The path will be {path}/{fileName} that is returned by GetPodDeviceMapPath, because CSI plugin will publish the volume to
+// pod device map path, directly.
 // Example: plugins/kubernetes.io/csi/volumeDevices/publish/{specName}/{podUID}
 func (m *csiBlockMapper) getPublishPath() string {
-	return filepath.Join(m.plugin.host.GetVolumeDevicePluginDir(CSIPluginName), "publish", m.specName, string(m.podUID))
+	path, fileName := m.GetPodDeviceMapPath()
+	return filepath.Join(path, fileName)
 }
 
 // GetPodDeviceMapPath returns pod's device file which will be mapped to a volume

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -14,6 +14,55 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+/*
+This file defines block volume related methods for CSI driver.
+CSI driver is responsible for staging/publishing volumes to their staging/publish paths.
+Mapping and unmapping of a device in a publish path to its global map path and its
+pod device map path are done by operation_executor through MapBlockVolume/UnmapBlockVolume
+(MapBlockVolume and UnmapBlockVolume take care for lock, symlink, and bind mount).
+
+Summary of block volume related CSI driver's methods are as follows:
+ - GetGlobalMapPath returns a global map path,
+ - GetPodDeviceMapPath returns a pod device map path and filename,
+ - SetUpDevice calls CSI's NodeStageVolume and stage a volume to its staging path,
+ - MapPodDevice calls CSI's NodePublishVolume and publish a volume to its publish path,
+ - UnmapPodDevice calls CSI's NodeUnpublishVolume and unpublish a volume from its publish path,
+ - TearDownDevice calls CSI's NodeUnstageVolume and unstage a volume from its staging path.
+
+These methods are called by below sequences:
+ - operation_executor.MountVolume
+   - csi.GetGlobalMapPath
+   - csi.SetupDevice
+     - NodeStageVolume
+   - ASW.MarkDeviceAsMounted
+   - csi.GetPodDeviceMapPath
+   - csi.MapPodDevice
+     - NodePublishVolume
+   - util.MapBlockVolume
+   - ASW.MarkVolumeAsMounted
+
+ - operation_executor.UnmountVolume
+   - csi.GetPodDeviceMapPath
+   - util.UnmapBlockVolume
+   - csi.UnmapPodDevice
+     - NodeUnpublishVolume
+   - ASW.MarkVolumeAsUnmounted
+
+ - operation_executor.UnmountDevice
+   - csi.TearDownDevice
+     - NodeUnstageVolume
+   - ASW.MarkDeviceAsUnmounted
+
+After successful MountVolume for block volume, directory structure will be like below:
+  /dev/loopX ... Descriptor lock(Loopback device to mapFile under global map path)
+  /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/{specName}/dev/ ... Global map path
+  /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/{specName}/dev/{podUID} ... MapFile(Bind mount to publish Path)
+  /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/{specName} ... Staging path
+  /var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/{specName}/{podUID} ... Publish path
+  /var/lib/kubelet/pods/{podUID}/volumeDevices/kubernetes.io~csi/ ... Pod device map path
+  /var/lib/kubelet/pods/{podUID}/volumeDevices/kubernetes.io~csi/{specName} ... MapFile(Symlink to publish path)
+*/
+
 package csi
 
 import (
@@ -72,7 +121,7 @@ func (m *csiBlockMapper) getPublishPath() string {
 }
 
 // GetPodDeviceMapPath returns pod's device file which will be mapped to a volume
-// returns: pods/{podUid}/volumeDevices/kubernetes.io~csi, {specName}
+// returns: pods/{podUID}/volumeDevices/kubernetes.io~csi, {specName}
 func (m *csiBlockMapper) GetPodDeviceMapPath() (string, string) {
 	path := m.plugin.host.GetPodVolumeDeviceDir(m.podUID, utilstrings.EscapeQualifiedName(CSIPluginName))
 	klog.V(4).Infof(log("blockMapper.GetPodDeviceMapPath [path=%s; name=%s]", path, m.specName))
@@ -148,7 +197,6 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 	accessMode v1.PersistentVolumeAccessMode,
 	csiSource *v1.CSIPersistentVolumeSource,
 	attachment *storage.VolumeAttachment,
-	stagingPath string,
 ) (string, error) {
 	klog.V(4).Infof(log("blockMapper.publishVolumeForBlock called"))
 
@@ -184,7 +232,7 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 		ctx,
 		m.volumeID,
 		m.readOnly,
-		stagingPath,
+		m.getStagingPath(),
 		publishPath,
 		accessMode,
 		publishVolumeInfo,
@@ -250,13 +298,7 @@ func (m *csiBlockMapper) SetUpDevice() error {
 	}
 
 	// Call NodeStageVolume
-	stagingPath, err := m.stageVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment)
-	if err != nil {
-		return err
-	}
-
-	// Call NodePublishVolume
-	_, err = m.publishVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment, stagingPath)
+	_, err = m.stageVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment)
 	if err != nil {
 		return err
 	}
@@ -265,7 +307,59 @@ func (m *csiBlockMapper) SetUpDevice() error {
 }
 
 func (m *csiBlockMapper) MapPodDevice() (string, error) {
-	return m.getPublishPath(), nil
+	if !m.plugin.blockEnabled {
+		return "", errors.New("CSIBlockVolume feature not enabled")
+	}
+	klog.V(4).Infof(log("blockMapper.MapPodDevice called"))
+
+	// Get csiSource from spec
+	if m.spec == nil {
+		return "", errors.New(log("blockMapper.MapPodDevice spec is nil"))
+	}
+
+	csiSource, err := getCSISourceFromSpec(m.spec)
+	if err != nil {
+		return "", errors.New(log("blockMapper.MapPodDevice failed to get CSI persistent source: %v", err))
+	}
+
+	driverName := csiSource.Driver
+	skip, err := m.plugin.skipAttach(driverName)
+	if err != nil {
+		return "", errors.New(log("blockMapper.MapPodDevice failed to check CSIDriver for %s: %v", driverName, err))
+	}
+
+	var attachment *storage.VolumeAttachment
+	if !skip {
+		// Search for attachment by VolumeAttachment.Spec.Source.PersistentVolumeName
+		nodeName := string(m.plugin.host.GetNodeName())
+		attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
+		attachment, err = m.k8s.StorageV1().VolumeAttachments().Get(attachID, meta.GetOptions{})
+		if err != nil {
+			return "", errors.New(log("blockMapper.MapPodDevice failed to get volume attachment [id=%v]: %v", attachID, err))
+		}
+	}
+
+	//TODO (vladimirvivien) implement better AccessModes mapping between k8s and CSI
+	accessMode := v1.ReadWriteOnce
+	if m.spec.PersistentVolume.Spec.AccessModes != nil {
+		accessMode = m.spec.PersistentVolume.Spec.AccessModes[0]
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	defer cancel()
+
+	csiClient, err := m.csiClientGetter.Get()
+	if err != nil {
+		return "", errors.New(log("blockMapper.MapPodDevice failed to get CSI client: %v", err))
+	}
+
+	// Call NodePublishVolume
+	publishPath, err := m.publishVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment)
+	if err != nil {
+		return "", err
+	}
+
+	return publishPath, nil
 }
 
 var _ volume.BlockVolumeUnmapper = &csiBlockMapper{}
@@ -321,29 +415,12 @@ func (m *csiBlockMapper) TearDownDevice(globalMapPath, devicePath string) error 
 		return errors.New("CSIBlockVolume feature not enabled")
 	}
 
-	klog.V(4).Infof(log("unmapper.TearDownDevice(globalMapPath=%s; devicePath=%s)", globalMapPath, devicePath))
-
 	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
 	defer cancel()
 
 	csiClient, err := m.csiClientGetter.Get()
 	if err != nil {
 		return errors.New(log("blockMapper.TearDownDevice failed to get CSI client: %v", err))
-	}
-
-	// Call NodeUnpublishVolume
-	publishPath := m.getPublishPath()
-	if _, err := os.Stat(publishPath); err != nil {
-		if os.IsNotExist(err) {
-			klog.V(4).Infof(log("blockMapper.TearDownDevice publishPath(%s) has already been deleted, skip calling NodeUnpublishVolume", publishPath))
-		} else {
-			return err
-		}
-	} else {
-		err := m.unpublishVolumeForBlock(ctx, csiClient, publishPath)
-		if err != nil {
-			return err
-		}
 	}
 
 	// Call NodeUnstageVolume
@@ -366,5 +443,32 @@ func (m *csiBlockMapper) TearDownDevice(globalMapPath, devicePath string) error 
 
 // UnmapPodDevice unmaps the block device path.
 func (m *csiBlockMapper) UnmapPodDevice() error {
+	if !m.plugin.blockEnabled {
+		return errors.New("CSIBlockVolume feature not enabled")
+	}
+	publishPath := m.getPublishPath()
+
+	csiClient, err := m.csiClientGetter.Get()
+	if err != nil {
+		return errors.New(log("blockMapper.UnmapPodDevice failed to get CSI client: %v", err))
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
+	defer cancel()
+
+	// Call NodeUnpublishVolume
+	if _, err := os.Stat(publishPath); err != nil {
+		if os.IsNotExist(err) {
+			klog.V(4).Infof(log("blockMapper.UnmapPodDevice publishPath(%s) has already been deleted, skip calling NodeUnpublishVolume", publishPath))
+		} else {
+			return err
+		}
+	} else {
+		err := m.unpublishVolumeForBlock(ctx, csiClient, publishPath)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -141,12 +141,12 @@ func TestBlockMapperGetPublishPath(t *testing.T) {
 		{
 			name:           "simple specName",
 			specVolumeName: "spec-0",
-			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s", "spec-0")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s/%s", "spec-0", testPodUID)),
 		},
 		{
 			name:           "specName with dots",
 			specVolumeName: "test.spec.1",
-			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s", "test.spec.1")),
+			path:           filepath.Join(tmpDir, fmt.Sprintf("plugins/kubernetes.io/csi/volumeDevices/publish/%s/%s", "test.spec.1", testPodUID)),
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -49,6 +49,40 @@ func prepareBlockMapperTest(plug *csiPlugin, specVolumeName string, t *testing.T
 	return csiMapper, spec, pv, nil
 }
 
+func prepareBlockUnmapperTest(plug *csiPlugin, specVolumeName string, t *testing.T) (*csiBlockMapper, *volume.Spec, *api.PersistentVolume, error) {
+	registerFakePlugin(testDriver, "endpoint", []string{"1.0.0"}, t)
+	pv := makeTestPV(specVolumeName, 10, testDriver, testVol)
+	spec := volume.NewSpecFromPersistentVolume(pv, pv.Spec.PersistentVolumeSource.CSI.ReadOnly)
+
+	// save volume data
+	dir := getVolumeDeviceDataDir(pv.ObjectMeta.Name, plug.host)
+	if err := os.MkdirAll(dir, 0755); err != nil && !os.IsNotExist(err) {
+		t.Errorf("failed to create dir [%s]: %v", dir, err)
+	}
+
+	if err := saveVolumeData(
+		dir,
+		volDataFileName,
+		map[string]string{
+			volDataKey.specVolID:  pv.ObjectMeta.Name,
+			volDataKey.driverName: testDriver,
+			volDataKey.volHandle:  testVol,
+		},
+	); err != nil {
+		t.Fatalf("failed to save volume data: %v", err)
+	}
+
+	unmapper, err := plug.NewBlockVolumeUnmapper(pv.ObjectMeta.Name, testPodUID)
+	if err != nil {
+		t.Fatalf("failed to make a new Unmapper: %v", err)
+	}
+
+	csiUnmapper := unmapper.(*csiBlockMapper)
+	csiUnmapper.csiClient = setupClient(t, true)
+
+	return csiUnmapper, spec, pv, nil
+}
+
 func TestBlockMapperGetGlobalMapPath(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIBlockVolume, true)()
 

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -239,15 +239,9 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 	}
 	t.Log("created attachement ", attachID)
 
-	devicePath, err := csiMapper.SetUpDevice()
+	err = csiMapper.SetUpDevice()
 	if err != nil {
 		t.Fatalf("mapper failed to SetupDevice: %v", err)
-	}
-
-	// Check if SetUpDevice returns the right path
-	publishPath := csiMapper.getPublishPath()
-	if devicePath != publishPath {
-		t.Fatalf("mapper.SetupDevice returned unexpected path %s instead of %v", devicePath, publishPath)
 	}
 
 	// Check if NodeStageVolume staged to the right path
@@ -267,12 +261,14 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 	if !ok {
 		t.Error("csi server may not have received NodePublishVolume call")
 	}
+
+	publishPath := csiMapper.getPublishPath()
 	if pvol.Path != publishPath {
 		t.Errorf("csi server expected path %s, got %s", publishPath, pvol.Path)
 	}
 }
 
-func TestBlockMapperMapDevice(t *testing.T) {
+func TestBlockMapperMapPodDevice(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIBlockVolume, true)()
 
 	plug, tmpDir := newTestPlugin(t, nil)
@@ -306,56 +302,18 @@ func TestBlockMapperMapDevice(t *testing.T) {
 	}
 	t.Log("created attachement ", attachID)
 
-	devicePath, err := csiMapper.SetUpDevice()
-	if err != nil {
-		t.Fatalf("mapper failed to SetupDevice: %v", err)
-	}
-	globalMapPath, err := csiMapper.GetGlobalMapPath(csiMapper.spec)
-	if err != nil {
-		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
-	}
-
-	// Actual SetupDevice should create a symlink to or a bind mout of device in devicePath.
-	// Create dummy file there before calling MapDevice to test it properly.
-	fd, err := os.Create(devicePath)
-	if err != nil {
-		t.Fatalf("mapper failed to create dummy file in devicePath: %v", err)
-	}
-	if err := fd.Close(); err != nil {
-		t.Fatalf("mapper failed to close dummy file in devicePath: %v", err)
-	}
-
 	// Map device to global and pod device map path
-	volumeMapPath, volName := csiMapper.GetPodDeviceMapPath()
-	err = csiMapper.MapDevice(devicePath, globalMapPath, volumeMapPath, volName, csiMapper.podUID)
+	path, err := csiMapper.MapPodDevice()
 	if err != nil {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
-
-	// Check if symlink {globalMapPath}/{podUID} exists
-	globalMapFilePath := filepath.Join(globalMapPath, string(csiMapper.podUID))
-	if _, err := os.Stat(globalMapFilePath); err != nil {
-		if os.IsNotExist(err) {
-			t.Errorf("mapper.MapDevice failed, symlink in globalMapPath not created: %v", err)
-			t.Errorf("mapper.MapDevice devicePath:%v, globalMapPath: %v, globalMapFilePath: %v",
-				devicePath, globalMapPath, globalMapFilePath)
-		} else {
-			t.Errorf("mapper.MapDevice failed: %v", err)
-		}
-	}
-
-	// Check if symlink {volumeMapPath}/{volName} exists
-	volumeMapFilePath := filepath.Join(volumeMapPath, volName)
-	if _, err := os.Stat(volumeMapFilePath); err != nil {
-		if os.IsNotExist(err) {
-			t.Errorf("mapper.MapDevice failed, symlink in volumeMapPath not created: %v", err)
-		} else {
-			t.Errorf("mapper.MapDevice failed: %v", err)
-		}
+	publishPath := csiMapper.getPublishPath()
+	if path != publishPath {
+		t.Errorf("path %s and %s doesn't match", path, publishPath)
 	}
 }
 
-func TestBlockMapperMapDeviceNotSupportAttach(t *testing.T) {
+func TestBlockMapperMapPodDeviceNotSupportAttach(t *testing.T) {
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIBlockVolume, true)()
 	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.CSIDriverRegistry, true)()
 
@@ -393,52 +351,15 @@ func TestBlockMapperMapDeviceNotSupportAttach(t *testing.T) {
 		t.Fatalf("Failed to make a new Mapper: %v", err)
 	}
 	csiMapper.csiClient = setupClient(t, true)
-	devicePath, err := csiMapper.SetUpDevice()
-	if err != nil {
-		t.Fatalf("mapper failed to SetupDevice: %v", err)
-	}
-	globalMapPath, err := csiMapper.GetGlobalMapPath(csiMapper.spec)
-	if err != nil {
-		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
-	}
-
-	// Actual SetupDevice should create a symlink to or a bind mout of device in devicePath.
-	// Create dummy file there before calling MapDevice to test it properly.
-	fd, err := os.Create(devicePath)
-	if err != nil {
-		t.Fatalf("mapper failed to create dummy file in devicePath: %v", err)
-	}
-	if err := fd.Close(); err != nil {
-		t.Fatalf("mapper failed to close dummy file in devicePath: %v", err)
-	}
 
 	// Map device to global and pod device map path
-	volumeMapPath, volName := csiMapper.GetPodDeviceMapPath()
-	err = csiMapper.MapDevice(devicePath, globalMapPath, volumeMapPath, volName, csiMapper.podUID)
+	path, err := csiMapper.MapPodDevice()
 	if err != nil {
 		t.Fatalf("mapper failed to GetGlobalMapPath: %v", err)
 	}
-
-	// Check if symlink {globalMapPath}/{podUID} exists
-	globalMapFilePath := filepath.Join(globalMapPath, string(csiMapper.podUID))
-	if _, err := os.Stat(globalMapFilePath); err != nil {
-		if os.IsNotExist(err) {
-			t.Errorf("mapper.MapDevice failed, symlink in globalMapPath not created: %v", err)
-			t.Errorf("mapper.MapDevice devicePath:%v, globalMapPath: %v, globalMapFilePath: %v",
-				devicePath, globalMapPath, globalMapFilePath)
-		} else {
-			t.Errorf("mapper.MapDevice failed: %v", err)
-		}
-	}
-
-	// Check if symlink {volumeMapPath}/{volName} exists
-	volumeMapFilePath := filepath.Join(volumeMapPath, volName)
-	if _, err := os.Stat(volumeMapFilePath); err != nil {
-		if os.IsNotExist(err) {
-			t.Errorf("mapper.MapDevice failed, symlink in volumeMapPath not created: %v", err)
-		} else {
-			t.Errorf("mapper.MapDevice failed: %v", err)
-		}
+	publishPath := csiMapper.getPublishPath()
+	if path != publishPath {
+		t.Errorf("path %s and %s doesn't match", path, publishPath)
 	}
 }
 

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -120,11 +120,20 @@ func (f *NodeClient) GetNodePublishedVolumes() map[string]CSIVolume {
 	return f.nodePublishedVolumes
 }
 
+// AddNodePublishedVolume adds specified volume to nodePublishedVolumes
+func (f *NodeClient) AddNodePublishedVolume(volID, deviceMountPath string, volumeContext map[string]string) {
+	f.nodePublishedVolumes[volID] = CSIVolume{
+		Path:          deviceMountPath,
+		VolumeContext: volumeContext,
+	}
+}
+
 // GetNodeStagedVolumes returns node staged volumes
 func (f *NodeClient) GetNodeStagedVolumes() map[string]CSIVolume {
 	return f.nodeStagedVolumes
 }
 
+// AddNodeStagedVolume adds specified volume to nodeStagedVolumes
 func (f *NodeClient) AddNodeStagedVolume(volID, deviceMountPath string, volumeContext map[string]string) {
 	f.nodeStagedVolumes[volID] = CSIVolume{
 		Path:          deviceMountPath,

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -412,20 +412,13 @@ type fcDiskMapper struct {
 
 var _ volume.BlockVolumeMapper = &fcDiskMapper{}
 
-func (b *fcDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *fcDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return util.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
-}
-
 type fcDiskUnmapper struct {
 	*fcDisk
 	deviceUtil util.DeviceUtil
 }
 
 var _ volume.BlockVolumeUnmapper = &fcDiskUnmapper{}
+var _ volume.BlockVolumeUnstager = &fcDiskUnmapper{}
 
 func (c *fcDiskUnmapper) TearDownDevice(mapPath, devicePath string) error {
 	err := c.manager.DetachBlockFCDisk(*c, mapPath, devicePath)

--- a/pkg/volume/gcepd/gce_pd_block.go
+++ b/pkg/volume/gcepd/gce_pd_block.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
-	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
 	utilstrings "k8s.io/utils/strings"
 )
@@ -136,10 +135,6 @@ func (plugin *gcePersistentDiskPlugin) newUnmapperInternal(volName string, podUI
 		}}, nil
 }
 
-func (c *gcePersistentDiskUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type gcePersistentDiskUnmapper struct {
 	*gcePersistentDisk
 }
@@ -152,14 +147,6 @@ type gcePersistentDiskMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &gcePersistentDiskMapper{}
-
-func (b *gcePersistentDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *gcePersistentDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return util.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/pdName

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -382,14 +382,6 @@ type iscsiDiskMapper struct {
 
 var _ volume.BlockVolumeMapper = &iscsiDiskMapper{}
 
-func (b *iscsiDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *iscsiDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return ioutil.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
-}
-
 type iscsiDiskUnmapper struct {
 	*iscsiDisk
 	exec       mount.Exec
@@ -397,6 +389,7 @@ type iscsiDiskUnmapper struct {
 }
 
 var _ volume.BlockVolumeUnmapper = &iscsiDiskUnmapper{}
+var _ volume.BlockVolumeUnstager = &iscsiDiskUnmapper{}
 
 // Even though iSCSI plugin has attacher/detacher implementation, iSCSI plugin
 // needs volume detach operation during TearDownDevice(). This method is only

--- a/pkg/volume/local/BUILD
+++ b/pkg/volume/local/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//pkg/volume/util/hostutil:go_default_library",
+        "//pkg/volume/util/volumepathhandler:go_default_library",
         "//pkg/volume/validation:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -612,16 +612,13 @@ type localVolumeMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &localVolumeMapper{}
+var _ volume.BlockVolumePublisher = &localVolumeMapper{}
 
 // SetUpDevice provides physical device path for the local PV.
-func (m *localVolumeMapper) SetUpDevice() (string, error) {
+func (m *localVolumeMapper) MapPodDevice() (string, error) {
 	globalPath := util.MakeAbsolutePath(runtime.GOOS, m.globalPath)
-	klog.V(4).Infof("SetupDevice returning path %s", globalPath)
+	klog.V(4).Infof("MapPodDevice returning path %s", globalPath)
 	return globalPath, nil
-}
-
-func (m *localVolumeMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return util.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
 }
 
 // localVolumeUnmapper implements the BlockVolumeUnmapper interface for local volumes.
@@ -630,12 +627,6 @@ type localVolumeUnmapper struct {
 }
 
 var _ volume.BlockVolumeUnmapper = &localVolumeUnmapper{}
-
-// TearDownDevice will undo SetUpDevice procedure. In local PV, all of this already handled by operation_generator.
-func (u *localVolumeUnmapper) TearDownDevice(mapPath, _ string) error {
-	klog.V(4).Infof("local: TearDownDevice completed for: %s", mapPath)
-	return nil
-}
 
 // GetGlobalMapPath returns global map path and error.
 // path: plugins/kubernetes.io/kubernetes.io/local-volume/volumeDevices/{volumeName}

--- a/pkg/volume/local/local_test.go
+++ b/pkg/volume/local/local_test.go
@@ -372,9 +372,13 @@ func TestMapUnmap(t *testing.T) {
 	if volName != testPVName {
 		t.Errorf("Got unexpected volNamne: %s, expected %s", volName, testPVName)
 	}
-	devPath, err := mapper.SetUpDevice()
-	if err != nil {
-		t.Errorf("Failed to SetUpDevice, err: %v", err)
+	var devPath string
+
+	if customMapper, ok := mapper.(volume.BlockVolumePublisher); ok {
+		devPath, err = customMapper.MapPodDevice()
+		if err != nil {
+			t.Errorf("Failed to MapPodDevice, err: %v", err)
+		}
 	}
 
 	if _, err := os.Stat(devPath); err != nil {
@@ -391,10 +395,6 @@ func TestMapUnmap(t *testing.T) {
 	}
 	if unmapper == nil {
 		t.Fatalf("Got a nil Unmapper")
-	}
-
-	if err := unmapper.TearDownDevice(globalPath, devPath); err != nil {
-		t.Errorf("TearDownDevice failed, err: %v", err)
 	}
 }
 

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -897,6 +897,7 @@ type rbdDiskMapper struct {
 }
 
 var _ volume.BlockVolumeUnmapper = &rbdDiskUnmapper{}
+var _ volume.BlockVolumeUnstager = &rbdDiskUnmapper{}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/{rbd pool}-image-{rbd image-name}/{podUid}
@@ -909,14 +910,6 @@ func (rbd *rbd) GetGlobalMapPath(spec *volume.Spec) (string, error) {
 // volumeName: pv0001
 func (rbd *rbd) GetPodDeviceMapPath() (string, string) {
 	return rbd.rbdPodDeviceMapPath()
-}
-
-func (rbd *rbdDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (rbd *rbdDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return volutil.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
 }
 
 func (rbd *rbd) rbdGlobalMapPath(spec *volume.Spec) (string, error) {

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -1119,6 +1119,11 @@ func (fv *FakeVolumePathHandler) IsDeviceBindMountExist(mapPath string) (bool, e
 	return true, nil
 }
 
+func (fv *FakeVolumePathHandler) IsFileExist(mapPath string) (bool, error) {
+	// nil is success, else error
+	return true, nil
+}
+
 func (fv *FakeVolumePathHandler) GetDeviceBindMountRefs(devPath string, mapPath string) ([]string, error) {
 	// nil is success, else error
 	return []string{}, nil

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -744,7 +744,8 @@ type FakeVolume struct {
 	GetDeviceMountPathCallCount int
 	SetUpDeviceCallCount        int
 	TearDownDeviceCallCount     int
-	MapDeviceCallCount          int
+	MapPodDeviceCallCount       int
+	UnmapPodDeviceCallCount     int
 	GlobalMapPathCallCount      int
 	PodDeviceMapPathCallCount   int
 }
@@ -820,11 +821,11 @@ func (fv *FakeVolume) TearDownAt(dir string) error {
 }
 
 // Block volume support
-func (fv *FakeVolume) SetUpDevice() (string, error) {
+func (fv *FakeVolume) SetUpDevice() error {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.SetUpDeviceCallCount++
-	return "", nil
+	return nil
 }
 
 // Block volume support
@@ -890,18 +891,33 @@ func (fv *FakeVolume) GetTearDownDeviceCallCount() int {
 }
 
 // Block volume support
-func (fv *FakeVolume) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, pod types.UID) error {
+func (fv *FakeVolume) UnmapPodDevice() error {
 	fv.Lock()
 	defer fv.Unlock()
-	fv.MapDeviceCallCount++
+	fv.UnmapPodDeviceCallCount++
 	return nil
 }
 
 // Block volume support
-func (fv *FakeVolume) GetMapDeviceCallCount() int {
+func (fv *FakeVolume) GetUnmapPodDeviceCallCount() int {
 	fv.RLock()
 	defer fv.RUnlock()
-	return fv.MapDeviceCallCount
+	return fv.UnmapPodDeviceCallCount
+}
+
+// Block volume support
+func (fv *FakeVolume) MapPodDevice() (string, error) {
+	fv.Lock()
+	defer fv.Unlock()
+	fv.MapPodDeviceCallCount++
+	return "", nil
+}
+
+// Block volume support
+func (fv *FakeVolume) GetMapPodDeviceCallCount() int {
+	fv.RLock()
+	defer fv.RUnlock()
+	return fv.MapPodDeviceCallCount
 }
 
 func (fv *FakeVolume) Attach(spec *Spec, nodeName types.NodeName) (string, error) {
@@ -1078,12 +1094,12 @@ type FakeVolumePathHandler struct {
 	sync.RWMutex
 }
 
-func (fv *FakeVolumePathHandler) MapDevice(devicePath string, mapDir string, linkName string) error {
+func (fv *FakeVolumePathHandler) MapDevice(devicePath string, mapDir string, linkName string, bindMount bool) error {
 	// nil is success, else error
 	return nil
 }
 
-func (fv *FakeVolumePathHandler) UnmapDevice(mapDir string, linkName string) error {
+func (fv *FakeVolumePathHandler) UnmapDevice(mapDir string, linkName string, bindMount bool) error {
 	// nil is success, else error
 	return nil
 }
@@ -1098,7 +1114,12 @@ func (fv *FakeVolumePathHandler) IsSymlinkExist(mapPath string) (bool, error) {
 	return true, nil
 }
 
-func (fv *FakeVolumePathHandler) GetDeviceSymlinkRefs(devPath string, mapPath string) ([]string, error) {
+func (fv *FakeVolumePathHandler) IsDeviceBindMountExist(mapPath string) (bool, error) {
+	// nil is success, else error
+	return true, nil
+}
+
+func (fv *FakeVolumePathHandler) GetDeviceBindMountRefs(devPath string, mapPath string) ([]string, error) {
 	// nil is success, else error
 	return []string{}, nil
 }
@@ -1113,14 +1134,14 @@ func (fv *FakeVolumePathHandler) AttachFileDevice(path string) (string, error) {
 	return "", nil
 }
 
+func (fv *FakeVolumePathHandler) DetachFileDevice(path string) error {
+	// nil is success, else error
+	return nil
+}
+
 func (fv *FakeVolumePathHandler) GetLoopDevice(path string) (string, error) {
 	// nil is success, else error
 	return "/dev/loop1", nil
-}
-
-func (fv *FakeVolumePathHandler) RemoveLoopDevice(device string) error {
-	// nil is success, else error
-	return nil
 }
 
 // FindEmptyDirectoryUsageOnTmpfs finds the expected usage of an empty directory existing on
@@ -1428,22 +1449,22 @@ func VerifyGetPodDeviceMapPathCallCount(
 		expectedPodDeviceMapPathCallCount)
 }
 
-// VerifyGetMapDeviceCallCount ensures that at least one of the Mappers for this
-// plugin has the expectedMapDeviceCallCount number of calls. Otherwise it
+// VerifyGetMapPodDeviceCallCount ensures that at least one of the Mappers for this
+// plugin has the expectedMapPodDeviceCallCount number of calls. Otherwise it
 // returns an error.
-func VerifyGetMapDeviceCallCount(
-	expectedMapDeviceCallCount int,
+func VerifyGetMapPodDeviceCallCount(
+	expectedMapPodDeviceCallCount int,
 	fakeVolumePlugin *FakeVolumePlugin) error {
 	for _, mapper := range fakeVolumePlugin.GetBlockVolumeMapper() {
-		actualCallCount := mapper.GetMapDeviceCallCount()
-		if actualCallCount >= expectedMapDeviceCallCount {
+		actualCallCount := mapper.GetMapPodDeviceCallCount()
+		if actualCallCount >= expectedMapPodDeviceCallCount {
 			return nil
 		}
 	}
 
 	return fmt.Errorf(
-		"No Mapper have expected MapdDeviceCallCount. Expected: <%v>.",
-		expectedMapDeviceCallCount)
+		"No Mapper have expected MapPodDeviceCallCount. Expected: <%v>.",
+		expectedMapPodDeviceCallCount)
 }
 
 // GetTestVolumePluginMgr creates, initializes, and returns a test volume plugin

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -952,12 +952,12 @@ func (oe *operationExecutor) CheckVolumeExistenceOperation(
 	// Block Volume case
 	// Check mount path directory if volume still exists, then return true if volume
 	// is there. Either plugin is attachable or non-attachable, the plugin should
-	// have symbolic link associated to raw block device under pod device map
+	// have file associated to raw block device under pod device map
 	// if volume exists.
 	blkutil := volumepathhandler.NewBlockVolumePathHandler()
-	var islinkExist bool
+	var isFileExist bool
 	var checkErr error
-	if islinkExist, checkErr = blkutil.IsSymlinkExist(mountPath); checkErr != nil {
+	if isFileExist, checkErr = blkutil.IsFileExist(mountPath); checkErr != nil {
 		return false, fmt.Errorf("Could not check whether the block volume %q (spec.Name: %q) pod %q (UID: %q) is mapped to: %v",
 			uniqueVolumeName,
 			volumeName,
@@ -965,5 +965,5 @@ func (oe *operationExecutor) CheckVolumeExistenceOperation(
 			podUID,
 			checkErr)
 	}
-	return islinkExist, nil
+	return isFileExist, nil
 }

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -501,30 +501,74 @@ func MakeAbsolutePath(goos, path string) string {
 	return "c:\\" + path
 }
 
-// MapBlockVolume is a utility function to provide a common way of mounting
+// MapBlockVolume is a utility function to provide a common way of mapping
 // block device path for a specified volume and pod.  This function should be
 // called by volume plugins that implements volume.BlockVolumeMapper.Map() method.
 func MapBlockVolume(
+	blkUtil volumepathhandler.BlockVolumePathHandler,
 	devicePath,
 	globalMapPath,
 	podVolumeMapPath,
 	volumeMapName string,
 	podUID utypes.UID,
 ) error {
-	blkUtil := volumepathhandler.NewBlockVolumePathHandler()
-
-	// map devicePath to global node path
-	mapErr := blkUtil.MapDevice(devicePath, globalMapPath, string(podUID))
+	// map devicePath to global node path as bind mount
+	mapErr := blkUtil.MapDevice(devicePath, globalMapPath, string(podUID), true /* bindMount */)
 	if mapErr != nil {
-		return mapErr
+		return fmt.Errorf("blkUtil.MapDevice failed. devicePath: %s, globalMapPath:%s, podUID: %s, bindMount: %v: %v",
+			devicePath, globalMapPath, string(podUID), true, mapErr)
 	}
 
 	// map devicePath to pod volume path
-	mapErr = blkUtil.MapDevice(devicePath, podVolumeMapPath, volumeMapName)
+	mapErr = blkUtil.MapDevice(devicePath, podVolumeMapPath, volumeMapName, false /* bindMount */)
 	if mapErr != nil {
-		return mapErr
+		return fmt.Errorf("blkUtil.MapDevice failed. devicePath: %s, podVolumeMapPath:%s, volumeMapName: %s, bindMount: %v: %v",
+			devicePath, podVolumeMapPath, volumeMapName, false, mapErr)
 	}
 
+	// Take file descriptor lock to keep a block device opened. Otherwise, there is a case
+	// that the block device is silently removed and attached another device with the same name.
+	// Container runtime can't handle this problem. To avoid unexpected condition fd lock
+	// for the block device is required.
+	_, mapErr = blkUtil.AttachFileDevice(filepath.Join(globalMapPath, string(podUID)))
+	if mapErr != nil {
+		return fmt.Errorf("blkUtil.AttachFileDevice failed. globalMapPath:%s, podUID: %s: %v",
+			globalMapPath, string(podUID), mapErr)
+	}
+
+	return nil
+}
+
+// UnmapBlockVolume is a utility function to provide a common way of unmapping
+// block device path for a specified volume and pod.  This function should be
+// called by volume plugins that implements volume.BlockVolumeMapper.Map() method.
+func UnmapBlockVolume(
+	blkUtil volumepathhandler.BlockVolumePathHandler,
+	globalUnmapPath,
+	podDeviceUnmapPath,
+	volumeMapName string,
+	podUID utypes.UID,
+) error {
+	// Release file descriptor lock.
+	err := blkUtil.DetachFileDevice(filepath.Join(globalUnmapPath, string(podUID)))
+	if err != nil {
+		return fmt.Errorf("blkUtil.DetachFileDevice failed. globalUnmapPath:%s, podUID: %s: %v",
+			globalUnmapPath, string(podUID), err)
+	}
+
+	// unmap devicePath from pod volume path
+	unmapDeviceErr := blkUtil.UnmapDevice(podDeviceUnmapPath, volumeMapName, false /* bindMount */)
+	if unmapDeviceErr != nil {
+		return fmt.Errorf("blkUtil.DetachFileDevice failed. podDeviceUnmapPath:%s, volumeMapName: %s, bindMount: %v: %v",
+			podDeviceUnmapPath, volumeMapName, false, unmapDeviceErr)
+	}
+
+	// unmap devicePath from global node path
+	unmapDeviceErr = blkUtil.UnmapDevice(globalUnmapPath, string(podUID), true /* bindMount */)
+	if unmapDeviceErr != nil {
+		return fmt.Errorf("blkUtil.DetachFileDevice failed. globalUnmapPath:%s, podUID: %s, bindMount: %v: %v",
+			globalUnmapPath, string(podUID), true, unmapDeviceErr)
+	}
 	return nil
 }
 

--- a/pkg/volume/util/volumepathhandler/BUILD
+++ b/pkg/volume/util/volumepathhandler/BUILD
@@ -10,9 +10,18 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/volume/util/volumepathhandler",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/mount:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/golang.org/x/sys/unix:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -47,6 +47,8 @@ type BlockVolumePathHandler interface {
 	IsSymlinkExist(mapPath string) (bool, error)
 	// IsDeviceBindMountExist retruns true if specified bind mount exists
 	IsDeviceBindMountExist(mapPath string) (bool, error)
+	// IsFileExist retruns true if specified file exists
+	IsFileExist(mapPath string) (bool, error)
 	// GetDeviceBindMountRefs searches bind mounts under global map path
 	GetDeviceBindMountRefs(devPath string, mapPath string) ([]string, error)
 	// FindGlobalMapPathUUIDFromPod finds {pod uuid} symbolic link under globalMapPath
@@ -275,6 +277,24 @@ func (v VolumePathHandler) IsDeviceBindMountExist(mapPath string) (bool, error) 
 	}
 	// If file exits but it's not device, return fale and no error
 	return false, nil
+}
+
+// IsFileExist returns true if specified file exists.
+// If file doesn't exist, return false with no error.
+// On other cases, return false with error from Lstat().
+func (v VolumePathHandler) IsFileExist(mapPath string) (bool, error) {
+	_, err := os.Lstat(mapPath)
+	if err != nil {
+		// If file doesn't exist, return false and no error
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		// Return error from Lstat()
+		return false, fmt.Errorf("failed to Lstat file %s: %v", mapPath, err)
+	}
+	// If file exits return true and no error
+	return true, nil
 }
 
 // GetDeviceBindMountRefs searches bind mounts under global map path

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -23,12 +23,14 @@ import (
 	"path/filepath"
 
 	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/util/mount"
 
 	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
 	losetupPath           = "losetup"
+	statPath              = "stat"
 	ErrDeviceNotFound     = "device not found"
 	ErrDeviceNotSupported = "device not supported"
 )
@@ -36,25 +38,28 @@ const (
 // BlockVolumePathHandler defines a set of operations for handling block volume-related operations
 type BlockVolumePathHandler interface {
 	// MapDevice creates a symbolic link to block device under specified map path
-	MapDevice(devicePath string, mapPath string, linkName string) error
+	MapDevice(devicePath string, mapPath string, linkName string, bindMount bool) error
 	// UnmapDevice removes a symbolic link to block device under specified map path
-	UnmapDevice(mapPath string, linkName string) error
+	UnmapDevice(mapPath string, linkName string, bindMount bool) error
 	// RemovePath removes a file or directory on specified map path
 	RemoveMapPath(mapPath string) error
 	// IsSymlinkExist retruns true if specified symbolic link exists
 	IsSymlinkExist(mapPath string) (bool, error)
-	// GetDeviceSymlinkRefs searches symbolic links under global map path
-	GetDeviceSymlinkRefs(devPath string, mapPath string) ([]string, error)
+	// IsDeviceBindMountExist retruns true if specified bind mount exists
+	IsDeviceBindMountExist(mapPath string) (bool, error)
+	// GetDeviceBindMountRefs searches bind mounts under global map path
+	GetDeviceBindMountRefs(devPath string, mapPath string) ([]string, error)
 	// FindGlobalMapPathUUIDFromPod finds {pod uuid} symbolic link under globalMapPath
 	// corresponding to map path symlink, and then return global map path with pod uuid.
 	FindGlobalMapPathUUIDFromPod(pluginDir, mapPath string, podUID types.UID) (string, error)
 	// AttachFileDevice takes a path to a regular file and makes it available as an
 	// attached block device.
 	AttachFileDevice(path string) (string, error)
+	// DetachFileDevice takes a path to the attached block device and
+	// detach it from block device.
+	DetachFileDevice(path string) error
 	// GetLoopDevice returns the full path to the loop device associated with the given path.
 	GetLoopDevice(path string) (string, error)
-	// RemoveLoopDevice removes specified loopback device
-	RemoveLoopDevice(device string) error
 }
 
 // NewBlockVolumePathHandler returns a new instance of BlockVolumeHandler.
@@ -68,7 +73,7 @@ type VolumePathHandler struct {
 }
 
 // MapDevice creates a symbolic link to block device under specified map path
-func (v VolumePathHandler) MapDevice(devicePath string, mapPath string, linkName string) error {
+func (v VolumePathHandler) MapDevice(devicePath string, mapPath string, linkName string, bindMount bool) error {
 	// Example of global map path:
 	//   globalMapPath/linkName: plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumePluginDependentPath}/{podUid}
 	//   linkName: {podUid}
@@ -77,13 +82,13 @@ func (v VolumePathHandler) MapDevice(devicePath string, mapPath string, linkName
 	//   podDeviceMapPath/linkName: pods/{podUid}/{DefaultKubeletVolumeDevicesDirName}/{escapeQualifiedPluginName}/{volumeName}
 	//   linkName: {volumeName}
 	if len(devicePath) == 0 {
-		return fmt.Errorf("Failed to map device to map path. devicePath is empty")
+		return fmt.Errorf("failed to map device to map path. devicePath is empty")
 	}
 	if len(mapPath) == 0 {
-		return fmt.Errorf("Failed to map device to map path. mapPath is empty")
+		return fmt.Errorf("failed to map device to map path. mapPath is empty")
 	}
 	if !filepath.IsAbs(mapPath) {
-		return fmt.Errorf("The map path should be absolute: map path: %s", mapPath)
+		return fmt.Errorf("the map path should be absolute: map path: %s", mapPath)
 	}
 	klog.V(5).Infof("MapDevice: devicePath %s", devicePath)
 	klog.V(5).Infof("MapDevice: mapPath %s", mapPath)
@@ -92,31 +97,119 @@ func (v VolumePathHandler) MapDevice(devicePath string, mapPath string, linkName
 	// Check and create mapPath
 	_, err := os.Stat(mapPath)
 	if err != nil && !os.IsNotExist(err) {
-		klog.Errorf("cannot validate map path: %s", mapPath)
-		return err
+		return fmt.Errorf("cannot validate map path: %s: %v", mapPath, err)
 	}
 	if err = os.MkdirAll(mapPath, 0750); err != nil {
-		return fmt.Errorf("Failed to mkdir %s, error %v", mapPath, err)
+		return fmt.Errorf("failed to mkdir %s: %v", mapPath, err)
 	}
+
+	if bindMount {
+		return mapBindMountDevice(v, devicePath, mapPath, linkName)
+	}
+	return mapSymlinkDevice(v, devicePath, mapPath, linkName)
+}
+
+func mapBindMountDevice(v VolumePathHandler, devicePath string, mapPath string, linkName string) error {
+	// Check bind mount exists
+	linkPath := filepath.Join(mapPath, string(linkName))
+
+	file, err := os.Stat(linkPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return fmt.Errorf("failed to stat file %s: %v", linkPath, err)
+		}
+
+		// Create file
+		newFile, err := os.OpenFile(linkPath, os.O_CREATE|os.O_RDWR, 0750)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %v", linkPath, err)
+		}
+		if err := newFile.Close(); err != nil {
+			return fmt.Errorf("failed to close file %s: %v", linkPath, err)
+		}
+	} else {
+		// Check if device file
+		// TODO: Need to check if this device file is actually the expected bind mount
+		if file.Mode()&os.ModeDevice == os.ModeDevice {
+			klog.Warningf("Warning: Map skipped because bind mount already exist on the path: %v", linkPath)
+			return nil
+		}
+
+		klog.Warningf("Warning: file %s is already exist but not mounted, skip creating file", linkPath)
+	}
+
+	// Bind mount file
+	mounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: mount.NewOSExec()}
+	if err := mounter.Mount(devicePath, linkPath, "" /* fsType */, []string{"bind"}); err != nil {
+		return fmt.Errorf("failed to bind mount devicePath: %s to linkPath %s: %v", devicePath, linkPath, err)
+	}
+
+	return nil
+}
+
+func mapSymlinkDevice(v VolumePathHandler, devicePath string, mapPath string, linkName string) error {
 	// Remove old symbolic link(or file) then create new one.
 	// This should be done because current symbolic link is
 	// stale across node reboot.
 	linkPath := filepath.Join(mapPath, string(linkName))
-	if err = os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
-		return err
+	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove file %s: %v", linkPath, err)
 	}
-	err = os.Symlink(devicePath, linkPath)
-	return err
+	return os.Symlink(devicePath, linkPath)
 }
 
 // UnmapDevice removes a symbolic link associated to block device under specified map path
-func (v VolumePathHandler) UnmapDevice(mapPath string, linkName string) error {
+func (v VolumePathHandler) UnmapDevice(mapPath string, linkName string, bindMount bool) error {
 	if len(mapPath) == 0 {
-		return fmt.Errorf("Failed to unmap device from map path. mapPath is empty")
+		return fmt.Errorf("failed to unmap device from map path. mapPath is empty")
 	}
 	klog.V(5).Infof("UnmapDevice: mapPath %s", mapPath)
 	klog.V(5).Infof("UnmapDevice: linkName %s", linkName)
 
+	if bindMount {
+		return unmapBindMountDevice(v, mapPath, linkName)
+	}
+	return unmapSymlinkDevice(v, mapPath, linkName)
+}
+
+func unmapBindMountDevice(v VolumePathHandler, mapPath string, linkName string) error {
+	// Check bind mount exists
+	linkPath := filepath.Join(mapPath, string(linkName))
+	if isMountExist, checkErr := v.IsDeviceBindMountExist(linkPath); checkErr != nil {
+		return checkErr
+	} else if !isMountExist {
+		klog.Warningf("Warning: Unmap skipped because bind mount does not exist on the path: %v", linkPath)
+
+		// Check if linkPath still exists
+		if _, err := os.Stat(linkPath); err != nil {
+			if !os.IsNotExist(err) {
+				return fmt.Errorf("failed to check if path %s exists: %v", linkPath, err)
+			}
+			// linkPath has already been removed
+			return nil
+		}
+		// Remove file
+		if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to remove file %s: %v", linkPath, err)
+		}
+		return nil
+	}
+
+	// Unmount file
+	mounter := &mount.SafeFormatAndMount{Interface: mount.New(""), Exec: mount.NewOSExec()}
+	if err := mounter.Unmount(linkPath); err != nil {
+		return fmt.Errorf("failed to unmount linkPath %s: %v", linkPath, err)
+	}
+
+	// Remove file
+	if err := os.Remove(linkPath); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove file %s: %v", linkPath, err)
+	}
+
+	return nil
+}
+
+func unmapSymlinkDevice(v VolumePathHandler, mapPath string, linkName string) error {
 	// Check symbolic link exists
 	linkPath := filepath.Join(mapPath, string(linkName))
 	if islinkExist, checkErr := v.IsSymlinkExist(linkPath); checkErr != nil {
@@ -125,19 +218,18 @@ func (v VolumePathHandler) UnmapDevice(mapPath string, linkName string) error {
 		klog.Warningf("Warning: Unmap skipped because symlink does not exist on the path: %v", linkPath)
 		return nil
 	}
-	err := os.Remove(linkPath)
-	return err
+	return os.Remove(linkPath)
 }
 
 // RemoveMapPath removes a file or directory on specified map path
 func (v VolumePathHandler) RemoveMapPath(mapPath string) error {
 	if len(mapPath) == 0 {
-		return fmt.Errorf("Failed to remove map path. mapPath is empty")
+		return fmt.Errorf("failed to remove map path. mapPath is empty")
 	}
 	klog.V(5).Infof("RemoveMapPath: mapPath %s", mapPath)
 	err := os.RemoveAll(mapPath)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return fmt.Errorf("failed to remove directory %s: %v", mapPath, err)
 	}
 	return nil
 }
@@ -147,86 +239,59 @@ func (v VolumePathHandler) RemoveMapPath(mapPath string) error {
 // On other cases, return false with error from Lstat().
 func (v VolumePathHandler) IsSymlinkExist(mapPath string) (bool, error) {
 	fi, err := os.Lstat(mapPath)
-	if err == nil {
-		// If file exits and it's symbolic link, return true and no error
-		if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
-			return true, nil
+	if err != nil {
+		// If file doesn't exist, return false and no error
+		if os.IsNotExist(err) {
+			return false, nil
 		}
-		// If file exits but it's not symbolic link, return fale and no error
-		return false, nil
+		// Return error from Lstat()
+		return false, fmt.Errorf("failed to Lstat file %s: %v", mapPath, err)
 	}
-	// If file doesn't exist, return false and no error
-	if os.IsNotExist(err) {
-		return false, nil
+	// If file exits and it's symbolic link, return true and no error
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		return true, nil
 	}
-	// Return error from Lstat()
-	return false, err
+	// If file exits but it's not symbolic link, return fale and no error
+	return false, nil
 }
 
-// GetDeviceSymlinkRefs searches symbolic links under global map path
-func (v VolumePathHandler) GetDeviceSymlinkRefs(devPath string, mapPath string) ([]string, error) {
+// IsDeviceBindMountExist returns true if specified file exists and the type is device.
+// If file doesn't exist, or file exists but not device, return false with no error.
+// On other cases, return false with error from Lstat().
+func (v VolumePathHandler) IsDeviceBindMountExist(mapPath string) (bool, error) {
+	fi, err := os.Lstat(mapPath)
+	if err != nil {
+		// If file doesn't exist, return false and no error
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+
+		// Return error from Lstat()
+		return false, fmt.Errorf("failed to Lstat file %s: %v", mapPath, err)
+	}
+	// If file exits and it's device, return true and no error
+	if fi.Mode()&os.ModeDevice == os.ModeDevice {
+		return true, nil
+	}
+	// If file exits but it's not device, return fale and no error
+	return false, nil
+}
+
+// GetDeviceBindMountRefs searches bind mounts under global map path
+func (v VolumePathHandler) GetDeviceBindMountRefs(devPath string, mapPath string) ([]string, error) {
 	var refs []string
 	files, err := ioutil.ReadDir(mapPath)
 	if err != nil {
-		return nil, fmt.Errorf("Directory cannot read %v", err)
+		return nil, fmt.Errorf("directory cannot read %v", err)
 	}
 	for _, file := range files {
-		if file.Mode()&os.ModeSymlink != os.ModeSymlink {
+		if file.Mode()&os.ModeDevice != os.ModeDevice {
 			continue
 		}
 		filename := file.Name()
-		fp, err := os.Readlink(filepath.Join(mapPath, filename))
-		if err != nil {
-			return nil, fmt.Errorf("Symbolic link cannot be retrieved %v", err)
-		}
-		klog.V(5).Infof("GetDeviceSymlinkRefs: filepath: %v, devPath: %v", fp, devPath)
-		if fp == devPath {
-			refs = append(refs, filepath.Join(mapPath, filename))
-		}
+		// TODO: Might need to check if the file is actually linked to devPath
+		refs = append(refs, filepath.Join(mapPath, filename))
 	}
-	klog.V(5).Infof("GetDeviceSymlinkRefs: refs %v", refs)
+	klog.V(5).Infof("GetDeviceBindMountRefs: refs %v", refs)
 	return refs, nil
-}
-
-// FindGlobalMapPathUUIDFromPod finds {pod uuid} symbolic link under globalMapPath
-// corresponding to map path symlink, and then return global map path with pod uuid.
-// ex. mapPath symlink: pods/{podUid}}/{DefaultKubeletVolumeDevicesDirName}/{escapeQualifiedPluginName}/{volumeName} -> /dev/sdX
-//     globalMapPath/{pod uuid}: plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumePluginDependentPath}/{pod uuid} -> /dev/sdX
-func (v VolumePathHandler) FindGlobalMapPathUUIDFromPod(pluginDir, mapPath string, podUID types.UID) (string, error) {
-	var globalMapPathUUID string
-	// Find symbolic link named pod uuid under plugin dir
-	err := filepath.Walk(pluginDir, func(path string, fi os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if (fi.Mode()&os.ModeSymlink == os.ModeSymlink) && (fi.Name() == string(podUID)) {
-			klog.V(5).Infof("FindGlobalMapPathFromPod: path %s, mapPath %s", path, mapPath)
-			if res, err := compareSymlinks(path, mapPath); err == nil && res {
-				globalMapPathUUID = path
-			}
-		}
-		return nil
-	})
-	if err != nil {
-		return "", err
-	}
-	klog.V(5).Infof("FindGlobalMapPathFromPod: globalMapPathUUID %s", globalMapPathUUID)
-	// Return path contains global map path + {pod uuid}
-	return globalMapPathUUID, nil
-}
-
-func compareSymlinks(global, pod string) (bool, error) {
-	devGlobal, err := os.Readlink(global)
-	if err != nil {
-		return false, err
-	}
-	devPod, err := os.Readlink(pod)
-	if err != nil {
-		return false, err
-	}
-	klog.V(5).Infof("CompareSymlinks: devGloBal %s, devPod %s", devGlobal, devPod)
-	if devGlobal == devPod {
-		return true, nil
-	}
-	return false, nil
 }

--- a/pkg/volume/util/volumepathhandler/volume_path_handler_linux.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler_linux.go
@@ -19,12 +19,17 @@ limitations under the License.
 package volumepathhandler
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
+	"golang.org/x/sys/unix"
+
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 )
 
@@ -33,7 +38,7 @@ import (
 func (v VolumePathHandler) AttachFileDevice(path string) (string, error) {
 	blockDevicePath, err := v.GetLoopDevice(path)
 	if err != nil && err.Error() != ErrDeviceNotFound {
-		return "", err
+		return "", fmt.Errorf("GetLoopDevice failed for path %s: %v", path, err)
 	}
 
 	// If no existing loop device for the path, create one
@@ -41,10 +46,31 @@ func (v VolumePathHandler) AttachFileDevice(path string) (string, error) {
 		klog.V(4).Infof("Creating device for path: %s", path)
 		blockDevicePath, err = makeLoopDevice(path)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("makeLoopDevice failed for path %s: %v", path, err)
 		}
 	}
 	return blockDevicePath, nil
+}
+
+// DetachFileDevice takes a path to the attached block device and
+// detach it from block device.
+func (v VolumePathHandler) DetachFileDevice(path string) error {
+	loopPath, err := v.GetLoopDevice(path)
+	if err != nil {
+		if err.Error() == ErrDeviceNotFound {
+			klog.Warningf("couldn't find loopback device which takes file descriptor lock. Skip detaching device. device path: %q", path)
+		} else {
+			return fmt.Errorf("GetLoopDevice failed for path %s: %v", path, err)
+		}
+	} else {
+		if len(loopPath) != 0 {
+			err = removeLoopDevice(loopPath)
+			if err != nil {
+				return fmt.Errorf("removeLoopDevice failed for path %s: %v", path, err)
+			}
+		}
+	}
+	return nil
 }
 
 // GetLoopDevice returns the full path to the loop device associated with the given path.
@@ -62,9 +88,9 @@ func (v VolumePathHandler) GetLoopDevice(path string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		klog.V(2).Infof("Failed device discover command for path %s: %v %s", path, err, out)
-		return "", err
+		return "", fmt.Errorf("losetup -j %s failed: %v", path, err)
 	}
-	return parseLosetupOutputForDevice(out)
+	return parseLosetupOutputForDevice(out, path)
 }
 
 func makeLoopDevice(path string) (string, error) {
@@ -73,13 +99,20 @@ func makeLoopDevice(path string) (string, error) {
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		klog.V(2).Infof("Failed device create command for path: %s %v %s ", path, err, out)
-		return "", err
+		return "", fmt.Errorf("losetup -f --show %s failed: %v", path, err)
 	}
-	return parseLosetupOutputForDevice(out)
+
+	// losetup -f --show {path} returns device in the format:
+	// /dev/loop1
+	if len(out) == 0 {
+		return "", errors.New(ErrDeviceNotFound)
+	}
+
+	return strings.TrimSpace(string(out)), nil
 }
 
-// RemoveLoopDevice removes specified loopback device
-func (v VolumePathHandler) RemoveLoopDevice(device string) error {
+// removeLoopDevice removes specified loopback device
+func removeLoopDevice(device string) error {
 	args := []string{"-d", device}
 	cmd := exec.Command(losetupPath, args...)
 	out, err := cmd.CombinedOutput()
@@ -88,21 +121,121 @@ func (v VolumePathHandler) RemoveLoopDevice(device string) error {
 			return nil
 		}
 		klog.V(2).Infof("Failed to remove loopback device: %s: %v %s", device, err, out)
-		return err
+		return fmt.Errorf("losetup -d %s failed: %v", device, err)
 	}
 	return nil
 }
 
-func parseLosetupOutputForDevice(output []byte) (string, error) {
+func parseLosetupOutputForDevice(output []byte, path string) (string, error) {
 	if len(output) == 0 {
 		return "", errors.New(ErrDeviceNotFound)
 	}
 
-	// losetup returns device in the format:
-	// /dev/loop1: [0073]:148662 (/dev/sda)
-	device := strings.TrimSpace(strings.SplitN(string(output), ":", 2)[0])
+	// losetup -j {path} returns device in the format:
+	// /dev/loop1: [0073]:148662 ({path})
+	// /dev/loop2: [0073]:148662 (/dev/sdX)
+	//
+	// losetup -j shows all the loop device for the same device that has the same
+	// major/minor number, by resolving symlink and matching major/minor number.
+	// Therefore, there will be other path than {path} in output, as shown in above output.
+	s := string(output)
+	// Find the line that exact matches to the path, or "({path})"
+	var matched string
+	scanner := bufio.NewScanner(strings.NewReader(s))
+	for scanner.Scan() {
+		if strings.HasSuffix(scanner.Text(), "("+path+")") {
+			matched = scanner.Text()
+			break
+		}
+	}
+	if len(matched) == 0 {
+		return "", errors.New(ErrDeviceNotFound)
+	}
+	s = matched
+
+	// Get device name, or the 0th field of the output separated with ":".
+	// We don't need 1st field or later to be splitted, so passing 2 to SplitN.
+	device := strings.TrimSpace(strings.SplitN(s, ":", 2)[0])
 	if len(device) == 0 {
 		return "", errors.New(ErrDeviceNotFound)
 	}
 	return device, nil
+}
+
+// FindGlobalMapPathUUIDFromPod finds {pod uuid} bind mount under globalMapPath
+// corresponding to map path symlink, and then return global map path with pod uuid.
+// (See pkg/volume/volume.go for details on a global map path and a pod device map path.)
+// ex. mapPath symlink: pods/{podUid}}/{DefaultKubeletVolumeDevicesDirName}/{escapeQualifiedPluginName}/{volumeName} -> /dev/sdX
+//     globalMapPath/{pod uuid} bind mount: plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumePluginDependentPath}/{pod uuid} -> /dev/sdX
+func (v VolumePathHandler) FindGlobalMapPathUUIDFromPod(pluginDir, mapPath string, podUID types.UID) (string, error) {
+	var globalMapPathUUID string
+	// Find symbolic link named pod uuid under plugin dir
+	err := filepath.Walk(pluginDir, func(path string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if (fi.Mode()&os.ModeDevice == os.ModeDevice) && (fi.Name() == string(podUID)) {
+			klog.V(5).Infof("FindGlobalMapPathFromPod: path %s, mapPath %s", path, mapPath)
+			if res, err := compareBindMountAndSymlinks(path, mapPath); err == nil && res {
+				globalMapPathUUID = path
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("FindGlobalMapPathUUIDFromPod failed: %v", err)
+	}
+	klog.V(5).Infof("FindGlobalMapPathFromPod: globalMapPathUUID %s", globalMapPathUUID)
+	// Return path contains global map path + {pod uuid}
+	return globalMapPathUUID, nil
+}
+
+// compareBindMountAndSymlinks returns if global path (bind mount) and
+// pod path (symlink) are pointing to the same device.
+// If there is an error in checking it returns error.
+func compareBindMountAndSymlinks(global, pod string) (bool, error) {
+	// To check if bind mount and symlink are pointing to the same device,
+	// we need to check if they are pointing to the devices that have same major/minor number.
+
+	// Get the major/minor number for global path
+	devNumGlobal, err := getDeviceMajorMinor(global)
+	if err != nil {
+		return false, fmt.Errorf("getDeviceMajorMinor failed for path %s: %v", global, err)
+	}
+
+	// Get the symlinked device from the pod path
+	devPod, err := os.Readlink(pod)
+	if err != nil {
+		return false, fmt.Errorf("failed to readlink path %s: %v", pod, err)
+	}
+	// Get the major/minor number for the symlinked device from the pod path
+	devNumPod, err := getDeviceMajorMinor(devPod)
+	if err != nil {
+		return false, fmt.Errorf("getDeviceMajorMinor failed for path %s: %v", devPod, err)
+	}
+	klog.V(5).Infof("CompareBindMountAndSymlinks: devNumGlobal %s, devNumPod %s", devNumGlobal, devNumPod)
+
+	// Check if the major/minor number are the same
+	if devNumGlobal == devNumPod {
+		return true, nil
+	}
+	return false, nil
+}
+
+// getDeviceMajorMinor returns major/minor number for the path with below format:
+// major:minor (in hex)
+// ex)
+//     fc:10
+func getDeviceMajorMinor(path string) (string, error) {
+	var stat unix.Stat_t
+
+	if err := unix.Stat(path, &stat); err != nil {
+		return "", fmt.Errorf("failed to stat path %s: %v", path, err)
+	}
+
+	devNumber := uint64(stat.Rdev)
+	major := unix.Major(devNumber)
+	minor := unix.Minor(devNumber)
+
+	return fmt.Sprintf("%x:%x", major, minor), nil
 }

--- a/pkg/volume/util/volumepathhandler/volume_path_handler_unsupported.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler_unsupported.go
@@ -20,6 +20,8 @@ package volumepathhandler
 
 import (
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // AttachFileDevice takes a path to a regular file and makes it available as an
@@ -28,12 +30,19 @@ func (v VolumePathHandler) AttachFileDevice(path string) (string, error) {
 	return "", fmt.Errorf("AttachFileDevice not supported for this build.")
 }
 
+// DetachFileDevice takes a path to the attached block device and
+// detach it from block device.
+func (v VolumePathHandler) DetachFileDevice(path string) error {
+	return fmt.Errorf("DetachFileDevice not supported for this build.")
+}
+
 // GetLoopDevice returns the full path to the loop device associated with the given path.
 func (v VolumePathHandler) GetLoopDevice(path string) (string, error) {
 	return "", fmt.Errorf("GetLoopDevice not supported for this build.")
 }
 
-// RemoveLoopDevice removes specified loopback device
-func (v VolumePathHandler) RemoveLoopDevice(device string) error {
-	return fmt.Errorf("RemoveLoopDevice not supported for this build.")
+// FindGlobalMapPathUUIDFromPod finds {pod uuid} bind mount under globalMapPath
+// corresponding to map path symlink, and then return global map path with pod uuid.
+func (v VolumePathHandler) FindGlobalMapPathUUIDFromPod(pluginDir, mapPath string, podUID types.UID) (string, error) {
+	return "", fmt.Errorf("FindGlobalMapPathUUIDFromPod not supported for this build.")
 }

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -41,12 +41,12 @@ type Volume interface {
 // and pod device map path.
 type BlockVolume interface {
 	// GetGlobalMapPath returns a global map path which contains
-	// symbolic links associated to a block device.
+	// bind mount associated to a block device.
 	// ex. plugins/kubernetes.io/{PluginName}/{DefaultKubeletVolumeDevicesDirName}/{volumePluginDependentPath}/{pod uuid}
 	GetGlobalMapPath(spec *Spec) (string, error)
 	// GetPodDeviceMapPath returns a pod device map path
 	// and name of a symbolic link associated to a block device.
-	// ex. pods/{podUid}}/{DefaultKubeletVolumeDevicesDirName}/{escapeQualifiedPluginName}/{volumeName}
+	// ex. pods/{podUid}/{DefaultKubeletVolumeDevicesDirName}/{escapeQualifiedPluginName}/, {volumeName}
 	GetPodDeviceMapPath() (string, string)
 }
 
@@ -152,35 +152,51 @@ type Unmounter interface {
 	TearDownAt(dir string) error
 }
 
-// BlockVolumeMapper interface provides methods to set up/map the volume.
+// BlockVolumeMapper interface is a mapper interface for block volume.
 type BlockVolumeMapper interface {
 	BlockVolume
-	// SetUpDevice prepares the volume to a self-determined directory path,
-	// which may or may not exist yet and returns combination of physical
-	// device path of a block volume and error.
-	// If the plugin is non-attachable, it should prepare the device
-	// in /dev/ (or where appropriate) and return unique device path.
-	// Unique device path across kubelet node reboot is required to avoid
-	// unexpected block volume destruction.
-	// If the plugin is attachable, it should not do anything here,
-	// just return empty string for device path.
-	// Instead, attachable plugin have to return unique device path
-	// at attacher.Attach() and attacher.WaitForAttach().
-	// This may be called more than once, so implementations must be idempotent.
-	SetUpDevice() (string, error)
-
-	// Map maps the block device path for the specified spec and pod.
-	MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error
 }
 
-// BlockVolumeUnmapper interface provides methods to cleanup/unmap the volumes.
+// BlockVolumeStager interface provides a method to stage the volume.
+type BlockVolumeStager interface {
+	BlockVolumeMapper
+	// SetUpDevice prepares the volume to the node by the plugin specific way.
+	// For most in-tree plugins, attacher.Attach() and attacher.WaitForAttach()
+	// will do necessary works.
+	// This may be called more than once, so implementations must be idempotent.
+	SetUpDevice() error
+}
+
+// BlockVolumePublisher interface provides a method to publish the volumes.
+type BlockVolumePublisher interface {
+	BlockVolumeMapper
+	// MapPodDevice maps the block device to a path and return the path.
+	// Unique device path across kubelet node reboot is required to avoid
+	// unexpected block volume destruction.
+	// If empty string is returned, the path retuned by attacher.Attach() and
+	// attacher.WaitForAttach() will be sued.
+	MapPodDevice() (string, error)
+}
+
+// BlockVolumeUnmapper interface is an unmapper interface for block volume.
 type BlockVolumeUnmapper interface {
 	BlockVolume
-	// TearDownDevice removes traces of the SetUpDevice procedure under
-	// a self-determined directory.
+}
+
+// BlockVolumeUnstager interface provides a method to unstage the volume.
+type BlockVolumeUnstager interface {
+	BlockVolumeUnmapper
+	// TearDownDevice removes traces of the SetUpDevice procedure.
 	// If the plugin is non-attachable, this method detaches the volume
 	// from a node.
 	TearDownDevice(mapPath string, devicePath string) error
+}
+
+// BlockVolumeUnpublisher interface provides a method to unpublish the volumes.
+type BlockVolumeUnpublisher interface {
+	BlockVolumeUnmapper
+	// UnmapPodDevice removes traces of the MapPodDevice procedure.
+	UnmapPodDevice() error
 }
 
 // Provisioner is an interface that creates templates for PersistentVolumes

--- a/pkg/volume/vsphere_volume/vsphere_volume_block.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_block.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/util/mount"
 	"k8s.io/kubernetes/pkg/volume"
-	"k8s.io/kubernetes/pkg/volume/util"
 	"k8s.io/kubernetes/pkg/volume/util/volumepathhandler"
 	utilstrings "k8s.io/utils/strings"
 )
@@ -133,22 +132,10 @@ type vsphereBlockVolumeMapper struct {
 	*vsphereVolume
 }
 
-func (v vsphereBlockVolumeMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (v vsphereBlockVolumeMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return util.MapBlockVolume(devicePath, globalMapPath, volumeMapPath, volumeMapName, podUID)
-}
-
 var _ volume.BlockVolumeUnmapper = &vsphereBlockVolumeUnmapper{}
 
 type vsphereBlockVolumeUnmapper struct {
 	*vsphereVolume
-}
-
-func (v *vsphereBlockVolumeUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
 }
 
 // GetGlobalMapPath returns global map path and error


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR changes staging/publish and unstaging/unpublish logics for block to be called from separate methods. Also, publish path is changed to per pod path from per volume path.

[Before]
- ```stageVolumeForBlock```: called from ```SetupDevice```
- ```publishVolumeForBlock```: called from ```SetupDevice```
- ```unstageVolumeForBlock```: called from ```TearDownDevice```
- ```unpublishVolumeForBlock```: called from ```TearDownDevice```
- publish path: ```plugins/kubernetes.io/csi/volumeDevices/publish/{pvname}```

[After]
- ```stageVolumeForBlock```: called from ```SetupDevice```
- ```publishVolumeForBlock```: called from ```MapPodDevice```
- ```unstageVolumeForBlock```: called from ```TearDownDevice```
- ```unpublishVolumeForBlock```: called from ```UnmapPodDevice```
- publish path:  ```plugins/kubernetes.io/csi/volumeDevices/publish/{pvname}/{podUid}```

Summary of discussion why this change needed is commented [here](https://github.com/kubernetes/kubernetes/issues/73773#issuecomment-462895942)

**Which issue(s) this PR fixes**:
Fixes #73773

**Special notes for your reviewer**:
/sig storage
@bswartz @msau42  @wongma7 @vladimirvivien @jsafrane @davidz627 @saad-ali 

This PR is an attempt to refactor https://github.com/kubernetes/kubernetes/pull/74026 .

**Does this PR introduce a user-facing change?**:
```release-note
All nodes need to be drained before upgrading Kubernetes cluster, because paths used for block volumes are changed in this release, so on-line upgrade of nodes aren't allowed. 
```
