### PR TITLE
fix DOCKER_BUILD_OPTS[@]: unbound variable

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -341,7 +341,7 @@ function kube::release::create_docker_images_for_server() {
     # provide `--pull` argument to `docker build` if `KUBE_BUILD_PULL_LATEST_IMAGES`
     # is set to y or Y; otherwise try to build the image without forcefully
     # pulling the latest base image.
-    local DOCKER_BUILD_OPTS=()
+    local DOCKER_BUILD_OPTS=("")
     if [[ "${KUBE_BUILD_PULL_LATEST_IMAGES}" =~ [yY] ]]; then
         DOCKER_BUILD_OPTS+=("--pull")
     fi


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind bug

**What this PR does / why we need it**:
Fix the `DOCKER_BUILD_OPTS[@]: unbound variable` error.
If we `export KUBE_BUILD_PULL_LATEST_IMAGES=n`，`DOCKER_BUILD_OPTS` will be an empty array and `"${DOCKER_BUILD_OPTS[@]}"` will report an error of `unbound variable`。

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85277

**Special notes for your reviewer**:
The bug depends on the bash version. https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u/7577209#7577209
