### PR TITLE
Updating kube-proxy to support new EndpointSlice address types

### DIFF
--- a/pkg/proxy/endpoints_test.go
+++ b/pkg/proxy/endpoints_test.go
@@ -1431,6 +1431,9 @@ func TestLastChangeTriggerTime(t *testing.T) {
 }
 
 func TestEndpointSliceUpdate(t *testing.T) {
+	fqdnSlice := generateEndpointSlice("svc1", "ns1", 2, 5, 999, []string{"host1"}, []*int32{utilpointer.Int32Ptr(80), utilpointer.Int32Ptr(443)})
+	fqdnSlice.AddressType = discovery.AddressTypeFQDN
+
 	testCases := map[string]struct {
 		startingSlices        []*discovery.EndpointSlice
 		endpointChangeTracker *EndpointChangeTracker
@@ -1469,6 +1472,18 @@ func TestEndpointSliceUpdate(t *testing.T) {
 			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, nil, nil, true),
 			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
 			paramEndpointSlice:    generateEndpointSlice("svc1", "ns1", 1, 3, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(80), utilpointer.Int32Ptr(443)}),
+			paramRemoveSlice:      false,
+			expectedReturnVal:     false,
+			expectedCurrentChange: nil,
+		},
+		// ensure that only valide address types are processed
+		"add an FQDN slice (invalid address type)": {
+			startingSlices: []*discovery.EndpointSlice{
+				generateEndpointSlice("svc1", "ns1", 1, 3, 999, []string{"host1", "host2"}, []*int32{utilpointer.Int32Ptr(80), utilpointer.Int32Ptr(443)}),
+			},
+			endpointChangeTracker: NewEndpointChangeTracker("host1", nil, nil, nil, true),
+			namespacedName:        types.NamespacedName{Name: "svc1", Namespace: "ns1"},
+			paramEndpointSlice:    fqdnSlice,
 			paramRemoveSlice:      false,
 			expectedReturnVal:     false,
 			expectedCurrentChange: nil,

--- a/pkg/proxy/ipvs/meta_proxier.go
+++ b/pkg/proxy/ipvs/meta_proxier.go
@@ -153,25 +153,47 @@ func (proxier *metaProxier) OnEndpointsSynced() {
 // OnEndpointSliceAdd is called whenever creation of a new endpoint slice object
 // is observed.
 func (proxier *metaProxier) OnEndpointSliceAdd(endpointSlice *discovery.EndpointSlice) {
-	// noop
+	switch endpointSlice.AddressType {
+	case discovery.AddressTypeIPv4:
+		proxier.ipv4Proxier.OnEndpointSliceAdd(endpointSlice)
+	case discovery.AddressTypeIPv6:
+		proxier.ipv6Proxier.OnEndpointSliceAdd(endpointSlice)
+	default:
+		klog.V(4).Infof("EndpointSlice address type not supported by kube-proxy: %s", endpointSlice.AddressType)
+	}
 }
 
 // OnEndpointSliceUpdate is called whenever modification of an existing endpoint
 // slice object is observed.
-func (proxier *metaProxier) OnEndpointSliceUpdate(_, endpointSlice *discovery.EndpointSlice) {
-	//noop
+func (proxier *metaProxier) OnEndpointSliceUpdate(oldEndpointSlice, newEndpointSlice *discovery.EndpointSlice) {
+	switch newEndpointSlice.AddressType {
+	case discovery.AddressTypeIPv4:
+		proxier.ipv4Proxier.OnEndpointSliceUpdate(oldEndpointSlice, newEndpointSlice)
+	case discovery.AddressTypeIPv6:
+		proxier.ipv6Proxier.OnEndpointSliceUpdate(oldEndpointSlice, newEndpointSlice)
+	default:
+		klog.V(4).Infof("EndpointSlice address type not supported by kube-proxy: %s", newEndpointSlice.AddressType)
+	}
 }
 
 // OnEndpointSliceDelete is called whenever deletion of an existing endpoint slice
 // object is observed.
 func (proxier *metaProxier) OnEndpointSliceDelete(endpointSlice *discovery.EndpointSlice) {
-	//noop
+	switch endpointSlice.AddressType {
+	case discovery.AddressTypeIPv4:
+		proxier.ipv4Proxier.OnEndpointSliceDelete(endpointSlice)
+	case discovery.AddressTypeIPv6:
+		proxier.ipv6Proxier.OnEndpointSliceDelete(endpointSlice)
+	default:
+		klog.V(4).Infof("EndpointSlice address type not supported by kube-proxy: %s", endpointSlice.AddressType)
+	}
 }
 
 // OnEndpointSlicesSynced is called once all the initial event handlers were
 // called and the state is fully propagated to local cache.
 func (proxier *metaProxier) OnEndpointSlicesSynced() {
-	//noop
+	proxier.ipv4Proxier.OnEndpointSlicesSynced()
+	proxier.ipv6Proxier.OnEndpointSlicesSynced()
 }
 
 // endpointsIPFamily that returns IPFamily of endpoints or error if


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This includes IPv4 and IPv6 address types and IPVS dual stack support. Importantly this ensures that EndpointSlices with a FQDN address type are not processed by kube-proxy.

**Special notes for your reviewer**:
This is intended to replace https://github.com/kubernetes/kubernetes/pull/84089

**Does this PR introduce a user-facing change?**:
```release-note
kube-proxy now supports DualStack feature with EndpointSlices and IPVS.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- EndpointSlice Enhancement Issue: https://github.com/kubernetes/enhancements/issues/752
- DualStack Enhancement Issue: https://github.com/kubernetes/enhancements/issues/563

/sig network
/priority important-soon
/cc @khenidak @andrewsykim @freehan @thockin 