### PR TITLE
don't error if set-resources patch is empty

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
@@ -267,7 +267,6 @@ func (o *SetResourcesOptions) Run() error {
 
 		//no changes
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			allErrs = append(allErrs, fmt.Errorf("info: %s was not changed\n", name))
 			continue
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -247,7 +247,6 @@ func (o *SubjectOptions) Run(fn updateSubjects) error {
 
 		//no changes
 		if string(patch.Patch) == "{}" || len(patch.Patch) == 0 {
-			allErrs = append(allErrs, fmt.Errorf("info: %s was not changed\n", name))
 			continue
 		}
 


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup

**What this PR does / why we need it**:

Currently when you pass an empty change to `kubectl set resources` or `kubectl set subject` the commands return an error.  With this PR, no error is returned.
To see issue:  
run `kubectl set resources deployment/anydep --limits=cpu=0,memory=100` 2xs

w/out this change, you'll see (upon 2nd run of cmd):
```
$ kubectl set resources deployment/hello-node --limits=cpu=0,memory=100 --requests=cpu=0,memory=0
error: info: deployments/hello-node was not changed
$ echo $?
1
```

w/ this PR:
```
$ kubectl set resources deployment/hello-node --limits=cpu=0,memory=100 --requests=cpu=0,memory=0
$ echo $?
0
```
**Does this PR introduce a user-facing change?**:

```release-note
kubectl set resources will no longer return an error if passed an empty change for a resource. 
kubectl set subject will no longer return an error if passed an empty change for a resource.  
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
