### PR TITLE
Promote raw block to GA

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -199,6 +199,7 @@ const (
 	// owner: @screeley44
 	// alpha: v1.9
 	// beta: v1.13
+	// ga: v1.17
 	//
 	// Enable Block volume support in containers.
 	BlockVolume featuregate.Feature = "BlockVolume"
@@ -529,7 +530,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	NodeDisruptionExclusion:        {Default: false, PreRelease: featuregate.Alpha},
 	CSIDriverRegistry:              {Default: true, PreRelease: featuregate.Beta},
 	CSINodeInfo:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.19
-	BlockVolume:                    {Default: true, PreRelease: featuregate.Beta},
+	BlockVolume:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.19
 	StorageObjectInUseProtection:   {Default: true, PreRelease: featuregate.GA},
 	ResourceLimitsPriorityFunction: {Default: false, PreRelease: featuregate.Alpha},
 	SupportIPVSProxyMode:           {Default: true, PreRelease: featuregate.GA},


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**Does this PR introduce a user-facing change?**:
```release-note
BlockVolume feature of in-tree volume plugins is now GA.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20191008-raw-block-support.md
[Usage]: https://kubernetes.io/docs/concepts/storage/persistent-volumes/#raw-block-volume-support
[Other doc]: https://github.com/kubernetes/website/pull/17399
```

/assign @msau42 @saad-ali 
Our TODO list for in-tree raw block is getting empty: https://github.com/orgs/kubernetes-csi/projects/4