### PR TITLE
Return early in Store#deleteWithoutFinalizers if Delete call encounters not found error

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -432,11 +432,8 @@ func (e *Store) deleteWithoutFinalizers(ctx context.Context, name, key string, o
 		// requests to remove all finalizers from the object, so we
 		// ignore the NotFound error.
 		if storage.IsNotFound(err) {
-			_, err := e.finalizeDelete(ctx, obj, true)
-			// clients are expecting an updated object if a PUT succeeded,
-			// but finalizeDelete returns a metav1.Status, so return
-			// the object in the request instead.
-			return obj, false, err
+			// return the object in the request instead.
+			return obj, false, nil
 		}
 		return nil, false, storeerr.InterpretDeleteError(err, e.qualifiedResourceFromContext(ctx), name)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When the Delete call in Store#deleteWithoutFinalizers encounters not found error, the finalizeDelete shouldn't be called since the object is gone.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
