### PR TITLE
Fix golint issues in pkg/kubelet/events/event.go

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -118,7 +118,6 @@ pkg/kubelet/dockershim/network/hostport
 pkg/kubelet/dockershim/network/hostport/testing
 pkg/kubelet/dockershim/network/kubenet
 pkg/kubelet/dockershim/network/testing
-pkg/kubelet/events
 pkg/kubelet/lifecycle
 pkg/kubelet/pluginmanager/pluginwatcher
 pkg/kubelet/pod/testing

--- a/pkg/kubelet/events/event.go
+++ b/pkg/kubelet/events/event.go
@@ -16,8 +16,8 @@ limitations under the License.
 
 package events
 
+// Container event reason list
 const (
-	// Container event reason list
 	CreatedContainer        = "Created"
 	StartedContainer        = "Started"
 	FailedToCreateContainer = "Failed"
@@ -26,22 +26,28 @@ const (
 	PreemptContainer        = "Preempting"
 	BackOffStartContainer   = "BackOff"
 	ExceededGracePeriod     = "ExceededGracePeriod"
+)
 
-	// Pod event reason list
+// Pod event reason list
+const (
 	FailedToKillPod                = "FailedKillPod"
 	FailedToCreatePodContainer     = "FailedCreatePodContainer"
 	FailedToMakePodDataDirectories = "Failed"
 	NetworkNotReady                = "NetworkNotReady"
+)
 
-	// Image event reason list
+// Image event reason list
+const (
 	PullingImage            = "Pulling"
 	PulledImage             = "Pulled"
 	FailedToPullImage       = "Failed"
 	FailedToInspectImage    = "InspectFailed"
 	ErrImageNeverPullPolicy = "ErrImageNeverPull"
 	BackOffPullImage        = "BackOff"
+)
 
-	// kubelet event reason list
+// kubelet event reason list
+const (
 	NodeReady                            = "NodeReady"
 	NodeNotReady                         = "NodeNotReady"
 	NodeSchedulable                      = "NodeSchedulable"
@@ -66,22 +72,32 @@ const (
 	SandboxChanged                       = "SandboxChanged"
 	FailedCreatePodSandBox               = "FailedCreatePodSandBox"
 	FailedStatusPodSandBox               = "FailedPodSandBoxStatus"
+)
 
-	// Image manager event reason list
+// Image manager event reason list
+const (
 	InvalidDiskCapacity = "InvalidDiskCapacity"
 	FreeDiskSpaceFailed = "FreeDiskSpaceFailed"
+)
 
-	// Probe event reason list
+// Probe event reason list
+const (
 	ContainerUnhealthy    = "Unhealthy"
 	ContainerProbeWarning = "ProbeWarning"
+)
 
-	// Pod worker event reason list
+// Pod worker event reason list
+const (
 	FailedSync = "FailedSync"
+)
 
-	// Config event reason list
+// Config event reason list
+const (
 	FailedValidation = "FailedValidation"
+)
 
-	// Lifecycle hooks
+// Lifecycle hooks
+const (
 	FailedPostStartHook = "FailedPostStartHook"
 	FailedPreStopHook   = "FailedPreStopHook"
 )


### PR DESCRIPTION
Change the single const statement in favour of multiple const event lists.
This way we don't need to put the name of the constant in the comment
and it's clearer that the comment refers to the whole list.

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Fixes golint issues in `pkg/kubelet/events/`

**Which issue(s) this PR fixes**:
Ref #68026

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```

```

/sig testing
/priority backlog
/area code-organization