### PR TITLE
Revert "Revert "enabling fluentd on kubemark""

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -55,7 +55,7 @@ function create-kubemark-master {
     # Disable all addons. They are running outside of the kubemark cluster.
     export KUBE_ENABLE_CLUSTER_AUTOSCALER=false
     export KUBE_ENABLE_CLUSTER_DNS=false
-    export KUBE_ENABLE_NODE_LOGGING=false
+    export KUBE_ENABLE_NODE_LOGGING=true
     export KUBE_ENABLE_METRICS_SERVER=false
     export KUBE_ENABLE_CLUSTER_MONITORING="none"
     export KUBE_ENABLE_L7_LOADBALANCING="none"


### PR DESCRIPTION
Reverts kubernetes/kubernetes#84858

Re-enabling fluentd on hollow nodes.
Fixes #84855

```release-note
NONE
```
