### PR TITLE
Automated cherry pick of #81880: Bumped the number of times a node tries to lookup itself

### DIFF
--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -112,7 +112,7 @@ func GetNodeHostIP(node *v1.Node) (net.IP, error) {
 func GetNodeIP(client clientset.Interface, hostname string) net.IP {
 	var nodeIP net.IP
 	backoff := wait.Backoff{
-		Steps:    5,
+		Steps:    6,
 		Duration: 1 * time.Second,
 		Factor:   2.0,
 		Jitter:   0.2,


### PR DESCRIPTION
Cherry pick of #81880 on release-1.17.

#81880: Bumped the number of times a node tries to lookup itself

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.