### PR TITLE
Bugfix: assumed pods would not removed immediately when pods have been deleted

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -197,6 +197,9 @@ func (sched *Scheduler) deletePodFromSchedulingQueue(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("unable to handle object in %T: %T", sched, obj))
 		return
 	}
+	if err := sched.SchedulerCache.RemoveAssumedPod(pod); err != nil {
+		utilruntime.HandleError(fmt.Errorf("unable to remove assumed pod from cache %T: %v", obj, err))
+	}
 	if err := sched.SchedulingQueue.Delete(pod); err != nil {
 		utilruntime.HandleError(fmt.Errorf("unable to dequeue %T: %v", obj, err))
 	}

--- a/pkg/scheduler/internal/cache/fake/fake_cache.go
+++ b/pkg/scheduler/internal/cache/fake/fake_cache.go
@@ -56,6 +56,9 @@ func (c *Cache) UpdatePod(oldPod, newPod *v1.Pod) error { return nil }
 // RemovePod is a fake method for testing.
 func (c *Cache) RemovePod(pod *v1.Pod) error { return nil }
 
+// RemoveAssumedPod is a fake method for testing.
+func (c *Cache) RemoveAssumedPod(pod *v1.Pod) error { return nil }
+
 // IsAssumedPod is a fake method for testing.
 func (c *Cache) IsAssumedPod(pod *v1.Pod) (bool, error) {
 	return c.IsAssumedPodFunc(pod), nil

--- a/pkg/scheduler/internal/cache/interface.go
+++ b/pkg/scheduler/internal/cache/interface.go
@@ -81,6 +81,9 @@ type Cache interface {
 	// RemovePod removes a pod. The pod's information would be subtracted from assigned node.
 	RemovePod(pod *v1.Pod) error
 
+	// RemoveAssumedPod removes a pod. The pod's information would be subtracted from assumed node.
+	RemoveAssumedPod(pod *v1.Pod) error
+
 	// GetPod returns the pod from the cache with the same namespace and the
 	// same name of the specified pod.
 	GetPod(pod *v1.Pod) (*v1.Pod, error)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85563 

**Special notes for your reviewer**:
See https://github.com/kubernetes/kubernetes/pull/21016#discussion_r52728635

Assumed pods would not be removed when pods have been deleted immediately.
Normally, it would not influence the scheduling progress.However since Framework  Handler provides GetShapshot() func, users may use snapShot to implement their own scheduler. e.g. we implemented  gang-scheduling which relies on the snapshot.

However, duplicated pods may exist in the snapshot.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Bugfix: assumed pods would not removed immediately when pods have been deleted
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
