### PR TITLE
Remove ready directory which created in empty volumeMounter setUp func

### DIFF
--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -389,6 +389,11 @@ func (ed *emptyDir) TearDown() error {
 
 // TearDownAt simply discards everything in the directory.
 func (ed *emptyDir) TearDownAt(dir string) error {
+	defer func() {
+		// remove ready dir which created in TearUp func
+		volumeutil.CleanReady(ed.getMetaDir())
+	}()
+
 	if pathExists, pathErr := mount.PathExists(dir); pathErr != nil {
 		return fmt.Errorf("Error checking if path exists: %v", pathErr)
 	} else if !pathExists {

--- a/pkg/volume/util/util.go
+++ b/pkg/volume/util/util.go
@@ -108,6 +108,13 @@ func SetReady(dir string) {
 	file.Close()
 }
 
+// CleanReady remove the 'ready' file
+func CleanReady(dir string) {
+	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+		klog.Errorf("remove directory %s error %v", dir, err)
+	}
+}
+
 // GetSecretForPod locates secret by name in the pod's namespace and returns secret map
 func GetSecretForPod(pod *v1.Pod, secretName string, kubeClient clientset.Interface) (map[string]string, error) {
 	secret := make(map[string]string)

--- a/pkg/volume/util/util_test.go
+++ b/pkg/volume/util/util_test.go
@@ -21,6 +21,9 @@ import (
 	"os"
 	"runtime"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	v1 "k8s.io/api/core/v1"
 
@@ -881,4 +884,11 @@ func TestGetPodVolumeNames(t *testing.T) {
 			}
 		})
 	}
+}
+func TestCleanReady(t *testing.T) {
+	tsDir, err := ioutil.TempDir("", time.Now().UTC().Format("..2006_01_02_15_04_05."))
+	assert.NoErrorf(t, err, "unable to create new temp directory: %v", err)
+	CleanReady(tsDir)
+	_, err = os.Stat(tsDir)
+	assert.True(t, os.IsNotExist(err))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind bug

**What this PR does / why we need it**:

For configMap volumeMounter , kubelet will  invoke emptyDir volumeMounter to do ```setUp``` and ```TearDown```. In emptyDir volumeMounter ```setUp``` func,  kubelet will check ```ready``` directory exist, if exist  and   If the medium is memory, and a mountpoint is present, then the volume will be thinked ready ,will not create volume directory again.
![image](https://user-images.githubusercontent.com/12136478/68675263-784e8f80-0592-11ea-85e8-2623c2369ef4.png)

In configMap volumeMounter, it invoke emtpyDir volumeMount to  do ```setUp```  and then write payload and so on, if failed, it will invoke emtpyDir volumeMount to do ```TearDown```
![image](https://user-images.githubusercontent.com/12136478/68675568-20fcef00-0593-11ea-9dec-4839794f35f3.png)

In emptyDir volumeMounter ``` TearDown ```, it will check volume directory whether exist, if not exist ,it will do nothing, else it will remove volume directory, but not clean ready directory.
![image](https://user-images.githubusercontent.com/12136478/68675746-7802c400-0593-11ea-8fc5-93f4578431b0.png)

In scenario，in ```setUp``` func, after volume directory and  ready directory created, but write payload  error, it will clean  volume directory. In next loop, because of ready directory exist, it will not create volume directory again, and then ```NewAtomicWriter``` func  which is check volume directory first will error, just like 
```
Nov 06 16:18:18 9-13-2-186 kubelet[1275]: E1106 16:18:18.186965    1275 configmap.go:244] Error creating atomic writer: stat /var/lib/kubelet/pods/a8bfc7bd-daff-11e9-b117-fae200526c00/volumes/kubernetes.io~configmap/kube-proxy-master: no such file or directory
Nov 06 16:18:18 9-13-2-186 kubelet[1275]: W1106 16:18:18.187092    1275 empty_dir.go:373] Warning: Unmount skipped because path does not exist:
/var/lib/kubelet/pods/a8bfc7bd-daff-11e9-b117-fae200526c00/volumes/kubernetes.io~configmap/kube-proxy-master
Nov 06 16:18:18 9-13-2-186 kubelet[1275]: E1106 16:18:18.187294    1275 nestedpendingoperations.go:267] Operation for "\"kubernetes.io/configmap
/a8bfc7bd-daff-11e9-b117-fae200526c00-kube-proxy-master\" (\"a8bfc7bd-daff-11e9-b117-fae200526c00\")" failed. No retries permitted until 2019-11
```

So in emptyDir volumeMounter ``` TearDown ```, kubelet should clean ready directory.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #72675 


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove ready dir which created in setup func
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
