### PR TITLE
Automated cherry pick of #84179: Fix startup probe test by checking updated values

### DIFF
--- a/test/e2e_node/startup_probe_test.go
+++ b/test/e2e_node/startup_probe_test.go
@@ -174,6 +174,10 @@ var _ = framework.KubeDescribe("StartupProbe [Serial] [Disruptive] [NodeAlphaFea
 			framework.ExpectNoError(err)
 
 			f.WaitForPodReady(p.Name)
+
+			p, err = podClient.Get(p.Name, metav1.GetOptions{})
+			framework.ExpectNoError(err)
+
 			isReady, err := testutils.PodRunningReady(p)
 			framework.ExpectNoError(err)
 			gomega.Expect(isReady).To(gomega.BeTrue(), "pod should be ready")


### PR DESCRIPTION
Cherry pick of #84179 on release-1.16.

#84179: Fix startup probe test by checking updated values

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```