### PR TITLE
Removed manifest-tool dependency from pause image

### DIFF
--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -14,8 +14,6 @@
 
 .PHONY: all push container clean orphan all-push push-manifest
 
-include ../../hack/make-rules/Makefile.manifest
-
 REGISTRY ?= staging-k8s.gcr.io
 IMAGE = $(REGISTRY)/pause
 IMAGE_WITH_ARCH = $(IMAGE)-$(ARCH)
@@ -31,6 +29,12 @@ ALL_ARCH = amd64 arm arm64 ppc64le s390x
 CFLAGS = -Os -Wall -Werror -static -DVERSION=v$(TAG)-$(REV)
 KUBE_CROSS_IMAGE ?= k8s.gcr.io/kube-cross
 KUBE_CROSS_VERSION ?= $(shell cat ../build-image/cross/VERSION)
+DOCKER_VERSION ?= $(shell docker version --format '{{.Client.Version}}' | cut -d"-" -f1 | gawk -F. '{ printf("%02d%02d%02d\n", $$1,$$2,$$3); }')
+
+ifeq ($(shell test $(DOCKER_VERSION) -gt 180600; echo $$?),0)
+	DOCKER_CLI_EXPERIMENTAL ?= enabled
+	export DOCKER_CLI_EXPERIMENTAL
+endif
 
 BIN = pause
 SRCS = pause.c
@@ -59,9 +63,6 @@ endif
 all: all-container
 
 all-push: all-push-images push-manifest
-
-push-manifest: manifest-tool
-	manifest-tool push from-args --platforms $(call join_platforms,$(ALL_ARCH)) --template $(IMAGE)-ARCH:$(TAG) --target $(IMAGE):$(TAG)
 
 sub-container-%:
 	$(MAKE) ARCH=$* container
@@ -93,6 +94,11 @@ push: .push-$(ARCH)
 .push-$(ARCH): .container-$(ARCH)
 	docker push $(IMAGE_WITH_ARCH):$(TAG)
 	touch $@
+
+push-manifest:
+	docker manifest create --amend $(IMAGE):$(TAG) $(foreach ALL_ARCH,$(ALL_ARCH),$(IMAGE)-$(ALL_ARCH):$(TAG))
+	docker manifest annotate --arch $(ARCH) $(IMAGE):$(TAG) $(IMAGE_WITH_ARCH):$(TAG)
+	docker manifest push --purge $(IMAGE):$(TAG)
 
 # Useful for testing, not automatically included in container image
 orphan: bin/orphan-$(ARCH)


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Removed manifest-tool dependency from pause Image.

**Which issue(s) this PR fixes**:
To fix  https://github.com/kubernetes/kubernetes/issues/69358

**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
NONE
