### PR TITLE
delete EqualPriority priority function, and make registering it a no op

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/BUILD
+++ b/pkg/scheduler/algorithmprovider/defaults/BUILD
@@ -20,7 +20,6 @@ go_library(
         "//pkg/scheduler/algorithm:go_default_library",
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/algorithm/priorities:go_default_library",
-        "//pkg/scheduler/core:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
-	"k8s.io/kubernetes/pkg/scheduler/core"
 )
 
 func init() {
@@ -43,10 +42,6 @@ func init() {
 			Weight: 1,
 		},
 	)
-	// EqualPriority is a prioritizer function that gives an equal weight of one to all nodes
-	// Register the priority function so that its available
-	// but do not include it as part of the default priorities
-	scheduler.RegisterPriorityMapReduceFunction(priorities.EqualPriority, core.EqualPriorityMap, nil, 1)
 	// Optional, cluster-autoscaler friendly priority function - give used nodes higher priority.
 	scheduler.RegisterPriorityMapReduceFunction(priorities.MostRequestedPriority, priorities.MostRequestedPriorityMap, nil, 1)
 	scheduler.RegisterPriorityMapReduceFunction(

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -148,7 +148,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"TestServiceAntiAffinity",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -204,7 +203,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"TestServiceAntiAffinity",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -269,7 +267,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -337,7 +334,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -416,7 +412,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -506,7 +501,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -597,7 +591,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -692,7 +685,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -799,7 +791,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -908,7 +899,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -1017,7 +1007,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{
@@ -1131,7 +1120,6 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 				"TestServiceAffinity",
 			),
 			wantPrioritizers: sets.NewString(
-				"EqualPriority",
 				"InterPodAffinityPriority",
 			),
 			wantPlugins: map[string][]config.Plugin{

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -357,8 +357,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 		expectsErr     bool
 	}{
 		{
-			predicates:   map[string]predicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			predicates: map[string]predicates.FitPredicate{"true": truePredicate},
 			extenders: []FakeExtender{
 				{
 					predicates: []fitPredicate{truePredicateExtender},
@@ -372,8 +371,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			name:       "test 1",
 		},
 		{
-			predicates:   map[string]predicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			predicates: map[string]predicates.FitPredicate{"true": truePredicate},
 			extenders: []FakeExtender{
 				{
 					predicates: []fitPredicate{truePredicateExtender},
@@ -387,8 +385,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			name:       "test 2",
 		},
 		{
-			predicates:   map[string]predicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			predicates: map[string]predicates.FitPredicate{"true": truePredicate},
 			extenders: []FakeExtender{
 				{
 					predicates: []fitPredicate{truePredicateExtender},
@@ -406,8 +403,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			name: "test 3",
 		},
 		{
-			predicates:   map[string]predicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			predicates: map[string]predicates.FitPredicate{"true": truePredicate},
 			extenders: []FakeExtender{
 				{
 					predicates: []fitPredicate{machine2PredicateExtender},
@@ -421,8 +417,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			name:       "test 4",
 		},
 		{
-			predicates:   map[string]predicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			predicates: map[string]predicates.FitPredicate{"true": truePredicate},
 			extenders: []FakeExtender{
 				{
 					predicates:   []fitPredicate{truePredicateExtender},
@@ -439,8 +434,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			name: "test 5",
 		},
 		{
-			predicates:   map[string]predicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			predicates: map[string]predicates.FitPredicate{"true": truePredicate},
 			extenders: []FakeExtender{
 				{
 					predicates:   []fitPredicate{truePredicateExtender},
@@ -511,8 +505,7 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			//
 			// If scheduler did not ignore the extender, the test would fail
 			// because of the errors from errorPredicateExtender.
-			predicates:   map[string]predicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
+			predicates: map[string]predicates.FitPredicate{"true": truePredicate},
 			extenders: []FakeExtender{
 				{
 					predicates: []fitPredicate{errorPredicateExtender},

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -718,16 +718,15 @@ func (g *genericScheduler) prioritizeNodes(
 	meta interface{},
 	nodes []*v1.Node,
 ) (framework.NodeScoreList, error) {
-	// If no priority configs are provided, then the EqualPriority function is applied
+	// If no priority configs are provided, then all nodes will have a score of one.
 	// This is required to generate the priority list in the required format
 	if len(g.prioritizers) == 0 && len(g.extenders) == 0 && !g.framework.HasScorePlugins() {
 		result := make(framework.NodeScoreList, 0, len(nodes))
 		for i := range nodes {
-			hostPriority, err := EqualPriorityMap(pod, meta, g.nodeInfoSnapshot.NodeInfoMap[nodes[i].Name])
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, hostPriority)
+			result = append(result, framework.NodeScore{
+				Name:  nodes[i].Name,
+				Score: 1,
+			})
 		}
 		return result, nil
 	}
@@ -875,18 +874,6 @@ func (g *genericScheduler) prioritizeNodes(
 		}
 	}
 	return result, nil
-}
-
-// EqualPriorityMap is a prioritizer function that gives an equal weight of one to all nodes
-func EqualPriorityMap(_ *v1.Pod, _ interface{}, nodeInfo *schedulernodeinfo.NodeInfo) (framework.NodeScore, error) {
-	node := nodeInfo.Node()
-	if node == nil {
-		return framework.NodeScore{}, fmt.Errorf("node not found")
-	}
-	return framework.NodeScore{
-		Name:  node.Name,
-		Score: 1,
-	}, nil
 }
 
 // pickOneNodeForPreemption chooses one node among the given nodes. It assumes

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -292,11 +292,10 @@ func TestGenericScheduler(t *testing.T) {
 		wErr                          error
 	}{
 		{
-			predicates:   map[string]algorithmpredicates.FitPredicate{"false": falsePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
-			nodes:        []string{"machine1", "machine2"},
-			pod:          &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "2", UID: types.UID("2")}},
-			name:         "test 1",
+			predicates: map[string]algorithmpredicates.FitPredicate{"false": falsePredicate},
+			nodes:      []string{"machine1", "machine2"},
+			pod:        &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "2", UID: types.UID("2")}},
+			name:       "test 1",
 			wErr: &FitError{
 				Pod:         &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "2", UID: types.UID("2")}},
 				NumAllNodes: 2,
@@ -309,7 +308,6 @@ func TestGenericScheduler(t *testing.T) {
 		},
 		{
 			predicates:    map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
-			prioritizers:  []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
 			nodes:         []string{"machine1", "machine2"},
 			pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "ignore", UID: types.UID("ignore")}},
 			expectedHosts: sets.NewString("machine1", "machine2"),
@@ -319,7 +317,6 @@ func TestGenericScheduler(t *testing.T) {
 		{
 			// Fits on a machine where the pod ID matches the machine name
 			predicates:    map[string]algorithmpredicates.FitPredicate{"matches": matchesPredicate},
-			prioritizers:  []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
 			nodes:         []string{"machine1", "machine2"},
 			pod:           &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "machine2", UID: types.UID("machine2")}},
 			expectedHosts: sets.NewString("machine2"),
@@ -402,10 +399,9 @@ func TestGenericScheduler(t *testing.T) {
 		},
 		{
 			// Pod with existing PVC
-			predicates:   map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
-			nodes:        []string{"machine1", "machine2"},
-			pvcs:         []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC"}}},
+			predicates: map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
+			nodes:      []string{"machine1", "machine2"},
+			pvcs:       []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC"}}},
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "ignore", UID: types.UID("ignore")},
 				Spec: v1.PodSpec{
@@ -426,9 +422,8 @@ func TestGenericScheduler(t *testing.T) {
 		},
 		{
 			// Pod with non existing PVC
-			predicates:   map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
-			nodes:        []string{"machine1", "machine2"},
+			predicates: map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
+			nodes:      []string{"machine1", "machine2"},
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "ignore", UID: types.UID("ignore")},
 				Spec: v1.PodSpec{
@@ -448,10 +443,9 @@ func TestGenericScheduler(t *testing.T) {
 		},
 		{
 			// Pod with deleting PVC
-			predicates:   map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
-			prioritizers: []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
-			nodes:        []string{"machine1", "machine2"},
-			pvcs:         []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC", DeletionTimestamp: &metav1.Time{}}}},
+			predicates: map[string]algorithmpredicates.FitPredicate{"true": truePredicate},
+			nodes:      []string{"machine1", "machine2"},
+			pvcs:       []v1.PersistentVolumeClaim{{ObjectMeta: metav1.ObjectMeta{Name: "existingPVC", DeletionTimestamp: &metav1.Time{}}}},
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "ignore", UID: types.UID("ignore")},
 				Spec: v1.PodSpec{
@@ -472,7 +466,6 @@ func TestGenericScheduler(t *testing.T) {
 		{
 			// alwaysCheckAllPredicates is true
 			predicates:               map[string]algorithmpredicates.FitPredicate{"true": truePredicate, "matches": matchesPredicate, "false": falsePredicate},
-			prioritizers:             []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
 			alwaysCheckAllPredicates: true,
 			nodes:                    []string{"1"},
 			pod:                      &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "2", UID: types.UID("2")}},
@@ -499,7 +492,6 @@ func TestGenericScheduler(t *testing.T) {
 			predicates: map[string]algorithmpredicates.FitPredicate{
 				"matches": algorithmpredicates.EvenPodsSpreadPredicate,
 			},
-			// prioritizers:  []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
 			nodes: []string{"machine1", "machine2"},
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", UID: types.UID("p"), Labels: map[string]string{"foo": ""}},
@@ -541,7 +533,6 @@ func TestGenericScheduler(t *testing.T) {
 			predicates: map[string]algorithmpredicates.FitPredicate{
 				"matches": algorithmpredicates.EvenPodsSpreadPredicate,
 			},
-			// prioritizers:  []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}},
 			nodes: []string{"machine1", "machine2", "machine3"},
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: "p", UID: types.UID("p"), Labels: map[string]string{"foo": ""}},
@@ -702,14 +693,13 @@ func makeScheduler(predicates map[string]algorithmpredicates.FitPredicate, nodes
 	for _, n := range nodes {
 		cache.AddNode(n)
 	}
-	prioritizers := []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}}
 
 	s := NewGenericScheduler(
 		cache,
 		internalqueue.NewSchedulingQueue(nil, nil),
 		predicates,
 		algorithmpredicates.EmptyPredicateMetadataProducer,
-		prioritizers,
+		nil,
 		priorities.EmptyPriorityMetadataProducer,
 		emptyFramework,
 		nil, nil, nil, nil, false, false,
@@ -821,14 +811,14 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 		for _, n := range nodes {
 			cache.AddNode(n)
 		}
-		prioritizers := []priorities.PriorityConfig{{Map: EqualPriorityMap, Weight: 1}}
+
 		queue := internalqueue.NewSchedulingQueue(nil, nil)
 		scheduler := NewGenericScheduler(
 			cache,
 			queue,
 			predicates,
 			algorithmpredicates.EmptyPredicateMetadataProducer,
-			prioritizers,
+			nil,
 			priorities.EmptyPriorityMetadataProducer,
 			emptyFramework,
 			nil, nil, nil, nil, false, false,

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -339,6 +339,10 @@ func (c *Configurator) CreateFromConfig(policy schedulerapi.Policy) (*Config, er
 		priorityKeys = provider.PriorityFunctionKeys
 	} else {
 		for _, priority := range policy.Priorities {
+			if priority.Name == priorities.EqualPriority {
+				klog.V(2).Infof("Skip registering priority: %s", priority.Name)
+				continue
+			}
 			klog.V(2).Infof("Registering priority: %s", priority.Name)
 			priorityKeys.Insert(RegisterCustomPriorityFunction(priority, c.configProducerArgs))
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Removes EqualPriority priority function, specifying it in the Policy API is a no op.

EqualPriority gives a score of 1 to all nodes, which means by design it is a no op. The scheduler already initializes the scores of the node to 1 when no priorities are configured.

**Which issue(s) this PR fixes**:
Part of #83554

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

