### PR TITLE
Remove metric be hidden log temporarily

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/desc.go
+++ b/staging/src/k8s.io/component-base/metrics/desc.go
@@ -119,7 +119,8 @@ func (d *Desc) determineDeprecationStatus(version semver.Version) {
 			return
 		}
 		if shouldHide(&version, selfVersion) {
-			klog.Warningf("This metric(%s) has been deprecated for more than one release, hiding.", d.fqName)
+			// TODO(RainbowMango): Remove this log temporarily. https://github.com/kubernetes/kubernetes/issues/85369
+			// klog.Warningf("This metric(%s) has been deprecated for more than one release, hiding.", d.fqName)
 			d.isHidden = true
 		}
 	})

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -102,7 +102,8 @@ func (r *lazyMetric) determineDeprecationStatus(version semver.Version) {
 			return
 		}
 		if shouldHide(&version, selfVersion) {
-			klog.Warningf("This metric has been deprecated for more than one release, hiding.")
+			// TODO(RainbowMango): Remove this log temporarily. https://github.com/kubernetes/kubernetes/issues/85369
+			// klog.Warningf("This metric has been deprecated for more than one release, hiding.")
 			r.isHidden = true
 		}
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Remove warning logs from binaries --version command.

This is a quick fix of the issue, we need to consider more about the way a metric be registered.

**Which issue(s) this PR fixes**:
Fixes #85369

**Special notes for your reviewer**:
According to @liggitt 's comments, if this PR is acceptable, we should cherry-pick to branch release-1.17.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority critical-urgent