### PR TITLE
resource-metrics: add pod/sandbox metrics to endpoint

### DIFF
--- a/pkg/kubelet/apis/resourcemetrics/v1alpha1/config.go
+++ b/pkg/kubelet/apis/resourcemetrics/v1alpha1/config.go
@@ -53,6 +53,30 @@ func Config() stats.ResourceMetricsConfig {
 				},
 			},
 		},
+		PodMetrics: []stats.PodResourceMetric{
+			{
+				Name:        "pod_cpu_usage_seconds_total",
+				Description: "Cumulative cpu time consumed by the pod in core-seconds",
+				ValueFn: func(s summary.PodStats) (*float64, time.Time) {
+					if s.CPU == nil {
+						return nil, time.Time{}
+					}
+					v := float64(*s.CPU.UsageCoreNanoSeconds) / float64(time.Second)
+					return &v, s.CPU.Time.Time
+				},
+			},
+			{
+				Name:        "pod_memory_working_set_bytes",
+				Description: "Current working set of the pod in bytes",
+				ValueFn: func(s summary.PodStats) (*float64, time.Time) {
+					if s.Memory == nil {
+						return nil, time.Time{}
+					}
+					v := float64(*s.Memory.WorkingSetBytes)
+					return &v, s.Memory.Time.Time
+				},
+			},
+		},
 		ContainerMetrics: []stats.ContainerResourceMetric{
 			{
 				Name:        "container_cpu_usage_seconds_total",


### PR DESCRIPTION
Signed-off-by: Eric Ernst <eric.ernst@intel.com>


**What type of PR is this?**
 
 /kind feature
 
**What this PR does / why we need it**:

It'd be great to be able to scrape pod-cgroup level metrics. Today this is skipped from within the metrics/resource/v1alpha end point.

When PodOverhead is beta, being able to easily measure the overhead associated with running a sandbox will be even more important.

**Which issue(s) this PR fixes**:
  

**Does this PR introduce a user-facing change?**:
 
```release-note
Add pod_ based CPU and memory metrics to the /metrics/resource/v1alpha endpoint
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
 