### PR TITLE
guard kubeadm dependencies on k8s.io/kubernetes

### DIFF
--- a/cmd/kubeadm/.import-restrictions
+++ b/cmd/kubeadm/.import-restrictions
@@ -31,7 +31,7 @@
 			]
 		},
 		{
-			"SelectorRegexp": "k8s[.]io/kubernetes/cmd",
+			"SelectorRegexp": "k8s[.]io/kubernetes",
 			"AllowedPrefixes": [
 				"k8s.io/kubernetes/cmd/kubeadm"
 			]
@@ -45,52 +45,6 @@
 				"k8s.io/utils/pointer",
 				"k8s.io/utils/net",
 				"k8s.io/utils/trace"
-			]
-		},
-		{
-			"SelectorRegexp": "k8s[.]io/kubernetes/pkg",
-			"AllowedPrefixes": [
-				"k8s.io/kubernetes/pkg/api/legacyscheme",
-				"k8s.io/kubernetes/pkg/apis/autoscaling",
-				"k8s.io/kubernetes/pkg/apis/core",
-				"k8s.io/kubernetes/pkg/api/service",
-				"k8s.io/kubernetes/pkg/apis/apps",
-				"k8s.io/kubernetes/pkg/apis/rbac",
-				"k8s.io/kubernetes/pkg/apis/scheduling",
-				"k8s.io/kubernetes/pkg/api/v1/pod",
-				"k8s.io/kubernetes/pkg/api/v1/service",
-				"k8s.io/kubernetes/pkg/capabilities",
-				"k8s.io/kubernetes/pkg/controller",
-				"k8s.io/kubernetes/pkg/features",
-				"k8s.io/kubernetes/pkg/fieldpath",
-				"k8s.io/kubernetes/pkg/kubelet/apis",
-				"k8s.io/kubernetes/pkg/kubelet/cm/cpuset",
-				"k8s.io/kubernetes/pkg/kubelet/qos",
-				"k8s.io/kubernetes/pkg/kubelet/types",
-				"k8s.io/kubernetes/pkg/master/ports",
-				"k8s.io/kubernetes/pkg/proxy/apis/config",
-				"k8s.io/kubernetes/pkg/proxy",
-				"k8s.io/kubernetes/pkg/registry/core/service/allocator",
-				"k8s.io/kubernetes/pkg/registry/core/service/ipallocator",
-				"k8s.io/kubernetes/pkg/security/apparmor",
-				"k8s.io/kubernetes/pkg/serviceaccount",
-				"k8s.io/kubernetes/pkg/util/async",
-				"k8s.io/kubernetes/pkg/util/conntrack",
-				"k8s.io/kubernetes/pkg/util/hash",
-				"k8s.io/kubernetes/pkg/util/iptables",
-				"k8s.io/kubernetes/pkg/util/parsers",
-				"k8s.io/kubernetes/pkg/util/sysctl",
-				"k8s.io/kubernetes/pkg/util/taints"
-			],
-			"ForbiddenPrefixes": [
-				"k8s.io/kubernetes/pkg/cloudprovider/providers",
-				"k8s.io/kubernetes/pkg/cloudprovider/providers/aws",
-				"k8s.io/kubernetes/pkg/cloudprovider/providers/azure",
-				"k8s.io/kubernetes/pkg/cloudprovider/providers/fake",
-				"k8s.io/kubernetes/pkg/cloudprovider/providers/gce",
-				"k8s.io/kubernetes/pkg/cloudprovider/providers/openstack",
-				"k8s.io/kubernetes/pkg/cloudprovider/providers/vsphere",
-				"k8s.io/kubernetes/pkg/client/clientset_generated/internalclientset"
 			]
 		},
 		{

--- a/cmd/kubeadm/app/util/apiclient/BUILD
+++ b/cmd/kubeadm/app/util/apiclient/BUILD
@@ -19,7 +19,6 @@ go_library(
     deps = [
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
-        "//pkg/kubelet/types:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/rbac/v1:go_default_library",

--- a/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
@@ -113,7 +113,7 @@ func (clg *ClientBackedDryRunGetter) Client() clientset.Interface {
 }
 
 // decodeUnversionedIntoAPIObject converts the *unversioned.Unversioned object returned from the dynamic client
-// to bytes; and then decodes it back _to an external api version (k8s.io/api vs k8s.io/kubernetes/pkg/api*)_ using the normal API machinery
+// to bytes; and then decodes it back _to an external api version (k8s.io/api)_ using the normal API machinery
 func decodeUnstructuredIntoAPIObject(action core.Action, unstructuredObj runtime.Unstructured) (runtime.Object, error) {
 	objBytes, err := json.Marshal(unstructuredObj)
 	if err != nil {

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -24,14 +24,13 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netutil "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/apimachinery/pkg/util/wait"
 	clientset "k8s.io/client-go/kubernetes"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
 // Waiter is an interface for waiting for criteria in Kubernetes to happen
@@ -246,7 +245,7 @@ func getStaticPodSingleHash(client clientset.Interface, nodeName string, compone
 		return "", err
 	}
 
-	staticPodHash := staticPod.Annotations[kubetypes.ConfigHashAnnotationKey]
+	staticPodHash := staticPod.Annotations["kubernetes.io/config.hash"]
 	fmt.Printf("Static pod: %s hash: %s\n", staticPodName, staticPodHash)
 	return staticPodHash, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
kubeadm trimmed all their dependencies on k8s.io/kubernetes! this ensures we don't accidentally pick up new ones

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/area kubeadm
/cc @neolit123 