### PR TITLE
Fix func VerifyLatencyWithinThreshold() to local 

### DIFF
--- a/test/e2e/framework/metrics/latencies.go
+++ b/test/e2e/framework/metrics/latencies.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"fmt"
 	"math"
 	"time"
 
@@ -30,21 +29,6 @@ const (
 	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
 	SingleCallTimeout = 5 * time.Minute
 )
-
-// VerifyLatencyWithinThreshold verifies whether 50, 90 and 99th percentiles of a latency metric are
-// within the expected threshold.
-func VerifyLatencyWithinThreshold(threshold, actual LatencyMetric, metricName string) error {
-	if actual.Perc50 > threshold.Perc50 {
-		return fmt.Errorf("too high %v latency 50th percentile: %v", metricName, actual.Perc50)
-	}
-	if actual.Perc90 > threshold.Perc90 {
-		return fmt.Errorf("too high %v latency 90th percentile: %v", metricName, actual.Perc90)
-	}
-	if actual.Perc99 > threshold.Perc99 {
-		return fmt.Errorf("too high %v latency 99th percentile: %v", metricName, actual.Perc99)
-	}
-	return nil
-}
 
 // PodLatencyData encapsulates pod startup latency information.
 type PodLatencyData struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

func VerifyLatencyWithinThreshold() is just used from test/e2e_node/density_test.go
this PR moves this func to test/e2e_node/density_test.go and also fixes it from global to local func.



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```


