### PR TITLE
Fix benchmark artifact parsing.

### DIFF
--- a/hack/jenkins/benchmark-dockerized.sh
+++ b/hack/jenkins/benchmark-dockerized.sh
@@ -59,7 +59,8 @@ cd "${GOPATH}/src/k8s.io/kubernetes"
 ./hack/install-etcd.sh
 
 # Run the benchmark tests and pretty-print the results into a separate file.
-make test-integration WHAT="$*" KUBE_TEST_ARGS="-run='XXX' -bench=. -benchmem" \
+make test-integration WHAT="$*" KUBE_TEST_ARGS="-run='XXX' -bench=. -benchmem  -alsologtostderr=false -logtostderr=false" \
+  | (go run test/integration/benchmark/extractlog/main.go) \
   | tee \
    >(prettybench -no-passthrough > "${ARTIFACTS}/BenchmarkResults.txt") \
    >(go run test/integration/benchmark/jsonify/main.go "${ARTIFACTS}/BenchmarkResults_benchmark_$(date -u +%Y-%m-%dT%H:%M:%SZ).json" || cat > /dev/null)

--- a/test/integration/BUILD
+++ b/test/integration/BUILD
@@ -39,6 +39,7 @@ filegroup(
         "//test/integration/apimachinery:all-srcs",
         "//test/integration/apiserver:all-srcs",
         "//test/integration/auth:all-srcs",
+        "//test/integration/benchmark/extractlog:all-srcs",
         "//test/integration/benchmark/jsonify:all-srcs",
         "//test/integration/client:all-srcs",
         "//test/integration/configmap:all-srcs",

--- a/test/integration/benchmark/extractlog/BUILD
+++ b/test/integration/benchmark/extractlog/BUILD
@@ -1,0 +1,28 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "k8s.io/kubernetes/test/integration/benchmark/extractlog",
+    visibility = ["//visibility:private"],
+)
+
+go_binary(
+    name = "extractlog",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/benchmark/extractlog/main.go
+++ b/test/integration/benchmark/extractlog/main.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() {
+	err := extractRawLog(os.Stdin)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// A json log entry contains keys such as "Time", "Action", "Package" and "Output".
+// We are only interested in "Output", which is the raw log.
+type jsonLog struct {
+	Output string `json:"output,omitempty"`
+}
+
+// jsonToRawLog converts a single line of json formatted log to raw log.
+// If there is an error, it returns the original input.
+func jsonToRawLog(line string) (string, error) {
+	var log jsonLog
+	if err := json.Unmarshal([]byte(line), &log); err != nil {
+		return line, err
+	}
+	return log.Output, nil
+}
+
+func extractRawLog(r io.Reader) error {
+	scan := bufio.NewScanner(r)
+	for scan.Scan() {
+		l, _ := jsonToRawLog(scan.Text())
+		// Print the raw log to stdout.
+		fmt.Println(l)
+	}
+	if err := scan.Err(); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The [scheduler benchmark test job](https://testgrid.k8s.io/sig-scalability-benchmarks#scheduler) has been succeeding however no result is shown on the [perfdash](http://perf-dash.k8s.io/#/?jobname=scheduler-benchmark&metriccategoryname=Scheduler&metricname=BenchmarkResults&benchmark=BenchmarkSchedulingInTreePVs%2F1000Nodes%2F1000Pods-8&metricName=time). This is because the log parser failed to parse test logs due to unexpected log format.
Interestingly enough, when the test fails, it actually (partially) prints the normal log format. As a result, the results we see on the perf dash are those failed tests...

**Detailed explanation**:
If the `ARTIFACTS` env var is set, logs will be printed in json format specified by [test.sh](https://github.com/kubernetes/kubernetes/blob/8618c093692f753c0fad1a4ab00912e9f218872a/hack/make-rules/test.sh#L159), which cannot be parsed by benchmark parser.  
This PR extracts raw logs from json format before passing to the benchmark parser.

* Json format log
``` 
{"Time":"2019-11-06T03:28:24.143461139Z","Action":"output","Package":"k8s.io/kubernetes/test/integration/scheduler_perf","Output":"BenchmarkSchedulingV/100Nodes/0Pods-8    \t"}
{"Time":"2019-11-06T03:28:24.143478Z","Action":"output","Package":"k8s.io/kubernetes/test/integration/scheduler_perf","Output":"     100\t  14863193 ns/op\t  563863 B/op\t    6973 allocs/op\n"}
```

* Log format that the benchmark parser expects
```
BenchmarkSchedulingCSIPVs/1000Nodes/1000Pods-12                              500          19287608 ns/op         1768107 B/op      46612 allocs/op
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This script is currently only used by scheduler benchmark tests.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
