### PR TITLE
close scheduler kube-apiserver

### DIFF
--- a/test/integration/util/util.go
+++ b/test/integration/util/util.go
@@ -47,10 +47,11 @@ func StartApiserver() (string, ShutdownFunc) {
 		h.M.GenericAPIServer.Handler.ServeHTTP(w, req)
 	}))
 
-	framework.RunAMasterUsingServer(framework.NewIntegrationTestMasterConfig(), s, h)
+	_, _, closeFn := framework.RunAMasterUsingServer(framework.NewIntegrationTestMasterConfig(), s, h)
 
 	shutdownFunc := func() {
 		klog.Infof("destroying API server")
+		closeFn()
 		s.Close()
 		klog.Infof("destroyed API server")
 	}


### PR DESCRIPTION
The scheduler perf test forgot to close the kube-apiserver.

/kind bug
/priority important-soon
@kubernetes/sig-scheduling-bugs 


```release-note
NONE
```

/assign @ahg-g 