### PR TITLE
Fix the import aliase nodev1beta1

### DIFF
--- a/test/e2e/node/runtimeclass.go
+++ b/test/e2e/node/runtimeclass.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/node/v1beta1"
+	nodev1beta1 "k8s.io/api/node/v1beta1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtimeclasstest "k8s.io/kubernetes/pkg/kubelet/runtimeclass/testing"
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 	f := framework.NewDefaultFramework("runtimeclass")
 
 	ginkgo.It("should reject a Pod requesting a RuntimeClass with conflicting node selector", func() {
-		scheduling := &v1beta1.Scheduling{
+		scheduling := &nodev1beta1.Scheduling{
 			NodeSelector: map[string]string{
 				"foo": "conflict",
 			},
@@ -72,7 +72,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 				Effect:   v1.TaintEffectNoSchedule,
 			},
 		}
-		scheduling := &v1beta1.Scheduling{
+		scheduling := &nodev1beta1.Scheduling{
 			NodeSelector: nodeSelector,
 			Tolerations:  tolerations,
 		}
@@ -118,7 +118,7 @@ var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
 })
 
 // newRuntimeClass returns a test runtime class.
-func newRuntimeClass(namespace, name string) *v1beta1.RuntimeClass {
+func newRuntimeClass(namespace, name string) *nodev1beta1.RuntimeClass {
 	uniqueName := fmt.Sprintf("%s-%s", namespace, name)
 	return runtimeclasstest.NewRuntimeClass(uniqueName, framework.PreconfiguredRuntimeClassHandler())
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind failing-test

**What this PR does / why we need it**:

When running ./hack/verify-import-aliases.sh locally, the following
error happened:
```
  $ ./hack/verify-import-aliases.sh
  checking-imports:
  ERROR wrong alias for import "k8s.io/api/node/v1beta1" should be
  nodev1beta1 in file test/e2e/node/runtimeclass.go
   test/e2e_node/system/specs
  exit status 1
```
This fixes it.

**Special notes for your reviewer**:

At this time, `./hack/verify-import-aliases.sh` is not operated at the CI system with https://github.com/kubernetes/kubernetes/blob/fc8f5a64106c30c50ee2bbcd1d35e6cd05f63b00/hack/make-rules/verify.sh#L33-L38
So we need to take care of this check script locally.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```