### PR TITLE
Removed unused method from e2e test framework

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -81,32 +81,6 @@ func (c *PodClient) Create(pod *v1.Pod) *v1.Pod {
 	return p
 }
 
-// CreateEventually retries pod creation for a while before failing
-// the test with the most recent error. This mimicks the behavior
-// of a controller (like the one for DaemonSet) and is necessary
-// because pod creation can fail while its service account is still
-// getting provisioned
-// (https://github.com/kubernetes/kubernetes/issues/68776).
-//
-// Both the timeout and polling interval are configurable as optional
-// arguments:
-// - The first optional argument is the timeout.
-// - The second optional argument is the polling interval.
-//
-// Both intervals can either be specified as time.Duration, parsable
-// duration strings or as floats/integers. In the last case they are
-// interpreted as seconds.
-func (c *PodClient) CreateEventually(pod *v1.Pod, opts ...interface{}) *v1.Pod {
-	c.mungeSpec(pod)
-	var ret *v1.Pod
-	gomega.Eventually(func() error {
-		p, err := c.PodInterface.Create(pod)
-		ret = p
-		return err
-	}, opts...).ShouldNot(gomega.HaveOccurred(), "Failed to create %q pod", pod.GetName())
-	return ret
-}
-
 // CreateSyncInNamespace creates a new pod according to the framework specifications in the given namespace, and waits for it to start.
 func (c *PodClient) CreateSyncInNamespace(pod *v1.Pod, namespace string) *v1.Pod {
 	p := c.Create(pod)


### PR DESCRIPTION
This PR is in preparation to start cleaning up test/e2e/framework/pods.go.

Signed-off-by: alejandrox1 <alarcj137@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**Which issue(s) this PR fixes**:
Part of #76206

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
/priority important-soon
/milestone v1.17
