### PR TITLE
Automated cherry pick of #85500: Set node cidr mask size ipv4/ipv6 config

### DIFF
--- a/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
+++ b/cmd/kube-controller-manager/app/options/nodeipamcontroller.go
@@ -57,6 +57,8 @@ func (o *NodeIPAMControllerOptions) ApplyTo(cfg *nodeipamconfig.NodeIPAMControll
 	}
 
 	cfg.NodeCIDRMaskSize = o.NodeCIDRMaskSize
+	cfg.NodeCIDRMaskSizeIPv4 = o.NodeCIDRMaskSizeIPv4
+	cfg.NodeCIDRMaskSizeIPv6 = o.NodeCIDRMaskSizeIPv6
 
 	return nil
 }


### PR DESCRIPTION
Cherry pick of #85500 on release-1.17.

#85500: Set node cidr mask size ipv4/ipv6 config

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
fix setting node cidr mask size for ipv4/ipv6 config
```