### PR TITLE
Check the error from markNodeAsReachable()

### DIFF
--- a/pkg/controller/nodelifecycle/node_lifecycle_controller.go
+++ b/pkg/controller/nodelifecycle/node_lifecycle_controller.go
@@ -789,7 +789,9 @@ func (nc *Controller) monitorNodeHealth() error {
 		nc.knownNodeSet[added[i].Name] = added[i]
 		nc.addPodEvictorForNewZone(added[i])
 		if nc.useTaintBasedEvictions {
-			nc.markNodeAsReachable(added[i])
+			if _, err = nc.markNodeAsReachable(added[i]); err != nil {
+				klog.Warningf("unable to mark node %s as reachable : %v", added[i].Name, err)
+			}
 		} else {
 			nc.cancelPodEviction(added[i])
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In Controller#monitorNodeHealth, the error return from markNodeAsReachable() is ignored.

This PR adds check of the error and logs accordingly.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
