### PR TITLE
Add peek function to heap data-store in client-go

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/heap.go
+++ b/staging/src/k8s.io/client-go/tools/cache/heap.go
@@ -114,6 +114,14 @@ func (h *heapData) Pop() interface{} {
 	return item.obj
 }
 
+// Peek is supposed to be called by heap.Peek only.
+func (h *heapData) Peek() interface{} {
+	if len(h.queue) > 0 {
+		return h.items[h.queue[0]].obj
+	}
+	return nil
+}
+
 // Heap is a thread-safe producer/consumer queue that implements a heap data structure.
 // It can be used to implement priority queues and similar data structures.
 type Heap struct {
@@ -256,6 +264,11 @@ func (h *Heap) Pop() (interface{}, error) {
 	}
 
 	return obj, nil
+}
+
+// Peek returns the head of the heap without removing it.
+func (h *Heap) Peek() interface{} {
+	return h.data.Peek()
 }
 
 // List returns a list of all the items.

--- a/staging/src/k8s.io/client-go/tools/cache/heap_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/heap_test.go
@@ -303,6 +303,20 @@ func TestHeap_Close(t *testing.T) {
 	}
 }
 
+// TestHeap_Peek tests Heap.Peek function.
+func TestHeap_Peek(t *testing.T) {
+	h := NewHeap(testHeapObjectKeyFunc, compareInts)
+	h.Add(mkHeapObj("foo", 10))
+	h.Add(mkHeapObj("bar", 1))
+	h.Add(mkHeapObj("bal", 31))
+
+	// Get head of the heap
+	obj := h.Peek()
+	if e, a := 1, obj.(testHeapObject).val; a != e {
+		t.Fatalf("expected %d, got %d", e, a)
+	}
+}
+
 // TestHeap_List tests Heap.List function.
 func TestHeap_List(t *testing.T) {
 	h := NewHeap(testHeapObjectKeyFunc, compareInts)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Adds a `Peek()` function to the built-in Heap data-structure in **client-go**. Peek is needed to get the root node of the heap without using Pop. Currently, there is no way to find the root node without Popping, and users of client-go might need such functionality.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
Peek is already implemented by internal heap that **kube-scheduler** uses. Changes in my PR try to resemble that while adding some test cases.

**Does this PR introduce a user-facing change?**:
```release-note
Added support for peeking root of built-in heap data-store in **client-go**.
```