### PR TITLE
Set user agent for e2e consistently

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -160,14 +160,6 @@ func (f *Framework) BeforeEach() {
 		ginkgo.By("Creating a kubernetes client")
 		config, err := LoadConfig()
 		ExpectNoError(err)
-		testDesc := ginkgo.CurrentGinkgoTestDescription()
-		if len(testDesc.ComponentTexts) > 0 {
-			componentTexts := strings.Join(testDesc.ComponentTexts, " ")
-			config.UserAgent = fmt.Sprintf(
-				"%v -- %v",
-				rest.DefaultKubernetesUserAgent(),
-				componentTexts)
-		}
 
 		config.QPS = f.Options.ClientQPS
 		config.Burst = f.Options.ClientBurst


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Moves the useragent computation into framework.LoadConfig(), so that requests made by clients created within individual tests are accurately attributed.

**Which issue(s) this PR fixes**:
xref https://github.com/cncf/apisnoop/issues/271

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @hh 