### PR TITLE
apiextensions: freeze and document supported v1.16 OpenAPI formats

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
@@ -359,6 +359,32 @@ message JSONSchemaProps {
 
   optional string type = 5;
 
+  // format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+  //
+  // - bsonobjectid: a bson object ID, i.e. a 24 characters hex string
+  // - uri: an URI as parsed by Golang net/url.ParseRequestURI
+  // - email: an email address as parsed by Golang net/mail.ParseAddress
+  // - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034].
+  // - ipv4: an IPv4 IP as parsed by Golang net.ParseIP
+  // - ipv6: an IPv6 IP as parsed by Golang net.ParseIP
+  // - cidr: a CIDR as parsed by Golang net.ParseCIDR
+  // - mac: a MAC address as parsed by Golang net.ParseMAC
+  // - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+  // - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+  // - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+  // - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+  // - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041"
+  // - isbn10: an ISBN10 number string like "0321751043"
+  // - isbn13: an ISBN13 number string like "978-0321751041"
+  // - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in
+  // - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$
+  // - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+  // - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559"
+  // - byte: base64 encoded binary data
+  // - password: any kind of string
+  // - date: a date string like "2006-01-02" as defined by full-date in RFC3339
+  // - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format
+  // - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
   optional string format = 6;
 
   optional string title = 7;

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
@@ -23,8 +23,36 @@ type JSONSchemaProps struct {
 	Ref         *string       `json:"$ref,omitempty" protobuf:"bytes,3,opt,name=ref"`
 	Description string        `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 	Type        string        `json:"type,omitempty" protobuf:"bytes,5,opt,name=type"`
-	Format      string        `json:"format,omitempty" protobuf:"bytes,6,opt,name=format"`
-	Title       string        `json:"title,omitempty" protobuf:"bytes,7,opt,name=title"`
+
+	// format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+	//
+	// - bsonobjectid: a bson object ID, i.e. a 24 characters hex string
+	// - uri: an URI as parsed by Golang net/url.ParseRequestURI
+	// - email: an email address as parsed by Golang net/mail.ParseAddress
+	// - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034].
+	// - ipv4: an IPv4 IP as parsed by Golang net.ParseIP
+	// - ipv6: an IPv6 IP as parsed by Golang net.ParseIP
+	// - cidr: a CIDR as parsed by Golang net.ParseCIDR
+	// - mac: a MAC address as parsed by Golang net.ParseMAC
+	// - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+	// - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+	// - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+	// - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+	// - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041"
+	// - isbn10: an ISBN10 number string like "0321751043"
+	// - isbn13: an ISBN13 number string like "978-0321751041"
+	// - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in
+	// - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$
+	// - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+	// - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559"
+	// - byte: base64 encoded binary data
+	// - password: any kind of string
+	// - date: a date string like "2006-01-02" as defined by full-date in RFC3339
+	// - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format
+	// - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
+	Format string `json:"format,omitempty" protobuf:"bytes,6,opt,name=format"`
+
+	Title string `json:"title,omitempty" protobuf:"bytes,7,opt,name=title"`
 	// default is a default value for undefined object fields.
 	// Defaulting is a beta feature under the CustomResourceDefaulting feature gate.
 	// Defaulting requires spec.preserveUnknownFields to be false.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -411,6 +411,32 @@ message JSONSchemaProps {
 
   optional string type = 5;
 
+  // format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+  //
+  // - bsonobjectid: a bson object ID, i.e. a 24 characters hex string
+  // - uri: an URI as parsed by Golang net/url.ParseRequestURI
+  // - email: an email address as parsed by Golang net/mail.ParseAddress
+  // - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034].
+  // - ipv4: an IPv4 IP as parsed by Golang net.ParseIP
+  // - ipv6: an IPv6 IP as parsed by Golang net.ParseIP
+  // - cidr: a CIDR as parsed by Golang net.ParseCIDR
+  // - mac: a MAC address as parsed by Golang net.ParseMAC
+  // - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+  // - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+  // - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+  // - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+  // - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041"
+  // - isbn10: an ISBN10 number string like "0321751043"
+  // - isbn13: an ISBN13 number string like "978-0321751041"
+  // - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in
+  // - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$
+  // - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+  // - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559"
+  // - byte: base64 encoded binary data
+  // - password: any kind of string
+  // - date: a date string like "2006-01-02" as defined by full-date in RFC3339
+  // - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format
+  // - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
   optional string format = 6;
 
   optional string title = 7;

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types_jsonschema.go
@@ -23,8 +23,36 @@ type JSONSchemaProps struct {
 	Ref         *string       `json:"$ref,omitempty" protobuf:"bytes,3,opt,name=ref"`
 	Description string        `json:"description,omitempty" protobuf:"bytes,4,opt,name=description"`
 	Type        string        `json:"type,omitempty" protobuf:"bytes,5,opt,name=type"`
-	Format      string        `json:"format,omitempty" protobuf:"bytes,6,opt,name=format"`
-	Title       string        `json:"title,omitempty" protobuf:"bytes,7,opt,name=title"`
+
+	// format is an OpenAPI v3 format string. Unknown formats are ignored. The following formats are validated:
+	//
+	// - bsonobjectid: a bson object ID, i.e. a 24 characters hex string
+	// - uri: an URI as parsed by Golang net/url.ParseRequestURI
+	// - email: an email address as parsed by Golang net/mail.ParseAddress
+	// - hostname: a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034].
+	// - ipv4: an IPv4 IP as parsed by Golang net.ParseIP
+	// - ipv6: an IPv6 IP as parsed by Golang net.ParseIP
+	// - cidr: a CIDR as parsed by Golang net.ParseCIDR
+	// - mac: a MAC address as parsed by Golang net.ParseMAC
+	// - uuid: an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+	// - uuid3: an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+	// - uuid4: an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+	// - uuid5: an UUID5 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+	// - isbn: an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041"
+	// - isbn10: an ISBN10 number string like "0321751043"
+	// - isbn13: an ISBN13 number string like "978-0321751041"
+	// - creditcard: a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in
+	// - ssn: a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$
+	// - hexcolor: an hexadecimal color code like "#FFFFFF: following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+	// - rgbcolor: an RGB color code like rgb like "rgb(255,255,2559"
+	// - byte: base64 encoded binary data
+	// - password: any kind of string
+	// - date: a date string like "2006-01-02" as defined by full-date in RFC3339
+	// - duration: a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format
+	// - datetime: a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339.
+	Format string `json:"format,omitempty" protobuf:"bytes,6,opt,name=format"`
+
+	Title string `json:"title,omitempty" protobuf:"bytes,7,opt,name=title"`
 	// default is a default value for undefined object fields.
 	// Defaulting is a beta feature under the CustomResourceDefaulting feature gate.
 	// CustomResourceDefinitions with defaults must be created using the v1 (or newer) CustomResourceDefinition API.

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -710,7 +710,7 @@ func (r *crdHandler) getOrCreateServingInfoFor(uid types.UID, name string) (*crd
 			if validationSchema != nil && validationSchema.OpenAPIV3Schema != nil && validationSchema.OpenAPIV3Schema.Properties != nil {
 				if statusSchema, ok := validationSchema.OpenAPIV3Schema.Properties["status"]; ok {
 					openapiSchema := &spec.Schema{}
-					if err := apiservervalidation.ConvertJSONSchemaProps(&statusSchema, openapiSchema); err != nil {
+					if err := apiservervalidation.ConvertJSONSchemaPropsWithPostProcess(&statusSchema, openapiSchema, apiservervalidation.StripUnsupportedFormatsPostProcess); err != nil {
 						return nil, err
 					}
 					statusValidator = validate.NewSchemaValidator(openapiSchema, nil, "", strfmt.Default, validate.DisableObjectArrayTypeCheck(true))

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/BUILD
@@ -8,11 +8,15 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["validation.go"],
+    srcs = [
+        "formats.go",
+        "validation.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/validation",
     importpath = "k8s.io/apiextensions-apiserver/pkg/apiserver/validation",
     deps = [
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/github.com/go-openapi/errors:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
@@ -36,7 +40,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["validation_test.go"],
+    srcs = [
+        "formats_test.go",
+        "validation_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions:go_default_library",
@@ -49,5 +56,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//vendor/github.com/go-openapi/spec:go_default_library",
+        "//vendor/github.com/go-openapi/strfmt:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"strings"
+
+	"github.com/go-openapi/spec"
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+var supportedFormats = sets.NewString(
+	"bsonobjectid", // bson object ID
+	"uri",          // an URI as parsed by Golang net/url.ParseRequestURI
+	"email",        // an email address as parsed by Golang net/mail.ParseAddress
+	"hostname",     // a valid representation for an Internet host name, as defined by RFC 1034, section 3.1 [RFC1034].
+	"ipv4",         // an IPv4 IP as parsed by Golang net.ParseIP
+	"ipv6",         // an IPv6 IP as parsed by Golang net.ParseIP
+	"cidr",         // a CIDR as parsed by Golang net.ParseCIDR
+	"mac",          // a MAC address as parsed by Golang net.ParseMAC
+	"uuid",         // an UUID that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+	"uuid3",        // an UUID3 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?3[0-9a-f]{3}-?[0-9a-f]{4}-?[0-9a-f]{12}$
+	"uuid4",        // an UUID4 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?4[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+	"uuid5",        // an UUID6 that allows uppercase defined by the regex (?i)^[0-9a-f]{8}-?[0-9a-f]{4}-?5[0-9a-f]{3}-?[89ab][0-9a-f]{3}-?[0-9a-f]{12}$
+	"isbn",         // an ISBN10 or ISBN13 number string like "0321751043" or "978-0321751041"
+	"isbn10",       // an ISBN10 number string like "0321751043"
+	"isbn13",       // an ISBN13 number string like "978-0321751041"
+	"creditcard",   // a credit card number defined by the regex ^(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|6(?:011|5[0-9][0-9])[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|(?:2131|1800|35\\d{3})\\d{11})$ with any non digit characters mixed in
+	"ssn",          // a U.S. social security number following the regex ^\\d{3}[- ]?\\d{2}[- ]?\\d{4}$
+	"hexcolor",     // an hexadecimal color code like "#FFFFFF", following the regex ^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$
+	"rgbcolor",     // an RGB color code like rgb like "rgb(255,255,2559"
+	"byte",         // base64 encoded binary data
+	"password",     // any kind of string
+	"date",         // a date string like "2006-01-02" as defined by full-date in RFC3339
+	"duration",     // a duration string like "22 ns" as parsed by Golang time.ParseDuration or compatible with Scala duration format
+	"datetime",     // a date time string like "2014-12-15T19:30:20.000Z" as defined by date-time in RFC3339
+)
+
+// StripUnsupportedFormatsPostProcess sets unsupported formats to empty string.
+func StripUnsupportedFormatsPostProcess(s *spec.Schema) error {
+	if len(s.Format) == 0 {
+		return nil
+	}
+
+	normalized := strings.Replace(s.Format, "-", "", -1) // go-openapi default format name normalization
+	if !supportedFormats.Has(normalized) {
+		s.Format = ""
+	}
+
+	return nil
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/formats_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+)
+
+func TestRegistryFormats(t *testing.T) {
+	for f := range supportedFormats {
+		if !strfmt.Default.ContainsName(f) {
+			t.Errorf("expected format %q in strfmt default registry", f)
+		}
+	}
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation/validation.go
@@ -35,7 +35,7 @@ func NewSchemaValidator(customResourceValidation *apiextensions.CustomResourceVa
 	openapiSchema := &spec.Schema{}
 	if customResourceValidation != nil {
 		// TODO: replace with NewStructural(...).ToGoOpenAPI
-		if err := ConvertJSONSchemaProps(customResourceValidation.OpenAPIV3Schema, openapiSchema); err != nil {
+		if err := ConvertJSONSchemaPropsWithPostProcess(customResourceValidation.OpenAPIV3Schema, openapiSchema, StripUnsupportedFormatsPostProcess); err != nil {
 			return nil, nil, err
 		}
 	}
@@ -103,7 +103,7 @@ func ConvertJSONSchemaProps(in *apiextensions.JSONSchemaProps, out *spec.Schema)
 type PostProcessFunc func(*spec.Schema) error
 
 // ConvertJSONSchemaPropsWithPostProcess converts the schema from apiextensions.JSONSchemaPropos to go-openapi/spec.Schema
-// and run a post process step on each JSONSchemaProps node.
+// and run a post process step on each JSONSchemaProps node. postProcess is never called for nil schemas.
 func ConvertJSONSchemaPropsWithPostProcess(in *apiextensions.JSONSchemaProps, out *spec.Schema, postProcess PostProcessFunc) error {
 	if in == nil {
 		return nil

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -649,7 +649,7 @@ func convertJSONSchemaProps(in []byte, out *spec.Schema) error {
 	if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(&external, &internal, nil); err != nil {
 		return err
 	}
-	if err := validation.ConvertJSONSchemaProps(&internal, out); err != nil {
+	if err := validation.ConvertJSONSchemaPropsWithPostProcess(&internal, out, validation.StripUnsupportedFormatsPostProcess); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
We silently supported every OpenAPI format that they currently vendored go-openapi/strfmt library supports. This PR sets schema.format to empty string for any unknown format string before validation. The base of supported strings is that of v0.19.0 vendored in Kubernetes 1.16.

```release-note
OpenAPI v3 format in CustomResourceDefinition schemas are now documented.
```