### PR TITLE
Use time.Until instead of t.Sub(time.Now())

### DIFF
--- a/cmd/kubeadm/app/cmd/token.go
+++ b/cmd/kubeadm/app/cmd/token.go
@@ -287,7 +287,7 @@ func formatBootstrapToken(obj *outputapiv1alpha1.BootstrapToken) string {
 	ttl := "<forever>"
 	expires := "<never>"
 	if obj.Expires != nil {
-		ttl = duration.ShortHumanDuration(obj.Expires.Sub(time.Now()))
+		ttl = duration.ShortHumanDuration(time.Until(obj.Expires.Time))
 		expires = obj.Expires.Format(time.RFC3339)
 	}
 	ttl = fmt.Sprintf("%-9s", ttl)

--- a/cmd/kubeadm/app/phases/certs/renewal/expiration.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/expiration.go
@@ -48,5 +48,5 @@ func newExpirationInfo(name string, cert *x509.Certificate, externallyManaged bo
 
 // ResidualTime returns the time missing to expiration
 func (e *ExpirationInfo) ResidualTime() time.Duration {
-	return e.ExpirationDate.Sub(time.Now())
+	return time.Until(e.ExpirationDate)
 }


### PR DESCRIPTION

**What type of PR is this?**

 /kind cleanup

**What this PR does / why we need it**:

Using time.Until(t) instead of t.Sub(time.Now())

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
