### PR TITLE
Add RainbowMango to owner list of metrics stability framework.

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/OWNERS
+++ b/staging/src/k8s.io/component-base/metrics/OWNERS
@@ -3,6 +3,7 @@
 approvers:
 - sig-instrumentation-approvers
 - logicalhan
+- RainbowMango
 reviewers:
 - sig-instrumentation-reviewers
 labels:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add RainbowMango to owner list of metrics stability framework.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority backlog
/assign @logicalhan 