### PR TITLE
Automated cherry pick of #85024: kubeadm: fix skipped etcd upgrade on secondary cp nodes

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -108,6 +108,7 @@ func newNodeOptions() *nodeOptions {
 	return &nodeOptions{
 		kubeConfigPath: constants.GetKubeletKubeConfigPath(),
 		dryRun:         false,
+		etcdUpgrade:    true,
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #85024 on release-1.16.

#85024: kubeadm: fix skipped etcd upgrade on secondary cp nodes

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.