### PR TITLE
Typecheck support for verifying providerless build

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -39,7 +39,8 @@ EXCLUDED_PATTERNS=(
 # Exclude typecheck in certain cases, if they're running in a separate job.
 if [[ ${EXCLUDE_TYPECHECK:-} =~ ^[yY]$ ]]; then
   EXCLUDED_PATTERNS+=(
-    "verify-typecheck.sh"          # runs in separate typecheck job
+    "verify-typecheck.sh"              # runs in separate typecheck job
+    "verify-typecheck-providerless.sh" # runs in separate typecheck job
     )
 fi
 

--- a/hack/verify-typecheck-providerless.sh
+++ b/hack/verify-typecheck-providerless.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+
+cd "${KUBE_ROOT}"
+# verify the providerless build
+# https://github.com/kubernetes/enhancements/blob/master/keps/sig-cloud-provider/20190729-building-without-in-tree-providers.md
+hack/verify-typecheck.sh --skip-test --tags=providerless --ignore-dirs=test

--- a/test/typecheck/main_test.go
+++ b/test/typecheck/main_test.go
@@ -146,7 +146,9 @@ func TestHandlePackage(t *testing.T) {
 }
 
 func TestHandlePath(t *testing.T) {
-	c := collector{}
+	c := collector{
+		ignoreDirs: standardIgnoreDirs,
+	}
 	e := errors.New("ex")
 	i, _ := os.Stat(".") // i.IsDir() == true
 	if c.handlePath("foo", nil, e) != e {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: Adds support to the typecheck utility for:
- ignoring extra directories
- skipping _test.go code
- specifying build tags

This is necessary to typecheck providerless build. We want to:
- set the providerless tag
- not check unit tests (we only build the binaries in providerless mode to validate provider removal from the core, we're not prepared to handle tests yet)
- not check test/* (e2e etc. do not have an agreed plan for removing in-tree providers yet)

Currently this gives us:
```
$ hack/verify-typecheck.sh --skip-test --tags=providerless --ignore-dirs=test
type-checking:  linux/amd64, windows/386, darwin/amd64, linux/arm, linux/386, windows/amd64, linux/arm64, linux/ppc64le, linux/s390x, darwin/386
ERROR(all) cmd/kube-controller-manager/app/plugins.go:141:70: too many arguments                         
ERROR(all) cmd/kube-controller-manager/app/plugins.go:141:20: cannot assign 1 values to 2 variables
ERROR(all) cmd/kube-controller-manager/app/plugins.go:88:70: too many arguments
ERROR(all) cmd/kube-controller-manager/app/plugins.go:88:20: cannot assign 1 values to 2 variables
ERROR(all) cmd/kube-controller-manager/app/plugins.go:63:70: too many arguments
ERROR(all) cmd/kube-controller-manager/app/plugins.go:63:20: cannot assign 1 values to 2 variables
ERROR(all) cmd/kubelet/app/plugins.go:68:60: too many arguments                                          
ERROR(all) cmd/kubelet/app/plugins.go:68:20: cannot assign 1 values to 2 variables
ERROR(all) pkg/controller/nodeipam/node_ipam_controller.go:135:83: cannot use nodeCIDRMaskSizes (variable of type []int) as int value in argument to startLegacyIPAM
ERROR(darwin) pkg/volume/awsebs/attacher_unsupported.go:23:17: undeclared name: awsElasticBlockStoreAttacher
ERROR(windows) pkg/volume/awsebs/attacher_windows.go:31:17: undeclared name: awsElasticBlockStoreAttacher
ERROR(windows) pkg/volume/awsebs/attacher_windows.go:38:17: undeclared name: awsElasticBlockStoreAttacher
ERROR(windows) pkg/volume/awsebs/attacher_windows.go:43:32: undeclared name: awsElasticBlockStorePluginName
ERROR(linux/386,linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x) pkg/volume/awsebs/attacher_linux.go:25:17: undeclared name: awsElasticBlockStoreAttacher
ERROR(linux/386,linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x) pkg/volume/awsebs/attacher_linux.go:26:17: undeclared name: getDiskByIDPaths
ERROR(linux/386,linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x) pkg/volume/awsebs/attacher_linux.go:26:38: KubernetesVolumeID not declared by package aws
ERROR(linux/386,linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x) pkg/volume/awsebs/attacher_linux.go:27:9: undeclared name: verifyDevicePath
ERROR(windows) pkg/volume/vsphere_volume/vsphere_volume_util_windows.go:36:29: undeclared name: diskByIDPath
ERROR(windows) pkg/volume/vsphere_volume/vsphere_volume_util_windows.go:54:43: undeclared name: diskByIDPath
ERROR(windows) pkg/volume/vsphere_volume/vsphere_volume_util_windows.go:54:56: undeclared name: diskSCSIPrefix
12260/12260 linux/386     translations/test/en_US/LC_MESSAGES                                             
exit status 1
!!! Type Check has failed. This may cause cross platform build failures.
!!! Please see https://git.k8s.io/kubernetes/test/typecheck for more information.
```

XREF: https://github.com/kubernetes/kubernetes/pull/85456

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
