### PR TITLE
Use framework.ExpectEqual() in unit test

### DIFF
--- a/test/e2e/framework/log_test.go
+++ b/test/e2e/framework/log_test.go
@@ -57,7 +57,7 @@ var _ = ginkgo.Describe("log", func() {
 		}()
 	})
 	ginkgo.It("asserts", func() {
-		gomega.Expect(false).To(gomega.Equal(true), "false is never true")
+		framework.ExpectEqual(false, true, "false is never true")
 	})
 	ginkgo.It("error", func() {
 		err := errors.New("an error with a long, useless description")
@@ -68,7 +68,7 @@ var _ = ginkgo.Describe("log", func() {
 	})
 	ginkgo.AfterEach(func() {
 		framework.Logf("after")
-		gomega.Expect(true).To(gomega.Equal(false), "true is never false either")
+		framework.ExpectEqual(true, false, "true is never false either")
 	})
 })
 
@@ -83,7 +83,6 @@ func TestFailureOutput(t *testing.T) {
 	runTests(fakeT, reporter)
 
 	// Now check the output.
-	g := gomega.NewGomegaWithT(t)
 	actual := normalizeReport(*reporter)
 
 	// output from AfterEach
@@ -117,16 +116,16 @@ func TestFailureOutput(t *testing.T) {
 		},
 	}
 	// Compare individual fields. Comparing the slices leads to unreadable error output when there is any mismatch.
-	g.Expect(len(actual)).To(gomega.Equal(len(expected)), "%d entries in %v", len(expected), actual)
+	framework.ExpectEqual(len(actual), len(expected), "%d entries in %v", len(expected), actual)
 	for i, a := range actual {
 		b := expected[i]
-		g.Expect(a.name).To(gomega.Equal(b.name), "name in %d", i)
-		g.Expect(a.output).To(gomega.Equal(b.output), "output in %d", i)
-		g.Expect(a.failure).To(gomega.Equal(b.failure), "failure in %d", i)
+		framework.ExpectEqual(a.name, b.name, "name in %d", i)
+		framework.ExpectEqual(a.output, b.output, "output in %d", i)
+		framework.ExpectEqual(a.failure, b.failure, "failure in %d", i)
 		// There may be additional stack entries from the "testing" package at the
 		// end. We ignore those in the comparison because the line number in them
 		// varies.
-		g.Expect(a.stack).To(gomega.Equal(b.stack), "stack in %d: %s", i, a.stack)
+		framework.ExpectEqual(a.stack, b.stack, "stack in %d: %s", i, a.stack)
 	}
 }
 

--- a/test/e2e/framework/timer/BUILD
+++ b/test/e2e/framework/timer/BUILD
@@ -15,7 +15,10 @@ go_test(
     name = "go_default_test",
     srcs = ["timer_test.go"],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/onsi/gomega:go_default_library"],
+    deps = [
+        "//test/e2e/framework:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )
 
 filegroup(

--- a/test/e2e/framework/timer/timer_test.go
+++ b/test/e2e/framework/timer/timer_test.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+
+	"k8s.io/kubernetes/test/e2e/framework"
 )
 
 var currentTime time.Time
@@ -64,9 +66,9 @@ func TestTimer(t *testing.T) {
 			}
 		]
 	}`))
-	gomega.Expect(timer.PrintHumanReadable()).To(gomega.Equal(`Phase 001-one: 5.5s so far
+	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 5.5s so far
 Phase 033-two: 3.5s
-`))
+`)
 
 	setCurrentTimeSinceEpoch(7*time.Second + 500*time.Millisecond)
 	phaseOne.End()
@@ -86,7 +88,7 @@ Phase 033-two: 3.5s
 			}
 		]
 	}`))
-	gomega.Expect(timer.PrintHumanReadable()).To(gomega.Equal(`Phase 001-one: 6.5s
+	framework.ExpectEqual(timer.PrintHumanReadable(), `Phase 001-one: 6.5s
 Phase 033-two: 3.5s
-`))
+`)
 }


### PR DESCRIPTION
Signed-off-by: clarklee92 <clarklee1992@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
Replace `gomega.Expect().To(gomega.Equal(), ...)` to `framework. ExpectEqual()` in
`test/e2e/framework/log_test.go` and `test/e2e/framework/timer/timer_test.go`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #79686

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

