### PR TITLE
Cleanup conversions in kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/BUILD
@@ -97,7 +97,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",
-        "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/podutils:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollout_status.go
@@ -23,7 +23,6 @@ import (
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kubectl/pkg/scheme"
 	deploymentutil "k8s.io/kubectl/pkg/util/deployment"
 )
 
@@ -59,7 +58,7 @@ type StatefulSetStatusViewer struct{}
 // Status returns a message describing deployment status, and a bool value indicating if the status is considered done.
 func (s *DeploymentStatusViewer) Status(obj runtime.Unstructured, revision int64) (string, bool, error) {
 	deployment := &appsv1.Deployment{}
-	err := scheme.Scheme.Convert(obj, deployment, nil)
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), deployment)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to convert %T to %T: %v", obj, deployment, err)
 	}
@@ -97,7 +96,7 @@ func (s *DaemonSetStatusViewer) Status(obj runtime.Unstructured, revision int64)
 	//ignoring revision as DaemonSets does not have history yet
 
 	daemon := &appsv1.DaemonSet{}
-	err := scheme.Scheme.Convert(obj, daemon, nil)
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), daemon)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to convert %T to %T: %v", obj, daemon, err)
 	}
@@ -120,7 +119,7 @@ func (s *DaemonSetStatusViewer) Status(obj runtime.Unstructured, revision int64)
 // Status returns a message describing statefulset status, and a bool value indicating if the status is considered done.
 func (s *StatefulSetStatusViewer) Status(obj runtime.Unstructured, revision int64) (string, bool, error) {
 	sts := &appsv1.StatefulSet{}
-	err := scheme.Scheme.Convert(obj, sts, nil)
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.UnstructuredContent(), sts)
 	if err != nil {
 		return "", false, fmt.Errorf("failed to convert %T to %T: %v", obj, sts, err)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollout_status_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollout_status_test.go
@@ -24,7 +24,7 @@ import (
 	api "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestDeploymentStatusViewerStatus(t *testing.T) {
@@ -128,7 +128,8 @@ func TestDeploymentStatusViewerStatus(t *testing.T) {
 				Status: test.status,
 			}
 			unstructuredD := &unstructured.Unstructured{}
-			err := scheme.Scheme.Convert(d, unstructuredD, nil)
+			var err error
+			unstructuredD.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(d)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -233,7 +234,8 @@ func TestDaemonSetStatusViewerStatus(t *testing.T) {
 			}
 
 			unstructuredD := &unstructured.Unstructured{}
-			err := scheme.Scheme.Convert(d, unstructuredD, nil)
+			var err error
+			unstructuredD.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(d)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -384,7 +386,8 @@ func TestStatefulSetStatusViewerStatus(t *testing.T) {
 			s.Generation = test.generation
 
 			unstructuredS := &unstructured.Unstructured{}
-			err := scheme.Scheme.Convert(s, unstructuredS, nil)
+			var err error
+			unstructuredS.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(s)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -422,7 +425,8 @@ func TestDaemonSetStatusViewerStatusWithWrongUpdateStrategyType(t *testing.T) {
 	}
 
 	unstructuredD := &unstructured.Unstructured{}
-	err := scheme.Scheme.Convert(d, unstructuredD, nil)
+	var err error
+	unstructuredD.Object, err = runtime.DefaultUnstructuredConverter.ToUnstructured(d)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Ref https://github.com/kubernetes/kubernetes/issues/84452

ToUnstructured/FromUnstructured doesn't assume that a bunch of predefined conversions are registered.

```release-note
NONE
```