### PR TITLE
Automated cherry pick of #85156: Remove an infinite poll

### DIFF
--- a/cmd/kubeadm/app/discovery/token/BUILD
+++ b/cmd/kubeadm/app/discovery/token/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//cmd/kubeadm/app/util/pubkeypin:go_default_library",
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd:go_default_library",

--- a/cmd/kubeadm/app/discovery/token/token.go
+++ b/cmd/kubeadm/app/discovery/token/token.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/clientcmd"
@@ -74,16 +73,11 @@ func RetrieveValidatedConfigInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmda
 		klog.V(1).Infof("[discovery] Created cluster-info discovery client, requesting info from %q\n", insecureBootstrapConfig.Clusters[clusterName].Server)
 
 		// Make an initial insecure connection to get the cluster-info ConfigMap
-		var insecureClusterInfo *v1.ConfigMap
-		wait.PollImmediateInfinite(constants.DiscoveryRetryInterval, func() (bool, error) {
-			var err error
-			insecureClusterInfo, err = insecureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
-			if err != nil {
-				klog.V(1).Infof("[discovery] Failed to request cluster info, will try again: [%s]\n", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		insecureClusterInfo, err := insecureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+		if err != nil {
+			klog.V(1).Infof("[discovery] Failed to request cluster info: [%s]\n", err)
+			return nil, err
+		}
 
 		// Validate the MAC on the kubeconfig from the ConfigMap and load it
 		insecureKubeconfigString, ok := insecureClusterInfo.Data[bootstrapapi.KubeConfigKey]
@@ -138,16 +132,11 @@ func RetrieveValidatedConfigInfo(cfg *kubeadmapi.JoinConfiguration) (*clientcmda
 		}
 
 		klog.V(1).Infof("[discovery] Requesting info from %q again to validate TLS against the pinned public key\n", insecureBootstrapConfig.Clusters[clusterName].Server)
-		var secureClusterInfo *v1.ConfigMap
-		wait.PollImmediateInfinite(constants.DiscoveryRetryInterval, func() (bool, error) {
-			var err error
-			secureClusterInfo, err = secureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
-			if err != nil {
-				klog.V(1).Infof("[discovery] Failed to request cluster info, will try again: [%s]\n", err)
-				return false, nil
-			}
-			return true, nil
-		})
+		secureClusterInfo, err := secureClient.CoreV1().ConfigMaps(metav1.NamespacePublic).Get(bootstrapapi.ConfigMapClusterInfo, metav1.GetOptions{})
+		if err != nil {
+			klog.V(1).Infof("[discovery] Failed to request cluster info: [%s]\n", err)
+			return nil, err
+		}
 
 		// Pull the kubeconfig from the securely-obtained ConfigMap and validate that it's the same as what we found the first time
 		secureKubeconfigBytes := []byte(secureClusterInfo.Data[bootstrapapi.KubeConfigKey])


### PR DESCRIPTION
Cherry pick of #85156 on release-1.16.

#85156: Remove an infinite poll

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubeadm: prevent infinite hang on "kubeadm join" using token discovery
```

/kind bug
/priority important-soon
