### PR TITLE
Fix golint errors for pkg/kubelet/dockershim/network/kubenet

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -122,7 +122,6 @@ pkg/kubelet/dockershim/network
 pkg/kubelet/dockershim/network/cni/testing
 pkg/kubelet/dockershim/network/hostport
 pkg/kubelet/dockershim/network/hostport/testing
-pkg/kubelet/dockershim/network/kubenet
 pkg/kubelet/dockershim/network/testing
 pkg/kubelet/events
 pkg/kubelet/lifecycle

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet.go
@@ -17,5 +17,6 @@ limitations under the License.
 package kubenet
 
 const (
+	// KubenetPluginName is a constant for the plugin name
 	KubenetPluginName = "kubenet"
 )

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
@@ -52,7 +52,10 @@ import (
 )
 
 const (
-	BridgeName    = "cbr0"
+	// BridgeName is the name of the interface used for the bridge
+	BridgeName = "cbr0"
+
+	// DefaultCNIDir is the directory that the CNI binaries will be searched for in
 	DefaultCNIDir = "/opt/cni/bin"
 
 	sysctlBridgeCallIPTables = "net/bridge/bridge-nf-call-iptables"
@@ -66,7 +69,8 @@ const (
 	zeroCIDRv6 = "::/0"
 	zeroCIDRv4 = "0.0.0.0/0"
 
-	NET_CONFIG_TEMPLATE = `{
+	// NetConfigTemplate is the default net config template
+	NetConfigTemplate = `{
   "cniVersion": "0.1.0",
   "name": "kubenet",
   "type": "bridge",
@@ -119,6 +123,7 @@ type kubenetNetworkPlugin struct {
 	podGateways       []net.IP
 }
 
+// NewPlugin creates a new instance of NetworkPlugin
 func NewPlugin(networkPluginDirs []string, cacheDir string) network.NetworkPlugin {
 	execer := utilexec.New()
 	iptInterface := utiliptables.New(execer, utiliptables.ProtocolIpv4)
@@ -270,7 +275,7 @@ func (plugin *kubenetNetworkPlugin) Event(name string, details map[string]interf
 			return
 		}
 		// create list of ips and gateways
-		cidr.IP[len(cidr.IP)-1] += 1 // Set bridge address to first address in IPNet
+		cidr.IP[len(cidr.IP)-1]++ // Set bridge address to first address in IPNet
 		plugin.podCIDRs = append(plugin.podCIDRs, cidr)
 		plugin.podGateways = append(plugin.podGateways, cidr.IP)
 	}
@@ -278,7 +283,7 @@ func (plugin *kubenetNetworkPlugin) Event(name string, details map[string]interf
 	//setup hairpinMode
 	setHairpin := plugin.hairpinMode == kubeletconfig.HairpinVeth
 
-	json := fmt.Sprintf(NET_CONFIG_TEMPLATE, BridgeName, plugin.mtu, network.DefaultInterfaceName, setHairpin, plugin.getRangesConfig(), plugin.getRoutesConfig())
+	json := fmt.Sprintf(NetConfigTemplate, BridgeName, plugin.mtu, network.DefaultInterfaceName, setHairpin, plugin.getRangesConfig(), plugin.getRoutesConfig())
 	klog.V(4).Infof("CNI network config set to %v", json)
 	plugin.netConfig, err = libcni.ConfFromBytes([]byte(json))
 	if err != nil {

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_unsupported.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_unsupported.go
@@ -30,6 +30,7 @@ type kubenetNetworkPlugin struct {
 	network.NoopNetworkPlugin
 }
 
+// NewPlugin creates a blank version of NetworkPlugin when kublet is not supported
 func NewPlugin(networkPluginDirs []string, cacheDir string) network.NetworkPlugin {
 	return &kubenetNetworkPlugin{}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This PR fixed linting issues in `pkg/kubelet/dockershim/network/kubenet`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/priority backlog
/area code-organization