### PR TITLE
Add envs for configuring hollow-node resource usage.

### DIFF
--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -62,8 +62,8 @@ spec:
           mountPath: /var/log
         resources:
           requests:
-            cpu: 40m
-            memory: 100M
+            cpu: {{hollow_kubelet_millicpu}}m
+            memory: {{hollow_kubelet_mem_Ki}}Ki
         securityContext:
           privileged: true
       - name: hollow-proxy
@@ -90,8 +90,8 @@ spec:
           mountPath: /var/log
         resources:
           requests:
-            cpu: {{HOLLOW_PROXY_CPU}}m
-            memory: {{HOLLOW_PROXY_MEM}}Ki
+            cpu: {{hollow_proxy_millicpu}}m
+            memory: {{hollow_proxy_mem_Ki}}Ki
       - name: hollow-node-problem-detector
         image: k8s.gcr.io/node-problem-detector:v0.8.0
         env:
@@ -117,8 +117,8 @@ spec:
           mountPath: /var/log
         resources:
           requests:
-            cpu: 20m
-            memory: 20Mi
+            cpu: {{npd_millicpu}}m
+            memory: {{npd_mem_Ki}}Ki
         securityContext:
           privileged: true
       # Keep the pod running on unreachable node for 15 minutes.

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -149,10 +149,16 @@ function create-kube-hollow-node-resources {
   if [ "${NUM_NODES}" -gt 1000 ]; then
     proxy_cpu=50
   fi
-  proxy_mem_per_node=50
+  proxy_cpu=${KUBEMARK_HOLLOW_PROXY_MILLICPU:-$proxy_cpu}
+  proxy_mem_per_node=${KUBEMARK_HOLLOW_PROXY_MEM_PER_NODE_KB:-50}
   proxy_mem=$((100 * 1024 + proxy_mem_per_node*NUM_NODES))
-  sed -i'' -e "s@{{HOLLOW_PROXY_CPU}}@${proxy_cpu}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
-  sed -i'' -e "s@{{HOLLOW_PROXY_MEM}}@${proxy_mem}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+
+  sed -i'' -e "s@{{hollow_kubelet_millicpu}}@${KUBEMARK_HOLLOW_KUBELET_MILLICPU:-40}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+  sed -i'' -e "s@{{hollow_kubelet_mem_Ki}}@${KUBEMARK_HOLLOW_KUBELET_MEM_KB:-$((100*1024))}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+  sed -i'' -e "s@{{hollow_proxy_millicpu}}@${proxy_cpu}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+  sed -i'' -e "s@{{hollow_proxy_mem_Ki}}@${proxy_mem}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+  sed -i'' -e "s@{{npd_millicpu}}@${KUBEMARK_NPD_MILLICPU:-20}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
+  sed -i'' -e "s@{{npd_mem_Ki}}@${KUBEMARK_NPD_MEM_KB:-$((20*1024))}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   sed -i'' -e "s@{{kubemark_image_registry}}@${KUBEMARK_IMAGE_REGISTRY}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   sed -i'' -e "s@{{kubemark_image_tag}}@${KUBEMARK_IMAGE_TAG}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   sed -i'' -e "s@{{master_ip}}@${MASTER_IP}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
It adds envs for configuring hollow-node resource usage which will allow to experiment in order to make kubemark cheaper.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
