### PR TITLE
[WIP] Unconditionally admit already running pods in the TopologyManager after kubelet restart

### DIFF
--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -204,8 +204,8 @@ func TestAdmit(t *testing.T) {
 
 	tcases := []struct {
 		name     string
-		result   lifecycle.PodAdmitResult
 		qosClass v1.PodQOSClass
+		podPhase v1.PodPhase
 		policy   Policy
 		hp       []HintProvider
 		expected bool
@@ -222,6 +222,65 @@ func TestAdmit(t *testing.T) {
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   NewNonePolicy(),
 			hp:       []HintProvider{},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Burstable. SingleNumaNode Policy. Pod already running. No Hints",
+			qosClass: v1.PodQOSBurstable,
+			podPhase: v1.PodRunning,
+			policy:   NewSingleNumaNodePolicy(numaNodes),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Burstable. Restricted Policy. Pod already running. No Hints",
+			qosClass: v1.PodQOSBurstable,
+			podPhase: v1.PodRunning,
+			policy:   NewRestrictedPolicy(numaNodes),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Burstable. BestEffort Policy. Pod already running. No Hints",
+			qosClass: v1.PodQOSBurstable,
+			podPhase: v1.PodRunning,
+			policy:   NewBestEffortPolicy(numaNodes),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Guaranteed. SingleNumaNode Policy. Pod already running. No Hints",
+			qosClass: v1.PodQOSGuaranteed,
+			podPhase: v1.PodRunning,
+			policy:   NewSingleNumaNodePolicy(numaNodes),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Guaranteed. Restricted Policy. Pod already running. No Hints",
+			qosClass: v1.PodQOSGuaranteed,
+			podPhase: v1.PodRunning,
+			policy:   NewRestrictedPolicy(numaNodes),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as Guaranteed. BestEffort Policy. Pod already running. No Hints",
+			qosClass: v1.PodQOSGuaranteed,
+			policy:   NewBestEffortPolicy(numaNodes),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
 			expected: true,
 		},
 		{
@@ -484,6 +543,7 @@ func TestAdmit(t *testing.T) {
 			},
 			Status: v1.PodStatus{
 				QOSClass: tc.qosClass,
+				Phase:    tc.podPhase,
 			},
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes a (potential) bug in the `TopologyManager`, whereby *already-running* pods could be rejected after a kubelet restart if a device plugin that governs one of its resources had not reregistered with the kubelet yet.

Reference: https://github.com/kubernetes/kubernetes/issues/84479#issuecomment-552034118

An attempt to fix this issue another way was proposed here: https://github.com/kubernetes/kubernetes/pull/85038. However, this approach won't work at present because we do not checkpoint any NUMA information about devices allocated to containers. The only way to obtain this information is to wait for the device plugin to come back online so we can query it. This is impossible, however, as the underlying cause of the issue is that the plugin has not yet come online when this calculation is being made.

Things to note: 
* Even with this fix, there is a chance that a pod might be rejected if it was in the process of coming online as the kubelet restarted and a plugin has not yet reregistered (even if it normally would have been admitted and the containers that consume the plugin resources have already been allocated).

* This change will now allow pods to continue running even if the `TopologyManager` policy changes across a kubelet restart and the affinity properties of the pod are different than the ones allowed by the new policy. We need to decide if this is acceptable or not before proceeding with this PR.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
After a kubelet restart, pods will now continue running even if the `TopologyManager` policy changes across a kubelet restart and the affinity properties of the pod are different than the ones allowed by the new policy.
```