### PR TITLE
use ExpectEqual in /e2e/auth

### DIFF
--- a/test/e2e/auth/node_authn.go
+++ b/test/e2e/auth/node_authn.go
@@ -19,7 +19,7 @@ package auth
 import (
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/pkg/master/ports"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -40,7 +40,7 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 
 		nodeList, err := f.ClientSet.CoreV1().Nodes().List(metav1.ListOptions{})
 		framework.ExpectNoError(err, "failed to list nodes in namespace: %s", ns)
-		gomega.Expect(len(nodeList.Items)).NotTo(gomega.BeZero())
+		framework.ExpectNotEqual(len(nodeList.Items), 0)
 
 		pickedNode := nodeList.Items[0]
 		nodeIPs = e2enode.GetAddresses(&pickedNode, v1.NodeExternalIP)
@@ -51,7 +51,8 @@ var _ = SIGDescribe("[Feature:NodeAuthenticator]", func() {
 		saName := "default"
 		sa, err := f.ClientSet.CoreV1().ServiceAccounts(ns).Get(saName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "failed to retrieve service account (%s:%s)", ns, saName)
-		gomega.Expect(len(sa.Secrets)).NotTo(gomega.BeZero())
+		framework.ExpectNotEqual(len(sa.Secrets), 0)
+
 	})
 
 	ginkgo.It("The kubelet's main port 10250 should reject requests with no credentials", func() {

--- a/test/e2e/auth/pod_security_policy.go
+++ b/test/e2e/auth/pod_security_policy.go
@@ -38,7 +38,6 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const nobodyUser = int64(65534)
@@ -115,7 +114,7 @@ var _ = SIGDescribe("PodSecurityPolicy", func() {
 			p, err = c.CoreV1().Pods(ns).Get(p.Name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
 			validated, found := p.Annotations[psputil.ValidatedPSPAnnotation]
-			gomega.Expect(found).To(gomega.BeTrue(), "PSP annotation not found")
+			framework.ExpectEqual(found, true, "PSP annotation not found")
 			framework.ExpectEqual(validated, expectedPSP.Name, "Unexpected validated PSP")
 		})
 	})
@@ -123,7 +122,7 @@ var _ = SIGDescribe("PodSecurityPolicy", func() {
 
 func expectForbidden(err error) {
 	framework.ExpectError(err, "should be forbidden")
-	gomega.Expect(apierrs.IsForbidden(err)).To(gomega.BeTrue(), "should be forbidden error")
+	framework.ExpectEqual(apierrs.IsForbidden(err), true, "should be forbidden error")
 }
 
 func testPrivilegedPods(tester func(pod *v1.Pod)) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
**What this PR does / why we need it**:
**Which issue(s) this PR fixes**:

Since #78922 ExpectEqual() is implemented as test framework.
This makes e2e tests use the function under test/e2e/auth.

Ref: #79686
**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

