### PR TITLE
e2e_kubeadm: fix missing suite --test* flags

### DIFF
--- a/test/e2e_kubeadm/e2e_kubeadm_suite_test.go
+++ b/test/e2e_kubeadm/e2e_kubeadm_suite_test.go
@@ -33,15 +33,12 @@ import (
 	e2econfig "k8s.io/kubernetes/test/e2e/framework/config"
 )
 
-func init() {
+func TestMain(m *testing.M) {
+	// Copy go flags in TestMain, to ensure go test flags are registered (no longer available in init() as of go1.13)
 	e2econfig.CopyFlags(e2econfig.Flags, flag.CommandLine)
 	framework.RegisterCommonFlags(flag.CommandLine)
 	framework.RegisterClusterFlags(flag.CommandLine)
-
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-}
-
-func TestMain(m *testing.M) {
 	pflag.Parse()
 	framework.AfterReadingAllFlags(&framework.TestContext)
 	os.Exit(m.Run())


### PR DESCRIPTION
**What this PR does / why we need it**:

The bump to 1.13 requires changes related to CLI flags and the init() function.
This affected the e2e_kubeadm test suite.

For more details see 00e1ffb4e015c9a033b6c1f5446e70822af4e964.

```
/home/prow/go/src/k8s.io/kubernetes/_output/bin/e2e_kubeadm.test -- --report-dir=/logs/artifacts --report-prefix=06-e2e-kubeadm --kubeconfig=/root/.kube/kind-config-kinder-regular]"
unknown flag: --test.timeout
Usage of /home/prow/go/src/k8s.io/kubernetes/_output/bin/e2e_kubeadm.test:
unknown flag: --test.timeout
```
https://k8s-testgrid.appspot.com/sig-cluster-lifecycle-kubeadm#kubeadm-kinder-master

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE?

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind failing-test
/priority critical-urgent
/assign @yastij @fabriziopandini 
