### PR TITLE
Remove potential Goroutine leak in kubeadm wait.go

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -157,7 +157,7 @@ func (w *KubeWaiter) WaitForHealthyKubelet(initalTimeout time.Duration, healthzE
 // WaitForKubeletAndFunc waits primarily for the function f to execute, even though it might take some time. If that takes a long time, and the kubelet
 // /healthz continuously are unhealthy, kubeadm will error out after a period of exponential backoff
 func (w *KubeWaiter) WaitForKubeletAndFunc(f func() error) error {
-	errorChan := make(chan error)
+	errorChan := make(chan error, 1)
 
 	go func(errC chan error, waiter Waiter) {
 		if err := waiter.WaitForHealthyKubelet(40*time.Second, fmt.Sprintf("http://localhost:%d/healthz", kubeadmconstants.KubeletHealthzPort)); err != nil {


### PR DESCRIPTION
In `WaitForKubeletAndFunc` there are potentially two writes yet
only one read on a non-buffered channel that is created locally and
not passed anywhere else.

Therefore, it could leak one of its two spawned Goroutines if either:
* The provided `f` takes longer than an erroneous result from
  `waiter.WaitForHealthyKubelet`, or;
* The provided `f` completes before an erroneous result from
  `waiter.WaitForHealthyKubelet`.

The fix is to add a one-element buffer so that the channel write
finishes promptly for the slower Goroutine, allowing it to finish and
freeing references to the now-buffered channel, letting it to be GC'd.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Goroutine leakages are generally frowned upon, even if control flow
often goes back up to `main` and promptly ends.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```