### PR TITLE
Add translation logic for EBS storage class fstype parameter

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs.go
@@ -45,8 +45,21 @@ func NewAWSElasticBlockStoreCSITranslator() InTreePlugin {
 	return &awsElasticBlockStoreCSITranslator{}
 }
 
-// TranslateInTreeStorageClassParametersToCSI translates InTree EBS storage class parameters to CSI storage class
+// TranslateInTreeStorageClassToCSI translates InTree EBS storage class parameters to CSI storage class
 func (t *awsElasticBlockStoreCSITranslator) TranslateInTreeStorageClassToCSI(sc *storage.StorageClass) (*storage.StorageClass, error) {
+	params := map[string]string{}
+
+	for k, v := range sc.Parameters {
+		switch strings.ToLower(k) {
+		case "fstype":
+			params["csi.storage.k8s.io/fstype"] = v
+		default:
+			params[k] = v
+		}
+	}
+
+	sc.Parameters = params
+
 	return sc, nil
 }
 

--- a/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/aws_ebs_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package plugins
 
 import (
+	"reflect"
 	"testing"
+
+	storage "k8s.io/api/storage/v1"
 )
 
 func TestKubernetesVolumeIDToEBSVolumeID(t *testing.T) {
@@ -62,5 +65,50 @@ func TestKubernetesVolumeIDToEBSVolumeID(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTranslateEBSInTreeStorageClassToCSI(t *testing.T) {
+	translator := NewAWSElasticBlockStoreCSITranslator()
+
+	cases := []struct {
+		name   string
+		sc     *storage.StorageClass
+		expSc  *storage.StorageClass
+		expErr bool
+	}{
+		{
+			name:  "translate normal",
+			sc:    NewStorageClass(map[string]string{"foo": "bar"}, nil),
+			expSc: NewStorageClass(map[string]string{"foo": "bar"}, nil),
+		},
+		{
+			name:  "translate empty map",
+			sc:    NewStorageClass(map[string]string{}, nil),
+			expSc: NewStorageClass(map[string]string{}, nil),
+		},
+
+		{
+			name:  "translate with fstype",
+			sc:    NewStorageClass(map[string]string{"fstype": "ext3"}, nil),
+			expSc: NewStorageClass(map[string]string{"csi.storage.k8s.io/fstype": "ext3"}, nil),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Testing %v", tc.name)
+		got, err := translator.TranslateInTreeStorageClassToCSI(tc.sc)
+		if err != nil && !tc.expErr {
+			t.Errorf("Did not expect error but got: %v", err)
+		}
+
+		if err == nil && tc.expErr {
+			t.Errorf("Expected error, but did not get one.")
+		}
+
+		if !reflect.DeepEqual(got, tc.expSc) {
+			t.Errorf("Got parameters: %v, expected :%v", got, tc.expSc)
+		}
+
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Add more CSI translation logic for EBS CSI migration. The logic covers the translation of storage class parameter from `fstype` to `csi.storage.k8s.io/fstype`. Also added unit test for it.

/cc @davidz627 @ddebroy 

TODOS:
 - [x] run migration e2e test

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
