### PR TITLE
Stop Watching when there is encoding error

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/watch.go
@@ -285,10 +285,12 @@ func (s *WatchServer) HandleWS(ws *websocket.Conn) {
 	buf := &bytes.Buffer{}
 	streamBuf := &bytes.Buffer{}
 	ch := s.Watching.ResultChan()
+
+	defer s.Watching.Stop()
+
 	for {
 		select {
 		case <-done:
-			s.Watching.Stop()
 			return
 		case event, ok := <-ch:
 			if !ok {
@@ -317,25 +319,21 @@ func (s *WatchServer) HandleWS(ws *websocket.Conn) {
 			if err != nil {
 				utilruntime.HandleError(fmt.Errorf("unable to convert watch object: %v", err))
 				// client disconnect.
-				s.Watching.Stop()
 				return
 			}
 			if err := s.Encoder.Encode(outEvent, streamBuf); err != nil {
 				// encoding error
 				utilruntime.HandleError(fmt.Errorf("unable to encode event: %v", err))
-				s.Watching.Stop()
 				return
 			}
 			if s.UseTextFraming {
 				if err := websocket.Message.Send(ws, streamBuf.String()); err != nil {
 					// Client disconnect.
-					s.Watching.Stop()
 					return
 				}
 			} else {
 				if err := websocket.Message.Send(ws, streamBuf.Bytes()); err != nil {
 					// Client disconnect.
-					s.Watching.Stop()
 					return
 				}
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In WatchServer#HandleWS, if s.EmbeddedEncoder.Encode() fails, s.Watching should be stopped.
This would make encoding error handling consistent with that of s.Encoder.Encode().

```release-note
kube-apiserver: fixed a bug that could cause a goroutine leak if the apiserver encountered an encoding error serving a watch to a websocket watcher
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
