### PR TITLE
use framework in  test/e2e/cloud/

### DIFF
--- a/test/e2e/cloud/BUILD
+++ b/test/e2e/cloud/BUILD
@@ -16,7 +16,6 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
-        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )
 

--- a/test/e2e/cloud/gcp/addon_update.go
+++ b/test/e2e/cloud/gcp/addon_update.go
@@ -35,7 +35,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 // TODO: it would probably be slightly better to build up the objects
@@ -247,7 +246,7 @@ var _ = SIGDescribe("Addon update", func() {
 		framework.SkipUnlessProviderIs("gce")
 
 		//these tests are long, so I squeezed several cases in one scenario
-		gomega.Expect(sshClient).NotTo(gomega.BeNil())
+		framework.ExpectNotEqual(sshClient, nil)
 		dir = f.Namespace.Name // we use it only to give a unique string for each test execution
 
 		temporaryRemotePathPrefix := "addon-test-dir"

--- a/test/e2e/cloud/gcp/kubelet_security.go
+++ b/test/e2e/cloud/gcp/kubelet_security.go
@@ -29,7 +29,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
@@ -75,7 +74,7 @@ var _ = SIGDescribe("Ports Security Check [Feature:KubeletSecurity]", func() {
 // checks whether the target port is closed
 func portClosedTest(f *framework.Framework, pickNode *v1.Node, port int) {
 	nodeAddrs := e2enode.GetAddresses(pickNode, v1.NodeExternalIP)
-	gomega.Expect(len(nodeAddrs)).NotTo(gomega.BeZero())
+	framework.ExpectNotEqual(len(nodeAddrs), 0)
 
 	for _, addr := range nodeAddrs {
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", addr, port), 1*time.Minute)

--- a/test/e2e/cloud/gcp/node_lease.go
+++ b/test/e2e/cloud/gcp/node_lease.go
@@ -43,7 +43,7 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 		c = f.ClientSet
 		ns = f.Namespace.Name
 		systemPods, err := e2epod.GetPodsInNamespace(c, ns, map[string]string{})
-		gomega.Expect(err).To(gomega.BeNil())
+		framework.ExpectEqual(err, nil)
 		systemPodsNo = int32(len(systemPods))
 		if strings.Index(framework.TestContext.CloudConfig.NodeInstanceGroup, ",") >= 0 {
 			framework.Failf("Test dose not support cluster setup with more than one MIG: %s", framework.TestContext.CloudConfig.NodeInstanceGroup)
@@ -94,13 +94,13 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 			// the cluster is restored to health.
 			ginkgo.By("waiting for system pods to successfully restart")
 			err := e2epod.WaitForPodsRunningReady(c, metav1.NamespaceSystem, systemPodsNo, 0, framework.PodReadyBeforeTimeout, map[string]string{})
-			gomega.Expect(err).To(gomega.BeNil())
+			framework.ExpectEqual(err, nil)
 		})
 
 		ginkgo.It("node lease should be deleted when corresponding node is deleted", func() {
 			leaseClient := c.CoordinationV1().Leases(v1.NamespaceNodeLease)
 			err := e2enode.WaitForReadyNodes(c, framework.TestContext.CloudConfig.NumNodes, 10*time.Minute)
-			gomega.Expect(err).To(gomega.BeNil())
+			framework.ExpectEqual(err, nil)
 
 			ginkgo.By("verify node lease exists for every nodes")
 			originalNodes, err := e2enode.GetReadySchedulableNodes(c)
@@ -124,11 +124,11 @@ var _ = SIGDescribe("[Disruptive]NodeLease", func() {
 			targetNumNodes := int32(framework.TestContext.CloudConfig.NumNodes - 1)
 			ginkgo.By(fmt.Sprintf("decreasing cluster size to %d", targetNumNodes))
 			err = framework.ResizeGroup(group, targetNumNodes)
-			gomega.Expect(err).To(gomega.BeNil())
+			framework.ExpectEqual(err, nil)
 			err = framework.WaitForGroupSize(group, targetNumNodes)
-			gomega.Expect(err).To(gomega.BeNil())
+			framework.ExpectEqual(err, nil)
 			err = e2enode.WaitForReadyNodes(c, framework.TestContext.CloudConfig.NumNodes-1, 10*time.Minute)
-			gomega.Expect(err).To(gomega.BeNil())
+			framework.ExpectEqual(err, nil)
 			targetNodes, err := e2enode.GetReadySchedulableNodes(c)
 			framework.ExpectNoError(err)
 			framework.ExpectEqual(len(targetNodes.Items), int(targetNumNodes))

--- a/test/e2e/cloud/nodes.go
+++ b/test/e2e/cloud/nodes.go
@@ -27,7 +27,6 @@ import (
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
@@ -62,7 +61,7 @@ var _ = SIGDescribe("[Feature:CloudProvider][Disruptive] Nodes", func() {
 		}
 
 		newNodes, err := e2enode.CheckReady(c, len(origNodes.Items)-1, 5*time.Minute)
-		gomega.Expect(err).To(gomega.BeNil())
+		framework.ExpectEqual(err, nil)
 		framework.ExpectEqual(len(newNodes), len(origNodes.Items)-1)
 
 		_, err = c.CoreV1().Nodes().Get(nodeToDelete.Name, metav1.GetOptions{})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/priority backlog
/release-note-none
**What this PR does / why we need it**:
**Which issue(s) this PR fixes**: 
This makes e2e tests use the function under test/e2e/autoscaling/、cloud/
Ref: #79686
**Special notes for your reviewer**:
**Does this PR introduce a user-facing change?**:
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

