### PR TITLE
Automated cherry pick of #85620: increase pv controller resync period to try to deflake

### DIFF
--- a/test/integration/volumescheduling/BUILD
+++ b/test/integration/volumescheduling/BUILD
@@ -17,7 +17,6 @@ go_test(
     tags = ["integration"],
     deps = [
         "//pkg/controller/volume/persistentvolume:go_default_library",
-        "//pkg/controller/volume/persistentvolume/options:go_default_library",
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/testing:go_default_library",

--- a/test/integration/volumescheduling/volume_binding_test.go
+++ b/test/integration/volumescheduling/volume_binding_test.go
@@ -40,7 +40,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/kubernetes/pkg/controller/volume/persistentvolume"
-	persistentvolumeoptions "k8s.io/kubernetes/pkg/controller/volume/persistentvolume/options"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/volume"
 	volumetest "k8s.io/kubernetes/pkg/volume/testing"
@@ -926,7 +925,7 @@ func setupCluster(t *testing.T, nsName string, numberOfNodes int, resyncPeriod t
 
 func initPVController(context *testContext, provisionDelaySeconds int) (*persistentvolume.PersistentVolumeController, informers.SharedInformerFactory, error) {
 	clientset := context.clientSet
-	// Informers factory for controllers, we disable resync period for testing.
+	// Informers factory for controllers
 	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
 
 	// Start PV controller for volume binding.
@@ -946,10 +945,11 @@ func initPVController(context *testContext, provisionDelaySeconds int) (*persist
 	}
 	plugins := []volume.VolumePlugin{plugin}
 
-	controllerOptions := persistentvolumeoptions.NewPersistentVolumeControllerOptions()
 	params := persistentvolume.ControllerParameters{
-		KubeClient:                clientset,
-		SyncPeriod:                controllerOptions.PVClaimBinderSyncPeriod,
+		KubeClient: clientset,
+		// Use a frequent resync period to retry API update conflicts due to
+		// https://github.com/kubernetes/kubernetes/issues/85320
+		SyncPeriod:                5 * time.Second,
 		VolumePlugins:             plugins,
 		Cloud:                     nil,
 		ClusterName:               "volume-test-cluster",


### PR DESCRIPTION
Cherry pick of #85620 on release-1.17.

#85620: increase pv controller resync period to try to deflake

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```