### PR TITLE
allow individual ca bundles to be empty in union

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig_test.go
@@ -100,12 +100,6 @@ func TestNewStaticCertKeyContent(t *testing.T) {
 			},
 		},
 		{
-			name:        "missingCA",
-			clientCA:    &staticCAContent{name: "test-ca", caBundle: &caBundleAndVerifier{caBundle: []byte("")}},
-			expected:    nil,
-			expectedErr: `not loading an empty client ca bundle from "test-ca"`,
-		},
-		{
 			name:     "nil",
 			expected: &dynamicCertificateContent{clientCA: caBundleContent{}, servingCert: certKeyContent{}},
 		},

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/union_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/union_content.go
@@ -48,7 +48,9 @@ func (c unionCAContent) Name() string {
 func (c unionCAContent) CurrentCABundleContent() []byte {
 	caBundles := [][]byte{}
 	for _, curr := range c {
-		caBundles = append(caBundles, curr.CurrentCABundleContent())
+		if currCABytes := curr.CurrentCABundleContent(); len(currCABytes) > 0 {
+			caBundles = append(caBundles, []byte(strings.TrimSpace(string(currCABytes))))
+		}
 	}
 
 	return bytes.Join(caBundles, []byte("\n"))


### PR DESCRIPTION
Since https://github.com/kubernetes/kubernetes/pull/84864 merged, we can have empty ca bundles.  This means that the union needs to skip empty ca bundles or you get invalid (empty) bundles.

/kind bug
/priority important-soon
@kubernetes/sig-api-machinery-bugs 

```release-note
NONE
```