### PR TITLE
verify: fix lint dependencies masking output

### DIFF
--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -85,7 +85,7 @@ pushd "${KUBE_ROOT}" > /dev/null 2>&1
   fi
 
   # Verify we are pinned to matching levels
-  hack/lint-dependencies.sh >&2
+  hack/lint-dependencies.sh
 popd > /dev/null 2>&1
 
 if [[ ${ret} -gt 0 ]]; then


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
While working on https://github.com/kubernetes/kubernetes/pull/84614, I found out that `hack/verify-vendor.sh` was masking the output to `hack/lint-dependencies.sh.` This fix unmasks that output.

/cc @liggitt 