### PR TITLE
Bump Cluster Autoscaler version to 1.17.0

### DIFF
--- a/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
+++ b/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
@@ -6,6 +6,14 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   # leader election
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update", "patch", "delete"]
+  # TODO: remove in 1.18; CA uses lease objects for leader election since 1.17
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["create"]

--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.17.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
This PR updates CA version in gce manifests to 1.17.0

As every release cycle we are merging the change just before release. The reason for late update is fact that Cluster Autoscaler vendors k8s code to simulate scheduler behavior. Yet it lives in separate repository. Therefore we need to build final release candidate just at the end of k8s release cycle.

This PR contains also commit from https://github.com/kubernetes/kubernetes/pull/77895 which allows CA to read `lease` objects as we changed leader election to use those in 1.17.

/kind bug
/priority critical-urgent
/sig autoscaling
/assign @mwielgus

```release-note
Update Cluster Autoscaler to 1.17.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.17.0
```
