### PR TITLE
fix terrible bug and inline GC for expiring cache

### DIFF
--- a/pkg/kubeapiserver/authenticator/config.go
+++ b/pkg/kubeapiserver/authenticator/config.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authenticator
 
 import (
-	"context"
 	"time"
 
 	"github.com/go-openapi/spec"
@@ -193,7 +192,7 @@ func (config Config) New() (authenticator.Request, *spec.SecurityDefinitions, er
 		tokenAuth := tokenunion.New(tokenAuthenticators...)
 		// Optionally cache authentication results
 		if config.TokenSuccessCacheTTL > 0 || config.TokenFailureCacheTTL > 0 {
-			tokenAuth = tokencache.New(context.TODO(), tokenAuth, true, config.TokenSuccessCacheTTL, config.TokenFailureCacheTTL)
+			tokenAuth = tokencache.New(tokenAuth, true, config.TokenSuccessCacheTTL, config.TokenFailureCacheTTL)
 		}
 		authenticators = append(authenticators, bearertoken.New(tokenAuth), websocket.NewProtocolAuthenticator(tokenAuth))
 		securityDefinitions["BearerToken"] = &spec.SecurityScheme{
@@ -313,5 +312,5 @@ func newWebhookTokenAuthenticator(webhookConfigFile string, version string, ttl 
 		return nil, err
 	}
 
-	return tokencache.New(context.TODO(), webhookTokenAuthenticator, false, ttl, ttl), nil
+	return tokencache.New(webhookTokenAuthenticator, false, ttl, ttl), nil
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring.go
@@ -70,7 +70,7 @@ func (c *Expiring) Get(key interface{}) (val interface{}, ok bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	e, ok := c.cache[key]
-	if !ok || c.clock.Now().After(e.expiry) {
+	if !ok || !c.clock.Now().Before(e.expiry) {
 		return nil, false
 	}
 	return e.val, true
@@ -148,7 +148,7 @@ func (c *Expiring) gc(now time.Time) {
 		// from looking at the (*expiringHeap).Pop() implmentation below.
 		// heap.Pop() swaps the first entry with the last entry of the heap, then
 		// calls (*expiringHeap).Pop() which returns the last element.
-		if len(c.heap) == 0 || now.After(c.heap[0].expiry) {
+		if len(c.heap) == 0 || now.Before(c.heap[0].expiry) {
 			return
 		}
 		cleanup := heap.Pop(&c.heap).(*expiringHeapEntry)

--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring.go
@@ -18,15 +18,13 @@ package cache
 
 import (
 	"container/heap"
-	"context"
 	"sync"
 	"time"
 
 	utilclock "k8s.io/apimachinery/pkg/util/clock"
 )
 
-// NewExpiring returns an initialized expiring cache. Users must call
-// (*Expiring).Run() to begin the GC goroutine.
+// NewExpiring returns an initialized expiring cache.
 func NewExpiring() *Expiring {
 	return NewExpiringWithClock(utilclock.RealClock{})
 }
@@ -80,9 +78,13 @@ func (c *Expiring) Get(key interface{}) (val interface{}, ok bool) {
 
 // Set sets a key/value/expiry entry in the map, overwriting any previous entry
 // with the same key. The entry expires at the given expiry time, but its TTL
-// may be lengthened or shortened by additional calls to Set().
+// may be lengthened or shortened by additional calls to Set(). Garbage
+// collection of expired entries occurs during calls to Set(), however calls to
+// Get() will not return expired entries that have not yet been garbage
+// collected.
 func (c *Expiring) Set(key interface{}, val interface{}, ttl time.Duration) {
-	expiry := c.clock.Now().Add(ttl)
+	now := c.clock.Now()
+	expiry := now.Add(ttl)
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -94,6 +96,9 @@ func (c *Expiring) Set(key interface{}, val interface{}, ttl time.Duration) {
 		expiry:     expiry,
 		generation: c.generation,
 	}
+
+	// Run GC inline before pushing the new entry.
+	c.gc(now)
 
 	heap.Push(&c.heap, &expiringHeapEntry{
 		key:        key,
@@ -134,28 +139,7 @@ func (c *Expiring) Len() int {
 	return len(c.cache)
 }
 
-const gcInterval = 50 * time.Millisecond
-
-// Run runs the GC goroutine. The goroutine exits when the passed in context is
-// cancelled.
-func (c *Expiring) Run(ctx context.Context) {
-	t := c.clock.NewTicker(gcInterval)
-	defer t.Stop()
-	for {
-		select {
-		case <-t.C():
-			c.gc()
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (c *Expiring) gc() {
-	now := c.clock.Now()
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
+func (c *Expiring) gc(now time.Time) {
 	for {
 		// Return from gc if the heap is empty or the next element is not yet
 		// expired.

--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring_test.go
@@ -103,6 +103,107 @@ func TestExpiration(t *testing.T) {
 	}
 }
 
+func TestGarbageCollection(t *testing.T) {
+	fc := &utilclock.FakeClock{}
+
+	type entry struct {
+		key, val string
+		ttl      time.Duration
+	}
+
+	tests := []struct {
+		name string
+		now  time.Time
+		set  []entry
+		want map[string]string
+	}{
+		{
+			name: "two entries just set",
+			now:  fc.Now().Add(0 * time.Second),
+			set: []entry{
+				{"a", "aa", 1 * time.Second},
+				{"b", "bb", 2 * time.Second},
+			},
+			want: map[string]string{
+				"a": "aa",
+				"b": "bb",
+			},
+		},
+		{
+			name: "first entry expired now",
+			now:  fc.Now().Add(1 * time.Second),
+			set: []entry{
+				{"a", "aa", 1 * time.Second},
+				{"b", "bb", 2 * time.Second},
+			},
+			want: map[string]string{
+				"b": "bb",
+			},
+		},
+		{
+			name: "first entry expired half a second ago",
+			now:  fc.Now().Add(1500 * time.Millisecond),
+			set: []entry{
+				{"a", "aa", 1 * time.Second},
+				{"b", "bb", 2 * time.Second},
+			},
+			want: map[string]string{
+				"b": "bb",
+			},
+		},
+		{
+			name: "three entries weird order",
+			now:  fc.Now().Add(1 * time.Second),
+			set: []entry{
+				{"c", "cc", 3 * time.Second},
+				{"a", "aa", 1 * time.Second},
+				{"b", "bb", 2 * time.Second},
+			},
+			want: map[string]string{
+				"b": "bb",
+				"c": "cc",
+			},
+		},
+		{
+			name: "expire multiple entries in one cycle",
+			now:  fc.Now().Add(2500 * time.Millisecond),
+			set: []entry{
+				{"a", "aa", 1 * time.Second},
+				{"b", "bb", 2 * time.Second},
+				{"c", "cc", 3 * time.Second},
+			},
+			want: map[string]string{
+				"c": "cc",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := NewExpiringWithClock(fc)
+			for _, e := range test.set {
+				c.Set(e.key, e.val, e.ttl)
+			}
+
+			c.gc(test.now)
+
+			for k, want := range test.want {
+				got, ok := c.Get(k)
+				if !ok {
+					t.Errorf("expected cache to have entry for key=%q but found none", k)
+					continue
+				}
+				if got != want {
+					t.Errorf("unexpected value for key=%q: got=%q, want=%q", k, got, want)
+				}
+			}
+			if got, want := c.Len(), len(test.want); got != want {
+				t.Errorf("unexpected cache size: got=%d, want=%d", got, want)
+			}
+		})
+	}
+}
+
 func BenchmarkExpiringCacheContention(b *testing.B) {
 	b.Run("evict_probablility=100%", func(b *testing.B) {
 		benchmarkExpiringCacheContention(b, 1)

--- a/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring_test.go
@@ -29,11 +29,7 @@ import (
 )
 
 func TestExpiringCache(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	cache := NewExpiring()
-	go cache.Run(ctx)
 
 	if result, ok := cache.Get("foo"); ok || result != nil {
 		t.Errorf("Expected null, false, got %#v, %v", result, ok)
@@ -62,12 +58,8 @@ func TestExpiringCache(t *testing.T) {
 }
 
 func TestExpiration(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	fc := &utilclock.FakeClock{}
 	c := NewExpiringWithClock(fc)
-	go c.Run(ctx)
 
 	c.Set("a", "a", time.Second)
 
@@ -100,12 +92,10 @@ func TestExpiration(t *testing.T) {
 	// remove the key.
 	c.Set("a", "a", time.Second)
 
-	c.mu.Lock()
 	e := c.cache["a"]
 	e.generation++
 	e.expiry = e.expiry.Add(1 * time.Second)
 	c.cache["a"] = e
-	c.mu.Unlock()
 
 	fc.Step(1 * time.Second)
 	if _, ok := c.Get("a"); !ok {
@@ -126,12 +116,8 @@ func BenchmarkExpiringCacheContention(b *testing.B) {
 }
 
 func benchmarkExpiringCacheContention(b *testing.B, prob float64) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	const numKeys = 1 << 16
 	cache := NewExpiring()
-	go cache.Run(ctx)
 
 	keys := []string{}
 	for i := 0; i < numKeys; i++ {
@@ -166,7 +152,6 @@ func TestStressExpiringCache(t *testing.T) {
 
 	const numKeys = 1 << 16
 	cache := NewExpiring()
-	go cache.Run(ctx)
 
 	keys := []string{}
 	for i := 0; i < numKeys; i++ {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/authenticatorfactory/delegating.go
@@ -17,7 +17,6 @@ limitations under the License.
 package authenticatorfactory
 
 import (
-	"context"
 	"errors"
 	"time"
 
@@ -84,7 +83,7 @@ func (c DelegatingAuthenticatorConfig) New() (authenticator.Request, *spec.Secur
 		if err != nil {
 			return nil, nil, err
 		}
-		cachingTokenAuth := cache.New(context.TODO(), tokenAuth, false, c.CacheTTL, c.CacheTTL)
+		cachingTokenAuth := cache.New(tokenAuth, false, c.CacheTTL, c.CacheTTL)
 		authenticators = append(authenticators, bearertoken.New(cachingTokenAuth), websocket.NewProtocolAuthenticator(cachingTokenAuth))
 
 		securityDefinitions["BearerToken"] = &spec.SecurityScheme{

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_simple.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_simple.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"time"
 
 	utilcache "k8s.io/apimachinery/pkg/util/cache"
@@ -28,10 +27,8 @@ type simpleCache struct {
 	cache *utilcache.Expiring
 }
 
-func newSimpleCache(ctx context.Context, clock clock.Clock) cache {
-	c := &simpleCache{cache: utilcache.NewExpiringWithClock(clock)}
-	go c.cache.Run(ctx)
-	return c
+func newSimpleCache(clock clock.Clock) cache {
+	return &simpleCache{cache: utilcache.NewExpiringWithClock(clock)}
 }
 
 func (c *simpleCache) get(key string) (*cacheRecord, bool) {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cache_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cache
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -31,9 +30,7 @@ import (
 )
 
 func TestSimpleCache(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	testCache(newSimpleCache(ctx, clock.RealClock{}), t)
+	testCache(newSimpleCache(clock.RealClock{}), t)
 }
 
 // Note: the performance profile of this benchmark may not match that in the production.
@@ -42,22 +39,16 @@ func TestSimpleCache(t *testing.T) {
 func BenchmarkCacheContentions(b *testing.B) {
 	for _, numKeys := range []int{1 << 8, 1 << 12, 1 << 16} {
 		b.Run(fmt.Sprintf("Simple/keys=%d", numKeys), func(b *testing.B) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			benchmarkCache(newSimpleCache(ctx, clock.RealClock{}), b, numKeys)
+			benchmarkCache(newSimpleCache(clock.RealClock{}), b, numKeys)
 		})
 		b.Run(fmt.Sprintf("Striped/keys=%d", numKeys), func(b *testing.B) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			benchmarkCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(ctx, clock.RealClock{}) }), b, numKeys)
+			benchmarkCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(clock.RealClock{}) }), b, numKeys)
 		})
 	}
 }
 
 func TestStripedCache(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	testCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(ctx, clock.RealClock{}) }), t)
+	testCache(newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(clock.RealClock{}) }), t)
 }
 
 func benchmarkCache(cache cache, b *testing.B, numKeys int) {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator.go
@@ -64,11 +64,11 @@ type cache interface {
 }
 
 // New returns a token authenticator that caches the results of the specified authenticator. A ttl of 0 bypasses the cache.
-func New(ctx context.Context, authenticator authenticator.Token, cacheErrs bool, successTTL, failureTTL time.Duration) authenticator.Token {
-	return newWithClock(ctx, authenticator, cacheErrs, successTTL, failureTTL, utilclock.RealClock{})
+func New(authenticator authenticator.Token, cacheErrs bool, successTTL, failureTTL time.Duration) authenticator.Token {
+	return newWithClock(authenticator, cacheErrs, successTTL, failureTTL, utilclock.RealClock{})
 }
 
-func newWithClock(ctx context.Context, authenticator authenticator.Token, cacheErrs bool, successTTL, failureTTL time.Duration, clock utilclock.Clock) authenticator.Token {
+func newWithClock(authenticator authenticator.Token, cacheErrs bool, successTTL, failureTTL time.Duration, clock utilclock.Clock) authenticator.Token {
 	randomCacheKey := make([]byte, 32)
 	if _, err := rand.Read(randomCacheKey); err != nil {
 		panic(err) // rand should never fail
@@ -86,7 +86,7 @@ func newWithClock(ctx context.Context, authenticator authenticator.Token, cacheE
 		// used. Currently we advertise support 5k nodes and 10k
 		// namespaces; a 32k entry cache is therefore a 2x safety
 		// margin.
-		cache: newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(ctx, clock) }),
+		cache: newStripedCache(32, fnvHashFunc, func() cache { return newSimpleCache(clock) }),
 
 		hashPool: &sync.Pool{
 			New: func() interface{} {

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/cached_token_authenticator_test.go
@@ -50,10 +50,7 @@ func TestCachedTokenAuthenticator(t *testing.T) {
 	})
 	fakeClock := utilclock.NewFakeClock(time.Now())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	a := newWithClock(ctx, fakeAuth, true, time.Minute, 0, fakeClock)
+	a := newWithClock(fakeAuth, true, time.Minute, 0, fakeClock)
 
 	calledWithToken, resultUsers, resultOk, resultErr = []string{}, nil, false, nil
 	a.AuthenticateToken(context.Background(), "bad1")
@@ -127,10 +124,7 @@ func TestCachedTokenAuthenticatorWithAudiences(t *testing.T) {
 	})
 	fakeClock := utilclock.NewFakeClock(time.Now())
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	a := newWithClock(ctx, fakeAuth, true, time.Minute, 0, fakeClock)
+	a := newWithClock(fakeAuth, true, time.Minute, 0, fakeClock)
 
 	resultUsers["audAusertoken1"] = &user.DefaultInfo{Name: "user1"}
 	resultUsers["audBusertoken1"] = &user.DefaultInfo{Name: "user1-different"}
@@ -276,8 +270,6 @@ func (s *singleBenchmark) run(b *testing.B) {
 }
 
 func (s *singleBenchmark) bench(b *testing.B) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	// Simulate slowness, qps limit, external service limitation, etc
 	const maxInFlight = 40
 	chokepoint := make(chan struct{}, maxInFlight)
@@ -285,7 +277,6 @@ func (s *singleBenchmark) bench(b *testing.B) {
 	var lookups uint64
 
 	a := newWithClock(
-		ctx,
 		authenticator.TokenFunc(func(ctx context.Context, token string) (*authenticator.Response, bool, error) {
 			atomic.AddUint64(&lookups, 1)
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
@@ -170,7 +170,7 @@ func (m *mockV1Service) HTTPStatusCode() int { return m.statusCode }
 
 // newV1TokenAuthenticator creates a temporary kubeconfig file from the provided
 // arguments and attempts to load a new WebhookTokenAuthenticator from it.
-func newV1TokenAuthenticator(ctx context.Context, serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
+func newV1TokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
 	tempfile, err := ioutil.TempFile("", "")
 	if err != nil {
 		return nil, err
@@ -203,7 +203,7 @@ func newV1TokenAuthenticator(ctx context.Context, serverURL string, clientCert, 
 		return nil, err
 	}
 
-	return cache.New(ctx, authn, false, cacheTime, cacheTime), nil
+	return cache.New(authn, false, cacheTime, cacheTime), nil
 }
 
 func TestV1TLSConfig(t *testing.T) {
@@ -259,10 +259,7 @@ func TestV1TLSConfig(t *testing.T) {
 			}
 			defer server.Close()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			wh, err := newV1TokenAuthenticator(ctx, server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0, nil)
+			wh, err := newV1TokenAuthenticator(server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0, nil)
 			if err != nil {
 				t.Errorf("%s: failed to create client: %v", tt.test, err)
 				return
@@ -485,14 +482,12 @@ func TestV1WebhookTokenAuthenticator(t *testing.T) {
 	token := "my-s3cr3t-t0ken"
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			wh, err := newV1TokenAuthenticator(ctx, s.URL, clientCert, clientKey, caCert, 0, tt.implicitAuds)
+			wh, err := newV1TokenAuthenticator(s.URL, clientCert, clientKey, caCert, 0, tt.implicitAuds)
 			if err != nil {
 				t.Fatal(err)
 			}
 
+			ctx := context.Background()
 			if tt.reqAuds != nil {
 				ctx = authenticator.WithAudiences(ctx, tt.reqAuds)
 			}
@@ -559,11 +554,8 @@ func TestV1WebhookCacheAndRetry(t *testing.T) {
 	}
 	defer s.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	// Create an authenticator that caches successful responses "forever" (100 days).
-	wh, err := newV1TokenAuthenticator(ctx, s.URL, clientCert, clientKey, caCert, 2400*time.Hour, nil)
+	wh, err := newV1TokenAuthenticator(s.URL, clientCert, clientKey, caCert, 2400*time.Hour, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
@@ -172,7 +172,7 @@ func (m *mockV1beta1Service) HTTPStatusCode() int { return m.statusCode }
 
 // newV1beta1TokenAuthenticator creates a temporary kubeconfig file from the provided
 // arguments and attempts to load a new WebhookTokenAuthenticator from it.
-func newV1beta1TokenAuthenticator(ctx context.Context, serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
+func newV1beta1TokenAuthenticator(serverURL string, clientCert, clientKey, ca []byte, cacheTime time.Duration, implicitAuds authenticator.Audiences) (authenticator.Token, error) {
 	tempfile, err := ioutil.TempFile("", "")
 	if err != nil {
 		return nil, err
@@ -205,7 +205,7 @@ func newV1beta1TokenAuthenticator(ctx context.Context, serverURL string, clientC
 		return nil, err
 	}
 
-	return cache.New(ctx, authn, false, cacheTime, cacheTime), nil
+	return cache.New(authn, false, cacheTime, cacheTime), nil
 }
 
 func TestV1beta1TLSConfig(t *testing.T) {
@@ -261,10 +261,7 @@ func TestV1beta1TLSConfig(t *testing.T) {
 			}
 			defer server.Close()
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			wh, err := newV1beta1TokenAuthenticator(ctx, server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0, nil)
+			wh, err := newV1beta1TokenAuthenticator(server.URL, tt.clientCert, tt.clientKey, tt.clientCA, 0, nil)
 			if err != nil {
 				t.Errorf("%s: failed to create client: %v", tt.test, err)
 				return
@@ -487,14 +484,12 @@ func TestV1beta1WebhookTokenAuthenticator(t *testing.T) {
 	token := "my-s3cr3t-t0ken"
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			wh, err := newV1beta1TokenAuthenticator(ctx, s.URL, clientCert, clientKey, caCert, 0, tt.implicitAuds)
+			wh, err := newV1beta1TokenAuthenticator(s.URL, clientCert, clientKey, caCert, 0, tt.implicitAuds)
 			if err != nil {
 				t.Fatal(err)
 			}
 
+			ctx := context.Background()
 			if tt.reqAuds != nil {
 				ctx = authenticator.WithAudiences(ctx, tt.reqAuds)
 			}
@@ -561,11 +556,8 @@ func TestV1beta1WebhookCacheAndRetry(t *testing.T) {
 	}
 	defer s.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	// Create an authenticator that caches successful responses "forever" (100 days).
-	wh, err := newV1beta1TokenAuthenticator(ctx, s.URL, clientCert, clientKey, caCert, 2400*time.Hour, nil)
+	wh, err := newV1beta1TokenAuthenticator(s.URL, clientCert, clientKey, caCert, 2400*time.Hour, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/auth/auth_test.go
+++ b/test/integration/auth/auth_test.go
@@ -70,7 +70,7 @@ func getTestTokenAuth() authenticator.Request {
 	return group.NewGroupAdder(bearertoken.New(tokenAuthenticator), []string{user.AllAuthenticated})
 }
 
-func getTestWebhookTokenAuth(ctx context.Context, serverURL string) (authenticator.Request, error) {
+func getTestWebhookTokenAuth(serverURL string) (authenticator.Request, error) {
 	kubecfgFile, err := ioutil.TempFile("", "webhook-kubecfg")
 	if err != nil {
 		return nil, err
@@ -90,7 +90,7 @@ func getTestWebhookTokenAuth(ctx context.Context, serverURL string) (authenticat
 	if err != nil {
 		return nil, err
 	}
-	return bearertoken.New(cache.New(ctx, webhookTokenAuth, false, 2*time.Minute, 2*time.Minute)), nil
+	return bearertoken.New(cache.New(webhookTokenAuth, false, 2*time.Minute, 2*time.Minute)), nil
 }
 
 func path(resource, namespace, name string) string {
@@ -1176,11 +1176,7 @@ func TestReadOnlyAuthorization(t *testing.T) {
 func TestWebhookTokenAuthenticator(t *testing.T) {
 	authServer := newTestWebhookTokenAuthServer()
 	defer authServer.Close()
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	authenticator, err := getTestWebhookTokenAuth(ctx, authServer.URL)
+	authenticator, err := getTestWebhookTokenAuth(authServer.URL)
 	if err != nil {
 		t.Fatalf("error starting webhook token authenticator server: %v", err)
 	}


### PR DESCRIPTION
I fudged cleanup of this comment:

https://github.com/kubernetes/kubernetes/pull/84424#discussion_r345346041

It needs to be the opposite of this:

https://github.com/kubernetes/kubernetes/blob/f2469a7a2c75a78b8c0b0514652511d105d2b2e7/staging/src/k8s.io/apimachinery/pkg/util/cache/expiring.go#L75

I've made the expiration test check cache size rather than just calling Get.

This change also inlines GC, removing the background goroutine. This appears to make virtually no difference in performance. I'm happy to separate out the bug fix as well.

Before (including the fix) and after (including fix plus GC inlining) benchmarks for 1s and 10s:

#### -benchtime=1s
Mostly loading.
```
$ benchstat before.1s.log after.1s.log 
name                                                  old time/op     new time/op     delta
CachedTokenAuthenticator/tokens=100_threads=1-60          661ns ± 6%      655ns ±12%     ~     (p=0.797 n=9+10)
CachedTokenAuthenticator/tokens=100_threads=16-60         594ns ±15%      502ns ±17%  -15.43%  (p=0.002 n=10+9)
CachedTokenAuthenticator/tokens=100_threads=256-60        649ns ±35%      686ns ±20%     ~     (p=0.387 n=9+9)
CachedTokenAuthenticator/tokens=500_threads=1-60          376ns ± 2%      387ns ± 2%   +2.98%  (p=0.000 n=10+10)
CachedTokenAuthenticator/tokens=500_threads=16-60         430ns ±17%      408ns ±14%     ~     (p=0.160 n=10+10)
CachedTokenAuthenticator/tokens=500_threads=256-60        843ns ±21%      674ns ±18%  -20.08%  (p=0.002 n=9+9)
CachedTokenAuthenticator/tokens=2500_threads=1-60         364ns ± 1%      361ns ± 1%     ~     (p=0.105 n=10+10)
CachedTokenAuthenticator/tokens=2500_threads=16-60        447ns ±13%      432ns ±13%     ~     (p=0.342 n=10+10)
CachedTokenAuthenticator/tokens=2500_threads=256-60      1.22µs ±25%     1.23µs ±30%     ~     (p=0.853 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=1-60        446ns ± 1%      407ns ± 1%   -8.82%  (p=0.000 n=8+9)
CachedTokenAuthenticator/tokens=12500_threads=16-60       602ns ± 8%      600ns ± 7%     ~     (p=0.838 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=256-60     12.1µs ± 8%     12.7µs ± 2%     ~     (p=0.278 n=10+9)
CachedTokenAuthenticator/tokens=62500_threads=1-60       18.0µs ± 0%     17.9µs ± 0%   -0.17%  (p=0.021 n=9+10)
CachedTokenAuthenticator/tokens=62500_threads=16-60      18.8µs ± 0%     18.8µs ± 0%     ~     (p=0.912 n=10+10)
CachedTokenAuthenticator/tokens=62500_threads=256-60     25.0µs ± 1%     25.1µs ± 1%     ~     (p=0.684 n=10+10)

name                                                  old lookups/op  new lookups/op  delta
CachedTokenAuthenticator/tokens=100_threads=1-60           0.00 ±12%       0.00 ±14%     ~     (p=0.754 n=10+10)
CachedTokenAuthenticator/tokens=100_threads=16-60          0.00 ±49%      0.00 ±103%     ~     (p=0.725 n=10+10)
CachedTokenAuthenticator/tokens=100_threads=256-60         0.01 ±46%       0.01 ±50%     ~     (p=0.450 n=9+9)
CachedTokenAuthenticator/tokens=500_threads=1-60           0.00 ± 3%       0.00 ± 5%     ~     (p=0.090 n=9+10)
CachedTokenAuthenticator/tokens=500_threads=16-60          0.00 ±59%       0.00 ±12%  -34.78%  (p=0.004 n=10+10)
CachedTokenAuthenticator/tokens=500_threads=256-60         0.02 ±20%       0.02 ±68%  -30.19%  (p=0.007 n=8+10)
CachedTokenAuthenticator/tokens=2500_threads=1-60          0.00 ± 2%       0.00 ± 3%   -5.10%  (p=0.000 n=10+10)
CachedTokenAuthenticator/tokens=2500_threads=16-60         0.00 ±24%       0.00 ±16%     ~     (p=0.109 n=10+10)
CachedTokenAuthenticator/tokens=2500_threads=256-60        0.03 ±25%       0.04 ±27%     ~     (p=0.853 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=1-60         0.01 ± 1%       0.01 ± 1%  -15.13%  (p=0.000 n=8+9)
CachedTokenAuthenticator/tokens=12500_threads=16-60        0.01 ± 7%       0.01 ±12%     ~     (p=0.221 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=256-60       0.40 ± 7%       0.42 ± 1%     ~     (p=0.055 n=10+9)
CachedTokenAuthenticator/tokens=62500_threads=1-60         0.65 ± 0%       0.65 ± 0%   -0.12%  (p=0.029 n=7+10)
CachedTokenAuthenticator/tokens=62500_threads=16-60        0.68 ± 0%       0.68 ± 0%     ~     (p=0.735 n=10+10)
CachedTokenAuthenticator/tokens=62500_threads=256-60       0.88 ± 1%       0.88 ± 1%     ~     (p=0.929 n=10+10)

name                                                  old alloc/op    new alloc/op    delta
CachedTokenAuthenticator/tokens=100_threads=1-60           300B ± 0%       300B ± 0%     ~     (p=1.000 n=10+10)
CachedTokenAuthenticator/tokens=100_threads=16-60          302B ± 0%       302B ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=100_threads=256-60         345B ± 5%       349B ± 5%     ~     (p=0.266 n=9+9)
CachedTokenAuthenticator/tokens=500_threads=1-60           297B ± 0%       297B ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=16-60          299B ± 0%       299B ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=256-60         354B ± 3%       344B ± 5%   -2.86%  (p=0.006 n=9+9)
CachedTokenAuthenticator/tokens=2500_threads=1-60          297B ± 0%       297B ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=16-60         298B ± 0%       299B ± 0%   +0.17%  (p=0.033 n=10+10)
CachedTokenAuthenticator/tokens=2500_threads=256-60        368B ±10%       397B ± 6%   +7.74%  (p=0.006 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=1-60         298B ± 0%       266B ± 0%  -10.74%  (p=0.000 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=16-60        302B ± 0%       302B ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=12500_threads=256-60     1.39kB ± 8%     1.44kB ± 2%     ~     (p=0.189 n=10+9)
CachedTokenAuthenticator/tokens=62500_threads=1-60         566B ± 0%       566B ± 0%     ~     (p=0.549 n=8+10)
CachedTokenAuthenticator/tokens=62500_threads=16-60        663B ± 0%       663B ± 0%     ~     (p=0.452 n=10+10)
CachedTokenAuthenticator/tokens=62500_threads=256-60     2.66kB ± 9%     2.69kB ± 4%     ~     (p=0.811 n=10+10)

name                                                  old allocs/op   new allocs/op   delta
CachedTokenAuthenticator/tokens=100_threads=1-60           11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=100_threads=16-60          11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=100_threads=256-60         11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=1-60           11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=16-60          11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=256-60         11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=1-60          11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=16-60         11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=256-60        10.4 ± 6%       11.4 ± 5%   +9.62%  (p=0.002 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=1-60         11.0 ± 0%       10.0 ± 0%   -9.09%  (p=0.000 n=10+10)
CachedTokenAuthenticator/tokens=12500_threads=16-60        11.0 ± 0%       11.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=12500_threads=256-60       14.0 ± 0%       14.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=1-60         15.0 ± 0%       15.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=16-60        15.0 ± 0%       15.0 ± 0%     ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=256-60       16.0 ± 0%       17.0 ± 0%   +6.25%  (p=0.000 n=10+10)
```

#### -benchtime=10s
Long enough to test caching and GC.
```
$ benchstat before.10s.log after.10s.log 
name                                                  old time/op     new time/op     delta
CachedTokenAuthenticator/tokens=100_threads=1-60          650ns ± 5%      632ns ±10%    ~     (p=0.690 n=5+5)
CachedTokenAuthenticator/tokens=100_threads=16-60         513ns ± 8%      500ns ± 6%    ~     (p=0.516 n=5+5)
CachedTokenAuthenticator/tokens=100_threads=256-60        744ns ±15%      701ns ±14%    ~     (p=0.548 n=5+5)
CachedTokenAuthenticator/tokens=500_threads=1-60          374ns ± 1%      373ns ± 0%    ~     (p=0.968 n=5+5)
CachedTokenAuthenticator/tokens=500_threads=16-60         428ns ± 5%      421ns ± 4%    ~     (p=0.421 n=5+5)
CachedTokenAuthenticator/tokens=500_threads=256-60        814ns ±11%      855ns ±11%    ~     (p=0.460 n=5+5)
CachedTokenAuthenticator/tokens=2500_threads=1-60         346ns ± 1%      352ns ± 1%  +1.79%  (p=0.016 n=5+5)
CachedTokenAuthenticator/tokens=2500_threads=16-60        418ns ± 7%      415ns ±16%    ~     (p=0.278 n=5+5)
CachedTokenAuthenticator/tokens=2500_threads=256-60       980ns ±10%      946ns ± 7%    ~     (p=0.548 n=5+5)
CachedTokenAuthenticator/tokens=12500_threads=1-60        309ns ± 1%      309ns ± 1%    ~     (p=0.913 n=5+5)
CachedTokenAuthenticator/tokens=12500_threads=16-60       494ns ± 9%      509ns ± 7%    ~     (p=0.516 n=5+5)
CachedTokenAuthenticator/tokens=12500_threads=256-60     1.60µs ± 2%     1.57µs ± 1%  -1.89%  (p=0.040 n=5+5)
CachedTokenAuthenticator/tokens=62500_threads=1-60        609ns ± 0%      616ns ± 0%  +1.12%  (p=0.008 n=5+5)
CachedTokenAuthenticator/tokens=62500_threads=16-60       710ns ± 0%      742ns ± 1%  +4.54%  (p=0.029 n=4+4)
CachedTokenAuthenticator/tokens=62500_threads=256-60     4.52µs ± 2%     4.51µs ± 1%    ~     (p=1.000 n=5+5)

name                                                  old lookups/op  new lookups/op  delta
CachedTokenAuthenticator/tokens=100_threads=1-60           0.00 ±10%       0.00 ± 7%    ~     (p=0.310 n=5+5)
CachedTokenAuthenticator/tokens=100_threads=16-60          0.00 ±29%       0.00 ±28%    ~     (p=0.421 n=5+5)
CachedTokenAuthenticator/tokens=100_threads=256-60         0.02 ±24%       0.02 ±24%    ~     (p=0.548 n=5+5)
CachedTokenAuthenticator/tokens=500_threads=1-60           0.00 ± 2%       0.00 ± 6%    ~     (p=0.690 n=5+5)
CachedTokenAuthenticator/tokens=500_threads=16-60          0.00 ± 9%       0.00 ± 7%    ~     (p=0.151 n=5+5)
CachedTokenAuthenticator/tokens=500_threads=256-60         0.02 ±17%       0.03 ±14%    ~     (p=0.310 n=5+5)
CachedTokenAuthenticator/tokens=2500_threads=1-60          0.00 ± 1%       0.00 ± 1%  +1.78%  (p=0.008 n=5+5)
CachedTokenAuthenticator/tokens=2500_threads=16-60         0.00 ±21%       0.00 ±23%    ~     (p=0.690 n=5+5)
CachedTokenAuthenticator/tokens=2500_threads=256-60        0.03 ±12%       0.03 ± 7%    ~     (p=0.595 n=5+5)
CachedTokenAuthenticator/tokens=12500_threads=1-60         0.00 ± 1%       0.00 ± 1%    ~     (p=0.841 n=5+5)
CachedTokenAuthenticator/tokens=12500_threads=16-60        0.01 ±16%       0.01 ±12%    ~     (p=0.500 n=5+5)
CachedTokenAuthenticator/tokens=12500_threads=256-60       0.05 ± 2%       0.05 ± 1%    ~     (p=0.151 n=5+5)
CachedTokenAuthenticator/tokens=62500_threads=1-60         0.02 ± 0%       0.02 ± 0%  +0.92%  (p=0.016 n=4+5)
CachedTokenAuthenticator/tokens=62500_threads=16-60        0.02 ± 1%       0.02 ±11%    ~     (p=0.746 n=5+5)
CachedTokenAuthenticator/tokens=62500_threads=256-60       0.16 ± 2%       0.16 ± 1%    ~     (p=0.873 n=5+5)

name                                                  old alloc/op    new alloc/op    delta
CachedTokenAuthenticator/tokens=100_threads=1-60           299B ± 0%       299B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=100_threads=16-60          293B ± 0%       293B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=100_threads=256-60         303B ± 0%       304B ± 0%    ~     (p=0.556 n=5+4)
CachedTokenAuthenticator/tokens=500_threads=1-60           296B ± 0%       296B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=16-60          296B ± 0%       296B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=256-60         305B ± 0%       305B ± 0%    ~     (p=0.444 n=5+5)
CachedTokenAuthenticator/tokens=2500_threads=1-60          297B ± 0%       297B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=16-60         297B ± 0%       297B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=256-60        307B ± 0%       306B ± 0%    ~     (p=0.095 n=4+5)
CachedTokenAuthenticator/tokens=12500_threads=1-60         264B ± 0%       264B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=12500_threads=16-60        297B ± 0%       297B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=12500_threads=256-60       315B ± 0%       314B ± 0%    ~     (p=0.095 n=5+4)
CachedTokenAuthenticator/tokens=62500_threads=1-60         299B ± 0%       299B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=16-60        300B ± 0%       300B ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=256-60       349B ± 0%       349B ± 0%    ~     (p=0.444 n=5+5)

name                                                  old allocs/op   new allocs/op   delta
CachedTokenAuthenticator/tokens=100_threads=1-60           11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=100_threads=16-60          11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=100_threads=256-60         11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=1-60           11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=16-60          11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=500_threads=256-60         11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=1-60          11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=16-60         11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=2500_threads=256-60        11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=12500_threads=1-60         10.0 ± 0%       10.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=12500_threads=16-60        11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=12500_threads=256-60       12.0 ± 0%       12.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=1-60         11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=16-60        11.0 ± 0%       11.0 ± 0%    ~     (all equal)
CachedTokenAuthenticator/tokens=62500_threads=256-60       12.0 ± 0%       12.0 ± 0%    ~     (all equal)
```

/kind bug
/sig auth
Fixes: #85317

```release-note
NONE
```
