### PR TITLE
correct command annotations to sh instead of yaml

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/imperative_porcelain/editing_workloads.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/imperative_porcelain/editing_workloads.md
@@ -20,22 +20,22 @@ editing it through a local file.
 
 {% sample lang="yaml" %}
 
-```yaml
+```sh
 # Edit the service named 'docker-registry':
 kubectl edit svc/docker-registry
 ```
 
-```yaml
+```sh
 # Use an alternative editor
 KUBE_EDITOR="nano" kubectl edit svc/docker-registry
 ```
 
-```yaml
+```sh
 # Edit the job 'myjob' in JSON using the v1 API format:
 kubectl edit job.v1.batch/myjob -o json
 ```
 
-```yaml
+```sh
 # Edit the deployment 'mydeployment' in YAML and save the modified config in its annotation:
 kubectl edit deployment/mydeployment -o yaml --save-config
 ```


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The annotation for the command should be sh, or bash maybe, but never yaml.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
