### PR TITLE
Remove the derprecated API RawRegister from stability framework

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -328,7 +328,7 @@ func (s *Server) InstallDefaultHandlers(enableCAdvisorJSONEndpoints bool) {
 	// prober metrics are exposed under a different endpoint
 
 	p := compbasemetrics.NewKubeRegistry()
-	compbasemetrics.RegisterProcessStartTime(p.RawRegister)
+	_ = compbasemetrics.RegisterProcessStartTime(p.Register)
 	p.MustRegister(prober.ProberResults)
 	s.restfulCont.Handle(proberMetricsPath,
 		compbasemetrics.HandlerFor(p, compbasemetrics.HandlerOpts{ErrorHandling: compbasemetrics.ContinueOnError}),

--- a/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/legacyregistry/registry.go
@@ -65,15 +65,6 @@ func RawMustRegister(cs ...prometheus.Collector) {
 	defaultRegistry.RawMustRegister(cs...)
 }
 
-// RawRegister registers a prometheus collector but uses the global registry, this
-// bypasses the metric stability framework
-//
-// Deprecated
-func RawRegister(c prometheus.Collector) error {
-	err := defaultRegistry.RawRegister(c)
-	return err
-}
-
 // CustomRegister registers a custom collector but uses the global registry.
 func CustomRegister(c metrics.StableCollector) error {
 	err := defaultRegistry.CustomRegister(c)

--- a/staging/src/k8s.io/component-base/metrics/processstarttime.go
+++ b/staging/src/k8s.io/component-base/metrics/processstarttime.go
@@ -20,29 +20,24 @@ import (
 	"os"
 	"time"
 
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/procfs"
 
 	"k8s.io/klog"
 )
 
-var processStartTime = prometheus.NewGaugeVec(
-	prometheus.GaugeOpts{
-		Name: "process_start_time_seconds",
-		Help: "Start time of the process since unix epoch in seconds.",
+var processStartTime = NewGaugeVec(
+	&GaugeOpts{
+		Name:           "process_start_time_seconds",
+		Help:           "Start time of the process since unix epoch in seconds.",
+		StabilityLevel: ALPHA,
 	},
 	[]string{},
 )
 
-// Registerer is an interface expected by RegisterProcessStartTime in order to register the metric
-type Registerer interface {
-	Register(prometheus.Collector) error
-}
-
 // RegisterProcessStartTime registers the process_start_time_seconds to
 // a prometheus registry. This metric needs to be included to ensure counter
 // data fidelity.
-func RegisterProcessStartTime(registrationFunc func(prometheus.Collector) error) error {
+func RegisterProcessStartTime(registrationFunc func(Registerable) error) error {
 	start, err := getProcessStart()
 	if err != nil {
 		klog.Errorf("Could not get process start time, %v", err)

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -98,8 +98,6 @@ type Registerable interface {
 // prometheus.Gatherer interfaces
 type KubeRegistry interface {
 	// Deprecated
-	RawRegister(prometheus.Collector) error
-	// Deprecated
 	RawMustRegister(...prometheus.Collector)
 	CustomRegister(c StableCollector) error
 	CustomMustRegister(cs ...StableCollector)
@@ -163,15 +161,6 @@ func (kr *kubeRegistry) CustomMustRegister(cs ...StableCollector) {
 	}
 
 	kr.PromRegistry.MustRegister(collectors...)
-}
-
-// RawRegister takes a native prometheus.Collector and registers the collector
-// to the registry. This bypasses metrics safety checks, so should only be used
-// to register custom prometheus collectors.
-//
-// Deprecated
-func (kr *kubeRegistry) RawRegister(c prometheus.Collector) error {
-	return kr.PromRegistry.Register(c)
 }
 
 // RawMustRegister takes a native prometheus.Collector and registers the collector


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
- mark `process_start_time_seconds` with `ALPHA`
- remove deprecated API `RawRegister` from stability framework

Testing result from local cluster:
```
# curl localhost:10255/metrics/probes
# HELP prober_probe_total [ALPHA] Cumulative number of a liveness, readiness or startup probe for a container by result.
# TYPE prober_probe_total counter
prober_probe_total{container="dnsmasq",namespace="kube-system",pod="kube-dns-547db76c8f-z8v6s",pod_uid="4c0c05c3-39b3-4e81-a520-84997d04cf48",probe_type="Liveness",result="successful"} 3
prober_probe_total{container="kubedns",namespace="kube-system",pod="kube-dns-547db76c8f-z8v6s",pod_uid="4c0c05c3-39b3-4e81-a520-84997d04cf48",probe_type="Liveness",result="successful"} 3
prober_probe_total{container="kubedns",namespace="kube-system",pod="kube-dns-547db76c8f-z8v6s",pod_uid="4c0c05c3-39b3-4e81-a520-84997d04cf48",probe_type="Readiness",result="successful"} 9
prober_probe_total{container="sidecar",namespace="kube-system",pod="kube-dns-547db76c8f-z8v6s",pod_uid="4c0c05c3-39b3-4e81-a520-84997d04cf48",probe_type="Liveness",result="successful"} 3
# HELP process_start_time_seconds [ALPHA] Start time of the process since unix epoch in seconds.
# TYPE process_start_time_seconds gauge
process_start_time_seconds 1.57416115245e+09
```

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubelet: the metric process_start_time_seconds be marked as with the ALPHA stability level.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority important-soon
/milestone v1.18