### PR TITLE
Allow apiserver/controller-manager clients to watch CRDs

### DIFF
--- a/cmd/cloud-controller-manager/app/options/options.go
+++ b/cmd/cloud-controller-manager/app/options/options.go
@@ -180,6 +180,7 @@ func (o *CloudControllerManagerOptions) ApplyTo(c *cloudcontrollerconfig.Config,
 		return err
 	}
 	c.Kubeconfig.DisableCompression = true
+	c.Kubeconfig.ContentConfig.AcceptContentTypes = o.Generic.ClientConnection.AcceptContentTypes
 	c.Kubeconfig.ContentConfig.ContentType = o.Generic.ClientConnection.ContentType
 	c.Kubeconfig.QPS = o.Generic.ClientConnection.QPS
 	c.Kubeconfig.Burst = int(o.Generic.ClientConnection.Burst)

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -450,6 +450,7 @@ func buildGenericConfig(
 	// Since not every generic apiserver has to support protobufs, we
 	// cannot default to it in generic apiserver and need to explicitly
 	// set it in kube-apiserver.
+	genericConfig.LoopbackClientConfig.ContentConfig.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
 	genericConfig.LoopbackClientConfig.ContentConfig.ContentType = "application/vnd.kubernetes.protobuf"
 	// Disable compression for self-communication, since we are going to be
 	// on a fast local network

--- a/cmd/kube-controller-manager/app/options/options.go
+++ b/cmd/kube-controller-manager/app/options/options.go
@@ -403,6 +403,7 @@ func (s KubeControllerManagerOptions) Config(allControllers []string, disabledBy
 		return nil, err
 	}
 	kubeconfig.DisableCompression = true
+	kubeconfig.ContentConfig.AcceptContentTypes = s.Generic.ClientConnection.AcceptContentTypes
 	kubeconfig.ContentConfig.ContentType = s.Generic.ClientConnection.ContentType
 	kubeconfig.QPS = s.Generic.ClientConnection.QPS
 	kubeconfig.Burst = int(s.Generic.ClientConnection.Burst)

--- a/pkg/proxy/apis/config/v1alpha1/defaults.go
+++ b/pkg/proxy/apis/config/v1alpha1/defaults.go
@@ -110,6 +110,9 @@ func SetDefaults_KubeProxyConfiguration(obj *kubeproxyconfigv1alpha1.KubeProxyCo
 		obj.ConfigSyncPeriod.Duration = 15 * time.Minute
 	}
 
+	if len(obj.ClientConnection.AcceptContentTypes) == 0 {
+		obj.ClientConnection.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	}
 	if len(obj.ClientConnection.ContentType) == 0 {
 		obj.ClientConnection.ContentType = "application/vnd.kubernetes.protobuf"
 	}

--- a/pkg/scheduler/apis/config/v1alpha1/defaults.go
+++ b/pkg/scheduler/apis/config/v1alpha1/defaults.go
@@ -128,6 +128,9 @@ func SetDefaults_KubeSchedulerConfiguration(obj *kubeschedulerconfigv1alpha1.Kub
 		obj.LeaderElection.LockObjectName = kubeschedulerconfigv1alpha1.SchedulerDefaultLockObjectName
 	}
 
+	if len(obj.ClientConnection.AcceptContentTypes) == 0 {
+		obj.ClientConnection.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	}
 	if len(obj.ClientConnection.ContentType) == 0 {
 		obj.ClientConnection.ContentType = "application/vnd.kubernetes.protobuf"
 	}

--- a/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go
+++ b/staging/src/k8s.io/component-base/config/v1alpha1/defaults.go
@@ -62,6 +62,9 @@ func RecommendedDefaultLeaderElectionConfiguration(obj *LeaderElectionConfigurat
 // be no easy way to opt-out. Instead, if you want to use this defaulting method
 // run it in your wrapper struct of this type in its `SetDefaults_` method.
 func RecommendedDefaultClientConnectionConfiguration(obj *ClientConnectionConfiguration) {
+	if len(obj.AcceptContentTypes) == 0 {
+		obj.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	}
 	if len(obj.ContentType) == 0 {
 		obj.ContentType = "application/vnd.kubernetes.protobuf"
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Modifies the client config for the apiserver/scheduler/controller-manager clients to indicate they accept json responses if protobuf is unavailable

**Which issue(s) this PR fixes**:
Fixes #67602

Builds on https://github.com/kubernetes/kubernetes/pull/84692, only the last commit is new

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @smarterclayton 