### PR TITLE
Remove unused func and struct from pod.go

### DIFF
--- a/test/e2e/framework/metrics/pod.go
+++ b/test/e2e/framework/metrics/pod.go
@@ -18,8 +18,6 @@ package metrics
 
 import (
 	"time"
-
-	e2eperftype "k8s.io/kubernetes/test/e2e/perftype"
 )
 
 // LatencyMetric is a struct for dashboard metrics.
@@ -28,54 +26,4 @@ type LatencyMetric struct {
 	Perc90  time.Duration `json:"Perc90"`
 	Perc99  time.Duration `json:"Perc99"`
 	Perc100 time.Duration `json:"Perc100"`
-}
-
-// PodStartupLatency is a struct for managing latency of pod startup.
-type PodStartupLatency struct {
-	CreateToScheduleLatency LatencyMetric `json:"createToScheduleLatency"`
-	ScheduleToRunLatency    LatencyMetric `json:"scheduleToRunLatency"`
-	RunToWatchLatency       LatencyMetric `json:"runToWatchLatency"`
-	ScheduleToWatchLatency  LatencyMetric `json:"scheduleToWatchLatency"`
-	E2ELatency              LatencyMetric `json:"e2eLatency"`
-}
-
-// SummaryKind returns the summary of pod startup latency.
-func (l *PodStartupLatency) SummaryKind() string {
-	return "PodStartupLatency"
-}
-
-// PrintHumanReadable returns pod startup letency with JSON format.
-func (l *PodStartupLatency) PrintHumanReadable() string {
-	return PrettyPrintJSON(l)
-}
-
-// PrintJSON returns pod startup letency with JSON format.
-func (l *PodStartupLatency) PrintJSON() string {
-	return PrettyPrintJSON(PodStartupLatencyToPerfData(l))
-}
-
-func latencyToPerfData(l LatencyMetric, name string) e2eperftype.DataItem {
-	return e2eperftype.DataItem{
-		Data: map[string]float64{
-			"Perc50":  float64(l.Perc50) / 1000000, // us -> ms
-			"Perc90":  float64(l.Perc90) / 1000000,
-			"Perc99":  float64(l.Perc99) / 1000000,
-			"Perc100": float64(l.Perc100) / 1000000,
-		},
-		Unit: "ms",
-		Labels: map[string]string{
-			"Metric": name,
-		},
-	}
-}
-
-// PodStartupLatencyToPerfData transforms PodStartupLatency to PerfData.
-func PodStartupLatencyToPerfData(latency *PodStartupLatency) *e2eperftype.PerfData {
-	perfData := &e2eperftype.PerfData{Version: currentAPICallMetricsVersion}
-	perfData.DataItems = append(perfData.DataItems, latencyToPerfData(latency.CreateToScheduleLatency, "create_to_schedule"))
-	perfData.DataItems = append(perfData.DataItems, latencyToPerfData(latency.ScheduleToRunLatency, "schedule_to_run"))
-	perfData.DataItems = append(perfData.DataItems, latencyToPerfData(latency.RunToWatchLatency, "run_to_watch"))
-	perfData.DataItems = append(perfData.DataItems, latencyToPerfData(latency.ScheduleToWatchLatency, "schedule_to_watch"))
-	perfData.DataItems = append(perfData.DataItems, latencyToPerfData(latency.E2ELatency, "pod_startup"))
-	return perfData
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

these global func and struct are no longer used since commit 59533f0 , so this PR removes them.

- func PodStartupLatencyToPerfData
- struct PodStartupLatency

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
