### PR TITLE
Output port as number in error message

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/proxy/proxy.go
@@ -35,7 +35,7 @@ func findServicePort(svc *v1.Service, port int32) (*v1.ServicePort, error) {
 			return &svcPort, nil
 		}
 	}
-	return nil, errors.NewServiceUnavailable(fmt.Sprintf("no service port %q found for service %q", port, svc.Name))
+	return nil, errors.NewServiceUnavailable(fmt.Sprintf("no service port %d found for service %q", port, svc.Name))
 }
 
 // ResourceLocation returns a URL to which one can send traffic for the specified service.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As reported in #85554, the port number was wrongly output as string.

**Which issue(s) this PR fixes**:
Fixes #85554

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
