### PR TITLE
Promote VolumeSubpathEnvExpansion e2e tests to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -410,6 +410,50 @@
     proper values.
   release: v1.9
   file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath expansion
+  codename: '[k8s.io] Variable Expansion should allow substituting values in a volume
+    subpath [sig-storage] [Conformance]'
+  description: Make sure a container's subpath can be set using an expansion of environment
+    variables.
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath with absolute path
+  codename: '[k8s.io] Variable Expansion should fail substituting values in a volume
+    subpath with absolute path [sig-storage][Slow] [Conformance]'
+  description: Make sure a container's subpath can not be set using an expansion of
+    environment variables when absolute path is supplied.
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath with backticks
+  codename: '[k8s.io] Variable Expansion should fail substituting values in a volume
+    subpath with backticks [sig-storage][Slow] [Conformance]'
+  description: Make sure a container's subpath can not be set using an expansion of
+    environment variables when backticks are supplied.
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath lifecycle
+  codename: '[k8s.io] Variable Expansion should not change the subpath mount on a
+    container restart if the environment variable changes [sig-storage][Slow] [Conformance]'
+  description: "Verify should not change the subpath mount on a container restart
+    if the environment variable changes 1.\tvalid subpathexpr starts a container running
+    2.\ttest for valid subpath writes 3.\tcontainer restarts 4.\tdelete cleanly"
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath test writes
+  codename: '[k8s.io] Variable Expansion should succeed in writing subpaths in container
+    [sig-storage][Slow] [Conformance]'
+  description: "Verify that a subpath expansion can be used to write files into subpaths.
+    1.\tvalid subpathexpr starts a container running 2.\ttest for valid subpath writes
+    3.\tsuccessful expansion of the subpathexpr isn't required for volume cleanup"
+  release: v1.19
+  file: test/e2e/common/expansion.go
+- testname: VolumeSubpathEnvExpansion, subpath ready from failed state
+  codename: '[k8s.io] Variable Expansion should verify that a failing subpath expansion
+    can be modified during the lifecycle of a container [sig-storage][Slow] [Conformance]'
+  description: Verify that a failing subpath expansion can be modified during the
+    lifecycle of a container.
+  release: v1.19
+  file: test/e2e/common/expansion.go
 - testname: Pod events, verify event from Scheduler and Kubelet
   codename: '[k8s.io] [sig-node] Events should be sent by kubelets and the scheduler
     about pods scheduling and running  [Conformance]'

--- a/test/e2e/common/expansion.go
+++ b/test/e2e/common/expansion.go
@@ -155,11 +155,11 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-		    Testname: var-expansion-subpath
-		    Description: Make sure a container's subpath can be set using an
-			expansion of environment variables.
+		Release : v1.19
+		Testname: VolumeSubpathEnvExpansion, subpath expansion
+		Description: Make sure a container's subpath can be set using an expansion of environment variables.
 	*/
-	ginkgo.It("should allow substituting values in a volume subpath [sig-storage]", func() {
+	framework.ConformanceIt("should allow substituting values in a volume subpath [sig-storage]", func() {
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
@@ -209,11 +209,11 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-		    Testname: var-expansion-subpath-with-backticks
-		    Description: Make sure a container's subpath can not be set using an
-			expansion of environment variables when backticks are supplied.
+		Release : v1.19
+		Testname: VolumeSubpathEnvExpansion, subpath with backticks
+		Description: Make sure a container's subpath can not be set using an expansion of environment variables when backticks are supplied.
 	*/
-	ginkgo.It("should fail substituting values in a volume subpath with backticks [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should fail substituting values in a volume subpath with backticks [sig-storage][Slow]", func() {
 
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
@@ -258,11 +258,11 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-		    Testname: var-expansion-subpath-with-absolute-path
-		    Description: Make sure a container's subpath can not be set using an
-			expansion of environment variables when absolute path is supplied.
+		Release : v1.19
+		Testname: VolumeSubpathEnvExpansion, subpath with absolute path
+		Description: Make sure a container's subpath can not be set using an expansion of environment variables when absolute path is supplied.
 	*/
-	ginkgo.It("should fail substituting values in a volume subpath with absolute path [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should fail substituting values in a volume subpath with absolute path [sig-storage][Slow]", func() {
 
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		pod := &v1.Pod{
@@ -307,10 +307,11 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-	   Testname: var-expansion-subpath-ready-from-failed-state
-	   Description: Verify that a failing subpath expansion can be modified during the lifecycle of a container.
+		Release : v1.19
+		Testname: VolumeSubpathEnvExpansion, subpath ready from failed state
+		Description: Verify that a failing subpath expansion can be modified during the lifecycle of a container.
 	*/
-	ginkgo.It("should verify that a failing subpath expansion can be modified during the lifecycle of a container [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should verify that a failing subpath expansion can be modified during the lifecycle of a container [sig-storage][Slow]", func() {
 
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		containerName := "dapi-container"
@@ -387,14 +388,15 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-		    Testname: var-expansion-subpath-test-writes
-		    Description: Verify that a subpath expansion can be used to write files into subpaths.
-			1.	valid subpathexpr starts a container running
-			2.	test for valid subpath writes
-			3.	successful expansion of the subpathexpr isn't required for volume cleanup
+		Release : v1.19
+		Testname: VolumeSubpathEnvExpansion, subpath test writes
+		Description: Verify that a subpath expansion can be used to write files into subpaths.
+		1.	valid subpathexpr starts a container running
+		2.	test for valid subpath writes
+		3.	successful expansion of the subpathexpr isn't required for volume cleanup
 
 	*/
-	ginkgo.It("should succeed in writing subpaths in container [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should succeed in writing subpaths in container [sig-storage][Slow]", func() {
 
 		podName := "var-expansion-" + string(uuid.NewUUID())
 		containerName := "dapi-container"
@@ -487,16 +489,16 @@ var _ = framework.KubeDescribe("Variable Expansion", func() {
 	})
 
 	/*
-		    Testname: var-expansion-subpath-lifecycle
-		    Description: Verify should not change the subpath mount on a container restart if the environment variable changes
-			1.	valid subpathexpr starts a container running
-			2.	test for valid subpath writes
-			3.	container restarts
-			4.	delete cleanly
-
+		Release : v1.19
+		Testname: VolumeSubpathEnvExpansion, subpath lifecycle
+		Description: Verify should not change the subpath mount on a container restart if the environment variable changes
+		1.	valid subpathexpr starts a container running
+		2.	test for valid subpath writes
+		3.	container restarts
+		4.	delete cleanly
 	*/
 
-	ginkgo.It("should not change the subpath mount on a container restart if the environment variable changes [sig-storage][Slow]", func() {
+	framework.ConformanceIt("should not change the subpath mount on a container restart if the environment variable changes [sig-storage][Slow]", func() {
 
 		suffix := string(uuid.NewUUID())
 		podName := fmt.Sprintf("var-expansion-%s", suffix)


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
VolumeSubpathEnvExpansion is GA in 1.17 so the e2e tests can be added to Conformance suite

**Which issue(s) this PR fixes**:
Fixes #85122

**Special notes for your reviewer**:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Please use the following format for linking documentation:
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20181029-volume-subpath-env-expansion.md
[Usage]: kubernetes/website#13846
[Other doc]: kubernetes/enhancements#559
