### PR TITLE
Test writing configurations with numeric names

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/BUILD
@@ -18,6 +18,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds a test case for the scenario described in https://github.com/kubernetes/kubernetes/issues/85394, which happened to be fixed by a bump to the yaml library, but should be tested specifically to ensure we don't regress. This same test fails on versions older than 1.14.8, 1.15.5, and 1.16.2.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery