### PR TITLE
migrate kubelet custom metrics to stability framework part 1

### DIFF
--- a/pkg/kubelet/metrics/collectors/BUILD
+++ b/pkg/kubelet/metrics/collectors/BUILD
@@ -13,7 +13,7 @@ go_library(
         "//pkg/kubelet/metrics:go_default_library",
         "//pkg/kubelet/server/stats:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/kubelet/metrics/collectors/log_metrics.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics.go
@@ -17,14 +17,13 @@ limitations under the License.
 package collectors
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/component-base/metrics"
 	"k8s.io/klog"
-
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
 var (
-	descLogSize = prometheus.NewDesc(
+	descLogSize = metrics.NewDesc(
 		"kubelet_container_log_filesystem_used_bytes",
 		"Bytes used by the container's logs on the filesystem.",
 		[]string{
@@ -33,28 +32,35 @@ var (
 			"pod",
 			"container",
 		}, nil,
+		metrics.ALPHA,
+		"",
 	)
 )
 
 type logMetricsCollector struct {
+	metrics.BaseStableCollector
+
 	podStats func() ([]statsapi.PodStats, error)
 }
 
-// NewLogMetricsCollector implements the prometheus.Collector interface and
+// Check if logMetricsCollector implements necessary interface
+var _ metrics.StableCollector = &logMetricsCollector{}
+
+// NewLogMetricsCollector implements the metrics.StableCollector interface and
 // exposes metrics about container's log volume size.
-func NewLogMetricsCollector(podStats func() ([]statsapi.PodStats, error)) prometheus.Collector {
+func NewLogMetricsCollector(podStats func() ([]statsapi.PodStats, error)) metrics.StableCollector {
 	return &logMetricsCollector{
 		podStats: podStats,
 	}
 }
 
-// Describe implements the prometheus.Collector interface.
-func (c *logMetricsCollector) Describe(ch chan<- *prometheus.Desc) {
+// DescribeWithStability implements the metrics.StableCollector interface.
+func (c *logMetricsCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 	ch <- descLogSize
 }
 
-// Collect implements the prometheus.Collector interface.
-func (c *logMetricsCollector) Collect(ch chan<- prometheus.Metric) {
+// CollectWithStability implements the metrics.StableCollector interface.
+func (c *logMetricsCollector) CollectWithStability(ch chan<- metrics.Metric) {
 	podStats, err := c.podStats()
 	if err != nil {
 		klog.Errorf("failed to get pod stats: %v", err)
@@ -64,9 +70,9 @@ func (c *logMetricsCollector) Collect(ch chan<- prometheus.Metric) {
 	for _, ps := range podStats {
 		for _, c := range ps.Containers {
 			if c.Logs != nil && c.Logs.UsedBytes != nil {
-				ch <- prometheus.MustNewConstMetric(
+				ch <- metrics.NewLazyConstMetric(
 					descLogSize,
-					prometheus.GaugeValue,
+					metrics.GaugeValue,
 					float64(*c.Logs.UsedBytes),
 					ps.PodRef.UID,
 					ps.PodRef.Namespace,

--- a/pkg/kubelet/metrics/collectors/log_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/log_metrics_test.go
@@ -25,18 +25,24 @@ import (
 )
 
 func TestNoMetricsCollected(t *testing.T) {
+	// Refresh Desc to share with different registry
+	descLogSize = descLogSize.GetRawDesc()
+
 	collector := &logMetricsCollector{
 		podStats: func() ([]statsapi.PodStats, error) {
 			return []statsapi.PodStats{}, nil
 		},
 	}
 
-	if err := testutil.CollectAndCompare(collector, strings.NewReader(""), ""); err != nil {
+	if err := testutil.CustomCollectAndCompare(collector, strings.NewReader(""), ""); err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestMetricsCollected(t *testing.T) {
+	// Refresh Desc to share with different registry
+	descLogSize = descLogSize.GetRawDesc()
+
 	size := uint64(18)
 	collector := &logMetricsCollector{
 		podStats: func() ([]statsapi.PodStats, error) {
@@ -60,8 +66,8 @@ func TestMetricsCollected(t *testing.T) {
 		},
 	}
 
-	err := testutil.CollectAndCompare(collector, strings.NewReader(`
-		# HELP kubelet_container_log_filesystem_used_bytes Bytes used by the container's logs on the filesystem.
+	err := testutil.CustomCollectAndCompare(collector, strings.NewReader(`
+		# HELP kubelet_container_log_filesystem_used_bytes [ALPHA] Bytes used by the container's logs on the filesystem.
 		# TYPE kubelet_container_log_filesystem_used_bytes gauge
 		kubelet_container_log_filesystem_used_bytes{container="containerName1",namespace="some-namespace",pod="podName1",uid="UID_some_id"} 18
 `), "kubelet_container_log_filesystem_used_bytes")

--- a/pkg/kubelet/metrics/collectors/volume_stats_test.go
+++ b/pkg/kubelet/metrics/collectors/volume_stats_test.go
@@ -34,17 +34,17 @@ func TestVolumeStatsCollector(t *testing.T) {
 	// Fixed metadata on type and help text. We prepend this to every expected
 	// output so we only have to modify a single place when doing adjustments.
 	const metadata = `
-		# HELP kubelet_volume_stats_available_bytes Number of available bytes in the volume
+		# HELP kubelet_volume_stats_available_bytes [ALPHA] Number of available bytes in the volume
 		# TYPE kubelet_volume_stats_available_bytes gauge
-		# HELP kubelet_volume_stats_capacity_bytes Capacity in bytes of the volume
+		# HELP kubelet_volume_stats_capacity_bytes [ALPHA] Capacity in bytes of the volume
 		# TYPE kubelet_volume_stats_capacity_bytes gauge
-		# HELP kubelet_volume_stats_inodes Maximum number of inodes in the volume
+		# HELP kubelet_volume_stats_inodes [ALPHA] Maximum number of inodes in the volume
 		# TYPE kubelet_volume_stats_inodes gauge
-		# HELP kubelet_volume_stats_inodes_free Number of free inodes in the volume
+		# HELP kubelet_volume_stats_inodes_free [ALPHA] Number of free inodes in the volume
 		# TYPE kubelet_volume_stats_inodes_free gauge
-		# HELP kubelet_volume_stats_inodes_used Number of used inodes in the volume
+		# HELP kubelet_volume_stats_inodes_used [ALPHA] Number of used inodes in the volume
 		# TYPE kubelet_volume_stats_inodes_used gauge
-		# HELP kubelet_volume_stats_used_bytes Number of used bytes in the volume
+		# HELP kubelet_volume_stats_used_bytes [ALPHA] Number of used bytes in the volume
 		# TYPE kubelet_volume_stats_used_bytes gauge
 	`
 
@@ -132,7 +132,7 @@ func TestVolumeStatsCollector(t *testing.T) {
 	mockStatsProvider := new(statstest.StatsProvider)
 	mockStatsProvider.On("ListPodStats").Return(podStats, nil)
 	mockStatsProvider.On("ListPodStatsAndUpdateCPUNanoCoreUsage").Return(podStats, nil)
-	if err := testutil.CollectAndCompare(&volumeStatsCollector{statsProvider: mockStatsProvider}, strings.NewReader(want), metrics...); err != nil {
+	if err := testutil.CustomCollectAndCompare(&volumeStatsCollector{statsProvider: mockStatsProvider}, strings.NewReader(want), metrics...); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 }

--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -499,7 +499,7 @@ var (
 var registerMetrics sync.Once
 
 // Register registers all metrics.
-func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.Collector) {
+func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.StableCollector) {
 	// Register the metrics.
 	registerMetrics.Do(func() {
 		legacyregistry.MustRegister(NodeName)
@@ -540,7 +540,7 @@ func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.C
 			legacyregistry.MustRegister(ConfigError)
 		}
 		for _, collector := range collectors {
-			legacyregistry.RawMustRegister(collector)
+			legacyregistry.CustomMustRegister(collector)
 		}
 	})
 }

--- a/pkg/kubelet/pluginmanager/metrics/BUILD
+++ b/pkg/kubelet/pluginmanager/metrics/BUILD
@@ -7,8 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kubelet/pluginmanager/cache:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/pluginmanager/metrics/metrics_test.go
+++ b/pkg/kubelet/pluginmanager/metrics/metrics_test.go
@@ -42,7 +42,7 @@ func TestMetricCollection(t *testing.T) {
 		t.Fatalf("AddOrUpdatePlugin failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	metricCollector := &totalPluginsCollector{asw, dsw}
+	metricCollector := &totalPluginsCollector{asw: asw, dsw: dsw}
 
 	// Check if getPluginCount returns correct data
 	count := metricCollector.getPluginCount()

--- a/pkg/kubelet/volumemanager/metrics/BUILD
+++ b/pkg/kubelet/volumemanager/metrics/BUILD
@@ -9,9 +9,8 @@ go_library(
         "//pkg/kubelet/volumemanager/cache:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/util:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/volumemanager/metrics/metrics.go
+++ b/pkg/kubelet/volumemanager/metrics/metrics.go
@@ -17,11 +17,10 @@ limitations under the License.
 package metrics
 
 import (
-	"k8s.io/component-base/metrics/legacyregistry"
 	"sync"
 
-	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/klog"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
 	"k8s.io/kubernetes/pkg/kubelet/volumemanager/cache"
 	"k8s.io/kubernetes/pkg/volume"
 	volumeutil "k8s.io/kubernetes/pkg/volume/util"
@@ -37,11 +36,12 @@ const (
 var (
 	registerMetrics sync.Once
 
-	totalVolumesDesc = prometheus.NewDesc(
+	totalVolumesDesc = metrics.NewDesc(
 		volumeManagerTotalVolumes,
 		"Number of volumes in Volume Manager",
 		[]string{"plugin_name", "state"},
 		nil,
+		metrics.ALPHA, "",
 	)
 )
 
@@ -60,36 +60,34 @@ func (v volumeCount) add(state, plugin string) {
 // Register registers Volume Manager metrics.
 func Register(asw cache.ActualStateOfWorld, dsw cache.DesiredStateOfWorld, pluginMgr *volume.VolumePluginMgr) {
 	registerMetrics.Do(func() {
-		legacyregistry.RawMustRegister(&totalVolumesCollector{asw, dsw, pluginMgr})
+		legacyregistry.CustomMustRegister(&totalVolumesCollector{asw: asw, dsw: dsw, pluginMgr: pluginMgr})
 	})
 }
 
 type totalVolumesCollector struct {
+	metrics.BaseStableCollector
+
 	asw       cache.ActualStateOfWorld
 	dsw       cache.DesiredStateOfWorld
 	pluginMgr *volume.VolumePluginMgr
 }
 
-var _ prometheus.Collector = &totalVolumesCollector{}
+var _ metrics.StableCollector = &totalVolumesCollector{}
 
-// Describe implements the prometheus.Collector interface.
-func (c *totalVolumesCollector) Describe(ch chan<- *prometheus.Desc) {
+// DescribeWithStability implements the metrics.StableCollector interface.
+func (c *totalVolumesCollector) DescribeWithStability(ch chan<- *metrics.Desc) {
 	ch <- totalVolumesDesc
 }
 
-// Collect implements the prometheus.Collector interface.
-func (c *totalVolumesCollector) Collect(ch chan<- prometheus.Metric) {
+// CollectWithStability implements the metrics.StableCollector interface.
+func (c *totalVolumesCollector) CollectWithStability(ch chan<- metrics.Metric) {
 	for stateName, pluginCount := range c.getVolumeCount() {
 		for pluginName, count := range pluginCount {
-			metric, err := prometheus.NewConstMetric(totalVolumesDesc,
-				prometheus.GaugeValue,
+			ch <- metrics.NewLazyConstMetric(totalVolumesDesc,
+				metrics.GaugeValue,
 				float64(count),
 				pluginName,
 				stateName)
-			if err != nil {
-				klog.Warningf("Failed to create metric : %v", err)
-			}
-			ch <- metric
 		}
 	}
 }

--- a/pkg/kubelet/volumemanager/metrics/metrics_test.go
+++ b/pkg/kubelet/volumemanager/metrics/metrics_test.go
@@ -83,7 +83,7 @@ func TestMetricCollection(t *testing.T) {
 		t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
 	}
 
-	metricCollector := &totalVolumesCollector{asw, dsw, volumePluginMgr}
+	metricCollector := &totalVolumesCollector{asw: asw, dsw: dsw, pluginMgr: volumePluginMgr}
 
 	// Check if getVolumeCount returns correct data
 	count := metricCollector.getVolumeCount()


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, custom metrics emitted from kubelet do not offer any stability guarantees.

And #83062 tries to make it possible to do so.

About metrics stability please refer to [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There are still some custom metrics under `pkg/kubelet/server` that I'd prefer to do it later.
Because it's a little different(can't make it one-line migration) and I'm trying to find a way to deal with them. 

**Does this PR introduce a user-facing change?**:
```release-note
Following metrics from kubelet are now marked as with the ALPHA stability level:
kubelet_container_log_filesystem_used_bytes
kubelet_volume_stats_capacity_bytes
kubelet_volume_stats_available_bytes
kubelet_volume_stats_used_bytes
kubelet_volume_stats_inodes
kubelet_volume_stats_inodes_free
kubelet_volume_stats_inodes_used
plugin_manager_total_plugins
volume_manager_total_volumes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
```

/priority important-soon
/milestone v1.17