### PR TITLE
kubeadm: check if image exists locally before pulling

### DIFF
--- a/cmd/kubeadm/app/cmd/config.go
+++ b/cmd/kubeadm/app/cmd/config.go
@@ -487,6 +487,11 @@ func NewImagesPull(runtime utilruntime.ContainerRuntime, images []string) *Image
 func PullControlPlaneImages(runtime utilruntime.ContainerRuntime, cfg *kubeadmapi.ClusterConfiguration) error {
 	images := images.GetControlPlaneImages(cfg)
 	for _, image := range images {
+		ret, err := runtime.ImageExists(image)
+		if ret && err == nil {
+			klog.V(1).Infof("[config/images] image exists: %s", image)
+			continue
+		}
 		if err := runtime.PullImage(image); err != nil {
 			return errors.Wrapf(err, "failed to pull image %q", image)
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**

Image pull is a time consuming operation. It makes sense to check
if image exists locally before pulling it from a registry.

With this change 'kubeadm config image pull' time decreased 10 times: from 20s to 2s 

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: speed up the 'kubeadm config image pull' command, by checking if an image exists locally before pulling it
```
```