### PR TITLE
Prevent slice index out of range

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/version/version.go
@@ -41,7 +41,7 @@ var (
 
 func parse(str string, semver bool) (*Version, error) {
 	parts := versionMatchRE.FindStringSubmatch(str)
-	if parts == nil {
+	if len(parts) < 3 {
 		return nil, fmt.Errorf("could not parse %q as version", str)
 	}
 	numbers, extra := parts[1], parts[2]
@@ -68,7 +68,7 @@ func parse(str string, semver bool) (*Version, error) {
 
 	if semver && extra != "" {
 		extraParts := extraMatchRE.FindStringSubmatch(extra)
-		if extraParts == nil {
+		if len(extraParts) < 3 {
 			return nil, fmt.Errorf("could not parse pre-release/metadata (%s) in version %q", extra, str)
 		}
 		v.preRelease, v.buildMetadata = extraParts[1], extraParts[2]


### PR DESCRIPTION
**What type of PR is this?**
Prevent slice index out of range

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

parts := versionMatchRE.FindStringSubmatch(str)
parts is a slice ,But its size is not guaranteed to be greater than 3
so parts[1].parts[2] is can panic: runtime error: index out of range

**Previous code**

```
parts := versionMatchRE.FindStringSubmatch(str)
if parts == nil {
	return nil, fmt.Errorf("could not parse %q as version", str)
}
numbers, extra := parts[1], parts[2]
```

**Now Code**
```
parts := versionMatchRE.FindStringSubmatch(str)
if len(parts) < 3 {
	return nil, fmt.Errorf("could not parse %q as version", str)
}
numbers, extra := parts[1], parts[2]
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



