### PR TITLE
Set go version in fluentd-elasticsearch addon

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/go.mod
+++ b/cluster/addons/fluentd-elasticsearch/es-image/go.mod
@@ -1,5 +1,7 @@
 module fake/import/path
 
+go 1.13
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

After upgrading to go 1.13.4, my IDE started adding the go version to this `go.mod`.
I set it to 1.12 to match the main `go.mod`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```