### PR TITLE
Change env to envs in the kustomize documentation

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/reference/kustomize.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/reference/kustomize.md
@@ -98,7 +98,7 @@ as well as `namePrefix`'s and `nameSuffix`'s.
 | Name          | Type      | Desc                                |
 | :------------ | :-------- | :---------------------------------- |
 | **behavior**  | string    | Merge behavior when the ConfigMap generator is defined in a base.  May be one of `create`, `replace`, `merge`. |
-| **env**       | string    | Single file to generate ConfigMap data entries from.  Should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair.  *Each line* will appear as an entry in the ConfigMap data field. |
+| **envs**      | []string  | List of files to generate ConfigMap data entries from. Each item should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair. *Each line* will appear as an entry in the ConfigMap data field. |
 | **files**     | []string  | List of files to generate ConfigMap data entries from. Each item should be a path to a local file, e.g. `path/to/file.config`, and the filename will appear as an entry in the ConfigMap data field with its contents as a value.  |
 | **literals**  | []string  | List of literal ConfigMap data entries. Each item should be a key and literal value, e.g. `somekey=somevalue`, and the key/value will appear as an entry in the ConfigMap data field.|
 | **name**      | string    | Name for the ConfigMap.  Modified by the `namePrefix` and `nameSuffix` fields. |
@@ -126,7 +126,8 @@ configMapGenerator:
 # generate a ConfigMap named my-system-env-<some-hash> where each key/value pair in the
 # env.txt appears as a data entry (separated by \n).
 - name: my-system-env
-  env: env.txt
+  envs:
+  - env.txt
 ```
 
 {% endmethod %}
@@ -186,7 +187,7 @@ as well as `namePrefix`'s and `nameSuffix`'s.
 | Name          | Type    | Desc                                |
 | :------------ | :------ | :---------------------------------- |
 | **behavior**  | string  | Merge behavior when the Secret generator is defined in a base.  May be one of `create`, `replace`, `merge`. |
-| **env**       | string  | Single file to generate Secret data entries from.  Should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair.  *Each line* will appear as an entry in the Secret data field. |
+| **envs**      | []string  | List of files to generate Secret data entries from. Each item should be a path to a local *env* file, e.g. `path/to/file.env`, where each line of the file is a `key=value` pair. *Each line* will appear as an entry in the Secret data field. |
 | **files**     | []string  | List of files to generate Secret data entries from. Each item should be a path to a local file, e.g. `path/to/file.config`, and the filename will appear as an entry in the ConfigMap data field with its contents as a value.  |
 | **literals**  | []string  | List of literal Secret data entries. Each item should be a key and literal value, e.g. `somekey=somevalue`, and the key/value will appear as an entry in the Secret data field.|
 | **name**      | string  | Name for the Secret.  Modified by the `namePrefix` and `nameSuffix` fields. |
@@ -206,9 +207,9 @@ secretGenerator:
     - secret/tls.key
   type: "kubernetes.io/tls"
 - name: env_file_secret
-  # env is a path to a file to read lines of key=val
-  # you can only specify one env file per secret.
-  env: env.txt
+  # envs is a list of paths to files containing lines of key=val
+  envs:
+  - env.txt
   type: Opaque
 ```
 


### PR DESCRIPTION
In https://github.com/kubernetes-sigs/kustomize/pull/1637 the deprecated `env` field was removed.

Signed-off-by: Tobias Nehrlich <tobias.nehrlich@vshn.ch>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The current documentation does not match the implementation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
none

**Special notes for your reviewer**:
none

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
