### PR TITLE
Fix golint issues in pkg/kubeapiserver

### DIFF
--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -429,7 +429,7 @@ func buildGenericConfig(
 	genericConfig.Version = &kubeVersion
 
 	storageFactoryConfig := kubeapiserver.NewStorageFactoryConfig()
-	storageFactoryConfig.ApiResourceConfig = genericConfig.MergedResourceConfig
+	storageFactoryConfig.APIResourceConfig = genericConfig.MergedResourceConfig
 	completedStorageFactoryConfig, err := storageFactoryConfig.Complete(s.Etcd)
 	if err != nil {
 		lastErr = err

--- a/pkg/kubeapiserver/default_storage_factory_builder.go
+++ b/pkg/kubeapiserver/default_storage_factory_builder.go
@@ -51,6 +51,7 @@ var SpecialDefaultResourcePrefixes = map[schema.GroupResource]string{
 	{Group: "policy", Resource: "podsecuritypolicies"}:     "podsecuritypolicy",
 }
 
+// NewStorageFactoryConfig returns a new StorageFactoryConfig set up with necessary resource overrides.
 func NewStorageFactoryConfig() *StorageFactoryConfig {
 
 	resources := []schema.GroupVersionResource{
@@ -73,9 +74,10 @@ func NewStorageFactoryConfig() *StorageFactoryConfig {
 	}
 }
 
+// StorageFactoryConfig is a configuration for creating storage factory.
 type StorageFactoryConfig struct {
 	StorageConfig                    storagebackend.Config
-	ApiResourceConfig                *serverstorage.ResourceConfig
+	APIResourceConfig                *serverstorage.ResourceConfig
 	DefaultResourceEncoding          *serverstorage.DefaultResourceEncodingConfig
 	DefaultStorageMediaType          string
 	Serializer                       runtime.StorageSerializer
@@ -84,6 +86,7 @@ type StorageFactoryConfig struct {
 	EncryptionProviderConfigFilepath string
 }
 
+// Complete completes the StorageFactoryConfig with provided etcdOptions returning completedStorageFactoryConfig.
 func (c *StorageFactoryConfig) Complete(etcdOptions *serveroptions.EtcdOptions) (*completedStorageFactoryConfig, error) {
 	c.StorageConfig = etcdOptions.StorageConfig
 	c.DefaultStorageMediaType = etcdOptions.DefaultStorageMediaType
@@ -92,10 +95,15 @@ func (c *StorageFactoryConfig) Complete(etcdOptions *serveroptions.EtcdOptions) 
 	return &completedStorageFactoryConfig{c}, nil
 }
 
+// completedStorageFactoryConfig is a wrapper around StorageFactoryConfig completed with etcd options.
+//
+// Note: this struct is intentionally unexported so that it can only be constructed via a StorageFactoryConfig.Complete
+// call. The implied consequence is that this does not comply with golint.
 type completedStorageFactoryConfig struct {
 	*StorageFactoryConfig
 }
 
+// New returns a new storage factory created from the completed storage factory configuration.
 func (c *completedStorageFactoryConfig) New() (*serverstorage.DefaultStorageFactory, error) {
 	resourceEncodingConfig := resourceconfig.MergeResourceEncodingConfigs(c.DefaultResourceEncoding, c.ResourceEncodingOverrides)
 	storageFactory := serverstorage.NewDefaultStorageFactory(
@@ -103,7 +111,7 @@ func (c *completedStorageFactoryConfig) New() (*serverstorage.DefaultStorageFact
 		c.DefaultStorageMediaType,
 		c.Serializer,
 		resourceEncodingConfig,
-		c.ApiResourceConfig,
+		c.APIResourceConfig,
 		SpecialDefaultResourcePrefixes)
 
 	storageFactory.AddCohabitatingResources(networking.Resource("networkpolicies"), extensions.Resource("networkpolicies"))

--- a/pkg/kubeapiserver/doc.go
+++ b/pkg/kubeapiserver/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// The kubeapiserver package holds code that is common to both the kube-apiserver
+// Package kubeapiserver holds code that is common to both the kube-apiserver
 // and the federation-apiserver, but isn't part of a generic API server.
 // For instance, the non-delegated authorization options are used by those two
 // servers, but no generic API server is likely to use them.

--- a/pkg/registry/registrytest/etcd.go
+++ b/pkg/registry/registrytest/etcd.go
@@ -44,7 +44,7 @@ func NewEtcdStorageForResource(t *testing.T, resource schema.GroupResource) (*st
 	if err != nil {
 		t.Fatal(err)
 	}
-	completedConfig.ApiResourceConfig = serverstorage.NewResourceConfig()
+	completedConfig.APIResourceConfig = serverstorage.NewResourceConfig()
 	factory, err := completedConfig.New()
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -278,7 +278,7 @@ func NewMasterConfigWithOptions(opts *MasterConfigOptions) *master.Config {
 	}
 
 	storageConfig := kubeapiserver.NewStorageFactoryConfig()
-	storageConfig.ApiResourceConfig = serverstorage.NewResourceConfig()
+	storageConfig.APIResourceConfig = serverstorage.NewResourceConfig()
 	completedStorageConfig, err := storageConfig.Complete(etcdOptions)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR fixes golint issues in `pkg/kubeapiserver`.

**Which issue(s) this PR fixes**:

Part of #68026

**Special notes for your reviewer**:

~~I made `CompletedStorageFactoryConfig` exported due to golint complain `exported method Complete returns unexported type *kubeapiserver.completedStorageFactoryConfig, which can be annoying to use`.~~

Note: the `pkg/kubeapiserver` is still in `.golint_failures` list due to the error: `pkg/kubeapiserver/default_storage_factory_builder.go:90:82: exported method Complete returns unexported type *kubeapiserver.completedStorageFactoryConfig, which can be annoying to use`, which is intentional. I've added the justifying comment to the structure.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

---

/priority backlog
/area code-organization
/area apiserver
/sig api-machinery
