### PR TITLE
Using time.Until(t) and time.Since(t) instead of t.Sub(time.Now())

### DIFF
--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -172,7 +172,7 @@ func isIssuedPastDeadline(csr *capi.CertificateSigningRequest) bool {
 
 // isOlderThan checks that t is a non-zero time after time.Now() + d.
 func isOlderThan(t metav1.Time, d time.Duration) bool {
-	return !t.IsZero() && time.Until(t.Time) < -1*d
+	return (!t.IsZero()) && (time.Since(t.Time) > d)
 }
 
 // isIssued checks if the CSR has `Issued` status. There is no explicit

--- a/pkg/controller/certificates/cleaner/cleaner.go
+++ b/pkg/controller/certificates/cleaner/cleaner.go
@@ -172,7 +172,7 @@ func isIssuedPastDeadline(csr *capi.CertificateSigningRequest) bool {
 
 // isOlderThan checks that t is a non-zero time after time.Now() + d.
 func isOlderThan(t metav1.Time, d time.Duration) bool {
-	return !t.IsZero() && t.Sub(time.Now()) < -1*d
+	return !t.IsZero() && time.Until(t.Time) < -1*d
 }
 
 // isIssued checks if the CSR has `Issued` status. There is no explicit

--- a/pkg/controller/client_builder_dynamic.go
+++ b/pkg/controller/client_builder_dynamic.go
@@ -193,7 +193,7 @@ func (ts *tokenSourceImpl) Token() (*oauth2.Token, error) {
 		return nil, fmt.Errorf("nil pointer of expiration in token request")
 	}
 
-	lifetime := retTokenRequest.Status.ExpirationTimestamp.Time.Sub(time.Now())
+	lifetime := time.Until(retTokenRequest.Status.ExpirationTimestamp.Time)
 	if lifetime < time.Minute*10 {
 		// possible clock skew issue, pin to minimum token lifetime
 		lifetime = time.Minute * 10


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
