### PR TITLE
apimachinery: Fix Dropped Test Error

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -115,7 +115,6 @@ vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation
 vendor/k8s.io/apimachinery/pkg/conversion
 vendor/k8s.io/apimachinery/pkg/labels
 vendor/k8s.io/apimachinery/pkg/runtime
-vendor/k8s.io/apimachinery/pkg/runtime/serializer
 vendor/k8s.io/apimachinery/pkg/runtime/serializer/json
 vendor/k8s.io/apimachinery/pkg/runtime/serializer/versioning
 vendor/k8s.io/apimachinery/pkg/util/framer

--- a/staging/src/k8s.io/apimachinery/pkg/conversion/converter_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/conversion/converter_test.go
@@ -568,6 +568,9 @@ func TestConverter_MapElemAddr(t *testing.T) {
 	}
 	third := Foo{}
 	err = c.Convert(&second, &third, AllowDifferentFieldTypeNames, nil)
+	if err != nil {
+		t.Fatalf("error on Convert: %v", err)
+	}
 	if e, a := first, third; !reflect.DeepEqual(e, a) {
 		t.Errorf("Unexpected diff: %v", diff.ObjectDiff(e, a))
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/codec_test.go
@@ -346,6 +346,9 @@ func TestDirectCodec(t *testing.T) {
 		t.Fatal(string(out))
 	}
 	a, _, err := directDecoder.Decode(out, nil, nil)
+	if err != nil {
+		t.Fatalf("error on Decode: %v", err)
+	}
 	e := &serializertesting.ExternalTestType1{
 		MyWeirdCustomEmbeddedVersionKindField: serializertesting.MyWeirdCustomEmbeddedVersionKindField{
 			APIVersion: "v1",

--- a/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/net/http_test.go
@@ -427,6 +427,7 @@ func TestConnectWithRedirects(t *testing.T) {
 			require.NoError(t, err, "unexpected request error")
 
 			result, err := ioutil.ReadAll(resp.Body)
+			assert.Nil(t, err)
 			require.NoError(t, resp.Body.Close())
 			if test.expectedRedirects < len(test.redirects) {
 				// Expect the last redirect to be returned.


### PR DESCRIPTION
This picks up three dropped test errors within `apimachinery`.