### PR TITLE
Fixes error in go_pkg()

### DIFF
--- a/build/code_generation.bzl
+++ b/build/code_generation.bzl
@@ -41,7 +41,8 @@ def go_pkg(pkg):
         ...
     )
     """
-    return go_prefix + "/" + pkg.replace("staging/src/", "vendor/", maxsplit = 1)
+    count = 1
+    return go_prefix + "/" + pkg.replace("staging/src/", "vendor/", count)
 
 def openapi_deps():
     deps = [
@@ -59,7 +60,7 @@ def applies(pkg, prefixes, default):
             return True
     return False
 
-def gen_openapi(outs, output_pkg, include_pkgs=[], exclude_pkgs=[]):
+def gen_openapi(outs, output_pkg, include_pkgs = [], exclude_pkgs = []):
     """Calls openapi-gen to produce the zz_generated.openapi.go file,
     which should be provided in outs.
     output_pkg should be set to the full go package name for this generated file.


### PR DESCRIPTION
* Fixes error in go_pkg() python function (there is no `maxsplit` parameter to the string `replace` method).

How to reproduce:

`$ bazel test //pkg/...`

results in the following error:

```
ERROR: /usr/local/google/home/seans/go/src/k8s.io/kubernetes/build/code_generation.bzl:44:30: Traceback (most recent call last):
	File "/usr/local/google/home/seans/go/src/k8s.io/kubernetes/pkg/generated/openapi/BUILD", line 6
		gen_openapi(<3 more arguments>)
	File "/usr/local/google/home/seans/go/src/k8s.io/kubernetes/build/code_generation.bzl", line 67, in gen_openapi
		go_genrule(<6 more arguments>)
	File "/usr/local/google/home/seans/go/src/k8s.io/kubernetes/build/code_generation.bzl", line 74, in go_genrule
		" ".join(<1 more arguments>)
	File "/usr/local/google/home/seans/go/src/k8s.io/kubernetes/build/code_generation.bzl", line 83, in " ".join
		",".join(<1 more arguments>)
	File "/usr/local/google/home/seans/go/src/k8s.io/kubernetes/build/code_generation.bzl", line 83, in ",".join
		go_pkg(pkg)
	File "/usr/local/google/home/seans/go/src/k8s.io/kubernetes/build/code_generation.bzl", line 44, in go_pkg
		pkg.replace("staging/src/", <2 more arguments>)
unexpected keyword 'maxsplit', for call to method replace(old, new, maxsplit = None) of 'string'
ERROR: package contains errors: pkg/generated/openapi
ERROR: error loading package 'pkg/generated/openapi': Package 'pkg/generated/openapi' contains errors
```

The operative error message is:

`unexpected keyword 'maxsplit', for call to method replace(old, new, maxsplit = None) of 'string'`

/kind bug
/priority important-soon

```release-note
NONE
```