### PR TITLE
Rename PluginConfigArgs to AlgorithmConfigArgs

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_predicates.go
@@ -24,7 +24,7 @@ import (
 func init() {
 	// Register functions that extract metadata used by predicates computations.
 	scheduler.RegisterPredicateMetadataProducerFactory(
-		func(args scheduler.PluginFactoryArgs) predicates.MetadataProducer {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.MetadataProducer {
 			f := &predicates.MetadataProducerFactory{}
 			return f.GetPredicateMetadata
 		})
@@ -54,7 +54,7 @@ func init() {
 	// Fit is determined by volume zone requirements.
 	scheduler.RegisterFitPredicateFactory(
 		predicates.NoVolumeZoneConflictPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			pvLister := args.InformerFactory.Core().V1().PersistentVolumes().Lister()
 			pvcLister := args.InformerFactory.Core().V1().PersistentVolumeClaims().Lister()
 			storageClassLister := args.InformerFactory.Storage().V1().StorageClasses().Lister()
@@ -64,7 +64,7 @@ func init() {
 	// Fit is determined by whether or not there would be too many AWS EBS volumes attached to the node
 	scheduler.RegisterFitPredicateFactory(
 		predicates.MaxEBSVolumeCountPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			csiNodeLister := scheduler.GetCSINodeLister(args.InformerFactory)
 			pvLister := args.InformerFactory.Core().V1().PersistentVolumes().Lister()
 			pvcLister := args.InformerFactory.Core().V1().PersistentVolumeClaims().Lister()
@@ -75,7 +75,7 @@ func init() {
 	// Fit is determined by whether or not there would be too many GCE PD volumes attached to the node
 	scheduler.RegisterFitPredicateFactory(
 		predicates.MaxGCEPDVolumeCountPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			csiNodeLister := scheduler.GetCSINodeLister(args.InformerFactory)
 			pvLister := args.InformerFactory.Core().V1().PersistentVolumes().Lister()
 			pvcLister := args.InformerFactory.Core().V1().PersistentVolumeClaims().Lister()
@@ -86,7 +86,7 @@ func init() {
 	// Fit is determined by whether or not there would be too many Azure Disk volumes attached to the node
 	scheduler.RegisterFitPredicateFactory(
 		predicates.MaxAzureDiskVolumeCountPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			csiNodeLister := scheduler.GetCSINodeLister(args.InformerFactory)
 			pvLister := args.InformerFactory.Core().V1().PersistentVolumes().Lister()
 			pvcLister := args.InformerFactory.Core().V1().PersistentVolumeClaims().Lister()
@@ -96,7 +96,7 @@ func init() {
 	)
 	scheduler.RegisterFitPredicateFactory(
 		predicates.MaxCSIVolumeCountPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			csiNodeLister := scheduler.GetCSINodeLister(args.InformerFactory)
 			pvLister := args.InformerFactory.Core().V1().PersistentVolumes().Lister()
 			pvcLister := args.InformerFactory.Core().V1().PersistentVolumeClaims().Lister()
@@ -106,7 +106,7 @@ func init() {
 	)
 	scheduler.RegisterFitPredicateFactory(
 		predicates.MaxCinderVolumeCountPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			csiNodeLister := scheduler.GetCSINodeLister(args.InformerFactory)
 			pvLister := args.InformerFactory.Core().V1().PersistentVolumes().Lister()
 			pvcLister := args.InformerFactory.Core().V1().PersistentVolumeClaims().Lister()
@@ -118,7 +118,7 @@ func init() {
 	// Fit is determined by inter-pod affinity.
 	scheduler.RegisterFitPredicateFactory(
 		predicates.MatchInterPodAffinityPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			return predicates.NewPodAffinityPredicate(args.SharedLister.NodeInfos(), args.SharedLister.Pods())
 		},
 	)
@@ -139,7 +139,7 @@ func init() {
 	// Fit is determined by volume topology requirements.
 	scheduler.RegisterFitPredicateFactory(
 		predicates.CheckVolumeBindingPred,
-		func(args scheduler.PluginFactoryArgs) predicates.FitPredicate {
+		func(args scheduler.AlgorithmFactoryArgs) predicates.FitPredicate {
 			return predicates.NewVolumeBindingPredicate(args.VolumeBinder)
 		},
 	)

--- a/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
+++ b/pkg/scheduler/algorithmprovider/defaults/register_priorities.go
@@ -25,7 +25,7 @@ import (
 func init() {
 	// Register functions that extract metadata used by priorities computations.
 	scheduler.RegisterPriorityMetadataProducerFactory(
-		func(args scheduler.PluginFactoryArgs) priorities.MetadataProducer {
+		func(args scheduler.AlgorithmFactoryArgs) priorities.MetadataProducer {
 			serviceLister := args.InformerFactory.Core().V1().Services().Lister()
 			controllerLister := args.InformerFactory.Core().V1().ReplicationControllers().Lister()
 			replicaSetLister := args.InformerFactory.Apps().V1().ReplicaSets().Lister()
@@ -40,7 +40,7 @@ func init() {
 	scheduler.RegisterPriorityConfigFactory(
 		priorities.ServiceSpreadingPriority,
 		scheduler.PriorityConfigFactory{
-			MapReduceFunction: func(args scheduler.PluginFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction) {
+			MapReduceFunction: func(args scheduler.AlgorithmFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction) {
 				serviceLister := args.InformerFactory.Core().V1().Services().Lister()
 				return priorities.NewSelectorSpreadPriority(serviceLister, algorithm.EmptyControllerLister{}, algorithm.EmptyReplicaSetLister{}, algorithm.EmptyStatefulSetLister{})
 			},
@@ -58,7 +58,7 @@ func init() {
 	scheduler.RegisterPriorityConfigFactory(
 		priorities.SelectorSpreadPriority,
 		scheduler.PriorityConfigFactory{
-			MapReduceFunction: func(args scheduler.PluginFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction) {
+			MapReduceFunction: func(args scheduler.AlgorithmFactoryArgs) (priorities.PriorityMapFunction, priorities.PriorityReduceFunction) {
 				serviceLister := args.InformerFactory.Core().V1().Services().Lister()
 				controllerLister := args.InformerFactory.Core().V1().ReplicationControllers().Lister()
 				replicaSetLister := args.InformerFactory.Apps().V1().ReplicaSets().Lister()

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -108,8 +108,8 @@ type Configurator struct {
 	pluginConfigProducerRegistry *plugins.ConfigProducerRegistry
 	nodeInfoSnapshot             *nodeinfosnapshot.Snapshot
 
-	factoryArgs        PluginFactoryArgs
-	configProducerArgs *plugins.ConfigProducerArgs
+	algorithmFactoryArgs AlgorithmFactoryArgs
+	configProducerArgs   *plugins.ConfigProducerArgs
 }
 
 // GetHardPodAffinitySymmetricWeight is exposed for testing.
@@ -232,12 +232,12 @@ func (c *Configurator) CreateFromKeys(predicateKeys, priorityKeys sets.String, e
 		return nil, err
 	}
 
-	priorityMetaProducer, err := getPriorityMetadataProducer(c.factoryArgs)
+	priorityMetaProducer, err := getPriorityMetadataProducer(c.algorithmFactoryArgs)
 	if err != nil {
 		return nil, err
 	}
 
-	predicateMetaProducer, err := getPredicateMetadataProducer(c.factoryArgs)
+	predicateMetaProducer, err := getPredicateMetadataProducer(c.algorithmFactoryArgs)
 	if err != nil {
 		return nil, err
 	}
@@ -337,7 +337,7 @@ func getBinderFunc(client clientset.Interface, extenders []algorithm.SchedulerEx
 // as framework plugins. Specifically, a priority will run as a framework plugin if a plugin config producer was
 // registered for that priority.
 func (c *Configurator) getPriorityConfigs(priorityKeys sets.String) ([]priorities.PriorityConfig, *schedulerapi.Plugins, []schedulerapi.PluginConfig, error) {
-	allPriorityConfigs, err := getPriorityFunctionConfigs(priorityKeys, c.factoryArgs)
+	allPriorityConfigs, err := getPriorityFunctionConfigs(priorityKeys, c.algorithmFactoryArgs)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -370,7 +370,7 @@ func (c *Configurator) getPriorityConfigs(priorityKeys sets.String) ([]prioritie
 // Note that the framework executes plugins according to their order in the Plugins list, and so predicates run as plugins
 // are added to the Plugins list according to the order specified in predicates.Ordering().
 func (c *Configurator) getPredicateConfigs(predicateKeys sets.String) (map[string]predicates.FitPredicate, *schedulerapi.Plugins, []schedulerapi.PluginConfig, error) {
-	allFitPredicates, err := getFitPredicateFunctions(predicateKeys, c.factoryArgs)
+	allFitPredicates, err := getFitPredicateFunctions(predicateKeys, c.algorithmFactoryArgs)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -560,7 +560,7 @@ func newConfigFactoryWithFrameworkRegistry(
 		pluginConfig:                   []schedulerapi.PluginConfig{},
 		pluginConfigProducerRegistry:   pluginConfigProducerRegistry,
 		nodeInfoSnapshot:               snapshot,
-		factoryArgs: PluginFactoryArgs{
+		algorithmFactoryArgs: AlgorithmFactoryArgs{
 			SharedLister:                   snapshot,
 			InformerFactory:                informerFactory,
 			HardPodAffinitySymmetricWeight: hardPodAffinitySymmetricWeight,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -326,7 +326,7 @@ func New(client clientset.Interface,
 		pluginConfig:                   options.frameworkPluginConfig,
 		pluginConfigProducerRegistry:   options.frameworkConfigProducerRegistry,
 		nodeInfoSnapshot:               snapshot,
-		factoryArgs: PluginFactoryArgs{
+		algorithmFactoryArgs: AlgorithmFactoryArgs{
 			SharedLister:                   snapshot,
 			InformerFactory:                informerFactory,
 			VolumeBinder:                   volumeBinder,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Renames PluginConfigArgs to AlgorithmConfigArgs to avoid confusion between legacy predicates/priorities (which in the past we referred to as plugins) and framework plugins.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

/cc @alculquicondor 
