### PR TITLE
Merging selectors used for spreading into one

### DIFF
--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -92,6 +92,7 @@ go_test(
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/pkg/scheduler/algorithm/priorities/metadata.go
+++ b/pkg/scheduler/algorithm/priorities/metadata.go
@@ -58,7 +58,7 @@ type priorityMetadata struct {
 	podLimits               *schedulernodeinfo.Resource
 	podTolerations          []v1.Toleration
 	affinity                *v1.Affinity
-	podSelectors            []labels.Selector
+	podSelector             labels.Selector
 	controllerRef           *metav1.OwnerReference
 	podFirstServiceSelector labels.Selector
 	totalNumNodes           int
@@ -88,7 +88,7 @@ func (pmf *MetadataFactory) PriorityMetadata(
 		podLimits:               getResourceLimits(pod),
 		podTolerations:          getAllTolerationPreferNoSchedule(pod.Spec.Tolerations),
 		affinity:                pod.Spec.Affinity,
-		podSelectors:            getSelectors(pod, pmf.serviceLister, pmf.controllerLister, pmf.replicaSetLister, pmf.statefulSetLister),
+		podSelector:             getSelector(pod, pmf.serviceLister, pmf.controllerLister, pmf.replicaSetLister, pmf.statefulSetLister),
 		controllerRef:           metav1.GetControllerOf(pod),
 		podFirstServiceSelector: getFirstServiceSelector(pod, pmf.serviceLister),
 		totalNumNodes:           totalNumNodes,
@@ -105,37 +105,48 @@ func getFirstServiceSelector(pod *v1.Pod, sl corelisters.ServiceLister) (firstSe
 	return nil
 }
 
-// getSelectors returns selectors of services, RCs and RSs matching the given pod.
-func getSelectors(pod *v1.Pod, sl corelisters.ServiceLister, cl corelisters.ReplicationControllerLister, rsl appslisters.ReplicaSetLister, ssl appslisters.StatefulSetLister) []labels.Selector {
-	var selectors []labels.Selector
+// getSelector returns a selector for the services, RCs, RSs, and SSs matching the given pod.
+func getSelector(pod *v1.Pod, sl corelisters.ServiceLister, cl corelisters.ReplicationControllerLister, rsl appslisters.ReplicaSetLister, ssl appslisters.StatefulSetLister) labels.Selector {
+	labelSet := make(labels.Set)
+	// Since services, RCs, RSs and SSs match the pod, they won't have conflicting
+	// labels. Merging is safe.
 
 	if services, err := sl.GetPodServices(pod); err == nil {
 		for _, service := range services {
-			selectors = append(selectors, labels.SelectorFromSet(service.Spec.Selector))
+			labelSet = labels.Merge(labelSet, service.Spec.Selector)
 		}
 	}
 
 	if rcs, err := cl.GetPodControllers(pod); err == nil {
 		for _, rc := range rcs {
-			selectors = append(selectors, labels.SelectorFromSet(rc.Spec.Selector))
+			labelSet = labels.Merge(labelSet, rc.Spec.Selector)
 		}
+	}
+
+	selector := labels.NewSelector()
+	if len(labelSet) != 0 {
+		selector = labelSet.AsSelector()
 	}
 
 	if rss, err := rsl.GetPodReplicaSets(pod); err == nil {
 		for _, rs := range rss {
-			if selector, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector); err == nil {
-				selectors = append(selectors, selector)
+			if other, err := metav1.LabelSelectorAsSelector(rs.Spec.Selector); err == nil {
+				if r, ok := other.Requirements(); ok {
+					selector = selector.Add(r...)
+				}
 			}
 		}
 	}
 
 	if sss, err := ssl.GetPodStatefulSets(pod); err == nil {
 		for _, ss := range sss {
-			if selector, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector); err == nil {
-				selectors = append(selectors, selector)
+			if other, err := metav1.LabelSelectorAsSelector(ss.Spec.Selector); err == nil {
+				if r, ok := other.Requirements(); ok {
+					selector = selector.Add(r...)
+				}
 			}
 		}
 	}
 
-	return selectors
+	return selector
 }

--- a/pkg/scheduler/algorithm/priorities/metadata_test.go
+++ b/pkg/scheduler/algorithm/priorities/metadata_test.go
@@ -23,6 +23,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/informers"
 	clientsetfake "k8s.io/client-go/kubernetes/fake"
 	priorityutil "k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util"
@@ -140,6 +141,7 @@ func TestPriorityMetadata(t *testing.T) {
 				podLimits:      nonPodLimits,
 				podTolerations: tolerations,
 				affinity:       podAffinity,
+				podSelector:    labels.NewSelector(),
 			},
 			name: "Produce a priorityMetadata with default requests",
 		},
@@ -149,8 +151,9 @@ func TestPriorityMetadata(t *testing.T) {
 				podLimits:      nonPodLimits,
 				podTolerations: tolerations,
 				affinity:       nil,
+				podSelector:    labels.NewSelector(),
 			},
-			name: "Produce a priorityMetadata with specified requests",
+			name: "Produce a priorityMetadata with tolerations and requests",
 		},
 		{
 			pod: podWithAffinityAndRequests,
@@ -158,8 +161,9 @@ func TestPriorityMetadata(t *testing.T) {
 				podLimits:      specifiedPodLimits,
 				podTolerations: nil,
 				affinity:       podAffinity,
+				podSelector:    labels.NewSelector(),
 			},
-			name: "Produce a priorityMetadata with specified requests",
+			name: "Produce a priorityMetadata with affinity and requests",
 		},
 	}
 	client := clientsetfake.NewSimpleClientset()

--- a/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
+++ b/pkg/scheduler/algorithm/priorities/selector_spreading_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -359,8 +360,8 @@ func TestSelectorSpreadPriority(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v \n", err)
 			}
-			if !reflect.DeepEqual(test.expectedList, list) {
-				t.Errorf("expected %#v, got %#v", test.expectedList, list)
+			if diff := cmp.Diff(test.expectedList, list); diff != "" {
+				t.Errorf("wrong priorities produced (-want, +got): %s", diff)
 			}
 		})
 	}

--- a/pkg/scheduler/algorithm/priorities/spreading_perf_test.go
+++ b/pkg/scheduler/algorithm/priorities/spreading_perf_test.go
@@ -96,7 +96,7 @@ func BenchmarkTestSelectorSpreadPriority(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				meta := &priorityMetadata{
-					podSelectors: getSelectors(pod, ss.serviceLister, ss.controllerLister, ss.replicaSetLister, ss.statefulSetLister),
+					podSelector: getSelector(pod, ss.serviceLister, ss.controllerLister, ss.replicaSetLister, ss.statefulSetLister),
 				}
 				_, err := runMapReducePriority(ss.CalculateSpreadPriorityMap, ss.CalculateSpreadPriorityReduce, meta, pod, snapshot, filteredNodes)
 				if err != nil {


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:

Merging selectors used for selector spreading into one. The selectors were ANDed during priority calculation later in the pipeline.
This refactoring will allow to reuse the priority metadata for even pod spreading.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/priority important-soon
/sig scheduling