### PR TITLE
Reverting managed-by-setup annotation

### DIFF
--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -1017,13 +1017,13 @@ __EOF__
   kubectl run testmetadata --image=nginx --replicas=2 --port=80 --expose --service-overrides='{ "metadata": { "annotations": { "zone-context": "home" } } } '
   # Check result
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" 'testmetadata:'
-  kube::test::get_object_assert 'service testmetadata' "{{.metadata.annotations}}" "map\[endpointslice.kubernetes.io/managed-by-setup:true zone-context:home\]"
+  kube::test::get_object_assert 'service testmetadata' "{{.metadata.annotations}}" "map\[zone-context:home\]"
 
   ### Expose deployment as a new service
   # Command
   kubectl expose deployment testmetadata  --port=1000 --target-port=80 --type=NodePort --name=exposemetadata --overrides='{ "metadata": { "annotations": { "zone-context": "work" } } } '
   # Check result
-  kube::test::get_object_assert 'service exposemetadata' "{{.metadata.annotations}}" "map\[endpointslice.kubernetes.io/managed-by-setup:true zone-context:work\]"
+  kube::test::get_object_assert 'service exposemetadata' "{{.metadata.annotations}}" "map\[zone-context:work\]"
 
   # Clean-Up
   # Command


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This ended up causing far more problems than it was worth, especially given that it just attempted to provide backwards compatibility with the alpha release.

**Which issue(s) this PR fixes**:
Fixes #85331

**Special notes for your reviewer**:
This is an alternative to https://github.com/kubernetes/kubernetes/pull/85324. I'm not sure which approach is actually preferable. 

**Does this PR introduce a user-facing change?**:
```release-note
When upgrading to 1.17 with a cluster with EndpointSlices enabled, the `endpointslice.kubernetes.io/managed-by` label needs to be set on each EndpointSlice.
```

/sig network
/priority critical-urgent
/cc @liggitt @thockin @freehan 