### PR TITLE
kubeadm: annotate CRI socket on `kubelet-finalize` phase

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
+++ b/cmd/kubeadm/app/cmd/phases/init/uploadconfig.go
@@ -29,7 +29,6 @@ import (
 	cmdutil "k8s.io/kubernetes/cmd/kubeadm/app/cmd/util"
 	kubeadmconstants "k8s.io/kubernetes/cmd/kubeadm/app/constants"
 	kubeletphase "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet"
-	patchnodephase "k8s.io/kubernetes/cmd/kubeadm/app/phases/patchnode"
 	"k8s.io/kubernetes/cmd/kubeadm/app/phases/uploadconfig"
 )
 
@@ -124,10 +123,6 @@ func runUploadKubeletConfig(c workflow.RunData) error {
 		return errors.Wrap(err, "error creating kubelet configuration ConfigMap")
 	}
 
-	klog.V(1).Infoln("[upload-config] Preserving the CRISocket information for the control-plane node")
-	if err := patchnodephase.AnnotateCRISocket(client, cfg.NodeRegistration.Name, cfg.NodeRegistration.CRISocket); err != nil {
-		return errors.Wrap(err, "Error writing Crisocket information for the control-plane node")
-	}
 	return nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When running `kubeadm init phase upload-config kubelet` the current
logic will try to read the config file and patch the node annotation
for the CRI socket.

Ideally, this logic should not be triggered under this phase, because
uploading the kubelet configuration to the cluster and patching the
current node CRI socket annotation are two different things.

Now that we introduced the `kubelet-finalize` phase, make this logic
happen under this phase on init. The rest (join, upgrade) are left
untouched.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1924

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/priority backlog
/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 
