### PR TITLE
test: avoid possible goroutine leaks in 4 test functions

### DIFF
--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -1154,7 +1154,7 @@ func TestRegisterWithApiServer(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		kubelet.registerWithAPIServer()
-		done <- struct{}{}
+		close(done)
 	}()
 	select {
 	case <-time.After(wait.ForeverTestTimeout):

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -345,7 +345,7 @@ func TestSchedulerNoPhantomPodAfterExpire(t *testing.T) {
 
 	waitPodExpireChan := make(chan struct{})
 	timeout := make(chan struct{})
-	errChan := make(chan error)
+	errChan := make(chan error, 1)
 	go func() {
 		for {
 			select {

--- a/pkg/util/async/bounded_frequency_runner_test.go
+++ b/pkg/util/async/bounded_frequency_runner_test.go
@@ -213,6 +213,7 @@ func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
 	timer := newFakeTimer()
 	runner := construct("test-runner", obj.F, minInterval, maxInterval, 1, timer)
 	stop := make(chan struct{})
+	defer close(stop)
 
 	var upd timerUpdate
 
@@ -274,9 +275,6 @@ func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
 	// Let minInterval pass
 	timer.advance(999 * time.Millisecond) // rel=1000ms
 	waitForRun("fourth run", t, timer, obj)
-
-	// Clean up.
-	stop <- struct{}{}
 }
 
 func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
@@ -284,6 +282,7 @@ func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
 	timer := newFakeTimer()
 	runner := construct("test-runner", obj.F, minInterval, maxInterval, 2, timer)
 	stop := make(chan struct{})
+	defer close(stop)
 
 	var upd timerUpdate
 
@@ -355,9 +354,6 @@ func Test_BoundedFrequencyRunnerBurst(t *testing.T) {
 	// Wait for maxInterval
 	timer.advance(10 * time.Second) // abs=15000ms, rel=10000ms
 	waitForRun("maxInterval", t, timer, obj)
-
-	// Clean up.
-	stop <- struct{}{}
 }
 
 func Test_BoundedFrequencyRunnerRetryAfter(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes 4 test functions where some goroutines will be leaked if timeout or `err != nil`. What block these goroutines are send or receive operations of unbuffered channels.
Although `t.Fatal()/Fatalf()/FailNow()` is called in these cases, it won't stop the leaking, because ["Calling FailNow does not stop those other goroutines." ](https://golang.org/pkg/testing/#T.FailNow)

**Special notes for your reviewer**:
The fix for 2 test functions are simple: adding 1 buffer to the channel to make send operation unblockable.
The fix for the other 2 functions are slightly more tricky:
As the code below shows, when `t.Fatalf()` in `checkTimer()` is called, the goroutine created by `go runner.Loop(stop)` will be blocked because `stop <- struct{}{}` will never be reached. So I moved the `stop <- struct{}{}` into a defer function, because when `t.Fatalf()` is called, it will execute all deferred calls, and the leaked goroutines will be unblocked.

```Go
func Test_BoundedFrequencyRunnerNoBurst(t *testing.T) {
	...
	stop := make(chan struct{})
	...

	// Start.
	go runner.Loop(stop)
	...
	checkTimer("init", t, upd, true, maxInterval)
	...

	// Clean up.
	stop <- struct{}{}
}

func (bfr *BoundedFrequencyRunner) Loop(stop <-chan struct{}) {
	...
	for {
		select {
		case <-stop:
			bfr.stop()
			klog.V(3).Infof("%s Loop stopping", bfr.name)
			return
		case ... // There is no other case containing return
		}
	}
}

func checkTimer(name string, t *testing.T, upd timerUpdate, active bool, next time.Duration) {
	if upd.active != active {
		t.Fatalf("%s: expected timer active=%v", name, active)
	}
	...
}
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```