### PR TITLE
Provided a mechanism to re-register hidden metrics

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -143,6 +143,19 @@ func (r *lazyMetric) Create(version *semver.Version) bool {
 	return r.IsCreated()
 }
 
+// ClearState will clear all the states marked by Create.
+// It intends to be used for re-register a hidden metric.
+func (r *lazyMetric) ClearState() {
+	r.createLock.Lock()
+	defer r.createLock.Unlock()
+
+	r.isDeprecated = false
+	r.isHidden = false
+	r.isCreated = false
+	r.markDeprecationOnce = *(new(sync.Once))
+	r.createOnce = *(new(sync.Once))
+}
+
 /*
 This code is directly lifted from the prometheus codebase. It's a convenience struct which
 allows you satisfy the Collector interface automatically if you already satisfy the Metric interface.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Provide a mechanism to re-register hidden metrics when `--show-enable-metrcis-for-version` is set.

It happens to deal with the metrics that be registered by init() call by import.

**Which issue(s) this PR fixes**:
Fixes #85411

**Special notes for your reviewer**:
This PR only contains the patch for the common collector(not for the custom collector), it's the minimum correction of #85411, and it can be picked to release-1.17. We haven't deprecated any custom collectors in v1.17.

We indeed need a collector tracker to record all collectors:
- The collection of all registered;  (helps to turn off a specific metric from command line)
- The collection of all hidden; (this case)

So, I think it's the right direction. 

**Does this PR introduce a user-facing change?**:
```release-note
kube-apiserver: Fixes a bug that hidden metrics can not be enabled by the command-line option `--show-hidden-metrics-for-version`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
