### PR TITLE
fix: return NodeScore in even pods spread priority

### DIFF
--- a/pkg/scheduler/algorithm/priorities/even_pods_spread.go
+++ b/pkg/scheduler/algorithm/priorities/even_pods_spread.go
@@ -147,7 +147,7 @@ func CalculateEvenPodsSpreadPriorityMap(pod *v1.Pod, meta interface{}, nodeInfo 
 		m = priorityMeta.podTopologySpreadMap
 	}
 	if m == nil {
-		return framework.NodeScore{}, nil
+		return framework.NodeScore{Name: node.Name, Score: 0}, nil
 	}
 
 	// no need to continue if the node is not qualified.


### PR DESCRIPTION
/sig scheduling
/kind bug
/priority backlog
/assign @Huang-Wei 

Priorities should either return a NodeScore or error

```release-note
NONE
```
