### PR TITLE
Tracking nodes with pods with affinity

### DIFF
--- a/pkg/scheduler/algorithm/priorities/interpod_affinity.go
+++ b/pkg/scheduler/algorithm/priorities/interpod_affinity.go
@@ -106,9 +106,16 @@ func (ipa *InterPodAffinity) CalculateInterPodAffinityPriority(pod *v1.Pod, shar
 
 	// pm stores (1) all nodes that should be considered and (2) the so-far computed score for each node.
 	pm := newPodAffinityPriorityMap(nodes)
-	allNodes, err := sharedLister.NodeInfos().List()
+
+	allNodes, err := sharedLister.NodeInfos().HavePodsWithAffinityList()
 	if err != nil {
 		return nil, err
+	}
+	if hasAffinityConstraints || hasAntiAffinityConstraints {
+		allNodes, err = sharedLister.NodeInfos().List()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// convert the topology key based weights to the node name based weights

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -179,7 +179,6 @@ func (g *genericScheduler) snapshot() error {
 // for cluster autoscaler integration.
 func (g *genericScheduler) PredicateMetadataProducer() predicates.PredicateMetadataProducer {
 	return g.predicateMetaProducer
-
 }
 
 // Schedule tries to schedule the given pod to one of the nodes in the node list.

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -239,10 +239,14 @@ func (cache *schedulerCache) UpdateNodeInfoSnapshot(nodeSnapshot *nodeinfosnapsh
 
 	// Take a snapshot of the nodes order in the tree
 	nodeSnapshot.NodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
+	nodeSnapshot.HavePodsWithAffinityNodeInfoList = make([]*schedulernodeinfo.NodeInfo, 0, cache.nodeTree.numNodes)
 	for i := 0; i < cache.nodeTree.numNodes; i++ {
 		nodeName := cache.nodeTree.next()
 		if n := nodeSnapshot.NodeInfoMap[nodeName]; n != nil {
 			nodeSnapshot.NodeInfoList = append(nodeSnapshot.NodeInfoList, n)
+			if len(n.PodsWithAffinity()) > 0 {
+				nodeSnapshot.HavePodsWithAffinityNodeInfoList = append(nodeSnapshot.HavePodsWithAffinityNodeInfoList, n)
+			}
 		} else {
 			klog.Errorf("node %q exist in nodeTree but not in NodeInfoMap, this should not happen.", nodeName)
 		}

--- a/pkg/scheduler/listers/fake/listers.go
+++ b/pkg/scheduler/listers/fake/listers.go
@@ -262,6 +262,12 @@ func (nodes NodeInfoLister) List() ([]*schedulernodeinfo.NodeInfo, error) {
 	return nodes, nil
 }
 
+// HavePodsWithAffinityList is supposed to list nodes with at least one pod with affinity. For the fake lister
+// we just return everything.
+func (nodes NodeInfoLister) HavePodsWithAffinityList() ([]*schedulernodeinfo.NodeInfo, error) {
+	return nodes, nil
+}
+
 // NewNodeInfoLister create a new fake NodeInfoLister from a slice of v1.Nodes.
 func NewNodeInfoLister(nodes []*v1.Node) schedulerlisters.NodeInfoLister {
 	nodeInfoList := make([]*schedulernodeinfo.NodeInfo, len(nodes))

--- a/pkg/scheduler/listers/listers.go
+++ b/pkg/scheduler/listers/listers.go
@@ -38,6 +38,8 @@ type PodLister interface {
 type NodeInfoLister interface {
 	// Returns the list of NodeInfos.
 	List() ([]*schedulernodeinfo.NodeInfo, error)
+	// Returns the list of NodeInfos of nodes with pods with affinity terms.
+	HavePodsWithAffinityList() ([]*schedulernodeinfo.NodeInfo, error)
 	// Returns the NodeInfo of the given node name.
 	Get(nodeName string) (*schedulernodeinfo.NodeInfo, error)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Adds a list to nodeinfo snapshot that tracks the nodes with at least one pod with affinity terms. This is useful to avoid iterating over unrelated nodes for inter-pod affinity priority and inter-pod anti-affinity predicate

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

This will help avoid the performance degradation from #84669

Before:
```
BenchmarkSchedulingV/5000Nodes/1000Pods-12          1000           6481403 ns/op
BenchmarkSchedulingPodAntiAffinity/5000Nodes/1000Pods-12                    1000           8203782 ns/op
BenchmarkSchedulingSecrets/5000Nodes/1000Pods-12                            1000           7180056 ns/op
BenchmarkSchedulingInTreePVs/5000Nodes/1000Pods-12                          1000          13674520 ns/op
BenchmarkSchedulingMigratedInTreePVs/5000Nodes/1000Pods-12                  1000          12901412 ns/op
BenchmarkSchedulingCSIPVs/5000Nodes/1000Pods-12                             1000          11295372 ns/op
BenchmarkSchedulingPodAffinity/5000Nodes/1000Pods-12                        1000          12800015 ns/op
BenchmarkSchedulingNodeAffinity/5000Nodes/1000Pods-12                       1000          11432830 ns/op

```
After:
```
BenchmarkSchedulingV/5000Nodes/1000Pods-12          1000           5593549 ns/op
BenchmarkSchedulingPodAntiAffinity/5000Nodes/1000Pods-12                    1000           7663664 ns/op
BenchmarkSchedulingSecrets/5000Nodes/1000Pods-12                            1000           6269434 ns/op
BenchmarkSchedulingInTreePVs/5000Nodes/1000Pods-12                          1000          12713162 ns/op
BenchmarkSchedulingMigratedInTreePVs/5000Nodes/1000Pods-12                  1000          11840169 ns/op
BenchmarkSchedulingCSIPVs/5000Nodes/1000Pods-12                             1000          10337815 ns/op
BenchmarkSchedulingPodAffinity/5000Nodes/1000Pods-12                        1000          12088693 ns/op
BenchmarkSchedulingNodeAffinity/5000Nodes/1000Pods-12                       1000          10787583 ns/op
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```


/assign @Huang-Wei 