### PR TITLE
fix restart kubelet lead to node NotReady for a while

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -369,6 +369,7 @@ func (kl *Kubelet) syncNodeStatus() {
 		// This will exit immediately if it doesn't need to do anything.
 		kl.registerWithAPIServer()
 	}
+	kl.updateRuntimeUp()
 	if err := kl.updateNodeStatus(); err != nil {
 		klog.Errorf("Unable to update node status: %v", err)
 	}

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -366,10 +366,10 @@ func (kl *Kubelet) syncNodeStatus() {
 		return
 	}
 	if kl.registerNode {
+		kl.updateRuntimeUp()
 		// This will exit immediately if it doesn't need to do anything.
 		kl.registerWithAPIServer()
 	}
-	kl.updateRuntimeUp()
 	if err := kl.updateNodeStatus(); err != nil {
 		klog.Errorf("Unable to update node status: %v", err)
 	}


### PR DESCRIPTION
fix restart kubelet lead to node NotReady for a while

**What type of PR is this?**
> /kind bug


**How to reproduce it (as minimally and precisely as possible)**:
First, disable NodeLease feature.
Then: `systemctl restart kubelet`
In `kubectl get node -w`
We can find that node will become NotReady for a while, and Ready soon.

**What this PR does / why we need it**:
When restart kubelet,  node will be NotReady for a while. But we consider not is already ready.

**Which issue(s) this PR fixes**:
fix: https://github.com/kubernetes/kubernetes/issues/84891
When restart kubelet,  node will be NotReady for a while. But we consider the node is already ready.

**Analyze**:

In kl.updateRuntimeUp(), it will check runtime state and update runtime status.
The init stauts of runtimeState is:
`func newRuntimeState( runtimeSyncThreshold time.Duration, ) *runtimeState { 
    return &runtimeState{
       lastBaseRuntimeSync: time.Time{},
       baseRuntimeSyncThreshold: runtimeSyncThreshold, 
      networkError: ErrNetworkUnknown, 
    } 
}`


We must notify that networkError is not nil and lastBaseRuntimeSync is time.Time{}.
If we restart kubelt, kubelet will exec kl.registerWithAPIServer() and kl.initialNode(context.TODO()).
In kl.initialNode will check runtime status and find it have error(networkerror and lastBaseRuntimeSync behind time.Now greater than baseRuntimeSyncThreshold).So this node status will be NotReady and post to APIServer. But This node is real ready.

kl.updateRuntimeUp() will exec in a Goroutine and is sometimes can not exec before kl.initialNode.

And I add kl.updateRuntimeUp() before kl.registerWithAPIServer() to ensure runtime real state.