### PR TITLE
Avoid constructing table printer on every componentstatus request

### DIFF
--- a/pkg/registry/core/componentstatus/BUILD
+++ b/pkg/registry/core/componentstatus/BUILD
@@ -23,7 +23,6 @@ go_library(
         "//pkg/probe/http:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/registry/core/componentstatus/rest.go
+++ b/pkg/registry/core/componentstatus/rest.go
@@ -28,7 +28,6 @@ import (
 
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -40,19 +39,15 @@ import (
 
 type REST struct {
 	GetServersToValidate func() map[string]*Server
+	rest.TableConvertor
 }
 
 // NewStorage returns a new REST.
 func NewStorage(serverRetriever func() map[string]*Server) *REST {
 	return &REST{
 		GetServersToValidate: serverRetriever,
+		TableConvertor:       printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
-}
-
-// ConvertToTable converts the result to the table.
-func (rs *REST) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metav1beta1.Table, error) {
-	tableConvertor := printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)}
-	return tableConvertor.ConvertToTable(ctx, object, tableOptions)
 }
 
 func (*REST) NamespaceScoped() bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

```release-note
NONE
```

/cc @deads2k 