### PR TITLE
Moving the detection of manual conversion functions to a dedicated struct

### DIFF
--- a/staging/src/k8s.io/code-generator/BUILD
+++ b/staging/src/k8s.io/code-generator/BUILD
@@ -21,6 +21,7 @@ filegroup(
         "//staging/src/k8s.io/code-generator/cmd/register-gen:all-srcs",
         "//staging/src/k8s.io/code-generator/cmd/set-gen:all-srcs",
         "//staging/src/k8s.io/code-generator/hack:all-srcs",
+        "//staging/src/k8s.io/code-generator/pkg/conversiongen:all-srcs",
         "//staging/src/k8s.io/code-generator/pkg/namer:all-srcs",
         "//staging/src/k8s.io/code-generator/pkg/util:all-srcs",
         "//staging/src/k8s.io/code-generator/third_party/forked/golang/reflect:all-srcs",

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/BUILD
@@ -12,6 +12,7 @@ go_library(
     importpath = "k8s.io/code-generator/cmd/conversion-gen/generators",
     deps = [
         "//staging/src/k8s.io/code-generator/cmd/conversion-gen/args:go_default_library",
+        "//staging/src/k8s.io/code-generator/pkg/conversiongen:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/generator:go_default_library",
         "//vendor/k8s.io/gengo/namer:go_default_library",

--- a/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
+++ b/staging/src/k8s.io/code-generator/cmd/conversion-gen/generators/conversion.go
@@ -17,7 +17,6 @@ limitations under the License.
 package generators
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -33,6 +32,7 @@ import (
 	"k8s.io/klog"
 
 	conversionargs "k8s.io/code-generator/cmd/conversion-gen/args"
+	"k8s.io/code-generator/pkg/conversiongen"
 )
 
 // These are the comment tags that carry parameters for conversion generation.
@@ -125,78 +125,6 @@ type conversionPair struct {
 	outType *types.Type
 }
 
-// All of the types in conversions map are of type "DeclarationOf" with
-// the underlying type being "Func".
-type conversionFuncMap map[conversionPair]*types.Type
-
-// Returns all manually-defined conversion functions in the package.
-func getManualConversionFunctions(context *generator.Context, pkg *types.Package, manualMap conversionFuncMap) {
-	if pkg == nil {
-		klog.Warningf("Skipping nil package passed to getManualConversionFunctions")
-		return
-	}
-	klog.V(5).Infof("Scanning for conversion functions in %v", pkg.Name)
-
-	scopeName := types.Ref(conversionPackagePath, "Scope").Name
-	errorName := types.Ref("", "error").Name
-	buffer := &bytes.Buffer{}
-	sw := generator.NewSnippetWriter(buffer, context, "$", "$")
-
-	for _, f := range pkg.Functions {
-		if f.Underlying == nil || f.Underlying.Kind != types.Func {
-			klog.Errorf("Malformed function: %#v", f)
-			continue
-		}
-		if f.Underlying.Signature == nil {
-			klog.Errorf("Function without signature: %#v", f)
-			continue
-		}
-		klog.V(8).Infof("Considering function %s", f.Name)
-		signature := f.Underlying.Signature
-		// Check whether the function is conversion function.
-		// Note that all of them have signature:
-		// func Convert_inType_To_outType(inType, outType, conversion.Scope) error
-		if signature.Receiver != nil {
-			klog.V(8).Infof("%s has a receiver", f.Name)
-			continue
-		}
-		if len(signature.Parameters) != 3 || signature.Parameters[2].Name != scopeName {
-			klog.V(8).Infof("%s has wrong parameters", f.Name)
-			continue
-		}
-		if len(signature.Results) != 1 || signature.Results[0].Name != errorName {
-			klog.V(8).Infof("%s has wrong results", f.Name)
-			continue
-		}
-		inType := signature.Parameters[0]
-		outType := signature.Parameters[1]
-		if inType.Kind != types.Pointer || outType.Kind != types.Pointer {
-			klog.V(8).Infof("%s has wrong parameter types", f.Name)
-			continue
-		}
-		// Now check if the name satisfies the convention.
-		// TODO: This should call the Namer directly.
-		args := argsFromType(inType.Elem, outType.Elem)
-		sw.Do("Convert_$.inType|public$_To_$.outType|public$", args)
-		if f.Name.Name == buffer.String() {
-			klog.V(4).Infof("Found conversion function %s", f.Name)
-			key := conversionPair{inType.Elem, outType.Elem}
-			// We might scan the same package twice, and that's OK.
-			if v, ok := manualMap[key]; ok && v != nil && v.Name.Package != pkg.Path {
-				panic(fmt.Sprintf("duplicate static conversion defined: %s -> %s from:\n%s.%s\n%s.%s", key.inType, key.outType, v.Name.Package, v.Name.Name, f.Name.Package, f.Name.Name))
-			}
-			manualMap[key] = f
-		} else {
-			// prevent user error when they don't get the correct conversion signature
-			if strings.HasPrefix(f.Name.Name, "Convert_") {
-				klog.Errorf("Rename function %s %s -> %s to match expected conversion signature", f.Name.Package, f.Name.Name, buffer.String())
-			}
-			klog.V(8).Infof("%s has wrong name", f.Name)
-		}
-		buffer.Reset()
-	}
-}
-
 func Packages(context *generator.Context, arguments *args.GeneratorArgs) generator.Packages {
 	boilerplate, err := arguments.LoadGoBoilerplate()
 	if err != nil {
@@ -207,8 +135,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 	header := append([]byte(fmt.Sprintf("// +build !%s\n\n", arguments.GeneratedBuildTag)), boilerplate...)
 
 	// Accumulate pre-existing conversion functions.
-	// TODO: This is too ad-hoc.  We need a better way.
-	manualConversions := conversionFuncMap{}
+	scopeVar := conversiongen.NewNamedVariable("s", types.Ref(conversionPackagePath, "Scope"))
+	manualConversionsTracker := conversiongen.NewManualConversionsTracker(scopeVar)
 
 	// Record types that are memory equivalent. A type is memory equivalent
 	// if it has the same memory layout and no nested manual conversion is
@@ -240,7 +168,9 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 		}
 
 		// Add conversion and defaulting functions.
-		getManualConversionFunctions(context, pkg, manualConversions)
+		if errs := manualConversionsTracker.FindManualConversionFunctions(context, pkg.Path); len(errs) != 0 {
+			klog.Fatalf("Failed to find manual conversion functions: %v", errs)
+		}
 
 		// Only generate conversions for packages which explicitly request it
 		// by specifying one or more "+k8s:conversion-gen=<peer-pkg>"
@@ -309,7 +239,9 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 			if nil == p {
 				klog.Fatalf("failed to find pkg: %s", pp)
 			}
-			getManualConversionFunctions(context, p, manualConversions)
+			if errs := manualConversionsTracker.FindManualConversionFunctions(context, p.Path); len(errs) != 0 {
+				klog.Fatalf("Failed to find manual conversion functions: %v", errs)
+			}
 		}
 
 		unsafeEquality := TypesEqual(memoryEquivalentTypes)
@@ -338,7 +270,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 				HeaderText:  header,
 				GeneratorFunc: func(c *generator.Context) (generators []generator.Generator) {
 					return []generator.Generator{
-						NewGenConversion(arguments.OutputFileBaseName, typesPkg.Path, pkg.Path, manualConversions, peerPkgs, unsafeEquality),
+						NewGenConversion(arguments.OutputFileBaseName, typesPkg.Path, pkg.Path, manualConversionsTracker, peerPkgs, unsafeEquality),
 					}
 				},
 				FilterFunc: func(c *generator.Context, t *types.Type) bool {
@@ -349,13 +281,13 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 	// If there is a manual conversion defined between two types, exclude it
 	// from being a candidate for unsafe conversion
-	for k, v := range manualConversions {
+	for k, v := range manualConversionsTracker.ConversionFunctions {
 		if isCopyOnly(v.CommentLines) {
 			klog.V(5).Infof("Conversion function %s will not block memory copy because it is copy-only", v.Name)
 			continue
 		}
 		// this type should be excluded from all equivalence, because the converter must be called.
-		memoryEquivalentTypes.Skip(k.inType, k.outType)
+		memoryEquivalentTypes.Skip(k.InType, k.OutType)
 	}
 
 	return packages
@@ -473,29 +405,29 @@ type genConversion struct {
 	// the package that the conversion funcs are going to be output to
 	outputPackage string
 	// packages that contain the peer of types in typesPacakge
-	peerPackages        []string
-	manualConversions   conversionFuncMap
-	imports             namer.ImportTracker
-	types               []*types.Type
-	explicitConversions []conversionPair
-	skippedFields       map[*types.Type][]string
-	useUnsafe           TypesEqual
+	peerPackages             []string
+	manualConversionsTracker *conversiongen.ManualConversionsTracker
+	imports                  namer.ImportTracker
+	types                    []*types.Type
+	explicitConversions      []conversionPair
+	skippedFields            map[*types.Type][]string
+	useUnsafe                TypesEqual
 }
 
-func NewGenConversion(sanitizedName, typesPackage, outputPackage string, manualConversions conversionFuncMap, peerPkgs []string, useUnsafe TypesEqual) generator.Generator {
+func NewGenConversion(sanitizedName, typesPackage, outputPackage string, manualConversionsTracker *conversiongen.ManualConversionsTracker, peerPkgs []string, useUnsafe TypesEqual) generator.Generator {
 	return &genConversion{
 		DefaultGen: generator.DefaultGen{
 			OptionalName: sanitizedName,
 		},
-		typesPackage:        typesPackage,
-		outputPackage:       outputPackage,
-		peerPackages:        peerPkgs,
-		manualConversions:   manualConversions,
-		imports:             generator.NewImportTracker(),
-		types:               []*types.Type{},
-		explicitConversions: []conversionPair{},
-		skippedFields:       map[*types.Type][]string{},
-		useUnsafe:           useUnsafe,
+		typesPackage:             typesPackage,
+		outputPackage:            outputPackage,
+		peerPackages:             peerPkgs,
+		manualConversionsTracker: manualConversionsTracker,
+		imports:                  generator.NewImportTracker(),
+		types:                    []*types.Type{},
+		explicitConversions:      []conversionPair{},
+		skippedFields:            map[*types.Type][]string{},
+		useUnsafe:                useUnsafe,
 	}
 }
 
@@ -633,8 +565,7 @@ func argsFromType(inType, outType *types.Type) generator.Args {
 const nameTmpl = "Convert_$.inType|publicIT$_To_$.outType|publicIT$"
 
 func (g *genConversion) preexists(inType, outType *types.Type) (*types.Type, bool) {
-	function, ok := g.manualConversions[conversionPair{inType, outType}]
-	return function, ok
+	return g.manualConversionsTracker.Preexists(inType, outType)
 }
 
 func (g *genConversion) Init(c *generator.Context, w io.Writer) error {
@@ -684,8 +615,9 @@ func (g *genConversion) Init(c *generator.Context, w io.Writer) error {
 		sw.Do("if err := s.AddGeneratedConversionFunc((*$.inType|raw$)(nil), (*$.outType|raw$)(nil), func(a, b interface{}, scope $.Scope|raw$) error { return "+nameTmpl+"(a.(*$.inType|raw$), b.(*$.outType|raw$), scope) }); err != nil { return err }\n", args)
 	}
 
-	var pairs []conversionPair
-	for pair, t := range g.manualConversions {
+	conversionFuncs := g.manualConversionsTracker.ConversionFunctions
+	var pairs []conversiongen.ConversionPair
+	for pair, t := range conversionFuncs {
 		if t.Name.Package != g.outputPackage {
 			continue
 		}
@@ -693,13 +625,13 @@ func (g *genConversion) Init(c *generator.Context, w io.Writer) error {
 	}
 	// sort by name of the conversion function
 	sort.Slice(pairs, func(i, j int) bool {
-		if g.manualConversions[pairs[i]].Name.Name < g.manualConversions[pairs[j]].Name.Name {
+		if conversionFuncs[pairs[i]].Name.Name < conversionFuncs[pairs[j]].Name.Name {
 			return true
 		}
 		return false
 	})
 	for _, pair := range pairs {
-		args := argsFromType(pair.inType, pair.outType).With("Scope", types.Ref(conversionPackagePath, "Scope")).With("fn", g.manualConversions[pair])
+		args := argsFromType(pair.InType, pair.OutType).With("Scope", types.Ref(conversionPackagePath, "Scope")).With("fn", conversionFuncs[pair])
 		sw.Do("if err := s.AddConversionFunc((*$.inType|raw$)(nil), (*$.outType|raw$)(nil), func(a, b interface{}, scope $.Scope|raw$) error { return $.fn|raw$(a.(*$.inType|raw$), b.(*$.outType|raw$), scope) }); err != nil { return err }\n", args)
 	}
 

--- a/staging/src/k8s.io/code-generator/pkg/conversiongen/BUILD
+++ b/staging/src/k8s.io/code-generator/pkg/conversiongen/BUILD
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "manual_conversions_tracker.go",
+        "utils.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/code-generator/pkg/conversiongen",
+    importpath = "k8s.io/code-generator/pkg/conversiongen",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/k8s.io/gengo/generator:go_default_library",
+        "//vendor/k8s.io/gengo/namer:go_default_library",
+        "//vendor/k8s.io/gengo/types:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/code-generator/pkg/conversiongen/doc.go
+++ b/staging/src/k8s.io/code-generator/pkg/conversiongen/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package conversiongen contains generic structures and helpers to write conversion generators.
+package conversiongen

--- a/staging/src/k8s.io/code-generator/pkg/conversiongen/manual_conversions_tracker.go
+++ b/staging/src/k8s.io/code-generator/pkg/conversiongen/manual_conversions_tracker.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversiongen
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"k8s.io/klog"
+
+	"k8s.io/gengo/generator"
+	"k8s.io/gengo/namer"
+	"k8s.io/gengo/types"
+)
+
+// ManualConversionsTracker keeps track of manually defined conversion functions.
+type ManualConversionsTracker struct {
+	// see the explanation on NewManualConversionsTracker.
+	additionalConversionArguments []NamedVariable
+
+	// processedPackages keeps track of which packages have already been processed, as there
+	// is no need to ever process the same package twice.
+	processedPackages map[string][]error
+
+	// ConversionFunctions keeps track of the manual function definitions known to this tracker.
+	ConversionFunctions map[ConversionPair]*types.Type
+
+	// see conversionFunctionName
+	buffer          *bytes.Buffer
+	conversionNamer *namer.NameStrategy
+}
+
+// NewManualConversionsTracker builds a new ManualConversionsTracker.
+// Additional conversion arguments allow users to set which arguments should be part of
+// a conversion function signature.
+// When generating conversion code, those will be added to the signature of each conversion function,
+// and then passed down to conversion functions for embedded types. This allows to generate
+// conversion code with additional argument, eg
+//    Convert_a_X_To_b_Y(in *a.X, out *b.Y, s conversion.Scope) error
+// Manually defined conversion functions will also be expected to have similar signatures.
+func NewManualConversionsTracker(additionalConversionArguments ...NamedVariable) *ManualConversionsTracker {
+	return &ManualConversionsTracker{
+		additionalConversionArguments: additionalConversionArguments,
+		processedPackages:             make(map[string][]error),
+		ConversionFunctions:           make(map[ConversionPair]*types.Type),
+		buffer:                        &bytes.Buffer{},
+		conversionNamer:               ConversionNamer(),
+	}
+}
+
+var errorName = types.Ref("", "error").Name
+
+// FindManualConversionFunctions looks for conversion functions in the given package.
+func (t *ManualConversionsTracker) FindManualConversionFunctions(context *generator.Context, packagePath string) (errors []error) {
+	if e, present := t.processedPackages[packagePath]; present {
+		// already processed
+		return e
+	}
+
+	pkg, err := context.AddDirectory(packagePath)
+	if err != nil {
+		return []error{fmt.Errorf("unable to add directory %q to context: %v", packagePath, err)}
+	}
+	if pkg == nil {
+		klog.Warningf("Skipping nil package passed to getManualConversionFunctions")
+		return
+	}
+	klog.V(5).Infof("Scanning for conversion functions in %v", pkg.Path)
+
+	for _, function := range pkg.Functions {
+		if function.Underlying == nil || function.Underlying.Kind != types.Func {
+			errors = append(errors, fmt.Errorf("malformed function: %#v", function))
+			continue
+		}
+		if function.Underlying.Signature == nil {
+			errors = append(errors, fmt.Errorf("function without signature: %#v", function))
+			continue
+		}
+
+		klog.V(8).Infof("Considering function %s", function.Name)
+
+		isConversionFunc, inType, outType := t.isConversionFunction(function)
+		if !isConversionFunc {
+			if strings.HasPrefix(function.Name.Name, conversionFunctionPrefix) {
+				errors = append(errors, fmt.Errorf("function %s %s does not match expected conversion signature",
+					function.Name.Package, function.Name.Name))
+			}
+			continue
+		}
+
+		// it is a conversion function
+		key := ConversionPair{inType.Elem, outType.Elem}
+		if previousConversionFunc, present := t.ConversionFunctions[key]; present {
+			errors = append(errors, fmt.Errorf("duplicate static conversion defined: %s -> %s from:\n%s.%s\n%s.%s",
+				inType, outType, previousConversionFunc.Name.Package, previousConversionFunc.Name.Name, function.Name.Package, function.Name.Name))
+			continue
+		}
+		t.ConversionFunctions[key] = function
+	}
+
+	t.processedPackages[packagePath] = errors
+	return
+}
+
+// isConversionFunction returns true iff the given function is a conversion function; that is of the form
+// func Convert_a_X_To_b_Y(in *a.X, out *b.Y, additionalConversionArguments...) error
+// If it is a signature functions, also returns the inType and outType.
+func (t *ManualConversionsTracker) isConversionFunction(function *types.Type) (bool, *types.Type, *types.Type) {
+	signature := function.Underlying.Signature
+
+	if signature.Receiver != nil {
+		klog.V(8).Infof("%s has a receiver", function.Name)
+		return false, nil, nil
+	}
+	if len(signature.Results) != 1 || signature.Results[0].Name != errorName {
+		klog.V(8).Infof("%s has wrong results", function.Name)
+		return false, nil, nil
+	}
+	// 2 (in and out) + additionalConversionArguments
+	if len(signature.Parameters) != 2+len(t.additionalConversionArguments) {
+		klog.V(8).Infof("%s has wrong number of parameters", function.Name)
+		return false, nil, nil
+	}
+	inType := signature.Parameters[0]
+	outType := signature.Parameters[1]
+	if inType.Kind != types.Pointer || outType.Kind != types.Pointer {
+		klog.V(8).Infof("%s does not have pointers parameters for in/out", function.Name)
+		return false, nil, nil
+	}
+	for i, extraArg := range t.additionalConversionArguments {
+		if signature.Parameters[i+2].Name != extraArg.Type.Name {
+			klog.V(8).Infof("%s's %d-th parameter has wrong type: %q VS %q",
+				function.Name, i+2, signature.Parameters[i+2].Name, extraArg.Type.Name)
+			return false, nil, nil
+		}
+	}
+
+	// check it satisfies the naming convention
+	if function.Name.Name != t.conversionFunctionName(inType.Elem, outType.Elem) {
+		return false, nil, nil
+	}
+
+	return true, inType, outType
+}
+
+// Preexists returns true iff a manual conversion function from inType to outType was found;
+// in which case it also returns the Type of the conversion function.
+func (t *ManualConversionsTracker) Preexists(inType, outType *types.Type) (*types.Type, bool) {
+	function, ok := t.ConversionFunctions[ConversionPair{inType, outType}]
+	return function, ok
+}
+
+// conversionFunctionName returns the name of the conversion function for in to out.
+func (t *ManualConversionsTracker) conversionFunctionName(in, out *types.Type) string {
+	return conversionFunctionName(in, out, t.conversionNamer, t.buffer)
+}

--- a/staging/src/k8s.io/code-generator/pkg/conversiongen/utils.go
+++ b/staging/src/k8s.io/code-generator/pkg/conversiongen/utils.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversiongen
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"k8s.io/gengo/generator"
+	"k8s.io/gengo/namer"
+	"k8s.io/gengo/types"
+	"k8s.io/klog"
+)
+
+// ConversionPair represents a conversion pair from inType to outType
+type ConversionPair struct {
+	InType  *types.Type
+	OutType *types.Type
+}
+
+// A NamedVariable represents a named variable to be rendered in snippets.
+type NamedVariable struct {
+	Name string
+	Type *types.Type
+}
+
+// NewNamedVariable builds a new NamedVariable.
+func NewNamedVariable(name string, t *types.Type) NamedVariable {
+	return NamedVariable{
+		Name: name,
+		Type: t,
+	}
+}
+
+const (
+	conversionFunctionPrefix = "Convert_"
+	snippetDelimiter         = "$"
+)
+
+func conversionFunctionNameTemplate(namer string) string {
+	return fmt.Sprintf("%s%s.inType|%s%s_To_%s.outType|%s%s",
+		conversionFunctionPrefix, snippetDelimiter, namer, snippetDelimiter, snippetDelimiter, namer, snippetDelimiter)
+}
+
+func argsFromType(inType, outType *types.Type) generator.Args {
+	return generator.Args{
+		"inType":  inType,
+		"outType": outType,
+	}
+}
+
+// ConversionNamer returns a namer for conversion function names.
+// It is a good namer to use as a default namer when using conversion generators,
+// so as to limit the number of changes the generator makes.
+func ConversionNamer() *namer.NameStrategy {
+	return &namer.NameStrategy{
+		Join: func(pre string, in []string, post string) string {
+			return strings.Join(in, "_")
+		},
+		PrependPackageNames: 1,
+	}
+}
+
+func conversionFunctionName(in, out *types.Type, conversionNamer *namer.NameStrategy, buffer *bytes.Buffer) string {
+	namerName := "conversion"
+	tmpl, err := template.New(fmt.Sprintf("conversion function name from %s to %s", in.Name, out.Name)).
+		Delims(snippetDelimiter, snippetDelimiter).
+		Funcs(map[string]interface{}{namerName: conversionNamer.Name}).
+		Parse(conversionFunctionNameTemplate(namerName))
+	if err != nil {
+		// this really shouldn't error out
+		klog.Fatalf("error when generating conversion function name: %v", err)
+	}
+	buffer.Reset()
+	err = tmpl.Execute(buffer, argsFromType(in, out))
+	if err != nil {
+		// this really shouldn't error out
+		klog.Fatalf("error when generating conversion function name: %v", err)
+	}
+	return buffer.String()
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

This PR is the first of a series of PRs aimed at making
https://github.com/kubernetes/kubernetes/pull/83621
easier to review; the final goal is to separate generic conversion logic
from the bits that are specific to Kubernetes, so that other projects
can re-use this library for generating code converting structs from one
package to structs from another.

**Special notes for your reviewer**:

Please see the discussion at https://github.com/kubernetes/kubernetes/pull/83621,
and more specifically https://github.com/kubernetes/kubernetes/pull/83621#issuecomment-548967945

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
