### PR TITLE
feat: initialize node status plugin

### DIFF
--- a/pkg/kubelet/BUILD
+++ b/pkg/kubelet/BUILD
@@ -68,6 +68,7 @@ go_library(
         "//pkg/kubelet/network/dns:go_default_library",
         "//pkg/kubelet/nodelease:go_default_library",
         "//pkg/kubelet/nodestatus:go_default_library",
+        "//pkg/kubelet/nodestatus/nodeaddress:go_default_library",
         "//pkg/kubelet/oom:go_default_library",
         "//pkg/kubelet/pleg:go_default_library",
         "//pkg/kubelet/pluginmanager:go_default_library",

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -38,6 +38,7 @@ import (
 	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/kubelet/events"
 	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
+	"k8s.io/kubernetes/pkg/kubelet/nodestatus/nodeaddress"
 	"k8s.io/kubernetes/pkg/kubelet/util"
 	schedulerapi "k8s.io/kubernetes/pkg/scheduler/api"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
@@ -547,7 +548,7 @@ func (kl *Kubelet) defaultNodeStatusFuncs() []func(*v1.Node) error {
 	}
 	var setters []func(n *v1.Node) error
 	setters = append(setters,
-		nodestatus.NodeAddress(kl.nodeIP, kl.nodeIPValidator, kl.hostname, kl.hostnameOverridden, kl.externalCloudProvider, kl.cloud, nodeAddressesFunc),
+		nodeaddress.New(kl.nodeIP, kl.nodeIPValidator, kl.hostname, kl.hostnameOverridden, kl.externalCloudProvider, kl.cloud, nodeAddressesFunc).Update,
 		nodestatus.MachineInfo(string(kl.nodeName), kl.maxPods, kl.podsPerCore, kl.GetCachedMachineInfo, kl.containerManager.GetCapacity,
 			kl.containerManager.GetDevicePluginResourceCapacity, kl.containerManager.GetNodeAllocatableReservation, kl.recordEvent),
 		nodestatus.VersionInfo(kl.cadvisor.VersionInfo, kl.containerRuntime.Type, kl.containerRuntime.Version),

--- a/pkg/kubelet/nodestatus/BUILD
+++ b/pkg/kubelet/nodestatus/BUILD
@@ -2,13 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["setters.go"],
+    srcs = [
+        "plugin.go",
+        "setters.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/kubelet/nodestatus",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/features:go_default_library",
-        "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
@@ -18,9 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
@@ -36,7 +36,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/kubelet/nodestatus/nodeaddress:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )
@@ -60,8 +63,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",
-        "//staging/src/k8s.io/cloud-provider:go_default_library",
-        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",

--- a/pkg/kubelet/nodestatus/nodeaddress/BUILD
+++ b/pkg/kubelet/nodestatus/nodeaddress/BUILD
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["node_address.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/nodestatus/nodeaddress",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kubelet/apis:go_default_library",
+        "//pkg/kubelet/nodestatus:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
+        "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["node_address_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/fake:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/kubelet/nodestatus/nodeaddress/node_address.go
+++ b/pkg/kubelet/nodestatus/nodeaddress/node_address.go
@@ -1,0 +1,234 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeaddress
+
+import (
+	"fmt"
+	"net"
+
+	v1 "k8s.io/api/core/v1"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
+	cloudprovider "k8s.io/cloud-provider"
+	"k8s.io/klog"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+	"k8s.io/kubernetes/pkg/kubelet/nodestatus"
+)
+
+// Plugin is the node status plugin.
+type Plugin struct {
+	nodeIP                net.IP
+	validateNodeIPFunc    func(net.IP) error
+	hostname              string
+	hostnameOverridden    bool
+	externalCloudProvider bool
+	cloud                 cloudprovider.Interface
+	nodeAddressesFunc     func() ([]v1.NodeAddress, error)
+}
+
+var _ nodestatus.Plugin = &Plugin{}
+
+// New returns a node address plugin.
+func New(
+	nodeIP net.IP, // typically Kubelet.nodeIP
+	validateNodeIPFunc func(net.IP) error, // typically Kubelet.nodeIPValidator
+	hostname string, // typically Kubelet.hostname
+	hostnameOverridden bool, // was the hostname force set?
+	externalCloudProvider bool, // typically Kubelet.externalCloudProvider
+	cloud cloudprovider.Interface, // typically Kubelet.cloud
+	nodeAddressesFunc func() ([]v1.NodeAddress, error), // typically Kubelet.cloudResourceSyncManager.NodeAddresses
+) *Plugin {
+	return &Plugin{
+		nodeIP:                nodeIP,
+		validateNodeIPFunc:    validateNodeIPFunc,
+		hostname:              hostname,
+		hostnameOverridden:    hostnameOverridden,
+		externalCloudProvider: externalCloudProvider,
+		cloud:                 cloud,
+		nodeAddressesFunc:     nodeAddressesFunc,
+	}
+}
+
+// Name is the name of the plugin.
+func (p *Plugin) Name() string {
+	return nodestatus.NodeAddressPluginName
+}
+
+// Update updates the status of the node.
+func (p *Plugin) Update(node *v1.Node) error {
+	hostname := p.hostname
+	nodeIP := p.nodeIP
+
+	if nodeIP != nil {
+		if err := p.validateNodeIPFunc(nodeIP); err != nil {
+			return fmt.Errorf("failed to validate nodeIP: %v", err)
+		}
+		klog.V(2).Infof("Using node IP: %q", nodeIP.String())
+	}
+
+	if p.externalCloudProvider {
+		if nodeIP != nil {
+			if node.ObjectMeta.Annotations == nil {
+				node.ObjectMeta.Annotations = make(map[string]string)
+			}
+			node.ObjectMeta.Annotations[kubeletapis.AnnotationProvidedIPAddr] = nodeIP.String()
+		}
+
+		// If --cloud-provider=external and node address is already set,
+		// then we return early because provider set addresses should take precedence.
+		// Otherwise, we try to look up the node IP and let the cloud provider override it later
+		// This should alleviate a lot of the bootstrapping issues with out-of-tree providers
+		if len(node.Status.Addresses) > 0 {
+			return nil
+		}
+	}
+	if p.cloud != nil {
+		cloudNodeAddresses, err := p.nodeAddressesFunc()
+		if err != nil {
+			return err
+		}
+
+		var nodeAddresses []v1.NodeAddress
+
+		// For every address supplied by the cloud provider that matches nodeIP, nodeIP is the enforced node address for
+		// that address Type (like InternalIP and ExternalIP), meaning other addresses of the same Type are discarded.
+		// See #61921 for more information: some cloud providers may supply secondary IPs, so nodeIP serves as a way to
+		// ensure that the correct IPs show up on a Node object.
+		if nodeIP != nil {
+			enforcedNodeAddresses := []v1.NodeAddress{}
+
+			nodeIPTypes := make(map[v1.NodeAddressType]bool)
+			for _, nodeAddress := range cloudNodeAddresses {
+				if nodeAddress.Address == nodeIP.String() {
+					enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
+					nodeIPTypes[nodeAddress.Type] = true
+				}
+			}
+
+			// nodeIP must be among the addresses supplied by the cloud provider
+			if len(enforcedNodeAddresses) == 0 {
+				return fmt.Errorf("failed to get node address from cloud provider that matches ip: %v", nodeIP)
+			}
+
+			// nodeIP was found, now use all other addresses supplied by the cloud provider NOT of the same Type as nodeIP.
+			for _, nodeAddress := range cloudNodeAddresses {
+				if !nodeIPTypes[nodeAddress.Type] {
+					enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
+				}
+			}
+
+			nodeAddresses = enforcedNodeAddresses
+		} else {
+			// If nodeIP is unset, just use the addresses provided by the cloud provider as-is
+			nodeAddresses = cloudNodeAddresses
+		}
+
+		switch {
+		case len(cloudNodeAddresses) == 0:
+			// the cloud provider didn't specify any addresses
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
+
+		case !hasAddressType(cloudNodeAddresses, v1.NodeHostName) && hasAddressValue(cloudNodeAddresses, hostname):
+			// the cloud provider didn't specify an address of type Hostname,
+			// but the auto-detected hostname matched an address reported by the cloud provider,
+			// so we can add it and count on the value being verifiable via cloud provider metadata
+			nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
+
+		case p.hostnameOverridden:
+			// the hostname was force-set via flag/config.
+			// this means the hostname might not be able to be validated via cloud provider metadata,
+			// but was a choice by the kubelet deployer we should honor
+			var existingHostnameAddress *v1.NodeAddress
+			for i := range nodeAddresses {
+				if nodeAddresses[i].Type == v1.NodeHostName {
+					existingHostnameAddress = &nodeAddresses[i]
+					break
+				}
+			}
+
+			if existingHostnameAddress == nil {
+				// no existing Hostname address found, add it
+				klog.Warningf("adding overridden hostname of %v to cloudprovider-reported addresses", hostname)
+				nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
+			} else if existingHostnameAddress.Address != hostname {
+				// override the Hostname address reported by the cloud provider
+				klog.Warningf("replacing cloudprovider-reported hostname of %v with overridden hostname of %v", existingHostnameAddress.Address, hostname)
+				existingHostnameAddress.Address = hostname
+			}
+		}
+		node.Status.Addresses = nodeAddresses
+	} else {
+		var ipAddr net.IP
+		var err error
+
+		// 1) Use nodeIP if set
+		// 2) If the user has specified an IP to HostnameOverride, use it
+		// 3) Lookup the IP from node name by DNS and use the first valid IPv4 address.
+		//    If the node does not have a valid IPv4 address, use the first valid IPv6 address.
+		// 4) Try to get the IP from the network interface used as default gateway
+		if nodeIP != nil {
+			ipAddr = nodeIP
+		} else if addr := net.ParseIP(hostname); addr != nil {
+			ipAddr = addr
+		} else {
+			var addrs []net.IP
+			addrs, _ = net.LookupIP(node.Name)
+			for _, addr := range addrs {
+				if err = p.validateNodeIPFunc(addr); err == nil {
+					if addr.To4() != nil {
+						ipAddr = addr
+						break
+					}
+					if addr.To16() != nil && ipAddr == nil {
+						ipAddr = addr
+					}
+				}
+			}
+
+			if ipAddr == nil {
+				ipAddr, err = utilnet.ChooseHostInterface()
+			}
+		}
+
+		if ipAddr == nil {
+			// We tried everything we could, but the IP address wasn't fetchable; error out
+			return fmt.Errorf("can't get ip address of node %s. error: %v", node.Name, err)
+		}
+		node.Status.Addresses = []v1.NodeAddress{
+			{Type: v1.NodeInternalIP, Address: ipAddr.String()},
+			{Type: v1.NodeHostName, Address: hostname},
+		}
+	}
+	return nil
+}
+
+func hasAddressType(addresses []v1.NodeAddress, addressType v1.NodeAddressType) bool {
+	for _, address := range addresses {
+		if address.Type == addressType {
+			return true
+		}
+	}
+	return false
+}
+
+func hasAddressValue(addresses []v1.NodeAddress, addressValue string) bool {
+	for _, address := range addresses {
+		if address.Address == addressValue {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/kubelet/nodestatus/nodeaddress/node_address_test.go
+++ b/pkg/kubelet/nodestatus/nodeaddress/node_address_test.go
@@ -1,0 +1,350 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodeaddress
+
+import (
+	"net"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/diff"
+	cloudprovider "k8s.io/cloud-provider"
+	fakecloud "k8s.io/cloud-provider/fake"
+)
+
+const (
+	testKubeletHostname = "127.0.0.1"
+)
+
+// TODO(mtaufen): below is ported from the old kubelet_node_status_test.go code, potentially add more test coverage for NodeAddress setter in future
+func TestNodeAddress(t *testing.T) {
+	cases := []struct {
+		name                  string
+		hostnameOverride      bool
+		nodeIP                net.IP
+		externalCloudProvider bool
+		nodeAddresses         []v1.NodeAddress
+		expectedAddresses     []v1.NodeAddress
+		shouldError           bool
+	}{
+		{
+			name:   "A single InternalIP",
+			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
+		},
+		{
+			name:   "NodeIP is external",
+			nodeIP: net.ParseIP("55.55.55.55"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
+		},
+		{
+			// Accommodating #45201 and #49202
+			name:   "InternalIP and ExternalIP are the same",
+			nodeIP: net.ParseIP("55.55.55.55"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "44.44.44.44"},
+				{Type: v1.NodeExternalIP, Address: "44.44.44.44"},
+				{Type: v1.NodeInternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
+		},
+		{
+			name:   "An Internal/ExternalIP, an Internal/ExternalDNS",
+			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeInternalDNS, Address: "ip-10-1-1-1.us-west-2.compute.internal"},
+				{Type: v1.NodeExternalDNS, Address: "ec2-55-55-55-55.us-west-2.compute.amazonaws.com"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeInternalDNS, Address: "ip-10-1-1-1.us-west-2.compute.internal"},
+				{Type: v1.NodeExternalDNS, Address: "ec2-55-55-55-55.us-west-2.compute.amazonaws.com"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
+		},
+		{
+			name:   "An Internal with multiple internal IPs",
+			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: "10.2.2.2"},
+				{Type: v1.NodeInternalIP, Address: "10.3.3.3"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
+		},
+		{
+			name:   "An InternalIP that isn't valid: should error",
+			nodeIP: net.ParseIP("10.2.2.2"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			expectedAddresses: nil,
+			shouldError:       true,
+		},
+		{
+			name:          "no cloud reported hostnames",
+			nodeAddresses: []v1.NodeAddress{},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname is auto-added in the absence of cloud-reported hostnames
+			},
+			shouldError: false,
+		},
+		{
+			name: "cloud reports hostname, no override",
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: "cloud-host"},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: "cloud-host"}, // cloud-reported hostname wins over detected hostname
+			},
+			shouldError: false,
+		},
+		{
+			name:   "cloud reports hostname, nodeIP is set, no override",
+			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: "cloud-host"},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: "cloud-host"}, // cloud-reported hostname wins over detected hostname
+			},
+			shouldError: false,
+		},
+		{
+			name: "cloud reports hostname, overridden",
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeHostName, Address: "cloud-host"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname}, // hostname-override wins over cloud-reported hostname
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+			},
+			hostnameOverride: true,
+			shouldError:      false,
+		},
+		{
+			name:                  "cloud provider is external",
+			nodeIP:                net.ParseIP("10.0.0.1"),
+			nodeAddresses:         []v1.NodeAddress{},
+			externalCloudProvider: true,
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname},
+			},
+			shouldError: false,
+		},
+		{
+			name: "cloud doesn't report hostname, no override, detected hostname mismatch",
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				// detected hostname is not auto-added if it doesn't match any cloud-reported addresses
+			},
+			shouldError: false,
+		},
+		{
+			name: "cloud doesn't report hostname, no override, detected hostname match",
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeExternalDNS, Address: testKubeletHostname}, // cloud-reported address value matches detected hostname
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeExternalDNS, Address: testKubeletHostname},
+				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname gets auto-added
+			},
+			shouldError: false,
+		},
+		{
+			name:   "cloud doesn't report hostname, nodeIP is set, no override, detected hostname match",
+			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeExternalDNS, Address: testKubeletHostname}, // cloud-reported address value matches detected hostname
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeExternalDNS, Address: testKubeletHostname},
+				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname gets auto-added
+			},
+			shouldError: false,
+		},
+		{
+			name:   "cloud doesn't report hostname, nodeIP is set, no override, detected hostname match with same type as nodeIP",
+			nodeIP: net.ParseIP("10.1.1.1"),
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeInternalIP, Address: testKubeletHostname}, // cloud-reported address value matches detected hostname
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname gets auto-added
+			},
+			shouldError: false,
+		},
+		{
+			name: "cloud doesn't report hostname, hostname override, hostname mismatch",
+			nodeAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+			},
+			expectedAddresses: []v1.NodeAddress{
+				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
+				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
+				{Type: v1.NodeHostName, Address: testKubeletHostname}, // overridden hostname gets auto-added
+			},
+			hostnameOverride: true,
+			shouldError:      false,
+		},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			// testCase setup
+			existingNode := &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, Annotations: make(map[string]string)},
+				Spec:       v1.NodeSpec{},
+				Status: v1.NodeStatus{
+					Addresses: []v1.NodeAddress{},
+				},
+			}
+
+			nodeIP := testCase.nodeIP
+			nodeIPValidator := func(nodeIP net.IP) error {
+				return nil
+			}
+			hostname := testKubeletHostname
+
+			nodeAddressesFunc := func() ([]v1.NodeAddress, error) {
+				return testCase.nodeAddresses, nil
+			}
+
+			// cloud provider is expected to be nil if external provider is set
+			var cloud cloudprovider.Interface
+			if testCase.externalCloudProvider {
+				cloud = nil
+			} else {
+				cloud = &fakecloud.Cloud{
+					Addresses: testCase.nodeAddresses,
+					Err:       nil,
+				}
+
+			}
+
+			// construct setter
+			plugin := New(nodeIP,
+				nodeIPValidator,
+				hostname,
+				testCase.hostnameOverride,
+				testCase.externalCloudProvider,
+				cloud,
+				nodeAddressesFunc)
+
+			// call setter on existing node
+			err := plugin.Update(existingNode)
+			if err != nil && !testCase.shouldError {
+				t.Fatalf("unexpected error: %v", err)
+			} else if err != nil && testCase.shouldError {
+				// expected an error, and got one, so just return early here
+				return
+			}
+
+			// Sort both sets for consistent equality
+			sortNodeAddresses(testCase.expectedAddresses)
+			sortNodeAddresses(existingNode.Status.Addresses)
+
+			assert.True(t, apiequality.Semantic.DeepEqual(testCase.expectedAddresses, existingNode.Status.Addresses),
+				"Diff: %s", diff.ObjectDiff(testCase.expectedAddresses, existingNode.Status.Addresses))
+		})
+	}
+}
+
+// sortableNodeAddress is a type for sorting []v1.NodeAddress
+type sortableNodeAddress []v1.NodeAddress
+
+func (s sortableNodeAddress) Len() int { return len(s) }
+func (s sortableNodeAddress) Less(i, j int) bool {
+	return (string(s[i].Type) + s[i].Address) < (string(s[j].Type) + s[j].Address)
+}
+func (s sortableNodeAddress) Swap(i, j int) { s[j], s[i] = s[i], s[j] }
+
+func sortNodeAddresses(addrs sortableNodeAddress) {
+	sort.Sort(addrs)
+}

--- a/pkg/kubelet/nodestatus/plugin.go
+++ b/pkg/kubelet/nodestatus/plugin.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodestatus
+
+import v1 "k8s.io/api/core/v1"
+
+const (
+	// NodeAddressPluginName is the name to node address plugin.
+	NodeAddressPluginName = "NodeAddress"
+)
+
+// Plugin is the node status plugin which update the node's
+// status.
+type Plugin interface {
+	// Name is the name of the plugin.
+	Name() string
+
+	// Update updates the status of the node.
+	Update(node *v1.Node) error
+}

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -19,24 +19,20 @@ package nodestatus
 import (
 	"fmt"
 	"math"
-	"net"
 	goruntime "runtime"
 	"strings"
 	"time"
 
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/component-base/version"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
-	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -55,177 +51,6 @@ const (
 // Setter modifies the node in-place, and returns an error if the modification failed.
 // Setters may partially mutate the node before returning an error.
 type Setter func(node *v1.Node) error
-
-// NodeAddress returns a Setter that updates address-related information on the node.
-func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
-	validateNodeIPFunc func(net.IP) error, // typically Kubelet.nodeIPValidator
-	hostname string, // typically Kubelet.hostname
-	hostnameOverridden bool, // was the hostname force set?
-	externalCloudProvider bool, // typically Kubelet.externalCloudProvider
-	cloud cloudprovider.Interface, // typically Kubelet.cloud
-	nodeAddressesFunc func() ([]v1.NodeAddress, error), // typically Kubelet.cloudResourceSyncManager.NodeAddresses
-) Setter {
-	return func(node *v1.Node) error {
-		if nodeIP != nil {
-			if err := validateNodeIPFunc(nodeIP); err != nil {
-				return fmt.Errorf("failed to validate nodeIP: %v", err)
-			}
-			klog.V(2).Infof("Using node IP: %q", nodeIP.String())
-		}
-
-		if externalCloudProvider {
-			if nodeIP != nil {
-				if node.ObjectMeta.Annotations == nil {
-					node.ObjectMeta.Annotations = make(map[string]string)
-				}
-				node.ObjectMeta.Annotations[kubeletapis.AnnotationProvidedIPAddr] = nodeIP.String()
-			}
-
-			// If --cloud-provider=external and node address is already set,
-			// then we return early because provider set addresses should take precedence.
-			// Otherwise, we try to look up the node IP and let the cloud provider override it later
-			// This should alleviate a lot of the bootstrapping issues with out-of-tree providers
-			if len(node.Status.Addresses) > 0 {
-				return nil
-			}
-		}
-		if cloud != nil {
-			cloudNodeAddresses, err := nodeAddressesFunc()
-			if err != nil {
-				return err
-			}
-
-			var nodeAddresses []v1.NodeAddress
-
-			// For every address supplied by the cloud provider that matches nodeIP, nodeIP is the enforced node address for
-			// that address Type (like InternalIP and ExternalIP), meaning other addresses of the same Type are discarded.
-			// See #61921 for more information: some cloud providers may supply secondary IPs, so nodeIP serves as a way to
-			// ensure that the correct IPs show up on a Node object.
-			if nodeIP != nil {
-				enforcedNodeAddresses := []v1.NodeAddress{}
-
-				nodeIPTypes := make(map[v1.NodeAddressType]bool)
-				for _, nodeAddress := range cloudNodeAddresses {
-					if nodeAddress.Address == nodeIP.String() {
-						enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
-						nodeIPTypes[nodeAddress.Type] = true
-					}
-				}
-
-				// nodeIP must be among the addresses supplied by the cloud provider
-				if len(enforcedNodeAddresses) == 0 {
-					return fmt.Errorf("failed to get node address from cloud provider that matches ip: %v", nodeIP)
-				}
-
-				// nodeIP was found, now use all other addresses supplied by the cloud provider NOT of the same Type as nodeIP.
-				for _, nodeAddress := range cloudNodeAddresses {
-					if !nodeIPTypes[nodeAddress.Type] {
-						enforcedNodeAddresses = append(enforcedNodeAddresses, v1.NodeAddress{Type: nodeAddress.Type, Address: nodeAddress.Address})
-					}
-				}
-
-				nodeAddresses = enforcedNodeAddresses
-			} else {
-				// If nodeIP is unset, just use the addresses provided by the cloud provider as-is
-				nodeAddresses = cloudNodeAddresses
-			}
-
-			switch {
-			case len(cloudNodeAddresses) == 0:
-				// the cloud provider didn't specify any addresses
-				nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
-
-			case !hasAddressType(cloudNodeAddresses, v1.NodeHostName) && hasAddressValue(cloudNodeAddresses, hostname):
-				// the cloud provider didn't specify an address of type Hostname,
-				// but the auto-detected hostname matched an address reported by the cloud provider,
-				// so we can add it and count on the value being verifiable via cloud provider metadata
-				nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
-
-			case hostnameOverridden:
-				// the hostname was force-set via flag/config.
-				// this means the hostname might not be able to be validated via cloud provider metadata,
-				// but was a choice by the kubelet deployer we should honor
-				var existingHostnameAddress *v1.NodeAddress
-				for i := range nodeAddresses {
-					if nodeAddresses[i].Type == v1.NodeHostName {
-						existingHostnameAddress = &nodeAddresses[i]
-						break
-					}
-				}
-
-				if existingHostnameAddress == nil {
-					// no existing Hostname address found, add it
-					klog.Warningf("adding overridden hostname of %v to cloudprovider-reported addresses", hostname)
-					nodeAddresses = append(nodeAddresses, v1.NodeAddress{Type: v1.NodeHostName, Address: hostname})
-				} else if existingHostnameAddress.Address != hostname {
-					// override the Hostname address reported by the cloud provider
-					klog.Warningf("replacing cloudprovider-reported hostname of %v with overridden hostname of %v", existingHostnameAddress.Address, hostname)
-					existingHostnameAddress.Address = hostname
-				}
-			}
-			node.Status.Addresses = nodeAddresses
-		} else {
-			var ipAddr net.IP
-			var err error
-
-			// 1) Use nodeIP if set
-			// 2) If the user has specified an IP to HostnameOverride, use it
-			// 3) Lookup the IP from node name by DNS and use the first valid IPv4 address.
-			//    If the node does not have a valid IPv4 address, use the first valid IPv6 address.
-			// 4) Try to get the IP from the network interface used as default gateway
-			if nodeIP != nil {
-				ipAddr = nodeIP
-			} else if addr := net.ParseIP(hostname); addr != nil {
-				ipAddr = addr
-			} else {
-				var addrs []net.IP
-				addrs, _ = net.LookupIP(node.Name)
-				for _, addr := range addrs {
-					if err = validateNodeIPFunc(addr); err == nil {
-						if addr.To4() != nil {
-							ipAddr = addr
-							break
-						}
-						if addr.To16() != nil && ipAddr == nil {
-							ipAddr = addr
-						}
-					}
-				}
-
-				if ipAddr == nil {
-					ipAddr, err = utilnet.ChooseHostInterface()
-				}
-			}
-
-			if ipAddr == nil {
-				// We tried everything we could, but the IP address wasn't fetchable; error out
-				return fmt.Errorf("can't get ip address of node %s. error: %v", node.Name, err)
-			}
-			node.Status.Addresses = []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: ipAddr.String()},
-				{Type: v1.NodeHostName, Address: hostname},
-			}
-		}
-		return nil
-	}
-}
-
-func hasAddressType(addresses []v1.NodeAddress, addressType v1.NodeAddressType) bool {
-	for _, address := range addresses {
-		if address.Type == addressType {
-			return true
-		}
-	}
-	return false
-}
-func hasAddressValue(addresses []v1.NodeAddress, addressValue string) bool {
-	for _, address := range addresses {
-		if address.Address == addressValue {
-			return true
-		}
-	}
-	return false
-}
 
 // MachineInfo returns a Setter that updates machine-related information on the node.
 func MachineInfo(nodeName string,

--- a/pkg/kubelet/nodestatus/setters_test.go
+++ b/pkg/kubelet/nodestatus/setters_test.go
@@ -19,7 +19,6 @@ package nodestatus
 import (
 	"errors"
 	"fmt"
-	"net"
 	"sort"
 	"strconv"
 	"testing"
@@ -27,15 +26,13 @@ import (
 
 	cadvisorapiv1 "github.com/google/cadvisor/info/v1"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/diff"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/apimachinery/pkg/util/uuid"
-	cloudprovider "k8s.io/cloud-provider"
-	fakecloud "k8s.io/cloud-provider/fake"
 	"k8s.io/component-base/version"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -49,311 +46,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	testKubeletHostname = "127.0.0.1"
-)
-
 // TODO(mtaufen): below is ported from the old kubelet_node_status_test.go code, potentially add more test coverage for NodeAddress setter in future
-func TestNodeAddress(t *testing.T) {
-	cases := []struct {
-		name                  string
-		hostnameOverride      bool
-		nodeIP                net.IP
-		externalCloudProvider bool
-		nodeAddresses         []v1.NodeAddress
-		expectedAddresses     []v1.NodeAddress
-		shouldError           bool
-	}{
-		{
-			name:   "A single InternalIP",
-			nodeIP: net.ParseIP("10.1.1.1"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			name:   "NodeIP is external",
-			nodeIP: net.ParseIP("55.55.55.55"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			// Accommodating #45201 and #49202
-			name:   "InternalIP and ExternalIP are the same",
-			nodeIP: net.ParseIP("55.55.55.55"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "44.44.44.44"},
-				{Type: v1.NodeExternalIP, Address: "44.44.44.44"},
-				{Type: v1.NodeInternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			name:   "An Internal/ExternalIP, an Internal/ExternalDNS",
-			nodeIP: net.ParseIP("10.1.1.1"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeInternalDNS, Address: "ip-10-1-1-1.us-west-2.compute.internal"},
-				{Type: v1.NodeExternalDNS, Address: "ec2-55-55-55-55.us-west-2.compute.amazonaws.com"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeInternalDNS, Address: "ip-10-1-1-1.us-west-2.compute.internal"},
-				{Type: v1.NodeExternalDNS, Address: "ec2-55-55-55-55.us-west-2.compute.amazonaws.com"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			name:   "An Internal with multiple internal IPs",
-			nodeIP: net.ParseIP("10.1.1.1"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeInternalIP, Address: "10.2.2.2"},
-				{Type: v1.NodeInternalIP, Address: "10.3.3.3"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			name:   "An InternalIP that isn't valid: should error",
-			nodeIP: net.ParseIP("10.2.2.2"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			expectedAddresses: nil,
-			shouldError:       true,
-		},
-		{
-			name:          "no cloud reported hostnames",
-			nodeAddresses: []v1.NodeAddress{},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname is auto-added in the absence of cloud-reported hostnames
-			},
-			shouldError: false,
-		},
-		{
-			name: "cloud reports hostname, no override",
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: "cloud-host"},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: "cloud-host"}, // cloud-reported hostname wins over detected hostname
-			},
-			shouldError: false,
-		},
-		{
-			name:   "cloud reports hostname, nodeIP is set, no override",
-			nodeIP: net.ParseIP("10.1.1.1"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: "cloud-host"},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: "cloud-host"}, // cloud-reported hostname wins over detected hostname
-			},
-			shouldError: false,
-		},
-		{
-			name: "cloud reports hostname, overridden",
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeHostName, Address: "cloud-host"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname}, // hostname-override wins over cloud-reported hostname
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-			},
-			hostnameOverride: true,
-			shouldError:      false,
-		},
-		{
-			name:                  "cloud provider is external",
-			nodeIP:                net.ParseIP("10.0.0.1"),
-			nodeAddresses:         []v1.NodeAddress{},
-			externalCloudProvider: true,
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.0.0.1"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname},
-			},
-			shouldError: false,
-		},
-		{
-			name: "cloud doesn't report hostname, no override, detected hostname mismatch",
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				// detected hostname is not auto-added if it doesn't match any cloud-reported addresses
-			},
-			shouldError: false,
-		},
-		{
-			name: "cloud doesn't report hostname, no override, detected hostname match",
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeExternalDNS, Address: testKubeletHostname}, // cloud-reported address value matches detected hostname
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeExternalDNS, Address: testKubeletHostname},
-				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname gets auto-added
-			},
-			shouldError: false,
-		},
-		{
-			name:   "cloud doesn't report hostname, nodeIP is set, no override, detected hostname match",
-			nodeIP: net.ParseIP("10.1.1.1"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeExternalDNS, Address: testKubeletHostname}, // cloud-reported address value matches detected hostname
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeExternalDNS, Address: testKubeletHostname},
-				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname gets auto-added
-			},
-			shouldError: false,
-		},
-		{
-			name:   "cloud doesn't report hostname, nodeIP is set, no override, detected hostname match with same type as nodeIP",
-			nodeIP: net.ParseIP("10.1.1.1"),
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeInternalIP, Address: testKubeletHostname}, // cloud-reported address value matches detected hostname
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname}, // detected hostname gets auto-added
-			},
-			shouldError: false,
-		},
-		{
-			name: "cloud doesn't report hostname, hostname override, hostname mismatch",
-			nodeAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-			},
-			expectedAddresses: []v1.NodeAddress{
-				{Type: v1.NodeInternalIP, Address: "10.1.1.1"},
-				{Type: v1.NodeExternalIP, Address: "55.55.55.55"},
-				{Type: v1.NodeHostName, Address: testKubeletHostname}, // overridden hostname gets auto-added
-			},
-			hostnameOverride: true,
-			shouldError:      false,
-		},
-	}
-	for _, testCase := range cases {
-		t.Run(testCase.name, func(t *testing.T) {
-			// testCase setup
-			existingNode := &v1.Node{
-				ObjectMeta: metav1.ObjectMeta{Name: testKubeletHostname, Annotations: make(map[string]string)},
-				Spec:       v1.NodeSpec{},
-				Status: v1.NodeStatus{
-					Addresses: []v1.NodeAddress{},
-				},
-			}
-
-			nodeIP := testCase.nodeIP
-			nodeIPValidator := func(nodeIP net.IP) error {
-				return nil
-			}
-			hostname := testKubeletHostname
-
-			nodeAddressesFunc := func() ([]v1.NodeAddress, error) {
-				return testCase.nodeAddresses, nil
-			}
-
-			// cloud provider is expected to be nil if external provider is set
-			var cloud cloudprovider.Interface
-			if testCase.externalCloudProvider {
-				cloud = nil
-			} else {
-				cloud = &fakecloud.Cloud{
-					Addresses: testCase.nodeAddresses,
-					Err:       nil,
-				}
-
-			}
-
-			// construct setter
-			setter := NodeAddress(nodeIP,
-				nodeIPValidator,
-				hostname,
-				testCase.hostnameOverride,
-				testCase.externalCloudProvider,
-				cloud,
-				nodeAddressesFunc)
-
-			// call setter on existing node
-			err := setter(existingNode)
-			if err != nil && !testCase.shouldError {
-				t.Fatalf("unexpected error: %v", err)
-			} else if err != nil && testCase.shouldError {
-				// expected an error, and got one, so just return early here
-				return
-			}
-
-			// Sort both sets for consistent equality
-			sortNodeAddresses(testCase.expectedAddresses)
-			sortNodeAddresses(existingNode.Status.Addresses)
-
-			assert.True(t, apiequality.Semantic.DeepEqual(testCase.expectedAddresses, existingNode.Status.Addresses),
-				"Diff: %s", diff.ObjectDiff(testCase.expectedAddresses, existingNode.Status.Addresses))
-		})
-	}
-}
 
 func TestMachineInfo(t *testing.T) {
 	const nodeName = "test-node"
@@ -1589,19 +1282,6 @@ func TestVolumeLimits(t *testing.T) {
 }
 
 // Test Helpers:
-
-// sortableNodeAddress is a type for sorting []v1.NodeAddress
-type sortableNodeAddress []v1.NodeAddress
-
-func (s sortableNodeAddress) Len() int { return len(s) }
-func (s sortableNodeAddress) Less(i, j int) bool {
-	return (string(s[i].Type) + s[i].Address) < (string(s[j].Type) + s[j].Address)
-}
-func (s sortableNodeAddress) Swap(i, j int) { s[j], s[i] = s[i], s[j] }
-
-func sortNodeAddresses(addrs sortableNodeAddress) {
-	sort.Sort(addrs)
-}
 
 // testEvent is used to record events for tests
 type testEvent struct {


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig node
/priority important-longterm

**What this PR does / why we need it**:

Create a node status plugin interface and convert the existing node address to plugin.

Some components of the kubelet depend on the `GetNode` function of kubelet, and `GetNode` function has a complicated process which finally depends on the components of kubelet and causes circular dependency.

With the node status plugin and registry, we could create the node status registry before the creation of the kubelet and register plugins after the initialization.

After we create the node status registry and convert all the node status functions to plugins, we could make a new struct to provide the `GetNode` function and start to break the dependency here

https://github.com/kubernetes/kubernetes/blob/ee81b306815268cfbc01501f9dae12ce38974405/pkg/kubelet/kubelet.go#L559-L562

The process of migration wouldn't break the code or any unit tests and could be done by trunks.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/85672

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
