### PR TITLE
WIP - Fix incorrect license location

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -421,7 +421,7 @@ function install-kube-binary-config {
     mv "${src_dir}/kubelet" "${KUBE_BIN}"
     mv "${src_dir}/kubectl" "${KUBE_BIN}"
 
-    mv "${KUBE_HOME}/kubernetes/LICENSE" "${KUBE_HOME}"
+    mv "${KUBE_HOME}/kubernetes/LICENSES" "${KUBE_HOME}"
     mv "${KUBE_HOME}/kubernetes/kubernetes-src.tar.gz" "${KUBE_HOME}"
   fi
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Reverts change made in https://github.com/kubernetes/kubernetes/pull/76586/files#diff-6a44976362555568e0243a480da2e86bR424 to pull from the correct licenses location from the extract build tar.

**Which issue(s) this PR fixes**:
Fixes #85196

```release-note
NONE
```

/cc @dims
