### PR TITLE
Check that endpoint has subset before accessing first subset

### DIFF
--- a/pkg/master/reconcilers/lease.go
+++ b/pkg/master/reconcilers/lease.go
@@ -67,9 +67,11 @@ func (s *storageLeases) ListLeases() ([]string, error) {
 		return nil, err
 	}
 
-	ipList := make([]string, len(ipInfoList.Items))
-	for i, ip := range ipInfoList.Items {
-		ipList[i] = ip.Subsets[0].Addresses[0].IP
+	ipList := make([]string, 0, len(ipInfoList.Items))
+	for _, ip := range ipInfoList.Items {
+		if len(ip.Subsets) > 0 && len(ip.Subsets[0].Addresses) > 0 && len(ip.Subsets[0].Addresses[0].IP) > 0 {
+			ipList = append(ipList, ip.Subsets[0].Addresses[0].IP)
+		}
 	}
 
 	klog.V(6).Infof("Current master IPs listed in storage are %v", ipList)

--- a/pkg/master/reconcilers/lease_test.go
+++ b/pkg/master/reconcilers/lease_test.go
@@ -617,6 +617,19 @@ func TestLeaseRemoveEndpoints(t *testing.T) {
 				}},
 			},
 		},
+		{
+			testName:      "endpoint with no subset",
+			serviceName:   "foo",
+			ip:            "5.6.7.8",
+			endpointPorts: []corev1.EndpointPort{{Name: "foo", Port: 8080, Protocol: "TCP"}},
+			endpointKeys:  []string{"1.2.3.4", "4.3.2.2", "4.3.2.3", "4.3.2.4"},
+			endpoints: &corev1.EndpointsList{
+				Items: []corev1.Endpoints{{
+					ObjectMeta: om("foo"),
+					Subsets:    nil,
+				}},
+			},
+		},
 	}
 	for _, test := range stopTests {
 		t.Run(test.testName, func(t *testing.T) {

--- a/pkg/master/reconcilers/mastercount.go
+++ b/pkg/master/reconcilers/mastercount.go
@@ -149,6 +149,10 @@ func (r *masterCountEndpointReconciler) RemoveEndpoints(serviceName string, ip n
 		return err
 	}
 
+	if len(e.Subsets) == 0 {
+		// no action is needed to remove the endpoint
+		return nil
+	}
 	// Remove our IP from the list of addresses
 	new := []corev1.EndpointAddress{}
 	for _, addr := range e.Subsets[0].Addresses {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes #84850 by checking that there is subset of the endpoint

**Which issue(s) this PR fixes**:
Fixes #84850

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
