### PR TITLE
Automated cherry pick of #85402: Remove metric be hidden log temporarily.

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/desc.go
+++ b/staging/src/k8s.io/component-base/metrics/desc.go
@@ -119,7 +119,8 @@ func (d *Desc) determineDeprecationStatus(version semver.Version) {
 			return
 		}
 		if shouldHide(&version, selfVersion) {
-			klog.Warningf("This metric(%s) has been deprecated for more than one release, hiding.", d.fqName)
+			// TODO(RainbowMango): Remove this log temporarily. https://github.com/kubernetes/kubernetes/issues/85369
+			// klog.Warningf("This metric(%s) has been deprecated for more than one release, hiding.", d.fqName)
 			d.isHidden = true
 		}
 	})

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -102,7 +102,8 @@ func (r *lazyMetric) determineDeprecationStatus(version semver.Version) {
 			return
 		}
 		if shouldHide(&version, selfVersion) {
-			klog.Warningf("This metric has been deprecated for more than one release, hiding.")
+			// TODO(RainbowMango): Remove this log temporarily. https://github.com/kubernetes/kubernetes/issues/85369
+			// klog.Warningf("This metric has been deprecated for more than one release, hiding.")
 			r.isHidden = true
 		}
 	})


### PR DESCRIPTION
Cherry pick of #85402 on release-1.17.

#85402: Remove metric be hidden log temporarily.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.