### PR TITLE
Remove unused function from e2e framework util.go

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -2363,20 +2363,6 @@ func GetClusterZones(c clientset.Interface) (sets.String, error) {
 	return zones, nil
 }
 
-// WaitForNodeHasTaintOrNot waits for a taint to be added/removed from the node until timeout occurs, whichever comes first.
-func WaitForNodeHasTaintOrNot(c clientset.Interface, nodeName string, taint *v1.Taint, wantTrue bool, timeout time.Duration) error {
-	if err := wait.PollImmediate(Poll, timeout, func() (bool, error) {
-		has, err := NodeHasTaint(c, nodeName, taint)
-		if err != nil {
-			return false, fmt.Errorf("Failed to check taint %s on node %s or not", taint.ToString(), nodeName)
-		}
-		return has == wantTrue, nil
-	}); err != nil {
-		return fmt.Errorf("expect node %v to have taint = %v within %v: %v", nodeName, wantTrue, timeout, err)
-	}
-	return nil
-}
-
 // GetFileModeRegex returns a file mode related regex which should be matched by the mounttest pods' output.
 // If the given mask is nil, then the regex will contain the default OS file modes, which are 0644 for Linux and 0775 for Windows.
 func GetFileModeRegex(filePath string, mask *int32) string {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The util.go file is so huge, it is better to make it small and simple
as possible for the maintenance.
This removes the following unused function:

- WaitForNodeHasTaintOrNot: Unused since 7e1794dcb1826ba8253064743ff021e85d69dfc3

Ref: https://github.com/kubernetes/kubernetes/issues/84380

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
