### PR TITLE
kubelet: add initial support for cgroupv2

### DIFF
--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -161,6 +161,10 @@ func validateSystemRequirements(mountUtil mount.Interface) (features, error) {
 		return f, fmt.Errorf("%s - %v", localErr, err)
 	}
 
+	if cgroups.IsCgroup2UnifiedMode() {
+		return f, nil
+	}
+
 	expectedCgroups := sets.NewString("cpu", "cpuacct", "cpuset", "memory")
 	for _, mountPoint := range mountPoints {
 		if mountPoint.Type == cgroupMountType {
@@ -882,6 +886,11 @@ func getContainer(pid int) (string, error) {
 	cgs, err := cgroups.ParseCgroupFile(fmt.Sprintf("/proc/%d/cgroup", pid))
 	if err != nil {
 		return "", err
+	}
+
+	if cgroups.IsCgroup2UnifiedMode() {
+		c, _ := cgs[""]
+		return c, nil
 	}
 
 	cpu, found := cgs["cpu"]

--- a/pkg/kubelet/cm/util/cgroups_linux.go
+++ b/pkg/kubelet/cm/util/cgroups_linux.go
@@ -23,19 +23,35 @@ import (
 	libcontainerutils "github.com/opencontainers/runc/libcontainer/utils"
 )
 
+const (
+	// CgroupRoot is the base path where cgroups are mounted
+	CgroupRoot = "/sys/fs/cgroup"
+)
+
 // GetPids gets pids of the desired cgroup
 // Forked from opencontainers/runc/libcontainer/cgroup/fs.Manager.GetPids()
 func GetPids(cgroupPath string) ([]int, error) {
-	dir, err := getCgroupPath(cgroupPath)
-	if err != nil {
-		return nil, err
+	dir := ""
+
+	if libcontainercgroups.IsCgroup2UnifiedMode() {
+		path, err := filepath.Rel("/", cgroupPath)
+		if err != nil {
+			return nil, err
+		}
+		dir = filepath.Join(CgroupRoot, path)
+	} else {
+		var err error
+		dir, err = getCgroupV1Path(cgroupPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return libcontainercgroups.GetPids(dir)
 }
 
-// getCgroupPath gets the file path to the "devices" subsystem of the desired cgroup.
+// getCgroupV1Path gets the file path to the "devices" subsystem of the desired cgroup.
 // cgroupPath is the path in the cgroup hierarchy.
-func getCgroupPath(cgroupPath string) (string, error) {
+func getCgroupV1Path(cgroupPath string) (string, error) {
 	cgroupPath = libcontainerutils.CleanPath(cgroupPath)
 
 	mnt, root, err := libcontainercgroups.FindCgroupMountpointAndRoot(cgroupPath, "devices")
@@ -50,7 +66,7 @@ func getCgroupPath(cgroupPath string) (string, error) {
 		return filepath.Join(root, mnt, cgroupPath), nil
 	}
 
-	parentPath, err := getCgroupParentPath(mnt, root)
+	parentPath, err := getCgroupV1ParentPath(mnt, root)
 	if err != nil {
 		return "", err
 	}
@@ -58,8 +74,8 @@ func getCgroupPath(cgroupPath string) (string, error) {
 	return filepath.Join(parentPath, cgroupPath), nil
 }
 
-// getCgroupParentPath gets the parent filepath to this cgroup, for resolving relative cgroup paths.
-func getCgroupParentPath(mountpoint, root string) (string, error) {
+// getCgroupV1ParentPath gets the parent filepath to this cgroup, for resolving relative cgroup paths.
+func getCgroupV1ParentPath(mountpoint, root string) (string, error) {
 	// Use GetThisCgroupDir instead of GetInitCgroupDir, because the creating
 	// process could in container and shared pid namespace with host, and
 	// /proc/1/cgroup could point to whole other world of cgroups.


### PR DESCRIPTION
 /kind feature

do a conversion from the cgroups v1 limits to cgroups v2.

e.g. cpu.shares on cgroups v1 has a range of [2-262144] while the
equivalent on cgroups v2 is cpu.weight that uses a range [1-10000].

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


**Does this PR introduce a user-facing change?**:

NONE

```release-note
Support for running on a host that uses cgroups v2 unified mode
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

- [KEP]: https://github.com/kubernetes/enhancements/pull/1370
