### PR TITLE
apiextension: simplify cases for XListType and XMapType in Structural

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/convert.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/convert.go
@@ -245,8 +245,13 @@ func newExtensions(s *apiextensions.JSONSchemaProps) (*Extensions, error) {
 		XEmbeddedResource: s.XEmbeddedResource,
 		XIntOrString:      s.XIntOrString,
 		XListMapKeys:      s.XListMapKeys,
-		XListType:         s.XListType,
-		XMapType:          s.XMapType,
+	}
+
+	if s.XListType != nil && *s.XListType != "atomic" {
+		ret.XListType = *s.XListType
+	}
+	if s.XMapType != nil && *s.XMapType != "granular" {
+		ret.XMapType = *s.XMapType
 	}
 
 	if s.XPreserveUnknownFields != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/goopenapi.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/goopenapi.go
@@ -81,11 +81,11 @@ func (x *Extensions) toGoOpenAPI(ret *spec.Schema) {
 	if len(x.XListMapKeys) > 0 {
 		ret.VendorExtensible.AddExtension("x-kubernetes-list-map-keys", x.XListMapKeys)
 	}
-	if x.XListType != nil {
-		ret.VendorExtensible.AddExtension("x-kubernetes-list-type", *x.XListType)
+	if len(x.XListType) != 0 {
+		ret.VendorExtensible.AddExtension("x-kubernetes-list-type", x.XListType)
 	}
-	if x.XMapType != nil {
-		ret.VendorExtensible.AddExtension("x-kubernetes-map-type", *x.XMapType)
+	if len(x.XMapType) != 0 {
+		ret.VendorExtensible.AddExtension("x-kubernetes-map-type", x.XMapType)
 	}
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/structural.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/structural.go
@@ -104,29 +104,30 @@ type Extensions struct {
 	// x-kubernetes-list-type annotates a list to further describe its topology.
 	// This extension must only be used on lists and may have 3 possible values:
 	//
-	// 1) `atomic`: the list is treated as a single entity, like a scalar.
+	// 1) `` for atomic: the list is treated as a single entity, like a scalar.
 	//      Atomic lists will be entirely replaced when updated. This extension
 	//      may be used on any type of list (struct, scalar, ...).
 	// 2) `set`:
 	//      Sets are lists that must not have multiple items with the same value. Each
-	//      value must be a scalar (or another atomic type).
+	//      value must be a scalar, an object with x-kubernetes-map-type `atomic` or an
+	//      array with x-kubernetes-list-type `atomic`.
 	// 3) `map`:
 	//      These lists are like maps in that their elements have a non-index key
 	//      used to identify them. Order is preserved upon merge. The map tag
 	//      must only be used on a list with elements of type object.
-	XListType *string
+	XListType string
 
 	// x-kubernetes-map-type annotates an object to further describe its topology.
 	// This extension must only be used when type is object and may have 2 possible values:
 	//
-	// 1) `granular`:
+	// 1) `` for granular:
 	//      These maps are actual maps (key-value pairs) and each fields are independent
 	//      from each other (they can each be manipulated by separate actors). This is
 	//      the default behaviour for all maps.
 	// 2) `atomic`: the list is treated as a single entity, like a scalar.
 	//      Atomic maps will be entirely replaced when updated.
 	// +optional
-	XMapType *string
+	XMapType string
 }
 
 // +k8s:deepcopy-gen=true

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/validation.go
@@ -308,11 +308,11 @@ func validateNestedValueValidation(v *NestedValueValidation, skipAnyOf, skipAllO
 	if len(v.ForbiddenExtensions.XListMapKeys) > 0 {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-list-map-keys"), "must be empty to be structural"))
 	}
-	if v.ForbiddenExtensions.XListType != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-list-type"), "must be undefined to be structural"))
+	if len(v.ForbiddenExtensions.XListType) != 0 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-list-type"), "must be atomic to be structural"))
 	}
-	if v.ForbiddenExtensions.XMapType != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-map-type"), "must be undefined to be structural"))
+	if len(v.ForbiddenExtensions.XMapType) != 0 {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("x-kubernetes-map-type"), "must be granular to be structural"))
 	}
 
 	// forbid reasoning about metadata because it can lead to metadata restriction we don't want

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/zz_generated.deepcopy.go
@@ -28,16 +28,6 @@ func (in *Extensions) DeepCopyInto(out *Extensions) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.XListType != nil {
-		in, out := &in.XListType, &out.XListType
-		*out = new(string)
-		**out = **in
-	}
-	if in.XMapType != nil {
-		in, out := &in.XMapType, &out.XMapType
-		*out = new(string)
-		**out = **in
-	}
 	return
 }
 


### PR DESCRIPTION
We made the choice that x-kubernetes-list-type and map-type can be empty and `atomic`/`granular`. This is an ambiguous representation we better avoid in the internal structural data structure.

/kind cleanup

```release-note
NONE
```