### PR TITLE
- Delete backing string set from a threadSafeMap index when the string set length reaches 0.

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/BUILD
+++ b/staging/src/k8s.io/client-go/tools/cache/BUILD
@@ -21,6 +21,7 @@ go_test(
         "reflector_test.go",
         "shared_informer_test.go",
         "store_test.go",
+        "thread_safe_store_test.go",
         "undelta_store_test.go",
     ],
     embed = [":go_default_library"],

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store.go
@@ -292,6 +292,13 @@ func (c *threadSafeMap) deleteFromIndices(obj interface{}, key string) {
 			set := index[indexValue]
 			if set != nil {
 				set.Delete(key)
+
+				// If we don't delete the set when zero, indices with high cardinality
+				// short lived resources can cause memory to increase over time from
+				// unused empty sets. See `kubernetes/kubernetes/issues/84959`.
+				if len(set) == 0 {
+					delete(index, indexValue)
+				}
 			}
 		}
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/thread_safe_store_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cache
+
+import (
+	"testing"
+)
+
+func TestThreadSafeStoreDeleteRemovesEmptySetsFromIndex(t *testing.T) {
+	testIndexer := "testIndexer"
+
+	indexers := Indexers{
+		testIndexer: func(obj interface{}) (strings []string, e error) {
+			indexes := []string{obj.(string)}
+			return indexes, nil
+		},
+	}
+
+	indices := Indices{}
+	store := NewThreadSafeStore(indexers, indices).(*threadSafeMap)
+
+	testKey := "testKey"
+
+	store.Add(testKey, testKey)
+
+	// Assumption check, there should be a set for the `testKey` with one element in the added index
+	set := store.indices[testIndexer][testKey]
+
+	if len(set) != 1 {
+		t.Errorf("Initial assumption of index backing string set having 1 element failed. Actual elements: %d", len(set))
+		return
+	}
+
+	store.Delete(testKey)
+	set, present := store.indices[testIndexer][testKey]
+
+	if present {
+		t.Errorf("Index backing string set not deleted from index. Set length: %d", len(set))
+	}
+}
+
+func TestThreadSafeStoreAddKeepsNonEmptySetPostDeleteFromIndex(t *testing.T) {
+	testIndexer := "testIndexer"
+	testIndex := "testIndex"
+
+	indexers := Indexers{
+		testIndexer: func(obj interface{}) (strings []string, e error) {
+			indexes := []string{testIndex}
+			return indexes, nil
+		},
+	}
+
+	indices := Indices{}
+	store := NewThreadSafeStore(indexers, indices).(*threadSafeMap)
+
+	store.Add("retain", "retain")
+	store.Add("delete", "delete")
+
+	// Assumption check, there should be a set for the `testIndex` with two elements
+	set := store.indices[testIndexer][testIndex]
+
+	if len(set) != 2 {
+		t.Errorf("Initial assumption of index backing string set having 2 elements failed. Actual elements: %d", len(set))
+		return
+	}
+
+	store.Delete("delete")
+	set, present := store.indices[testIndexer][testIndex]
+
+	if !present {
+		t.Errorf("Index backing string set erroneously deleted from index.")
+		return
+	}
+
+	if len(set) != 1 {
+		t.Errorf("Index backing string set has incorrect length, expect 1. Set length: %d", len(set))
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/sig api-machinery
/kind bug

**What this PR does / why we need it**:

Reduce memory footprint of `threadSafeMap` for indices that have churn of high-cardinality keys. E.g. namespaces.

**Which issue(s) this PR fixes**:
Fixes #84959

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```