### PR TITLE
Fix golint failures for pkg/kubectl/cmd/convert

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -101,7 +101,6 @@ pkg/credentialprovider
 pkg/features
 pkg/kubeapiserver
 pkg/kubeapiserver/options
-pkg/kubectl/cmd/convert
 pkg/kubelet/apis/config/v1beta1
 pkg/kubelet/checkpointmanager/testing/example_checkpoint_formats/v1
 pkg/kubelet/cm

--- a/pkg/kubectl/cmd/convert/convert.go
+++ b/pkg/kubectl/cmd/convert/convert.go
@@ -60,8 +60,8 @@ var (
 		kubectl convert -f . | kubectl create -f -`))
 )
 
-// ConvertOptions have the data required to perform the convert operation
-type ConvertOptions struct {
+// convertOptions have the data required to perform the convert operation
+type convertOptions struct {
 	PrintFlags *genericclioptions.PrintFlags
 	Printer    printers.ResourcePrinter
 
@@ -76,8 +76,8 @@ type ConvertOptions struct {
 	genericclioptions.IOStreams
 }
 
-func NewConvertOptions(ioStreams genericclioptions.IOStreams) *ConvertOptions {
-	return &ConvertOptions{
+func newConvertOptions(ioStreams genericclioptions.IOStreams) *convertOptions {
+	return &convertOptions{
 		PrintFlags: genericclioptions.NewPrintFlags("converted").WithTypeSetter(scheme.Scheme).WithDefaultOutput("yaml"),
 		local:      true,
 		IOStreams:  ioStreams,
@@ -87,7 +87,7 @@ func NewConvertOptions(ioStreams genericclioptions.IOStreams) *ConvertOptions {
 // NewCmdConvert creates a command object for the generic "convert" action, which
 // translates the config file into a given version.
 func NewCmdConvert(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
-	o := NewConvertOptions(ioStreams)
+	o := newConvertOptions(ioStreams)
 
 	cmd := &cobra.Command{
 		Use:                   "convert -f FILENAME",
@@ -111,7 +111,7 @@ func NewCmdConvert(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 }
 
 // Complete collects information required to run Convert command from command line.
-func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err error) {
+func (o *convertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err error) {
 	err = o.FilenameOptions.RequireFilenameOrKustomize()
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func (o *ConvertOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) (err er
 }
 
 // RunConvert implements the generic Convert command
-func (o *ConvertOptions) RunConvert() error {
+func (o *convertOptions) RunConvert() error {
 
 	// Convert must be removed from kubectl, since kubectl can not depend on
 	// Kubernetes "internal" dependencies. These "internal" dependencies can

--- a/pkg/kubectl/cmd/convert/import_known_versions.go
+++ b/pkg/kubectl/cmd/convert/import_known_versions.go
@@ -16,9 +16,9 @@ limitations under the License.
 
 package convert
 
-// These imports are the API groups the client will support.
-// TODO: Remove these manual install once we don't need legacy scheme in convert
 import (
+	// These blank imports are the API groups the client will support.
+	// TODO: Remove these manual install once we don't need legacy scheme in convert
 	_ "k8s.io/kubernetes/pkg/apis/apps/install"
 	_ "k8s.io/kubernetes/pkg/apis/authentication/install"
 	_ "k8s.io/kubernetes/pkg/apis/authorization/install"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Address the golint failures for pkg/kubectl/cmd/convert.

A couple different types of lint failures were present.

One was a golint failure around unexplained blank imports, which could be easily
addressed by moving an already existing comments.

More complicated were two failures around publicly exported
functions/types (i.e. complaining about lack of comments and stutter for
`convert.ConvertOptions` and `convert.NewConvertOptions`).
I noticed neither the type nor the function was ever
referenced outside the `convert` module,
so I made the module no longer export them. Making them private addressed
the golint failures.

In my mind, this visibility change is acceptable, because
I don't believe there's a good reason for another module to use
`convertOptions` or `newConvertOptions`.

**Which issue(s) this PR fixes**:
xref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
