### PR TITLE
Add single-item list/watch to delegated authentication reader role

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/namespace_policy.go
@@ -77,7 +77,7 @@ func init() {
 		ObjectMeta: metav1.ObjectMeta{Name: "extension-apiserver-authentication-reader"},
 		Rules: []rbacv1.PolicyRule{
 			// this particular config map is exposed and contains authentication configuration information
-			rbacv1helpers.NewRule("get").Groups(legacyGroup).Resources("configmaps").Names("extension-apiserver-authentication").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch").Groups(legacyGroup).Resources("configmaps").Names("extension-apiserver-authentication").RuleOrDie(),
 		},
 	})
 	addNamespaceRole(metav1.NamespaceSystem, rbacv1.Role{

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-roles.yaml
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/testdata/namespace-roles.yaml
@@ -55,6 +55,8 @@ items:
     - configmaps
     verbs:
     - get
+    - list
+    - watch
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: Role
   metadata:


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds single-item list/watch permission to the delegated authentication reader role

**Which issue(s) this PR fixes**:
Fixes #85374

https://github.com/kubernetes/kubernetes/pull/85004/files#diff-5ea42d528d6fd9e42e6a4f44359343bcR83 switched to a list/watch, but did not add required permissions to the authentication reader role.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig auth
/assign @deads2k