### PR TITLE
Store topology spread constraints in metadata with labels.Selector

### DIFF
--- a/pkg/scheduler/algorithm/priorities/spreading_perf_test.go
+++ b/pkg/scheduler/algorithm/priorities/spreading_perf_test.go
@@ -59,8 +59,12 @@ func BenchmarkTestDefaultEvenPodsSpreadPriority(b *testing.B) {
 			b.ResetTimer()
 
 			for i := 0; i < b.N; i++ {
+				tpSpreadMap, err := buildPodTopologySpreadMap(pod, filteredNodes, snapshot.NodeInfoList)
+				if err != nil {
+					b.Fatal(err)
+				}
 				meta := &priorityMetadata{
-					podTopologySpreadMap: buildPodTopologySpreadMap(pod, filteredNodes, snapshot.NodeInfoList),
+					podTopologySpreadMap: tpSpreadMap,
 				}
 				var gotList framework.NodeScoreList
 				for _, n := range filteredNodes {
@@ -70,7 +74,7 @@ func BenchmarkTestDefaultEvenPodsSpreadPriority(b *testing.B) {
 					}
 					gotList = append(gotList, score)
 				}
-				err := CalculateEvenPodsSpreadPriorityReduce(pod, meta, snapshot, gotList)
+				err = CalculateEvenPodsSpreadPriorityReduce(pod, meta, snapshot, gotList)
 				if err != nil {
 					b.Fatal(err)
 				}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Stores topology spread constraints in predicates and priority metadata, also parsing `labels.Selector`. This allows:

1. Single filtering of the constraints
1. Single parsing of selectors. This will also enable setting default constraints with generated selectors.

Additionally, this improves the performance of EvenPodsSpreadPriority, making it about 2x faster:

```
== master ==
BenchmarkTestDefaultEvenPodsSpreadPriority/100nodes-56         	    1148	   1150543 ns/op
BenchmarkTestDefaultEvenPodsSpreadPriority/1000nodes-56        	     190	   6018880 ns/op

BenchmarkTestCalculateEvenPodsSpreadPriority/1000nodes/single-constraint-zone-56         	    3369	    343371 ns/op
BenchmarkTestCalculateEvenPodsSpreadPriority/1000nodes/single-constraint-node-56         	    3195	    353818 ns/op
BenchmarkTestCalculateEvenPodsSpreadPriority/1000nodes/two-constraints-zone-node-56      	    2323	    498521 ns/op

== this PR ==

BenchmarkTestDefaultEvenPodsSpreadPriority/100nodes-56         	    2653	    491937 ns/op
BenchmarkTestDefaultEvenPodsSpreadPriority/1000nodes-56        	     322	   3582697 ns/op

BenchmarkTestCalculateEvenPodsSpreadPriority/1000nodes/single-constraint-zone-56         	    5017	    248531 ns/op
BenchmarkTestCalculateEvenPodsSpreadPriority/1000nodes/single-constraint-node-56         	    4014	    253732 ns/op
BenchmarkTestCalculateEvenPodsSpreadPriority/1000nodes/two-constraints-zone-node-56      	    3434	    300619 ns/op
```

Ref #84936

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
