### PR TITLE
Enable verify-import-aliases check in CI

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -34,7 +34,6 @@ EXCLUDED_PATTERNS=(
   "verify-all.sh"                # this script calls the make rule and would cause a loop
   "verify-linkcheck.sh"          # runs in separate Jenkins job once per day due to high network usage
   "verify-*-dockerized.sh"       # Don't run any scripts that intended to be run dockerized
-  "verify-import-aliases.sh"     # to be run periodically by folks working on conformance tests
   )
 
 # Exclude typecheck in certain cases, if they're running in a separate job.


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

Recently there was a violation of import-aliases rule and https://github.com/kubernetes/kubernetes/pull/84942 is for fixing that.
This enables the import-aliases rule for blocking such violation anymore.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```