### PR TITLE
Move suites.go to e2e package

### DIFF
--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -47,6 +47,7 @@ go_library(
         "examples.go",
         "gke_local_ssd.go",
         "gke_node_pools.go",
+        "suites.go",
     ],
     importpath = "k8s.io/kubernetes/test/e2e",
     deps = [
@@ -67,6 +68,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/auth:go_default_library",
         "//test/e2e/framework/log:go_default_library",
+        "//test/e2e/framework/metrics:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/providers/aws:go_default_library",

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -70,9 +70,9 @@ var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
 })
 
 var _ = ginkgo.SynchronizedAfterSuite(func() {
-	framework.CleanupSuite()
+	CleanupSuite()
 }, func() {
-	framework.AfterSuiteActions()
+	AfterSuiteActions()
 })
 
 // RunE2ETests checks configuration parameters (specified through flags) and then runs

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -22,7 +22,6 @@ go_library(
         "resource_usage_gatherer.go",
         "size.go",
         "skip.go",
-        "suites.go",
         "test_context.go",
         "util.go",
     ],

--- a/test/e2e/suites.go
+++ b/test/e2e/suites.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package framework
+package e2e
 
 import (
 	"fmt"
@@ -22,7 +22,7 @@ import (
 	"path"
 	"time"
 
-	// TODO: Remove the following imports (ref: https://github.com/kubernetes/kubernetes/issues/81245)
+	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 )
 
@@ -32,36 +32,36 @@ import (
 // and then the function that only runs on the first Ginkgo node.
 func CleanupSuite() {
 	// Run on all Ginkgo nodes
-	Logf("Running AfterSuite actions on all nodes")
-	RunCleanupActions()
+	framework.Logf("Running AfterSuite actions on all nodes")
+	framework.RunCleanupActions()
 }
 
 // AfterSuiteActions are actions that are run on ginkgo's SynchronizedAfterSuite
 func AfterSuiteActions() {
 	// Run only Ginkgo on node 1
-	Logf("Running AfterSuite actions on node 1")
-	if TestContext.ReportDir != "" {
-		CoreDump(TestContext.ReportDir)
+	framework.Logf("Running AfterSuite actions on node 1")
+	if framework.TestContext.ReportDir != "" {
+		framework.CoreDump(framework.TestContext.ReportDir)
 	}
-	if TestContext.GatherSuiteMetricsAfterTest {
+	if framework.TestContext.GatherSuiteMetricsAfterTest {
 		if err := gatherTestSuiteMetrics(); err != nil {
-			Logf("Error gathering metrics: %v", err)
+			framework.Logf("Error gathering metrics: %v", err)
 		}
 	}
-	if TestContext.NodeKiller.Enabled {
-		close(TestContext.NodeKiller.NodeKillerStopCh)
+	if framework.TestContext.NodeKiller.Enabled {
+		close(framework.TestContext.NodeKiller.NodeKillerStopCh)
 	}
 }
 
 func gatherTestSuiteMetrics() error {
-	Logf("Gathering metrics")
-	c, err := LoadClientset()
+	framework.Logf("Gathering metrics")
+	c, err := framework.LoadClientset()
 	if err != nil {
 		return fmt.Errorf("error loading client: %v", err)
 	}
 
 	// Grab metrics for apiserver, scheduler, controller-manager, kubelet (for non-kubemark case) and cluster autoscaler (optionally).
-	grabber, err := e2emetrics.NewMetricsGrabber(c, nil, !ProviderIs("kubemark"), true, true, true, TestContext.IncludeClusterAutoscalerMetrics)
+	grabber, err := e2emetrics.NewMetricsGrabber(c, nil, !framework.ProviderIs("kubemark"), true, true, true, framework.TestContext.IncludeClusterAutoscalerMetrics)
 	if err != nil {
 		return fmt.Errorf("failed to create MetricsGrabber: %v", err)
 	}
@@ -73,13 +73,13 @@ func gatherTestSuiteMetrics() error {
 
 	metricsForE2E := (*e2emetrics.ComponentCollection)(&received)
 	metricsJSON := metricsForE2E.PrintJSON()
-	if TestContext.ReportDir != "" {
-		filePath := path.Join(TestContext.ReportDir, "MetricsForE2ESuite_"+time.Now().Format(time.RFC3339)+".json")
+	if framework.TestContext.ReportDir != "" {
+		filePath := path.Join(framework.TestContext.ReportDir, "MetricsForE2ESuite_"+time.Now().Format(time.RFC3339)+".json")
 		if err := ioutil.WriteFile(filePath, []byte(metricsJSON), 0644); err != nil {
 			return fmt.Errorf("error writing to %q: %v", filePath, err)
 		}
 	} else {
-		Logf("\n\nTest Suite Metrics:\n%s\n", metricsJSON)
+		framework.Logf("\n\nTest Suite Metrics:\n%s\n", metricsJSON)
 	}
 
 	return nil


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

suites.go is used from e2e.go only and suites.go has invalid dependency
to subpackage of e2e framework as e2e core framework.
So this moves suites.go from e2e core framework.

Ref: https://github.com/kubernetes/kubernetes/issues/81245

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
