### PR TITLE
Refactor mapper/unmapper of block volume

### DIFF
--- a/pkg/kubelet/kubelet_volumes_test.go
+++ b/pkg/kubelet/kubelet_volumes_test.go
@@ -555,10 +555,14 @@ func (f *stubBlockVolume) SetUpDevice() (string, error) {
 	return "", nil
 }
 
-func (f stubBlockVolume) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
+func (f stubBlockVolume) MapPodDevice() error {
 	return nil
 }
 
 func (f *stubBlockVolume) TearDownDevice(mapPath string, devicePath string) error {
+	return nil
+}
+
+func (f *stubBlockVolume) UnmapPodDevice() error {
 	return nil
 }

--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -527,7 +527,7 @@ func Test_Run_Positive_VolumeAttachAndMap(t *testing.T) {
 		1 /* expectedAttachCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))
@@ -631,7 +631,7 @@ func Test_Run_Positive_BlockVolumeMapControllerAttachEnabled(t *testing.T) {
 	assert.NoError(t, volumetesting.VerifyZeroAttachCalls(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))
@@ -731,7 +731,7 @@ func Test_Run_Positive_BlockVolumeAttachMapUnmapDetach(t *testing.T) {
 		1 /* expectedAttachCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))
@@ -847,7 +847,7 @@ func Test_Run_Positive_VolumeUnmapControllerAttachEnabled(t *testing.T) {
 	assert.NoError(t, volumetesting.VerifyZeroAttachCalls(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyWaitForAttachCallCount(
 		1 /* expectedWaitForAttachCallCount */, fakePlugin))
-	assert.NoError(t, volumetesting.VerifyGetMapDeviceCallCount(
+	assert.NoError(t, volumetesting.VerifyGetMapPodDeviceCallCount(
 		1 /* expectedGetMapDeviceCallCount */, fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin))
 	assert.NoError(t, volumetesting.VerifyZeroDetachCallCount(fakePlugin))

--- a/pkg/volume/awsebs/aws_ebs_block.go
+++ b/pkg/volume/awsebs/aws_ebs_block.go
@@ -125,10 +125,6 @@ func (plugin *awsElasticBlockStorePlugin) newUnmapperInternal(volName string, po
 		}}, nil
 }
 
-func (c *awsElasticBlockStoreUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type awsElasticBlockStoreUnmapper struct {
 	*awsElasticBlockStore
 }
@@ -141,14 +137,6 @@ type awsElasticBlockStoreMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &awsElasticBlockStoreMapper{}
-
-func (b *awsElasticBlockStoreMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *awsElasticBlockStoreMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/volumeID

--- a/pkg/volume/azure_dd/azure_dd_block.go
+++ b/pkg/volume/azure_dd/azure_dd_block.go
@@ -118,10 +118,6 @@ func (plugin *azureDataDiskPlugin) newUnmapperInternal(volName string, podUID ty
 	return &azureDataDiskUnmapper{dataDisk: disk}, nil
 }
 
-func (c *azureDataDiskUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type azureDataDiskUnmapper struct {
 	*dataDisk
 }
@@ -134,14 +130,6 @@ type azureDataDiskMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &azureDataDiskMapper{}
-
-func (b *azureDataDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *azureDataDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/volumeID

--- a/pkg/volume/cinder/cinder_block.go
+++ b/pkg/volume/cinder/cinder_block.go
@@ -128,10 +128,6 @@ func (plugin *cinderPlugin) newUnmapperInternal(volName string, podUID types.UID
 		}}, nil
 }
 
-func (c *cinderPluginUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type cinderPluginUnmapper struct {
 	*cinderVolume
 }
@@ -144,14 +140,6 @@ type cinderVolumeMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &cinderVolumeMapper{}
-
-func (b *cinderVolumeMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *cinderVolumeMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/volumeID

--- a/pkg/volume/fc/fc.go
+++ b/pkg/volume/fc/fc.go
@@ -414,20 +414,13 @@ type fcDiskMapper struct {
 
 var _ volume.BlockVolumeMapper = &fcDiskMapper{}
 
-func (b *fcDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *fcDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
-}
-
 type fcDiskUnmapper struct {
 	*fcDisk
 	deviceUtil util.DeviceUtil
 }
 
 var _ volume.BlockVolumeUnmapper = &fcDiskUnmapper{}
+var _ volume.CustomBlockVolumeUnmapper = &fcDiskUnmapper{}
 
 func (c *fcDiskUnmapper) TearDownDevice(mapPath, devicePath string) error {
 	err := c.manager.DetachBlockFCDisk(*c, mapPath, devicePath)
@@ -439,6 +432,10 @@ func (c *fcDiskUnmapper) TearDownDevice(mapPath, devicePath string) error {
 		return fmt.Errorf("fc: failed to delete the directory: %s\nError: %v", mapPath, err)
 	}
 	klog.V(4).Infof("fc: successfully detached disk: %s", mapPath)
+	return nil
+}
+
+func (c *fcDiskUnmapper) UnmapPodDevice() error {
 	return nil
 }
 

--- a/pkg/volume/gcepd/gce_pd_block.go
+++ b/pkg/volume/gcepd/gce_pd_block.go
@@ -135,10 +135,6 @@ func (plugin *gcePersistentDiskPlugin) newUnmapperInternal(volName string, podUI
 		}}, nil
 }
 
-func (c *gcePersistentDiskUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
-}
-
 type gcePersistentDiskUnmapper struct {
 	*gcePersistentDisk
 }
@@ -151,14 +147,6 @@ type gcePersistentDiskMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &gcePersistentDiskMapper{}
-
-func (b *gcePersistentDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *gcePersistentDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
-}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/pdName

--- a/pkg/volume/iscsi/iscsi.go
+++ b/pkg/volume/iscsi/iscsi.go
@@ -384,14 +384,6 @@ type iscsiDiskMapper struct {
 
 var _ volume.BlockVolumeMapper = &iscsiDiskMapper{}
 
-func (b *iscsiDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (b *iscsiDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
-}
-
 type iscsiDiskUnmapper struct {
 	*iscsiDisk
 	exec       utilexec.Interface
@@ -399,6 +391,7 @@ type iscsiDiskUnmapper struct {
 }
 
 var _ volume.BlockVolumeUnmapper = &iscsiDiskUnmapper{}
+var _ volume.CustomBlockVolumeUnmapper = &iscsiDiskUnmapper{}
 
 // Even though iSCSI plugin has attacher/detacher implementation, iSCSI plugin
 // needs volume detach operation during TearDownDevice(). This method is only
@@ -414,6 +407,10 @@ func (c *iscsiDiskUnmapper) TearDownDevice(mapPath, _ string) error {
 		return fmt.Errorf("iscsi: failed to delete the directory: %s\nError: %v", mapPath, err)
 	}
 	klog.V(4).Infof("iscsi: successfully detached disk: %s", mapPath)
+	return nil
+}
+
+func (c *iscsiDiskUnmapper) UnmapPodDevice() error {
 	return nil
 }
 

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -612,16 +612,18 @@ type localVolumeMapper struct {
 }
 
 var _ volume.BlockVolumeMapper = &localVolumeMapper{}
+var _ volume.CustomBlockVolumeMapper = &localVolumeMapper{}
 
-// SetUpDevice provides physical device path for the local PV.
-func (m *localVolumeMapper) SetUpDevice() (string, error) {
-	globalPath := util.MakeAbsolutePath(runtime.GOOS, m.globalPath)
-	klog.V(4).Infof("SetupDevice returning path %s", globalPath)
-	return globalPath, nil
+// SetUpDevice prepares the volume to the node by the plugin specific way.
+func (m *localVolumeMapper) SetUpDevice() error {
+	return nil
 }
 
-func (m *localVolumeMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
+// SetUpDevice provides physical device path for the local PV.
+func (m *localVolumeMapper) MapPodDevice() (string, error) {
+	globalPath := util.MakeAbsolutePath(runtime.GOOS, m.globalPath)
+	klog.V(4).Infof("MapPodDevice returning path %s", globalPath)
+	return globalPath, nil
 }
 
 // localVolumeUnmapper implements the BlockVolumeUnmapper interface for local volumes.
@@ -630,12 +632,6 @@ type localVolumeUnmapper struct {
 }
 
 var _ volume.BlockVolumeUnmapper = &localVolumeUnmapper{}
-
-// TearDownDevice will undo SetUpDevice procedure. In local PV, all of this already handled by operation_generator.
-func (u *localVolumeUnmapper) TearDownDevice(mapPath, _ string) error {
-	klog.V(4).Infof("local: TearDownDevice completed for: %s", mapPath)
-	return nil
-}
 
 // GetGlobalMapPath returns global map path and error.
 // path: plugins/kubernetes.io/kubernetes.io/local-volume/volumeDevices/{volumeName}

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -619,7 +619,7 @@ func (m *localVolumeMapper) SetUpDevice() error {
 	return nil
 }
 
-// SetUpDevice provides physical device path for the local PV.
+// MapPodDevice provides physical device path for the local PV.
 func (m *localVolumeMapper) MapPodDevice() (string, error) {
 	globalPath := util.MakeAbsolutePath(runtime.GOOS, m.globalPath)
 	klog.V(4).Infof("MapPodDevice returning path %s", globalPath)

--- a/pkg/volume/local/local_test.go
+++ b/pkg/volume/local/local_test.go
@@ -372,9 +372,17 @@ func TestMapUnmap(t *testing.T) {
 	if volName != testPVName {
 		t.Errorf("Got unexpected volNamne: %s, expected %s", volName, testPVName)
 	}
-	devPath, err := mapper.SetUpDevice()
-	if err != nil {
-		t.Errorf("Failed to SetUpDevice, err: %v", err)
+	var devPath string
+
+	if customMapper, ok := mapper.(volume.CustomBlockVolumeMapper); ok {
+		err = customMapper.SetUpDevice()
+		if err != nil {
+			t.Errorf("Failed to SetUpDevice, err: %v", err)
+		}
+		devPath, err = customMapper.MapPodDevice()
+		if err != nil {
+			t.Errorf("Failed to MapPodDevice, err: %v", err)
+		}
 	}
 
 	if _, err := os.Stat(devPath); err != nil {
@@ -393,8 +401,14 @@ func TestMapUnmap(t *testing.T) {
 		t.Fatalf("Got a nil Unmapper")
 	}
 
-	if err := unmapper.TearDownDevice(globalPath, devPath); err != nil {
-		t.Errorf("TearDownDevice failed, err: %v", err)
+	if customUnmapper, ok := unmapper.(volume.CustomBlockVolumeUnmapper); ok {
+		if err := customUnmapper.UnmapPodDevice(); err != nil {
+			t.Errorf("UnmapPodDevice failed, err: %v", err)
+		}
+
+		if err := customUnmapper.TearDownDevice(globalPath, devPath); err != nil {
+			t.Errorf("TearDownDevice failed, err: %v", err)
+		}
 	}
 }
 

--- a/pkg/volume/rbd/rbd.go
+++ b/pkg/volume/rbd/rbd.go
@@ -898,6 +898,7 @@ type rbdDiskMapper struct {
 }
 
 var _ volume.BlockVolumeUnmapper = &rbdDiskUnmapper{}
+var _ volume.CustomBlockVolumeUnmapper = &rbdDiskUnmapper{}
 
 // GetGlobalMapPath returns global map path and error
 // path: plugins/kubernetes.io/{PluginName}/volumeDevices/{rbd pool}-image-{rbd image-name}/{podUid}
@@ -910,14 +911,6 @@ func (rbd *rbd) GetGlobalMapPath(spec *volume.Spec) (string, error) {
 // volumeName: pv0001
 func (rbd *rbd) GetPodDeviceMapPath() (string, string) {
 	return rbd.rbdPodDeviceMapPath()
-}
-
-func (rbd *rbdDiskMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (rbd *rbdDiskMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
 }
 
 func (rbd *rbd) rbdGlobalMapPath(spec *volume.Spec) (string, error) {
@@ -1000,6 +993,10 @@ func (rbd *rbdDiskUnmapper) TearDownDevice(mapPath, _ string) error {
 	}
 	klog.V(4).Infof("rbd: successfully detached disk: %s", mapPath)
 
+	return nil
+}
+
+func (rbd *rbdDiskUnmapper) UnmapPodDevice() error {
 	return nil
 }
 

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -804,7 +804,8 @@ type FakeVolume struct {
 	GetDeviceMountPathCallCount int
 	SetUpDeviceCallCount        int
 	TearDownDeviceCallCount     int
-	MapDeviceCallCount          int
+	MapPodDeviceCallCount       int
+	UnmapPodDeviceCallCount     int
 	GlobalMapPathCallCount      int
 	PodDeviceMapPathCallCount   int
 }
@@ -880,11 +881,11 @@ func (fv *FakeVolume) TearDownAt(dir string) error {
 }
 
 // Block volume support
-func (fv *FakeVolume) SetUpDevice() (string, error) {
+func (fv *FakeVolume) SetUpDevice() error {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.SetUpDeviceCallCount++
-	return "", nil
+	return nil
 }
 
 // Block volume support
@@ -950,18 +951,33 @@ func (fv *FakeVolume) GetTearDownDeviceCallCount() int {
 }
 
 // Block volume support
-func (fv *FakeVolume) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, pod types.UID) error {
+func (fv *FakeVolume) UnmapPodDevice() error {
 	fv.Lock()
 	defer fv.Unlock()
-	fv.MapDeviceCallCount++
+	fv.UnmapPodDeviceCallCount++
 	return nil
 }
 
 // Block volume support
-func (fv *FakeVolume) GetMapDeviceCallCount() int {
+func (fv *FakeVolume) GetUnmapPodDeviceCallCount() int {
 	fv.RLock()
 	defer fv.RUnlock()
-	return fv.MapDeviceCallCount
+	return fv.UnmapPodDeviceCallCount
+}
+
+// Block volume support
+func (fv *FakeVolume) MapPodDevice() (string, error) {
+	fv.Lock()
+	defer fv.Unlock()
+	fv.MapPodDeviceCallCount++
+	return "", nil
+}
+
+// Block volume support
+func (fv *FakeVolume) GetMapPodDeviceCallCount() int {
+	fv.RLock()
+	defer fv.RUnlock()
+	return fv.MapPodDeviceCallCount
 }
 
 func (fv *FakeVolume) Attach(spec *Spec, nodeName types.NodeName) (string, error) {
@@ -1493,22 +1509,22 @@ func VerifyGetPodDeviceMapPathCallCount(
 		expectedPodDeviceMapPathCallCount)
 }
 
-// VerifyGetMapDeviceCallCount ensures that at least one of the Mappers for this
-// plugin has the expectedMapDeviceCallCount number of calls. Otherwise it
+// VerifyGetMapPodDeviceCallCount ensures that at least one of the Mappers for this
+// plugin has the expectedMapPodDeviceCallCount number of calls. Otherwise it
 // returns an error.
-func VerifyGetMapDeviceCallCount(
-	expectedMapDeviceCallCount int,
+func VerifyGetMapPodDeviceCallCount(
+	expectedMapPodDeviceCallCount int,
 	fakeVolumePlugin *FakeVolumePlugin) error {
 	for _, mapper := range fakeVolumePlugin.GetBlockVolumeMapper() {
-		actualCallCount := mapper.GetMapDeviceCallCount()
-		if actualCallCount >= expectedMapDeviceCallCount {
+		actualCallCount := mapper.GetMapPodDeviceCallCount()
+		if actualCallCount >= expectedMapPodDeviceCallCount {
 			return nil
 		}
 	}
 
 	return fmt.Errorf(
-		"No Mapper have expected MapdDeviceCallCount. Expected: <%v>.",
-		expectedMapDeviceCallCount)
+		"No Mapper have expected MapPodDeviceCallCount. Expected: <%v>.",
+		expectedMapPodDeviceCallCount)
 }
 
 // GetTestVolumePluginMgr creates, initializes, and returns a test volume plugin

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -252,7 +252,7 @@ func (v VolumePathHandler) IsSymlinkExist(mapPath string) (bool, error) {
 	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
 		return true, nil
 	}
-	// If file exits but it's not symbolic link, return fale and no error
+	// If file exits but it's not symbolic link, return false and no error
 	return false, nil
 }
 
@@ -274,7 +274,7 @@ func (v VolumePathHandler) IsDeviceBindMountExist(mapPath string) (bool, error) 
 	if fi.Mode()&os.ModeDevice == os.ModeDevice {
 		return true, nil
 	}
-	// If file exits but it's not device, return fale and no error
+	// If file exits but it's not device, return false and no error
 	return false, nil
 }
 

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -152,35 +152,43 @@ type Unmounter interface {
 	TearDownAt(dir string) error
 }
 
-// BlockVolumeMapper interface provides methods to set up/map the volume.
+// BlockVolumeMapper interface is a mapper interface for block volume.
 type BlockVolumeMapper interface {
 	BlockVolume
-	// SetUpDevice prepares the volume to a self-determined directory path,
-	// which may or may not exist yet and returns combination of physical
-	// device path of a block volume and error.
-	// If the plugin is non-attachable, it should prepare the device
-	// in /dev/ (or where appropriate) and return unique device path.
-	// Unique device path across kubelet node reboot is required to avoid
-	// unexpected block volume destruction.
-	// If the plugin is attachable, it should not do anything here,
-	// just return empty string for device path.
-	// Instead, attachable plugin have to return unique device path
-	// at attacher.Attach() and attacher.WaitForAttach().
-	// This may be called more than once, so implementations must be idempotent.
-	SetUpDevice() (string, error)
-
-	// Map maps the block device path for the specified spec and pod.
-	MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error
 }
 
-// BlockVolumeUnmapper interface provides methods to cleanup/unmap the volumes.
+// CustomBlockVolumeMapper interface provides custom methods to set up/map the volume.
+type CustomBlockVolumeMapper interface {
+	BlockVolumeMapper
+	// SetUpDevice prepares the volume to the node by the plugin specific way.
+	// For most in-tree plugins, attacher.Attach() and attacher.WaitForAttach()
+	// will do necessary works.
+	// This may be called more than once, so implementations must be idempotent.
+	SetUpDevice() error
+
+	// MapPodDevice maps the block device to a path and return the path.
+	// Unique device path across kubelet node reboot is required to avoid
+	// unexpected block volume destruction.
+	// If empty string is returned, the path retuned by attacher.Attach() and
+	// attacher.WaitForAttach() will be sued.
+	MapPodDevice() (string, error)
+}
+
+// BlockVolumeUnmapper interface is an unmapper interface for block volume.
 type BlockVolumeUnmapper interface {
 	BlockVolume
-	// TearDownDevice removes traces of the SetUpDevice procedure under
-	// a self-determined directory.
+}
+
+// CustomBlockVolumeUnmapper interface provides custom methods to cleanup/unmap the volumes.
+type CustomBlockVolumeUnmapper interface {
+	BlockVolumeUnmapper
+	// TearDownDevice removes traces of the SetUpDevice procedure.
 	// If the plugin is non-attachable, this method detaches the volume
 	// from a node.
 	TearDownDevice(mapPath string, devicePath string) error
+
+	// UnmapPodDevice removes traces of the MapPodDevice procedure.
+	UnmapPodDevice() error
 }
 
 // Provisioner is an interface that creates templates for PersistentVolumes

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -170,7 +170,7 @@ type CustomBlockVolumeMapper interface {
 	// Unique device path across kubelet node reboot is required to avoid
 	// unexpected block volume destruction.
 	// If empty string is returned, the path retuned by attacher.Attach() and
-	// attacher.WaitForAttach() will be sued.
+	// attacher.WaitForAttach() will be used.
 	MapPodDevice() (string, error)
 }
 

--- a/pkg/volume/vsphere_volume/vsphere_volume_block.go
+++ b/pkg/volume/vsphere_volume/vsphere_volume_block.go
@@ -132,22 +132,10 @@ type vsphereBlockVolumeMapper struct {
 	*vsphereVolume
 }
 
-func (v vsphereBlockVolumeMapper) SetUpDevice() (string, error) {
-	return "", nil
-}
-
-func (v vsphereBlockVolumeMapper) MapDevice(devicePath, globalMapPath, volumeMapPath, volumeMapName string, podUID types.UID) error {
-	return nil
-}
-
 var _ volume.BlockVolumeUnmapper = &vsphereBlockVolumeUnmapper{}
 
 type vsphereBlockVolumeUnmapper struct {
 	*vsphereVolume
-}
-
-func (v *vsphereBlockVolumeUnmapper) TearDownDevice(mapPath, devicePath string) error {
-	return nil
 }
 
 // GetGlobalMapPath returns global map path and error


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:


**Which issue(s) this PR fixes**:
This PR is a refactoring of mapper/unmapper of block volume.

There are two issues in the current implementation:
- Most plugins don't require plugin specific map/unmap but mapper/unmapper interface requires all plugins to implement their methods,
- Actual device path should decided on `MapPodDevice` not `SetUpDevice`, but path is returned on `SetUpDevice` 

This PR fix these issues with below changes:

- Add CustomBlockVolumeMapper and CustomBlockVolumeUnmapper interface
- Move SetUpDevice and MapPodDevice to CustomBlockVolumeMapper
- Move TearDownDevice and UnmapPodDevice to CustomBlockVolumeUnmapper
- Implement CustomBlockVolumeMapper only in local and csi plugin
- Implement CustomBlockVolumeUnmapper only in fc, iscsi, rbd, and csi plugin
- Change MapPodDevice to return path and SetUpDevice not to return path

**Special notes for your reviewer**:
/sig storage

This PR depends on #84660 and first three commit came from the PR. So, for this PR, only the rest of commits should be reviewed. This PR is needed for #73773 to separate staging/publish and unstaging/unpublish logics for CSI driver. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: