### PR TITLE
Track collectors by fqName

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/counter.go
+++ b/staging/src/k8s.io/component-base/metrics/counter.go
@@ -41,7 +41,7 @@ func NewCounter(opts *CounterOpts) *Counter {
 		lazyMetric:  lazyMetric{},
 	}
 	kc.setPrometheusCounter(noop)
-	kc.lazyInit(kc)
+	kc.lazyInit(kc, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return kc
 }
 
@@ -92,7 +92,7 @@ func NewCounterVec(opts *CounterOpts, labels []string) *CounterVec {
 		originalLabels: labels,
 		lazyMetric:     lazyMetric{},
 	}
-	cv.lazyInit(cv)
+	cv.lazyInit(cv, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return cv
 }
 

--- a/staging/src/k8s.io/component-base/metrics/gauge.go
+++ b/staging/src/k8s.io/component-base/metrics/gauge.go
@@ -43,7 +43,7 @@ func NewGauge(opts *GaugeOpts) *Gauge {
 		lazyMetric: lazyMetric{},
 	}
 	kc.setPrometheusGauge(noop)
-	kc.lazyInit(kc)
+	kc.lazyInit(kc, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return kc
 }
 
@@ -94,7 +94,7 @@ func NewGaugeVec(opts *GaugeOpts, labels []string) *GaugeVec {
 		originalLabels: labels,
 		lazyMetric:     lazyMetric{},
 	}
-	cv.lazyInit(cv)
+	cv.lazyInit(cv, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return cv
 }
 

--- a/staging/src/k8s.io/component-base/metrics/histogram.go
+++ b/staging/src/k8s.io/component-base/metrics/histogram.go
@@ -53,7 +53,7 @@ func NewHistogram(opts *HistogramOpts) *Histogram {
 		lazyMetric:    lazyMetric{},
 	}
 	h.setPrometheusHistogram(noopMetric{})
-	h.lazyInit(h)
+	h.lazyInit(h, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return h
 }
 
@@ -104,7 +104,7 @@ func NewHistogramVec(opts *HistogramOpts, labels []string) *HistogramVec {
 		originalLabels: labels,
 		lazyMetric:     lazyMetric{},
 	}
-	v.lazyInit(v)
+	v.lazyInit(v, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return v
 }
 

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -158,6 +158,11 @@ func (r *lazyMetric) ClearState() {
 	r.createOnce = *(new(sync.Once))
 }
 
+// FQName returns the fully-qualified metric name of the collector.
+func (r *lazyMetric) FQName() string {
+	return r.fqName
+}
+
 /*
 This code is directly lifted from the prometheus codebase. It's a convenience struct which
 allows you satisfy the Collector interface automatically if you already satisfy the Metric interface.

--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -63,6 +63,7 @@ implements kubeCollector to get deferred registration behavior. You must call la
 with the kubeCollector itself as an argument.
 */
 type lazyMetric struct {
+	fqName              string
 	isDeprecated        bool
 	isHidden            bool
 	isCreated           bool
@@ -81,7 +82,8 @@ func (r *lazyMetric) IsCreated() bool {
 // lazyInit provides the lazyMetric with a reference to the kubeCollector it is supposed
 // to allow lazy initialization for. It should be invoked in the factory function which creates new
 // kubeCollector type objects.
-func (r *lazyMetric) lazyInit(self kubeCollector) {
+func (r *lazyMetric) lazyInit(self kubeCollector, fqName string) {
+	r.fqName = fqName
 	r.self = self
 }
 
@@ -98,7 +100,7 @@ func (r *lazyMetric) determineDeprecationStatus(version semver.Version) {
 			r.isDeprecated = true
 		}
 		if ShouldShowHidden() {
-			klog.Warningf("Hidden metrics have been manually overridden, showing this very deprecated metric.")
+			klog.Warningf("Hidden metrics (%s) have been manually overridden, showing this very deprecated metric.", r.fqName)
 			return
 		}
 		if shouldHide(&version, selfVersion) {

--- a/staging/src/k8s.io/component-base/metrics/summary.go
+++ b/staging/src/k8s.io/component-base/metrics/summary.go
@@ -44,7 +44,7 @@ func NewSummary(opts *SummaryOpts) *Summary {
 		lazyMetric:  lazyMetric{},
 	}
 	s.setPrometheusSummary(noopMetric{})
-	s.lazyInit(s)
+	s.lazyInit(s, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return s
 }
 
@@ -98,7 +98,7 @@ func NewSummaryVec(opts *SummaryOpts, labels []string) *SummaryVec {
 		originalLabels: labels,
 		lazyMetric:     lazyMetric{},
 	}
-	v.lazyInit(v)
+	v.lazyInit(v, BuildFQName(opts.Namespace, opts.Subsystem, opts.Name))
 	return v
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
1. Pass fqName of a collector when init, which helps make logs more helpful. 

```
W1126 21:59:59.269409   14179 metric.go:103] Hidden metrics (rest_client_request_latency_seconds) have been manually overridden, showing this very deprecated metric.
W1126 21:59:59.269432   14179 metric.go:103] Hidden metrics (apiserver_storage_transformation_latencies_microseconds) have been manually overridden, showing this very deprecated metric.
```
2. Track hidden metrics by pair<fqName, metric>. (We are going to track all registered metrics in the same way, in order to disable individual metrics by command-line flags.)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/milestone v1.18