### PR TITLE
Adding EndpointSlice API util to simplify migration from Endpoints

### DIFF
--- a/pkg/BUILD
+++ b/pkg/BUILD
@@ -12,6 +12,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/api/endpoints:all-srcs",
+        "//pkg/api/endpointslice:all-srcs",
         "//pkg/api/legacyscheme:all-srcs",
         "//pkg/api/persistentvolume:all-srcs",
         "//pkg/api/persistentvolumeclaim:all-srcs",

--- a/pkg/api/endpointslice/BUILD
+++ b/pkg/api/endpointslice/BUILD
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["util.go"],
+    importpath = "k8s.io/kubernetes/pkg/api/endpointslice",
+    visibility = ["//visibility:public"],
+    deps = ["//staging/src/k8s.io/api/discovery/v1alpha1:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["util_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/api/discovery/v1alpha1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/api/endpointslice/util.go
+++ b/pkg/api/endpointslice/util.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointslice
+
+import (
+	discovery "k8s.io/api/discovery/v1alpha1"
+)
+
+// EndpointsByPort groups lists of Endpoints by EndpointPort.
+type EndpointsByPort map[discovery.EndpointPort][]discovery.Endpoint
+
+// GetEndpointsByPort accepts a list of EndpointSlices and returns
+// EndpointsByPort, lists of Endpoints grouped by EndpointPort.
+func GetEndpointsByPort(endpointSlices []*discovery.EndpointSlice) EndpointsByPort {
+	endpointsByPort := EndpointsByPort{}
+	for _, endpointSlice := range endpointSlices {
+		for _, port := range endpointSlice.Ports {
+			endpointsByPort[port] = append(endpointsByPort[port], endpointSlice.Endpoints...)
+		}
+	}
+	return endpointsByPort
+}
+
+// GetEndpointsForPort accepts a port name along with a list of EndpointSlices
+// and returns EndpointsByPort. Since a given port name may result in multiple
+// port numbers, Endpoints are returned as a map grouped by EndpointPort.
+func GetEndpointsForPort(portName string, endpointSlices []*discovery.EndpointSlice) EndpointsByPort {
+	endpointsByPort := EndpointsByPort{}
+	for _, endpointSlice := range endpointSlices {
+		for _, port := range endpointSlice.Ports {
+			if port.Name != nil && *port.Name == portName {
+				endpointsByPort[port] = append(endpointsByPort[port], endpointSlice.Endpoints...)
+			}
+		}
+	}
+	return endpointsByPort
+}

--- a/pkg/api/endpointslice/util_test.go
+++ b/pkg/api/endpointslice/util_test.go
@@ -1,0 +1,232 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointslice
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	discovery "k8s.io/api/discovery/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilpointer "k8s.io/utils/pointer"
+)
+
+func TestGetEndpointsByPort(t *testing.T) {
+	ns := "foo"
+	endpoints, ports, endpointSlices := setupTestData(ns)
+
+	testCases := map[string]struct {
+		endpointSlices          []*discovery.EndpointSlice
+		expectedEndpointsByPort EndpointsByPort
+	}{
+		"1 endpoint slice, multiple ports": {
+			endpointSlices: endpointSlices[0:1],
+			expectedEndpointsByPort: EndpointsByPort{
+				ports[0]: endpoints[0:3],
+				ports[1]: endpoints[0:3],
+			},
+		},
+		"2 endpoint slices, multiple ports": {
+			endpointSlices: endpointSlices[0:2],
+			expectedEndpointsByPort: EndpointsByPort{
+				ports[0]: endpoints[0:5],
+				ports[1]: endpoints[0:3],
+				ports[3]: endpoints[3:5],
+			},
+		},
+		"1 endpoint slice, 1 port": {
+			endpointSlices: endpointSlices[2:3],
+			expectedEndpointsByPort: EndpointsByPort{
+				ports[2]: endpoints[5:],
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			endpointsByPort := GetEndpointsByPort(tc.endpointSlices)
+
+			if len(tc.expectedEndpointsByPort) != len(endpointsByPort) {
+				t.Fatalf("Expected %d ports, got %d", len(tc.expectedEndpointsByPort), len(endpointsByPort))
+			}
+
+			for port, endpoints := range endpointsByPort {
+				expectedEndpoints, ok := tc.expectedEndpointsByPort[port]
+				if !ok {
+					t.Fatalf("Got unexpected port: %v", port)
+				}
+				if !endpointsEqual(expectedEndpoints, endpoints) {
+					t.Errorf("Expected endpoints: %v, got: %v", expectedEndpoints, endpoints)
+				}
+			}
+		})
+	}
+}
+
+func TestGetEndpointsForPort(t *testing.T) {
+	ns := "foo"
+	endpoints, ports, endpointSlices := setupTestData(ns)
+
+	testCases := map[string]struct {
+		portName                string
+		expectedEndpointsByPort EndpointsByPort
+	}{
+		"http": {
+			portName: "http",
+			expectedEndpointsByPort: EndpointsByPort{
+				ports[1]: endpoints[0:3],
+			},
+		},
+		"https": {
+			portName: "https",
+			expectedEndpointsByPort: EndpointsByPort{
+				ports[0]: endpoints[0:5],
+			},
+		},
+		"dns": {
+			portName: "dns",
+			expectedEndpointsByPort: EndpointsByPort{
+				ports[2]: endpoints[5:],
+				ports[3]: endpoints[3:5],
+			},
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			endpointsByPort := GetEndpointsForPort(tc.portName, endpointSlices)
+
+			if len(tc.expectedEndpointsByPort) != len(endpointsByPort) {
+				t.Fatalf("Expected %d ports, got %d", len(tc.expectedEndpointsByPort), len(endpointsByPort))
+			}
+
+			for port, endpoints := range endpointsByPort {
+				expectedEndpoints, ok := tc.expectedEndpointsByPort[port]
+				if !ok {
+					t.Fatalf("Got unexpected port: %v", port)
+				}
+				if !endpointsEqual(expectedEndpoints, endpoints) {
+					t.Errorf("Expected endpoints: %v, got: %v", expectedEndpoints, endpoints)
+				}
+			}
+		})
+	}
+}
+
+func setupTestData(ns string) ([]discovery.Endpoint, []discovery.EndpointPort, []*discovery.EndpointSlice) {
+	tcpProtocol := corev1.ProtocolTCP
+	udpProtocol := corev1.ProtocolUDP
+
+	serviceNames := []string{"svc1", "svc2"}
+
+	ports := []discovery.EndpointPort{{
+		Name:     utilpointer.StringPtr("https"),
+		Port:     utilpointer.Int32Ptr(443),
+		Protocol: &tcpProtocol,
+	}, {
+		Name:     utilpointer.StringPtr("http"),
+		Port:     utilpointer.Int32Ptr(80),
+		Protocol: &tcpProtocol,
+	}, {
+		Name:     utilpointer.StringPtr("dns"),
+		Port:     utilpointer.Int32Ptr(53),
+		Protocol: &udpProtocol,
+	}, {
+		Name:     utilpointer.StringPtr("dns"),
+		Port:     utilpointer.Int32Ptr(3053),
+		Protocol: &udpProtocol,
+	}}
+
+	endpoints := []discovery.Endpoint{{
+		Addresses: []string{"10.0.0.1"},
+	}, {
+		Addresses: []string{"10.0.0.2"},
+	}, {
+		Addresses: []string{"10.0.0.3"},
+	}, {
+		Addresses: []string{"10.0.0.4"},
+	}, {
+		Addresses: []string{"10.0.0.5"},
+	}, {
+		Addresses: []string{"10.0.0.6"},
+	}}
+
+	endpointSlices := []*discovery.EndpointSlice{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "epslice1",
+			Namespace: ns,
+			Labels: map[string]string{
+				discovery.LabelServiceName: serviceNames[0],
+				"sliceName":                "epslice1",
+			},
+		},
+		Ports:       []discovery.EndpointPort{ports[0], ports[1]},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints:   endpoints[0:3],
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "epslice2",
+			Namespace: ns,
+			Labels: map[string]string{
+				discovery.LabelServiceName: serviceNames[0],
+				"sliceName":                "epslice2",
+			},
+		},
+		Ports:       []discovery.EndpointPort{ports[0], ports[3]},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints:   endpoints[3:5],
+	}, {
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "epslice3",
+			Namespace: ns,
+			Labels: map[string]string{
+				discovery.LabelServiceName: serviceNames[1],
+				"sliceName":                "epslice3",
+			},
+		},
+		Ports:       []discovery.EndpointPort{ports[2]},
+		AddressType: discovery.AddressTypeIPv4,
+		Endpoints:   endpoints[5:],
+	}}
+
+	return endpoints, ports, endpointSlices
+}
+
+func endpointsEqual(endpoints1, endpoints2 []discovery.Endpoint) bool {
+	if len(endpoints1) != len(endpoints2) {
+		return false
+	}
+
+	for _, ep1 := range endpoints1 {
+		if !endpointIn(ep1, endpoints2) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func endpointIn(endpoint discovery.Endpoint, endpoints []discovery.Endpoint) bool {
+	for _, ep := range endpoints {
+		if reflect.DeepEqual(ep, endpoint) {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This util adds functions to help group endpoints from related EndpointSlices into combined lists of Endpoints.

**Does this PR introduce a user-facing change?**:
```release-note
Add EndpointSliceLister expansion to simplify working with EndpointSlices.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752

/priority important-longterm
/sig network
/cc @freehan 