### PR TITLE
Enable profiling by default in the scheduler 

### DIFF
--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -260,6 +260,10 @@ pluginConfig:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           true,
+					EnableContentionProfiling: true,
+				},
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       true,
@@ -343,6 +347,10 @@ pluginConfig:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "", // defaults empty when not running from config file
 				MetricsBindAddress:             "", // defaults empty when not running from config file
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           true,
+					EnableContentionProfiling: true,
+				},
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       true,
@@ -404,6 +412,10 @@ pluginConfig:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "", // defaults empty when not running from config file
 				MetricsBindAddress:             "", // defaults empty when not running from config file
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           true,
+					EnableContentionProfiling: true,
+				},
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       true,
@@ -440,6 +452,10 @@ pluginConfig:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           true,
+					EnableContentionProfiling: true,
+				},
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       true,
@@ -518,6 +534,10 @@ pluginConfig:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           true,
+					EnableContentionProfiling: true,
+				},
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       true,
@@ -557,6 +577,10 @@ pluginConfig:
 				HardPodAffinitySymmetricWeight: 1,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           true,
+					EnableContentionProfiling: true,
+				},
 				LeaderElection: kubeschedulerconfig.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       false,

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -156,4 +156,16 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubeschedulerconfigv1alpha1.Kub
 		val := int64(10)
 		obj.PodMaxBackoffSeconds = &val
 	}
+
+	// Enable profiling by default in the scheduler
+	if obj.EnableProfiling == nil {
+		enableProfiling := true
+		obj.EnableProfiling = &enableProfiling
+	}
+
+	// Enable contention profiling by default if profiling is enabled
+	if *obj.EnableProfiling && obj.EnableContentionProfiling == nil {
+		enableContentionProfiling := true
+		obj.EnableContentionProfiling = &enableContentionProfiling
+	}
 }

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestSchedulerDefaults(t *testing.T) {
+	enable := true
 	tests := []struct {
 		name     string
 		config   *kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration
@@ -42,6 +43,10 @@ func TestSchedulerDefaults(t *testing.T) {
 				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
 				HealthzBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
 				MetricsBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           &enable,
+					EnableContentionProfiling: &enable,
+				},
 				LeaderElection: kubeschedulerconfigv1alpha1.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       pointer.BoolPtr(true),
@@ -80,6 +85,10 @@ func TestSchedulerDefaults(t *testing.T) {
 				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
 				HealthzBindAddress:             pointer.StringPtr("1.2.3.4:10251"),
 				MetricsBindAddress:             pointer.StringPtr("1.2.3.4:10251"),
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           &enable,
+					EnableContentionProfiling: &enable,
+				},
 				LeaderElection: kubeschedulerconfigv1alpha1.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       pointer.BoolPtr(true),
@@ -118,6 +127,10 @@ func TestSchedulerDefaults(t *testing.T) {
 				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
 				HealthzBindAddress:             pointer.StringPtr("0.0.0.0:12345"),
 				MetricsBindAddress:             pointer.StringPtr("0.0.0.0:12345"),
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           &enable,
+					EnableContentionProfiling: &enable,
+				},
 				LeaderElection: kubeschedulerconfigv1alpha1.KubeSchedulerLeaderElectionConfiguration{
 					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
 						LeaderElect:       pointer.BoolPtr(true),


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig scheduling
/priority important-soon
/milestone v1.17

**What this PR does / why we need it**:
It is useful when debugging the performance of a running cluster. API server already enables profiling by default.

**Which issue(s) this PR fixes**:
Fixes #84799

**Does this PR introduce a user-facing change?**:
```release-note
Profiling is enabled by default in the scheduler 
```

/assign @ahg-g