### PR TITLE
Remove duplicate judgment

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -218,10 +218,12 @@ func NamespaceKeyRootFunc(ctx context.Context, prefix string) string {
 // a resource relative to the given prefix enforcing namespace rules. If the
 // context does not contain a namespace, it errors.
 func NamespaceKeyFunc(ctx context.Context, prefix string, name string) (string, error) {
-	key := NamespaceKeyRootFunc(ctx, prefix)
+	key := prefix
 	ns, ok := genericapirequest.NamespaceFrom(ctx)
 	if !ok || len(ns) == 0 {
 		return "", kubeerr.NewBadRequest("Namespace parameter required.")
+	} else if ok && len(ns) > 0 {
+		key = key + "/" + ns
 	}
 	if len(name) == 0 {
 		return "", kubeerr.NewBadRequest("Name parameter required.")


### PR DESCRIPTION
**What type of PR is this?**
Remove duplicate judgment
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

NamespaceKeyFunc function the judgment in is repeated

```
key := NamespaceKeyRootFunc(ctx, prefix)
ns, ok := genericapirequest.NamespaceFrom(ctx)
if !ok || len(ns) == 0 {}
```
baseuse if `!ok || len(ns) == 0`  then `key == prefix `
so we don't need to call this function `genericapirequest.NamespaceFrom(ctx)` twice

This can improve the efficiency of function execution
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



