### PR TITLE
Plumb authorization webhook version from CLI to config

### DIFF
--- a/pkg/kubeapiserver/options/authorization.go
+++ b/pkg/kubeapiserver/options/authorization.go
@@ -118,6 +118,7 @@ func (s *BuiltInAuthorizationOptions) ToAuthorizationConfig(versionedInformerFac
 		AuthorizationModes:          s.Modes,
 		PolicyFile:                  s.PolicyFile,
 		WebhookConfigFile:           s.WebhookConfigFile,
+		WebhookVersion:              s.WebhookVersion,
 		WebhookCacheAuthorizedTTL:   s.WebhookCacheAuthorizedTTL,
 		WebhookCacheUnauthorizedTTL: s.WebhookCacheUnauthorizedTTL,
 		VersionedInformerFactory:    versionedInformerFactory,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Plumbs version from the CLI flag to the authorizer webhook config correctly. Fixes regression in #84768

**Does this PR introduce a user-facing change?**:
```release-note
Resolves error from v1.17.0-beta.2 with --authorizer-mode webhook complaining about an invalid version
```

/sig auth
/assign @enj 
/cc @enj 