### PR TITLE
Utilize runtime cache when cleaning up orphaned pod dirs

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1035,20 +1035,14 @@ func (kl *Kubelet) HandlePodCleanups() error {
 
 	kl.removeOrphanedPodStatuses(allPods, mirrorPods)
 	// Note that we just killed the unwanted pods. This may not have reflected
-	// in the cache. We need to bypass the cache to get the latest set of
-	// running pods to clean up the volumes.
-	// TODO: Evaluate the performance impact of bypassing the runtime cache.
-	runningPods, err = kl.containerRuntime.GetPods(false)
-	if err != nil {
-		klog.Errorf("Error listing containers: %#v", err)
-		return err
-	}
+	// in the cache. Getting the latest set of running pods to clean up the volumes,
+	// considering the desired Pods as well.
 
 	// Remove any orphaned volumes.
 	// Note that we pass all pods (including terminated pods) to the function,
 	// so that we don't remove volumes associated with terminated but not yet
 	// deleted pods.
-	err = kl.cleanupOrphanedPodDirs(allPods, runningPods)
+	err = kl.cleanupOrphanedPodDirs(allPods, runningPods, desiredPods)
 	if err != nil {
 		// We want all cleanup tasks to be run even if one of them failed. So
 		// we just log an error here and continue other cleanup tasks.

--- a/pkg/kubelet/kubelet_volumes.go
+++ b/pkg/kubelet/kubelet_volumes.go
@@ -91,13 +91,17 @@ func (kl *Kubelet) newVolumeMounterFromPlugins(spec *volume.Spec, pod *v1.Pod, o
 
 // cleanupOrphanedPodDirs removes the volumes of pods that should not be
 // running and that have no containers running.  Note that we roll up logs here since it runs in the main loop.
-func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*v1.Pod, runningPods []*kubecontainer.Pod) error {
+func (kl *Kubelet) cleanupOrphanedPodDirs(pods []*v1.Pod, runningPods []*kubecontainer.Pod, desiredPods map[types.UID]sets.Empty) error {
 	allPods := sets.NewString()
 	for _, pod := range pods {
 		allPods.Insert(string(pod.UID))
 	}
 	for _, pod := range runningPods {
 		allPods.Insert(string(pod.ID))
+	}
+	for uid := range desiredPods {
+		// if the Pod is not in desiredPods, it should be in the process of being killed
+		allPods.Insert(string(uid))
 	}
 
 	found, err := kl.listPodsFromDisk()

--- a/pkg/kubelet/kubelet_volumes_linux_test.go
+++ b/pkg/kubelet/kubelet_volumes_linux_test.go
@@ -27,6 +27,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 )
@@ -137,7 +139,7 @@ func TestCleanupOrphanedPodDirs(t *testing.T) {
 				}
 			}
 
-			err := kubelet.cleanupOrphanedPodDirs(tc.pods, nil)
+			err := kubelet.cleanupOrphanedPodDirs(tc.pods, nil, map[types.UID]sets.Empty{})
 			if tc.expectErr && err == nil {
 				t.Errorf("%s failed: expected error, got success", name)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In Kubelet#HandlePodCleanups, we call containerRuntime.GetPods because runtime cache hasn't reflected recent pod killings.

Since the selection of pods to kill is based on desiredPods, we don't need to call containerRuntime.GetPods.
Instead, we utilize desiredPods to establish the allPods set.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
