### PR TITLE
Migrate custom collector for kube-scheduler

### DIFF
--- a/pkg/controller/volume/attachdetach/metrics/BUILD
+++ b/pkg/controller/volume/attachdetach/metrics/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/controller/volume/attachdetach/metrics/metrics.go
+++ b/pkg/controller/volume/attachdetach/metrics/metrics.go
@@ -19,8 +19,6 @@ package metrics
 import (
 	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	"k8s.io/apimachinery/pkg/labels"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/component-base/metrics"
@@ -35,15 +33,17 @@ import (
 const pluginNameNotAvailable = "N/A"
 
 var (
-	inUseVolumeMetricDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("", "storage_count", "attachable_volumes_in_use"),
+	inUseVolumeMetricDesc = metrics.NewDesc(
+		metrics.BuildFQName("", "storage_count", "attachable_volumes_in_use"),
 		"Measure number of volumes in use",
-		[]string{"node", "volume_plugin"}, nil)
+		[]string{"node", "volume_plugin"}, nil,
+		metrics.ALPHA, "")
 
-	totalVolumesMetricDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("", "attachdetach_controller", "total_volumes"),
+	totalVolumesMetricDesc = metrics.NewDesc(
+		metrics.BuildFQName("", "attachdetach_controller", "total_volumes"),
 		"Number of volumes in A/D Controller",
-		[]string{"plugin_name", "state"}, nil)
+		[]string{"plugin_name", "state"}, nil,
+		metrics.ALPHA, "")
 
 	forcedDetachMetricCounter = metrics.NewCounter(
 		&metrics.CounterOpts{
@@ -62,7 +62,7 @@ func Register(pvcLister corelisters.PersistentVolumeClaimLister,
 	dsw cache.DesiredStateOfWorld,
 	pluginMgr *volume.VolumePluginMgr) {
 	registerMetrics.Do(func() {
-		legacyregistry.RawMustRegister(newAttachDetachStateCollector(pvcLister,
+		legacyregistry.CustomMustRegister(newAttachDetachStateCollector(pvcLister,
 			podLister,
 			pvLister,
 			asw,
@@ -73,6 +73,8 @@ func Register(pvcLister corelisters.PersistentVolumeClaimLister,
 }
 
 type attachDetachStateCollector struct {
+	metrics.BaseStableCollector
+
 	pvcLister       corelisters.PersistentVolumeClaimLister
 	podLister       corelisters.PodLister
 	pvLister        corelisters.PersistentVolumeLister
@@ -104,45 +106,37 @@ func newAttachDetachStateCollector(
 	asw cache.ActualStateOfWorld,
 	dsw cache.DesiredStateOfWorld,
 	pluginMgr *volume.VolumePluginMgr) *attachDetachStateCollector {
-	return &attachDetachStateCollector{pvcLister, podLister, pvLister, asw, dsw, pluginMgr}
+	return &attachDetachStateCollector{pvcLister: pvcLister, podLister: podLister, pvLister: pvLister, asw: asw, dsw: dsw, volumePluginMgr: pluginMgr}
 }
 
 // Check if our collector implements necessary collector interface
-var _ prometheus.Collector = &attachDetachStateCollector{}
+var _ metrics.StableCollector = &attachDetachStateCollector{}
 
-func (collector *attachDetachStateCollector) Describe(ch chan<- *prometheus.Desc) {
+func (collector *attachDetachStateCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 	ch <- inUseVolumeMetricDesc
 	ch <- totalVolumesMetricDesc
 }
 
-func (collector *attachDetachStateCollector) Collect(ch chan<- prometheus.Metric) {
+func (collector *attachDetachStateCollector) CollectWithStability(ch chan<- metrics.Metric) {
 	nodeVolumeMap := collector.getVolumeInUseCount()
 	for nodeName, pluginCount := range nodeVolumeMap {
 		for pluginName, count := range pluginCount {
-			metric, err := prometheus.NewConstMetric(inUseVolumeMetricDesc,
-				prometheus.GaugeValue,
+			ch <- metrics.NewLazyConstMetric(inUseVolumeMetricDesc,
+				metrics.GaugeValue,
 				float64(count),
 				string(nodeName),
 				pluginName)
-			if err != nil {
-				klog.Warningf("Failed to create metric : %v", err)
-			}
-			ch <- metric
 		}
 	}
 
 	stateVolumeMap := collector.getTotalVolumesCount()
 	for stateName, pluginCount := range stateVolumeMap {
 		for pluginName, count := range pluginCount {
-			metric, err := prometheus.NewConstMetric(totalVolumesMetricDesc,
-				prometheus.GaugeValue,
+			ch <- metrics.NewLazyConstMetric(totalVolumesMetricDesc,
+				metrics.GaugeValue,
 				float64(count),
 				pluginName,
 				string(stateName))
-			if err != nil {
-				klog.Warningf("Failed to create metric : %v", err)
-			}
-			ch <- metric
 		}
 	}
 }

--- a/pkg/controller/volume/persistentvolume/metrics/BUILD
+++ b/pkg/controller/volume/persistentvolume/metrics/BUILD
@@ -10,8 +10,6 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/controller/volume/persistentvolume/metrics/metrics.go
+++ b/pkg/controller/volume/persistentvolume/metrics/metrics.go
@@ -20,12 +20,9 @@ import (
 	"sync"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/component-base/metrics"
 	"k8s.io/component-base/metrics/legacyregistry"
-	"k8s.io/klog"
 	metricutil "k8s.io/kubernetes/pkg/volume/util"
 )
 
@@ -59,41 +56,50 @@ type PVCLister interface {
 // Register all metrics for pv controller.
 func Register(pvLister PVLister, pvcLister PVCLister) {
 	registerMetrics.Do(func() {
-		legacyregistry.RawMustRegister(newPVAndPVCCountCollector(pvLister, pvcLister))
+		legacyregistry.CustomMustRegister(newPVAndPVCCountCollector(pvLister, pvcLister))
 		legacyregistry.MustRegister(volumeOperationErrorsMetric)
 	})
 }
 
 func newPVAndPVCCountCollector(pvLister PVLister, pvcLister PVCLister) *pvAndPVCCountCollector {
-	return &pvAndPVCCountCollector{pvLister, pvcLister}
+	return &pvAndPVCCountCollector{pvLister: pvLister, pvcLister: pvcLister}
 }
 
 // Custom collector for current pod and container counts.
 type pvAndPVCCountCollector struct {
+	metrics.BaseStableCollector
+
 	// Cache for accessing information about PersistentVolumes.
 	pvLister PVLister
 	// Cache for accessing information about PersistentVolumeClaims.
 	pvcLister PVCLister
 }
 
-var (
-	boundPVCountDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("", pvControllerSubsystem, boundPVKey),
-		"Gauge measuring number of persistent volume currently bound",
-		[]string{storageClassLabel}, nil)
-	unboundPVCountDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("", pvControllerSubsystem, unboundPVKey),
-		"Gauge measuring number of persistent volume currently unbound",
-		[]string{storageClassLabel}, nil)
+// Check if our collector implements necessary collector interface
+var _ metrics.StableCollector = &pvAndPVCCountCollector{}
 
-	boundPVCCountDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("", pvControllerSubsystem, boundPVCKey),
+var (
+	boundPVCountDesc = metrics.NewDesc(
+		metrics.BuildFQName("", pvControllerSubsystem, boundPVKey),
+		"Gauge measuring number of persistent volume currently bound",
+		[]string{storageClassLabel}, nil,
+		metrics.ALPHA, "")
+	unboundPVCountDesc = metrics.NewDesc(
+		metrics.BuildFQName("", pvControllerSubsystem, unboundPVKey),
+		"Gauge measuring number of persistent volume currently unbound",
+		[]string{storageClassLabel}, nil,
+		metrics.ALPHA, "")
+
+	boundPVCCountDesc = metrics.NewDesc(
+		metrics.BuildFQName("", pvControllerSubsystem, boundPVCKey),
 		"Gauge measuring number of persistent volume claim currently bound",
-		[]string{namespaceLabel}, nil)
-	unboundPVCCountDesc = prometheus.NewDesc(
-		prometheus.BuildFQName("", pvControllerSubsystem, unboundPVCKey),
+		[]string{namespaceLabel}, nil,
+		metrics.ALPHA, "")
+	unboundPVCCountDesc = metrics.NewDesc(
+		metrics.BuildFQName("", pvControllerSubsystem, unboundPVCKey),
 		"Gauge measuring number of persistent volume claim currently unbound",
-		[]string{namespaceLabel}, nil)
+		[]string{namespaceLabel}, nil,
+		metrics.ALPHA, "")
 
 	volumeOperationErrorsMetric = metrics.NewCounterVec(
 		&metrics.CounterOpts{
@@ -104,19 +110,19 @@ var (
 		[]string{"plugin_name", "operation_name"})
 )
 
-func (collector *pvAndPVCCountCollector) Describe(ch chan<- *prometheus.Desc) {
+func (collector *pvAndPVCCountCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 	ch <- boundPVCountDesc
 	ch <- unboundPVCountDesc
 	ch <- boundPVCCountDesc
 	ch <- unboundPVCCountDesc
 }
 
-func (collector *pvAndPVCCountCollector) Collect(ch chan<- prometheus.Metric) {
+func (collector *pvAndPVCCountCollector) CollectWithStability(ch chan<- metrics.Metric) {
 	collector.pvCollect(ch)
 	collector.pvcCollect(ch)
 }
 
-func (collector *pvAndPVCCountCollector) pvCollect(ch chan<- prometheus.Metric) {
+func (collector *pvAndPVCCountCollector) pvCollect(ch chan<- metrics.Metric) {
 	boundNumberByStorageClass := make(map[string]int)
 	unboundNumberByStorageClass := make(map[string]int)
 	for _, pvObj := range collector.pvLister.List() {
@@ -131,32 +137,22 @@ func (collector *pvAndPVCCountCollector) pvCollect(ch chan<- prometheus.Metric) 
 		}
 	}
 	for storageClassName, number := range boundNumberByStorageClass {
-		metric, err := prometheus.NewConstMetric(
+		ch <- metrics.NewLazyConstMetric(
 			boundPVCountDesc,
-			prometheus.GaugeValue,
+			metrics.GaugeValue,
 			float64(number),
 			storageClassName)
-		if err != nil {
-			klog.Warningf("Create bound pv number metric failed: %v", err)
-			continue
-		}
-		ch <- metric
 	}
 	for storageClassName, number := range unboundNumberByStorageClass {
-		metric, err := prometheus.NewConstMetric(
+		ch <- metrics.NewLazyConstMetric(
 			unboundPVCountDesc,
-			prometheus.GaugeValue,
+			metrics.GaugeValue,
 			float64(number),
 			storageClassName)
-		if err != nil {
-			klog.Warningf("Create unbound pv number metric failed: %v", err)
-			continue
-		}
-		ch <- metric
 	}
 }
 
-func (collector *pvAndPVCCountCollector) pvcCollect(ch chan<- prometheus.Metric) {
+func (collector *pvAndPVCCountCollector) pvcCollect(ch chan<- metrics.Metric) {
 	boundNumberByNamespace := make(map[string]int)
 	unboundNumberByNamespace := make(map[string]int)
 	for _, pvcObj := range collector.pvcLister.List() {
@@ -171,28 +167,18 @@ func (collector *pvAndPVCCountCollector) pvcCollect(ch chan<- prometheus.Metric)
 		}
 	}
 	for namespace, number := range boundNumberByNamespace {
-		metric, err := prometheus.NewConstMetric(
+		ch <- metrics.NewLazyConstMetric(
 			boundPVCCountDesc,
-			prometheus.GaugeValue,
+			metrics.GaugeValue,
 			float64(number),
 			namespace)
-		if err != nil {
-			klog.Warningf("Create bound pvc number metric failed: %v", err)
-			continue
-		}
-		ch <- metric
 	}
 	for namespace, number := range unboundNumberByNamespace {
-		metric, err := prometheus.NewConstMetric(
+		ch <- metrics.NewLazyConstMetric(
 			unboundPVCCountDesc,
-			prometheus.GaugeValue,
+			metrics.GaugeValue,
 			float64(number),
 			namespace)
-		if err != nil {
-			klog.Warningf("Create unbound pvc number metric failed: %v", err)
-			continue
-		}
-		ch <- metric
 	}
 }
 
@@ -228,7 +214,7 @@ type OperationStartTimeCache struct {
 // NewOperationStartTimeCache creates a operation timestamp cache
 func NewOperationStartTimeCache() OperationStartTimeCache {
 	return OperationStartTimeCache{
-		cache: sync.Map{}, //[string]operationTimestamp {}
+		cache: sync.Map{}, // [string]operationTimestamp {}
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Migrate custom collector functionality to the [metrics stability framework](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md).

It makes possible to offer stability guarantees for these metrics.

**Which issue(s) this PR fixes**:
Refer https://github.com/kubernetes/enhancements/issues/1238

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Following metrics from kube-controller-manager are now marked as with the ALPHA stability level:
storage_count_attachable_volumes_in_use
attachdetach_controller_total_volumes
pv_collector_bound_pv_count
pv_collector_unbound_pv_count
pv_collector_bound_pvc_count
pv_collector_unbound_pvc_count
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
```
