### PR TITLE
use framework  refactor code in test/e2e/common

### DIFF
--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -66,7 +66,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		framework.ExpectNoError(err)
 		isReady, err := testutils.PodRunningReady(p)
 		framework.ExpectNoError(err)
-		gomega.Expect(isReady).To(gomega.BeTrue(), "pod should be ready")
+		framework.ExpectEqual(isReady, true, "pod should be ready")
 
 		// We assume the pod became ready when the container became ready. This
 		// is true for a single container pod.
@@ -105,7 +105,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 		framework.ExpectNoError(err)
 
 		isReady, _ := testutils.PodRunningReady(p)
-		gomega.Expect(isReady).NotTo(gomega.BeTrue(), "pod should be not ready")
+		framework.ExpectNotEqual(isReady, true, "pod should be not ready")
 
 		restartCount := getRestartCount(p)
 		gomega.Expect(restartCount == 0).To(gomega.BeTrue(), "pod should have a restart count of 0 but got %v", restartCount)

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -829,14 +829,14 @@ var _ = framework.KubeDescribe("Pods", func() {
 
 		ginkgo.By("submitting the pod to kubernetes")
 		podClient.CreateSync(pod)
-		gomega.Expect(podClient.PodIsReady(podName)).To(gomega.BeFalse(), "Expect pod's Ready condition to be false initially.")
+		framework.ExpectEqual(podClient.PodIsReady(podName), false, "Expect pod's Ready condition to be false initially.")
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to true", readinessGate1))
 		_, err := podClient.Patch(podName, types.StrategicMergePatchType, []byte(fmt.Sprintf(patchStatusFmt, readinessGate1, "True")), "status")
 		framework.ExpectNoError(err)
 		// Sleep for 10 seconds.
 		time.Sleep(maxReadyStatusUpdateTolerance)
-		gomega.Expect(podClient.PodIsReady(podName)).To(gomega.BeFalse(), "Expect pod's Ready condition to be false with only one condition in readinessGates equal to True")
+		framework.ExpectEqual(podClient.PodIsReady(podName), false, "Expect pod's Ready condition to be false with only one condition in readinessGates equal to True")
 
 		ginkgo.By(fmt.Sprintf("patching pod status with condition %q to true", readinessGate2))
 		_, err = podClient.Patch(podName, types.StrategicMergePatchType, []byte(fmt.Sprintf(patchStatusFmt, readinessGate2, "True")), "status")

--- a/test/e2e/common/runtimeclass.go
+++ b/test/e2e/common/runtimeclass.go
@@ -34,7 +34,6 @@ import (
 	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = ginkgo.Describe("[sig-node] RuntimeClass", func() {
@@ -125,7 +124,7 @@ func expectPodRejection(f *framework.Framework, pod *v1.Pod) {
 	} else {
 		_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(pod)
 		framework.ExpectError(err, "should be forbidden")
-		gomega.Expect(apierrs.IsForbidden(err)).To(gomega.BeTrue(), "should be forbidden error")
+		framework.ExpectEqual(apierrs.IsForbidden(err), true, "should be forbidden error")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/release-note-none
/priority backlog
**What this PR does / why we need it**:
**Which issue(s) this PR fixes**: 
This makes e2e tests use the function under test/e2e/common.
Ref: #79686
**Special notes for your reviewer**:
/assign @oomichi 
**Does this PR introduce a user-facing change?**:
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

