### PR TITLE
fix etcd version check error on ARM

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -46,7 +46,7 @@ kube::etcd::validate() {
   fi
 
   # validate installed version is at least equal to minimum
-  version=$(etcd --version | tail -n +1 | head -n 1 | cut -d " " -f 3)
+  version=$(etcd --version | grep Version | tail -n +1 | head -n 1 | cut -d " " -f 3)
   if [[ $(kube::etcd::version "${ETCD_VERSION}") -gt $(kube::etcd::version "${version}") ]]; then
    export PATH=${KUBE_ROOT}/third_party/etcd:${PATH}
    hash etcd


### PR DESCRIPTION
"etcd -version" command output an additional line on ARM platform:
"running etcd on unsupported architecture "arm64" since
ETCD_UNSUPPORTED_ARCH is set"
Currently etcd version filtering code can not get correct version
number.

Signed-off-by: Howard Zhang <howard.zhang@arm.com>

**What type of PR is this?**
> /kind failing-test


**What this PR does / why we need it**:
Ensure hack/local-up-cluster.sh can run on arm

**Which issue(s) this PR fixes**:
#85600

**Special notes for your reviewer**:
no

**Does this PR introduce a user-facing change?**:
no


**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
no

