### PR TITLE
[1/2] Default Topology Spread Constraints: API

### DIFF
--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -69,6 +69,7 @@ go_test(
     deps = [
         "//cmd/kube-scheduler/app/config:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -28,7 +28,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/diff"
@@ -36,6 +36,19 @@ import (
 	componentbaseconfig "k8s.io/component-base/config"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
+
+var defaultTopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+	{
+		MaxSkew:           1,
+		TopologyKey:       corev1.LabelHostname,
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+	},
+	{
+		MaxSkew:           1,
+		TopologyKey:       corev1.LabelZoneFailureDomain,
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+	},
+}
 
 func TestSchedulerOptions(t *testing.T) {
 	// temp dir
@@ -76,6 +89,10 @@ apiVersion: kubescheduler.config.k8s.io/v1alpha1
 kind: KubeSchedulerConfiguration
 clientConnection:
   kubeconfig: "%s"
+topologySpreadConstraints:
+- maxSkew: 1
+  topologyKey: example.com/rack
+  whenUnsatisfiable: ScheduleAnyway
 leaderElection:
   leaderElect: true`, configKubeconfig)), os.FileMode(0600)); err != nil {
 		t.Fatal(err)
@@ -258,8 +275,15 @@ pluginConfig:
 				SchedulerName:                  "default-scheduler",
 				AlgorithmSource:                kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &defaultSource},
 				HardPodAffinitySymmetricWeight: 1,
-				HealthzBindAddress:             "0.0.0.0:10251",
-				MetricsBindAddress:             "0.0.0.0:10251",
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "example.com/rack",
+						WhenUnsatisfiable: "ScheduleAnyway",
+					},
+				},
+				HealthzBindAddress: "0.0.0.0:10251",
+				MetricsBindAddress: "0.0.0.0:10251",
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           true,
 					EnableContentionProfiling: true,
@@ -345,6 +369,7 @@ pluginConfig:
 				SchedulerName:                  "default-scheduler",
 				AlgorithmSource:                kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &defaultSource},
 				HardPodAffinitySymmetricWeight: 1,
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             "", // defaults empty when not running from config file
 				MetricsBindAddress:             "", // defaults empty when not running from config file
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
@@ -410,6 +435,7 @@ pluginConfig:
 				SchedulerName:                  "default-scheduler",
 				AlgorithmSource:                kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &defaultSource},
 				HardPodAffinitySymmetricWeight: 1,
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             "", // defaults empty when not running from config file
 				MetricsBindAddress:             "", // defaults empty when not running from config file
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
@@ -450,6 +476,7 @@ pluginConfig:
 				SchedulerName:                  "default-scheduler",
 				AlgorithmSource:                kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &defaultSource},
 				HardPodAffinitySymmetricWeight: 1,
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
@@ -532,6 +559,7 @@ pluginConfig:
 				SchedulerName:                  "default-scheduler",
 				AlgorithmSource:                kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &defaultSource},
 				HardPodAffinitySymmetricWeight: 1,
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
@@ -575,6 +603,7 @@ pluginConfig:
 				SchedulerName:                  "default-scheduler",
 				AlgorithmSource:                kubeschedulerconfig.SchedulerAlgorithmSource{Provider: &defaultSource},
 				HardPodAffinitySymmetricWeight: 1,
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             "0.0.0.0:10251",
 				MetricsBindAddress:             "0.0.0.0:10251",
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -45,7 +45,7 @@ var defaultTopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 	},
 	{
 		MaxSkew:           1,
-		TopologyKey:       corev1.LabelZoneFailureDomain,
+		TopologyKey:       corev1.LabelZoneFailureDomainStable,
 		WhenUnsatisfiable: corev1.ScheduleAnyway,
 	},
 }

--- a/pkg/scheduler/apis/config/BUILD
+++ b/pkg/scheduler/apis/config/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/apis/config",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -62,8 +62,9 @@ type KubeSchedulerConfiguration struct {
 	// Label selectors must be empty, as they are deduced from the pods'
 	// membership in Services, Replication Controllers, Replica sets or Stateful
 	// sets.
-	// Omit to use the default: soft spreading among nodes and zones.
-	// Set to empty to disable.
+	// By default, it is set to soft pod spreading among nodes and zones.
+	// This is part of EvenPodsSpread feature, so it is only honored when the
+	// feature is enabled.
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint
 
 	// LeaderElection defines the configuration of leader election client.

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -19,6 +19,7 @@ package config
 import (
 	"math"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfig "k8s.io/component-base/config"
@@ -54,6 +55,14 @@ type KubeSchedulerConfiguration struct {
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
 	HardPodAffinitySymmetricWeight int32
+
+	// TopologySpreadConstraints is the cluster-level configuration for
+	// topology-based spreading.
+	// Constraints are applied to pods that don't define any in their PodSpec.
+	// Label selectors must be empty, as they are deduced from the pods'
+	// membership in Services, Replication Controllers, Replica sets or Stateful
+	// sets.
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint
 
 	// LeaderElection defines the configuration of leader election client.
 	LeaderElection KubeSchedulerLeaderElectionConfiguration

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -57,7 +57,7 @@ type KubeSchedulerConfiguration struct {
 	HardPodAffinitySymmetricWeight int32
 
 	// TopologySpreadConstraints is the cluster-level configuration for
-	// topology-based top spreading.
+	// topology-based pod spreading.
 	// Constraints are applied to pods that don't define any in their PodSpec.
 	// Label selectors must be empty, as they are deduced from the pods'
 	// membership in Services, Replication Controllers, Replica sets or Stateful

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -57,11 +57,13 @@ type KubeSchedulerConfiguration struct {
 	HardPodAffinitySymmetricWeight int32
 
 	// TopologySpreadConstraints is the cluster-level configuration for
-	// topology-based spreading.
+	// topology-based top spreading.
 	// Constraints are applied to pods that don't define any in their PodSpec.
 	// Label selectors must be empty, as they are deduced from the pods'
 	// membership in Services, Replication Controllers, Replica sets or Stateful
 	// sets.
+	// Omit to use the default: soft spreading among nodes and zones.
+	// Set to empty to disable.
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint
 
 	// LeaderElection defines the configuration of leader election client.

--- a/pkg/scheduler/apis/config/v1alpha1/BUILD
+++ b/pkg/scheduler/apis/config/v1alpha1/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//pkg/apis/core:go_default_library",
         "//pkg/master/ports:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -35,11 +36,13 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/scheduler/apis/config:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//staging/src/k8s.io/component-base/config:go_default_library",
         "//staging/src/k8s.io/component-base/config/v1alpha1:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/config/v1alpha1:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"strconv"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	kubeschedulerconfigv1alpha1 "k8s.io/kube-scheduler/config/v1alpha1"
@@ -55,6 +56,22 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubeschedulerconfigv1alpha1.Kub
 	if policy := obj.AlgorithmSource.Policy; policy != nil {
 		if policy.ConfigMap != nil && len(policy.ConfigMap.Namespace) == 0 {
 			obj.AlgorithmSource.Policy.ConfigMap.Namespace = api.NamespaceSystem
+		}
+	}
+
+	// Note that an empty list won't be parsed as nil.
+	if obj.TopologySpreadConstraints == nil {
+		obj.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelHostname,
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+			},
+			{
+				MaxSkew:           1,
+				TopologyKey:       corev1.LabelZoneFailureDomain,
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+			},
 		}
 	}
 

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -72,8 +72,7 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubeschedulerconfigv1alpha1.Kub
 		}
 	}
 
-	// Note that an empty list won't be parsed as nil.
-	if obj.TopologySpreadConstraints == nil {
+	if len(obj.TopologySpreadConstraints) == 0 {
 		obj.TopologySpreadConstraints = make([]corev1.TopologySpreadConstraint, len(defaultTopologySpreadConstraints))
 		for i := range defaultTopologySpreadConstraints {
 			obj.TopologySpreadConstraints[i] = *defaultTopologySpreadConstraints[i].DeepCopy()

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -31,6 +31,19 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
+var defaultTopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+	{
+		MaxSkew:           1,
+		TopologyKey:       corev1.LabelHostname,
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+	},
+	{
+		MaxSkew:           1,
+		TopologyKey:       corev1.LabelZoneFailureDomain,
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+	},
+}
+
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
@@ -61,17 +74,9 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubeschedulerconfigv1alpha1.Kub
 
 	// Note that an empty list won't be parsed as nil.
 	if obj.TopologySpreadConstraints == nil {
-		obj.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
-			{
-				MaxSkew:           1,
-				TopologyKey:       corev1.LabelHostname,
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-			},
-			{
-				MaxSkew:           1,
-				TopologyKey:       corev1.LabelZoneFailureDomain,
-				WhenUnsatisfiable: corev1.ScheduleAnyway,
-			},
+		obj.TopologySpreadConstraints = make([]corev1.TopologySpreadConstraint, len(defaultTopologySpreadConstraints))
+		for i := range defaultTopologySpreadConstraints {
+			obj.TopologySpreadConstraints[i] = *defaultTopologySpreadConstraints[i].DeepCopy()
 		}
 	}
 

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -39,7 +39,7 @@ var defaultTopologySpreadConstraints = []corev1.TopologySpreadConstraint{
 	},
 	{
 		MaxSkew:           1,
-		TopologyKey:       corev1.LabelZoneFailureDomain,
+		TopologyKey:       corev1.LabelZoneFailureDomainStable,
 		WhenUnsatisfiable: corev1.ScheduleAnyway,
 	},
 }

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -17,15 +17,29 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"reflect"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config/v1alpha1"
 	kubeschedulerconfigv1alpha1 "k8s.io/kube-scheduler/config/v1alpha1"
 	"k8s.io/utils/pointer"
 )
+
+var defaultTopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+	{
+		MaxSkew:           1,
+		TopologyKey:       corev1.LabelHostname,
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+	},
+	{
+		MaxSkew:           1,
+		TopologyKey:       corev1.LabelZoneFailureDomain,
+		WhenUnsatisfiable: corev1.ScheduleAnyway,
+	},
+}
 
 func TestSchedulerDefaults(t *testing.T) {
 	enable := true
@@ -41,6 +55,7 @@ func TestSchedulerDefaults(t *testing.T) {
 				SchedulerName:                  pointer.StringPtr("default-scheduler"),
 				AlgorithmSource:                kubeschedulerconfigv1alpha1.SchedulerAlgorithmSource{Provider: pointer.StringPtr("DefaultProvider")},
 				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
 				MetricsBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
@@ -83,6 +98,7 @@ func TestSchedulerDefaults(t *testing.T) {
 				SchedulerName:                  pointer.StringPtr("default-scheduler"),
 				AlgorithmSource:                kubeschedulerconfigv1alpha1.SchedulerAlgorithmSource{Provider: pointer.StringPtr("DefaultProvider")},
 				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             pointer.StringPtr("1.2.3.4:10251"),
 				MetricsBindAddress:             pointer.StringPtr("1.2.3.4:10251"),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
@@ -125,8 +141,105 @@ func TestSchedulerDefaults(t *testing.T) {
 				SchedulerName:                  pointer.StringPtr("default-scheduler"),
 				AlgorithmSource:                kubeschedulerconfigv1alpha1.SchedulerAlgorithmSource{Provider: pointer.StringPtr("DefaultProvider")},
 				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
+				TopologySpreadConstraints:      defaultTopologySpreadConstraints,
 				HealthzBindAddress:             pointer.StringPtr("0.0.0.0:12345"),
 				MetricsBindAddress:             pointer.StringPtr("0.0.0.0:12345"),
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           &enable,
+					EnableContentionProfiling: &enable,
+				},
+				LeaderElection: kubeschedulerconfigv1alpha1.KubeSchedulerLeaderElectionConfiguration{
+					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
+						LeaderElect:       pointer.BoolPtr(true),
+						LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
+						RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+						RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+						ResourceLock:      "endpointsleases",
+						ResourceNamespace: "",
+						ResourceName:      "",
+					},
+					LockObjectName:      "kube-scheduler",
+					LockObjectNamespace: "kube-system",
+				},
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					QPS:         50,
+					Burst:       100,
+					ContentType: "application/vnd.kubernetes.protobuf",
+				},
+				DisablePreemption:        pointer.BoolPtr(false),
+				PercentageOfNodesToScore: pointer.Int32Ptr(50),
+				BindTimeoutSeconds:       pointer.Int64Ptr(600),
+				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
+				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				Plugins:                  nil,
+			},
+		},
+		{
+			name: "empty spread constraints",
+			config: &kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{
+				TopologySpreadConstraints: make([]corev1.TopologySpreadConstraint, 0),
+			},
+			expected: &kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{
+				SchedulerName:                  pointer.StringPtr("default-scheduler"),
+				AlgorithmSource:                kubeschedulerconfigv1alpha1.SchedulerAlgorithmSource{Provider: pointer.StringPtr("DefaultProvider")},
+				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
+				TopologySpreadConstraints:      make([]corev1.TopologySpreadConstraint, 0),
+				HealthzBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
+				MetricsBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
+				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
+					EnableProfiling:           &enable,
+					EnableContentionProfiling: &enable,
+				},
+				LeaderElection: kubeschedulerconfigv1alpha1.KubeSchedulerLeaderElectionConfiguration{
+					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
+						LeaderElect:       pointer.BoolPtr(true),
+						LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
+						RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
+						RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
+						ResourceLock:      "endpointsleases",
+						ResourceNamespace: "",
+						ResourceName:      "",
+					},
+					LockObjectName:      "kube-scheduler",
+					LockObjectNamespace: "kube-system",
+				},
+				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
+					QPS:         50,
+					Burst:       100,
+					ContentType: "application/vnd.kubernetes.protobuf",
+				},
+				DisablePreemption:        pointer.BoolPtr(false),
+				PercentageOfNodesToScore: pointer.Int32Ptr(50),
+				BindTimeoutSeconds:       pointer.Int64Ptr(600),
+				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
+				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
+				Plugins:                  nil,
+			},
+		},
+		{
+			name: "custom spread constraints",
+			config: &kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "rack",
+						WhenUnsatisfiable: "DoNotSchedule",
+					},
+				},
+			},
+			expected: &kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{
+				SchedulerName:                  pointer.StringPtr("default-scheduler"),
+				AlgorithmSource:                kubeschedulerconfigv1alpha1.SchedulerAlgorithmSource{Provider: pointer.StringPtr("DefaultProvider")},
+				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
+				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+					{
+						MaxSkew:           1,
+						TopologyKey:       "rack",
+						WhenUnsatisfiable: "DoNotSchedule",
+					},
+				},
+				HealthzBindAddress: pointer.StringPtr("0.0.0.0:10251"),
+				MetricsBindAddress: pointer.StringPtr("0.0.0.0:10251"),
 				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
 					EnableProfiling:           &enable,
 					EnableContentionProfiling: &enable,
@@ -161,8 +274,8 @@ func TestSchedulerDefaults(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			SetDefaults_KubeSchedulerConfiguration(tc.config)
-			if !reflect.DeepEqual(tc.expected, tc.config) {
-				t.Errorf("Expected:\n%#v\n\nGot:\n%#v", tc.expected, tc.config)
+			if diff := cmp.Diff(tc.expected, tc.config); diff != "" {
+				t.Errorf("Invalid defaults (-want, +got): %s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -28,19 +28,6 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-var defaultTopologySpreadConstraints = []corev1.TopologySpreadConstraint{
-	{
-		MaxSkew:           1,
-		TopologyKey:       corev1.LabelHostname,
-		WhenUnsatisfiable: corev1.ScheduleAnyway,
-	},
-	{
-		MaxSkew:           1,
-		TopologyKey:       corev1.LabelZoneFailureDomain,
-		WhenUnsatisfiable: corev1.ScheduleAnyway,
-	},
-}
-
 func TestSchedulerDefaults(t *testing.T) {
 	enable := true
 	tests := []struct {

--- a/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults_test.go
@@ -162,48 +162,6 @@ func TestSchedulerDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "empty spread constraints",
-			config: &kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{
-				TopologySpreadConstraints: make([]corev1.TopologySpreadConstraint, 0),
-			},
-			expected: &kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{
-				SchedulerName:                  pointer.StringPtr("default-scheduler"),
-				AlgorithmSource:                kubeschedulerconfigv1alpha1.SchedulerAlgorithmSource{Provider: pointer.StringPtr("DefaultProvider")},
-				HardPodAffinitySymmetricWeight: pointer.Int32Ptr(1),
-				TopologySpreadConstraints:      make([]corev1.TopologySpreadConstraint, 0),
-				HealthzBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
-				MetricsBindAddress:             pointer.StringPtr("0.0.0.0:10251"),
-				DebuggingConfiguration: componentbaseconfig.DebuggingConfiguration{
-					EnableProfiling:           &enable,
-					EnableContentionProfiling: &enable,
-				},
-				LeaderElection: kubeschedulerconfigv1alpha1.KubeSchedulerLeaderElectionConfiguration{
-					LeaderElectionConfiguration: componentbaseconfig.LeaderElectionConfiguration{
-						LeaderElect:       pointer.BoolPtr(true),
-						LeaseDuration:     metav1.Duration{Duration: 15 * time.Second},
-						RenewDeadline:     metav1.Duration{Duration: 10 * time.Second},
-						RetryPeriod:       metav1.Duration{Duration: 2 * time.Second},
-						ResourceLock:      "endpointsleases",
-						ResourceNamespace: "",
-						ResourceName:      "",
-					},
-					LockObjectName:      "kube-scheduler",
-					LockObjectNamespace: "kube-system",
-				},
-				ClientConnection: componentbaseconfig.ClientConnectionConfiguration{
-					QPS:         50,
-					Burst:       100,
-					ContentType: "application/vnd.kubernetes.protobuf",
-				},
-				DisablePreemption:        pointer.BoolPtr(false),
-				PercentageOfNodesToScore: pointer.Int32Ptr(50),
-				BindTimeoutSeconds:       pointer.Int64Ptr(600),
-				PodInitialBackoffSeconds: pointer.Int64Ptr(1),
-				PodMaxBackoffSeconds:     pointer.Int64Ptr(10),
-				Plugins:                  nil,
-			},
-		},
-		{
 			name: "custom spread constraints",
 			config: &kubeschedulerconfigv1alpha1.KubeSchedulerConfiguration{
 				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
@@ -23,6 +23,7 @@ package v1alpha1
 import (
 	unsafe "unsafe"
 
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -151,6 +152,7 @@ func autoConvert_v1alpha1_KubeSchedulerConfiguration_To_config_KubeSchedulerConf
 	if err := v1.Convert_Pointer_int32_To_int32(&in.HardPodAffinitySymmetricWeight, &out.HardPodAffinitySymmetricWeight, s); err != nil {
 		return err
 	}
+	out.TopologySpreadConstraints = *(*[]corev1.TopologySpreadConstraint)(unsafe.Pointer(&in.TopologySpreadConstraints))
 	if err := Convert_v1alpha1_KubeSchedulerLeaderElectionConfiguration_To_config_KubeSchedulerLeaderElectionConfiguration(&in.LeaderElection, &out.LeaderElection, s); err != nil {
 		return err
 	}
@@ -209,6 +211,7 @@ func autoConvert_config_KubeSchedulerConfiguration_To_v1alpha1_KubeSchedulerConf
 	if err := v1.Convert_int32_To_Pointer_int32(&in.HardPodAffinitySymmetricWeight, &out.HardPodAffinitySymmetricWeight, s); err != nil {
 		return err
 	}
+	out.TopologySpreadConstraints = *(*[]corev1.TopologySpreadConstraint)(unsafe.Pointer(&in.TopologySpreadConstraints))
 	if err := Convert_config_KubeSchedulerLeaderElectionConfiguration_To_v1alpha1_KubeSchedulerLeaderElectionConfiguration(&in.LeaderElection, &out.LeaderElection, s); err != nil {
 		return err
 	}

--- a/pkg/scheduler/apis/config/validation/BUILD
+++ b/pkg/scheduler/apis/config/validation/BUILD
@@ -9,6 +9,7 @@ go_library(
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation:go_default_library",

--- a/pkg/scheduler/apis/config/validation/BUILD
+++ b/pkg/scheduler/apis/config/validation/BUILD
@@ -23,6 +23,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/scheduler/apis/config:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/component-base/config:go_default_library",
     ],

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -94,7 +94,7 @@ func validateTopologySpreadConstraints(constraints []v1.TopologySpreadConstraint
 			allErrs = append(allErrs, field.NotSupported(f, c.WhenUnsatisfiable, supportedScheduleActions.List()))
 		}
 		if c.LabelSelector != nil {
-			f := field.Forbidden(p.Child("labelSelector"), "cluster-level constraint must not define a selector")
+			f := field.Forbidden(p.Child("labelSelector"), "cluster-level constraint must not define a selector, as they are deduced for each Pod")
 			allErrs = append(allErrs, f)
 		}
 		if err := validateSpreadConstraintNotRepeat(p.Child("{topologyKey, whenUnsatisfiable}"), c, constraints[i+1:]); err != nil {

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -85,9 +86,11 @@ func validateTopologySpreadConstraints(constraints []v1.TopologySpreadConstraint
 			f := p.Child("maxSkew")
 			allErrs = append(allErrs, field.Invalid(f, c.MaxSkew, "must be greater than zero"))
 		}
+		topologyKeyP := p.Child("topologyKey")
 		if len(c.TopologyKey) == 0 {
-			f := p.Child("topologyKey")
-			allErrs = append(allErrs, field.Required(f, "can not be empty"))
+			allErrs = append(allErrs, field.Required(topologyKeyP, "can not be empty"))
+		} else {
+			allErrs = append(allErrs, metav1validation.ValidateLabelName(c.TopologyKey, topologyKeyP)...)
 		}
 		if !supportedScheduleActions.Has(string(c.WhenUnsatisfiable)) {
 			f := p.Child("whenUnsatisfiable")

--- a/pkg/scheduler/apis/config/validation/validation.go
+++ b/pkg/scheduler/apis/config/validation/validation.go
@@ -94,7 +94,7 @@ func validateTopologySpreadConstraints(constraints []v1.TopologySpreadConstraint
 			f := field.Forbidden(p.Child("labelSelector"), "cluster-level constraint must not define a selector, as they are deduced for each Pod")
 			allErrs = append(allErrs, f)
 		}
-		if err := validateSpreadConstraintNotRepeat(p.Child("{topologyKey, whenUnsatisfiable}"), c, constraints[i+1:]); err != nil {
+		if err := validateSpreadConstraintNotRepeat(p, c, constraints[i+1:]); err != nil {
 			allErrs = append(allErrs, err)
 		}
 	}

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package config
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -102,6 +103,13 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 	*out = *in
 	out.TypeMeta = in.TypeMeta
 	in.AlgorithmSource.DeepCopyInto(&out.AlgorithmSource)
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	out.LeaderElection = in.LeaderElection
 	out.ClientConnection = in.ClientConnection
 	out.DebuggingConfiguration = in.DebuggingConfiguration

--- a/staging/publishing/import-restrictions.yaml
+++ b/staging/publishing/import-restrictions.yaml
@@ -195,6 +195,7 @@
 
 - baseImportPath: "./vendor/k8s.io/kube-scheduler/"
   allowedImports:
+  - k8s.io/api
   - k8s.io/apimachinery
   - k8s.io/component-base
   - k8s.io/klog

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/BUILD
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/kube-scheduler/config/v1alpha1",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -51,7 +51,7 @@ type KubeSchedulerConfiguration struct {
 	HardPodAffinitySymmetricWeight *int32 `json:"hardPodAffinitySymmetricWeight,omitempty"`
 
 	// TopologySpreadConstraints is the cluster-level configuration for
-	// topology-based spreading.
+	// topology-based pod spreading.
 	// Constraints are applied to pods that don't define any in their PodSpec.
 	// Label selectors must be empty, as they are deduced from the pods'
 	// membership in Services, Replication Controllers, Replica sets or Stateful

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
@@ -48,6 +49,17 @@ type KubeSchedulerConfiguration struct {
 	// corresponding to every RequiredDuringScheduling affinity rule.
 	// HardPodAffinitySymmetricWeight represents the weight of implicit PreferredDuringScheduling affinity rule, in the range 0-100.
 	HardPodAffinitySymmetricWeight *int32 `json:"hardPodAffinitySymmetricWeight,omitempty"`
+
+	// TopologySpreadConstraints is the cluster-level configuration for
+	// topology-based spreading.
+	// Constraints are applied to pods that don't define any in their PodSpec.
+	// Label selectors must be empty, as they are deduced from the pods'
+	// membership in Services, Replication Controllers, Replica sets or Stateful
+	// sets.
+	// Omit to use the default: soft spreading among nodes and zones.
+	// Set to empty to disable.
+	// +listType=atomic
+	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints"`
 
 	// LeaderElection defines the configuration of leader election client.
 	LeaderElection KubeSchedulerLeaderElectionConfiguration `json:"leaderElection"`

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/types.go
@@ -56,8 +56,9 @@ type KubeSchedulerConfiguration struct {
 	// Label selectors must be empty, as they are deduced from the pods'
 	// membership in Services, Replication Controllers, Replica sets or Stateful
 	// sets.
-	// Omit to use the default: soft spreading among nodes and zones.
-	// Set to empty to disable.
+	// By default, it is set to soft pod spreading among nodes and zones.
+	// This is part of EvenPodsSpread feature, so it is only honored when the
+	// feature is enabled.
 	// +listType=atomic
 	TopologySpreadConstraints []corev1.TopologySpreadConstraint `json:"topologySpreadConstraints"`
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	v1 "k8s.io/api/core/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -38,6 +39,13 @@ func (in *KubeSchedulerConfiguration) DeepCopyInto(out *KubeSchedulerConfigurati
 		in, out := &in.HardPodAffinitySymmetricWeight, &out.HardPodAffinitySymmetricWeight
 		*out = new(int32)
 		**out = **in
+	}
+	if in.TopologySpreadConstraints != nil {
+		in, out := &in.TopologySpreadConstraints, &out.TopologySpreadConstraints
+		*out = make([]v1.TopologySpreadConstraint, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 	in.LeaderElection.DeepCopyInto(&out.LeaderElection)
 	out.ClientConnection = in.ClientConnection

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -5,6 +5,7 @@ module k8s.io/kube-scheduler
 go 1.12
 
 require (
+	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
 )


### PR DESCRIPTION
/kind api-change
/kind feature

**What this PR does / why we need it**:
Add API to sheduler's component config to set cluster-level topology spread constraints.

**Which issue(s) this PR fixes**:

Part of #80639 and kubernetes/enhancements#1258

**Does this PR introduce a user-facing change?**:

```release-note
New topologySpreadConstraints field in kube-scheduler's component config.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20190926-default-even-pod-spreading.md)