### PR TITLE
Validate scheduler configuration from config file

### DIFF
--- a/cmd/kube-scheduler/app/options/options.go
+++ b/cmd/kube-scheduler/app/options/options.go
@@ -174,6 +174,9 @@ func (o *Options) ApplyTo(c *schedulerappconfig.Config) error {
 		if err != nil {
 			return err
 		}
+		if err := validation.ValidateKubeSchedulerConfiguration(cfg).ToAggregate(); err != nil {
+			return err
+		}
 
 		// use the loaded config file only, with the exception of --address and --port. This means that
 		// none of the deprecated flags in o.Deprecated are taken into consideration. This is the old


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Ensure that configuration read from a file is also validated. We were only validating the default configuration.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```