### PR TITLE
Automated cherry pick of #75176: fix kubectl describe hpa does not work at version 1.14

### DIFF
--- a/pkg/kubectl/describe/versioned/BUILD
+++ b/pkg/kubectl/describe/versioned/BUILD
@@ -18,6 +18,7 @@ go_library(
         "//pkg/kubectl/util/slice:go_default_library",
         "//pkg/kubectl/util/storage:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v2beta2:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
@@ -73,6 +74,7 @@ go_test(
     deps = [
         "//pkg/kubectl/describe:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/autoscaling/v2beta2:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/networking/v1:go_default_library",


### PR DESCRIPTION
Cherry pick of #75176 on release-1.14.

#75176: make describers of different versions work properly when

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.