### PR TITLE
Addon Manager: Fix parsing KUBECTL_EXTRA_PRUNE_WHITELIST

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -120,7 +120,7 @@ function generate_prune_whitelist_flags() {
 # besides the default ones.
 extra_prune_whitelist=
 if [ -n "${KUBECTL_EXTRA_PRUNE_WHITELIST:-}" ]; then
-  extra_prune_whitelist=( "${KUBECTL_EXTRA_PRUNE_WHITELIST:-}" )
+  read -ra extra_prune_whitelist <<< "${KUBECTL_EXTRA_PRUNE_WHITELIST}"
 fi
 prune_whitelist=( "${KUBECTL_PRUNE_WHITELIST[@]}"  "${extra_prune_whitelist[@]}" )
 prune_whitelist_flags=$(generate_prune_whitelist_flags "${prune_whitelist[@]}")


### PR DESCRIPTION
When there are two or more parameters it should result in:

```
kubectl ... --prune-whitelist paramter1 --prune-whitelist parameter2 ...
```

but it wrongly generates:

```
kubectl ... --prune-whitelist parameter1 parameter2 ...
```

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes parsing of KUBECTL_EXTRA_PRUNE_WHITELIST in cluster/addons/addon-manager/kube-addons.sh

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85343

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

/sig release