### PR TITLE
Recreate target group when externalTrafficPolicy changes to local

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_loadbalancer.go
@@ -238,10 +238,11 @@ func (c *Cloud) ensureLoadBalancerv2(namespacedName types.NamespacedName, loadBa
 						}
 					}
 
-					// recreate targetGroup if trafficPort or protocol changed
+					// recreate targetGroup if trafficPort or protocol changed, or if healthCheckProtocol changed from TCP
 					targetGroupRecreated := false
 					targetGroup, ok := nodePortTargetGroup[nodePort]
-					if !ok || aws.StringValue(targetGroup.Protocol) != mapping.TrafficProtocol {
+					invalidHealthCheckProtocolModification := aws.StringValue(targetGroup.HealthCheckProtocol) == elbv2.ProtocolEnumTcp && aws.StringValue(targetGroup.HealthCheckProtocol) != mapping.HealthCheckProtocol
+					if !ok || aws.StringValue(targetGroup.Protocol) != mapping.TrafficProtocol || invalidHealthCheckProtocolModification {
 						// create new target group
 						targetGroup, err = c.ensureTargetGroup(
 							nil,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
When the `externalTrafficPolicy` of a service is modified from Cluster to Local, the function ensureTargetGroup will try to change the Target Group's HealthCheckProtocol from TCP to HTTP. This results in an `InvalidConfigurationRequest`. From the [AWS SDK docs](https://docs.aws.amazon.com/sdk-for-go/api/service/elbv2/#ModifyTargetGroupInput): 
```
    // If the protocol of the target group is TCP, you can't modify this setting.
    HealthCheckProtocol *string `type:"string" enum:"ProtocolEnum"
```
This fix adds a check in `ensureLoadBalancerv2` to recreate the target group if the HealthCheckProtocol is changing from TCP to anything else. 

**Which issue(s) this PR fixes**:
Fixes #80996

**Special notes for your reviewer**:
First PR to Kubernetes 👍

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```