### PR TITLE
modify dockerID to containerID

### DIFF
--- a/pkg/kubelet/kuberuntime/legacy.go
+++ b/pkg/kubelet/kuberuntime/legacy.go
@@ -44,9 +44,9 @@ func legacyLogSymlink(containerID string, containerName, podName, podNamespace s
 		containerName, containerID)
 }
 
-func logSymlink(containerLogsDir, podFullName, containerName, dockerID string) string {
+func logSymlink(containerLogsDir, podFullName, containerName, containerID string) string {
 	suffix := fmt.Sprintf(".%s", legacyLogSuffix)
-	logPath := fmt.Sprintf("%s_%s-%s", podFullName, containerName, dockerID)
+	logPath := fmt.Sprintf("%s_%s-%s", podFullName, containerName, containerID)
 	// Length of a filename cannot exceed 255 characters in ext4 on Linux.
 	if len(logPath) > ext4MaxFileNameLen-len(suffix) {
 		logPath = logPath[:ext4MaxFileNameLen-len(suffix)]


### PR DESCRIPTION
*What type of PR is this?**
/kind flake
/sig node

**What this PR does / why we need it**:
modify dockerID to containerID
this change further enforces the usage of container instead of docker in variable names.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
