### PR TITLE
Skip GetPodNetworkStatus when CNI not yet initialized

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni_windows.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_windows.go
@@ -45,6 +45,10 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 		return nil, fmt.Errorf("CNI failed to retrieve network namespace path: %v", err)
 	}
 
+	if plugin.getDefaultNetwork() == nil {
+		return nil, fmt.Errorf("CNI network not yet initialized, skipping pod network status for container %q", id)
+	}
+
 	// Because the default remote runtime request timeout is 4 min,so set slightly less than 240 seconds
 	// Todo get the timeout from parent ctx
 	cniTimeoutCtx, cancelFunc := context.WithTimeout(context.Background(), network.CNITimeoutSec*time.Second)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Without this scheduling a pod on Windows results in a panic from `addToNetwork` when it tries to read `NetworkConfig` and `CNIConfig` off the nil network.

This realistically only happens if you try to schedule a `hostNetwork` pod onto a Windows node before you've configured networking. Host networking isn't really supported/functional on Windows, but I'm trying to explore the feasibility of bootstrapping CNI setup through kubelet, and `hostNetwork: true` is the only way to tell kubelet to run a pod despite networking not being configured.

An additional note if you try to reproduce this bug: you'll need to create a Docker network named `host` on the node as well. Without this kubelet/dockershim will complain that no such network exists.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
```
