### PR TITLE
WIP: Provider/Azure: Enable HTTP headers in credential provider.

### DIFF
--- a/pkg/credentialprovider/azure/azure_acr_helper.go
+++ b/pkg/credentialprovider/azure/azure_acr_helper.go
@@ -73,6 +73,9 @@ const userAgent = "kubernetes-credentialprovider-acr"
 
 const dockerTokenLoginUsernameGUID = "00000000-0000-0000-0000-000000000000"
 
+const metadataSourceClient = "X-Meta-Source-Client"
+const azureKubeletHTTPHeaderValue = "azure/kubelet"
+
 var client = &http.Client{}
 
 func receiveChallengeFromLoginServer(serverAddress string) (*authDirective, error) {

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -200,6 +200,7 @@ func (a *acrProvider) Provide(image string) credentialprovider.DockerConfig {
 				Username: a.config.AADClientID,
 				Password: a.config.AADClientSecret,
 				Email:    dummyRegistryEmail,
+				HttpHeaders: map[string]string{metadataSourceClient: azureKubeletHTTPHeaderValue},
 			}
 			cfg[url] = *cred
 		}
@@ -246,6 +247,7 @@ func getACRDockerEntryFromARMToken(a *acrProvider, loginServer string) (*credent
 		Username: dockerTokenLoginUsernameGUID,
 		Password: registryRefreshToken,
 		Email:    dummyRegistryEmail,
+		HttpHeaders: map[string]string{metadataSourceClient: azureKubeletHTTPHeaderValue},
 	}, nil
 }
 

--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -54,6 +54,9 @@ type DockerConfigEntry struct {
 	Password string
 	Email    string
 	Provider DockerConfigProvider
+
+	// +optional
+	HttpHeaders map[string]string `json:"HttpHeaders,omitempty"`
 }
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
>/kind feature
> /kind flake

/kind feature

**What this PR does / why we need it**:

Provider/Azure: Enable HTTP headers in credential provider so that the Azure Container Registry could 
track the source services and agents from which ACR is used.

Ref: https://github.com/kubernetes/kubernetes/issues/78893

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
