### PR TITLE
kubeadm: alpha certs should skip missing files

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/certs.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs.go
@@ -206,6 +206,11 @@ func renewCert(flags *renewFlags, kdir string, handler *renewal.CertificateRenew
 		return err
 	}
 
+	if ok, _ := rm.CertificateExists(handler.Name); !ok {
+		fmt.Printf("MISSING! %s\n", handler.LongName)
+		return nil
+	}
+
 	// if the renewal operation is set to generate CSR request only
 	if flags.csrOnly {
 		// checks a path for storing CSR request is given
@@ -282,36 +287,54 @@ func newCmdCertsExpiration(out io.Writer, kdir string) *cobra.Command {
 			w := tabwriter.NewWriter(out, 10, 4, 3, ' ', 0)
 			fmt.Fprintln(w, "CERTIFICATE\tEXPIRES\tRESIDUAL TIME\tCERTIFICATE AUTHORITY\tEXTERNALLY MANAGED")
 			for _, handler := range rm.Certificates() {
-				e, err := rm.GetCertificateExpirationInfo(handler.Name)
-				if err != nil {
-					return err
+				if ok, _ := rm.CertificateExists(handler.Name); ok {
+					e, err := rm.GetCertificateExpirationInfo(handler.Name)
+					if err != nil {
+						return err
+					}
+
+					s := fmt.Sprintf("%s\t%s\t%s\t%s\t%-8v",
+						e.Name,
+						e.ExpirationDate.Format("Jan 02, 2006 15:04 MST"),
+						duration.ShortHumanDuration(e.ResidualTime()),
+						handler.CAName,
+						yesNo(e.ExternallyManaged),
+					)
+
+					fmt.Fprintln(w, s)
+					continue
 				}
 
-				s := fmt.Sprintf("%s\t%s\t%s\t%s\t%-8v",
-					e.Name,
-					e.ExpirationDate.Format("Jan 02, 2006 15:04 MST"),
-					duration.ShortHumanDuration(e.ResidualTime()),
-					handler.CAName,
-					yesNo(e.ExternallyManaged),
+				// the certificate does not exist (for any reason)
+				s := fmt.Sprintf("!MISSING! %s\t\t\t\t",
+					handler.Name,
 				)
-
 				fmt.Fprintln(w, s)
 			}
 			fmt.Fprintln(w)
 			fmt.Fprintln(w, "CERTIFICATE AUTHORITY\tEXPIRES\tRESIDUAL TIME\tEXTERNALLY MANAGED")
 			for _, handler := range rm.CAs() {
-				e, err := rm.GetCAExpirationInfo(handler.Name)
-				if err != nil {
-					return err
+				if ok, _ := rm.CAExists(handler.Name); ok {
+					e, err := rm.GetCAExpirationInfo(handler.Name)
+					if err != nil {
+						return err
+					}
+
+					s := fmt.Sprintf("%s\t%s\t%s\t%-8v",
+						e.Name,
+						e.ExpirationDate.Format("Jan 02, 2006 15:04 MST"),
+						duration.ShortHumanDuration(e.ResidualTime()),
+						yesNo(e.ExternallyManaged),
+					)
+
+					fmt.Fprintln(w, s)
+					continue
 				}
 
-				s := fmt.Sprintf("%s\t%s\t%s\t%-8v",
-					e.Name,
-					e.ExpirationDate.Format("Jan 02, 2006 15:04 MST"),
-					duration.ShortHumanDuration(e.ResidualTime()),
-					yesNo(e.ExternallyManaged),
+				// the CA does not exist (for any reason)
+				s := fmt.Sprintf("!MISSING! %s\t\t\t",
+					handler.Name,
 				)
-
 				fmt.Fprintln(w, s)
 			}
 			w.Flush()

--- a/cmd/kubeadm/app/phases/certs/renewal/manager.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager.go
@@ -315,6 +315,16 @@ func (rm *Manager) CreateRenewCSR(name, outdir string) error {
 	return nil
 }
 
+// CertificateExists returns true if a certificate exists.
+func (rm *Manager) CertificateExists(name string) (bool, error) {
+	handler, ok := rm.certificates[name]
+	if !ok {
+		return false, errors.Errorf("%s is not a known certificate", name)
+	}
+
+	return handler.readwriter.Exists(), nil
+}
+
 // GetCertificateExpirationInfo returns certificate expiration info.
 // For PKI certificates, use the name defined in the certsphase package, while for certificates
 // embedded in the kubeConfig files, use the kubeConfig file name defined in the kubeadm constants package.
@@ -339,6 +349,16 @@ func (rm *Manager) GetCertificateExpirationInfo(name string) (*ExpirationInfo, e
 
 	// returns the certificate expiration info
 	return newExpirationInfo(name, cert, externallyManaged), nil
+}
+
+// CAExists returns true if a certificate authority exists.
+func (rm *Manager) CAExists(name string) (bool, error) {
+	handler, ok := rm.cas[name]
+	if !ok {
+		return false, errors.Errorf("%s is not a known certificate", name)
+	}
+
+	return handler.readwriter.Exists(), nil
 }
 
 // GetCAExpirationInfo returns CA expiration info.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR makes kubeadm alpha certs command to work at best effort (do whatever is possible) without blocking at the first error

**Which issue(s) this PR fixes**: 
Fixes: https://github.com/kubernetes/kubeadm/issues/1850

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm alpha certs command now skip missing files
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/sig cluster-lifecycle
/area kubeadm
/priority backlog

/assign @neolit123
