### PR TITLE
Promote PodDisruptionBudget e2e test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -698,6 +698,13 @@
     MUST succeed. It MUST succeed when deleting the Deployment.
   release: v1.20
   file: test/e2e/apps/deployment.go
+- testname: 'PodDisruptionBudget: Status updates'
+  codename: '[sig-apps] DisruptionController should observe PodDisruptionBudget status
+    updated [Conformance]'
+  description: Disruption controller MUST update the PDB status with how many disruptions
+    are allowed.
+  release: v1.21
+  file: test/e2e/apps/disruption.go
 - testname: Jobs, orphan pods, re-adoption
   codename: '[sig-apps] Job should adopt matching orphans and release non-matching
     pods [Conformance]'

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -95,7 +95,13 @@ var _ = SIGDescribe("DisruptionController", func() {
 		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromString("1%"), defaultLabels)
 	})
 
-	ginkgo.It("should observe PodDisruptionBudget status updated", func() {
+	/*
+	   Release : v1.21
+	   Testname: PodDisruptionBudget: Status updates
+	   Description: Disruption controller MUST update the PDB status with
+	   how many disruptions are allowed.
+	*/
+	framework.ConformanceIt("should observe PodDisruptionBudget status updated", func() {
 		createPDBMinAvailableOrDie(cs, ns, defaultName, intstr.FromInt(1), defaultLabels)
 
 		createPodsOrDie(cs, ns, 3)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

PDBs are graduating to GA (https://github.com/kubernetes/kubernetes/pull/99290). We need conformance tests for GA.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
Must merge after https://github.com/kubernetes/kubernetes/pull/99290

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
KEP: https://github.com/kubernetes/enhancements/pull/904
/area conformance
@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-apps-pr-reviews @kubernetes/cncf-conformance-wg

/cc @liggitt @johnbelamaric 
/priority important-soon