### PR TITLE
Use log functions of core framework on e2e/storage/utils

### DIFF
--- a/test/e2e/storage/utils/BUILD
+++ b/test/e2e/storage/utils/BUILD
@@ -31,7 +31,6 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
         "//staging/src/k8s.io/client-go/util/exec:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/ssh:go_default_library",

--- a/test/e2e/storage/utils/host_exec.go
+++ b/test/e2e/storage/utils/host_exec.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/util/exec"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2elog "k8s.io/kubernetes/test/e2e/framework/log"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
@@ -38,10 +37,10 @@ type Result struct {
 // LogResult records result log
 func LogResult(result Result) {
 	remote := result.Host
-	e2elog.Logf("exec %s: command:   %s", remote, result.Cmd)
-	e2elog.Logf("exec %s: stdout:    %q", remote, result.Stdout)
-	e2elog.Logf("exec %s: stderr:    %q", remote, result.Stderr)
-	e2elog.Logf("exec %s: exit code: %d", remote, result.Code)
+	framework.Logf("exec %s: command:   %s", remote, result.Cmd)
+	framework.Logf("exec %s: stdout:    %q", remote, result.Stdout)
+	framework.Logf("exec %s: stderr:    %q", remote, result.Stderr)
+	framework.Logf("exec %s: exit code: %d", remote, result.Code)
 }
 
 // HostExec represents interface we require to execute commands on remote host.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR makes test/e2e/storage/utils to use log functions of core framework.

**Which issue(s) this PR fixes**:
Ref #81427

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
