### PR TITLE
Move password retrieval to openstack_test.go

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack.go
@@ -221,7 +221,6 @@ func (cfg Config) toAuth3Options() tokens3.AuthOptions {
 func configFromEnv() (cfg Config, ok bool) {
 	cfg.Global.AuthURL = os.Getenv("OS_AUTH_URL")
 	cfg.Global.Username = os.Getenv("OS_USERNAME")
-	cfg.Global.Password = os.Getenv("OS_PASSWORD")
 	cfg.Global.Region = os.Getenv("OS_REGION_NAME")
 	cfg.Global.UserID = os.Getenv("OS_USER_ID")
 	cfg.Global.TrustID = os.Getenv("OS_TRUST_ID")

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_test.go
@@ -119,6 +119,8 @@ func TestReadConfig(t *testing.T) {
  [Metadata]
  search-order = configDrive, metadataService
  `))
+	cfg.Global.Password = os.Getenv("OS_PASSWORD")
+
 	if err != nil {
 		t.Fatalf("Should succeed when a valid config is provided: %s", err)
 	}
@@ -476,8 +478,17 @@ func TestNodeAddresses(t *testing.T) {
 	}
 }
 
+func configFromEnvWithPasswd() (cfg Config, ok bool) {
+	cfg, ok = configFromEnv()
+	if !ok {
+		return cfg, ok
+	}
+	cfg.Global.Password = os.Getenv("OS_PASSWORD")
+	return cfg, ok
+}
+
 func TestNewOpenStack(t *testing.T) {
-	cfg, ok := configFromEnv()
+	cfg, ok := configFromEnvWithPasswd()
 	if !ok {
 		t.Skip("No config found in environment")
 	}
@@ -489,7 +500,7 @@ func TestNewOpenStack(t *testing.T) {
 }
 
 func TestLoadBalancer(t *testing.T) {
-	cfg, ok := configFromEnv()
+	cfg, ok := configFromEnvWithPasswd()
 	if !ok {
 		t.Skip("No config found in environment")
 	}
@@ -553,7 +564,7 @@ func TestZones(t *testing.T) {
 var diskPathRegexp = regexp.MustCompile("/dev/disk/(?:by-id|by-path)/")
 
 func TestVolumes(t *testing.T) {
-	cfg, ok := configFromEnv()
+	cfg, ok := configFromEnvWithPasswd()
 	if !ok {
 		t.Skip("No config found in environment")
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes #81117 by moving password retrieval to test.

**Which issue(s) this PR fixes**:
Fixes #81117

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
