### PR TITLE
Automated cherry pick of #85524: Initialize FeatureGate map for KubeProxy config. #1929

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/defaults.go
+++ b/cmd/kubeadm/app/componentconfigs/defaults.go
@@ -65,6 +65,12 @@ func DefaultKubeProxyConfiguration(internalcfg *kubeadmapi.ClusterConfiguration)
 	if internalcfg.ComponentConfigs.KubeProxy != nil {
 		Scheme.Convert(internalcfg.ComponentConfigs.KubeProxy, externalproxycfg, nil)
 	}
+	// The below code is necessary because while KubeProxy may be defined, the user may not
+	// have defined any feature-gates, thus FeatureGates will be nil and the later insertion
+	// of any feature-gates (e.g. IPv6DualStack) will cause a panic.
+	if internalcfg.ComponentConfigs.KubeProxy.FeatureGates == nil {
+		internalcfg.ComponentConfigs.KubeProxy.FeatureGates = map[string]bool{}
+	}
 
 	if externalproxycfg.ClusterCIDR == "" && internalcfg.Networking.PodSubnet != "" {
 		externalproxycfg.ClusterCIDR = internalcfg.Networking.PodSubnet


### PR DESCRIPTION
Cherry pick of #85524 on release-1.16.

#85524: Initialize FeatureGate map for KubeProxy config. #1929

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.