### PR TITLE
let standalone npd use kubelet credentials

### DIFF
--- a/cluster/addons/node-problem-detector/kubelet-user-standalone/npd-binding.yaml
+++ b/cluster/addons/node-problem-detector/kubelet-user-standalone/npd-binding.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubelet-user-npd-binding
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-problem-detector
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: kubelet


### PR DESCRIPTION
This will allow for the NODE_PROBLEM_DETECTOR_TOKEN to be removed from GCE metadata, while retaining the increased visibility offered by a `standalone` NPD.

/kind feature
/kind cleanup
/sig cloud-provider
/area provider/gcp
/release-note-none
/priority important-soon

```release-note
NONE
```