### PR TITLE
Replace nginx image with agnhost in sig-node pods tests

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -67,8 +67,9 @@ var _ = SIGDescribe("Pods Extended", func() {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:  "nginx",
-							Image: imageutils.GetE2EImage(imageutils.Nginx),
+							Name:  "agnhost",
+							Image: imageutils.GetE2EImage(imageutils.Agnhost),
+							Args:  []string{"pause"},
 						},
 					},
 				},
@@ -197,8 +198,9 @@ var _ = SIGDescribe("Pods Extended", func() {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name:  "nginx",
-							Image: imageutils.GetE2EImage(imageutils.Nginx),
+							Name:  "agnhost",
+							Image: imageutils.GetE2EImage(imageutils.Agnhost),
+							Args:  []string{"pause"},
 							Resources: v1.ResourceRequirements{
 								Limits: v1.ResourceList{
 									v1.ResourceCPU:    resource.MustParse("100m"),


### PR DESCRIPTION
Part of a continued effort to replace test images with Agnhost where possible.

```release-note
NONE
```