### PR TITLE
Limiting the scope of new kubectl get e2e tests to decrease flakiness

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -438,13 +438,9 @@ var _ = SIGDescribe("Kubectl client", func() {
 				"BackendConfig":         true,
 				"NodeMetrics":           true,
 				"PodMetrics":            true,
-				"ScalingPolicy":         true,
 				"VolumeSnapshotClass":   true,
 				"VolumeSnapshotContent": true,
 				"VolumeSnapshot":        true,
-
-				// A CRD created by other e2e tests without any test data.
-				"Noxu": true,
 			}
 
 			apiGroups, err := c.Discovery().ServerPreferredResources()
@@ -453,6 +449,13 @@ var _ = SIGDescribe("Kubectl client", func() {
 			testableResources := etcd.GetEtcdStorageDataForNamespace(f.Namespace.Name)
 
 			for _, group := range apiGroups {
+				// This limits the scope of this test to exclude CRDs. This
+				// assumes that CRDs will not have a .k8s.io group and will have
+				// a . in their name.
+				if !strings.Contains(group.GroupVersion, ".k8s.io") && strings.Contains(group.GroupVersion, ".") {
+					continue
+				}
+
 				for _, resource := range group.APIResources {
 					if !verbsContain(resource.Verbs, "get") || ignoredResources[resource.Kind] || strings.HasPrefix(resource.Name, "e2e-test") {
 						continue


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
The `kubectl get output` e2e test I'd previously added ended up being flaky in certain e2e test scenarios. It relies on getting a list of API resources in the cluster and running `kubectl get` calls against them. The problem ended up being that other e2e tests could create resources that would cause this test to fail. This change limits the scope of the tests to exclude CRDs. This should still allow the test to catch new Kubernetes resources with improperly configured kubectl output while limiting the flakiness of the test.

**Which issue(s) this PR fixes**:
Fixes #84863

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cli testing
/priority critical-urgent
/cc @wojtek-t @oxddr 