### PR TITLE
Reorder stackdriver setup in windows startup script

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -131,13 +131,6 @@ try {
   Create-Directories
   Download-HelperScripts
 
-  # Even if Stackdriver is already installed, the function will still [re]start the service.
-  if (IsLoggingEnabled $kube_env) {
-    Install-LoggingAgent
-    Configure-LoggingAgent
-    Restart-LoggingAgent
-  }
-
   Create-DockerRegistryKey
   Configure-Dockerd
   DownloadAndInstall-KubernetesBinaries
@@ -151,6 +144,12 @@ try {
   Configure-GcePdTools
   Configure-Kubelet
 
+  # Even if Stackdriver is already installed, the function will still [re]start the service.
+  if (IsLoggingEnabled $kube_env) {
+    Install-LoggingAgent
+    Configure-LoggingAgent
+    Restart-LoggingAgent
+  }
   Start-WorkerServices
   Log-Output 'Waiting 15 seconds for node to join cluster.'
   Start-Sleep 15


### PR DESCRIPTION
Stackdriver was failing to initialize correctly because it could not connect to metadata server. It could not connect to metadata server because the HNS initialization in the windows startup script, reset the network.

So, move stackdriver startup block after HNS stabilizes. At the later stage of the init script, metadata server is available and stackdriver is setup correctly.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes stackdriver logging for windows node pool. Without this the stackdriver setup fails inconsistently.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
The start up sequence of windows script is being refined. When looking for workload logs in stackdriver console, we discovered this issue. So by moving the block to after HNS setup, we improve the chances of correct stackdriver startup by many fold.

**Does this PR introduce a user-facing change?**:
No
