### PR TITLE
[kubeadm] Remove nested retries

### DIFF
--- a/cmd/kubeadm/app/discovery/token/BUILD
+++ b/cmd/kubeadm/app/discovery/token/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//cmd/kubeadm/app/util/pubkeypin:go_default_library",
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
@@ -74,16 +73,11 @@ func RetrieveValidatedConfigInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmda
 		klog.V(1).Infof("[discovery] Created cluster-info discovery client, requesting info from %q\n", insecureBootstrapConfig.Clusters[clusterName].Server)
 
 		// Make an initial insecure connection to get the cluster-info ConfigMap
-		var insecureClusterInfo *v1.ConfigMap
-		wait.PollImmediateInfinite(constants.DiscoveryRetryInterval, func() (bool, error) {
-			var err error
-			insecureClusterInfo, err = insecureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
-			if err != nil {
-				klog.V(1).Infof("[discovery] Failed to request cluster info, will try again: [%s]\n", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		insecureClusterInfo, err := insecureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+		if err != nil {
+			klog.V(1).Infof("[discovery] Failed to request cluster info: [%s]\n", err)
+			return nil, err
+		}
 
 		// Validate the MAC on the kubeconfig from the ConfigMap and load it
 		insecureKubeconfigString, ok := insecureClusterInfo.Data[bootstrapapi.KubeConfigKey]
@@ -138,16 +132,11 @@ func RetrieveValidatedConfigInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmda
 		}
 
 		klog.V(1).Infof("[discovery] Requesting info from %q again to validate TLS against the pinned public key\n", insecureBootstrapConfig.Clusters[clusterName].Server)
-		var secureClusterInfo *v1.ConfigMap
-		wait.PollImmediateInfinite(constants.DiscoveryRetryInterval, func() (bool, error) {
-			var err error
-			secureClusterInfo, err = secureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
-			if err != nil {
-				klog.V(1).Infof("[discovery] Failed to request cluster info, will try again: [%s]\n", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		secureClusterInfo, err := secureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+		if err != nil {
+			klog.V(1).Infof("[discovery] Failed to request cluster info: [%s]\n", err)
+			return nil, err
+		}
 
 		// Pull the kubeconfig from the securely-obtained ConfigMap and validate that it's the same as what we found the first time
 		secureKubeconfigBytes := []byte(secureClusterInfo.Data[bootstrapapi.KubeConfigKey])


### PR DESCRIPTION
This infinite poll can make kubeadm init/join hang forever due
to a lack of function cancelling.

Signed-off-by: Chuck Ha <chuckh@vmware.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR removes a bug in `kubeadm init/join` commands where it would hang forever if the API server never became accessible.

**Which issue(s) this PR fixes**:
Fixes kubernetes/kubeadm#1851

**Special notes for your reviewer**:
This removes the PollInfinite because the function calling PollInfinite already polls and there is no need for a second poll within a poll.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a bug in kubeadm that caused init and join to hang indefinitely in specific conditions.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
https://github.com/kubernetes/kubeadm/issues/1851#issuecomment-553117808

/assign @neolit123 