### PR TITLE
expose PredicateMetadataProducer in generic scheduler

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -131,6 +131,10 @@ type ScheduleAlgorithm interface {
 	// Extenders returns a slice of extender config. This is exposed for
 	// testing.
 	Extenders() []algorithm.SchedulerExtender
+	// GetPredicateMetadataProducer returns the predicate metadata producer. This is needed
+	// for cluster autoscaler integration.
+	// TODO(ahg-g): remove this once CA migrates to creating a Framework instead of a full scheduler.
+	PredicateMetadataProducer() predicates.PredicateMetadataProducer
 }
 
 // ScheduleResult represents the result of one pod scheduled. It will contain
@@ -169,6 +173,13 @@ type genericScheduler struct {
 func (g *genericScheduler) snapshot() error {
 	// Used for all fit and priority funcs.
 	return g.cache.UpdateNodeInfoSnapshot(g.nodeInfoSnapshot)
+}
+
+// GetPredicateMetadataProducer returns the predicate metadata producer. This is needed
+// for cluster autoscaler integration.
+func (g *genericScheduler) PredicateMetadataProducer() predicates.PredicateMetadataProducer {
+	return g.predicateMetaProducer
+
 }
 
 // Schedule tries to schedule the given pod to one of the nodes in the node list.

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -152,6 +152,11 @@ type mockScheduler struct {
 	err    error
 }
 
+func (es mockScheduler) PredicateMetadataProducer() predicates.PredicateMetadataProducer {
+	return nil
+
+}
+
 func (es mockScheduler) Schedule(ctx context.Context, state *framework.CycleState, pod *v1.Pod) (core.ScheduleResult, error) {
 	return es.result, es.err
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
exposes PredicateMetadataProducer in generic scheduler, this is needed for cluster autoscaler integration.

**Which issue(s) this PR fixes**:
Fixes #84651

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

