### PR TITLE
client-go/tools: Docs: Clarify what's "old" core/v1 and what's "new" events/v1beta1

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/BUILD
+++ b/staging/src/k8s.io/client-go/tools/events/BUILD
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "doc.go",
         "event_broadcaster.go",
         "event_recorder.go",
         "fake.go",

--- a/staging/src/k8s.io/client-go/tools/events/doc.go
+++ b/staging/src/k8s.io/client-go/tools/events/doc.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2014 The Kubernetes Authors.
+Copyright 2019 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package record has all client logic for recording and reporting
-// "k8s.io/api/core/v1".Event events.
-package record // import "k8s.io/client-go/tools/record"
+// Package events has all client logic for recording and reporting
+// "k8s.io/api/events/v1beta1".Event events.
+package events // import "k8s.io/client-go/tools/events"

--- a/staging/src/k8s.io/client-go/tools/record/event.go
+++ b/staging/src/k8s.io/client-go/tools/record/event.go
@@ -132,14 +132,14 @@ type EventBroadcaster interface {
 	Shutdown()
 }
 
-// EventRecorderAdapter is a wrapper around EventRecorder implementing the
-// new EventRecorder interface.
+// EventRecorderAdapter is a wrapper around a "k8s.io/client-go/tools/record".EventRecorder
+// implementing the new "k8s.io/client-go/tools/events".EventRecorder interface.
 type EventRecorderAdapter struct {
 	recorder EventRecorder
 }
 
-// NewEventRecorderAdapter returns an adapter implementing new EventRecorder
-// interface.
+// NewEventRecorderAdapter returns an adapter implementing the new
+// "k8s.io/client-go/tools/events".EventRecorder interface.
 func NewEventRecorderAdapter(recorder EventRecorder) *EventRecorderAdapter {
 	return &EventRecorderAdapter{
 		recorder: recorder,


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation
/sig scalability

**What this PR does / why we need it**:

With the work going in to https://github.com/kubernetes/enhancements/issues/383 / https://git.k8s.io/community/contributors/design-proposals/instrumentation/events-redesign.md it's confusing what's what.  I believe that it is important for the documentation to distinguish between pre-"events-redesign.md" and post-"events-redesign.md" things.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

This is split off from #84798 at the suggestion of @wojtek-t.  This is the portion of #84798 that does not require API review.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```