### PR TITLE
Cherrypick to 1.16 - Update sigs.k8s.io/structured-merge-diff to v1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -485,7 +485,7 @@ replace (
 	modernc.org/strutil => modernc.org/strutil v1.0.0
 	modernc.org/xc => modernc.org/xc v1.0.0
 	sigs.k8s.io/kustomize => sigs.k8s.io/kustomize v2.0.3+incompatible
-	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca
+	sigs.k8s.io/structured-merge-diff => sigs.k8s.io/structured-merge-diff v1.0.1
 	sigs.k8s.io/yaml => sigs.k8s.io/yaml v1.1.0
 	vbom.ml/util => vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc
 )

--- a/go.sum
+++ b/go.sum
@@ -521,8 +521,8 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/kustomize v2.0.3+incompatible h1:JUufWFNlI44MdtnjUqVnvh29rR37PQFzPbLXqhyOyX0=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
+sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+WTN9XTA=
+sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc h1:MksmcCZQWAQJCTA5T0jgI/0sJ51AVm4Z41MrmfczEoc=

--- a/staging/src/k8s.io/apiextensions-apiserver/go.sum
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.sum
@@ -376,7 +376,7 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
+sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+WTN9XTA=
+sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/staging/src/k8s.io/apiserver/go.mod
+++ b/staging/src/k8s.io/apiserver/go.mod
@@ -57,7 +57,7 @@ require (
 	k8s.io/klog v0.4.0
 	k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf
 	k8s.io/utils v0.0.0-20190801114015-581e00157fb1
-	sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca
+	sigs.k8s.io/structured-merge-diff v1.0.1
 	sigs.k8s.io/yaml v1.1.0
 )
 

--- a/staging/src/k8s.io/apiserver/go.sum
+++ b/staging/src/k8s.io/apiserver/go.sum
@@ -288,7 +288,7 @@ k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLK
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
+sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+WTN9XTA=
+sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/staging/src/k8s.io/kube-aggregator/go.sum
+++ b/staging/src/k8s.io/kube-aggregator/go.sum
@@ -330,7 +330,7 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
+sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+WTN9XTA=
+sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/staging/src/k8s.io/legacy-cloud-providers/go.sum
+++ b/staging/src/k8s.io/legacy-cloud-providers/go.sum
@@ -289,6 +289,6 @@ k8s.io/kube-openapi v0.0.0-20190816220812-743ec37842bf/go.mod h1:1TqjTSzOxsLGIKf
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1 h1:+ySTxfHnfzZb9ys375PXNlLhkJPLKgHajBU0N62BDvE=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
+sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/staging/src/k8s.io/sample-apiserver/go.sum
+++ b/staging/src/k8s.io/sample-apiserver/go.sum
@@ -327,7 +327,7 @@ modernc.org/strutil v1.0.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs
 modernc.org/xc v1.0.0/go.mod h1:mRNCo0bvLjGhHO9WsyuKVU4q0ceiDDDoEeWDJHrNx8I=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca h1:6dsH6AYQWbyZmtttJNe8Gq1cXOeS1BdV3eW37zHilAQ=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
+sigs.k8s.io/structured-merge-diff v1.0.1 h1:LOs1LZWMsz1xs77Phr/pkB4LFaavH7IVq/3+WTN9XTA=
+sigs.k8s.io/structured-merge-diff v1.0.1/go.mod h1:IIgPezJWb76P0hotTxzDbWsMYB8APh18qZnxkomBpxA=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1921,7 +1921,7 @@ sigs.k8s.io/kustomize/pkg/transformers
 sigs.k8s.io/kustomize/pkg/transformers/config
 sigs.k8s.io/kustomize/pkg/transformers/config/defaultconfig
 sigs.k8s.io/kustomize/pkg/types
-# sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca => sigs.k8s.io/structured-merge-diff v0.0.0-20190817042607-6149e4549fca
+# sigs.k8s.io/structured-merge-diff v1.0.1 => sigs.k8s.io/structured-merge-diff v1.0.1
 sigs.k8s.io/structured-merge-diff/fieldpath
 sigs.k8s.io/structured-merge-diff/merge
 sigs.k8s.io/structured-merge-diff/schema

--- a/vendor/sigs.k8s.io/structured-merge-diff/value/value.go
+++ b/vendor/sigs.k8s.io/structured-merge-diff/value/value.go
@@ -36,92 +36,185 @@ type Value struct {
 
 // Equals returns true iff the two values are equal.
 func (v Value) Equals(rhs Value) bool {
-	return !v.Less(rhs) && !rhs.Less(v)
+	if v.FloatValue != nil || rhs.FloatValue != nil {
+		var lf float64
+		if v.FloatValue != nil {
+			lf = float64(*v.FloatValue)
+		} else if v.IntValue != nil {
+			lf = float64(*v.IntValue)
+		} else {
+			return false
+		}
+		var rf float64
+		if rhs.FloatValue != nil {
+			rf = float64(*rhs.FloatValue)
+		} else if rhs.IntValue != nil {
+			rf = float64(*rhs.IntValue)
+		} else {
+			return false
+		}
+		return lf == rf
+	}
+	if v.IntValue != nil {
+		if rhs.IntValue != nil {
+			return *v.IntValue == *rhs.IntValue
+		}
+		return false
+	}
+	if v.StringValue != nil {
+		if rhs.StringValue != nil {
+			return *v.StringValue == *rhs.StringValue
+		}
+		return false
+	}
+	if v.BooleanValue != nil {
+		if rhs.BooleanValue != nil {
+			return *v.BooleanValue == *rhs.BooleanValue
+		}
+		return false
+	}
+	if v.ListValue != nil {
+		if rhs.ListValue != nil {
+			return v.ListValue.Equals(rhs.ListValue)
+		}
+		return false
+	}
+	if v.MapValue != nil {
+		if rhs.MapValue != nil {
+			return v.MapValue.Equals(rhs.MapValue)
+		}
+		return false
+	}
+	if v.Null {
+		if rhs.Null {
+			return true
+		}
+		return false
+	}
+	// No field is set, on either objects.
+	return true
 }
 
 // Less provides a total ordering for Value (so that they can be sorted, even
 // if they are of different types).
 func (v Value) Less(rhs Value) bool {
+	return v.Compare(rhs) == -1
+}
+
+// Compare provides a total ordering for Value (so that they can be
+// sorted, even if they are of different types). The result will be 0 if
+// v==rhs, -1 if v < rhs, and +1 if v > rhs.
+func (v Value) Compare(rhs Value) int {
 	if v.FloatValue != nil {
 		if rhs.FloatValue == nil {
 			// Extra: compare floats and ints numerically.
 			if rhs.IntValue != nil {
-				return float64(*v.FloatValue) < float64(*rhs.IntValue)
+				return v.FloatValue.Compare(Float(*rhs.IntValue))
 			}
-			return true
+			return -1
 		}
-		return *v.FloatValue < *rhs.FloatValue
+		return v.FloatValue.Compare(*rhs.FloatValue)
 	} else if rhs.FloatValue != nil {
 		// Extra: compare floats and ints numerically.
 		if v.IntValue != nil {
-			return float64(*v.IntValue) < float64(*rhs.FloatValue)
+			return Float(*v.IntValue).Compare(*rhs.FloatValue)
 		}
-		return false
+		return 1
 	}
 
 	if v.IntValue != nil {
 		if rhs.IntValue == nil {
-			return true
+			return -1
 		}
-		return *v.IntValue < *rhs.IntValue
+		return v.IntValue.Compare(*rhs.IntValue)
 	} else if rhs.IntValue != nil {
-		return false
+		return 1
 	}
 
 	if v.StringValue != nil {
 		if rhs.StringValue == nil {
-			return true
+			return -1
 		}
-		return *v.StringValue < *rhs.StringValue
+		return strings.Compare(string(*v.StringValue), string(*rhs.StringValue))
 	} else if rhs.StringValue != nil {
-		return false
+		return 1
 	}
 
 	if v.BooleanValue != nil {
 		if rhs.BooleanValue == nil {
-			return true
+			return -1
 		}
-		if *v.BooleanValue == *rhs.BooleanValue {
-			return false
-		}
-		return *v.BooleanValue == false
+		return v.BooleanValue.Compare(*rhs.BooleanValue)
 	} else if rhs.BooleanValue != nil {
-		return false
+		return 1
 	}
 
 	if v.ListValue != nil {
 		if rhs.ListValue == nil {
-			return true
+			return -1
 		}
-		return v.ListValue.Less(rhs.ListValue)
+		return v.ListValue.Compare(rhs.ListValue)
 	} else if rhs.ListValue != nil {
-		return false
+		return 1
 	}
 	if v.MapValue != nil {
 		if rhs.MapValue == nil {
-			return true
+			return -1
 		}
-		return v.MapValue.Less(rhs.MapValue)
+		return v.MapValue.Compare(rhs.MapValue)
 	} else if rhs.MapValue != nil {
-		return false
+		return 1
 	}
 	if v.Null {
 		if !rhs.Null {
-			return true
+			return -1
 		}
-		return false
+		return 0
 	} else if rhs.Null {
-		return false
+		return 1
 	}
 
 	// Invalid Value-- nothing is set.
-	return false
+	return 0
 }
 
 type Int int64
 type Float float64
 type String string
 type Boolean bool
+
+// Compare compares integers. The result will be 0 if i==rhs, -1 if i <
+// rhs, and +1 if i > rhs.
+func (i Int) Compare(rhs Int) int {
+	if i > rhs {
+		return 1
+	} else if i < rhs {
+		return -1
+	}
+	return 0
+}
+
+// Compare compares floats. The result will be 0 if f==rhs, -1 if f <
+// rhs, and +1 if f > rhs.
+func (f Float) Compare(rhs Float) int {
+	if f > rhs {
+		return 1
+	} else if f < rhs {
+		return -1
+	}
+	return 0
+}
+
+// Compare compares booleans. The result will be 0 if b==rhs, -1 if b <
+// rhs, and +1 if b > rhs.
+func (b Boolean) Compare(rhs Boolean) int {
+	if b == rhs {
+		return 0
+	} else if b == false {
+		return -1
+	}
+	return 1
+}
 
 // Field is an individual key-value pair.
 type Field struct {
@@ -134,29 +227,44 @@ type List struct {
 	Items []Value
 }
 
+// Equals compares two lists lexically.
+func (l *List) Equals(rhs *List) bool {
+	if len(l.Items) != len(rhs.Items) {
+		return false
+	}
+
+	for i, lv := range l.Items {
+		if !lv.Equals(rhs.Items[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 // Less compares two lists lexically.
 func (l *List) Less(rhs *List) bool {
+	return l.Compare(rhs) == -1
+}
+
+// Compare compares two lists lexically. The result will be 0 if l==rhs, -1
+// if l < rhs, and +1 if l > rhs.
+func (l *List) Compare(rhs *List) int {
 	i := 0
 	for {
 		if i >= len(l.Items) && i >= len(rhs.Items) {
 			// Lists are the same length and all items are equal.
-			return false
+			return 0
 		}
 		if i >= len(l.Items) {
 			// LHS is shorter.
-			return true
+			return -1
 		}
 		if i >= len(rhs.Items) {
 			// RHS is shorter.
-			return false
+			return 1
 		}
-		if l.Items[i].Less(rhs.Items[i]) {
-			// LHS is less; return
-			return true
-		}
-		if rhs.Items[i].Less(l.Items[i]) {
-			// RHS is less; return
-			return false
+		if c := l.Items[i].Compare(rhs.Items[i]); c != 0 {
+			return c
 		}
 		// The items are equal; continue.
 		i++
@@ -191,8 +299,30 @@ func (m *Map) computeOrder() []int {
 	return m.order
 }
 
+// Equals compares two maps lexically.
+func (m *Map) Equals(rhs *Map) bool {
+	if len(m.Items) != len(rhs.Items) {
+		return false
+	}
+	for _, lfield := range m.Items {
+		rfield, ok := rhs.Get(lfield.Name)
+		if !ok {
+			return false
+		}
+		if !lfield.Value.Equals(rfield.Value) {
+			return false
+		}
+	}
+	return true
+}
+
 // Less compares two maps lexically.
 func (m *Map) Less(rhs *Map) bool {
+	return m.Compare(rhs) == -1
+}
+
+// Compare compares two maps lexically.
+func (m *Map) Compare(rhs *Map) int {
 	var noAllocL, noAllocR [2]int
 	var morder, rorder []int
 
@@ -238,28 +368,22 @@ func (m *Map) Less(rhs *Map) bool {
 	for {
 		if i >= len(morder) && i >= len(rorder) {
 			// Maps are the same length and all items are equal.
-			return false
+			return 0
 		}
 		if i >= len(morder) {
 			// LHS is shorter.
-			return true
+			return -1
 		}
 		if i >= len(rorder) {
 			// RHS is shorter.
-			return false
+			return 1
 		}
 		fa, fb := &m.Items[morder[i]], &rhs.Items[rorder[i]]
-		if fa.Name != fb.Name {
-			// the map having the field name that sorts lexically less is "less"
-			return fa.Name < fb.Name
+		if c := strings.Compare(fa.Name, fb.Name); c != 0 {
+			return c
 		}
-		if fa.Value.Less(fb.Value) {
-			// LHS is less; return
-			return true
-		}
-		if fb.Value.Less(fa.Value) {
-			// RHS is less; return
-			return false
+		if c := fa.Value.Compare(fb.Value); c != 0 {
+			return c
 		}
 		// The items are equal; continue.
 		i++


### PR DESCRIPTION
I think we have to manually cherrypick this, since it requires a dependency version bump. If that isn't allowed I can try remaking this as a PR to master and a cherry-picking that commit.

/kind bug
/sig api-machinery
/priority important-soon

**What this PR does / why we need it**:
Fixes a bug which caused the Compare function to be very inefficient for objects with large atomic maps. In k8s, this could be triggered by applying to a CRD (the actual custom resource definition, not the CR) with a very large validation for at least one of it's versions, and result in all subsequent modifying requests to that CRD to take upwards of 25 seconds.

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a performance issue when using server-side apply with objects with very large atomic maps.
```