### PR TITLE
adding support for container.name in downward api

### DIFF
--- a/pkg/api/v1/resource/helpers.go
+++ b/pkg/api/v1/resource/helpers.go
@@ -180,6 +180,8 @@ func ExtractContainerResourceValue(fs *v1.ResourceFieldSelector, container *v1.C
 	}
 
 	switch fs.Resource {
+	case "name":
+		return container.Name, nil
 	case "limits.cpu":
 		return convertResourceCPUToString(container.Resources.Limits.Cpu(), divisor)
 	case "limits.memory":

--- a/pkg/apis/core/validation/validation_test.go
+++ b/pkg/apis/core/validation/validation_test.go
@@ -3134,6 +3134,13 @@ func TestValidateVolumes(t *testing.T) {
 								},
 							},
 							{
+								Path: "name",
+								ResourceFieldRef: &core.ResourceFieldSelector{
+									ContainerName: "test-container",
+									Resource:      "name",
+								},
+							},
+							{
 								Path: "cpu_limit",
 								ResourceFieldRef: &core.ResourceFieldSelector{
 									ContainerName: "test-container",


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds the ability to use the Downward API to inject the `container.name` into a container via ResourceFieldRef. Adding the ability for a container to discover its name through the downward API allows operators to write automation that is aware of where it is running within a Pod.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

Thanks for taking a look at this tiny PR!

**Does this PR introduce a user-facing change?**:

This updates the Downward API with a new field - documentation will need to be updated to accomodate.


