### PR TITLE
Add certificate identification to error message when x509 auth fails

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go
@@ -19,8 +19,10 @@ package x509
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/hex"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -82,6 +84,27 @@ func (f UserConversionFunc) User(chain []*x509.Certificate) (*authenticator.Resp
 	return f(chain)
 }
 
+func columnSeparatedHex(d []byte) string {
+	h := strings.ToUpper(hex.EncodeToString(d))
+	var sb strings.Builder
+	for i, r := range h {
+		sb.WriteRune(r)
+		if i%2 == 1 && i != len(h)-1 {
+			sb.WriteRune(':')
+		}
+	}
+	return sb.String()
+}
+
+func certificateIdentifier(c *x509.Certificate) string {
+	return fmt.Sprintf(
+		"SN=%d, SKID=%s, AKID=%s",
+		c.SerialNumber,
+		columnSeparatedHex(c.SubjectKeyId),
+		columnSeparatedHex(c.AuthorityKeyId),
+	)
+}
+
 // VerifyOptionFunc is function which provides a shallow copy of the VerifyOptions to the authenticator.  This allows
 // for cases where the options (particularly the CAs) can change.  If the bool is false, then the returned VerifyOptions
 // are ignored and the authenticator will express "no opinion".  This allows a clear signal for cases where a CertPool
@@ -129,7 +152,11 @@ func (a *Authenticator) AuthenticateRequest(req *http.Request) (*authenticator.R
 	clientCertificateExpirationHistogram.Observe(remaining.Seconds())
 	chains, err := req.TLS.PeerCertificates[0].Verify(optsCopy)
 	if err != nil {
-		return nil, false, err
+		return nil, false, fmt.Errorf(
+			"verifying certificate %s failed: %w",
+			certificateIdentifier(req.TLS.PeerCertificates[0]),
+			err,
+		)
 	}
 
 	var errlist []error


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When reading apiserver logs I am seeing messages like
```
authentication.go:89] Unable to authenticate the request due to an error: x509: certificate signed by unknown authority
```
but that's not really helpful since I don't know which client is failing.

Adding the subject will help identify the client since that's where we get the user name from.
https://github.com/kubernetes/kubernetes/blob/c97baa339b5043424522dc7932fc3891f15543cb/staging/src/k8s.io/apiserver/pkg/authentication/request/x509/x509.go#L222-L232


**Does this PR introduce a user-facing change?**:
```release-note
None
```

/cc @sttts @deads2k 
@kubernetes/sig-api-machinery-pr-reviews 