### PR TITLE
Bumps CoreDNS to 1.6.5 and updates manifest for kube-up

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -63,7 +63,7 @@ dependencies:
 
 
   - name: "coredns-kube-up"
-    version: 1.6.2
+    version: 1.6.5
     refPaths:
     - path: cluster/addons/dns/coredns/coredns.yaml.base
       match: k8s.gcr.io/coredns

--- a/cluster/addons/dns/coredns/coredns.yaml.base
+++ b/cluster/addons/dns/coredns/coredns.yaml.base
@@ -63,7 +63,9 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+            lameduck 5s
+        }
         ready
         kubernetes __PILLAR__DNS__DOMAIN__ in-addr.arpa ip6.arpa {
             pods insecure
@@ -116,7 +118,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.6.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.in
+++ b/cluster/addons/dns/coredns/coredns.yaml.in
@@ -63,7 +63,9 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+            lameduck 5s
+        }
         ready
         kubernetes {{ pillar['dns_domain'] }} in-addr.arpa ip6.arpa {
             pods insecure
@@ -116,7 +118,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.6.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/addons/dns/coredns/coredns.yaml.sed
+++ b/cluster/addons/dns/coredns/coredns.yaml.sed
@@ -63,7 +63,9 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+            lameduck 5s
+        }
         ready
         kubernetes $DNS_DOMAIN in-addr.arpa ip6.arpa {
             pods insecure
@@ -116,7 +118,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: k8s.gcr.io/coredns:1.6.2
+        image: k8s.gcr.io/coredns:1.6.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -464,35 +464,35 @@ function update-coredns-config() {
   case "$(uname -m)" in
       x86_64*)
         host_arch=amd64
-        corefile_tool_SHA="fd4d8a42d8a1c38cb49b75cca3c7c82677b97c0c6e5ee2a7d5fb02314ccfbb59"
+        corefile_tool_SHA="8019665ef9e7d40e2cd468d0d3e72d641584a2e33d2d436135919ff576054257"
         ;;
       i?86_64*)
         host_arch=amd64
-        corefile_tool_SHA="fd4d8a42d8a1c38cb49b75cca3c7c82677b97c0c6e5ee2a7d5fb02314ccfbb59"
+        corefile_tool_SHA="8019665ef9e7d40e2cd468d0d3e72d641584a2e33d2d436135919ff576054257"
         ;;
       amd64*)
         host_arch=amd64
-        corefile_tool_SHA="fd4d8a42d8a1c38cb49b75cca3c7c82677b97c0c6e5ee2a7d5fb02314ccfbb59"
+        corefile_tool_SHA="8019665ef9e7d40e2cd468d0d3e72d641584a2e33d2d436135919ff576054257"
         ;;
       aarch64*)
         host_arch=arm64
-        corefile_tool_SHA="05503f379eaaa703034c50da7ce7c273d7a7b3569eddb55afe300bd6d6c40988"
+        corefile_tool_SHA="923fcf6e0d1ccb85bdab9b0a732e5a7d27d1346ddff2cdde205e31f126e6c491"
         ;;
       arm64*)
         host_arch=arm64
-        corefile_tool_SHA="05503f379eaaa703034c50da7ce7c273d7a7b3569eddb55afe300bd6d6c40988"
+        corefile_tool_SHA="923fcf6e0d1ccb85bdab9b0a732e5a7d27d1346ddff2cdde205e31f126e6c491"
         ;;
       arm*)
         host_arch=arm
-        corefile_tool_SHA="bc826bde6662c11cbb6e6e215397d07d4fedb754c1a6e208271d7d784eb28600"
+        corefile_tool_SHA="caf026a50ba0284b96d4125d9f7d18ff867860031ea9124322d88f6baf9f6a48"
         ;;
       s390x*)
         host_arch=s390x
-        corefile_tool_SHA="4ed6b7067f65dc8f147a4dd116242495fbec5e6057bb68e1868ef1fb25e07993"
+        corefile_tool_SHA="119d25b44a54deec7e1af4c54af01eb3609c376301e586888cfc1f56951729f9"
         ;;
       ppc64le*)
         host_arch=ppc64le
-         corefile_tool_SHA="7bce38ed762a2607e158c65b378e6f23e2b80fc4e93dcf50a55f986c7ea2db43"
+         corefile_tool_SHA="8e873c3363d09d73fe34699981b79d977613c19da3d8d2473582ca24368abefd"
         ;;
       *)
         echo "Unsupported host arch. Must be x86_64, 386, arm, arm64, s390x or ppc64le." >&2
@@ -502,7 +502,7 @@ function update-coredns-config() {
 
   # Download the CoreDNS migration tool
   echo "== Downloading the CoreDNS migration tool =="
-  wget -P ${download_dir} "https://github.com/coredns/corefile-migration/releases/download/v1.0.2/corefile-tool-${host_arch}" >/dev/null 2>&1
+  wget -P ${download_dir} "https://github.com/coredns/corefile-migration/releases/download/v1.0.4/corefile-tool-${host_arch}" >/dev/null 2>&1
 
   local -r checkSHA=$(sha256sum ${download_dir}/corefile-tool-${host_arch} | cut -d " " -f 1)
   if [[ "${checkSHA}" != "${corefile_tool_SHA}" ]]; then


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

 - Bumps the CoreDNS version to 1.6.5
 - Updates the corefile-migration library to v1.0.4 which includes migration support up to CoreDNS v1.6.5

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This PR is dependent on the CoreDNS 1.6.5 image be pushed to gcr.io for which https://github.com/kubernetes/kubernetes/issues/84993 has been opened.

/hold 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubeadm now includes CoreDNS version 1.6.5
 - `kubernetes` plugin adds metrics to measure kubernetes control plane latency.
 -  the `health` plugin now includes the `lameduck` option by default, which waits for a duration before shutting down.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
