### PR TITLE
Revert "Make writing file via container in tests sync for real this time by enclosing multiple commands in quotes"

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -478,7 +478,7 @@ func (f *Framework) WriteFileViaContainer(podName, containerName string, path st
 			return fmt.Errorf("Unsupported character in string to write: %v", c)
 		}
 	}
-	command := fmt.Sprintf("\"echo '%s' > '%s'; sync\"", contents, path)
+	command := fmt.Sprintf("echo '%s' > '%s'; sync", contents, path)
 	stdout, stderr, err := kubectlExecWithRetry(f.Namespace.Name, podName, containerName, "--", "/bin/sh", "-c", command)
 	if err != nil {
 		Logf("error running kubectl exec to write file: %v\nstdout=%v\nstderr=%v)", err, string(stdout), string(stderr))


### PR DESCRIPTION
Reverts kubernetes/kubernetes#84656

due to failing tests:
https://github.com/kubernetes/kubernetes/issues/84691
https://github.com/kubernetes/kubernetes/issues/84675

/assign @msau42 