### PR TITLE
Remove unused function from e2e framework rest.go

### DIFF
--- a/test/e2e/framework/replicaset/BUILD
+++ b/test/e2e/framework/replicaset/BUILD
@@ -10,7 +10,6 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/framework/replicaset",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/controller/deployment/util:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/framework/replicaset/rest.go
+++ b/test/e2e/framework/replicaset/rest.go
@@ -17,12 +17,8 @@ limitations under the License.
 package replicaset
 
 import (
-	"fmt"
-
 	appsv1 "k8s.io/api/apps/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
-	deploymentutil "k8s.io/kubernetes/pkg/controller/deployment/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 	testutils "k8s.io/kubernetes/test/utils"
 )
@@ -30,23 +26,4 @@ import (
 // UpdateReplicaSetWithRetries updates replicaset template with retries.
 func UpdateReplicaSetWithRetries(c clientset.Interface, namespace, name string, applyUpdate testutils.UpdateReplicaSetFunc) (*appsv1.ReplicaSet, error) {
 	return testutils.UpdateReplicaSetWithRetries(c, namespace, name, applyUpdate, framework.Logf, framework.Poll, framework.PollShortTimeout)
-}
-
-// CheckNewRSAnnotations check if the new RS's annotation is as expected
-func CheckNewRSAnnotations(c clientset.Interface, ns, deploymentName string, expectedAnnotations map[string]string) error {
-	deployment, err := c.AppsV1().Deployments(ns).Get(deploymentName, metav1.GetOptions{})
-	if err != nil {
-		return err
-	}
-	newRS, err := deploymentutil.GetNewReplicaSet(deployment, c.AppsV1())
-	if err != nil {
-		return err
-	}
-	for k, v := range expectedAnnotations {
-		// Skip checking revision annotations
-		if k != deploymentutil.RevisionAnnotation && v != newRS.Annotations[k] {
-			return fmt.Errorf("Expected new RS annotations = %+v, got %+v", expectedAnnotations, newRS.Annotations)
-		}
-	}
-	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This removes the following unused function:

- CheckNewRSAnnotations: Unused since #70672

Ref: #84380

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
