### PR TITLE
Option to use CONNMARK instead of MARK for marking/matching service VIP traffic

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -163,6 +163,7 @@ func newProxyServer(
 			recorder,
 			healthzServer,
 			config.NodePortAddresses,
+			config.IPTables.UseConnMark,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)
@@ -202,6 +203,7 @@ func newProxyServer(
 				healthzServer,
 				config.IPVS.Scheduler,
 				config.NodePortAddresses,
+				config.IPTables.UseConnMark,
 			)
 		} else {
 			proxier, err = ipvs.NewProxier(
@@ -223,6 +225,7 @@ func newProxyServer(
 				healthzServer,
 				config.IPVS.Scheduler,
 				config.NodePortAddresses,
+				config.IPTables.UseConnMark,
 			)
 		}
 		if err != nil {

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -96,6 +96,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.ContainerLogMaxSize = "10Mi"
 			obj.ConfigMapAndSecretChangeDetectionStrategy = "Watch"
 			obj.AllowedUnsafeSysctls = []string{}
+			obj.UseConnMark = true
 		},
 	}
 }

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -308,6 +308,9 @@ type KubeletConfiguration struct {
 	// These sysctls are namespaced but not allowed by default.  For example: "kernel.msg*,net.ipv4.route.min_pmtu"
 	// +optional
 	AllowedUnsafeSysctls []string
+	// Whether iptables CONNMARK should be used instead of MARK for marking and matching packets for source NAT. By
+	// default, iptables MARK is used.
+	UseConnMark bool
 
 	/* the following fields are meant for Node Allocatable */
 

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -330,6 +330,9 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.KubeReservedCgroup = in.KubeReservedCgroup
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.AllowedUnsafeSysctls = *(*[]string)(unsafe.Pointer(&in.AllowedUnsafeSysctls))
+	if err := v1.Convert_Pointer_bool_To_bool(&in.UseConnMark, &out.UseConnMark, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -457,6 +460,9 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	}
 	out.ConfigMapAndSecretChangeDetectionStrategy = v1beta1.ResourceChangeDetectionStrategy(in.ConfigMapAndSecretChangeDetectionStrategy)
 	out.AllowedUnsafeSysctls = *(*[]string)(unsafe.Pointer(&in.AllowedUnsafeSysctls))
+	if err := v1.Convert_bool_To_Pointer_bool(&in.UseConnMark, &out.UseConnMark, s); err != nil {
+		return err
+	}
 	out.SystemReserved = *(*map[string]string)(unsafe.Pointer(&in.SystemReserved))
 	out.KubeReserved = *(*map[string]string)(unsafe.Pointer(&in.KubeReserved))
 	out.SystemReservedCgroup = in.SystemReservedCgroup

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -541,6 +541,7 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 		experimentalHostUserNamespaceDefaulting: utilfeature.DefaultFeatureGate.Enabled(features.ExperimentalHostUserNamespaceDefaultingGate),
 		keepTerminatedPodVolumes:                keepTerminatedPodVolumes,
 		nodeStatusMaxImages:                     nodeStatusMaxImages,
+		useConnMark:                             kubeCfg.UseConnMark,
 	}
 
 	if klet.cloud != nil {
@@ -1221,6 +1222,10 @@ type Kubelet struct {
 
 	// Handles RuntimeClass objects for the Kubelet.
 	runtimeClassManager *runtimeclass.Manager
+
+	// When set iptables CONNMARK will be used in place of iptables MARK for marking and matching
+	// of service VIP traffic.
+	useConnMark bool
 }
 
 // setupDataDirs creates:

--- a/pkg/kubemark/hollow_proxy.go
+++ b/pkg/kubemark/hollow_proxy.go
@@ -99,6 +99,7 @@ func NewHollowProxyOrDie(
 			recorder,
 			nil,
 			[]string{},
+			false,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("unable to create proxier: %v", err)

--- a/pkg/proxy/apis/config/types.go
+++ b/pkg/proxy/apis/config/types.go
@@ -39,6 +39,9 @@ type KubeProxyIPTablesConfiguration struct {
 	// minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').
 	MinSyncPeriod metav1.Duration
+	// useConnMark allows toggling of the use of iptables CONNMARK rules instead of MARK rules for marking
+	// traffic to service VIPs.
+	UseConnMark bool
 }
 
 // KubeProxyIPVSConfiguration contains ipvs-related configuration

--- a/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/proxy/apis/config/v1alpha1/zz_generated.conversion.go
@@ -196,6 +196,7 @@ func autoConvert_v1alpha1_KubeProxyIPTablesConfiguration_To_config_KubeProxyIPTa
 	out.MasqueradeAll = in.MasqueradeAll
 	out.SyncPeriod = in.SyncPeriod
 	out.MinSyncPeriod = in.MinSyncPeriod
+	out.UseConnMark = in.UseConnMark
 	return nil
 }
 
@@ -209,6 +210,7 @@ func autoConvert_config_KubeProxyIPTablesConfiguration_To_v1alpha1_KubeProxyIPTa
 	out.MasqueradeAll = in.MasqueradeAll
 	out.SyncPeriod = in.SyncPeriod
 	out.MinSyncPeriod = in.MinSyncPeriod
+	out.UseConnMark = in.UseConnMark
 	return nil
 }
 

--- a/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-proxy/config/v1alpha1/types.go
@@ -35,6 +35,9 @@ type KubeProxyIPTablesConfiguration struct {
 	// minSyncPeriod is the minimum period that iptables rules are refreshed (e.g. '5s', '1m',
 	// '2h22m').
 	MinSyncPeriod metav1.Duration `json:"minSyncPeriod"`
+	// useConnMark is a toggle for using iptables CONNMARK to mark and match service VIP traffic instead
+	// of iptables MARK.
+	UseConnMark bool `json:"useConnMark"`
 }
 
 // KubeProxyIPVSConfiguration contains ipvs-related configuration

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -743,6 +743,12 @@ type KubeletConfiguration struct {
 	// Default: []
 	// +optional
 	AllowedUnsafeSysctls []string `json:"allowedUnsafeSysctls,omitempty"`
+	// Whether or not to use iptables CONNMARK to mark traffic to service VIPs instead of iptables MARK.
+	// Default: false
+	// +optional
+	UseConnMark *bool `json:"useConnMark,omitempty"`
+
+
 }
 
 type KubeletAuthorizationMode string

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -285,6 +285,11 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.UseConnMark != nil {
+		in, out := &in.UseConnMark, &out.UseConnMark
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
As mentioned in the linked issue the use of iptables MARK can become problematic because it persists through packet encapsulation (eg for GRE, vxlan, or IPinIP tunnels which many CNI providers make use of) resulting in the encapsulating packet being marked for source NAT when it should not be.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/78948

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Added configuration switch(`UseConnMark`) to `kube-proxy` and `kubelet` to be able to use iptables `CONNMARK` instead of iptables `MARK` for marking and matching service VIP traffic.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/sig network