### PR TITLE
Restore hints for containers which already have devices

### DIFF
--- a/pkg/kubelet/cm/devicemanager/topology_hints_test.go
+++ b/pkg/kubelet/cm/devicemanager/topology_hints_test.go
@@ -317,6 +317,39 @@ func TestGetTopologyHints(t *testing.T) {
 			},
 		},
 		{
+			description:   "Single device type, some allocated to container",
+			podUID:        "fakePod",
+			containerName: "fakeContainer",
+			request: map[string]string{
+				"testdevice": "1",
+			},
+			devices: map[string][]pluginapi.Device{
+				"testdevice": {
+					makeNUMADevice("Dev1", 0),
+					makeNUMADevice("Dev2", 1),
+				},
+			},
+			allocatedDevices: map[string]map[string]map[string][]string{
+				"fakePod": {
+					"fakeContainer": {
+						"testdevice": {"Dev1"},
+					},
+				},
+			},
+			expectedHints: map[string][]topologymanager.TopologyHint{
+				"testdevice": {
+					{
+						NUMANodeAffinity: makeSocketMask(0),
+						Preferred:        true,
+					},
+					{
+						NUMANodeAffinity: makeSocketMask(0, 1),
+						Preferred:        false,
+					},
+				},
+			},
+		},
+		{
 			description:   "Single device type, less already allocated to container than requested",
 			podUID:        "fakePod",
 			containerName: "fakeContainer",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR restores topology hints for containers which already have devices, even if the current resource is not a „plugin“ resource.

Ref: https://github.com/kubernetes/kubernetes/issues/84479#issuecomment-552034118

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
