### PR TITLE
Make test-cmd effective again

### DIFF
--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -138,6 +138,8 @@ kube::test::describe_object_assert() {
 
   for match in "${matches[@]}"; do
     if grep -q "${match}" <<< "${result}"; then
+      echo "matched ${match}"
+    else
       echo "${bold}${red}"
       echo "$(kube::test::get_caller): FAIL!"
       echo "Describe ${resource} ${object}"
@@ -204,6 +206,8 @@ kube::test::describe_resource_assert() {
 
   for match in "${matches[@]}"; do
     if grep -q "${match}" <<< "${result}"; then
+      echo "matched ${match}"
+    else
       echo "${bold}${red}"
       echo "FAIL!"
       echo "Describe ${resource}"

--- a/hack/lib/test.sh
+++ b/hack/lib/test.sh
@@ -260,14 +260,10 @@ kube::test::describe_resource_events_assert() {
     fi
 }
 
-# Compare sort-by resource name output with expected order specify in the last parameter
+# Compare sort-by resource name output (first column, skipping first line) with expected order specify in the last parameter
 kube::test::if_sort_by_has_correct_order() {
-  IFS=" " read -r -a array <<< "$(echo "$1" |awk '{if(NR!=1) print $1}')"
   local var
-  for i in "${array[@]}"; do
-    var+="${i}:"
-  done
-
+  var="$(echo "$1" | awk '{if(NR!=1) print $1}' | tr '\n' ':')"
   kube::test::if_has_string "${var}" "${@:$#}"
 }
 

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -278,15 +278,15 @@ run_pod_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
   # Command
   kubectl create -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml "${kube_flags[@]}"
-  kubectl create -f test/e2e/testing-manifests/kubectl/redis-master-pod.yaml "${kube_flags[@]}"
-  # Post-condition: valid-pod and redis-master PODs are created
-  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'redis-master:valid-pod:'
+  kubectl create -f test/e2e/testing-manifests/kubectl/agnhost-master-pod.yaml "${kube_flags[@]}"
+  # Post-condition: valid-pod and agnhost-master PODs are created
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'agnhost-master:valid-pod:'
 
   ### Delete multiple PODs at once
-  # Pre-condition: valid-pod and redis-master PODs exist
-  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'redis-master:valid-pod:'
+  # Pre-condition: valid-pod and agnhost-master PODs exist
+  kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" 'agnhost-master:valid-pod:'
   # Command
-  kubectl delete pods valid-pod redis-master "${kube_flags[@]}" --grace-period=0 --force # delete multiple pods at once
+  kubectl delete pods valid-pod agnhost-master "${kube_flags[@]}" --grace-period=0 --force # delete multiple pods at once
   # Post-condition: no POD exists
   kube::test::get_object_assert pods "{{range.items}}{{$id_field}}:{{end}}" ''
 

--- a/test/cmd/get.sh
+++ b/test/cmd/get.sh
@@ -96,11 +96,7 @@ run_kubectl_get_tests() {
   # Post-condition: POD abc should error since it doesn't exist
   kube::test::if_has_string "${output_message}" 'pods "abc" not found'
   # Post-condition: make sure we don't display an empty List
-  if kube::test::if_has_string "${output_message}" 'List'; then
-    echo 'Unexpected List output'
-    echo "${LINENO} $(basename "$0")"
-    exit 1
-  fi
+  kube::test::if_has_not_string "${output_message}" 'List'
 
   ### Test kubectl get all
   output_message=$(kubectl --v=6 --namespace default get all --chunk-size=0 2>&1 "${kube_flags[@]}")

--- a/test/e2e/testing-manifests/kubectl/agnhost-master-pod.yaml
+++ b/test/e2e/testing-manifests/kubectl/agnhost-master-pod.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    name: agnhost
+    role: master
+  name: agnhost-master
+spec:
+  containers:
+    - name: master
+      image: gcr.io/kubernetes-e2e-test-images/agnhost:1.0
+      env:
+        - name: MASTER
+          value: "true"
+      ports:
+        - containerPort: 6379
+      resources:
+        limits:
+          cpu: "0.1"
+      volumeMounts:
+        - mountPath: /agnhost-master-data
+          name: data
+    - name: sentinel
+      image: gcr.io/kubernetes-e2e-test-images/agnhost:1.0
+      env:
+        - name: SENTINEL
+          value: "true"
+      ports:
+        - containerPort: 26379
+  volumes:
+    - name: data
+      emptyDir: {}


### PR DESCRIPTION
/kind bug
/priority critical-urgent

Fixes the following issues:
- [x] test-cmd not failing the job when commands failed - broken since https://github.com/kubernetes/kubernetes/commit/313044abd7a23699b5d744c4157ca7392673d587#diff-7976a1974df5995ca28f32cc945e92acL135 - this masked the following bugs introduced:
  - [x] test-cmd assertions running backwards (failing when the expected output was present) - broken in https://github.com/kubernetes/kubernetes/commit/1b7ba643bb60fa0d7886b848a50867767563373b#diff-c66999b857e6a798fdf6265ac10dd24dL133-L200
  - [x] test-cmd attempting to use missing files - broken in https://github.com/kubernetes/kubernetes/pull/81358#discussion_r343358202
  - [x] test-cmd not verifying sorted order correctly - broken in https://github.com/kubernetes/kubernetes/pull/81882/files#r317346553
- [x] add a self-test to ensure failures inside test commands result in failure
- [x] resolve shellcheck issues without breaking tests

/cc
/assign

```release-note
NONE
```