### PR TITLE
Clarify client-go issue location

### DIFF
--- a/staging/src/k8s.io/client-go/CONTRIBUTING.md
+++ b/staging/src/k8s.io/client-go/CONTRIBUTING.md
@@ -1,8 +1,6 @@
 # Contributing guidelines
 
-Do not open pull requests directly against this repository; they will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
-
-While pull requests should be in kubernetes/kubernetes, issues pertaining only to client-go should be opened in [kubernetes/client-go](https://git.k8s.io/client-go).
+Do not open pull requests directly against kubernetes/client-go repository (except for README.md); they will be ignored. Instead, please open pull requests and issues against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
 
 This repository is published from [kubernetes/kubernetes/staging/src/k8s.io/client-go](https://git.k8s.io/kubernetes/staging/src/k8s.io/client-go) by the [kubernetes publishing-bot](https://git.k8s.io/publishing-bot).
 

--- a/staging/src/k8s.io/client-go/CONTRIBUTING.md
+++ b/staging/src/k8s.io/client-go/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 # Contributing guidelines
 
-Do not open pull requests directly against this repository, they will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
+Do not open pull requests directly against this repository; they will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
+
+While pull requests should be in kubernetes/kubernetes, issues pertaining only to client-go should be opened in [kubernetes/client-go](https://git.k8s.io/client-go).
 
 This repository is published from [kubernetes/kubernetes/staging/src/k8s.io/client-go](https://git.k8s.io/kubernetes/staging/src/k8s.io/client-go) by the [kubernetes publishing-bot](https://git.k8s.io/publishing-bot).
 


### PR DESCRIPTION
While pull requests should be in kubernetes/kubernetes, it seems issues are
tracked in client-go repo.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

It is confusing where to make a Github issue to discuss this project; my searching found Github issues addressing client-go in both kubernetes/client-go and kubernetes/kubernetes. The CONTRIBUTING doc says PRs (except for README.md) must be in the latter, but does not say anything about Github issues.

Now, if I'm wrong, tell me and I'll update it to point the other way :).

**Does this PR introduce a user-facing change?**:
No
