### PR TITLE
Restrict mirror pod owner references

### DIFF
--- a/plugin/pkg/admission/noderestriction/admission.go
+++ b/plugin/pkg/admission/noderestriction/admission.go
@@ -177,43 +177,7 @@ func (p *Plugin) Admit(ctx context.Context, a admission.Attributes, o admission.
 func (p *Plugin) admitPod(nodeName string, a admission.Attributes) error {
 	switch a.GetOperation() {
 	case admission.Create:
-		// require a pod object
-		pod, ok := a.GetObject().(*api.Pod)
-		if !ok {
-			return admission.NewForbidden(a, fmt.Errorf("unexpected type %T", a.GetObject()))
-		}
-
-		// only allow nodes to create mirror pods
-		if _, isMirrorPod := pod.Annotations[api.MirrorPodAnnotationKey]; !isMirrorPod {
-			return admission.NewForbidden(a, fmt.Errorf("pod does not have %q annotation, node %q can only create mirror pods", api.MirrorPodAnnotationKey, nodeName))
-		}
-
-		// only allow nodes to create a pod bound to itself
-		if pod.Spec.NodeName != nodeName {
-			return admission.NewForbidden(a, fmt.Errorf("node %q can only create pods with spec.nodeName set to itself", nodeName))
-		}
-
-		// don't allow a node to create a pod that references any other API objects
-		if pod.Spec.ServiceAccountName != "" {
-			return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference a service account", nodeName))
-		}
-		hasSecrets := false
-		podutil.VisitPodSecretNames(pod, func(name string) (shouldContinue bool) { hasSecrets = true; return false })
-		if hasSecrets {
-			return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference secrets", nodeName))
-		}
-		hasConfigMaps := false
-		podutil.VisitPodConfigmapNames(pod, func(name string) (shouldContinue bool) { hasConfigMaps = true; return false })
-		if hasConfigMaps {
-			return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference configmaps", nodeName))
-		}
-		for _, v := range pod.Spec.Volumes {
-			if v.PersistentVolumeClaim != nil {
-				return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference persistentvolumeclaims", nodeName))
-			}
-		}
-
-		return nil
+		return p.admitPodCreate(nodeName, a)
 
 	case admission.Delete:
 		// get the existing pod
@@ -233,6 +197,60 @@ func (p *Plugin) admitPod(nodeName string, a admission.Attributes) error {
 	default:
 		return admission.NewForbidden(a, fmt.Errorf("unexpected operation %q, node %q can only create and delete mirror pods", a.GetOperation(), nodeName))
 	}
+}
+
+func (p *Plugin) admitPodCreate(nodeName string, a admission.Attributes) error {
+	// require a pod object
+	pod, ok := a.GetObject().(*api.Pod)
+	if !ok {
+		return admission.NewForbidden(a, fmt.Errorf("unexpected type %T", a.GetObject()))
+	}
+
+	// only allow nodes to create mirror pods
+	if _, isMirrorPod := pod.Annotations[api.MirrorPodAnnotationKey]; !isMirrorPod {
+		return admission.NewForbidden(a, fmt.Errorf("pod does not have %q annotation, node %q can only create mirror pods", api.MirrorPodAnnotationKey, nodeName))
+	}
+
+	// only allow nodes to create a pod bound to itself
+	if pod.Spec.NodeName != nodeName {
+		return admission.NewForbidden(a, fmt.Errorf("node %q can only create pods with spec.nodeName set to itself", nodeName))
+	}
+	if len(pod.OwnerReferences) > 0 {
+		if len(pod.OwnerReferences) > 1 {
+			return admission.NewForbidden(a, fmt.Errorf("node %q can only create pods with a single owner reference set to itself", nodeName))
+		}
+		owner := pod.OwnerReferences[0]
+		if owner.APIVersion != v1.SchemeGroupVersion.String() ||
+			owner.Kind != "Node" ||
+			owner.Name != nodeName {
+			return admission.NewForbidden(a, fmt.Errorf("node %q can only create pods with an owner reference set to itself", nodeName))
+		}
+		if owner.Controller == nil || !*owner.Controller {
+			return admission.NewForbidden(a, fmt.Errorf("node %q can only create pods with a controller owner reference set to itself", nodeName))
+		}
+	}
+
+	// don't allow a node to create a pod that references any other API objects
+	if pod.Spec.ServiceAccountName != "" {
+		return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference a service account", nodeName))
+	}
+	hasSecrets := false
+	podutil.VisitPodSecretNames(pod, func(name string) (shouldContinue bool) { hasSecrets = true; return false })
+	if hasSecrets {
+		return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference secrets", nodeName))
+	}
+	hasConfigMaps := false
+	podutil.VisitPodConfigmapNames(pod, func(name string) (shouldContinue bool) { hasConfigMaps = true; return false })
+	if hasConfigMaps {
+		return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference configmaps", nodeName))
+	}
+	for _, v := range pod.Spec.Volumes {
+		if v.PersistentVolumeClaim != nil {
+			return admission.NewForbidden(a, fmt.Errorf("node %q can not create pods that reference persistentvolumeclaims", nodeName))
+		}
+	}
+
+	return nil
 }
 
 // admitPodStatus allows to update the status of a pod if it is


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Restrict mirror pod owner references to only refer to the creating node.

See http://git.k8s.io/enhancements/keps/sig-auth/20190916-noderestriction-pods.md

Manually tested.

**Which issue(s) this PR fixes**:
For https://github.com/kubernetes/enhancements/issues/1314

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Mirror pods may not include owner references, except for the reference to the owning node that is auto injected by the Kubelet.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: http://git.k8s.io/enhancements/keps/sig-auth/20190916-noderestriction-pods.md
```

/sig node
/sig auth
/priority important-soon
/milestone v1.17

/assign @liggitt @derekwaynecarr 