### PR TITLE
Revert "remove redundant `source` in shell"

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -24,7 +24,9 @@ TMP_ROOT="$(dirname "${BASH_SOURCE[@]}")/../.."
 KUBE_ROOT=$(readlink -e "${TMP_ROOT}" 2> /dev/null || perl -MCwd -e 'print Cwd::abs_path shift' "${TMP_ROOT}")
 
 source "${KUBE_ROOT}/test/kubemark/skeleton/util.sh"
+source "${KUBE_ROOT}/test/kubemark/cloud-provider-config.sh"
 source "${KUBE_ROOT}/test/kubemark/${CLOUD_PROVIDER}/util.sh"
+source "${KUBE_ROOT}/cluster/kubemark/${CLOUD_PROVIDER}/config-default.sh"
 
 if [[ -f "${KUBE_ROOT}/test/kubemark/${CLOUD_PROVIDER}/startup.sh" ]] ; then
   source "${KUBE_ROOT}/test/kubemark/${CLOUD_PROVIDER}/startup.sh"


### PR DESCRIPTION
This reverts commit 197964210ac3f02757b9a1cfa4898283274076fc.

It breaks all kubemark periodic tests - https://k8s-testgrid.appspot.com/sig-scalability-kubemark
Example failure (https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-kubemark-100-gce/1198635036526514177):
```
W1124 16:20:35.524] ./test/kubemark/start-kubemark.sh: line 27: CLOUD_PROVIDER: unbound variable
```


**What type of PR is this?**

/kind bug

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig scalability
/priority critical-urgent
