### PR TITLE
Fixing EndpointSlice controller panic

### DIFF
--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -281,8 +281,9 @@ func (r *reconciler) reconcileByPortMapping(
 			}
 		}
 
-		// If an endpoint was updated or removed, mark for update or delete
-		if endpointUpdated || len(existingSlice.Endpoints) != len(newEndpoints) {
+		// If an endpoint was updated or removed, or the EndpointSlice needs
+		// a managed-by label, mark for update or delete
+		if endpointUpdated || len(existingSlice.Endpoints) != len(newEndpoints) || needsManagedByLabel(existingSlice) {
 			if len(existingSlice.Endpoints) > len(newEndpoints) {
 				numRemoved += len(existingSlice.Endpoints) - len(newEndpoints)
 			}
@@ -291,6 +292,9 @@ func (r *reconciler) reconcileByPortMapping(
 				sliceNamesToDelete.Insert(existingSlice.Name)
 			} else {
 				// otherwise, mark for update
+				if needsManagedByLabel(existingSlice) {
+					slicesByName[existingSlice.Name] = addManagedByLabel(existingSlice)
+				}
 				existingSlice.Endpoints = newEndpoints
 				sliceNamesToUpdate.Insert(existingSlice.Name)
 			}

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -373,7 +373,13 @@ func newServiceAndEndpointMeta(name, namespace string) (v1.Service, endpointMeta
 	}
 
 	svc := v1.Service{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				managedBySetupAnnotation: managedBySetupCompleteValue,
+			},
+		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{{
 				TargetPort: portNameIntStr,
@@ -399,6 +405,9 @@ func newEmptyEndpointSlice(n int, namespace string, endpointMeta endpointMeta, s
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.%d", svc.Name, n),
 			Namespace: namespace,
+			Labels: map[string]string{
+				discovery.LabelManagedBy: controllerName,
+			},
 		},
 		Ports:       endpointMeta.Ports,
 		AddressType: endpointMeta.AddressType,

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/controller_policy.go
@@ -153,7 +153,8 @@ func buildControllerRoles() ([]rbacv1.ClusterRole, []rbacv1.ClusterRoleBinding) 
 		addControllerRole(&controllerRoles, &controllerRoleBindings, rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: saRolePrefix + "endpointslice-controller"},
 			Rules: []rbacv1.PolicyRule{
-				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("services", "pods", "nodes").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("pods", "nodes").RuleOrDie(),
+				rbacv1helpers.NewRule("get", "list", "watch", "patch").Groups(legacyGroup).Resources("services").RuleOrDie(),
 				rbacv1helpers.NewRule("get", "list", "create", "update", "delete").Groups(discoveryGroup).Resources("endpointslices").RuleOrDie(),
 				eventsRule(),
 			},

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/controller-roles.yaml
@@ -462,10 +462,18 @@ items:
     resources:
     - nodes
     - pods
+    verbs:
+    - get
+    - list
+    - watch
+  - apiGroups:
+    - ""
+    resources:
     - services
     verbs:
     - get
     - list
+    - patch
     - watch
   - apiGroups:
     - discovery.k8s.io


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As found by @liggitt, there is a bug in the EndpointSlice controller that can cause it to panic. This is caused by attempting to modify a Service object from an informer directly instead of first copying the object. This PR should fix that.

**Special notes for your reviewer**:
Unfortunately it turns out that one of my tests covering this was affected by this chance. There is both a fake clientset and fake lister that are initialized together but don't seem as connected as one would like - the test is adding the same resources to both the lister store and the fake clientset. The test that's affected relied on the client updating the EndpointSlice with the managed-by label followed by the lister listing EndpointSlices with that label. This previously worked since I was modifying the EndpointSlice in place. Now that I'm doing a proper deep copy here, that portion of the test is not effective. I've adjusted the test for now and added a TODO to fix the test. I'm assuming there's a better way to initialize a lister and fake clientset where I won't run into this kind of problem? The generation is here: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/endpointslice/endpointslice_controller_test.go#L53. 

At this point, that specific function of that test is not particularly critical, and fixing this panic is, so I think it's worth moving forward with this fix as is unless there's something obvious I'm overlooking.

**Which issue(s) this PR fixes**:
Fixes #85331

**Does this PR introduce a user-facing change?**:
```release-note
Fixes panic in EndpointSlice controller when setting managed-by annotation.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
- Enhancement Issue: kubernetes/enhancements#752

/sig network
/priority critical-urgent
/assign @liggitt 