### PR TITLE
[experimental]: instrument etcd request/response object sizes

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -92,7 +92,7 @@ func newDefaultFieldManager(f Manager, objectCreater runtime.ObjectCreater, kind
 	f = NewStripMetaManager(f)
 	f = NewBuildManagerInfoManager(f, kind.GroupVersion())
 	f = NewCapManagersManager(f, DefaultMaxUpdateManagers)
-	f = NewSkipNonAppliedManager(f, objectCreater, kind)
+	//f = NewSkipNonAppliedManager(f, objectCreater, kind)
 	return NewFieldManager(f)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -92,7 +92,7 @@ func newDefaultFieldManager(f Manager, objectCreater runtime.ObjectCreater, kind
 	f = NewStripMetaManager(f)
 	f = NewBuildManagerInfoManager(f, kind.GroupVersion())
 	f = NewCapManagersManager(f, DefaultMaxUpdateManagers)
-	//f = NewSkipNonAppliedManager(f, objectCreater, kind)
+	f = NewSkipNonAppliedManager(f, objectCreater, kind)
 	return NewFieldManager(f)
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/metrics/metrics.go
@@ -53,6 +53,7 @@ var (
 		&compbasemetrics.HistogramOpts{
 			Name:           "etcd_request_size_bytes",
 			Help:           "Etcd request size in bytes for each operation and object type.",
+			Buckets:        []float64{0, 64, 128, 256, 512, 1028, 2048, 4096, 8192, 16384, 32768, 65536, 1048576},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"operation", "type"},
@@ -61,6 +62,7 @@ var (
 		&compbasemetrics.HistogramOpts{
 			Name:           "etcd_response_size_bytes",
 			Help:           "Etcd response size in bytes for each operation and object type.",
+			Buckets:        []float64{0, 64, 128, 256, 512, 1028, 2048, 4096, 8192, 16384, 32768, 65536, 1048576},
 			StabilityLevel: compbasemetrics.ALPHA,
 		},
 		[]string{"operation", "type"},

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/store.go
@@ -886,7 +886,7 @@ func observeSuccessfulOperation(verb, typeName string, startTime time.Time, requ
 	metrics.RecordEtcdRequestLatency(verb, typeName, startTime)
 	metrics.RecordEtcdRequestSize(verb, typeName, requestSize)
 	metrics.RecordEtcdResponseSize(verb, typeName,responseSize)
-	klog.Infof("etcd request: operation:%s type:%q request-size: %d, response-size: %d", verb, typeName, responseSize, responseSize)
+	klog.Infof("etcd request: operation:%s type:%q request-size: %d, response-size: %d, latency: %v", verb, typeName, responseSize, responseSize, time.Now().Sub(startTime))
 }
 
 func size(kvs []*mvccpb.KeyValue) uint64 {


### PR DESCRIPTION
Experimentally adding metrics and logging of etcd object sizes in requests and responses, broken out by operation and k8s type.

Using this in the short term to inspect server side apply performance.

/kind feature

```release-note
TODO
```