### PR TITLE
Add check for docker engine liveness in preflight

### DIFF
--- a/cmd/kubeadm/app/util/system/docker_validator.go
+++ b/cmd/kubeadm/app/util/system/docker_validator.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"os/exec"
 	"regexp"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -32,11 +33,13 @@ type DockerValidator struct {
 }
 
 // dockerInfo holds a local subset of the Info struct from
-// github.com/docker/docker/api/types.
+// https://github.com/docker/cli/blob/master/cli/command/system/info.go
+// and https://github.com/moby/moby/blob/master/api/types/types.go
 // The JSON output from 'docker info' should map to this struct.
 type dockerInfo struct {
-	Driver        string `json:"Driver"`
-	ServerVersion string `json:"ServerVersion"`
+	Driver        string   `json:"Driver"`
+	ServerVersion string   `json:"ServerVersion"`
+	ServerErrors  []string `json:",omitempty"`
 }
 
 // Name is part of the system.Validator interface.
@@ -81,6 +84,10 @@ func (d *DockerValidator) unmarshalDockerInfo(b []byte, info *dockerInfo) error 
 
 func (d *DockerValidator) validateDockerInfo(spec *DockerSpec, info dockerInfo) ([]error, []error) {
 	// Validate docker version.
+	if info.ServerErrors != nil {
+		return nil, []error{errors.Errorf(`error verifying docker info: "%s"`, strings.Join(info.ServerErrors, `", "`))}
+	}
+
 	matched := false
 	for _, v := range spec.Version {
 		r := regexp.MustCompile(v)

--- a/cmd/kubeadm/app/util/system/docker_validator_test.go
+++ b/cmd/kubeadm/app/util/system/docker_validator_test.go
@@ -91,6 +91,12 @@ func TestValidateDockerInfo(t *testing.T) {
 			err:  false,
 			warn: true,
 		},
+		{
+			name: "Docker daemon not available",
+			info: dockerInfo{ServerErrors: []string{"Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running"}},
+			err:  true,
+			warn: false,
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			warn, err := v.validateDockerInfo(spec, test.info)
@@ -121,6 +127,11 @@ func TestUnmarshalDockerInfo(t *testing.T) {
 			name:         "valid: expected dockerInfo is valid",
 			input:        `{ "Driver":"foo", "ServerVersion":"bar" }`,
 			expectedInfo: dockerInfo{Driver: "foo", ServerVersion: "bar"},
+		},
+		{
+			name:         "valid: expected dockerInfo is valid although daemon is not running",
+			input:        `{ "ServerErrors":["Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"]}`,
+			expectedInfo: dockerInfo{ServerErrors: []string{"Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running"}},
 		},
 		{
 			name:          "invalid: the JSON input is not valid",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

If docker engine/server is not running, the preflight check will now report:

```
system validation failed: [unsupported docker version: ]
```

because the output of `docker info --format "{{json .}}"` is:

```json
{
  "ServerErrors": [
    "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"
  ],
  "ClientInfo": {
    "Debug": false,
    "Plugins": [],
    "Warnings": null
  }
}
```

With this PR the check will report:

```
system validation failed: [error when fetching docker info: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?"]
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

/assign random-liu

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```