### PR TITLE
SafeSysctlWhitelist: add net.ipv4.ping_group_range (allow ping without CAP_NET_RAW)

### DIFF
--- a/pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go
+++ b/pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go
@@ -34,6 +34,7 @@ func SafeSysctlWhitelist() []string {
 		"kernel.shm_rmid_forced",
 		"net.ipv4.ip_local_port_range",
 		"net.ipv4.tcp_syncookies",
+		"net.ipv4.ping_group_range",
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature (?)

**What this PR does / why we need it**:

Allow setting sysctl value `net.ipv4.ping_group_range`, which can be used for allowing `ping` command without `CAP_NET_RAW` capability.

e.g. `net.ipv4.ping_group_range="0 42"` to allow ping for users with GID 0-GID 42.

This sysctl value was introduced in kernel 3.0 and has been namespaced since its birth.

https://github.com/torvalds/linux/commit/c319b4d76b9e583a5d88d6bf190e079c4e43213d#diff-5b536a7a92abed603bbb4caa61613270R57

release-note:

```release-note
SafeSysctlWhitelist: add net.ipv4.ping_group_range
```