### PR TITLE
omit namespace to avoid ambiguity

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -577,11 +577,7 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	w.Flush()
 	if trackingWriter.Written == 0 && !o.IgnoreNotFound && len(allErrs) == 0 {
 		// if we wrote no output, and had no errors, and are not ignoring NotFound, be sure we output something
-		if !o.AllNamespaces {
-			fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found in %s namespace.", o.Namespace))
-		} else {
-			fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found"))
-		}
+		fmt.Fprintln(o.ErrOut, fmt.Sprintf("No resources found"))
 	}
 	return utilerrors.NewAggregate(allErrs)
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get_test.go
@@ -558,7 +558,7 @@ func TestNoBlankLinesForGetAll(t *testing.T) {
 	if e, a := expected, buf.String(); e != a {
 		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
-	expectedErr := `No resources found in test namespace.
+	expectedErr := `No resources found
 `
 	if e, a := expectedErr, errbuf.String(); e != a {
 		t.Errorf("expectedErr\n%v\ngot\n%v", e, a)
@@ -648,7 +648,7 @@ func TestGetEmptyTable(t *testing.T) {
 	if e, a := expected, buf.String(); e != a {
 		t.Errorf("expected\n%v\ngot\n%v", e, a)
 	}
-	expectedErr := `No resources found in test namespace.
+	expectedErr := `No resources found
 `
 	if e, a := expectedErr, errbuf.String(); e != a {
 		t.Errorf("expectedErr\n%v\ngot\n%v", e, a)


### PR DESCRIPTION

**What type of PR is this?**

> /area kubectl
> /kind cleanup

**What this PR does / why we need it**:This PR resolve eliminate the ambiguity `kubectl get` returnd.

**Which issue(s) this PR fixes**:https://github.com/kubernetes/kubectl/issues/757

**Special notes for your reviewer**:
/assign @deads2k @juanvallejo

**Does this PR introduce a user-facing change?**:Yes

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
