### PR TITLE
clean up PriorityFunction

### DIFF
--- a/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
+++ b/pkg/scheduler/algorithm/priorities/balanced_resource_allocation_test.go
@@ -409,9 +409,8 @@ func TestBalancedResourceAllocation(t *testing.T) {
 					info.TransientInfo.TransNodeInfo.RequestedVolumes = len(test.pod.Spec.Volumes)
 				}
 			}
-			function := priorityFunction(BalancedResourceAllocationMap, nil, nil)
 
-			list, err := function(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(BalancedResourceAllocationMap, nil, nil, test.pod, snapshot, test.nodes)
 
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)

--- a/pkg/scheduler/algorithm/priorities/image_locality_test.go
+++ b/pkg/scheduler/algorithm/priorities/image_locality_test.go
@@ -185,7 +185,7 @@ func TestImageLocalityPriority(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, test.nodes)
-			list, err := priorityFunction(ImageLocalityPriorityMap, nil, &priorityMetadata{totalNumNodes: len(test.nodes)})(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(ImageLocalityPriorityMap, nil, &priorityMetadata{totalNumNodes: len(test.nodes)}, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/least_requested_test.go
+++ b/pkg/scheduler/algorithm/priorities/least_requested_test.go
@@ -254,7 +254,7 @@ func TestLeastRequested(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, test.nodes)
-			list, err := priorityFunction(LeastRequestedPriorityMap, nil, nil)(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(LeastRequestedPriorityMap, nil, nil, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/most_requested_test.go
+++ b/pkg/scheduler/algorithm/priorities/most_requested_test.go
@@ -211,7 +211,7 @@ func TestMostRequested(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			snapshot := nodeinfosnapshot.NewSnapshot(test.pods, test.nodes)
-			list, err := priorityFunction(MostRequestedPriorityMap, nil, nil)(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(MostRequestedPriorityMap, nil, nil, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/node_affinity_test.go
+++ b/pkg/scheduler/algorithm/priorities/node_affinity_test.go
@@ -168,8 +168,7 @@ func TestNodeAffinityPriority(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			snapshot := nodeinfosnapshot.NewSnapshot(nil, test.nodes)
-			nap := priorityFunction(CalculateNodeAffinityPriorityMap, CalculateNodeAffinityPriorityReduce, nil)
-			list, err := nap(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(CalculateNodeAffinityPriorityMap, CalculateNodeAffinityPriorityReduce, nil, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods_test.go
+++ b/pkg/scheduler/algorithm/priorities/node_prefer_avoid_pods_test.go
@@ -142,7 +142,7 @@ func TestNodePreferAvoidPriority(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			snapshot := nodeinfosnapshot.NewSnapshot(nil, test.nodes)
-			list, err := priorityFunction(CalculateNodePreferAvoidPodsPriorityMap, nil, nil)(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(CalculateNodePreferAvoidPodsPriorityMap, nil, nil, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/algorithm/priorities/requested_to_capacity_ratio_test.go
@@ -241,7 +241,7 @@ func TestRequestedToCapacityRatio(t *testing.T) {
 		newPod := buildResourcesPod("", test.requested)
 
 		snapshot := nodeinfosnapshot.NewSnapshot(scheduledPods, nodes)
-		list, err := priorityFunction(RequestedToCapacityRatioResourceAllocationPriorityDefault().PriorityMap, nil, nil)(newPod, snapshot, nodes)
+		list, err := runMapReducePriority(RequestedToCapacityRatioResourceAllocationPriorityDefault().PriorityMap, nil, nil, newPod, snapshot, nodes)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -390,7 +390,7 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 			functionShape, _ := NewFunctionShape([]FunctionShapePoint{{0, 0}, {100, 10}})
 			resourceToWeightMap := ResourceToWeightMap{v1.ResourceName("intel.com/foo"): 1}
 			prior := RequestedToCapacityRatioResourceAllocationPriority(functionShape, resourceToWeightMap)
-			list, err := priorityFunction(prior.PriorityMap, nil, nil)(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(prior.PriorityMap, nil, nil, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -615,7 +615,7 @@ func TestResourceBinPackingMultipleExtended(t *testing.T) {
 			functionShape, _ := NewFunctionShape([]FunctionShapePoint{{0, 0}, {100, 10}})
 			resourceToWeightMap := ResourceToWeightMap{v1.ResourceName("intel.com/foo"): 3, v1.ResourceName("intel.com/bar"): 5}
 			prior := RequestedToCapacityRatioResourceAllocationPriority(functionShape, resourceToWeightMap)
-			list, err := priorityFunction(prior.PriorityMap, nil, nil)(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(prior.PriorityMap, nil, nil, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/resource_limits.go
+++ b/pkg/scheduler/algorithm/priorities/resource_limits.go
@@ -19,7 +19,7 @@ package priorities
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 
@@ -43,7 +43,7 @@ func ResourceLimitsPriorityMap(pod *v1.Pod, meta interface{}, nodeInfo *schedule
 
 	// compute pod limits
 	var podLimits *schedulernodeinfo.Resource
-	if priorityMeta, ok := meta.(*priorityMetadata); ok {
+	if priorityMeta, ok := meta.(*priorityMetadata); ok && priorityMeta != nil {
 		// We were able to parse metadata, use podLimits from there.
 		podLimits = priorityMeta.podLimits
 	} else {

--- a/pkg/scheduler/algorithm/priorities/resource_limits_test.go
+++ b/pkg/scheduler/algorithm/priorities/resource_limits_test.go
@@ -20,7 +20,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	nodeinfosnapshot "k8s.io/kubernetes/pkg/scheduler/nodeinfo/snapshot"
@@ -144,14 +144,12 @@ func TestResourceLimitsPriority(t *testing.T) {
 			}
 
 			for _, hasMeta := range []bool{true, false} {
-				var function PriorityFunction
-				if hasMeta {
-					function = priorityFunction(ResourceLimitsPriorityMap, nil, metadata)
-				} else {
-					function = priorityFunction(ResourceLimitsPriorityMap, nil, nil)
+				meta := metadata
+				if !hasMeta {
+					meta = nil
 				}
 
-				list, err := function(test.pod, snapshot, test.nodes)
+				list, err := runMapReducePriority(ResourceLimitsPriorityMap, nil, meta, test.pod, snapshot, test.nodes)
 
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)

--- a/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -355,8 +355,7 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			)
 			metaData := metaDataProducer(test.pod, nodes, snapshot)
 
-			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData)
-			list, err := ttp(test.pod, snapshot, makeNodeList(test.nodes))
+			list, err := runMapReducePriority(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData, test.pod, snapshot, makeNodeList(test.nodes))
 			if err != nil {
 				t.Errorf("unexpected error: %v \n", err)
 			}
@@ -593,8 +592,7 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 				1,
 			)
 			metaData := metaDataProducer(test.pod, nodes, snapshot)
-			ttp := priorityFunction(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData)
-			list, err := ttp(test.pod, snapshot, makeLabeledNodeList(labeledNodes))
+			list, err := runMapReducePriority(selectorSpread.CalculateSpreadPriorityMap, selectorSpread.CalculateSpreadPriorityReduce, metaData, test.pod, snapshot, makeLabeledNodeList(labeledNodes))
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
@@ -783,8 +781,7 @@ func TestZoneSpreadPriority(t *testing.T) {
 				1,
 			)
 			metaData := metaDataProducer(test.pod, nodes, snapshot)
-			ttp := priorityFunction(zoneSpread.CalculateAntiAffinityPriorityMap, zoneSpread.CalculateAntiAffinityPriorityReduce, metaData)
-			list, err := ttp(test.pod, snapshot, makeLabeledNodeList(test.nodes))
+			list, err := runMapReducePriority(zoneSpread.CalculateAntiAffinityPriorityMap, zoneSpread.CalculateAntiAffinityPriorityReduce, metaData, test.pod, snapshot, makeLabeledNodeList(test.nodes))
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/spreading_perf_test.go
+++ b/pkg/scheduler/algorithm/priorities/spreading_perf_test.go
@@ -98,8 +98,7 @@ func BenchmarkTestSelectorSpreadPriority(b *testing.B) {
 				meta := &priorityMetadata{
 					podSelectors: getSelectors(pod, ss.serviceLister, ss.controllerLister, ss.replicaSetLister, ss.statefulSetLister),
 				}
-				ttp := priorityFunction(ss.CalculateSpreadPriorityMap, ss.CalculateSpreadPriorityReduce, meta)
-				_, err := ttp(pod, snapshot, filteredNodes)
+				_, err := runMapReducePriority(ss.CalculateSpreadPriorityMap, ss.CalculateSpreadPriorityReduce, meta, pod, snapshot, filteredNodes)
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
+++ b/pkg/scheduler/algorithm/priorities/taint_toleration_test.go
@@ -228,8 +228,7 @@ func TestTaintAndToleration(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			snapshot := nodeinfosnapshot.NewSnapshot(nil, test.nodes)
-			ttp := priorityFunction(ComputeTaintTolerationPriorityMap, ComputeTaintTolerationPriorityReduce, nil)
-			list, err := ttp(test.pod, snapshot, test.nodes)
+			list, err := runMapReducePriority(ComputeTaintTolerationPriorityMap, ComputeTaintTolerationPriorityReduce, nil, test.pod, snapshot, test.nodes)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}

--- a/pkg/scheduler/algorithm/priorities/test_util.go
+++ b/pkg/scheduler/algorithm/priorities/test_util.go
@@ -19,7 +19,7 @@ package priorities
 import (
 	"sort"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
@@ -58,27 +58,25 @@ func makeNodeWithExtendedResource(node string, milliCPU, memory int64, extendedR
 	}
 }
 
-func priorityFunction(mapFn PriorityMapFunction, reduceFn PriorityReduceFunction, metaData interface{}) PriorityFunction {
-	return func(pod *v1.Pod, sharedLister schedulerlisters.SharedLister, nodes []*v1.Node) (framework.NodeScoreList, error) {
-		result := make(framework.NodeScoreList, 0, len(nodes))
-		for i := range nodes {
-			nodeInfo, err := sharedLister.NodeInfos().Get(nodes[i].Name)
-			if err != nil {
-				return nil, err
-			}
-			hostResult, err := mapFn(pod, metaData, nodeInfo)
-			if err != nil {
-				return nil, err
-			}
-			result = append(result, hostResult)
+func runMapReducePriority(mapFn PriorityMapFunction, reduceFn PriorityReduceFunction, metaData interface{}, pod *v1.Pod, sharedLister schedulerlisters.SharedLister, nodes []*v1.Node) (framework.NodeScoreList, error) {
+	result := make(framework.NodeScoreList, 0, len(nodes))
+	for i := range nodes {
+		nodeInfo, err := sharedLister.NodeInfos().Get(nodes[i].Name)
+		if err != nil {
+			return nil, err
 		}
-		if reduceFn != nil {
-			if err := reduceFn(pod, metaData, sharedLister, result); err != nil {
-				return nil, err
-			}
+		hostResult, err := mapFn(pod, metaData, nodeInfo)
+		if err != nil {
+			return nil, err
 		}
-		return result, nil
+		result = append(result, hostResult)
 	}
+	if reduceFn != nil {
+		if err := reduceFn(pod, metaData, sharedLister, result); err != nil {
+			return nil, err
+		}
+	}
+	return result, nil
 }
 
 func sortNodeScoreList(out framework.NodeScoreList) {

--- a/pkg/scheduler/algorithm/priorities/types.go
+++ b/pkg/scheduler/algorithm/priorities/types.go
@@ -38,11 +38,6 @@ type PriorityReduceFunction func(pod *v1.Pod, meta interface{}, sharedLister sch
 // is now used for only for priority functions. For predicates please use PredicateMetadataProducer.
 type PriorityMetadataProducer func(pod *v1.Pod, filteredNodes []*v1.Node, sharedLister schedulerlisters.SharedLister) interface{}
 
-// PriorityFunction is a function that computes scores for all nodes.
-// DEPRECATED
-// Use Map-Reduce pattern for priority functions.
-type PriorityFunction func(pod *v1.Pod, sharedLister schedulerlisters.SharedLister, nodes []*v1.Node) (framework.NodeScoreList, error)
-
 // PriorityConfig is a config used for a priority function.
 type PriorityConfig struct {
 	Name   string

--- a/pkg/scheduler/algorithm_factory.go
+++ b/pkg/scheduler/algorithm_factory.go
@@ -70,19 +70,13 @@ type PredicateMetadataProducerFactory func(PluginFactoryArgs) predicates.Predica
 // FitPredicateFactory produces a FitPredicate from the given args.
 type FitPredicateFactory func(PluginFactoryArgs) predicates.FitPredicate
 
-// PriorityFunctionFactory produces a PriorityConfig from the given args.
-// DEPRECATED
-// Use Map-Reduce pattern for priority functions.
-type PriorityFunctionFactory func(PluginFactoryArgs) priorities.PriorityFunction
-
-// PriorityFunctionFactory2 produces map & reduce priority functions
+// PriorityFunctionFactory produces map & reduce priority functions
 // from a given args.
-// FIXME: Rename to PriorityFunctionFactory.
-type PriorityFunctionFactory2 func(PluginFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction)
+type PriorityFunctionFactory func(PluginFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction)
 
 // PriorityConfigFactory produces a PriorityConfig from the given function and weight
 type PriorityConfigFactory struct {
-	MapReduceFunction PriorityFunctionFactory2
+	MapReduceFunction PriorityFunctionFactory
 	Weight            int64
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
1.  clean up PriorityFunction
2. clean up PriorityFunctionFactory
3. rename PriorityFunctionFactory2

/sig scheduling
/assign @ahg-g 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #84947

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
