### PR TITLE
Update GetDiskFormat() base on new version blkid

### DIFF
--- a/pkg/util/mount/mount_linux_test.go
+++ b/pkg/util/mount/mount_linux_test.go
@@ -437,3 +437,119 @@ func TestSearchMountPoints(t *testing.T) {
 		}
 	}
 }
+
+func TestGetDiskType(t *testing.T) {
+	tests := []struct {
+		name     string
+		disk     string
+		output   string
+		sep      string
+		expected string
+	}{
+		{
+			name:     "test_empty_n",
+			disk:     "/dev/loop3",
+			output:   "",
+			sep:      "\n",
+			expected: "",
+		},
+		{
+			name:     "test_old",
+			disk:     "/dev/loop3",
+			output:   "DEVNAME=/dev/loop3\nTYPE=xfs\n",
+			sep:      "\n",
+			expected: "xfs",
+		},
+		{
+			name:     "test_new_n",
+			disk:     "/dev/loop3",
+			output:   "/dev/loop3: UUID=\"b60a3828-ea89-4f6f-b9c8-670ab628f4bb\" TYPE=\"xfs\"\n",
+			sep:      "\n",
+			expected: "",
+		},
+		{
+			name:     "test_new",
+			disk:     "/dev/loop3",
+			output:   "/dev/loop3: UUID=\"b60a3828-ea89-4f6f-b9c8-670ab628f4bb\" TYPE=\"xfs\"\n",
+			sep:      " ",
+			expected: "xfs",
+		},
+		{
+			name:     "test_new_n_space",
+			disk:     "/dev/loop3",
+			output:   "/dev/loop3: UUID=\"b60a3828-ea89-4f6f-b9c8-670ab628f4bb\" TYPE=\"xfs\"",
+			sep:      "\n",
+			expected: "",
+		},
+		{
+			name:     "test_new_space",
+			disk:     "/dev/loop3",
+			output:   "/dev/loop3: UUID=\"b60a3828-ea89-4f6f-b9c8-670ab628f4bb\" TYPE=\"xfs\"",
+			sep:      " ",
+			expected: "xfs",
+		},
+		{
+			name:     "test_new_noquote_n",
+			disk:     "/dev/loop3",
+			output:   "/dev/loop3: UUID=b60a3828-ea89-4f6f-b9c8-670ab628f4bb TYPE=xfs\n",
+			sep:      "\n",
+			expected: "",
+		},
+		{
+			name:     "test_new_noquote",
+			disk:     "/dev/loop3",
+			output:   "/dev/loop3: UUID=b60a3828-ea89-4f6f-b9c8-670ab628f4bb TYPE=xfs\n",
+			sep:      " ",
+			expected: "xfs",
+		},
+		{
+			name:     "test_old_partition_n",
+			disk:     "/dev/loop0",
+			output:   "DEVNAME=/dev/loop0\nPTTYPE=dos\n",
+			sep:      "\n",
+			expected: "unknown data, probably partitions",
+		},
+		{
+			name:     "test_old_partition",
+			disk:     "/dev/loop0",
+			output:   "DEVNAME=/dev/loop0\nPTTYPE=dos\n",
+			sep:      " ",
+			expected: "",
+		},
+		{
+			name:     "test_new_partition_n",
+			disk:     "/dev/loop0",
+			output:   "/dev/loop0: UUID=61a18521-3b84-4d20-ac35-0d3f819ce6b8 PTTYPE=dos\n",
+			sep:      "\n",
+			expected: "",
+		},
+		{
+			name:     "test_new_partition",
+			disk:     "/dev/loop0",
+			output:   "/dev/loop0: UUID=61a18521-3b84-4d20-ac35-0d3f819ce6b8 PTTYPE=dos\n",
+			sep:      " ",
+			expected: "unknown data, probably partitions",
+		},
+		{
+			name:     "test_bad_data_n",
+			disk:     "/dev/loop3p1",
+			output:   "bad data\n",
+			sep:      "\n",
+			expected: "",
+		},
+		{
+			name:     "test_bad_data",
+			disk:     "/dev/loop3p1",
+			output:   "bad data\n",
+			sep:      " ",
+			expected: "",
+		},
+	}
+	for _, test := range tests {
+		result := getDiskType(test.disk, test.output, test.sep)
+		if result != test.expected {
+			t.Errorf("test %q failed: actually %v expected %v ", test.name, result, test.expected)
+		}
+
+	}
+}


### PR DESCRIPTION
Related to: #85203
This pr could get disk format base on new version blkid, and it
work fine on old version blkid

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
