### PR TITLE
fix kube-apiserver poststarthook additions to avoid duplicating them

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -120,6 +120,9 @@ func createAggregatorConfig(
 		},
 	}
 
+	// we need to clear the poststarthooks so we don't add them multiple times to all the servers (that fails)
+	aggregatorConfig.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+
 	return aggregatorConfig, nil
 }
 

--- a/cmd/kube-apiserver/app/apiextensions.go
+++ b/cmd/kube-apiserver/app/apiextensions.go
@@ -92,6 +92,9 @@ func createAPIExtensionsConfig(
 		},
 	}
 
+	// we need to clear the poststarthooks so we don't add them multiple times to all the servers (that fails)
+	apiextensionsConfig.GenericConfig.PostStartHooks = map[string]genericapiserver.PostStartHookConfigEntry{}
+
 	return apiextensionsConfig, nil
 }
 


### PR DESCRIPTION
I found this trying to wire up some of the dynamic cert controllers to general poststarthooks.  The kube-apiserver reuses the same config in multiple server creations, so we have to only include these in one of them.

/kind bug
/priority important-soon
@kubernetes/sig-api-machinery-bugs 

/assign @sttts 

```release-note
NONE
```