### PR TITLE
Promote a TCP socket probe test to Conformance

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -103,6 +103,7 @@ test/e2e/common/container_probe.go: "with readiness probe that fails should neve
 test/e2e/common/container_probe.go: "should be restarted with a exec \\\"cat /tmp/health\\\" liveness probe"
 test/e2e/common/container_probe.go: "should *not* be restarted with a exec \\\"cat /tmp/health\\\" liveness probe"
 test/e2e/common/container_probe.go: "should be restarted with a /healthz http liveness probe"
+test/e2e/common/container_probe.go: "should *not* be restarted with a tcp:8080 liveness probe"
 test/e2e/common/container_probe.go: "should have monotonically increasing restart count"
 test/e2e/common/container_probe.go: "should *not* be restarted with a /healthz http liveness probe"
 test/e2e/common/docker_containers.go: "should use the image defaults if command and args are blank"

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -159,11 +159,11 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 
 	/*
-		Release : v1.15
+		Release : v1.18
 		Testname: Pod liveness probe, using tcp socket, no restart
-		Description: A Pod is created with liveness probe on tcp socket 8080. The http handler on port 8080 will return http errors after 10 seconds, but socket will remain open. Liveness probe MUST not fail to check health and the restart count should remain 0.
+		Description: A Pod is created with liveness probe on tcp socket 8080. The http handler on port 8080 will return http errors after 10 seconds, but the socket will remain open. Liveness probe MUST not fail to check health and the restart count should remain 0.
 	*/
-	ginkgo.It("should *not* be restarted with a tcp:8080 liveness probe [NodeConformance]", func() {
+	framework.ConformanceIt("should *not* be restarted with a tcp:8080 liveness probe [NodeConformance]", func() {
 		livenessProbe := &v1.Probe{
 			Handler:             tcpSocketHandler(8080),
 			InitialDelaySeconds: 15,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There are currently no Conformance tests that exercise the [TCPSocketAction](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.10/#tcpsocketaction-v1-core) field of Container probes (liveness or readiness). This PR promotes an e2e test which was explicitly added for this purpose back in the 1.15 timeframe.

**Special notes for your reviewer**:
- [testgrid link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=probe) to demonstrate that this test is low-latency and non-flaky
- this isn't intended to land in the 1.17 timeframe

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```