### PR TITLE
Automated cherry pick of #83953: fix string trim func isBackendPoolOnSameLB in azure

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
@@ -347,7 +347,7 @@ func isBackendPoolOnSameLB(newBackendPoolID string, existingBackendPools []strin
 	}
 
 	newLBName := matches[1]
-	newLBNameTrimmed := strings.TrimRight(newLBName, InternalLoadBalancerNameSuffix)
+	newLBNameTrimmed := strings.TrimSuffix(newLBName, InternalLoadBalancerNameSuffix)
 	for _, backendPool := range existingBackendPools {
 		matches := backendPoolIDRE.FindStringSubmatch(backendPool)
 		if len(matches) != 2 {
@@ -355,7 +355,7 @@ func isBackendPoolOnSameLB(newBackendPoolID string, existingBackendPools []strin
 		}
 
 		lbName := matches[1]
-		if !strings.EqualFold(strings.TrimRight(lbName, InternalLoadBalancerNameSuffix), newLBNameTrimmed) {
+		if !strings.EqualFold(strings.TrimSuffix(lbName, InternalLoadBalancerNameSuffix), newLBNameTrimmed) {
 			return false, lbName, nil
 		}
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap_test.go
@@ -260,6 +260,14 @@ func TestIsBackendPoolOnSameLB(t *testing.T) {
 			},
 			expectError: true,
 		},
+		{
+			backendPoolID: "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/malformed-lb1-internal/backendAddressPools/pool1",
+			existingBackendPools: []string{
+				"/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/loadBalancers/malformed-lb1-lanretni/backendAddressPools/pool2",
+			},
+			expected:       false,
+			expectedLBName: "malformed-lb1-lanretni",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Cherry pick of #83953 on release-1.15.

#83953: fix string trim func isBackendPoolOnSameLB in azure

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.