### PR TITLE
Drop version from static openapi json file

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -86,7 +86,7 @@ fi
 
 kube::log::status "Updating " "${OPENAPI_ROOT_DIR}"
 
-curl -w "\n" -fs "${API_HOST}:${API_PORT}/openapi/v2" | jq -S . > "${OPENAPI_ROOT_DIR}/swagger.json"
+curl -w "\n" -fs "${API_HOST}:${API_PORT}/openapi/v2" | jq -S '.info.version="unversioned"' > "${OPENAPI_ROOT_DIR}/swagger.json"
 
 kube::log::status "SUCCESS"
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This changes the version tag in the static commited openapi json file back to what it was prior to https://github.com/kubernetes/kubernetes/pull/37055#discussion_r88752416.

Consumers of the actual openapi spec from live API servers are unaffected.

The presence of this branch-specific version in a CI-verified file is preventing release branches from fast-forwarding while they are tracking master. That means release branches end up with large merge commits, fast-forwarding the branch requires a build and openapi generation (see kubernetes/sig-release#845), and commit SHAs don't match.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @justaugustus @Katharine 