### PR TITLE
kubeadm: don't check if image exists before pulling

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -833,14 +833,6 @@ func (ImagePullCheck) Name() string {
 // Check pulls images required by kubeadm. This is a mutating check
 func (ipc ImagePullCheck) Check() (warnings, errorList []error) {
 	for _, image := range ipc.imageList {
-		ret, err := ipc.runtime.ImageExists(image)
-		if ret && err == nil {
-			klog.V(1).Infof("image exists: %s", image)
-			continue
-		}
-		if err != nil {
-			errorList = append(errorList, errors.Wrapf(err, "failed to check if image %s exists", image))
-		}
 		klog.V(1).Infof("pulling %s", image)
 		if err := ipc.runtime.PullImage(image); err != nil {
 			errorList = append(errorList, errors.Wrapf(err, "failed to pull image %s", image))

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -753,18 +753,20 @@ func TestSetHasItemOrAll(t *testing.T) {
 func TestImagePullCheck(t *testing.T) {
 	fcmd := fakeexec.FakeCmd{
 		RunScript: []fakeexec.FakeRunAction{
-			// Test case 1: img1 and img2 exist, img3 doesn't exist
+			// Test case 1: pull 3 images successfully
 			func() ([]byte, []byte, error) { return nil, nil, nil },
 			func() ([]byte, []byte, error) { return nil, nil, nil },
-			func() ([]byte, []byte, error) { return nil, nil, &fakeexec.FakeExitError{Status: 1} },
+			func() ([]byte, []byte, error) { return nil, nil, nil },
 
-			// Test case 2: images don't exist
-			func() ([]byte, []byte, error) { return nil, nil, &fakeexec.FakeExitError{Status: 1} },
+			// Test case 2: image pull errors
+			func() ([]byte, []byte, error) { return nil, nil, nil },
 			func() ([]byte, []byte, error) { return nil, nil, &fakeexec.FakeExitError{Status: 1} },
 			func() ([]byte, []byte, error) { return nil, nil, &fakeexec.FakeExitError{Status: 1} },
 		},
 		CombinedOutputScript: []fakeexec.FakeCombinedOutputAction{
-			// Test case1: pull only img3
+			// Test case1: pull 3 images
+			func() ([]byte, error) { return nil, nil },
+			func() ([]byte, error) { return nil, nil },
 			func() ([]byte, error) { return nil, nil },
 			// Test case 2: fail to pull image2 and image3
 			func() ([]byte, error) { return nil, nil },
@@ -775,10 +777,6 @@ func TestImagePullCheck(t *testing.T) {
 
 	fexec := fakeexec.FakeExec{
 		CommandScript: []fakeexec.FakeCommandAction{
-			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
-			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
-			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
-			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
 			func(cmd string, args ...string) exec.Cmd { return fakeexec.InitFakeCmd(&fcmd, cmd, args...) },
@@ -803,7 +801,7 @@ func TestImagePullCheck(t *testing.T) {
 		t.Fatalf("did not expect any warnings but got %q", warnings)
 	}
 	if len(errors) != 0 {
-		t.Fatalf("expected 1 errors but got %d: %q", len(errors), errors)
+		t.Fatalf("expected 0 errors but got %d: %q", len(errors), errors)
 	}
 
 	warnings, errors = check.Check()


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR addresses concern raised in the [opposite PR](https://github.com/kubernetes/kubernetes/pull/85479#issuecomment-556355929):

```
We pull by tag IIRC, so there's a side effect that if 
what the tag points to changes we won't pull it.
```

Removed check for image existence as kubeadm may miss image tags if they're updated.

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: make sure images are pre-pulled even if a tag did not change but their contents changed
```