### PR TITLE
Support Azure Stack dynamic environments

### DIFF
--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -144,7 +144,7 @@ func (a *acrProvider) loadConfig(rdr io.Reader) error {
 		klog.Errorf("Failed to load azure credential file: %v", err)
 	}
 
-	a.environment, err = auth.ParseAzureEnvironment(a.config.Cloud, a.config.cloudFQDN, a.config.IdentitySystem)
+	a.environment, err = auth.ParseAzureEnvironment(a.config.Cloud, a.config.CloudFQDN, a.config.IdentitySystem)
 	if err != nil {
 		return err
 	}

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -144,7 +144,7 @@ func (a *acrProvider) loadConfig(rdr io.Reader) error {
 		klog.Errorf("Failed to load azure credential file: %v", err)
 	}
 
-	a.environment, err = auth.ParseAzureEnvironment(a.config.Cloud, a.config.CloudFQDN, a.config.IdentitySystem)
+	a.environment, err = auth.ParseAzureEnvironment(a.config.Cloud, a.config.ResourceManagerEndpoint, a.config.IdentitySystem)
 	if err != nil {
 		return err
 	}

--- a/pkg/credentialprovider/azure/azure_credentials.go
+++ b/pkg/credentialprovider/azure/azure_credentials.go
@@ -144,7 +144,7 @@ func (a *acrProvider) loadConfig(rdr io.Reader) error {
 		klog.Errorf("Failed to load azure credential file: %v", err)
 	}
 
-	a.environment, err = auth.ParseAzureEnvironment(a.config.Cloud)
+	a.environment, err = auth.ParseAzureEnvironment(a.config.Cloud, a.config.cloudFQDN, a.config.IdentitySystem)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
@@ -173,14 +173,11 @@ func decodePkcs12(pkcs []byte, password string) (*x509.Certificate, *rsa.Private
 // azureStackOverrides ensures that the Environment matches what AKSe currently generates for Azure Stack
 func azureStackOverrides(env *azure.Environment, resourceManagerEndpoint, identitySystem string) {
 	env.ManagementPortalURL = strings.Replace(resourceManagerEndpoint, "https://management.", "https://portal.", -1)
-	// TODO: figure out why AKSe does this, why is autorest not setting ServiceManagementEndpoint?
 	env.ServiceManagementEndpoint = env.TokenAudience
-	// TODO: figure out why AKSe does this, may not be required, ResourceManagerVMDNSSuffix is not referenced anywhere
 	env.ResourceManagerVMDNSSuffix = strings.Replace(resourceManagerEndpoint, "https://management.", "cloudapp.", -1)
 	env.ResourceManagerVMDNSSuffix = strings.TrimSuffix(env.ResourceManagerVMDNSSuffix, "/")
 	if strings.EqualFold(identitySystem, ADFSIdentitySystem) {
 		env.ActiveDirectoryEndpoint = strings.TrimSuffix(env.ActiveDirectoryEndpoint, "/")
 		env.ActiveDirectoryEndpoint = strings.TrimSuffix(env.ActiveDirectoryEndpoint, "adfs")
 	}
-	// NOTE: autorest sets KeyVaultEndpoint while AKSe does not
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -325,7 +325,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 		}
 	}
 
-	env, err := auth.ParseAzureEnvironment(config.Cloud, config.CloudFQDN, config.IdentitySystem)
+	env, err := auth.ParseAzureEnvironment(config.Cloud, config.ResourceManagerEndpoint, config.IdentitySystem)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -325,7 +325,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 		}
 	}
 
-	env, err := auth.ParseAzureEnvironment(config.Cloud)
+	env, err := auth.ParseAzureEnvironment(config.Cloud, config.CloudFQDN, config.IdentitySystem)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/area provider/azure

**What this PR does / why we need it**:

Azure and Azure Stack clouds expose the same set of APIs that the cloud provider consumes. For public and government clouds, [go-autorest](https://github.com/Azure/go-autorest) defines a set of cloud Environment instances (one per cloud). With Azure Stack, enterprises are required to use their own domain. Therefore, the environment endpoints must be derived from the cloud’s “metadata endpoint”. This PR automates the environment generation.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes-sigs/cloud-provider-azure/issues/259

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
