### PR TITLE
Fold delta dedup into DeltaFIFO#queueActionLocked

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo.go
@@ -256,22 +256,6 @@ func (f *DeltaFIFO) addIfNotPresent(id string, deltas Deltas) {
 	f.cond.Broadcast()
 }
 
-// re-listing and watching can deliver the same update multiple times in any
-// order. This will combine the most recent two deltas if they are the same.
-func dedupDeltas(deltas Deltas) Deltas {
-	n := len(deltas)
-	if n < 2 {
-		return deltas
-	}
-	a := &deltas[n-1]
-	b := &deltas[n-2]
-	if out := isDup(a, b); out != nil {
-		d := append(Deltas{}, deltas[:n-2]...)
-		return append(d, *out)
-	}
-	return deltas
-}
-
 // If a & b represent the same event, returns the delta that ought to be kept.
 // Otherwise, returns nil.
 // TODO: is there anything other than deletions that need deduping?
@@ -303,8 +287,23 @@ func (f *DeltaFIFO) queueActionLocked(actionType DeltaType, obj interface{}) err
 		return KeyError{obj, err}
 	}
 
-	newDeltas := append(f.items[id], Delta{actionType, obj})
-	newDeltas = dedupDeltas(newDeltas)
+	var newDeltas Deltas
+	addition := &Delta{actionType, obj}
+	if len(f.items[id]) < 1 {
+		newDeltas = append(Deltas{}, *addition)
+	} else {
+		// re-listing and watching can deliver the same update multiple times in any
+		// order. This will combine the most recent two deltas if they are the same.
+		n := len(f.items[id])
+		last := &f.items[id][n-1]
+		if out := isDup(last, addition); out != nil {
+			// replace the duplicate
+			f.items[id][n-1] = *out
+			newDeltas = f.items[id]
+		} else {
+			newDeltas = append(f.items[id], *addition)
+		}
+	}
 
 	if len(newDeltas) > 0 {
 		if _, exists := f.items[id]; !exists {

--- a/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/delta_fifo_test.go
@@ -156,6 +156,17 @@ func TestDeltaFIFO_requeueOnPop(t *testing.T) {
 	}
 }
 
+func BenchmarkAddUpdate(t *testing.B) {
+	t.ReportAllocs()
+	t.ResetTimer()
+	f := NewDeltaFIFO(testFifoObjectKeyFunc, nil)
+	for n := 0; n < t.N; n++ {
+		f.Add(mkFifoObj("foo", 10))
+		f.Update(mkFifoObj("foo", 12))
+		f.Delete(mkFifoObj("foo", 15))
+	}
+}
+
 func TestDeltaFIFO_addUpdate(t *testing.T) {
 	f := NewDeltaFIFO(testFifoObjectKeyFunc, nil)
 	f.Add(mkFifoObj("foo", 10))


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently delta dedup is done after the new delta is appended.
This creates unnecessary truncation / append operations.

This PR folds dedup into DeltaFIFO#queueActionLocked and reduces unnecessary allocation(s).

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
