### PR TITLE
Automated cherry pick of #75054: Remove the condition for only wait for KMS key is used

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws.go
+++ b/pkg/cloudprovider/providers/aws/aws.go
@@ -2400,19 +2400,17 @@ func (c *Cloud) CreateDisk(volumeOptions *VolumeOptions) (KubernetesVolumeID, er
 	}
 	volumeName := KubernetesVolumeID("aws://" + aws.StringValue(response.AvailabilityZone) + "/" + string(awsID))
 
-	// AWS has a bad habbit of reporting success when creating a volume with
-	// encryption keys that either don't exists or have wrong permissions.
-	// Such volume lives for couple of seconds and then it's silently deleted
-	// by AWS. There is no other check to ensure that given KMS key is correct,
-	// because Kubernetes may have limited permissions to the key.
-	if len(volumeOptions.KmsKeyID) > 0 {
-		err := c.waitUntilVolumeAvailable(volumeName)
-		if err != nil {
-			if isAWSErrorVolumeNotFound(err) {
-				err = fmt.Errorf("failed to create encrypted volume: the volume disappeared after creation, most likely due to inaccessible KMS encryption key")
-			}
-			return "", err
+	err = c.waitUntilVolumeAvailable(volumeName)
+	if err != nil {
+		// AWS has a bad habbit of reporting success when creating a volume with
+		// encryption keys that either don't exists or have wrong permissions.
+		// Such volume lives for couple of seconds and then it's silently deleted
+		// by AWS. There is no other check to ensure that given KMS key is correct,
+		// because Kubernetes may have limited permissions to the key.
+		if isAWSErrorVolumeNotFound(err) {
+			err = fmt.Errorf("failed to create encrypted volume: the volume disappeared after creation, most likely due to inaccessible KMS encryption key")
 		}
+		return "", err
 	}
 
 	return volumeName, nil

--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -1828,11 +1828,18 @@ func TestCreateDisk(t *testing.T) {
 			}},
 		},
 	}
+
 	volume := &ec2.Volume{
 		AvailabilityZone: aws.String("us-east-1a"),
 		VolumeId:         aws.String("vol-volumeId0"),
+		State:            aws.String("available"),
 	}
 	awsServices.ec2.(*MockedFakeEC2).On("CreateVolume", request).Return(volume, nil)
+
+	describeVolumesRequest := &ec2.DescribeVolumesInput{
+		VolumeIds: []*string{aws.String("vol-volumeId0")},
+	}
+	awsServices.ec2.(*MockedFakeEC2).On("DescribeVolumes", describeVolumesRequest).Return([]*ec2.Volume{volume}, nil)
 
 	volumeID, err := c.CreateDisk(volumeOptions)
 	assert.Nil(t, err, "Error creating disk: %v", err)


### PR DESCRIPTION
Cherry pick of #75054 on release-1.14.

#75054: Remove the condition for only wait for KMS key is used

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.