### PR TITLE
e2e_node: check if image exists locally before pulling

### DIFF
--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -98,7 +98,11 @@ func (dp *dockerPuller) Name() string {
 }
 
 func (dp *dockerPuller) Pull(image string) ([]byte, error) {
-	return exec.Command("docker", "pull", image).CombinedOutput()
+	// TODO(random-liu): Use docker client to get rid of docker binary dependency.
+	if exec.Command("docker", "inspect", "--type=image", image).Run() != nil {
+		return exec.Command("docker", "pull", image).CombinedOutput()
+	}
+	return nil, nil
 }
 
 type remotePuller struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

'docker pull' is a time consuming operation. It makes sense to check
if image exists locally before pulling it from a registry.

Checked if image exists by running 'docker inspect'. Only pull if
image doesn't exist.

This reduced image pulling from 1m9.5s to 1.4s on my system if all images present locally

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```