### PR TITLE
kubectl/drain: add disable-eviction option

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain.go
@@ -192,6 +192,7 @@ func NewCmdDrain(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmd.Flags().DurationVar(&o.drainer.Timeout, "timeout", o.drainer.Timeout, "The length of time to wait before giving up, zero means infinite")
 	cmd.Flags().StringVarP(&o.drainer.Selector, "selector", "l", o.drainer.Selector, "Selector (label query) to filter on")
 	cmd.Flags().StringVarP(&o.drainer.PodSelector, "pod-selector", "", o.drainer.PodSelector, "Label selector to filter pods on the node")
+	cmd.Flags().BoolVar(&o.drainer.DisableEviction, "disable-eviction", o.drainer.DisableEviction, "Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, use with caution.")
 
 	cmdutil.AddDryRunFlag(cmd)
 	return cmd

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -51,8 +51,12 @@ type Helper struct {
 	DeleteLocalData     bool
 	Selector            string
 	PodSelector         string
-	Out                 io.Writer
-	ErrOut              io.Writer
+
+	// DisableEviction forces drain to use delete rather than evict
+	DisableEviction bool
+
+	Out    io.Writer
+	ErrOut io.Writer
 
 	// TODO(justinsb): unnecessary?
 	DryRun bool
@@ -178,17 +182,20 @@ func (d *Helper) DeleteOrEvictPods(pods []corev1.Pod) error {
 		return nil
 	}
 
-	policyGroupVersion, err := CheckEvictionSupport(d.Client)
-	if err != nil {
-		return err
-	}
-
 	// TODO(justinsb): unnecessary?
 	getPodFn := func(namespace, name string) (*corev1.Pod, error) {
 		return d.Client.CoreV1().Pods(namespace).Get(name, metav1.GetOptions{})
 	}
-	if len(policyGroupVersion) > 0 {
-		return d.evictPods(pods, policyGroupVersion, getPodFn)
+
+	if !d.DisableEviction {
+		policyGroupVersion, err := CheckEvictionSupport(d.Client)
+		if err != nil {
+			return err
+		}
+
+		if len(policyGroupVersion) > 0 {
+			return d.evictPods(pods, policyGroupVersion, getPodFn)
+		}
 	}
 
 	return d.deletePods(pods, getPodFn)

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain_test.go
@@ -220,90 +220,114 @@ func TestCheckEvictionSupport(t *testing.T) {
 }
 
 func TestDeleteOrEvict(t *testing.T) {
-	for _, evictionSupported := range []bool{true, false} {
-		evictionSupported := evictionSupported
-		t.Run(fmt.Sprintf("evictionSupported=%v", evictionSupported),
-			func(t *testing.T) {
-				h := &Helper{
-					Out:                os.Stdout,
-					GracePeriodSeconds: 10,
-				}
+	tests := []struct {
+		description       string
+		evictionSupported bool
+		disableEviction   bool
+	}{
+		{
+			description:       "eviction supported/enabled",
+			evictionSupported: true,
+			disableEviction:   false,
+		},
+		{
+			description:       "eviction unsupported/disabled",
+			evictionSupported: false,
+			disableEviction:   false,
+		},
+		{
+			description:       "eviction supported/disabled",
+			evictionSupported: true,
+			disableEviction:   true,
+		},
+		{
+			description:       "eviction unsupported/disabled",
+			evictionSupported: false,
+			disableEviction:   false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.description, func(t *testing.T) {
+			h := &Helper{
+				Out:                os.Stdout,
+				GracePeriodSeconds: 10,
+			}
 
-				// Create 4 pods, and try to remove the first 2
-				var expectedEvictions []policyv1beta1.Eviction
-				var create []runtime.Object
-				deletePods := []corev1.Pod{}
-				for i := 1; i <= 4; i++ {
-					pod := &corev1.Pod{}
-					pod.Name = fmt.Sprintf("mypod-%d", i)
-					pod.Namespace = "default"
+			// Create 4 pods, and try to remove the first 2
+			var expectedEvictions []policyv1beta1.Eviction
+			var create []runtime.Object
+			deletePods := []corev1.Pod{}
+			for i := 1; i <= 4; i++ {
+				pod := &corev1.Pod{}
+				pod.Name = fmt.Sprintf("mypod-%d", i)
+				pod.Namespace = "default"
 
-					create = append(create, pod)
-					if i <= 2 {
-						deletePods = append(deletePods, *pod)
+				create = append(create, pod)
+				if i <= 2 {
+					deletePods = append(deletePods, *pod)
 
-						if evictionSupported {
-							eviction := policyv1beta1.Eviction{}
-							eviction.Kind = "Eviction"
-							eviction.APIVersion = "policy/v1"
-							eviction.Namespace = pod.Namespace
-							eviction.Name = pod.Name
+					if tc.evictionSupported && !tc.disableEviction {
+						eviction := policyv1beta1.Eviction{}
+						eviction.Kind = "Eviction"
+						eviction.APIVersion = "policy/v1"
+						eviction.Namespace = pod.Namespace
+						eviction.Name = pod.Name
 
-							gracePeriodSeconds := int64(h.GracePeriodSeconds)
-							eviction.DeleteOptions = &metav1.DeleteOptions{
-								GracePeriodSeconds: &gracePeriodSeconds,
-							}
-
-							expectedEvictions = append(expectedEvictions, eviction)
+						gracePeriodSeconds := int64(h.GracePeriodSeconds)
+						eviction.DeleteOptions = &metav1.DeleteOptions{
+							GracePeriodSeconds: &gracePeriodSeconds,
 						}
+
+						expectedEvictions = append(expectedEvictions, eviction)
 					}
 				}
+			}
 
-				// Build the fake client
-				k := fake.NewSimpleClientset(create...)
-				if evictionSupported {
-					addEvictionSupport(t, k)
-				}
-				h.Client = k
+			// Build the fake client
+			k := fake.NewSimpleClientset(create...)
+			if tc.evictionSupported {
+				addEvictionSupport(t, k)
+			}
+			h.Client = k
+			h.DisableEviction = tc.disableEviction
+			// Do the eviction
+			if err := h.DeleteOrEvictPods(deletePods); err != nil {
+				t.Fatalf("error from DeleteOrEvictPods: %v", err)
+			}
 
-				// Do the eviction
-				if err := h.DeleteOrEvictPods(deletePods); err != nil {
-					t.Fatalf("error from DeleteOrEvictPods: %v", err)
-				}
-
-				// Test that other pods are still there
-				var remainingPods []string
-				{
-					podList, err := k.CoreV1().Pods("").List(metav1.ListOptions{})
-					if err != nil {
-						t.Fatalf("error listing pods: %v", err)
-					}
-
-					for _, pod := range podList.Items {
-						remainingPods = append(remainingPods, pod.Namespace+"/"+pod.Name)
-					}
-					sort.Strings(remainingPods)
-				}
-				expected := []string{"default/mypod-3", "default/mypod-4"}
-				if !reflect.DeepEqual(remainingPods, expected) {
-					t.Errorf("unexpected remaining pods after DeleteOrEvictPods; actual %v; expected %v", remainingPods, expected)
+			// Test that other pods are still there
+			var remainingPods []string
+			{
+				podList, err := k.CoreV1().Pods("").List(metav1.ListOptions{})
+				if err != nil {
+					t.Fatalf("error listing pods: %v", err)
 				}
 
-				// Test that pods were evicted as expected
-				var actualEvictions []policyv1beta1.Eviction
-				for _, action := range k.Actions() {
-					if action.GetVerb() != "create" || action.GetResource().Resource != "pods" || action.GetSubresource() != "eviction" {
-						continue
-					}
-					eviction := *action.(ktest.CreateAction).GetObject().(*policyv1beta1.Eviction)
-					actualEvictions = append(actualEvictions, eviction)
+				for _, pod := range podList.Items {
+					remainingPods = append(remainingPods, pod.Namespace+"/"+pod.Name)
 				}
-				sort.Slice(actualEvictions, func(i, j int) bool {
-					return actualEvictions[i].Name < actualEvictions[j].Name
-				})
-				if !reflect.DeepEqual(actualEvictions, expectedEvictions) {
-					t.Errorf("unexpected evictions; actual %v; expected %v", actualEvictions, expectedEvictions)
+				sort.Strings(remainingPods)
+			}
+			expected := []string{"default/mypod-3", "default/mypod-4"}
+			if !reflect.DeepEqual(remainingPods, expected) {
+				t.Errorf("%s: unexpected remaining pods after DeleteOrEvictPods; actual %v; expected %v", tc.description, remainingPods, expected)
+			}
+
+			// Test that pods were evicted as expected
+			var actualEvictions []policyv1beta1.Eviction
+			for _, action := range k.Actions() {
+				if action.GetVerb() != "create" || action.GetResource().Resource != "pods" || action.GetSubresource() != "eviction" {
+					continue
 				}
+				eviction := *action.(ktest.CreateAction).GetObject().(*policyv1beta1.Eviction)
+				actualEvictions = append(actualEvictions, eviction)
+			}
+			sort.Slice(actualEvictions, func(i, j int) bool {
+				return actualEvictions[i].Name < actualEvictions[j].Name
 			})
+			if !reflect.DeepEqual(actualEvictions, expectedEvictions) {
+				t.Errorf("%s: unexpected evictions; actual %v; expected %v", tc.description, actualEvictions, expectedEvictions)
+			}
+		})
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
Currently, if eviction is supported during a drain operation,
eviction is always used.

This commit allows the user to specify disabling eviction.
This is particularly useful when you wish to ignore
PodDisruptionBudgets after a normal drain has failed for
some time.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/83307

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubectl/drain: add disable-eviction option.
Force drain to use delete, even if eviction is supported. This will bypass checking PodDisruptionBudgets, and should be used with caution.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
