### PR TITLE
Ignore the pods of daemonSet when Scheduler selects victims

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -1125,10 +1125,22 @@ func (g *genericScheduler) selectVictimsOnNode(
 		}
 		return nil
 	}
-	// As the first step, remove all the lower priority pods from the node and
+	// As the first step, remove all the lower priority pods(except the pods of daemonSet) from the node and
 	// check if the given pod can be scheduled.
 	podPriority := podutil.GetPodPriority(pod)
 	for _, p := range nodeInfo.Pods() {
+		// ignore the pods of daemonSet.
+		ignore := false
+		for _, ownerReference := range p.OwnerReferences {
+			if "DaemonSet" == ownerReference.Kind {
+				ignore = true
+				break
+			}
+		}
+		if ignore {
+			continue
+		}
+
 		if podutil.GetPodPriority(p) < podPriority {
 			potentialVictims = append(potentialVictims, p)
 			if err := removePod(p); err != nil {


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/kind feature

**What this PR does / why we need it**:
Ignore the pods of daemonSet when Scheduler selects victims

Sometimes users run a daemonSet without priority, kube-scheduler can't evict the pods of the daemonSet.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
