### PR TITLE
Ensure ContainerPath is right format for mounts in Windows containers

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -288,6 +288,12 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 			Propagation:    v.Propagation,
 		}
 
+		// Docker on Windows does some path fixups that were not carried into ContainerD.
+		// Make sure the ContainerPaths which are interpreted inside the container
+		//  have 'c:' and slashes facing the right way
+		if (goruntime.GOOS == "windows" && m.Type() != types.DockerContainerRuntime) {
+			mount.ContainerPath = volumeutil.GetWindowsPath(v.ContainerPath)
+		}
 		volumeMounts = append(volumeMounts, mount)
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -289,8 +289,8 @@ func (m *kubeGenericRuntimeManager) makeMounts(opts *kubecontainer.RunContainerO
 		}
 
 		// Docker on Windows does some path fixups that were not carried into ContainerD.
-		// Make sure the ContainerPaths which are interpreted inside the container
-		//  have 'c:' and slashes facing the right way
+		// If using ContainerD, make sure paths inside the container have 'c:' and slashes facing the right way.
+		// This check would need to be changed later to support a Linux container on a Windows node
 		if (goruntime.GOOS == "windows" && m.Type() != types.DockerContainerRuntime) {
 			mount.ContainerPath = volumeutil.GetWindowsPath(v.ContainerPath)
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Docker seemed to be able to handle container mount paths such as `c:/var/run/secrets/kubernetes.io/serviceaccount` without errors. This isn't exactly valid on Windows as it should be `\` instead of `/` separators.

ContainerD is using these paths as-is on Windows, and failing. This change checks for the Windows+ContainerD combination and cleans up the paths to be valid on Windows.

**Which issue(s) this PR fixes**:

Fixes: https://github.com/kubernetes/kubernetes/issues/85142

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

No, this is an in-progress feature.

```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Enhancement+KEP: https://github.com/kubernetes/enhancements/issues/1001

/milestone v1.18
/sig windows