### PR TITLE
Clean up cluster-service label from calico-policy-controller

### DIFF
--- a/cluster/addons/calico-policy-controller/bgpconfigurations-crd.yaml
+++ b/cluster/addons/calico-policy-controller/bgpconfigurations-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: bgpconfigurations.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/bgppeers-crd.yaml
+++ b/cluster/addons/calico-policy-controller/bgppeers-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: bgppeers.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/blockaffinity-crd.yaml
+++ b/cluster/addons/calico-policy-controller/blockaffinity-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: blockaffinities.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/calico-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/calico-clusterrole.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   # The CNI plugin needs to get pods, nodes, and namespaces.

--- a/cluster/addons/calico-policy-controller/calico-clusterrolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/calico-clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: calico
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/addons/calico-policy-controller/calico-cpva-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/calico-cpva-clusterrole.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-cpva
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   - apiGroups: [""]

--- a/cluster/addons/calico-policy-controller/calico-cpva-clusterrolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/calico-cpva-clusterrolebinding.yaml
@@ -3,7 +3,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: calico-cpva
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 subjects:
   - kind: ServiceAccount

--- a/cluster/addons/calico-policy-controller/calico-cpva-serviceaccount.yaml
+++ b/cluster/addons/calico-policy-controller/calico-cpva-serviceaccount.yaml
@@ -4,5 +4,4 @@ metadata:
   name: calico-cpva
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-daemonset.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico-node
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: calico-node
 spec:

--- a/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-configmap.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico-node-vertical-autoscaler
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 data:
   node-autoscaler: |-

--- a/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/calico-node-vertical-autoscaler-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-node-autoscaler
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1

--- a/cluster/addons/calico-policy-controller/calico-serviceaccount.yaml
+++ b/cluster/addons/calico-policy-controller/calico-serviceaccount.yaml
@@ -4,5 +4,4 @@ metadata:
   name: calico
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/calico-policy-controller/clusterinformations-crd.yaml
+++ b/cluster/addons/calico-policy-controller/clusterinformations-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: clusterinformations.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/felixconfigurations-crd.yaml
+++ b/cluster/addons/calico-policy-controller/felixconfigurations-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: felixconfigurations.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/globalbgpconfig-crd.yaml
+++ b/cluster/addons/calico-policy-controller/globalbgpconfig-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: globalbgpconfigs.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/globalfelixconfig-crd.yaml
+++ b/cluster/addons/calico-policy-controller/globalfelixconfig-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: globalfelixconfigs.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/globalnetworkpolicy-crd.yaml
+++ b/cluster/addons/calico-policy-controller/globalnetworkpolicy-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworkpolicies.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/globalnetworksets-crd.yaml
+++ b/cluster/addons/calico-policy-controller/globalnetworksets-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: globalnetworksets.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/hostendpoints-crd.yaml
+++ b/cluster/addons/calico-policy-controller/hostendpoints-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: hostendpoints.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/ipamblock-crd.yaml
+++ b/cluster/addons/calico-policy-controller/ipamblock-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: ipamblocks.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/ipamconfig-crd.yaml
+++ b/cluster/addons/calico-policy-controller/ipamconfig-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: ipamconfigs.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/ipamhandle-crd.yaml
+++ b/cluster/addons/calico-policy-controller/ipamhandle-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: ipamhandles.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/ippool-crd.yaml
+++ b/cluster/addons/calico-policy-controller/ippool-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: ippools.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Cluster

--- a/cluster/addons/calico-policy-controller/networkpolicies-crd.yaml
+++ b/cluster/addons/calico-policy-controller/networkpolicies-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: networkpolicies.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Namespaced

--- a/cluster/addons/calico-policy-controller/networkset-crd.yaml
+++ b/cluster/addons/calico-policy-controller/networkset-crd.yaml
@@ -3,7 +3,6 @@ kind: CustomResourceDefinition
 metadata:
   name: networksets.crd.projectcalico.org
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   scope: Namespaced

--- a/cluster/addons/calico-policy-controller/podsecuritypolicies/calico-node-psp-binding.yaml
+++ b/cluster/addons/calico-policy-controller/podsecuritypolicies/calico-node-psp-binding.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     addonmanager.kubernetes.io/mode: Reconcile
-    kubernetes.io/cluster-service: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/cluster/addons/calico-policy-controller/typha-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-deployment.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico-typha
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
     k8s-app: calico-typha
 spec:

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   name: typha-cpha
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   - apiGroups: [""]

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: typha-cpha
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-configmap.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico-typha-horizontal-autoscaler
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 data:
   ladder: |-

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha-autoscaler
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-role.yaml
@@ -4,7 +4,6 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   - apiGroups: [""]

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-rolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-rolebinding.yaml
@@ -4,7 +4,6 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-serviceaccount.yaml
+++ b/cluster/addons/calico-policy-controller/typha-horizontal-autoscaler-serviceaccount.yaml
@@ -4,5 +4,4 @@ metadata:
   name: typha-cpha
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-clusterrole.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-clusterrole.yaml
@@ -3,7 +3,6 @@ kind: ClusterRole
 metadata:
   name: typha-cpva
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   - apiGroups: [""]

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-clusterrolebinding.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-clusterrolebinding.yaml
@@ -3,7 +3,6 @@ kind: ClusterRoleBinding
 metadata:
   name: typha-cpva
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-configmap.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   name: calico-typha-vertical-autoscaler
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 data:
   typha-autoscaler: |-

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: calico-typha-autoscaler
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile
 spec:
   replicas: 1

--- a/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-serviceaccount.yaml
+++ b/cluster/addons/calico-policy-controller/typha-vertical-autoscaler-serviceaccount.yaml
@@ -4,5 +4,4 @@ metadata:
   name: typha-cpva
   namespace: kube-system
   labels:
-    kubernetes.io/cluster-service: "true"
     addonmanager.kubernetes.io/mode: Reconcile


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`kubernetes.io/cluster-service` is deprecated by kube-addon-manager. The label is used by `kubectl cluster-info` only for `kind: Services` resources.
The PR removes the label usage from `calico-policy-controller` addon for non `kind: Service` resources.
Ref #72757.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
/cc @spiffxp

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
