### PR TITLE
Add show-hidden-metrics-for-version to scheduler

### DIFF
--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -42,6 +42,7 @@ go_library(
         "//staging/src/k8s.io/component-base/cli/flag:go_default_library",
         "//staging/src/k8s.io/component-base/codec:go_default_library",
         "//staging/src/k8s.io/component-base/config:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",


### PR DESCRIPTION
/kind feature

Ref https://github.com/kubernetes/kubernetes/issues/85270
Canonical flag implementation kubernetes/enhancements#1206

**Does this PR introduce a user-facing change?:**
```release-note
New flag `--show-hidden-metrics-for-version` in kube-scheduler can be used to show all hidden metrics that deprecated in the previous minor release.
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:**
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
```
/cc @RainbowMango 
