### PR TITLE
e2e: Fix error where pods not logged

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1311,7 +1311,6 @@ func DumpNodeDebugInfo(c clientset.Interface, nodeNames []string, logFunc func(f
 
 // getKubeletPods retrieves the list of pods on the kubelet.
 func getKubeletPods(c clientset.Interface, node string) (*v1.PodList, error) {
-	var result *v1.PodList
 	var client restclient.Result
 	finished := make(chan struct{}, 1)
 	go func() {
@@ -1327,6 +1326,7 @@ func getKubeletPods(c clientset.Interface, node string) (*v1.PodList, error) {
 	}()
 	select {
 	case <-finished:
+		result := &v1.PodList{}
 		if err := client.Into(result); err != nil {
 			return &v1.PodList{}, err
 		}


### PR DESCRIPTION
This was changed recently in #84640, but result must be pre-populated.

Example error:

`Nov  6 00:18:05.296: INFO: Unable to retrieve kubelet pods for node master-us-central1-c-t81q: expected pointer, but got nil`


/kind bug
/kind failing-test

```release-note
NONE
```