### PR TITLE
Initialize FeatureGate map for KubeProxy config. #1929

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/defaults.go
+++ b/cmd/kubeadm/app/componentconfigs/defaults.go
@@ -63,6 +63,12 @@ func DefaultKubeProxyConfiguration(internalcfg *kubeadmapi.ClusterConfiguration)
 			FeatureGates: map[string]bool{},
 		}
 	}
+	// The below code is necessary because while KubeProxy may be defined, the user may not
+	// have defined any feature-gates, thus FeatureGates will be nil and the later insertion
+	// of any feature-gates (e.g. IPv6DualStack) will cause a panic.
+	if internalcfg.ComponentConfigs.KubeProxy.FeatureGates == nil {
+		internalcfg.ComponentConfigs.KubeProxy.FeatureGates = map[string]bool{}
+	}
 
 	externalproxycfg := internalcfg.ComponentConfigs.KubeProxy
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes/kubeadm/issues/1929

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1929

**Does this PR introduce a user-facing change?**:

```release-note
kubeadm: fix a panic in case the KubeProxyConfiguration feature gates were not initialized.
```

@neolit123 @rosti 