### PR TITLE
fix apiserver to advertise IPv6 endpoints if bound to IPv6

### DIFF
--- a/cmd/kubeadm/app/util/config/common.go
+++ b/cmd/kubeadm/app/util/config/common.go
@@ -139,10 +139,10 @@ func VerifyAPIServerBindAddress(address string) error {
 	return nil
 }
 
-// ChooseAPIServerBindAddress is a wrapper for netutil.ChooseBindAddress that also handles
+// ChooseAPIServerBindAddress is a wrapper for netutil.ResolveBindAddress that also handles
 // the case where no default routes were found and an IP for the API server could not be obtained.
 func ChooseAPIServerBindAddress(bindAddress net.IP) (net.IP, error) {
-	ip, err := netutil.ChooseBindAddress(bindAddress)
+	ip, err := netutil.ResolveBindAddress(bindAddress)
 	if err != nil {
 		if netutil.IsNoRoutesError(err) {
 			klog.Warningf("WARNING: could not obtain a bind address for the API Server: %v; using: %s", err, constants.DefaultAPIServerBindAddress)

--- a/pkg/kubeapiserver/options/serving.go
+++ b/pkg/kubeapiserver/options/serving.go
@@ -60,7 +60,7 @@ func DefaultAdvertiseAddress(s *genericoptions.ServerRunOptions, insecure *gener
 	}
 
 	if s.AdvertiseAddress == nil || s.AdvertiseAddress.IsUnspecified() {
-		hostIP, err := utilnet.ChooseBindAddress(insecure.BindAddress)
+		hostIP, err := utilnet.ResolveBindAddress(insecure.BindAddress)
 		if err != nil {
 			return fmt.Errorf("unable to find suitable network address.error='%v'. "+
 				"Try to set the AdvertiseAddress directly or provide a valid BindAddress to fix this", err)

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/interface.go
@@ -36,6 +36,13 @@ const (
 	familyIPv6 AddressFamily = 6
 )
 
+type AddressFamilyPreference []AddressFamily
+
+var (
+	preferIPv4 = AddressFamilyPreference{familyIPv4, familyIPv6}
+	preferIPv6 = AddressFamilyPreference{familyIPv6, familyIPv4}
+)
+
 const (
 	// LoopbackInterfaceName is the default name of the loopback interface
 	LoopbackInterfaceName = "lo"
@@ -58,7 +65,7 @@ type RouteFile struct {
 	parse func(input io.Reader) ([]Route, error)
 }
 
-// noRoutesError can be returned by ChooseBindAddress() in case of no routes
+// noRoutesError can be returned in case of no routes
 type noRoutesError struct {
 	message string
 }
@@ -259,7 +266,7 @@ func getIPFromInterface(intfName string, forFamily AddressFamily, nw networkInte
 	return nil, nil
 }
 
-// memberOF tells if the IP is of the desired family. Used for checking interface addresses.
+// memberOf tells if the IP is of the desired family. Used for checking interface addresses.
 func memberOf(ip net.IP, family AddressFamily) bool {
 	if ip.To4() != nil {
 		return family == familyIPv4
@@ -270,8 +277,8 @@ func memberOf(ip net.IP, family AddressFamily) bool {
 
 // chooseIPFromHostInterfaces looks at all system interfaces, trying to find one that is up that
 // has a global unicast address (non-loopback, non-link local, non-point2point), and returns the IP.
-// Searches for IPv4 addresses, and then IPv6 addresses.
-func chooseIPFromHostInterfaces(nw networkInterfacer) (net.IP, error) {
+// addressFamilies determines whether it prefers IPv4 or IPv6
+func chooseIPFromHostInterfaces(nw networkInterfacer, addressFamilies AddressFamilyPreference) (net.IP, error) {
 	intfs, err := nw.Interfaces()
 	if err != nil {
 		return nil, err
@@ -279,7 +286,7 @@ func chooseIPFromHostInterfaces(nw networkInterfacer) (net.IP, error) {
 	if len(intfs) == 0 {
 		return nil, fmt.Errorf("no interfaces found on host.")
 	}
-	for _, family := range []AddressFamily{familyIPv4, familyIPv6} {
+	for _, family := range addressFamilies {
 		klog.V(4).Infof("Looking for system interface with a global IPv%d address", uint(family))
 		for _, intf := range intfs {
 			if !isInterfaceUp(&intf) {
@@ -326,15 +333,19 @@ func chooseIPFromHostInterfaces(nw networkInterfacer) (net.IP, error) {
 // IP of the interface with a gateway on it (with priority given to IPv4). For a node
 // with no internet connection, it returns error.
 func ChooseHostInterface() (net.IP, error) {
+	return chooseHostInterface(preferIPv4)
+}
+
+func chooseHostInterface(addressFamilies AddressFamilyPreference) (net.IP, error) {
 	var nw networkInterfacer = networkInterface{}
 	if _, err := os.Stat(ipv4RouteFile); os.IsNotExist(err) {
-		return chooseIPFromHostInterfaces(nw)
+		return chooseIPFromHostInterfaces(nw, addressFamilies)
 	}
 	routes, err := getAllDefaultRoutes()
 	if err != nil {
 		return nil, err
 	}
-	return chooseHostInterfaceFromRoute(routes, nw)
+	return chooseHostInterfaceFromRoute(routes, nw, addressFamilies)
 }
 
 // networkInterfacer defines an interface for several net library functions. Production
@@ -382,10 +393,10 @@ func getAllDefaultRoutes() ([]Route, error) {
 }
 
 // chooseHostInterfaceFromRoute cycles through each default route provided, looking for a
-// global IP address from the interface for the route. Will first look all each IPv4 route for
-// an IPv4 IP, and then will look at each IPv6 route for an IPv6 IP.
-func chooseHostInterfaceFromRoute(routes []Route, nw networkInterfacer) (net.IP, error) {
-	for _, family := range []AddressFamily{familyIPv4, familyIPv6} {
+// global IP address from the interface for the route. addressFamilies determines whether it
+// prefers IPv4 or IPv6
+func chooseHostInterfaceFromRoute(routes []Route, nw networkInterfacer, addressFamilies AddressFamilyPreference) (net.IP, error) {
+	for _, family := range addressFamilies {
 		klog.V(4).Infof("Looking for default routes with IPv%d addresses", uint(family))
 		for _, route := range routes {
 			if route.Family != family {
@@ -406,12 +417,19 @@ func chooseHostInterfaceFromRoute(routes []Route, nw networkInterfacer) (net.IP,
 	return nil, fmt.Errorf("unable to select an IP from default routes.")
 }
 
-// If bind-address is usable, return it directly
-// If bind-address is not usable (unset, 0.0.0.0, or loopback), we will use the host's default
-// interface.
-func ChooseBindAddress(bindAddress net.IP) (net.IP, error) {
+// ResolveBindAddress returns the IP address of a daemon, based on the given bindAddress:
+// If bindAddress is unset, it returns the host's default IP, as with ChooseHostInterface().
+// If bindAddress is unspecified or loopback, it returns the default IP of the same
+// address family as bindAddress.
+// Otherwise, it just returns bindAddress.
+func ResolveBindAddress(bindAddress net.IP) (net.IP, error) {
+	addressFamilies := preferIPv4
+	if bindAddress != nil && memberOf(bindAddress, familyIPv6) {
+		addressFamilies = preferIPv6
+	}
+
 	if bindAddress == nil || bindAddress.IsUnspecified() || bindAddress.IsLoopback() {
-		hostIP, err := ChooseHostInterface()
+		hostIP, err := chooseHostInterface(addressFamilies)
 		if err != nil {
 			return nil, err
 		}
@@ -426,7 +444,7 @@ func ChooseBindAddress(bindAddress net.IP) (net.IP, error) {
 // e.g when using BGP to announce a host IP over link-local ip addresses and this ip address is attached to the lo interface.
 func ChooseBindAddressForInterface(intfName string) (net.IP, error) {
 	var nw networkInterfacer = networkInterface{}
-	for _, family := range []AddressFamily{familyIPv4, familyIPv6} {
+	for _, family := range preferIPv4 {
 		ip, err := getIPFromInterface(intfName, family, nw)
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -109,10 +109,10 @@ func NewSecureServingOptions() *SecureServingOptions {
 }
 
 func (s *SecureServingOptions) DefaultExternalAddress() (net.IP, error) {
-	if !s.ExternalAddress.IsUnspecified() {
+	if s.ExternalAddress != nil && !s.ExternalAddress.IsUnspecified() {
 		return s.ExternalAddress, nil
 	}
-	return utilnet.ChooseBindAddress(s.BindAddress)
+	return utilnet.ResolveBindAddress(s.BindAddress)
 }
 
 func (s *SecureServingOptions) Validate() []error {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
If you run `kube-apiserver --bind-address ::` on a machine with both an IPv4 address and an IPv6 address, it will bind to all interfaces and then advertise the IPv4 address in the `kubernetes.default` Endpoints, exactly like it would have if you had said `kube-apiserver --bind-address 127.0.0.1`. You can't get it to advertise its IPv6 address without explicitly passing `--advertise-address`, and in that case you have to figure it out yourself (which in turn means that you need a host-specific config file).

This fixes `utilnet.ChooseBindAddress()` to respect the address family of the passed-in address and try to return another address of the same family. Within k/k, `ChooseBindAddress` is only used by kube-apiserver (and by kubeadm for creating the kube-apiserver config). I'm not sure if things in other repos use that function and depend on the current blatantly-IPv4-biased behavior.

Beyond the `ChooseBindAddress` fix, this also fixes another apiserver-specific bug, which is that if you didn't explicitly specify an advertise address, it would always autodetect it based on the insecure bind address rather than the secure bind address, because the secure config code wasn't checking if `s.ExternalAddress` was nil (and `IsUnspecified()` returns `false` for a nil IP, so `SecureServingOptions.DefaultExternalAddress()` would end up returning nil, so it would fall back to figuring out the advertise address from the insecure options instead.)

**Which issue(s) this PR fixes**:
Fixes #72404

**Special notes for your reviewer**:
I tried to minimize the changes to `k8s.io/apimachinery/pkg/util/net/interface.go` rather than rewriting it in the nicest possible way...

**Does this PR introduce a user-facing change?**:
```release-note
If given an IPv6 bind-address, kube-apiserver will now advertise an IPv6 endpoint for the kubernetes.default service.
```

/sig network
/area ipv6
cc @khenidak @aojea (not sure who else might have opinions here?)