### PR TITLE
Destroy REST storages when destroying API server

### DIFF
--- a/pkg/master/BUILD
+++ b/pkg/master/BUILD
@@ -116,6 +116,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/discovery:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/healthz:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/storage:go_default_library",

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -66,6 +66,7 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/apiserver/pkg/registry/generic"
+	registryrest "k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/healthz"
 	serverstorage "k8s.io/apiserver/pkg/server/storage"
@@ -412,6 +413,11 @@ func (m *Master) InstallLegacyAPI(c *completedConfig, restOptionsGetter generic.
 		return fmt.Errorf("Error building core storage: %v", err)
 	}
 
+	m.GenericAPIServer.AddPreShutdownHookOrDie("NewLegacyRESTStorageDestroy", func() error {
+		legacyRESTStorage.Destroy()
+		return nil
+	})
+
 	controllerName := "bootstrap-controller"
 	coreClient := corev1client.NewForConfigOrDie(c.GenericConfig.LoopbackClientConfig)
 	bootstrapController := c.NewBootstrapController(legacyRESTStorage, coreClient, coreClient, coreClient, coreClient.RESTClient())
@@ -446,6 +452,7 @@ type RESTStorageProvider interface {
 // InstallAPIs will install the APIs for the restStorageProviders if they are enabled.
 func (m *Master) InstallAPIs(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter, restStorageProviders ...RESTStorageProvider) error {
 	apiGroupsInfo := []*genericapiserver.APIGroupInfo{}
+	var destroyFuncs []func()
 
 	for _, restStorageBuilder := range restStorageProviders {
 		groupName := restStorageBuilder.GroupName()
@@ -472,7 +479,21 @@ func (m *Master) InstallAPIs(apiResourceConfigSource serverstorage.APIResourceCo
 		}
 
 		apiGroupsInfo = append(apiGroupsInfo, &apiGroupInfo)
+		for _, versionedResourceStorage := range apiGroupInfo.VersionedResourcesStorageMap {
+			for _, storage := range versionedResourceStorage {
+				if d, ok := storage.(registryrest.Destroyable); ok {
+					destroyFuncs = append(destroyFuncs, d.Destroy)
+				}
+			}
+		}
 	}
+
+	m.GenericAPIServer.AddPreShutdownHookOrDie("InstallAPIsRESTStorageDestroy", func() error {
+		for _, destroyFn := range destroyFuncs {
+			destroyFn()
+		}
+		return nil
+	})
 
 	if err := m.GenericAPIServer.InstallAPIGroups(apiGroupsInfo...); err != nil {
 		return fmt.Errorf("Error in registering group versions: %v", err)

--- a/pkg/registry/core/namespace/storage/storage.go
+++ b/pkg/registry/core/namespace/storage/storage.go
@@ -88,6 +88,10 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST, *Finaliz
 	return &REST{store: store, status: &statusStore}, &StatusREST{store: &statusStore}, &FinalizeREST{store: &finalizeStore}, nil
 }
 
+func (r *REST) Destroy() {
+	r.store.DestroyFunc()
+}
+
 func (r *REST) NamespaceScoped() bool {
 	return r.store.NamespaceScoped()
 }

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -246,6 +246,19 @@ func NoNamespaceKeyFunc(ctx context.Context, prefix string, name string) (string
 	return key, nil
 }
 
+// Destroy implements RESTStorage.Destroyable.
+func (e *Store) Destroy() {
+	// Nothing to destroy by default since e.DestroyFunc is set by a decorator
+	// inside Store.CompleteWithOptions. The decorator is injected so there is
+	// no guarantee value of e.DestroyFunc will be always set.
+	// E.g. in case of etcd3, the decorator is equivalent to calling an etcd3
+	// storage backend factory (k8s.io/apiserver/pkg/storage/storagebackend/factory)
+	// which among other steps is responsible for creating a connection to etcd3 server.
+	if e.DestroyFunc != nil {
+		e.DestroyFunc()
+	}
+}
+
 // New implements RESTStorage.New.
 func (e *Store) New() runtime.Object {
 	return e.NewFunc()

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -58,6 +58,12 @@ type Storage interface {
 	New() runtime.Object
 }
 
+// Destroyable indicates a RESTful storage is capable of cleaning its allocated resources.
+type Destroyable interface {
+	// Destroy clears resources allocated by the storage, e.g. etcd connections
+	Destroy()
+}
+
 // Scoper indicates what scope the resource is at. It must be specified.
 // It is usually provided automatically based on your strategy.
 type Scoper interface {
@@ -274,6 +280,7 @@ type StandardStorage interface {
 	GracefulDeleter
 	CollectionDeleter
 	Watcher
+	Destroyable
 }
 
 // Redirector know how to return a remote resource's location.

--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -47,10 +47,11 @@ func StartApiserver() (string, ShutdownFunc) {
 		h.M.GenericAPIServer.Handler.ServeHTTP(w, req)
 	}))
 
-	framework.RunAMasterUsingServer(framework.NewIntegrationTestMasterConfig(), s, h)
+	_, _, closeFn := framework.RunAMasterUsingServer(framework.NewIntegrationTestMasterConfig(), s, h)
 
 	shutdownFunc := func() {
 		klog.Infof("destroying API server")
+		closeFn()
 		s.Close()
 		klog.Infof("destroyed API server")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, master does not allow to call clean up functions of
created REST storage. Each REST storage carries a connection
to etcd. When an API server is created in a loop, there is no
way to clean all the connections. So the number of open connections
grows up until it exceeds configured upper limit and new REST storages
fail to be created.

Given every API server is mostly run as a separate service (as
a single instance), there is no need to close the etcd connections.
However, when golang benchmark is used, semantics of the benchmark
requires to create multiple instances of the API server in sequence.
Thus, it's necessary to close all open connection when an API server
is torn down. Otherwise, the number of open connections will exceed
configured upper limit eventually and API server initialization will
fail.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
k8s.io/kubernetes/pkg/registry/core/rest.LegacyRESTStorageProvider.NewLegacyRESTStorage returns additional function which cleans REST storages initialized inside NewLegacyRESTStorage.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
