### PR TITLE
proxier: improve node topology event handler logic

### DIFF
--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -600,14 +600,16 @@ func (proxier *Proxier) OnNodeAdd(node *v1.Node) {
 		klog.Errorf("Received a watch event for a node %s that doesn't match the current node %v", node.Name, proxier.hostname)
 		return
 	}
-	oldLabels := proxier.nodeLabels
-	newLabels := node.Labels
-	proxier.mu.Lock()
-	proxier.nodeLabels = newLabels
-	proxier.mu.Unlock()
-	if !reflect.DeepEqual(oldLabels, newLabels) {
-		proxier.syncProxyRules()
+
+	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
+		return
 	}
+
+	proxier.mu.Lock()
+	proxier.nodeLabels = node.Labels
+	proxier.mu.Unlock()
+
+	proxier.syncProxyRules()
 }
 
 // OnNodeUpdate is called whenever modification of an existing
@@ -617,14 +619,16 @@ func (proxier *Proxier) OnNodeUpdate(oldNode, node *v1.Node) {
 		klog.Errorf("Received a watch event for a node %s that doesn't match the current node %v", node.Name, proxier.hostname)
 		return
 	}
-	oldLabels := proxier.nodeLabels
-	newLabels := node.Labels
-	proxier.mu.Lock()
-	proxier.nodeLabels = newLabels
-	proxier.mu.Unlock()
-	if !reflect.DeepEqual(oldLabels, newLabels) {
-		proxier.syncProxyRules()
+
+	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
+		return
 	}
+
+	proxier.mu.Lock()
+	proxier.nodeLabels = node.Labels
+	proxier.mu.Unlock()
+
+	proxier.syncProxyRules()
 }
 
 // OnNodeDelete is called whever deletion of an existing node
@@ -637,6 +641,7 @@ func (proxier *Proxier) OnNodeDelete(node *v1.Node) {
 	proxier.mu.Lock()
 	proxier.nodeLabels = nil
 	proxier.mu.Unlock()
+
 	proxier.syncProxyRules()
 }
 

--- a/pkg/proxy/ipvs/proxier.go
+++ b/pkg/proxy/ipvs/proxier.go
@@ -906,14 +906,16 @@ func (proxier *Proxier) OnNodeAdd(node *v1.Node) {
 		klog.Errorf("Received a watch event for a node %s that doesn't match the current node %v", node.Name, proxier.hostname)
 		return
 	}
-	oldLabels := proxier.nodeLabels
-	newLabels := node.Labels
-	proxier.mu.Lock()
-	proxier.nodeLabels = newLabels
-	proxier.mu.Unlock()
-	if !reflect.DeepEqual(oldLabels, newLabels) {
-		proxier.syncProxyRules()
+
+	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
+		return
 	}
+
+	proxier.mu.Lock()
+	proxier.nodeLabels = node.Labels
+	proxier.mu.Unlock()
+
+	proxier.syncProxyRules()
 }
 
 // OnNodeUpdate is called whenever modification of an existing
@@ -923,14 +925,16 @@ func (proxier *Proxier) OnNodeUpdate(oldNode, node *v1.Node) {
 		klog.Errorf("Received a watch event for a node %s that doesn't match the current node %v", node.Name, proxier.hostname)
 		return
 	}
-	oldLabels := proxier.nodeLabels
-	newLabels := node.Labels
-	proxier.mu.Lock()
-	proxier.nodeLabels = newLabels
-	proxier.mu.Unlock()
-	if !reflect.DeepEqual(oldLabels, newLabels) {
-		proxier.syncProxyRules()
+
+	if reflect.DeepEqual(proxier.nodeLabels, node.Labels) {
+		return
 	}
+
+	proxier.mu.Lock()
+	proxier.nodeLabels = node.Labels
+	proxier.mu.Unlock()
+
+	proxier.syncProxyRules()
 }
 
 // OnNodeDelete is called whever deletion of an existing node
@@ -943,6 +947,7 @@ func (proxier *Proxier) OnNodeDelete(node *v1.Node) {
 	proxier.mu.Lock()
 	proxier.nodeLabels = nil
 	proxier.mu.Unlock()
+
 	proxier.syncProxyRules()
 }
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kiman@vmware.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Improves logic of the node event handler for Service Topology by returning earlier if the node topology did not change. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
