### PR TITLE
Add Reset() API to stability framework

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -159,3 +159,12 @@ func (v *CounterVec) Delete(labels map[string]string) bool {
 	}
 	return v.CounterVec.Delete(labels)
 }
+
+// Reset deletes all metrics in this vector.
+func (v *CounterVec) Reset() {
+	if !v.IsCreated() {
+		return
+	}
+
+	v.CounterVec.Reset()
+}

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -161,6 +161,15 @@ func (v *GaugeVec) Delete(labels map[string]string) bool {
 	return v.GaugeVec.Delete(labels)
 }
 
+// Reset deletes all metrics in this vector.
+func (v *GaugeVec) Reset() {
+	if !v.IsCreated() {
+		return
+	}
+
+	v.GaugeVec.Reset()
+}
+
 func newGaugeFunc(opts GaugeOpts, function func() float64, v semver.Version) GaugeFunc {
 	g := NewGauge(&opts)
 

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -166,3 +166,12 @@ func (v *HistogramVec) Delete(labels map[string]string) bool {
 	}
 	return v.HistogramVec.Delete(labels)
 }
+
+// Reset deletes all metrics in this vector.
+func (v *HistogramVec) Reset() {
+	if !v.IsCreated() {
+		return
+	}
+
+	v.HistogramVec.Reset()
+}

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -160,3 +160,12 @@ func (v *SummaryVec) Delete(labels map[string]string) bool {
 	}
 	return v.SummaryVec.Delete(labels)
 }
+
+// Reset deletes all metrics in this vector.
+func (v *SummaryVec) Reset() {
+	if !v.IsCreated() {
+		return
+	}
+
+	v.SummaryVec.Reset()
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add Reset() API for :
- SummaryVec
- GaugeVec
- HistogramVec
- Reset

The two PR rely on this:
- #83837
- #83838

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: