### PR TITLE
migrate kubelet custom metrics to stability framework part 2

### DIFF
--- a/pkg/kubelet/apis/resourcemetrics/v1alpha1/BUILD
+++ b/pkg/kubelet/apis/resourcemetrics/v1alpha1/BUILD
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/kubelet/apis/stats/v1alpha1:go_default_library",
         "//pkg/kubelet/server/stats:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
     ],
 )
 

--- a/pkg/kubelet/server/BUILD
+++ b/pkg/kubelet/server/BUILD
@@ -52,7 +52,6 @@ go_library(
         "//vendor/github.com/google/cadvisor/container:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/google/cadvisor/metrics:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/kubelet/server/stats/BUILD
+++ b/pkg/kubelet/server/stats/BUILD
@@ -26,9 +26,9 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -49,8 +49,8 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
-        "//vendor/github.com/prometheus/client_model/go:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/mock:go_default_library",
     ] + select({

--- a/pkg/kubelet/server/stats/prometheus_resource_metrics_test.go
+++ b/pkg/kubelet/server/stats/prometheus_resource_metrics_test.go
@@ -18,27 +18,113 @@ package stats
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
-	dto "github.com/prometheus/client_model/go"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/testutil"
 	statsapi "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
+	summary "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1"
 )
 
-const (
-	errorName = "scrape_error"
-	errorHelp = "1 if there was an error while getting container metrics, 0 otherwise"
-)
-
+// TODO(RainbowMango): The Desc variables and value functions should be shared with source code.
+// It can not be shared now because there is a import cycle.
+// Consider deprecate endpoint `/resource/v1alpha1` as stability framework could offer guarantee now.
 var (
-	noError  = float64(0)
-	hasError = float64(1)
+	nodeCPUUsageDesc = metrics.NewDesc("node_cpu_usage_seconds_total",
+		"Cumulative cpu time consumed by the node in core-seconds",
+		nil,
+		nil,
+		metrics.ALPHA,
+		"")
+
+	nodeMemoryUsageDesc = metrics.NewDesc("node_memory_working_set_bytes",
+		"Current working set of the node in bytes",
+		nil,
+		nil,
+		metrics.ALPHA,
+		"")
+
+	containerCPUUsageDesc = metrics.NewDesc("container_cpu_usage_seconds_total",
+		"Cumulative cpu time consumed by the container in core-seconds",
+		[]string{"container", "pod", "namespace"},
+		nil,
+		metrics.ALPHA,
+		"")
+
+	containerMemoryUsageDesc = metrics.NewDesc("container_memory_working_set_bytes",
+		"Current working set of the container in bytes",
+		[]string{"container", "pod", "namespace"},
+		nil,
+		metrics.ALPHA,
+		"")
 )
+
+// getNodeCPUMetrics returns CPU utilization of a node.
+func getNodeCPUMetrics(s summary.NodeStats) (*float64, time.Time) {
+	if s.CPU == nil {
+		return nil, time.Time{}
+	}
+	v := float64(*s.CPU.UsageCoreNanoSeconds) / float64(time.Second)
+	return &v, s.CPU.Time.Time
+}
+
+// getNodeMemoryMetrics returns memory utilization of a node.
+func getNodeMemoryMetrics(s summary.NodeStats) (*float64, time.Time) {
+	if s.Memory == nil {
+		return nil, time.Time{}
+	}
+	v := float64(*s.Memory.WorkingSetBytes)
+	return &v, s.Memory.Time.Time
+}
+
+// getContainerCPUMetrics returns CPU utilization of a container.
+func getContainerCPUMetrics(s summary.ContainerStats) (*float64, time.Time) {
+	if s.CPU == nil {
+		return nil, time.Time{}
+	}
+	v := float64(*s.CPU.UsageCoreNanoSeconds) / float64(time.Second)
+	return &v, s.CPU.Time.Time
+}
+
+// getContainerMemoryMetrics returns memory utilization of a container.
+func getContainerMemoryMetrics(s summary.ContainerStats) (*float64, time.Time) {
+	if s.Memory == nil {
+		return nil, time.Time{}
+	}
+	v := float64(*s.Memory.WorkingSetBytes)
+	return &v, s.Memory.Time.Time
+}
+
+// Config is the v1alpha1 resource metrics definition
+func Config() ResourceMetricsConfig {
+	return ResourceMetricsConfig{
+		NodeMetrics: []NodeResourceMetric{
+			{
+				Desc:    nodeCPUUsageDesc,
+				ValueFn: getNodeCPUMetrics,
+			},
+			{
+				Desc:    nodeMemoryUsageDesc,
+				ValueFn: getNodeMemoryMetrics,
+			},
+		},
+		ContainerMetrics: []ContainerResourceMetric{
+			{
+				Desc:    containerCPUUsageDesc,
+				ValueFn: getContainerCPUMetrics,
+			},
+			{
+				Desc:    containerMemoryUsageDesc,
+				ValueFn: getContainerMemoryMetrics,
+			},
+		},
+	}
+}
 
 type mockSummaryProvider struct {
 	mock.Mock
@@ -54,60 +140,32 @@ func (m *mockSummaryProvider) GetCPUAndMemoryStats() (*statsapi.Summary, error) 
 	return args.Get(0).(*statsapi.Summary), args.Error(1)
 }
 
-type collectResult struct {
-	desc   *prometheus.Desc
-	metric *dto.Metric
-}
-
 func TestCollectResourceMetrics(t *testing.T) {
-	testTime := metav1.Now()
-	for _, tc := range []struct {
-		description     string
-		config          ResourceMetricsConfig
-		summary         *statsapi.Summary
-		summaryErr      error
-		expectedMetrics []collectResult
+	testTime := metav1.NewTime(time.Unix(2, 0)) // a static timestamp: 2000
+
+	tests := []struct {
+		name                 string
+		config               ResourceMetricsConfig
+		summary              *statsapi.Summary
+		summaryErr           error
+		expectedMetricsNames []string
+		expectedMetrics      string
 	}{
 		{
-			description: "error getting summary",
-			config:      ResourceMetricsConfig{},
-			summary:     nil,
-			summaryErr:  fmt.Errorf("failed to get summary"),
-			expectedMetrics: []collectResult{
-				{
-					desc:   prometheus.NewDesc(errorName, errorHelp, []string{}, nil),
-					metric: &dto.Metric{Gauge: &dto.Gauge{Value: &hasError}},
-				},
-			},
+			name:                 "error getting summary",
+			config:               Config(),
+			summary:              nil,
+			summaryErr:           fmt.Errorf("failed to get summary"),
+			expectedMetricsNames: []string{"scrape_error"},
+			expectedMetrics: `
+				# HELP scrape_error [ALPHA] 1 if there was an error while getting container metrics, 0 otherwise
+				# TYPE scrape_error gauge
+				scrape_error 1
+			`,
 		},
 		{
-			description: "arbitrary node metrics",
-			config: ResourceMetricsConfig{
-				NodeMetrics: []NodeResourceMetric{
-					{
-						Name:        "node_foo",
-						Description: "a metric from nodestats",
-						ValueFn: func(s statsapi.NodeStats) (*float64, time.Time) {
-							if s.CPU == nil {
-								return nil, time.Time{}
-							}
-							v := float64(*s.CPU.UsageCoreNanoSeconds) / float64(time.Second)
-							return &v, s.CPU.Time.Time
-						},
-					},
-					{
-						Name:        "node_bar",
-						Description: "another metric from nodestats",
-						ValueFn: func(s statsapi.NodeStats) (*float64, time.Time) {
-							if s.Memory == nil {
-								return nil, time.Time{}
-							}
-							v := float64(*s.Memory.WorkingSetBytes)
-							return &v, s.Memory.Time.Time
-						},
-					},
-				},
-			},
+			name:   "arbitrary node metrics",
+			config: Config(),
 			summary: &statsapi.Summary{
 				Node: statsapi.NodeStats{
 					CPU: &statsapi.CPUStats{
@@ -121,49 +179,26 @@ func TestCollectResourceMetrics(t *testing.T) {
 				},
 			},
 			summaryErr: nil,
-			expectedMetrics: []collectResult{
-				{
-					desc:   prometheus.NewDesc("node_foo", "a metric from nodestats", []string{}, nil),
-					metric: &dto.Metric{Gauge: &dto.Gauge{Value: float64Ptr(10)}},
-				},
-				{
-					desc:   prometheus.NewDesc("node_bar", "another metric from nodestats", []string{}, nil),
-					metric: &dto.Metric{Gauge: &dto.Gauge{Value: float64Ptr(1000)}},
-				},
-				{
-					desc:   prometheus.NewDesc(errorName, errorHelp, []string{}, nil),
-					metric: &dto.Metric{Gauge: &dto.Gauge{Value: &noError}},
-				},
+			expectedMetricsNames: []string{
+				"node_cpu_usage_seconds_total",
+				"node_memory_working_set_bytes",
+				"scrape_error",
 			},
+			expectedMetrics: `
+				# HELP node_cpu_usage_seconds_total [ALPHA] Cumulative cpu time consumed by the node in core-seconds
+				# TYPE node_cpu_usage_seconds_total gauge
+				node_cpu_usage_seconds_total 10 2000
+				# HELP node_memory_working_set_bytes [ALPHA] Current working set of the node in bytes
+				# TYPE node_memory_working_set_bytes gauge
+				node_memory_working_set_bytes 1000 2000
+				# HELP scrape_error [ALPHA] 1 if there was an error while getting container metrics, 0 otherwise
+				# TYPE scrape_error gauge
+				scrape_error 0
+			`,
 		},
 		{
-			description: "arbitrary container metrics for different container, pods and namespaces",
-			config: ResourceMetricsConfig{
-				ContainerMetrics: []ContainerResourceMetric{
-					{
-						Name:        "container_foo",
-						Description: "a metric from container stats",
-						ValueFn: func(s statsapi.ContainerStats) (*float64, time.Time) {
-							if s.CPU == nil {
-								return nil, time.Time{}
-							}
-							v := float64(*s.CPU.UsageCoreNanoSeconds) / float64(time.Second)
-							return &v, s.CPU.Time.Time
-						},
-					},
-					{
-						Name:        "container_bar",
-						Description: "another metric from container stats",
-						ValueFn: func(s statsapi.ContainerStats) (*float64, time.Time) {
-							if s.Memory == nil {
-								return nil, time.Time{}
-							}
-							v := float64(*s.Memory.WorkingSetBytes)
-							return &v, s.Memory.Time.Time
-						},
-					},
-				},
-			},
+			name:   "arbitrary container metrics for different container, pods and namespaces",
+			config: Config(),
 			summary: &statsapi.Summary{
 				Pods: []statsapi.PodStats{
 					{
@@ -218,131 +253,43 @@ func TestCollectResourceMetrics(t *testing.T) {
 				},
 			},
 			summaryErr: nil,
-			expectedMetrics: []collectResult{
-				{
-					desc: prometheus.NewDesc("container_foo", "a metric from container stats", []string{"container", "pod", "namespace"}, nil),
-					metric: &dto.Metric{
-						Gauge: &dto.Gauge{Value: float64Ptr(10)},
-						Label: []*dto.LabelPair{
-							{Name: stringPtr("container"), Value: stringPtr("container_a")},
-							{Name: stringPtr("namespace"), Value: stringPtr("namespace_a")},
-							{Name: stringPtr("pod"), Value: stringPtr("pod_a")},
-						},
-					},
-				},
-				{
-					desc: prometheus.NewDesc("container_bar", "another metric from container stats", []string{"container", "pod", "namespace"}, nil),
-					metric: &dto.Metric{
-						Gauge: &dto.Gauge{Value: float64Ptr(1000)},
-						Label: []*dto.LabelPair{
-							{Name: stringPtr("container"), Value: stringPtr("container_a")},
-							{Name: stringPtr("namespace"), Value: stringPtr("namespace_a")},
-							{Name: stringPtr("pod"), Value: stringPtr("pod_a")},
-						},
-					},
-				},
-				{
-					desc: prometheus.NewDesc("container_foo", "a metric from container stats", []string{"container", "pod", "namespace"}, nil),
-					metric: &dto.Metric{
-						Gauge: &dto.Gauge{Value: float64Ptr(10)},
-						Label: []*dto.LabelPair{
-							{Name: stringPtr("container"), Value: stringPtr("container_b")},
-							{Name: stringPtr("namespace"), Value: stringPtr("namespace_a")},
-							{Name: stringPtr("pod"), Value: stringPtr("pod_a")},
-						},
-					},
-				},
-				{
-					desc: prometheus.NewDesc("container_bar", "another metric from container stats", []string{"container", "pod", "namespace"}, nil),
-					metric: &dto.Metric{
-						Gauge: &dto.Gauge{Value: float64Ptr(1000)},
-						Label: []*dto.LabelPair{
-							{Name: stringPtr("container"), Value: stringPtr("container_b")},
-							{Name: stringPtr("namespace"), Value: stringPtr("namespace_a")},
-							{Name: stringPtr("pod"), Value: stringPtr("pod_a")},
-						},
-					},
-				},
-				{
-					desc: prometheus.NewDesc("container_foo", "a metric from container stats", []string{"container", "pod", "namespace"}, nil),
-					metric: &dto.Metric{
-						Gauge: &dto.Gauge{Value: float64Ptr(10)},
-						Label: []*dto.LabelPair{
-							{Name: stringPtr("container"), Value: stringPtr("container_a")},
-							{Name: stringPtr("namespace"), Value: stringPtr("namespace_b")},
-							{Name: stringPtr("pod"), Value: stringPtr("pod_b")},
-						},
-					},
-				},
-				{
-					desc: prometheus.NewDesc("container_bar", "another metric from container stats", []string{"container", "pod", "namespace"}, nil),
-					metric: &dto.Metric{
-						Gauge: &dto.Gauge{Value: float64Ptr(1000)},
-						Label: []*dto.LabelPair{
-							{Name: stringPtr("container"), Value: stringPtr("container_a")},
-							{Name: stringPtr("namespace"), Value: stringPtr("namespace_b")},
-							{Name: stringPtr("pod"), Value: stringPtr("pod_b")},
-						},
-					},
-				},
-				{
-					desc:   prometheus.NewDesc(errorName, errorHelp, []string{}, nil),
-					metric: &dto.Metric{Gauge: &dto.Gauge{Value: &noError}},
-				},
+			expectedMetricsNames: []string{
+				"container_cpu_usage_seconds_total",
+				"container_memory_working_set_bytes",
+				"scrape_error",
 			},
+			expectedMetrics: `
+				# HELP scrape_error [ALPHA] 1 if there was an error while getting container metrics, 0 otherwise
+				# TYPE scrape_error gauge
+				scrape_error 0
+				# HELP container_cpu_usage_seconds_total [ALPHA] Cumulative cpu time consumed by the container in core-seconds
+				# TYPE container_cpu_usage_seconds_total gauge
+				container_cpu_usage_seconds_total{container="container_a",namespace="namespace_a",pod="pod_a"} 10 2000
+				container_cpu_usage_seconds_total{container="container_a",namespace="namespace_b",pod="pod_b"} 10 2000
+				container_cpu_usage_seconds_total{container="container_b",namespace="namespace_a",pod="pod_a"} 10 2000
+				# HELP container_memory_working_set_bytes [ALPHA] Current working set of the container in bytes
+				# TYPE container_memory_working_set_bytes gauge
+				container_memory_working_set_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 1000 2000
+				container_memory_working_set_bytes{container="container_a",namespace="namespace_b",pod="pod_b"} 1000 2000
+				container_memory_working_set_bytes{container="container_b",namespace="namespace_a",pod="pod_a"} 1000 2000
+			`,
 		},
-	} {
-		t.Run(tc.description, func(t *testing.T) {
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
 			provider := &mockSummaryProvider{}
 			provider.On("GetCPUAndMemoryStats").Return(tc.summary, tc.summaryErr)
 			collector := NewPrometheusResourceMetricCollector(provider, tc.config)
-			metrics := collectMetrics(t, collector, len(tc.expectedMetrics))
-			for i := range metrics {
-				assertEqual(t, metrics[i], tc.expectedMetrics[i])
+
+			if err := testutil.CustomCollectAndCompare(collector, strings.NewReader(tc.expectedMetrics), tc.expectedMetricsNames...); err != nil {
+				t.Fatal(err)
 			}
 		})
 	}
 }
 
-// collectMetrics is a wrapper around a prometheus.Collector which returns the metrics added to the metric channel as a slice.metric
-// It will block indefinitely if the collector does not collect exactly numMetrics.
-func collectMetrics(t *testing.T, collector prometheus.Collector, numMetrics int) (results []collectResult) {
-	metricsCh := make(chan prometheus.Metric)
-	done := make(chan struct{})
-	go func() {
-		collector.Collect(metricsCh)
-		done <- struct{}{}
-	}()
-	for i := 0; i < numMetrics; i++ {
-		metric := <-metricsCh
-		metricProto := &dto.Metric{}
-		assert.NoError(t, metric.Write(metricProto))
-		results = append(results, collectResult{desc: metric.Desc(), metric: metricProto})
-	}
-	<-done
-	return
-}
-
-// assertEqual asserts for semanitic equality for fields we care about
-func assertEqual(t *testing.T, expected, actual collectResult) {
-	assert.Equal(t, expected.desc.String(), actual.desc.String())
-	assert.Equal(t, *expected.metric.Gauge.Value, *actual.metric.Gauge.Value, "for desc: %v", expected.desc.String())
-	assert.Equal(t, len(expected.metric.Label), len(actual.metric.Label))
-	if len(expected.metric.Label) == len(actual.metric.Label) {
-		for i := range expected.metric.Label {
-			assert.Equal(t, *expected.metric.Label[i], *actual.metric.Label[i], "for desc: %v", expected.desc.String())
-		}
-	}
-}
-
-func stringPtr(s string) *string {
-	return &s
-}
-
 func uint64Ptr(u uint64) *uint64 {
 	return &u
-}
-
-func float64Ptr(f float64) *float64 {
-	return &f
 }

--- a/staging/src/k8s.io/component-base/metrics/value.go
+++ b/staging/src/k8s.io/component-base/metrics/value.go
@@ -17,6 +17,8 @@ limitations under the License.
 package metrics
 
 import (
+	"time"
+
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -43,4 +45,16 @@ func NewLazyConstMetric(desc *Desc, valueType ValueType, value float64, labelVal
 		return nil
 	}
 	return prometheus.MustNewConstMetric(desc.toPrometheusDesc(), valueType.toPromValueType(), value, labelValues...)
+}
+
+// NewLazyMetricWithTimestamp is a helper of NewMetricWithTimestamp.
+//
+// Warning: the Metric 'm' must be the one created by NewLazyConstMetric(),
+//          otherwise, no stability guarantees would be offered.
+func NewLazyMetricWithTimestamp(t time.Time, m Metric) Metric {
+	if m == nil {
+		return nil
+	}
+
+	return prometheus.NewMetricWithTimestamp(t, m)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, custom metrics emitted from kubelet do not offer any stability guarantees.

And #83062 tries to make it possible to do so.

About metrics stability please refer to [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md) .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
IMO, we can use the stability framework to offer stability guarantee and drop the traditional versioned endpoint like `xxx/v1alpha`.

More details please refer to [why not traditional versioned endpoint](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md#alternatives).

Please let me know if we need a follow-up issue or KEP.

**Does this PR introduce a user-facing change?**:
```release-note
Following metrics from kubelet are now marked as with the ALPHA stability level:
node_cpu_usage_seconds_total
node_memory_working_set_bytes
container_cpu_usage_seconds_total
container_memory_working_set_bytes
scrape_error
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190404-kubernetes-control-plane-metrics-stability.md
- [Usage]: <link>
- [Other doc]: <link>
```

/priority important-soon
/milestone v1.17