### PR TITLE
Dockershim: Execute sandbox with less privileges

### DIFF
--- a/cluster/images/conformance/go-runner/BUILD
+++ b/cluster/images/conformance/go-runner/BUILD
@@ -41,6 +41,7 @@ go_test(
         "env_test.go",
         "tar_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = ["//vendor/github.com/pkg/errors:go_default_library"],
 )

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -29,6 +29,7 @@ const (
 	// When these values are updated, also update test/e2e/framework/util.go
 	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
 	defaultPodSandboxImageVersion = "3.1"
+	defaultPodSandboxSeccomp      = `{"defaultAction":"SCMP_ACT_ERRNO","architectures":["SCMP_ARCH_X86_64","SCMP_ARCH_X86","SCMP_ARCH_X32"],"syscalls":[{"names":["arch_prctl","brk","close","execve","exit_group","futex","mprotect","nanosleep","stat","write","uname","pause","rt_sigaction","getpid","wait4","waitid","fork","getppid"],"action": "SCMP_ACT_ALLOW"}]}`
 )
 
 var (
@@ -50,6 +51,7 @@ func NewContainerRuntimeOptions() *config.ContainerRuntimeOptions {
 		DockerEndpoint:             dockerEndpoint,
 		DockershimRootDirectory:    "/var/lib/dockershim",
 		PodSandboxImage:            defaultPodSandboxImage,
+		PodSandboxSeccomp:          defaultPodSandboxSeccomp,
 		ImagePullProgressDeadline:  metav1.Duration{Duration: 1 * time.Minute},
 		ExperimentalDockershim:     false,
 

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
@@ -60,13 +62,12 @@ func NewContainerRuntimeOptions() *config.ContainerRuntimeOptions {
 		dockerEndpoint = "unix:///var/run/docker.sock"
 	}
 
-	return &config.ContainerRuntimeOptions{
+	crOptions := &config.ContainerRuntimeOptions{
 		ContainerRuntime:           kubetypes.DockerContainerRuntime,
 		RedirectContainerStreaming: false,
 		DockerEndpoint:             dockerEndpoint,
 		DockershimRootDirectory:    "/var/lib/dockershim",
 		PodSandboxImage:            defaultPodSandboxImage,
-		PodSandboxSeccomp:          defaultPodSandboxSeccomp,
 		ImagePullProgressDeadline:  metav1.Duration{Duration: 1 * time.Minute},
 		ExperimentalDockershim:     false,
 
@@ -75,4 +76,10 @@ func NewContainerRuntimeOptions() *config.ContainerRuntimeOptions {
 		CNIConfDir:  "/etc/cni/net.d",
 		CNICacheDir: "/var/lib/cni/cache",
 	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodSandboxSeccomp) {
+		crOptions.PodSandboxSeccomp = defaultPodSandboxSeccomp
+	}
+
+	return crOptions
 }

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -29,7 +29,7 @@ const (
 	// When these values are updated, also update test/e2e/framework/util.go
 	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
 	defaultPodSandboxImageVersion = "3.1"
-	defaultPodSandboxSeccomp      = `{"defaultAction":"SCMP_ACT_ERRNO","architectures":["SCMP_ARCH_X86_64","SCMP_ARCH_X86","SCMP_ARCH_X32"],"syscalls":[{"names":["arch_prctl","brk","close","execve","exit_group","futex","mprotect","nanosleep","stat","write","uname","pause","rt_sigaction","getpid","wait4","waitid","fork","getppid"],"action": "SCMP_ACT_ALLOW"}]}`
+	defaultPodSandboxSeccomp      = `{"defaultAction":"SCMP_ACT_ERRNO","archMap":[{"architecture":"SCMP_ARCH_X86_64","subArchitectures":["SCMP_ARCH_X86","SCMP_ARCH_X32"]},{"architecture":"SCMP_ARCH_AARCH64","subArchitectures":["SCMP_ARCH_ARM"]},{"architecture":"SCMP_ARCH_MIPS64","subArchitectures":["SCMP_ARCH_MIPS","SCMP_ARCH_MIPS64N32"]},{"architecture":"SCMP_ARCH_MIPS64N32","subArchitectures":["SCMP_ARCH_MIPS","SCMP_ARCH_MIPS64"]},{"architecture":"SCMP_ARCH_MIPSEL64","subArchitectures":["SCMP_ARCH_MIPSEL","SCMP_ARCH_MIPSEL64N32"]},{"architecture":"SCMP_ARCH_MIPSEL64N32","subArchitectures":["SCMP_ARCH_MIPSEL","SCMP_ARCH_MIPSEL64"]},{"architecture":"SCMP_ARCH_S390X","subArchitectures":["SCMP_ARCH_S390"]}],"syscalls":[{"names":["arch_prctl","brk","close","execve","exit_group","futex","mprotect","nanosleep","stat","write","uname","pause","rt_sigaction","getpid","wait4","waitid","fork","getppid"],"action":"SCMP_ACT_ALLOW"}]}`
 )
 
 var (

--- a/cmd/kubelet/app/options/container_runtime.go
+++ b/cmd/kubelet/app/options/container_runtime.go
@@ -29,7 +29,22 @@ const (
 	// When these values are updated, also update test/e2e/framework/util.go
 	defaultPodSandboxImageName    = "k8s.gcr.io/pause"
 	defaultPodSandboxImageVersion = "3.1"
-	defaultPodSandboxSeccomp      = `{"defaultAction":"SCMP_ACT_ERRNO","archMap":[{"architecture":"SCMP_ARCH_X86_64","subArchitectures":["SCMP_ARCH_X86","SCMP_ARCH_X32"]},{"architecture":"SCMP_ARCH_AARCH64","subArchitectures":["SCMP_ARCH_ARM"]},{"architecture":"SCMP_ARCH_MIPS64","subArchitectures":["SCMP_ARCH_MIPS","SCMP_ARCH_MIPS64N32"]},{"architecture":"SCMP_ARCH_MIPS64N32","subArchitectures":["SCMP_ARCH_MIPS","SCMP_ARCH_MIPS64"]},{"architecture":"SCMP_ARCH_MIPSEL64","subArchitectures":["SCMP_ARCH_MIPSEL","SCMP_ARCH_MIPSEL64N32"]},{"architecture":"SCMP_ARCH_MIPSEL64N32","subArchitectures":["SCMP_ARCH_MIPSEL","SCMP_ARCH_MIPSEL64"]},{"architecture":"SCMP_ARCH_S390X","subArchitectures":["SCMP_ARCH_S390"]}],"syscalls":[{"names":["arch_prctl","brk","close","execve","exit_group","futex","mprotect","nanosleep","stat","write","uname","pause","rt_sigaction","getpid","wait4","waitid","fork","getppid"],"action":"SCMP_ACT_ALLOW"}]}`
+	defaultPodSandboxSeccomp      = `{
+	"defaultAction":"SCMP_ACT_ERRNO",
+	"archMap":[{
+		"architecture":"SCMP_ARCH_X86_64","subArchitectures":["SCMP_ARCH_X86","SCMP_ARCH_X32"] },{
+		"architecture":"SCMP_ARCH_AARCH64","subArchitectures":["SCMP_ARCH_ARM"] },{
+		"architecture":"SCMP_ARCH_MIPS64","subArchitectures":["SCMP_ARCH_MIPS","SCMP_ARCH_MIPS64N32"] },{
+		"architecture":"SCMP_ARCH_MIPS64N32","subArchitectures":["SCMP_ARCH_MIPS","SCMP_ARCH_MIPS64"] },{
+		"architecture":"SCMP_ARCH_MIPSEL64","subArchitectures":["SCMP_ARCH_MIPSEL","SCMP_ARCH_MIPSEL64N32"] },{
+		"architecture":"SCMP_ARCH_MIPSEL64N32","subArchitectures":["SCMP_ARCH_MIPSEL","SCMP_ARCH_MIPSEL64"] },{
+		"architecture":"SCMP_ARCH_S390X","subArchitectures":["SCMP_ARCH_S390"] 
+	}],
+	"syscalls":[{
+		"names":["arch_prctl","brk","close","execve","exit_group","futex","mprotect","nanosleep","stat","write","uname","pause","rt_sigaction","getpid","wait4","waitid","fork","getppid"],
+		"action":"SCMP_ACT_ALLOW"
+	}]
+}`
 )
 
 var (

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1294,7 +1294,7 @@ func RunDockershim(f *options.KubeletFlags, c *kubeletconfiginternal.KubeletConf
 	}
 
 	// Standalone dockershim will always start the local streaming server.
-	ds, err := dockershim.NewDockerService(dockerClientConfig, r.PodSandboxImage, streamingConfig, &pluginSettings,
+	ds, err := dockershim.NewDockerService(dockerClientConfig, r.PodSandboxImage, r.PodSandboxSeccomp, streamingConfig, &pluginSettings,
 		f.RuntimeCgroups, c.CgroupDriver, r.DockershimRootDirectory, true /*startLocalStreamingServer*/)
 	if err != nil {
 		return err

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -529,6 +529,12 @@ const (
 	//
 	// Enables a feature to make secrets and configmaps data immutable.
 	ImmutableEphemeralVolumes featuregate.Feature = "ImmutableEphemeralVolumes"
+
+	// owner: @pjbgf
+	// alpha: v1.18
+	//
+	// Enables a feature to add built-in seccomp profile to the pod sandbox container.
+	PodSandboxSeccomp featuregate.Feature = "PodSandboxSeccomp"
 )
 
 func init() {
@@ -613,6 +619,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	PodDisruptionBudget:                            {Default: true, PreRelease: featuregate.Beta},
 	ServiceTopology:                                {Default: false, PreRelease: featuregate.Alpha},
 	ImmutableEphemeralVolumes:                      {Default: false, PreRelease: featuregate.Alpha},
+	PodSandboxSeccomp:                              {Default: false, PreRelease: featuregate.Alpha},
 
 	// inherited features from generic apiserver, relisted here to get a conflict if it is changed
 	// unintentionally on either side:

--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -51,6 +51,8 @@ type ContainerRuntimeOptions struct {
 	// PodSandboxImage is the image whose network/ipc namespaces
 	// containers in each pod will use.
 	PodSandboxImage string
+	// PodSandboxSeccomp defines the seccomp profile that the infrastructure container will use.
+	PodSandboxSeccomp string
 	// DockerEndpoint is the path to the docker endpoint to communicate with.
 	DockerEndpoint string
 	// If no pulling progress is made before the deadline imagePullProgressDeadline,

--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -37,6 +37,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/credentialprovider:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/kubelet/apis/config:go_default_library",
         "//pkg/kubelet/checkpointmanager:go_default_library",
         "//pkg/kubelet/checkpointmanager/checksum:go_default_library",
@@ -62,6 +63,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/tools/remotecommand:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",
         "//vendor/github.com/armon/circbuf:go_default_library",
@@ -103,6 +105,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/features:go_default_library",
         "//pkg/kubelet/checkpointmanager:go_default_library",
         "//pkg/kubelet/container:go_default_library",
         "//pkg/kubelet/container/testing:go_default_library",
@@ -113,6 +116,8 @@ go_test(
         "//pkg/kubelet/util/cache:go_default_library",
         "//pkg/security/apparmor:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",
         "//vendor/github.com/blang/semver:go_default_library",
         "//vendor/github.com/docker/docker/api/types:go_default_library",

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -652,14 +652,18 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 	}
 
 	// Set security options.
-	securityOpts, err := ds.getSecurityOpts(c.GetLinux().GetSecurityContext().GetSeccompProfilePath(), securityOptSeparator)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate sandbox security options for sandbox %q: %v", c.Metadata.Name, err)
-	}
+	securityOpts := ds.getSandBoxSecurityOpts(securityOptSeparator)
 	hc.SecurityOpt = append(hc.SecurityOpt, securityOpts...)
 
 	applyExperimentalCreateConfig(createConfig, c.Annotations)
 	return createConfig, nil
+}
+
+func (ds *dockerService) getSandBoxSecurityOpts(separator rune) []string {
+	return []string{
+		"no-new-privileges",
+		strings.Join([]string{"seccomp", string(separator), ds.podSandBoxSeccomp}, ""),
+	}
 }
 
 // networkNamespaceMode returns the network runtimeapi.NamespaceMode for this container.

--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -28,8 +28,10 @@ import (
 	dockercontainer "github.com/docker/docker/api/types/container"
 	dockerfilters "github.com/docker/docker/api/types/filters"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog"
+	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager/errors"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -652,7 +654,16 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 	}
 
 	// Set security options.
-	securityOpts := ds.getSandBoxSecurityOpts(securityOptSeparator)
+	securityOpts, err := ds.getSecurityOpts(c.GetLinux().GetSecurityContext().GetSeccompProfilePath(), securityOptSeparator)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate sandbox security options for sandbox %q: %v", c.Metadata.Name, err)
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.PodSandboxSeccomp) {
+		// overrides sandbox seccomp with built-in profile
+		securityOpts = ds.getSandBoxSecurityOpts(securityOptSeparator)
+	}
+
 	hc.SecurityOpt = append(hc.SecurityOpt, securityOpts...)
 
 	applyExperimentalCreateConfig(createConfig, c.Annotations)

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -160,13 +160,13 @@ func TestSandboxStatus(t *testing.T) {
 func TestSandboxHasLeastPrivilegesConfig(t *testing.T) {
 	ds, _, _ := newTestDockerService()
 	config := makeSandboxConfig("foo", "bar", "1", 0)
-	ds.podSandBoxSeccomp = "{defaultAction=\"SCMP_ACT_ERRNO\"}"
+	ds.podSandBoxSeccomp = `{defaultAction="SCMP_ACT_ERRNO"}`
 
 	// test the default
 	createConfig, err := ds.makeSandboxDockerConfig(config, defaultSandboxImage)
 	assert.NoError(t, err)
 	assert.Equal(t, "no-new-privileges", createConfig.HostConfig.SecurityOpt[0], "no-new-privileges not set")
-	assert.True(t, strings.HasPrefix(createConfig.HostConfig.SecurityOpt[1], "seccomp={defaultAction=\"SCMP_ACT_ERRNO\"}"), "seccomp not set")
+	assert.True(t, strings.HasPrefix(createConfig.HostConfig.SecurityOpt[1], `seccomp={defaultAction="SCMP_ACT_ERRNO"}`), "seccomp not set")
 
 	// test that users can't overwrite the sandboxes' seccomp
 	config.Linux = &runtimeapi.LinuxPodSandboxConfig{
@@ -177,7 +177,7 @@ func TestSandboxHasLeastPrivilegesConfig(t *testing.T) {
 	createConfig, err = ds.makeSandboxDockerConfig(config, defaultSandboxImage)
 	assert.NoError(t, err)
 	assert.Equal(t, "no-new-privileges", createConfig.HostConfig.SecurityOpt[0], "no-new-privileges not set")
-	assert.True(t, strings.HasPrefix(createConfig.HostConfig.SecurityOpt[1], "seccomp={defaultAction=\"SCMP_ACT_ERRNO\"}"), "seccomp not set")
+	assert.True(t, strings.HasPrefix(createConfig.HostConfig.SecurityOpt[1], `seccomp={defaultAction="SCMP_ACT_ERRNO"}`), "seccomp not set")
 }
 
 // TestSandboxStatusAfterRestart tests that retrieving sandbox status returns

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -28,7 +28,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/network"
@@ -158,6 +161,8 @@ func TestSandboxStatus(t *testing.T) {
 // TestSandboxHasLeastPrivilegesConfig tests that the sandbox is set with no-new-privileges
 // and it has a seccomp profile.
 func TestSandboxHasLeastPrivilegesConfig(t *testing.T) {
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodSandboxSeccomp, true)()
+
 	ds, _, _ := newTestDockerService()
 	config := makeSandboxConfig("foo", "bar", "1", 0)
 	ds.podSandBoxSeccomp = `{defaultAction="SCMP_ACT_ERRNO"}`

--- a/pkg/kubelet/dockershim/docker_service.go
+++ b/pkg/kubelet/dockershim/docker_service.go
@@ -29,7 +29,7 @@ import (
 	dockertypes "github.com/docker/docker/api/types"
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/checkpointmanager"
@@ -188,8 +188,9 @@ func NewDockerClientFromConfig(config *ClientConfig) libdocker.Interface {
 
 // NewDockerService creates a new `DockerService` struct.
 // NOTE: Anything passed to DockerService should be eventually handled in another way when we switch to running the shim as a different process.
-func NewDockerService(config *ClientConfig, podSandboxImage string, streamingConfig *streaming.Config, pluginSettings *NetworkPluginSettings,
-	cgroupsName string, kubeCgroupDriver string, dockershimRootDir string, startLocalStreamingServer bool) (DockerService, error) {
+func NewDockerService(config *ClientConfig, podSandboxImage string, podSandboxSeccomp string, streamingConfig *streaming.Config,
+	pluginSettings *NetworkPluginSettings, cgroupsName string, kubeCgroupDriver string, dockershimRootDir string,
+	startLocalStreamingServer bool) (DockerService, error) {
 
 	client := NewDockerClientFromConfig(config)
 
@@ -284,11 +285,12 @@ func NewDockerService(config *ClientConfig, podSandboxImage string, streamingCon
 }
 
 type dockerService struct {
-	client           libdocker.Interface
-	os               kubecontainer.OSInterface
-	podSandboxImage  string
-	streamingRuntime *streamingRuntime
-	streamingServer  streaming.Server
+	client            libdocker.Interface
+	os                kubecontainer.OSInterface
+	podSandboxImage   string
+	podSandBoxSeccomp string
+	streamingRuntime  *streamingRuntime
+	streamingServer   streaming.Server
 
 	network *network.PluginManager
 	// Map of podSandboxID :: network-is-ready

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -354,7 +354,7 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 
 		// Create and start the CRI shim running as a grpc server.
 		streamingConfig := getStreamingConfig(kubeCfg, kubeDeps, crOptions)
-		ds, err := dockershim.NewDockerService(kubeDeps.DockerClientConfig, crOptions.PodSandboxImage, streamingConfig,
+		ds, err := dockershim.NewDockerService(kubeDeps.DockerClientConfig, crOptions.PodSandboxImage, crOptions.PodSandboxSeccomp, streamingConfig,
 			&pluginSettings, runtimeCgroups, kubeCfg.CgroupDriver, crOptions.DockershimRootDirectory, !crOptions.RedirectContainerStreaming)
 		if err != nil {
 			return err
@@ -673,51 +673,9 @@ func NewMainKubelet(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	klet.resourceAnalyzer = serverstats.NewResourceAnalyzer(klet, kubeCfg.VolumeStatsAggPeriod.Duration)
 
 	// if left at nil, that means it is unneeded
-	var legacyLogProvider kuberuntime.LegacyLogProvider
-
-	switch containerRuntime {
-	case kubetypes.DockerContainerRuntime:
-		// Create and start the CRI shim running as a grpc server.
-		streamingConfig := getStreamingConfig(kubeCfg, kubeDeps, crOptions)
-		ds, err := dockershim.NewDockerService(kubeDeps.DockerClientConfig, crOptions.PodSandboxImage, crOptions.PodSandboxSeccomp, streamingConfig,
-			&pluginSettings, runtimeCgroups, kubeCfg.CgroupDriver, crOptions.DockershimRootDirectory, !crOptions.RedirectContainerStreaming)
-		if err != nil {
-			return nil, err
-		}
-		if crOptions.RedirectContainerStreaming {
-			klet.criHandler = ds
-		}
-
-		// The unix socket for kubelet <-> dockershim communication.
-		klog.V(5).Infof("RemoteRuntimeEndpoint: %q, RemoteImageEndpoint: %q",
-			remoteRuntimeEndpoint,
-			remoteImageEndpoint)
-		klog.V(2).Infof("Starting the GRPC server for the docker CRI shim.")
-		server := dockerremote.NewDockerServer(remoteRuntimeEndpoint, ds)
-		if err := server.Start(); err != nil {
-			return nil, err
-		}
-
-		// Create dockerLegacyService when the logging driver is not supported.
-		supported, err := ds.IsCRISupportedLogDriver()
-		if err != nil {
-			return nil, err
-		}
-		if !supported {
-			klet.dockerLegacyService = ds
-			legacyLogProvider = ds
-		}
-	case kubetypes.RemoteContainerRuntime:
-		// No-op.
-		break
-	default:
-		return nil, fmt.Errorf("unsupported CRI runtime: %q", containerRuntime)
-	}
-	runtimeService, imageService, err := getRuntimeAndImageServices(remoteRuntimeEndpoint, remoteImageEndpoint, kubeCfg.RuntimeRequestTimeout)
-	if err != nil {
-		return nil, err
-	}
-	klet.runtimeService = runtimeService
+	klet.dockerLegacyService = kubeDeps.dockerLegacyService
+	klet.criHandler = kubeDeps.criHandler
+	klet.runtimeService = kubeDeps.RemoteRuntimeService
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.RuntimeClass) && kubeDeps.KubeClient != nil {
 		klet.runtimeClassManager = runtimeclass.NewManager(kubeDeps.KubeClient)

--- a/pkg/kubelet/kuberuntime/BUILD
+++ b/pkg/kubelet/kuberuntime/BUILD
@@ -32,6 +32,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/kubelet/kuberuntime",
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
+        "//pkg/apis/core:go_default_library",
         "//pkg/credentialprovider:go_default_library",
         "//pkg/credentialprovider/secrets:go_default_library",
         "//pkg/features:go_default_library",

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -22,7 +22,7 @@ import (
 	"net/url"
 	"sort"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -143,7 +143,10 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxLinuxConfig(pod *v1.Pod) (
 	lc := &runtimeapi.LinuxPodSandboxConfig{
 		CgroupParent: cgroupParent,
 		SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
-			Privileged:         kubecontainer.HasPrivilegedContainer(pod),
+			Privileged: kubecontainer.HasPrivilegedContainer(pod),
+
+			// Seccomp profile will be overwritten by the container runtime
+			// Leaving this here for: 1. backwards compatibility 2. ensure that at least one seccomp will be applied
 			SeccompProfilePath: m.getSeccompProfileFromAnnotations(pod.Annotations, ""),
 		},
 	}

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -27,7 +27,6 @@ import (
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/features"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/types"
@@ -138,28 +137,17 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxConfig(pod *v1.Pod, attemp
 	return podSandboxConfig, nil
 }
 
-// If PodSandboxSeccomp is enabled, overwrites pod level profile with SeccompProfileRuntimeDefault
-// This allows for pod level profiles to be applied only for user-containers, making them less privileged.
-func (m *kubeGenericRuntimeManager) getSandboxSeccompProfilePath(pod *v1.Pod) string {
-	// TODO: Allow for json seccomp profiles to be sent across to CRI, alongside with the "no-new-privileges" flag.
-	// This would allow for defaultPodSandboxSeccomp to be used instead.
-	profileName := m.getSeccompProfileFromAnnotations(pod.Annotations, "")
-
-	if utilfeature.DefaultFeatureGate.Enabled(features.PodSandboxSeccomp) {
-		profileName = core.SeccompProfileRuntimeDefault
-	}
-
-	return profileName
-}
-
 // generatePodSandboxLinuxConfig generates LinuxPodSandboxConfig from v1.Pod.
 func (m *kubeGenericRuntimeManager) generatePodSandboxLinuxConfig(pod *v1.Pod) (*runtimeapi.LinuxPodSandboxConfig, error) {
 	cgroupParent := m.runtimeHelper.GetPodCgroupParent(pod)
 	lc := &runtimeapi.LinuxPodSandboxConfig{
 		CgroupParent: cgroupParent,
 		SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
-			Privileged:         kubecontainer.HasPrivilegedContainer(pod),
-			SeccompProfilePath: m.getSandboxSeccompProfilePath(pod),
+			Privileged: kubecontainer.HasPrivilegedContainer(pod),
+
+			// Seccomp profile will be overwritten by the container runtime
+			// Leaving this here for: 1. backwards compatibility 2. ensure that at least one seccomp will be applied
+			SeccompProfilePath: m.getSeccompProfileFromAnnotations(pod.Annotations, ""),
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Decreases the sandbox's attack surface by running it with `no-new-privileges` and with its own optimised seccomp profile.

As a side effect, it allows end users to set seccomp profiles at pod level with the same profile as they would for container level, considering the pod only has containers with `AllowPrivilegeEscalation=false`. 

Without this PR users had to whitelist some syscalls regardless of their containers needing them: `capset`, `set_tid_address`, `setgid`, `setgroups`, `setuid` and etc. More information and examples at #84623.

**Which issue(s) this PR fixes**:
Fixes #84623 (for dockershim)


**Special notes for your reviewer**:
Feature parity with other runtimes will be done through a different PR. 

**Does this PR introduce a user-facing change?**:
```release-note
dockershim security: pod sandbox now runs with `no-new-privileges` and with its own seccomp profile
dockershim seccomp: custom profiles can now have smaller footprints when set at pod level with containers using AllowPrivilegeEscalation=false
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/cc @tallclair @Random-Liu
/sig node