### PR TITLE
add port-forward svc/ completion

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -258,10 +258,19 @@ __kubectl_custom_func() {
             return
             ;;
         kubectl_logs)
+            __kubectl_parse_get "deployments" "{{ range .items  }}deploy/{{ .metadata.name }} {{ end }}"
+            __kubectl_parse_get "statefulsets" "{{ range .items  }}sts/{{ .metadata.name }} {{ end }}"
+            __kubectl_parse_get "replicasets" "{{ range .items  }}rs/{{ .metadata.name }} {{ end }}"
+            __kubectl_parse_get "jobs" "{{ range .items  }}job/{{ .metadata.name }} {{ end }}"
             __kubectl_require_pod_and_container
             return
             ;;
-        kubectl_exec | kubectl_port-forward | kubectl_top_pod | kubectl_attach)
+		kubectl_port-forward)
+	    	__kubectl_parse_get "service" "{{ range .items  }}svc/{{ .metadata.name }} {{ end }}"
+            __kubectl_get_resource_pod
+            return
+            ;;
+        kubectl_exec | kubectl_top_pod | kubectl_attach)
             __kubectl_get_resource_pod
             return
             ;;


### PR DESCRIPTION
**What this PR does / why we need it**:
adds bash completion for 
`kubectl port-forward svc/<tab>`
`kubectl logs <tab>`

**Which issue(s) this PR fixes**:
Fixes #79718

**Special notes for your reviewer**:
Thanks for your work. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/kind feature
/sig cli
