### PR TITLE
Fix blank import error for pkg/controller

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	clientretry "k8s.io/client-go/util/retry"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
+	// Ensure the core apis are installed.
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
 	hashutil "k8s.io/kubernetes/pkg/util/hash"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix the blank import error raised by golint for `pkg/controller`.

We can not remove `pkg/controller` from `hack/.golint_failures`, because
other Golint violations still exist. The majority of those violations
relate to publicly exported functions/variables/types not having the
proper documentation. I don't have the context to add helpful comments,
so this commit does not address the remaining failures.

**Which issue(s) this PR fixes**:
xref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
