### PR TITLE
Build: Use a better filter on find

### DIFF
--- a/hack/make-rules/helpers/cache_go_dirs.sh
+++ b/hack/make-rules/helpers/cache_go_dirs.sh
@@ -44,10 +44,10 @@ function kfind() {
         \(                         \
         -not \(                    \
             \(                     \
-                -path ./vendor -o  \
                 -path ./_\* -o     \
                 -path ./.\* -o     \
-                -path ./docs       \
+                -path ./vendor -o  \
+                -path ./Godeps     \
             \) -prune              \
         \)                         \
         \)                         \


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

The build can hit "args too long" errors if we don't filter properly.



```release-note
NONE
```
