### PR TITLE
e2e storage: public API for testsuites, support CSIInlineVolume type for generic resource

### DIFF
--- a/test/e2e/storage/testpatterns/testpattern.go
+++ b/test/e2e/storage/testpatterns/testpattern.go
@@ -76,6 +76,11 @@ var (
 		Name:    "Inline-volume (default fs)",
 		VolType: InlineVolume,
 	}
+	// DefaultFsEphemeralVolume is TestPattern for "Ephemeral-volume (default fs)"
+	DefaultFsEphemeralVolume = TestPattern{
+		Name:    "Ephemeral-volume (default fs)",
+		VolType: CSIInlineVolume,
+	}
 	// DefaultFsPreprovisionedPV is TestPattern for "Pre-provisioned PV (default fs)"
 	DefaultFsPreprovisionedPV = TestPattern{
 		Name:    "Pre-provisioned PV (default fs)",
@@ -92,6 +97,12 @@ var (
 	// Ext3InlineVolume is TestPattern for "Inline-volume (ext3)"
 	Ext3InlineVolume = TestPattern{
 		Name:    "Inline-volume (ext3)",
+		VolType: InlineVolume,
+		FsType:  "ext3",
+	}
+	// Ext3EphemeralVolume is TestPattern for "Ephemeral-volume (ext3)"
+	Ext3EphemeralVolume = TestPattern{
+		Name:    "Ephemeral-volume (ext3)",
 		VolType: InlineVolume,
 		FsType:  "ext3",
 	}
@@ -116,6 +127,12 @@ var (
 		VolType: InlineVolume,
 		FsType:  "ext4",
 	}
+	// Ext4EphemeralVolume is TestPattern for "Ephemeral-volume (ext4)"
+	Ext4EphemeralVolume = TestPattern{
+		Name:    "Ephemeral-volume (ext4)",
+		VolType: CSIInlineVolume,
+		FsType:  "ext4",
+	}
 	// Ext4PreprovisionedPV is TestPattern for "Pre-provisioned PV (ext4)"
 	Ext4PreprovisionedPV = TestPattern{
 		Name:    "Pre-provisioned PV (ext4)",
@@ -135,6 +152,13 @@ var (
 	XfsInlineVolume = TestPattern{
 		Name:       "Inline-volume (xfs)",
 		VolType:    InlineVolume,
+		FsType:     "xfs",
+		FeatureTag: "[Slow]",
+	}
+	// XfsEphemeralVolume is TestPattern for "Ephemeral-volume (xfs)"
+	XfsEphemeralVolume = TestPattern{
+		Name:       "Ephemeral-volume (xfs)",
+		VolType:    CSIInlineVolume,
 		FsType:     "xfs",
 		FeatureTag: "[Slow]",
 	}
@@ -159,6 +183,13 @@ var (
 	NtfsInlineVolume = TestPattern{
 		Name:       "Inline-volume (ntfs)",
 		VolType:    InlineVolume,
+		FsType:     "ntfs",
+		FeatureTag: "[sig-windows]",
+	}
+	// NtfsEphemeralVolume is TestPattern for "Ephemeral-volume (ntfs)"
+	NtfsEphemeralVolume = TestPattern{
+		Name:       "Ephemeral-volume (ntfs)",
+		VolType:    CSIInlineVolume,
 		FsType:     "ntfs",
 		FeatureTag: "[sig-windows]",
 	}

--- a/test/e2e/storage/testsuites/BUILD
+++ b/test/e2e/storage/testsuites/BUILD
@@ -76,7 +76,13 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["base_test.go"],
+    srcs = [
+        "api_test.go",
+        "base_test.go",
+    ],
     embed = [":go_default_library"],
-    deps = ["//test/e2e/framework/volume:go_default_library"],
+    deps = [
+        "//test/e2e/framework/volume:go_default_library",
+        "//test/e2e/storage/testpatterns:go_default_library",
+    ],
 )

--- a/test/e2e/storage/testsuites/api_test.go
+++ b/test/e2e/storage/testsuites/api_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package testsuites_test is used intentionally to ensure that the
+// code below only has access to exported names. It doesn't have any
+// actual test. That the custom volume test suite defined below
+// compile is the test.
+//
+// It's needed because we don't have any in-tree volume test
+// suite implementations that aren't in the "testuites" package itself.
+// We don't need this for the "TestDriver" interface because there
+// we have implementations in a separate package.
+package testsuites_test
+
+import (
+	"k8s.io/kubernetes/test/e2e/framework/volume"
+	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
+	"k8s.io/kubernetes/test/e2e/storage/testsuites"
+)
+
+type fakeSuite struct {
+}
+
+func (f *fakeSuite) GetTestSuiteInfo() testsuites.TestSuiteInfo {
+	return testsuites.TestSuiteInfo{
+		Name:               "fake",
+		FeatureTag:         "",
+		TestPatterns:       []testpatterns.TestPattern{testpatterns.DefaultFsDynamicPV},
+		SupportedSizeRange: volume.SizeRange{Min: "1Mi", Max: "1Gi"},
+	}
+}
+
+func (f *fakeSuite) DefineTests(testsuites.TestDriver, testpatterns.TestPattern) {
+}
+
+func (f *fakeSuite) SkipRedundantSuite(testsuites.TestDriver, testpatterns.TestPattern) {
+}
+
+var _ testsuites.TestSuite = &fakeSuite{}

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -39,9 +39,9 @@ var _ TestSuite = &disruptiveTestSuite{}
 func InitDisruptiveTestSuite() TestSuite {
 	return &disruptiveTestSuite{
 		tsInfo: TestSuiteInfo{
-			name:       "disruptive",
-			featureTag: "[Disruptive]",
-			testPatterns: []testpatterns.TestPattern{
+			Name:       "disruptive",
+			FeatureTag: "[Disruptive]",
+			TestPatterns: []testpatterns.TestPattern{
 				// FSVolMode is already covered in subpath testsuite
 				testpatterns.DefaultFsInlineVolume,
 				testpatterns.FsVolModePreprovisionedPV,
@@ -52,15 +52,15 @@ func InitDisruptiveTestSuite() TestSuite {
 		},
 	}
 }
-func (s *disruptiveTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (s *disruptiveTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return s.tsInfo
 }
 
-func (s *disruptiveTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (s *disruptiveTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 	skipVolTypePatterns(pattern, driver, testpatterns.NewVolTypeMap(testpatterns.PreprovisionedPV))
 }
 
-func (s *disruptiveTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (s *disruptiveTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
@@ -68,8 +68,8 @@ func (s *disruptiveTestSuite) defineTests(driver TestDriver, pattern testpattern
 		cs clientset.Interface
 		ns *v1.Namespace
 
-		// genericVolumeTestResource contains pv, pvc, sc, etc., owns cleaning that up
-		resource *genericVolumeTestResource
+		// VolumeResource contains pv, pvc, sc, etc., owns cleaning that up
+		resource *VolumeResource
 		pod      *v1.Pod
 	}
 	var l local
@@ -94,8 +94,8 @@ func (s *disruptiveTestSuite) defineTests(driver TestDriver, pattern testpattern
 			framework.Skipf("Driver %s doesn't support %v -- skipping", driver.GetDriverInfo().Name, pattern.VolMode)
 		}
 
-		testVolumeSizeRange := s.getTestSuiteInfo().supportedSizeRange
-		l.resource = createGenericVolumeTestResource(driver, l.config, pattern, testVolumeSizeRange)
+		testVolumeSizeRange := s.GetTestSuiteInfo().SupportedSizeRange
+		l.resource = CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
 	}
 
 	cleanup := func() {
@@ -108,7 +108,7 @@ func (s *disruptiveTestSuite) defineTests(driver TestDriver, pattern testpattern
 		}
 
 		if l.resource != nil {
-			err := l.resource.cleanupResource()
+			err := l.resource.CleanupResource()
 			errs = append(errs, err)
 			l.resource = nil
 		}
@@ -154,9 +154,9 @@ func (s *disruptiveTestSuite) defineTests(driver TestDriver, pattern testpattern
 					var pvcs []*v1.PersistentVolumeClaim
 					var inlineSources []*v1.VolumeSource
 					if pattern.VolType == testpatterns.InlineVolume {
-						inlineSources = append(inlineSources, l.resource.volSource)
+						inlineSources = append(inlineSources, l.resource.VolSource)
 					} else {
-						pvcs = append(pvcs, l.resource.pvc)
+						pvcs = append(pvcs, l.resource.Pvc)
 					}
 					ginkgo.By("Creating a pod with pvc")
 					l.pod, err = e2epod.CreateSecPodWithNodeSelection(l.cs, l.ns.Name, pvcs, inlineSources, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)

--- a/test/e2e/storage/testsuites/driveroperations.go
+++ b/test/e2e/storage/testsuites/driveroperations.go
@@ -37,7 +37,7 @@ func GetDriverNameWithFeatureTags(driver TestDriver) string {
 	return fmt.Sprintf("[Driver: %s]%s", dInfo.Name, dInfo.FeatureTag)
 }
 
-// CreateVolume creates volume for test unless dynamicPV test
+// CreateVolume creates volume for test unless dynamicPV or CSI ephemeral inline volume test
 func CreateVolume(driver TestDriver, config *PerTestConfig, volType testpatterns.TestVolType) TestVolume {
 	switch volType {
 	case testpatterns.InlineVolume:
@@ -46,6 +46,8 @@ func CreateVolume(driver TestDriver, config *PerTestConfig, volType testpatterns
 		if pDriver, ok := driver.(PreprovisionedVolumeTestDriver); ok {
 			return pDriver.CreateVolume(config, volType)
 		}
+	case testpatterns.CSIInlineVolume:
+		fallthrough
 	case testpatterns.DynamicPV:
 		// No need to create volume
 	default:

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -45,8 +45,8 @@ var _ TestSuite = &ephemeralTestSuite{}
 func InitEphemeralTestSuite() TestSuite {
 	return &ephemeralTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "ephemeral",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "ephemeral",
+			TestPatterns: []testpatterns.TestPattern{
 				{
 					Name:    "inline ephemeral CSI volume",
 					VolType: testpatterns.CSIInlineVolume,
@@ -56,14 +56,14 @@ func InitEphemeralTestSuite() TestSuite {
 	}
 }
 
-func (p *ephemeralTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (p *ephemeralTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return p.tsInfo
 }
 
-func (p *ephemeralTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (p *ephemeralTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 }
 
-func (p *ephemeralTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (p *ephemeralTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -45,29 +45,29 @@ var _ TestSuite = &multiVolumeTestSuite{}
 func InitMultiVolumeTestSuite() TestSuite {
 	return &multiVolumeTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "multiVolume [Slow]",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "multiVolume [Slow]",
+			TestPatterns: []testpatterns.TestPattern{
 				testpatterns.FsVolModePreprovisionedPV,
 				testpatterns.FsVolModeDynamicPV,
 				testpatterns.BlockVolModePreprovisionedPV,
 				testpatterns.BlockVolModeDynamicPV,
 			},
-			supportedSizeRange: volume.SizeRange{
+			SupportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
 			},
 		},
 	}
 }
 
-func (t *multiVolumeTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (t *multiVolumeTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *multiVolumeTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *multiVolumeTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 	skipVolTypePatterns(pattern, driver, testpatterns.NewVolTypeMap(testpatterns.PreprovisionedPV))
 }
 
-func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
@@ -75,7 +75,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		cs        clientset.Interface
 		ns        *v1.Namespace
 		driver    TestDriver
-		resources []*genericVolumeTestResource
+		resources []*VolumeResource
 
 		intreeOps   opCounts
 		migratedOps opCounts
@@ -112,7 +112,7 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 	cleanup := func() {
 		var errs []error
 		for _, resource := range l.resources {
-			errs = append(errs, resource.cleanupResource())
+			errs = append(errs, resource.CleanupResource())
 		}
 
 		errs = append(errs, tryFunc(l.driverCleanup))
@@ -141,10 +141,10 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		numVols := 2
 
 		for i := 0; i < numVols; i++ {
-			testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-			resource := createGenericVolumeTestResource(driver, l.config, pattern, testVolumeSizeRange)
+			testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+			resource := CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
 			l.resources = append(l.resources, resource)
-			pvcs = append(pvcs, resource.pvc)
+			pvcs = append(pvcs, resource.Pvc)
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
@@ -184,10 +184,10 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		numVols := 2
 
 		for i := 0; i < numVols; i++ {
-			testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-			resource := createGenericVolumeTestResource(driver, l.config, pattern, testVolumeSizeRange)
+			testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+			resource := CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
 			l.resources = append(l.resources, resource)
-			pvcs = append(pvcs, resource.pvc)
+			pvcs = append(pvcs, resource.Pvc)
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
@@ -223,10 +223,10 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 				// 1st volume should be block and set filesystem for 2nd and later volumes
 				curPattern.VolMode = v1.PersistentVolumeFilesystem
 			}
-			testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-			resource := createGenericVolumeTestResource(driver, l.config, curPattern, testVolumeSizeRange)
+			testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+			resource := CreateVolumeResource(driver, l.config, curPattern, testVolumeSizeRange)
 			l.resources = append(l.resources, resource)
-			pvcs = append(pvcs, resource.pvc)
+			pvcs = append(pvcs, resource.Pvc)
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
@@ -275,10 +275,10 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 				// 1st volume should be block and set filesystem for 2nd and later volumes
 				curPattern.VolMode = v1.PersistentVolumeFilesystem
 			}
-			testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-			resource := createGenericVolumeTestResource(driver, l.config, curPattern, testVolumeSizeRange)
+			testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+			resource := CreateVolumeResource(driver, l.config, curPattern, testVolumeSizeRange)
 			l.resources = append(l.resources, resource)
-			pvcs = append(pvcs, resource.pvc)
+			pvcs = append(pvcs, resource.Pvc)
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
@@ -301,13 +301,13 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		}
 
 		// Create volume
-		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-		resource := createGenericVolumeTestResource(l.driver, l.config, pattern, testVolumeSizeRange)
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+		resource := CreateVolumeResource(l.driver, l.config, pattern, testVolumeSizeRange)
 		l.resources = append(l.resources, resource)
 
 		// Test access to the volume from pods on different node
 		TestConcurrentAccessToSingleVolume(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, resource.pvc, numPods, true /* sameNode */)
+			e2epod.NodeSelection{Name: l.config.ClientNodeName}, resource.Pvc, numPods, true /* sameNode */)
 	})
 
 	// This tests below configuration:
@@ -336,13 +336,13 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		}
 
 		// Create volume
-		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-		resource := createGenericVolumeTestResource(l.driver, l.config, pattern, testVolumeSizeRange)
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+		resource := CreateVolumeResource(l.driver, l.config, pattern, testVolumeSizeRange)
 		l.resources = append(l.resources, resource)
 
 		// Test access to the volume from pods on different node
 		TestConcurrentAccessToSingleVolume(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, resource.pvc, numPods, false /* sameNode */)
+			e2epod.NodeSelection{Name: l.config.ClientNodeName}, resource.Pvc, numPods, false /* sameNode */)
 	})
 }
 

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -69,26 +69,26 @@ var _ TestSuite = &provisioningTestSuite{}
 func InitProvisioningTestSuite() TestSuite {
 	return &provisioningTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "provisioning",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "provisioning",
+			TestPatterns: []testpatterns.TestPattern{
 				testpatterns.DefaultFsDynamicPV,
 				testpatterns.NtfsDynamicPV,
 			},
-			supportedSizeRange: volume.SizeRange{
+			SupportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
 			},
 		},
 	}
 }
 
-func (p *provisioningTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (p *provisioningTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return p.tsInfo
 }
 
-func (p *provisioningTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (p *provisioningTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 }
 
-func (p *provisioningTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (p *provisioningTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
@@ -111,7 +111,7 @@ func (p *provisioningTestSuite) defineTests(driver TestDriver, pattern testpatte
 	ginkgo.BeforeEach(func() {
 		// Check preconditions.
 		if pattern.VolType != testpatterns.DynamicPV {
-			framework.Skipf("Suite %q does not support %v", p.tsInfo.name, pattern.VolType)
+			framework.Skipf("Suite %q does not support %v", p.tsInfo.Name, pattern.VolType)
 		}
 		ok := false
 		dDriver, ok = driver.(DynamicPVTestDriver)
@@ -133,7 +133,7 @@ func (p *provisioningTestSuite) defineTests(driver TestDriver, pattern testpatte
 		l.config, l.driverCleanup = driver.PrepareTest(f)
 		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
 		l.cs = l.config.Framework.ClientSet
-		testVolumeSizeRange := p.getTestSuiteInfo().supportedSizeRange
+		testVolumeSizeRange := p.GetTestSuiteInfo().SupportedSizeRange
 		driverVolumeSizeRange := dDriver.GetDriverInfo().SupportedSizeRange
 		claimSize, err := getSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
 		framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -56,25 +56,25 @@ var _ TestSuite = &snapshottableTestSuite{}
 func InitSnapshottableTestSuite() TestSuite {
 	return &snapshottableTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "snapshottable",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "snapshottable",
+			TestPatterns: []testpatterns.TestPattern{
 				testpatterns.DynamicSnapshot,
 			},
-			supportedSizeRange: volume.SizeRange{
+			SupportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
 			},
 		},
 	}
 }
 
-func (s *snapshottableTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (s *snapshottableTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return s.tsInfo
 }
 
-func (s *snapshottableTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (s *snapshottableTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 }
 
-func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	var (
 		sDriver SnapshottableTestDriver
 		dDriver DynamicPVTestDriver
@@ -117,7 +117,7 @@ func (s *snapshottableTestSuite) defineTests(driver TestDriver, pattern testpatt
 		if class == nil {
 			framework.Skipf("Driver %q does not define Dynamic Provision StorageClass - skipping", driver.GetDriverInfo().Name)
 		}
-		testVolumeSizeRange := s.getTestSuiteInfo().supportedSizeRange
+		testVolumeSizeRange := s.GetTestSuiteInfo().SupportedSizeRange
 		driverVolumeSizeRange := dDriver.GetDriverInfo().SupportedSizeRange
 		claimSize, err := getSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
 		framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -46,7 +46,7 @@ type topologyTest struct {
 	intreeOps   opCounts
 	migratedOps opCounts
 
-	resource      genericVolumeTestResource
+	resource      VolumeResource
 	pod           *v1.Pod
 	allTopologies []topology
 }
@@ -59,8 +59,8 @@ var _ TestSuite = &topologyTestSuite{}
 func InitTopologyTestSuite() TestSuite {
 	return &topologyTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "topology",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "topology",
+			TestPatterns: []testpatterns.TestPattern{
 				testpatterns.TopologyImmediate,
 				testpatterns.TopologyDelayed,
 			},
@@ -68,14 +68,14 @@ func InitTopologyTestSuite() TestSuite {
 	}
 }
 
-func (t *topologyTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (t *topologyTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *topologyTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *topologyTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 }
 
-func (t *topologyTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *topologyTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	var (
 		dInfo   = driver.GetDriverInfo()
 		dDriver DynamicPVTestDriver
@@ -111,10 +111,9 @@ func (t *topologyTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 		// Now do the more expensive test initialization.
 		l.config, l.driverCleanup = driver.PrepareTest(f)
 
-		l.resource = genericVolumeTestResource{
-			driver:  driver,
-			config:  l.config,
-			pattern: pattern,
+		l.resource = VolumeResource{
+			Config:  l.config,
+			Pattern: pattern,
 		}
 
 		// After driver is installed, check driver topologies on nodes
@@ -135,17 +134,17 @@ func (t *topologyTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 			framework.Skipf("Not enough topologies in cluster -- skipping")
 		}
 
-		l.resource.sc = dDriver.GetDynamicProvisionStorageClass(l.config, pattern.FsType)
-		framework.ExpectNotEqual(l.resource.sc, nil, "driver failed to provide a StorageClass")
-		l.resource.sc.VolumeBindingMode = &pattern.BindingMode
+		l.resource.Sc = dDriver.GetDynamicProvisionStorageClass(l.config, pattern.FsType)
+		framework.ExpectNotEqual(l.resource.Sc, nil, "driver failed to provide a StorageClass")
+		l.resource.Sc.VolumeBindingMode = &pattern.BindingMode
 
-		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
 		driverVolumeSizeRange := dDriver.GetDriverInfo().SupportedSizeRange
 		claimSize, err := getSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
 		framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)
-		l.resource.pvc = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
+		l.resource.Pvc = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 			ClaimSize:        claimSize,
-			StorageClassName: &(l.resource.sc.Name),
+			StorageClassName: &(l.resource.Sc.Name),
 		}, l.config.Framework.Namespace.Name)
 
 		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
@@ -153,7 +152,7 @@ func (t *topologyTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 	}
 
 	cleanup := func(l topologyTest) {
-		t.cleanupResources(cs, &l)
+		t.CleanupResources(cs, &l)
 		err := tryFunc(l.driverCleanup)
 		l.driverCleanup = nil
 		framework.ExpectNoError(err, "while cleaning up driver")
@@ -172,7 +171,7 @@ func (t *topologyTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 		if len(l.allTopologies) > dInfo.NumAllowedTopologies {
 			excludedIndex = rand.Intn(len(l.allTopologies))
 		}
-		allowedTopologies := t.setAllowedTopologies(l.resource.sc, l.allTopologies, excludedIndex)
+		allowedTopologies := t.setAllowedTopologies(l.resource.Sc, l.allTopologies, excludedIndex)
 
 		t.createResources(cs, &l, nil)
 
@@ -201,7 +200,7 @@ func (t *topologyTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 
 		// Exclude one topology
 		excludedIndex := rand.Intn(len(l.allTopologies))
-		t.setAllowedTopologies(l.resource.sc, l.allTopologies, excludedIndex)
+		t.setAllowedTopologies(l.resource.Sc, l.allTopologies, excludedIndex)
 
 		// Set pod nodeSelector to the excluded topology
 		exprs := []v1.NodeSelectorRequirement{}
@@ -322,19 +321,19 @@ func (t *topologyTestSuite) verifyNodeTopology(node *v1.Node, allowedTopos []top
 
 func (t *topologyTestSuite) createResources(cs clientset.Interface, l *topologyTest, affinity *v1.Affinity) {
 	var err error
-	framework.Logf("Creating storage class object and pvc object for driver - sc: %v, pvc: %v", l.resource.sc, l.resource.pvc)
+	framework.Logf("Creating storage class object and pvc object for driver - sc: %v, pvc: %v", l.resource.Sc, l.resource.Pvc)
 
 	ginkgo.By("Creating sc")
-	l.resource.sc, err = cs.StorageV1().StorageClasses().Create(l.resource.sc)
+	l.resource.Sc, err = cs.StorageV1().StorageClasses().Create(l.resource.Sc)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating pvc")
-	l.resource.pvc, err = cs.CoreV1().PersistentVolumeClaims(l.resource.pvc.Namespace).Create(l.resource.pvc)
+	l.resource.Pvc, err = cs.CoreV1().PersistentVolumeClaims(l.resource.Pvc.Namespace).Create(l.resource.Pvc)
 	framework.ExpectNoError(err)
 
 	ginkgo.By("Creating pod")
 	l.pod = e2epod.MakeSecPod(l.config.Framework.Namespace.Name,
-		[]*v1.PersistentVolumeClaim{l.resource.pvc},
+		[]*v1.PersistentVolumeClaim{l.resource.Pvc},
 		nil,
 		false,
 		"",
@@ -347,13 +346,13 @@ func (t *topologyTestSuite) createResources(cs clientset.Interface, l *topologyT
 	framework.ExpectNoError(err)
 }
 
-func (t *topologyTestSuite) cleanupResources(cs clientset.Interface, l *topologyTest) {
+func (t *topologyTestSuite) CleanupResources(cs clientset.Interface, l *topologyTest) {
 	if l.pod != nil {
 		ginkgo.By("Deleting pod")
 		err := e2epod.DeletePodWithWait(cs, l.pod)
 		framework.ExpectNoError(err, "while deleting pod")
 	}
 
-	err := l.resource.cleanupResource()
+	err := l.resource.CleanupResource()
 	framework.ExpectNoError(err, "while clean up resource")
 }

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -63,35 +63,35 @@ var _ TestSuite = &volumeIOTestSuite{}
 func InitVolumeIOTestSuite() TestSuite {
 	return &volumeIOTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "volumeIO",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "volumeIO",
+			TestPatterns: []testpatterns.TestPattern{
 				testpatterns.DefaultFsInlineVolume,
 				testpatterns.DefaultFsPreprovisionedPV,
 				testpatterns.DefaultFsDynamicPV,
 			},
-			supportedSizeRange: volume.SizeRange{
+			SupportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
 			},
 		},
 	}
 }
 
-func (t *volumeIOTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (t *volumeIOTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *volumeIOTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *volumeIOTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 	skipVolTypePatterns(pattern, driver, testpatterns.NewVolTypeMap(
 		testpatterns.PreprovisionedPV,
 		testpatterns.InlineVolume))
 }
 
-func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *volumeIOTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
 
-		resource *genericVolumeTestResource
+		resource *VolumeResource
 
 		intreeOps   opCounts
 		migratedOps opCounts
@@ -116,9 +116,9 @@ func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 		l.config, l.driverCleanup = driver.PrepareTest(f)
 		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
 
-		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-		l.resource = createGenericVolumeTestResource(driver, l.config, pattern, testVolumeSizeRange)
-		if l.resource.volSource == nil {
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+		l.resource = CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
+		if l.resource.VolSource == nil {
 			framework.Skipf("Driver %q does not define volumeSource - skipping", dInfo.Name)
 		}
 
@@ -127,7 +127,7 @@ func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 	cleanup := func() {
 		var errs []error
 		if l.resource != nil {
-			errs = append(errs, l.resource.cleanupResource())
+			errs = append(errs, l.resource.CleanupResource())
 			l.resource = nil
 		}
 
@@ -155,7 +155,7 @@ func (t *volumeIOTestSuite) defineTests(driver TestDriver, pattern testpatterns.
 		podSec := v1.PodSecurityContext{
 			FSGroup: fsGroup,
 		}
-		err := testVolumeIO(f, cs, convertTestConfig(l.config), *l.resource.volSource, &podSec, testFile, fileSizes)
+		err := testVolumeIO(f, cs, convertTestConfig(l.config), *l.resource.VolSource, &podSec, testFile, fileSizes)
 		framework.ExpectNoError(err)
 	})
 }

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -57,36 +57,36 @@ var _ TestSuite = &volumeModeTestSuite{}
 func InitVolumeModeTestSuite() TestSuite {
 	return &volumeModeTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "volumeMode",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "volumeMode",
+			TestPatterns: []testpatterns.TestPattern{
 				testpatterns.FsVolModePreprovisionedPV,
 				testpatterns.FsVolModeDynamicPV,
 				testpatterns.BlockVolModePreprovisionedPV,
 				testpatterns.BlockVolModeDynamicPV,
 			},
-			supportedSizeRange: volume.SizeRange{
+			SupportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
 			},
 		},
 	}
 }
 
-func (t *volumeModeTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (t *volumeModeTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *volumeModeTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *volumeModeTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 }
 
-func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *volumeModeTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
 
 		cs clientset.Interface
 		ns *v1.Namespace
-		// genericVolumeTestResource contains pv, pvc, sc, etc., owns cleaning that up
-		genericVolumeTestResource
+		// VolumeResource contains pv, pvc, sc, etc., owns cleaning that up
+		VolumeResource
 
 		intreeOps   opCounts
 		migratedOps opCounts
@@ -114,7 +114,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
 	}
 
-	// manualInit initializes l.genericVolumeTestResource without creating the PV & PVC objects.
+	// manualInit initializes l.VolumeResource without creating the PV & PVC objects.
 	manualInit := func() {
 		init()
 
@@ -127,14 +127,13 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 			volumeNodeAffinity *v1.VolumeNodeAffinity
 		)
 
-		l.genericVolumeTestResource = genericVolumeTestResource{
-			driver:  driver,
-			config:  l.config,
-			pattern: pattern,
+		l.VolumeResource = VolumeResource{
+			Config:  l.config,
+			Pattern: pattern,
 		}
 
 		// Create volume for pre-provisioned volume tests
-		l.volume = CreateVolume(driver, l.config, pattern.VolType)
+		l.Volume = CreateVolume(driver, l.config, pattern.VolType)
 
 		switch pattern.VolType {
 		case testpatterns.PreprovisionedPV:
@@ -144,31 +143,31 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				scName = fmt.Sprintf("%s-%s-sc-for-file", l.ns.Name, dInfo.Name)
 			}
 			if pDriver, ok := driver.(PreprovisionedPVTestDriver); ok {
-				pvSource, volumeNodeAffinity = pDriver.GetPersistentVolumeSource(false, fsType, l.volume)
+				pvSource, volumeNodeAffinity = pDriver.GetPersistentVolumeSource(false, fsType, l.Volume)
 				if pvSource == nil {
 					framework.Skipf("Driver %q does not define PersistentVolumeSource - skipping", dInfo.Name)
 				}
 
 				storageClass, pvConfig, pvcConfig := generateConfigsForPreprovisionedPVTest(scName, volBindMode, pattern.VolMode, *pvSource, volumeNodeAffinity)
-				l.sc = storageClass
-				l.pv = e2epv.MakePersistentVolume(pvConfig)
-				l.pvc = e2epv.MakePersistentVolumeClaim(pvcConfig, l.ns.Name)
+				l.Sc = storageClass
+				l.Pv = e2epv.MakePersistentVolume(pvConfig)
+				l.Pvc = e2epv.MakePersistentVolumeClaim(pvcConfig, l.ns.Name)
 			}
 		case testpatterns.DynamicPV:
 			if dDriver, ok := driver.(DynamicPVTestDriver); ok {
-				l.sc = dDriver.GetDynamicProvisionStorageClass(l.config, fsType)
-				if l.sc == nil {
+				l.Sc = dDriver.GetDynamicProvisionStorageClass(l.config, fsType)
+				if l.Sc == nil {
 					framework.Skipf("Driver %q does not define Dynamic Provision StorageClass - skipping", dInfo.Name)
 				}
-				l.sc.VolumeBindingMode = &volBindMode
-				testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
+				l.Sc.VolumeBindingMode = &volBindMode
+				testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
 				driverVolumeSizeRange := dInfo.SupportedSizeRange
 				claimSize, err := getSizeRangesIntersection(testVolumeSizeRange, driverVolumeSizeRange)
 				framework.ExpectNoError(err, "determine intersection of test size range %+v and driver size range %+v", testVolumeSizeRange, driverVolumeSizeRange)
 
-				l.pvc = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
+				l.Pvc = e2epv.MakePersistentVolumeClaim(e2epv.PersistentVolumeClaimConfig{
 					ClaimSize:        claimSize,
-					StorageClassName: &(l.sc.Name),
+					StorageClassName: &(l.Sc.Name),
 					VolumeMode:       &pattern.VolMode,
 				}, l.ns.Name)
 			}
@@ -179,7 +178,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 
 	cleanup := func() {
 		var errs []error
-		errs = append(errs, l.cleanupResource())
+		errs = append(errs, l.CleanupResource())
 		errs = append(errs, tryFunc(l.driverCleanup))
 		l.driverCleanup = nil
 		framework.ExpectNoError(errors.NewAggregate(errs), "while cleaning up resource")
@@ -198,22 +197,22 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				var err error
 
 				ginkgo.By("Creating sc")
-				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
+				l.Sc, err = l.cs.StorageV1().StorageClasses().Create(l.Sc)
 				framework.ExpectNoError(err, "Failed to create sc")
 
 				ginkgo.By("Creating pv and pvc")
-				l.pv, err = l.cs.CoreV1().PersistentVolumes().Create(l.pv)
+				l.Pv, err = l.cs.CoreV1().PersistentVolumes().Create(l.Pv)
 				framework.ExpectNoError(err, "Failed to create pv")
 
 				// Prebind pv
-				l.pvc.Spec.VolumeName = l.pv.Name
-				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
+				l.Pvc.Spec.VolumeName = l.Pv.Name
+				l.Pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.Pvc)
 				framework.ExpectNoError(err, "Failed to create pvc")
 
-				framework.ExpectNoError(e2epv.WaitOnPVandPVC(l.cs, l.ns.Name, l.pv, l.pvc), "Failed to bind pv and pvc")
+				framework.ExpectNoError(e2epv.WaitOnPVandPVC(l.cs, l.ns.Name, l.Pv, l.Pvc), "Failed to bind pv and pvc")
 
 				ginkgo.By("Creating pod")
-				pod := e2epod.MakeSecPod(l.ns.Name, []*v1.PersistentVolumeClaim{l.pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil)
+				pod := e2epod.MakeSecPod(l.ns.Name, []*v1.PersistentVolumeClaim{l.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil)
 				// Setting node
 				pod.Spec.NodeName = l.config.ClientNodeName
 				pod, err = l.cs.CoreV1().Pods(l.ns.Name).Create(pod)
@@ -252,16 +251,16 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				var err error
 
 				ginkgo.By("Creating sc")
-				l.sc, err = l.cs.StorageV1().StorageClasses().Create(l.sc)
+				l.Sc, err = l.cs.StorageV1().StorageClasses().Create(l.Sc)
 				framework.ExpectNoError(err, "Failed to create sc")
 
 				ginkgo.By("Creating pv and pvc")
-				l.pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.pvc)
+				l.Pvc, err = l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Create(l.Pvc)
 				framework.ExpectNoError(err, "Failed to create pvc")
 
 				eventSelector := fields.Set{
 					"involvedObject.kind":      "PersistentVolumeClaim",
-					"involvedObject.name":      l.pvc.Name,
+					"involvedObject.name":      l.Pvc.Name,
 					"involvedObject.namespace": l.ns.Name,
 					"reason":                   volevents.ProvisioningFailed,
 				}.AsSelector().String()
@@ -274,7 +273,7 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 				}
 
 				// Check the pvc is still pending
-				pvc, err := l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Get(l.pvc.Name, metav1.GetOptions{})
+				pvc, err := l.cs.CoreV1().PersistentVolumeClaims(l.ns.Name).Get(l.Pvc.Name, metav1.GetOptions{})
 				framework.ExpectNoError(err, "Failed to re-read the pvc after event (or timeout)")
 				framework.ExpectEqual(pvc.Status.Phase, v1.ClaimPending, "PVC phase isn't pending")
 			})
@@ -286,13 +285,13 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 	ginkgo.It("should fail to use a volume in a pod with mismatched mode [Slow]", func() {
 		skipTestIfBlockNotSupported(driver)
 		init()
-		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-		l.genericVolumeTestResource = *createGenericVolumeTestResource(driver, l.config, pattern, testVolumeSizeRange)
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+		l.VolumeResource = *CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
 		defer cleanup()
 
 		ginkgo.By("Creating pod")
 		var err error
-		pod := e2epod.MakeSecPod(l.ns.Name, []*v1.PersistentVolumeClaim{l.pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil)
+		pod := e2epod.MakeSecPod(l.ns.Name, []*v1.PersistentVolumeClaim{l.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil)
 		// Change volumeMounts to volumeDevices and the other way around
 		pod = swapVolumeMode(pod)
 
@@ -335,13 +334,13 @@ func (t *volumeModeTestSuite) defineTests(driver TestDriver, pattern testpattern
 			skipTestIfBlockNotSupported(driver)
 		}
 		init()
-		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-		l.genericVolumeTestResource = *createGenericVolumeTestResource(driver, l.config, pattern, testVolumeSizeRange)
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+		l.VolumeResource = *CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
 		defer cleanup()
 
 		ginkgo.By("Creating pod")
 		var err error
-		pod := e2epod.MakeSecPod(l.ns.Name, []*v1.PersistentVolumeClaim{l.pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil)
+		pod := e2epod.MakeSecPod(l.ns.Name, []*v1.PersistentVolumeClaim{l.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil)
 		for i := range pod.Spec.Containers {
 			pod.Spec.Containers[i].VolumeDevices = nil
 			pod.Spec.Containers[i].VolumeMounts = nil

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -46,8 +46,8 @@ var _ TestSuite = &volumesTestSuite{}
 func InitVolumesTestSuite() TestSuite {
 	return &volumesTestSuite{
 		tsInfo: TestSuiteInfo{
-			name: "volumes",
-			testPatterns: []testpatterns.TestPattern{
+			Name: "volumes",
+			TestPatterns: []testpatterns.TestPattern{
 				// Default fsType
 				testpatterns.DefaultFsInlineVolume,
 				testpatterns.DefaultFsPreprovisionedPV,
@@ -72,18 +72,18 @@ func InitVolumesTestSuite() TestSuite {
 				testpatterns.BlockVolModePreprovisionedPV,
 				testpatterns.BlockVolModeDynamicPV,
 			},
-			supportedSizeRange: volume.SizeRange{
+			SupportedSizeRange: volume.SizeRange{
 				Min: "1Mi",
 			},
 		},
 	}
 }
 
-func (t *volumesTestSuite) getTestSuiteInfo() TestSuiteInfo {
+func (t *volumesTestSuite) GetTestSuiteInfo() TestSuiteInfo {
 	return t.tsInfo
 }
 
-func (t *volumesTestSuite) skipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *volumesTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
 }
 
 func skipExecTest(driver TestDriver) {
@@ -100,12 +100,12 @@ func skipTestIfBlockNotSupported(driver TestDriver) {
 	}
 }
 
-func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+func (t *volumesTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
 	type local struct {
 		config        *PerTestConfig
 		driverCleanup func()
 
-		resource *genericVolumeTestResource
+		resource *VolumeResource
 
 		intreeOps   opCounts
 		migratedOps opCounts
@@ -127,9 +127,9 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 		// Now do the more expensive test initialization.
 		l.config, l.driverCleanup = driver.PrepareTest(f)
 		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
-		testVolumeSizeRange := t.getTestSuiteInfo().supportedSizeRange
-		l.resource = createGenericVolumeTestResource(driver, l.config, pattern, testVolumeSizeRange)
-		if l.resource.volSource == nil {
+		testVolumeSizeRange := t.GetTestSuiteInfo().SupportedSizeRange
+		l.resource = CreateVolumeResource(driver, l.config, pattern, testVolumeSizeRange)
+		if l.resource.VolSource == nil {
 			framework.Skipf("Driver %q does not define volumeSource - skipping", dInfo.Name)
 		}
 	}
@@ -137,7 +137,7 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 	cleanup := func() {
 		var errs []error
 		if l.resource != nil {
-			errs = append(errs, l.resource.cleanupResource())
+			errs = append(errs, l.resource.CleanupResource())
 			l.resource = nil
 		}
 
@@ -160,7 +160,7 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 
 		tests := []volume.Test{
 			{
-				Volume: *l.resource.volSource,
+				Volume: *l.resource.VolSource,
 				Mode:   pattern.VolMode,
 				File:   "index.html",
 				// Must match content
@@ -193,7 +193,7 @@ func (t *volumesTestSuite) defineTests(driver TestDriver, pattern testpatterns.T
 			init()
 			defer cleanup()
 
-			testScriptInPod(f, l.resource.volType, l.resource.volSource, l.config)
+			testScriptInPod(f, l.resource.VolType, l.resource.VolSource, l.config)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Implementing a test suite was impossible outside of the
k8s.io/kubernetes/test/e2e/storage/testsuites package because all
interfaces and structs used by them were private.

**Special notes for your reviewer**:

As part of revamping the API, genericVolumeTestResource also gets
exported because it is useful for other test suites. Because the
TestResource interface became obsolete a while ago and isn't used
anymore, the new name is just testsuites.VolumeResource.

testpatterns.CSIInlineVolume needs special handling in a few places.
It can now be used in a test pattern for a test suite that uses a
VolumeResource instance.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
