### PR TITLE
fix the defect in the shell scripts

### DIFF
--- a/cluster/common.sh
+++ b/cluster/common.sh
@@ -323,6 +323,9 @@ function find-tar() {
 #   KUBE_MANIFESTS_TAR
 function find-release-tars() {
   SERVER_BINARY_TAR=$(find-tar kubernetes-server-linux-amd64.tar.gz)
+  if [[ -z "${SERVER_BINARY_TAR}" ]]; then
+	  exit 1
+  fi
   if [[ "${NUM_WINDOWS_NODES}" -gt "0" ]]; then
     NODE_BINARY_TAR=$(find-tar kubernetes-node-windows-amd64.tar.gz)
   fi


### PR DESCRIPTION
when the binary is missing, it should prompt for downloading instead of
silently move on.



**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
If the binary `kubernetes-server-linux-amd64.tar.gz` for example doesn't exist,  it should expect `download-release-binaries` function to download from external, but the defect in the shell script make it silently move on.

This could be reproduced with `cluster/kube-up.sh` while no binary is presented on your local system, pls see detail from the issue below.

Which issue(s) this PR fixes:
Fixes #85405

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
