### PR TITLE
Ignored error when cpumanager state restore from checkpoint failed.

### DIFF
--- a/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_checkpoint.go
@@ -54,9 +54,8 @@ func NewCheckpointState(stateDir, checkpointName, policyName string, initialCont
 	}
 
 	if err := stateCheckpoint.restoreState(); err != nil {
-		//lint:ignore ST1005 user-facing error message
-		return nil, fmt.Errorf("could not restore state from checkpoint: %v, please drain this node and delete the CPU manager checkpoint file %q before restarting Kubelet",
-			err, path.Join(stateDir, checkpointName))
+		klog.Errorf("could not restore state from checkpoint %s, error: %v", path.Join(stateDir, checkpointName), err)
+		klog.Warningf("cpumanager cannot guarantee sane CPU affinity for existing containers unless drain this node and remove policy state file")
 	}
 
 	return stateCheckpoint, nil

--- a/pkg/kubelet/cm/cpumanager/state/state_file.go
+++ b/pkg/kubelet/cm/cpumanager/state/state_file.go
@@ -60,12 +60,8 @@ func NewFileState(filePath string, policyName string, initialContainers containe
 	}
 
 	if err := stateFile.tryRestoreState(); err != nil {
-		// could not restore state, init new state file
-		klog.Errorf("[cpumanager] state file: unable to restore state from disk (%v)"+
-			" We cannot guarantee sane CPU affinity for existing containers."+
-			" Please drain this node and delete the CPU manager state file \"%s\" before restarting Kubelet.",
-			err, stateFile.stateFilePath)
-		return nil, err
+		klog.Errorf("[cpumanager] state file: unable to restore state from disk (%v)", err)
+		klog.Warningf("cpumanager cannot guarantee sane CPU affinity for existing containers unless drain this node and remove policy state file")
 	}
 
 	return stateFile, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Ignored error when cpumanager state restore from checkpioint failed.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #84783, https://github.com/kubernetes/kubernetes/issues/84703


Maybe we should not refuse to start kubelet when cpu manager state checkpoint changed or corrupted. 

I suppose it is OK that just log a warning or error and then the reconciler can reconcile to correct state for new containers, irrespective of the small probability of inconsistence for existing containers' cpuset cgroup.


dependent on PR: https://github.com/kubernetes/kubernetes/pull/84705

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
