### PR TITLE
Updating docs to specify json/yaml byte data is base-64 encoded

### DIFF
--- a/pkg/apis/admissionregistration/types.go
+++ b/pkg/apis/admissionregistration/types.go
@@ -509,7 +509,7 @@ type WebhookClientConfig struct {
 	// +optional
 	Service *ServiceReference
 
-	// `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
+	// `caBundle` is a PEM and base-64 encoded CA bundle which will be used to validate the webhook's server certificate.
 	// If unspecified, system trust roots on the apiserver are used.
 	// +optional
 	CABundle []byte

--- a/pkg/apis/auditregistration/types.go
+++ b/pkg/apis/auditregistration/types.go
@@ -169,7 +169,7 @@ type WebhookClientConfig struct {
 	// +optional
 	Service *ServiceReference
 
-	// `caBundle` is a PEM encoded CA bundle which will be used to validate the webhook's server certificate.
+	// `caBundle` is a PEM and base-64 encoded CA bundle which will be used to validate the webhook's server certificate.
 	// If unspecified, system trust roots on the apiserver are used.
 	// +optional
 	CABundle []byte


### PR DESCRIPTION
[Update docs to indicate that API values of []byte are always base64-encoded](https://github.com/kubernetes/kubernetes/issues/72158)