### PR TITLE
Return early when resource with matching name and group is found

### DIFF
--- a/cmd/kube-controller-manager/app/controllermanager.go
+++ b/cmd/kube-controller-manager/app/controllermanager.go
@@ -615,9 +615,11 @@ func shouldTurnOnDynamicClient(client clientset.Interface) bool {
 
 	for _, resource := range apiResourceList.APIResources {
 		if resource.Name == "serviceaccounts/token" &&
-			resource.Group == "authentication.k8s.io" &&
-			sets.NewString(resource.Verbs...).Has("create") {
-			return true
+			resource.Group == "authentication.k8s.io" {
+			if sets.NewString(resource.Verbs...).Has("create") {
+				return true
+			}
+			return false
 		}
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In shouldTurnOnDynamicClient, when resource with matching name and group is found, we check whether the verbs contain 'create'. If not, we can return early.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
