### PR TITLE
Automated cherry pick of #84963: json unmarshal coded error at function applyJSPatch()

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -340,7 +340,7 @@ func (p *jsonPatcher) applyJSPatch(versionedJS []byte) (patchedJS []byte, retErr
 		// TODO(liggitt): drop this once golang json parser limits stack depth (https://github.com/golang/go/issues/31789)
 		if len(p.patchBytes) > 1024*1024 {
 			v := []interface{}{}
-			if err := json.Unmarshal(p.patchBytes, v); err != nil {
+			if err := json.Unmarshal(p.patchBytes, &v); err != nil {
 				return nil, errors.NewBadRequest(fmt.Sprintf("error decoding patch: %v", err))
 			}
 		}
@@ -364,7 +364,7 @@ func (p *jsonPatcher) applyJSPatch(versionedJS []byte) (patchedJS []byte, retErr
 		// TODO(liggitt): drop this once golang json parser limits stack depth (https://github.com/golang/go/issues/31789)
 		if len(p.patchBytes) > 1024*1024 {
 			v := map[string]interface{}{}
-			if err := json.Unmarshal(p.patchBytes, v); err != nil {
+			if err := json.Unmarshal(p.patchBytes, &v); err != nil {
 				return nil, errors.NewBadRequest(fmt.Sprintf("error decoding patch: %v", err))
 			}
 		}

--- a/test/integration/apiserver/max_request_body_bytes_test.go
+++ b/test/integration/apiserver/max_request_body_bytes_test.go
@@ -93,6 +93,14 @@ func TestMaxResourceSize(t *testing.T) {
 			t.Errorf("expected success or bad request err, got %v", err)
 		}
 	})
+	t.Run("JSONPatchType should handle a valid patch just under the max limit", func(t *testing.T) {
+		patchBody := []byte(`[{"op":"add","path":"/foo","value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}]`)
+		err = rest.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+			Body(patchBody).Do().Error()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 	t.Run("MergePatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.MergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
@@ -101,12 +109,28 @@ func TestMaxResourceSize(t *testing.T) {
 			t.Errorf("expected success or bad request err, got %v", err)
 		}
 	})
+	t.Run("MergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
+		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
+		err = rest.Patch(types.MergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+			Body(patchBody).Do().Error()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
 	t.Run("StrategicMergePatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.StrategicMergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
 			Body(patchBody).Do().Error()
 		if err != nil && !errors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
+		}
+	})
+	t.Run("StrategicMergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
+		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
+		err = rest.Patch(types.StrategicMergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
+			Body(patchBody).Do().Error()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
 		}
 	})
 	t.Run("Delete should limit the request body size", func(t *testing.T) {


### PR DESCRIPTION
Cherry pick of #84963 on release-1.14.

#84963: json unmarshal coded error at function applyJSPatch()

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.