### PR TITLE
Introduce a custom error type to be returned by authenticators.

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-image/go.mod
+++ b/cluster/addons/fluentd-elasticsearch/es-image/go.mod
@@ -33,3 +33,5 @@ require (
 	k8s.io/utils v0.0.0-20181221173059-8a16e7dd8fb6 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )
+
+go 1.13

--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -247,9 +247,9 @@ func NewServer(
 func (s *Server) InstallAuthFilter() {
 	s.restfulCont.Filter(func(req *restful.Request, resp *restful.Response, chain *restful.FilterChain) {
 		// Authenticate
-		info, ok, err := s.auth.AuthenticateRequest(req.Request)
-		if err != nil {
-			klog.Errorf("Unable to authenticate the request due to an error: %v", err)
+		info, ok, authErr := s.auth.AuthenticateRequest(req.Request)
+		if authErr != nil {
+			klog.Errorf("Unable to authenticate the request due to an error: %v", authErr)
 			resp.WriteErrorString(http.StatusUnauthorized, "Unauthorized")
 			return
 		}
@@ -262,10 +262,10 @@ func (s *Server) InstallAuthFilter() {
 		attrs := s.auth.GetRequestAttributes(info.User, req.Request)
 
 		// Authorize
-		decision, _, err := s.auth.Authorize(req.Request.Context(), attrs)
-		if err != nil {
+		decision, _, authzErr := s.auth.Authorize(req.Request.Context(), attrs)
+		if authzErr != nil {
 			msg := fmt.Sprintf("Authorization error (user=%s, verb=%s, resource=%s, subresource=%s)", attrs.GetUser().GetName(), attrs.GetVerb(), attrs.GetResource(), attrs.GetSubresource())
-			klog.Errorf(msg, err)
+			klog.Errorf(msg, authzErr)
 			resp.WriteErrorString(http.StatusInternalServerError, msg)
 			return
 		}

--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap.go
@@ -89,7 +89,7 @@ func tokenErrorf(s *corev1.Secret, format string, i ...interface{}) {
 //
 //     ( token-id ).( token-secret )
 //
-func (t *TokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+func (t *TokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	tokenID, tokenSecret, err := bootstraptokenutil.ParseToken(token)
 	if err != nil {
 		// Token isn't of the correct form, ignore it.
@@ -103,7 +103,7 @@ func (t *TokenAuthenticator) AuthenticateToken(ctx context.Context, token string
 			klog.V(3).Infof("No secret of name %s to match bootstrap bearer token", secretName)
 			return nil, false, nil
 		}
-		return nil, false, err
+		return nil, false, &authenticator.AuthError{AuthenticatorID: "bootstrap", Err: err}
 	}
 
 	if secret.DeletionTimestamp != nil {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/audagnostic_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticator/audagnostic_test.go
@@ -31,7 +31,7 @@ func TestAuthenticate(t *testing.T) {
 	type treq struct {
 		resp          *Response
 		authenticated bool
-		err           error
+		err           *AuthError
 
 		wantResp          *Response
 		wantAuthenticated bool
@@ -87,7 +87,7 @@ func TestAuthenticate(t *testing.T) {
 					wantAuthenticated: true,
 				},
 				{
-					err:     errors.New("uhoh"),
+					err:     &AuthError{AuthenticatorID: "foo", Err: errors.New("uhoh")},
 					wantErr: true,
 				},
 				{
@@ -136,7 +136,7 @@ func TestAuthenticate(t *testing.T) {
 					wantAuthenticated: true,
 				},
 				{
-					err: errors.New("uhoh"),
+					err: &AuthError{AuthenticatorID: "foo", Err: errors.New("uhoh")},
 
 					wantErr: true,
 				},
@@ -185,7 +185,7 @@ func TestAuthenticate(t *testing.T) {
 					wantAuthenticated: false,
 				},
 				{
-					err: errors.New("uhoh"),
+					err: &AuthError{AuthenticatorID: "foo", Err: errors.New("uhoh")},
 
 					wantAuthenticated: false,
 				},
@@ -205,7 +205,7 @@ func TestAuthenticate(t *testing.T) {
 					t.Run(fmt.Sprintf("auds=%q,implicit=%q", taudcfg.auds, taudcfg.implicitAuds), func(t *testing.T) {
 						ctx := context.Background()
 						ctx = WithAudiences(ctx, taudcfg.auds)
-						resp, ok, err := authenticate(ctx, taudcfg.implicitAuds, func() (*Response, bool, error) {
+						resp, ok, err := authenticate(ctx, taudcfg.implicitAuds, func() (*Response, bool, *AuthError) {
 							if treq.resp != nil {
 								resp := *treq.resp
 								return &resp, treq.authenticated, treq.err

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/authenticated_group_adder.go
@@ -36,7 +36,7 @@ func NewAuthenticatedGroupAdder(auth authenticator.Request) authenticator.Reques
 	return &AuthenticatedGroupAdder{auth}
 }
 
-func (g *AuthenticatedGroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+func (g *AuthenticatedGroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	r, ok, err := g.Authenticator.AuthenticateRequest(req)
 	if err != nil || !ok {
 		return nil, ok, err

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder.go
@@ -36,7 +36,7 @@ func NewGroupAdder(auth authenticator.Request, groups []string) authenticator.Re
 	return &GroupAdder{auth, groups}
 }
 
-func (g *GroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+func (g *GroupAdder) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	r, ok, err := g.Authenticator.AuthenticateRequest(req)
 	if err != nil || !ok {
 		return nil, ok, err

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/group_adder_test.go
@@ -28,7 +28,7 @@ import (
 func TestGroupAdder(t *testing.T) {
 	adder := authenticator.Request(
 		NewGroupAdder(
-			authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+			authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 				return &authenticator.Response{User: &user.DefaultInfo{Name: "user", Groups: []string{"original"}}}, true, nil
 			}),
 			[]string{"added"},
@@ -96,7 +96,7 @@ func TestAuthenticatedGroupAdder(t *testing.T) {
 	for _, test := range tests {
 		adder := authenticator.Request(
 			NewAuthenticatedGroupAdder(
-				authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+				authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 					return &authenticator.Response{User: test.inputUser}, true, nil
 				}),
 			),

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder.go
@@ -36,7 +36,7 @@ func NewTokenGroupAdder(auth authenticator.Token, groups []string) authenticator
 	return &TokenGroupAdder{auth, groups}
 }
 
-func (g *TokenGroupAdder) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+func (g *TokenGroupAdder) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	r, ok, err := g.Authenticator.AuthenticateToken(ctx, token)
 	if err != nil || !ok {
 		return nil, ok, err

--- a/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/group/token_group_adder_test.go
@@ -28,7 +28,7 @@ import (
 func TestTokenGroupAdder(t *testing.T) {
 	adder := authenticator.Token(
 		NewTokenGroupAdder(
-			authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+			authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, *authenticator.AuthError) {
 				return &authenticator.Response{User: &user.DefaultInfo{Name: "user", Groups: []string{"original"}}}, true, nil
 			}),
 			[]string{"added"},

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/anonymous/anonymous.go
@@ -30,7 +30,7 @@ const (
 )
 
 func NewAuthenticator() authenticator.Request {
-	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+	return authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 		auds, _ := authenticator.AudiencesFrom(req.Context())
 		return &authenticator.Response{
 			User: &user.DefaultInfo{

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/bearertoken/bearertoken.go
@@ -32,9 +32,9 @@ func New(auth authenticator.Token) *Authenticator {
 	return &Authenticator{auth}
 }
 
-var invalidToken = errors.New("invalid bearer token")
+var invalidToken = &authenticator.AuthError{AuthenticatorID: "bearer-token", Err: errors.New("invalid bearer token")}
 
-func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	auth := strings.TrimSpace(req.Header.Get("Authorization"))
 	if auth == "" {
 		return nil, false, nil

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/headerrequest/requestheader.go
@@ -154,7 +154,7 @@ func NewDynamicVerifyOptionsSecure(verifyOptionFn x509request.VerifyOptionFunc, 
 	return x509request.NewDynamicCAVerifier(verifyOptionFn, headerAuthenticator, proxyClientNames)
 }
 
-func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+func (a *requestHeaderAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	name := headerValue(req.Header, a.nameHeaders.Value())
 	if len(name) == 0 {
 		return nil, false, nil

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/union/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/union/union.go
@@ -50,7 +50,7 @@ func NewFailOnError(authRequestHandlers ...authenticator.Request) authenticator.
 }
 
 // AuthenticateRequest authenticates the request using a chain of authenticator.Request objects.
-func (authHandler *unionAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+func (authHandler *unionAuthRequestHandler) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	var errlist []error
 	for _, currAuthRequestHandler := range authHandler.Handlers {
 		resp, ok, err := currAuthRequestHandler.AuthenticateRequest(req)
@@ -67,5 +67,5 @@ func (authHandler *unionAuthRequestHandler) AuthenticateRequest(req *http.Reques
 		}
 	}
 
-	return nil, false, utilerrors.NewAggregate(errlist)
+	return nil, false, &authenticator.AuthError{AuthenticatorID: "union", Err: utilerrors.NewAggregate(errlist)}
 }

--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509_test.go
@@ -590,8 +590,8 @@ func TestX509(t *testing.T) {
 		"custom conversion error": {
 			Opts:  getDefaultVerifyOptions(t),
 			Certs: getCerts(t, clientCNCert),
-			User: UserConversionFunc(func(chain []*x509.Certificate) (*authenticator.Response, bool, error) {
-				return nil, false, errors.New("custom error")
+			User: UserConversionFunc(func(chain []*x509.Certificate) (*authenticator.Response, bool, *authenticator.AuthError) {
+				return nil, false, &authenticator.AuthError{AuthenticatorID: "x509", Err: errors.New("custom error")}
 			}),
 
 			ExpectOK:  false,
@@ -600,7 +600,7 @@ func TestX509(t *testing.T) {
 		"custom conversion success": {
 			Opts:  getDefaultVerifyOptions(t),
 			Certs: getCerts(t, clientCNCert),
-			User: UserConversionFunc(func(chain []*x509.Certificate) (*authenticator.Response, bool, error) {
+			User: UserConversionFunc(func(chain []*x509.Certificate) (*authenticator.Response, bool, *authenticator.AuthError) {
 				return &authenticator.Response{User: &user.DefaultInfo{Name: "custom"}}, true, nil
 			}),
 
@@ -808,7 +808,7 @@ func TestX509Verifier(t *testing.T) {
 		}
 
 		authCall := false
-		auth := authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+		auth := authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 			authCall = true
 			return &authenticator.Response{User: &user.DefaultInfo{Name: "innerauth"}}, true, nil
 		})

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
@@ -97,12 +97,12 @@ func newWithClock(authenticator authenticator.Token, cacheErrs bool, successTTL,
 }
 
 // AuthenticateToken implements authenticator.Token
-func (a *cachedTokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+func (a *cachedTokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	auds, _ := authenticator.AudiencesFrom(ctx)
 
 	key := keyFunc(a.hashPool, auds, token)
 	if record, ok := a.cache.get(key); ok {
-		return record.resp, record.ok, record.err
+		return record.resp, record.ok, &authenticator.AuthError{AuthenticatorID: "cached-token", Err: record.err}
 	}
 
 	resp, ok, err := a.authenticator.AuthenticateToken(ctx, token)

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/tokenfile/tokenfile.go
@@ -90,7 +90,7 @@ func NewCSV(path string) (*TokenAuthenticator, error) {
 	}, nil
 }
 
-func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string) (*authenticator.Response, bool, error) {
+func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	user, ok := a.tokens[value]
 	if !ok {
 		return nil, false, nil

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/union/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/union/union.go
@@ -50,7 +50,7 @@ func NewFailOnError(authTokenHandlers ...authenticator.Token) authenticator.Toke
 }
 
 // AuthenticateToken authenticates the token using a chain of authenticator.Token objects.
-func (authHandler *unionAuthTokenHandler) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+func (authHandler *unionAuthTokenHandler) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	var errlist []error
 	for _, currAuthRequestHandler := range authHandler.Handlers {
 		info, ok, err := currAuthRequestHandler.AuthenticateToken(ctx, token)
@@ -67,5 +67,5 @@ func (authHandler *unionAuthTokenHandler) AuthenticateToken(ctx context.Context,
 		}
 	}
 
-	return nil, false, utilerrors.NewAggregate(errlist)
+	return nil, false, &authenticator.AuthError{AuthenticatorID: "union", Err: utilerrors.NewAggregate(errlist)}
 }

--- a/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/deprecated_insecure_serving.go
@@ -82,7 +82,7 @@ func (s *DeprecatedInsecureServingInfo) NewLoopbackClientConfig() (*rest.Config,
 // but allows apiserver code to stop special-casing a nil user to skip authorization checks.
 type InsecureSuperuser struct{}
 
-func (InsecureSuperuser) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+func (InsecureSuperuser) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	auds, _ := authenticator.AudiencesFrom(req.Context())
 	return &authenticator.Response{
 		User: &user.DefaultInfo{

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/password/passwordfile/passwordfile.go
@@ -81,7 +81,7 @@ func NewCSV(path string) (*PasswordAuthenticator, error) {
 	return &PasswordAuthenticator{users}, nil
 }
 
-func (a *PasswordAuthenticator) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, error) {
+func (a *PasswordAuthenticator) AuthenticatePassword(ctx context.Context, username, password string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	user, ok := a.users[username]
 	if !ok {
 		return nil, false, nil

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth.go
@@ -36,7 +36,7 @@ func New(auth authenticator.Password) *Authenticator {
 var errInvalidAuth = errors.New("invalid username/password combination")
 
 // AuthenticateRequest authenticates the request using the "Authorization: Basic" header in the request
-func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, error) {
+func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	username, password, found := req.BasicAuth()
 	if !found {
 		return nil, false, nil
@@ -46,7 +46,7 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 
 	// If the password authenticator didn't error, provide a default error
 	if !ok && err == nil {
-		err = errInvalidAuth
+		err = &authenticator.AuthError{AuthenticatorID: "basic-auth", Err: errInvalidAuth}
 	}
 
 	return resp, ok, err

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/request/basicauth/basicauth_test.go
@@ -33,10 +33,10 @@ type testPassword struct {
 
 	User user.Info
 	OK   bool
-	Err  error
+	Err  *authenticator.AuthError
 }
 
-func (t *testPassword) AuthenticatePassword(ctx context.Context, user, password string) (*authenticator.Response, bool, error) {
+func (t *testPassword) AuthenticatePassword(ctx context.Context, user, password string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	t.Called = true
 	t.Username = user
 	t.Password = password
@@ -78,7 +78,7 @@ func TestBasicAuth(t *testing.T) {
 			ExpectedOK:       true,
 		},
 		"password auth returned error": {
-			Password:         testPassword{Err: errors.New("auth error")},
+			Password:         testPassword{Err: &authenticator.AuthError{AuthenticatorID: "basic-aith", Err: errors.New("auth error")}},
 			ExpectedCalled:   true,
 			ExpectedUsername: "myuser",
 			ExpectedPassword: "mypw",

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/tokentest.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/tokentest/tokentest.go
@@ -33,7 +33,7 @@ func New() *TokenAuthenticator {
 	}
 }
 
-func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string) (*authenticator.Response, bool, error) {
+func (a *TokenAuthenticator) AuthenticateToken(ctx context.Context, value string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	user, ok := a.Tokens[value]
 	if !ok {
 		return nil, false, nil

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
@@ -74,7 +74,7 @@ func newWithBackoff(tokenReview authenticationclient.TokenReviewInterface, initi
 }
 
 // AuthenticateToken implements the authenticator.Token interface.
-func (w *WebhookTokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+func (w *WebhookTokenAuthenticator) AuthenticateToken(ctx context.Context, token string) (*authenticator.Response, bool, *authenticator.AuthError) {
 	// We take implicit audiences of the API server at WebhookTokenAuthenticator
 	// construction time. The outline of how we validate audience here is:
 	//
@@ -105,7 +105,7 @@ func (w *WebhookTokenAuthenticator) AuthenticateToken(ctx context.Context, token
 	if err != nil {
 		// An error here indicates bad configuration or an outage. Log for debugging.
 		klog.Errorf("Failed to make webhook authenticator request: %v", err)
-		return nil, false, err
+		return nil, false, &authenticator.AuthError{AuthenticatorID: "webhook", Err: err}
 	}
 
 	if checkAuds {
@@ -125,7 +125,7 @@ func (w *WebhookTokenAuthenticator) AuthenticateToken(ctx context.Context, token
 		if len(r.Status.Error) != 0 {
 			err = errors.New(r.Status.Error)
 		}
-		return nil, false, err
+		return nil, false, &authenticator.AuthError{AuthenticatorID: "webhook", Err: err}
 	}
 
 	var extra map[string][]string

--- a/test/integration/auth/accessreview_test.go
+++ b/test/integration/auth/accessreview_test.go
@@ -47,7 +47,7 @@ func (sarAuthorizer) Authorize(ctx context.Context, a authorizer.Attributes) (au
 	return authorizer.DecisionAllow, "you're not dave", nil
 }
 
-func alwaysAlice(req *http.Request) (*authenticator.Response, bool, error) {
+func alwaysAlice(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 	return &authenticator.Response{
 		User: &user.DefaultInfo{
 			Name: "alice",
@@ -148,7 +148,7 @@ func TestSubjectAccessReview(t *testing.T) {
 func TestSelfSubjectAccessReview(t *testing.T) {
 	username := "alice"
 	masterConfig := framework.NewIntegrationTestMasterConfig()
-	masterConfig.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, error) {
+	masterConfig.GenericConfig.Authentication.Authenticator = authenticator.RequestFunc(func(req *http.Request) (*authenticator.Response, bool, *authenticator.AuthError) {
 		return &authenticator.Response{
 			User: &user.DefaultInfo{Name: username},
 		}, true, nil

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -75,7 +75,7 @@ func (alwaysAllow) Authorize(ctx context.Context, requestAttributes authorizer.A
 }
 
 // alwaysEmpty simulates "no authentication" for old tests
-func alwaysEmpty(req *http.Request) (*authauthenticator.Response, bool, error) {
+func alwaysEmpty(req *http.Request) (*authauthenticator.Response, bool, *authauthenticator.AuthError) {
 	return &authauthenticator.Response{
 		User: &user.DefaultInfo{
 			Name: "",

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -382,7 +382,7 @@ func startServiceAccountTestServer(t *testing.T) (*clientset.Clientset, restclie
 	// Set up two authenticators:
 	// 1. A token authenticator that maps the rootToken to the "root" user
 	// 2. A ServiceAccountToken authenticator that validates ServiceAccount tokens
-	rootTokenAuth := authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
+	rootTokenAuth := authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, *authenticator.AuthError) {
 		if token == rootToken {
 			return &authenticator.Response{User: &user.DefaultInfo{Name: rootUserName}}, true, nil
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind feature
**What this PR does / why we need it**:
This is a stepping stone towards being able to classify authentication's metrics based on the authenticator. 
Introduction of this custom error message will allow to classify/label authentication failures based on the  authenticator(ex. x509, bearer-token, etc). 
Changes to metrics will be added on a separate PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
