### PR TITLE
attribute a type to the token authentication failure

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/request/union/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/request/union/union.go
@@ -17,6 +17,7 @@ limitations under the License.
 package union
 
 import (
+	"fmt"
 	"net/http"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -58,7 +59,7 @@ func (authHandler *unionAuthRequestHandler) AuthenticateRequest(req *http.Reques
 			if authHandler.FailOnError {
 				return resp, ok, err
 			}
-			errlist = append(errlist, err)
+			errlist = append(errlist, fmt.Errorf("%T: %v", currAuthRequestHandler, err))
 			continue
 		}
 

--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/union/union.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/union/union.go
@@ -18,6 +18,7 @@ package union
 
 import (
 	"context"
+	"fmt"
 
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
@@ -58,7 +59,7 @@ func (authHandler *unionAuthTokenHandler) AuthenticateToken(ctx context.Context,
 			if authHandler.FailOnError {
 				return info, ok, err
 			}
-			errlist = append(errlist, err)
+			errlist = append(errlist, fmt.Errorf("%T: %v", currAuthRequestHandler, err))
 			continue
 		}
 


### PR DESCRIPTION
When there a multiple token validation failures, it's pretty annoying to figure out which is which, especially when they aren't actually errors.

/kind cleanup
/priority important-long-term
@kubernetes/sig-auth-pr-reviews 

```release-note
NONE
```