### PR TITLE
kubeadm: fix skipped etcd upgrade on secondary CP nodes

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -106,6 +106,7 @@ func newNodeOptions() *nodeOptions {
 		kubeConfigPath: constants.GetKubeletKubeConfigPath(),
 		dryRun:         false,
 		renewCerts:     true,
+		etcdUpgrade:    true,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
digging into 1.16->1.17 upgrade failures (related to our tool kinder and the etcdctl 3.4 flag breakage):
https://storage.googleapis.com/kubernetes-jenkins/logs/ci-kubernetes-e2e-kubeadm-kinder-upgrade-1-16-1-17/1192826661331013632/build-log.txt

i've noticed:

```
etcd-kinder-upgrade-control-plane-1 << k8s.gcr.io/etcd:3.4.3-0, 
etcd-kinder-upgrade-control-plane-2 << k8s.gcr.io/etcd:3.3.15-0, 
etcd-kinder-upgrade-control-plane-3 << k8s.gcr.io/etcd:3.3.15-0, 
```
after upgrade, which indicated that the etcd manifest is not being upgraded on secondary CP nodes by the new `kubeadm upgrade node` command backend!

enable etcd upgrade by default, which the expected/recommended behavior.

this needs to be backported to 1.16.
it's not need for 1.15, because the etcd version on 1.14 and 1.15 is the same.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: fix skipped etcd upgrade on secondary control-plane nodes when the command "kubeadm upgrade node" is used.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @fabriziopandini 
/kind bug
/priority critical-urgent
