### PR TITLE
Add --server flag for version command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version.go
@@ -49,6 +49,7 @@ var (
 // Options is a struct to support version command
 type Options struct {
 	ClientOnly bool
+	ServerOnly bool
 	Short      bool
 	Output     string
 
@@ -80,6 +81,7 @@ func NewCmdVersion(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *co
 		},
 	}
 	cmd.Flags().BoolVar(&o.ClientOnly, "client", o.ClientOnly, "Client version only (no server required).")
+	cmd.Flags().BoolVar(&o.ServerOnly, "server", o.ServerOnly, "Server version only.")
 	cmd.Flags().BoolVar(&o.Short, "short", o.Short, "Print just the version number.")
 	cmd.Flags().StringVarP(&o.Output, "output", "o", o.Output, "One of 'yaml' or 'json'.")
 	return cmd
@@ -118,7 +120,9 @@ func (o *Options) Run() error {
 	)
 
 	clientVersion := version.Get()
-	versionInfo.ClientVersion = &clientVersion
+	if !o.ServerOnly {
+		versionInfo.ClientVersion = &clientVersion
+	}
 
 	if !o.ClientOnly && o.discoveryClient != nil {
 		// Always request fresh data from the server
@@ -130,12 +134,16 @@ func (o *Options) Run() error {
 	switch o.Output {
 	case "":
 		if o.Short {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
+			if !o.ServerOnly {
+				fmt.Fprintf(o.Out, "Client Version: %s\n", clientVersion.GitVersion)
+			}
 			if serverVersion != nil {
 				fmt.Fprintf(o.Out, "Server Version: %s\n", serverVersion.GitVersion)
 			}
 		} else {
-			fmt.Fprintf(o.Out, "Client Version: %s\n", fmt.Sprintf("%#v", clientVersion))
+			if !o.ServerOnly {
+				fmt.Fprintf(o.Out, "Client Version: %s\n", fmt.Sprintf("%#v", clientVersion))
+			}
 			if serverVersion != nil {
 				fmt.Fprintf(o.Out, "Server Version: %s\n", fmt.Sprintf("%#v", *serverVersion))
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
/kind feature
> /kind flake

**What this PR does / why we need it**:

It adds the --server flag for the `kubectl version` command
This makes it easier to write/derive the server version for automated processes
This also maintains consistency since there already is a --client flag that returns client version

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85614

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
None
<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
