### PR TITLE
provide functionality for custom collector testing

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/desc.go
+++ b/staging/src/k8s.io/component-base/metrics/desc.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"github.com/blang/semver"
@@ -155,4 +156,17 @@ func (d *Desc) initialize() {
 func (d *Desc) initializeDeprecatedDesc() {
 	d.markDeprecated()
 	d.initialize()
+}
+
+// GetRawDesc will returns a new *Desc with original parameters provided to NewDesc().
+//
+// It will be useful in testing scenario that the same Desc be registered to different registry.
+//   1. Desc `D` is registered to registry 'A' in TestA (Note: `D` maybe created)
+//   2. Desc `D` is registered to registry 'B' in TestB (Note: since 'D' has been created once, thus will be ignored by registry 'B')
+func (d *Desc) GetRawDesc() *Desc {
+	// remove stability from help if any
+	stabilityStr := fmt.Sprintf("[%v] ", d.stabilityLevel)
+	rawHelp := strings.Replace(d.help, stabilityStr, "", -1)
+
+	return NewDesc(d.fqName, rawHelp, d.variableLabels, d.constLabels, d.stabilityLevel, d.deprecatedVersion)
 }

--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
@@ -38,3 +38,13 @@ func CollectAndCompare(c metrics.Collector, expected io.Reader, metricNames ...s
 func GatherAndCompare(g metrics.Gatherer, expected io.Reader, metricNames ...string) error {
 	return testutil.GatherAndCompare(g, expected, metricNames...)
 }
+
+// CustomCollectAndCompare registers the provided StableCollector with a newly created
+// registry. It then does the same as GatherAndCompare, gathering the
+// metrics from the pedantic Registry.
+func CustomCollectAndCompare(c metrics.StableCollector, expected io.Reader, metricNames ...string) error {
+	registry := metrics.NewKubeRegistry()
+	registry.CustomMustRegister(c)
+
+	return GatherAndCompare(registry, expected, metricNames...)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
1. Add a test util `CustomCollectAndCompare(...)`  especially for custom collectors.
2. Add an API `GetRawDesc()` to Desc, which makes it possible to share a desc with the different registry.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
I found this issue on https://github.com/kubernetes/kubernetes/pull/84907 which unit test failed.
I'd prefer to provide a separate PR, thus we can push forward fast and avoid blocking following migration.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
