### PR TITLE
Remove unused skip functions

### DIFF
--- a/test/e2e/framework/skip.go
+++ b/test/e2e/framework/skip.go
@@ -50,15 +50,6 @@ func SkipUnlessAtLeast(value int, minValue int, message string) {
 	}
 }
 
-// SkipIfContainerRuntimeIs skips if the container runtime is included in the runtimes.
-func SkipIfContainerRuntimeIs(runtimes ...string) {
-	for _, containerRuntime := range runtimes {
-		if containerRuntime == TestContext.ContainerRuntime {
-			skipInternalf(1, "Not supported under container runtime %s", containerRuntime)
-		}
-	}
-}
-
 // SkipUnlessLocalEphemeralStorageEnabled skips if the LocalStorageCapacityIsolation is not enabled.
 func SkipUnlessLocalEphemeralStorageEnabled() {
 	if !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
@@ -165,13 +156,6 @@ func SkipUnlessServerVersionGTE(v *utilversion.Version, c discovery.ServerVersio
 func SkipUnlessSSHKeyPresent() {
 	if _, err := e2essh.GetSigner(TestContext.Provider); err != nil {
 		skipInternalf(1, "No SSH Key for provider %s: '%v'", TestContext.Provider, err)
-	}
-}
-
-// SkipUnlessTaintBasedEvictionsEnabled skips if the TaintBasedEvictions is not enabled.
-func SkipUnlessTaintBasedEvictionsEnabled() {
-	if !utilfeature.DefaultFeatureGate.Enabled(features.TaintBasedEvictions) {
-		skipInternalf(1, "Only supported when %v feature is enabled", features.TaintBasedEvictions)
 	}
 }
 


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This removes the following functions from e2e/framework/skip.go:

- SkipUnlessTaintBasedEvictionsEnabled: Unused since 7e1794dcb1826ba8253064743ff021e85d69dfc3
- SkipIfContainerRuntimeIs: Unused since 19a588eeda50ffb452c15d3017d4872b12f0d916

Ref: https://github.com/kubernetes/kubernetes/issues/84380

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
