### PR TITLE
Fix --resource-version handling in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -264,6 +264,16 @@ func (o AnnotateOptions) RunAnnotate() error {
 			outputObj = obj
 		} else {
 			name, namespace := info.Name, info.Namespace
+
+			if len(o.resourceVersion) != 0 {
+				// ensure resourceVersion is always sent in the patch by clearing it from the starting JSON
+				accessor, err := meta.Accessor(obj)
+				if err != nil {
+					return err
+				}
+				accessor.SetResourceVersion("")
+			}
+
 			oldData, err := json.Marshal(obj)
 			if err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/BUILD
@@ -37,6 +37,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -253,6 +253,16 @@ func (o *LabelOptions) RunLabel() error {
 		var outputObj runtime.Object
 		var dataChangeMsg string
 		obj := info.Object
+
+		if len(o.resourceVersion) != 0 {
+			// ensure resourceVersion is always sent in the patch by clearing it from the starting JSON
+			accessor, err := meta.Accessor(obj)
+			if err != nil {
+				return err
+			}
+			accessor.SetResourceVersion("")
+		}
+
 		oldData, err := json.Marshal(obj)
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label_test.go
@@ -18,6 +18,7 @@ package label
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
 	"reflect"
 	"strings"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
@@ -494,5 +496,72 @@ func TestLabelMultipleObjects(t *testing.T) {
 	}
 	if strings.Count(buf.String(), "labeled") != len(pods.Items) {
 		t.Errorf("not all labels are set: %s", buf.String())
+	}
+}
+
+func TestLabelResourceVersion(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	tf.UnstructuredClient = &fake.RESTClient{
+		GroupVersion:         schema.GroupVersion{Group: "testgroup", Version: "v1"},
+		NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+		Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+			switch req.Method {
+			case "GET":
+				switch req.URL.Path {
+				case "/namespaces/test/pods/foo":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     cmdtesting.DefaultHeader(),
+						Body: ioutil.NopCloser(bytes.NewBufferString(
+							`{"kind":"Pod","apiVersion":"v1","metadata":{"name":"foo","namespace":"test","resourceVersion":"10"}}`,
+						))}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}
+			case "PATCH":
+				switch req.URL.Path {
+				case "/namespaces/test/pods/foo":
+					body, err := ioutil.ReadAll(req.Body)
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !bytes.Equal(body, []byte(`{"metadata":{"labels":{"a":"b"},"resourceVersion":"10"}}`)) {
+						t.Fatalf("expected patch with resourceVersion set, got %s", string(body))
+					}
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     cmdtesting.DefaultHeader(),
+						Body: ioutil.NopCloser(bytes.NewBufferString(
+							`{"kind":"Pod","apiVersion":"v1","metadata":{"name":"foo","namespace":"test","resourceVersion":"11"}}`,
+						))}, nil
+				default:
+					t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+					return nil, nil
+				}
+			default:
+				t.Fatalf("unexpected request: %s %#v\n%#v", req.Method, req.URL, req)
+				return nil, nil
+			}
+		}),
+	}
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	iostreams, _, bufOut, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdLabel(tf, iostreams)
+	cmd.SetOutput(bufOut)
+	options := NewLabelOptions(iostreams)
+	options.resourceVersion = "10"
+	args := []string{"pods/foo", "a=b"}
+	if err := options.Complete(tf, cmd, args); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := options.Validate(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := options.RunLabel(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #85198

**Does this PR introduce a user-facing change?**:
```release-note
kubectl: --resource-version now works properly in label/annotate/set selector commands when racing with other clients to update the target object
```

/sig cli
/assign @soltysh 