### PR TITLE
Automated cherry pick of #85444: Provided a mechanism to re-register hidden metrics.

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -143,6 +143,19 @@ func (r *lazyMetric) Create(version *semver.Version) bool {
 	return r.IsCreated()
 }
 
+// ClearState will clear all the states marked by Create.
+// It intends to be used for re-register a hidden metric.
+func (r *lazyMetric) ClearState() {
+	r.createLock.Lock()
+	defer r.createLock.Unlock()
+
+	r.isDeprecated = false
+	r.isHidden = false
+	r.isCreated = false
+	r.markDeprecationOnce = *(new(sync.Once))
+	r.createOnce = *(new(sync.Once))
+}
+
 /*
 This code is directly lifted from the prometheus codebase. It's a convenience struct which
 allows you satisfy the Collector interface automatically if you already satisfy the Metric interface.


### PR DESCRIPTION
Cherry pick of #85444 on release-1.17.

#85444: Provided a mechanism to re-register hidden metrics.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.