### PR TITLE
kubelet/types: fix comment-related golint issues

### DIFF
--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -16,15 +16,27 @@ limitations under the License.
 
 package types
 
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// Defaults.
 const (
-	// system default DNS resolver configuration
+	// ResolvConfDefault defines the default DNS resolver configuration.
 	ResolvConfDefault = "/etc/resolv.conf"
 
-	// different container runtimes
-	DockerContainerRuntime = "docker"
-	RemoteContainerRuntime = "remote"
+	// NamespaceDefault defines the default namespace.
+	NamespaceDefault = metav1.NamespaceDefault
+)
 
-	// User visible keys for managing node allocatable enforcement on the node.
+// Container runtimes.
+const (
+	// DockerContainerRuntime defines the docker container runtime.
+	DockerContainerRuntime = "docker"
+	// RemoteContainerRuntime defines the remote container runtime.
+	RemoteContainerRuntime = "remote"
+)
+
+// User visible keys for managing node allocatable enforcement on the node.
+const (
 	NodeAllocatableEnforcementKey = "pods"
 	SystemReservedEnforcementKey  = "system-reserved"
 	KubeReservedEnforcementKey    = "kube-reserved"

--- a/pkg/kubelet/types/doc.go
+++ b/pkg/kubelet/types/doc.go
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Common types in the Kubelet.
+// Package types defines the common types in the Kubelet.
 package types // import "k8s.io/kubernetes/pkg/kubelet/types"

--- a/pkg/kubelet/types/labels.go
+++ b/pkg/kubelet/types/labels.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package types
 
+// Kubernetes labels.
 const (
 	KubernetesPodNameLabel       = "io.kubernetes.pod.name"
 	KubernetesPodNamespaceLabel  = "io.kubernetes.pod.namespace"
@@ -23,18 +24,22 @@ const (
 	KubernetesContainerNameLabel = "io.kubernetes.container.name"
 )
 
+// GetContainerName returns the value associated with the container name label.
 func GetContainerName(labels map[string]string) string {
 	return labels[KubernetesContainerNameLabel]
 }
 
+// GetPodName returns the value associated with the pod name label.
 func GetPodName(labels map[string]string) string {
 	return labels[KubernetesPodNameLabel]
 }
 
+// GetPodUID returns the value associated with the pod UID label.
 func GetPodUID(labels map[string]string) string {
 	return labels[KubernetesPodUIDLabel]
 }
 
+// GetPodNamespace returns the value associated with the pod namespace label.
 func GetPodNamespace(labels map[string]string) string {
 	return labels[KubernetesPodNamespaceLabel]
 }

--- a/pkg/kubelet/types/pod_update.go
+++ b/pkg/kubelet/types/pod_update.go
@@ -20,10 +20,10 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/apis/scheduling"
 )
 
+// Configuration constants.
 const (
 	ConfigSourceAnnotationKey    = "kubernetes.io/config.source"
 	ConfigMirrorAnnotationKey    = v1.MirrorPodAnnotationKey
@@ -34,6 +34,7 @@ const (
 // PodOperation defines what changes will be made on a pod configuration.
 type PodOperation int
 
+// Collection of possible PodOperation values.
 const (
 	// This is the current pod configuration
 	SET PodOperation = iota
@@ -50,18 +51,18 @@ const (
 	RECONCILE
 	// Pods with the given ids have been restored from a checkpoint.
 	RESTORE
+)
 
-	// These constants identify the sources of pods
-	// Updates from a file
+// Constants to identify the sources of pods.
+const (
+	// FileSource updates from a file.
 	FileSource = "file"
-	// Updates from querying a web page
+	// HTTPSource updates from querying a web page.
 	HTTPSource = "http"
-	// Updates from Kubernetes API Server
+	// ApiserverSource updates from Kubernetes API Server.
 	ApiserverSource = "api"
-	// Updates from all sources
+	// AllSource updates from all sources.
 	AllSource = "*"
-
-	NamespaceDefault = metav1.NamespaceDefault
 )
 
 // PodUpdate defines an operation sent on the channel. You can add or remove single services by
@@ -79,7 +80,7 @@ type PodUpdate struct {
 	Source string
 }
 
-// Gets all validated sources from the specified sources.
+// GetValidatedSources gets all validated sources from the specified sources.
 func GetValidatedSources(sources []string) ([]string, error) {
 	validated := make([]string, 0, len(sources))
 	for _, source := range sources {

--- a/pkg/kubelet/types/types.go
+++ b/pkg/kubelet/types/types.go
@@ -59,7 +59,8 @@ func (t *Timestamp) GetString() string {
 	return t.time.Format(time.RFC3339Nano)
 }
 
-// A type to help sort container statuses based on container names.
+// SortedContainerStatuses implements the sort.Interface for []v1.ContainerStatus
+// based on container names.
 type SortedContainerStatuses []v1.ContainerStatus
 
 func (s SortedContainerStatuses) Len() int      { return len(s) }
@@ -70,7 +71,7 @@ func (s SortedContainerStatuses) Less(i, j int) bool {
 }
 
 // SortInitContainerStatuses ensures that statuses are in the order that their
-// init container appears in the pod spec
+// init container appears in the pod spec.
 func SortInitContainerStatuses(p *v1.Pod, statuses []v1.ContainerStatus) {
 	containers := p.Spec.InitContainers
 	current := 0
@@ -93,8 +94,9 @@ type Reservation struct {
 	Kubernetes v1.ResourceList
 }
 
-// A pod UID which has been translated/resolved to the representation known to kubelets.
+// ResolvedPodUID is a pod UID which has been translated/resolved to
+// the representation known to kubelets.
 type ResolvedPodUID types.UID
 
-// A pod UID for a mirror pod.
+// MirrorPodUID is pod UID for a mirror pod.
 type MirrorPodUID types.UID


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR cleans all the comment-related issues raised by golint in the `kubelet/types` package.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

