### PR TITLE
WIP - Plumb resourceVersion precondition to storage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -178,11 +178,18 @@ func (i *defaultUpdatedObjectInfo) Preconditions() *metav1.Preconditions {
 
 	// If empty, no preconditions needed
 	uid := accessor.GetUID()
-	if len(uid) == 0 {
+	rv := accessor.GetResourceVersion()
+	if len(uid) == 0 && len(rv) == 0 {
 		return nil
 	}
-
-	return &metav1.Preconditions{UID: &uid}
+	p := &metav1.Preconditions{}
+	if len(uid) > 0 {
+		p.UID = &uid
+	}
+	if len(rv) > 0 {
+		p.ResourceVersion = &rv
+	}
+	return p
 }
 
 // UpdatedObject satisfies the UpdatedObjectInfo interface.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
resourceVersion was added to preconditions to support delete, but was never hooked up for update. This isn't a bug, we handle the resourceVersion precondition inside the GuaranteedUpdate loop, but hoisting it into a storage precondition would be more consistent and let it get checked earlier in the handling chain, skipping unnecessary work in case of a conflict.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
