### PR TITLE
Add apierrors as alias for k8s.io/apimachinery/pkg/api/errors

### DIFF
--- a/hack/.import-aliases
+++ b/hack/.import-aliases
@@ -38,6 +38,7 @@
   "k8s.io/api/storage/v1": "storagev1",
   "k8s.io/api/storage/v1alpha1": "storagev1alpha1",
   "k8s.io/api/storage/v1beta1": "storagev1beta1",
+  "k8s.io/apimachinery/pkg/api/errors": "apierrors",
   "k8s.io/kubernetes/pkg/controller/apis/config/v1alpha1": "controllerconfigv1alpha1",
   "k8s.io/kubernetes/pkg/kubelet/apis/config/v1beta1": "kubeletconfigv1beta1",
   "k8s.io/kubelet/pkg/apis/deviceplugin/v1alpha": "kubeletdevicepluginv1alpha",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Many files under `test/` import `"k8s.io/apimachinery/pkg/api/errors"`.
But, different aliases are defined for each file.

For example,
```
test/e2e/auth/service_accounts.go:
        apierrors "k8s.io/apimachinery/pkg/api/errors"

test/e2e/auth/pod_security_policy.go:
        apierrs "k8s.io/apimachinery/pkg/api/errors"

test/e2e/auth/audit_dynamic.go:
        "k8s.io/apimachinery/pkg/api/errors"
```
```
$ grep -rs \"k8s.io/apimachinery/pkg/api/errors\" test/ | grep apierrors | wc -l
15
$ grep -rs \"k8s.io/apimachinery/pkg/api/errors\" test/ | grep apierrs | wc -l
32
$ grep -rs \"k8s.io/apimachinery/pkg/api/errors\" test/ | egrep -v "apierrors|apierrs" |  wc -l
60
```
We can get more readability if the aliases are unified.
Therefore, this PR adds `apierrs` to `hack/.import-aliases` being used with `hack/verify-import-aliases.sh`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
