### PR TITLE
fix kubectl diff panic

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -257,6 +257,7 @@ type InfoObject struct {
 	Force           bool
 	ServerSideApply bool
 	ForceConflicts  bool
+	genericclioptions.IOStreams
 }
 
 var _ Object = &InfoObject{}
@@ -325,7 +326,7 @@ func (obj InfoObject) Merged() (runtime.Object, error) {
 		ResourceVersion: resourceVersion,
 	}
 
-	_, result, err := patcher.Patch(obj.Info.Object, modified, obj.Info.Source, obj.Info.Namespace, obj.Info.Name, nil)
+	_, result, err := patcher.Patch(obj.Info.Object, modified, obj.Info.Source, obj.Info.Namespace, obj.Info.Name, obj.ErrOut)
 	return result, err
 }
 
@@ -492,6 +493,7 @@ func (o *DiffOptions) Run() error {
 				Force:           force,
 				ServerSideApply: o.ServerSideApply,
 				ForceConflicts:  o.ForceConflicts,
+				IOStreams:       o.Diff.IOStreams,
 			}
 
 			err = differ.Diff(obj, printer)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes [#85033](https://github.com/kubernetes/kubernetes/issues/85033)

**Special notes for your reviewer**:
nil pointer as io.Writer will cause panic in [kubectl diff](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go#L920)
**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
