### PR TITLE
Fix apply --prune to visit cli specified namespace

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -372,6 +372,11 @@ func (o *ApplyOptions) Run() error {
 		}
 	}
 
+	// Enforce CLI specified namespace on server request.
+	if o.EnforceNamespace {
+		o.VisitedNamespaces.Insert(o.Namespace)
+	}
+
 	// Generates the objects using the resource builder if they have not
 	// already been stored by calling "SetObjects()" in the pre-processor.
 	infos, err := o.GetObjects()
@@ -424,7 +429,6 @@ func (o *ApplyOptions) Run() error {
 				}
 				if errors.IsConflict(err) {
 					err = fmt.Errorf(`%v
-
 Please review the fields above--they currently have other managers. Here
 are the ways you can resolve this warning:
 * If you intend to manage all of these fields, please re-run the apply
@@ -435,7 +439,6 @@ are the ways you can resolve this warning:
 * You may co-own fields by updating your manifest to match the existing
   value; in this case, you'll become the manager if the other manager(s)
   stop managing the field (remove it from their configuration).
-
 See http://k8s.io/docs/reference/using-api/api-concepts/#conflicts`, err)
 				}
 				return err


### PR DESCRIPTION
**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
It fixes a bug that causes `kubectl apply --prune -n <namespace>` to fail since it does not check the cli specified namespace.

**Which issue(s) this PR fixes**:
Fixes #85357

**Does this PR introduce a user-facing change?**:
```release-note
`kubectl apply  -f <file> --prune -n <namespace>` should prune all resources not defined in the file in the cli specified namespace.
```

