### PR TITLE
kubelet/network: add sig-network-approvers to OWNERS

### DIFF
--- a/pkg/kubelet/network/OWNERS
+++ b/pkg/kubelet/network/OWNERS
@@ -1,9 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- thockin
 - dchen1107
-- freehan
+- sig-network-approvers
 emeritus_approvers:
 - matchstick
 reviewers:


### PR DESCRIPTION
Add sig-network-approvers to kubelet/network OWNERS

@thockin @freehan 

```release-note
NONE
```