### PR TITLE
Automated cherry pick of #84291: Clarify startupProbe e2e tests

### DIFF
--- a/test/e2e_node/startup_probe_test.go
+++ b/test/e2e_node/startup_probe_test.go
@@ -19,7 +19,7 @@ package e2e_node
 import (
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/pkg/features"
@@ -59,15 +59,15 @@ var _ = framework.KubeDescribe("StartupProbe [Serial] [Disruptive] [NodeAlphaFea
 
 		/*
 			Release : v1.16
-			Testname: Pod liveness probe, using local file, delayed by startup probe
-			Description: A Pod is created with liveness probe that uses ‘exec’ command to cat the non-existent /tmp/health file. Liveness probe MUST NOT fail until startup probe expires.
+			Testname: Pod startup probe restart
+			Description: A Pod is created with a failing startup probe. The Pod MUST be killed and restarted incrementing restart count to 1, even if liveness would succeed.
 		*/
-		framework.ConformanceIt("should *not* be restarted with a exec \"cat /tmp/health\" because startup probe delays it [NodeConformance]", func() {
+		framework.ConformanceIt("should be restarted startup probe fails [NodeConformance]", func() {
 			cmd := []string{"/bin/sh", "-c", "sleep 600"}
 			livenessProbe := &v1.Probe{
 				Handler: v1.Handler{
 					Exec: &v1.ExecAction{
-						Command: []string{"cat", "/tmp/health"},
+						Command: []string{"/bin/true"},
 					},
 				},
 				InitialDelaySeconds: 15,
@@ -76,36 +76,7 @@ var _ = framework.KubeDescribe("StartupProbe [Serial] [Disruptive] [NodeAlphaFea
 			startupProbe := &v1.Probe{
 				Handler: v1.Handler{
 					Exec: &v1.ExecAction{
-						Command: []string{"cat", "/tmp/health"},
-					},
-				},
-				InitialDelaySeconds: 15,
-				FailureThreshold:    60,
-			}
-			pod := startupPodSpec(startupProbe, nil, livenessProbe, cmd)
-			common.RunLivenessTest(f, pod, 0, defaultObservationTimeout)
-		})
-
-		/*
-			Release : v1.16
-			Testname: Pod liveness probe, using local file, delayed by startup probe
-			Description: A Pod is created with liveness probe that uses ‘exec’ command to cat the non-existent /tmp/health file. Liveness probe MUST fail after startup probe expires. The Pod MUST now be killed and restarted incrementing restart count to 1.
-		*/
-		framework.ConformanceIt("should be restarted with a exec \"cat /tmp/health\" because startup probe does not delay it long enough [NodeConformance]", func() {
-			cmd := []string{"/bin/sh", "-c", "sleep 600"}
-			livenessProbe := &v1.Probe{
-				Handler: v1.Handler{
-					Exec: &v1.ExecAction{
-						Command: []string{"cat", "/tmp/health"},
-					},
-				},
-				InitialDelaySeconds: 15,
-				FailureThreshold:    1,
-			}
-			startupProbe := &v1.Probe{
-				Handler: v1.Handler{
-					Exec: &v1.ExecAction{
-						Command: []string{"cat", "/tmp/health"},
+						Command: []string{"/bin/false"},
 					},
 				},
 				InitialDelaySeconds: 15,
@@ -117,15 +88,44 @@ var _ = framework.KubeDescribe("StartupProbe [Serial] [Disruptive] [NodeAlphaFea
 
 		/*
 			Release : v1.16
-			Testname: Pod liveness probe, using local file, startup finished restart
-			Description: A Pod is created with liveness probe that uses ‘exec’ command to cat /temp/health file. The Container is started by creating /tmp/startup after 10 seconds, triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing restart count to 1.
+			Testname: Pod liveness probe delayed (long) by startup probe
+			Description: A Pod is created with failing liveness and startup probes. Liveness probe MUST NOT fail until startup probe expires.
 		*/
-		framework.ConformanceIt("should be restarted with a exec \"cat /tmp/health\" after startup probe succeeds it [NodeConformance]", func() {
+		framework.ConformanceIt("should *not* be restarted by liveness probe because startup probe delays it [NodeConformance]", func() {
+			cmd := []string{"/bin/sh", "-c", "sleep 600"}
+			livenessProbe := &v1.Probe{
+				Handler: v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: []string{"/bin/false"},
+					},
+				},
+				InitialDelaySeconds: 15,
+				FailureThreshold:    1,
+			}
+			startupProbe := &v1.Probe{
+				Handler: v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: []string{"/bin/false"},
+					},
+				},
+				InitialDelaySeconds: 15,
+				FailureThreshold:    60,
+			}
+			pod := startupPodSpec(startupProbe, nil, livenessProbe, cmd)
+			common.RunLivenessTest(f, pod, 0, defaultObservationTimeout)
+		})
+
+		/*
+			Release : v1.16
+			Testname: Pod liveness probe fails after startup success
+			Description: A Pod is created with failing liveness probe and delayed startup probe that uses ‘exec’ command to cat /temp/health file. The Container is started by creating /tmp/startup after 10 seconds, triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing restart count to 1.
+		*/
+		framework.ConformanceIt("should be restarted by liveness probe after startup probe enables it [NodeConformance]", func() {
 			cmd := []string{"/bin/sh", "-c", "sleep 10; echo ok >/tmp/startup; sleep 600"}
 			livenessProbe := &v1.Probe{
 				Handler: v1.Handler{
 					Exec: &v1.ExecAction{
-						Command: []string{"cat", "/tmp/health"},
+						Command: []string{"/bin/false"},
 					},
 				},
 				InitialDelaySeconds: 15,


### PR DESCRIPTION
Cherry pick of #84291 on release-1.16.

#84291: Clarify startupProbe e2e tests

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```