### PR TITLE
Fix GKE upgrade test.

### DIFF
--- a/test/e2e/framework/nodes_util.go
+++ b/test/e2e/framework/nodes_util.go
@@ -271,7 +271,7 @@ func nodePoolsGKE() ([]string, error) {
 		locationParamGKE(),
 		"list",
 		fmt.Sprintf("--cluster=%s", TestContext.CloudConfig.Cluster),
-		`--format="get(name)"`,
+		"--format=get(name)",
 	}
 	stdout, _, err := RunCmd("gcloud", appendContainerCommandGroupIfNeeded(args)...)
 	if err != nil {


### PR DESCRIPTION
Fix GKE upgrade test failure introduced by https://github.com/kubernetes/kubernetes/pull/84174.

We get the following error:
```
ERROR: (gcloud.container.node-pools.list) Name expected [
     table(
        name,
        config.machineType,
        config.diskSizeGb,
        version:label=NODE_VERSION
     )
 *HERE* "get(name)"].
```

The reason is that the format is passed in with "quotes", and gcloud doesn't understand it.

We should cherry-pick this into 1.17 to fix the upgrade test.

Signed-off-by: Lantao Liu <lantaol@google.com>

```release-note
none
```