### PR TITLE
Automated cherry pick of #84523: retain corefile when migration fails

### DIFF
--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -235,10 +235,13 @@ func createCoreDNSAddon(deploymentBytes, serviceBytes, configBytes []byte, clien
 	if err != nil {
 		return errors.Wrap(err, "unable to fetch CoreDNS current installed version and ConfigMap.")
 	}
+
+	var hasCoreDNSMigrationFailed bool
 	if IsCoreDNSConfigMapMigrationRequired(corefile) {
 		if err := migrateCoreDNSCorefile(client, coreDNSConfigMap, corefile, currentInstalledCoreDNSVersion); err != nil {
 			// Errors in Corefile Migration is verified during preflight checks. This part will be executed when a user has chosen
 			// to ignore preflight check errors.
+			hasCoreDNSMigrationFailed = true
 			klog.Warningf("the CoreDNS Configuration was not migrated: %v. The existing CoreDNS Corefile configuration has been retained.", err)
 			if err := apiclient.CreateOrRetainConfigMap(client, coreDNSConfigMap, kubeadmconstants.CoreDNSConfigMap); err != nil {
 				return err
@@ -285,9 +288,16 @@ func createCoreDNSAddon(deploymentBytes, serviceBytes, configBytes []byte, clien
 		return errors.Wrapf(err, "%s Deployment", unableToDecodeCoreDNS)
 	}
 
-	// Create the Deployment for CoreDNS or update it in case it already exists
-	if err := apiclient.CreateOrUpdateDeployment(client, coreDNSDeployment); err != nil {
-		return err
+	// Create the deployment for CoreDNS or retain it in case the CoreDNS migration has failed during upgrade
+	if hasCoreDNSMigrationFailed {
+		if err := apiclient.CreateOrRetainDeployment(client, coreDNSDeployment, kubeadmconstants.CoreDNSDeploymentName); err != nil {
+			return err
+		}
+	} else {
+		// Create the Deployment for CoreDNS or update it in case it already exists
+		if err := apiclient.CreateOrUpdateDeployment(client, coreDNSDeployment); err != nil {
+			return err
+		}
 	}
 
 	coreDNSService := &v1.Service{}

--- a/cmd/kubeadm/app/phases/addons/dns/dns.go
+++ b/cmd/kubeadm/app/phases/addons/dns/dns.go
@@ -237,7 +237,12 @@ func createCoreDNSAddon(deploymentBytes, serviceBytes, configBytes []byte, clien
 	}
 	if IsCoreDNSConfigMapMigrationRequired(corefile) {
 		if err := migrateCoreDNSCorefile(client, coreDNSConfigMap, corefile, currentInstalledCoreDNSVersion); err != nil {
-			return err
+			// Errors in Corefile Migration is verified during preflight checks. This part will be executed when a user has chosen
+			// to ignore preflight check errors.
+			klog.Warningf("the CoreDNS Configuration was not migrated: %v. The existing CoreDNS Corefile configuration has been retained.", err)
+			if err := apiclient.CreateOrRetainConfigMap(client, coreDNSConfigMap, kubeadmconstants.CoreDNSConfigMap); err != nil {
+				return err
+			}
 		}
 	} else {
 		if err := apiclient.CreateOrUpdateConfigMap(client, coreDNSConfigMap); err != nil {

--- a/cmd/kubeadm/app/phases/upgrade/preflight.go
+++ b/cmd/kubeadm/app/phases/upgrade/preflight.go
@@ -108,7 +108,7 @@ func checkMigration(client clientset.Interface) error {
 
 	_, err = migration.Migrate(currentInstalledCoreDNSversion, kubeadmconstants.CoreDNSVersion, corefile, false)
 	if err != nil {
-		return errors.Wrap(err, "the CoreDNS configuration will not be migrated, and may be incompatible with the upgraded version of CoreDNS")
+		return errors.Wrap(err, "CoreDNS will not be upgraded")
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/phases/upgrade/preflight.go
+++ b/cmd/kubeadm/app/phases/upgrade/preflight.go
@@ -108,7 +108,7 @@ func checkMigration(client clientset.Interface) error {
 
 	_, err = migration.Migrate(currentInstalledCoreDNSversion, kubeadmconstants.CoreDNSVersion, corefile, false)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "the CoreDNS configuration will not be migrated, and may be incompatible with the upgraded version of CoreDNS")
 	}
 	return nil
 }

--- a/cmd/kubeadm/app/util/apiclient/idempotency.go
+++ b/cmd/kubeadm/app/util/apiclient/idempotency.go
@@ -147,6 +147,21 @@ func CreateOrUpdateDeployment(client clientset.Interface, deploy *apps.Deploymen
 	return nil
 }
 
+// CreateOrRetainDeployment creates a Deployment if the target resource doesn't exist. If the resource exists already, this function will retain the resource instead.
+func CreateOrRetainDeployment(client clientset.Interface, deploy *apps.Deployment, deployName string) error {
+	if _, err := client.AppsV1().Deployments(deploy.ObjectMeta.Namespace).Get(deployName, metav1.GetOptions{}); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return nil
+		}
+		if _, err := client.AppsV1().Deployments(deploy.ObjectMeta.Namespace).Create(deploy); err != nil {
+			if !apierrors.IsAlreadyExists(err) {
+				return errors.Wrap(err, "unable to create deployment")
+			}
+		}
+	}
+	return nil
+}
+
 // CreateOrUpdateDaemonSet creates a DaemonSet if the target resource doesn't exist. If the resource exists already, this function will update the resource instead.
 func CreateOrUpdateDaemonSet(client clientset.Interface, ds *apps.DaemonSet) error {
 	if _, err := client.AppsV1().DaemonSets(ds.ObjectMeta.Namespace).Create(ds); err != nil {


### PR DESCRIPTION
Cherry pick of #84523 on release-1.16.

#84523: retain corefile when migration fails

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.


This fixes cases in https://github.com/kubernetes/kubernetes/issues/84326 where the upgrade of kubeadm panics and fails when a custom image of CoreDNS is specified and a user chooses to ignore the preflight check.

```release-note
In cases where the CoreDNS migration isn't supported and the user chooses to ignore the warnings from the preflight check, the migration will be skipped and the ConfigMap and Deployment of CoreDNS will be retained.
```