### PR TITLE
fix staticcheck in test/integration/apiserver

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -81,8 +81,6 @@ test/images/agnhost/pause
 test/images/agnhost/serve-hostname
 test/images/agnhost/webhook
 test/images/pets/peer-finder
-test/integration/apiserver
-test/integration/apiserver/admissionwebhook
 test/integration/auth
 test/integration/client
 test/integration/deployment

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -596,7 +596,7 @@ func testWebhookAdmission(t *testing.T, watchCache bool) {
 		})
 	}
 
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 	perResourceDuration := time.Duration(int(duration) / count)
 	if perResourceDuration >= 150*time.Millisecond {
 		t.Errorf("expected resources to process in < 150ms, average was %v", perResourceDuration)
@@ -736,6 +736,10 @@ func testResourceDelete(c *testContext) {
 		}
 		return true, nil
 	})
+	if err != nil {
+		c.t.Error(err)
+		return
+	}
 
 	// remove the finalizer
 	_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Patch(
@@ -1431,17 +1435,11 @@ var (
 )
 
 func shouldTestResource(gvr schema.GroupVersionResource, resource metav1.APIResource) bool {
-	if !sets.NewString(resource.Verbs...).HasAny("create", "update", "patch", "connect", "delete", "deletecollection") {
-		return false
-	}
-	return true
+	return sets.NewString(resource.Verbs...).HasAny("create", "update", "patch", "connect", "delete", "deletecollection")
 }
 
 func shouldTestResourceVerb(gvr schema.GroupVersionResource, resource metav1.APIResource, verb string) bool {
-	if !sets.NewString(resource.Verbs...).Has(verb) {
-		return false
-	}
-	return true
+	return sets.NewString(resource.Verbs...).Has(verb)
 }
 
 //

--- a/test/integration/apiserver/admissionwebhook/client_auth_test.go
+++ b/test/integration/apiserver/admissionwebhook/client_auth_test.go
@@ -247,11 +247,11 @@ func newClientAuthWebhookHandler(t *testing.T, recorder *clientAuthRecorder) htt
 		defer r.Body.Close()
 		data, err := ioutil.ReadAll(r.Body)
 		if err != nil {
-			http.Error(w, err.Error(), 400)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		review := v1beta1.AdmissionReview{}
 		if err := json.Unmarshal(data, &review); err != nil {
-			http.Error(w, err.Error(), 400)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 		}
 		if review.Request.UserInfo.Username != testClientAuthClientUsername {
 			// skip requests not originating from this integration test's client
@@ -261,17 +261,17 @@ func newClientAuthWebhookHandler(t *testing.T, recorder *clientAuthRecorder) htt
 
 		if authz := r.Header.Get("Authorization"); authz != "Bearer localhost-match-with-port" {
 			t.Errorf("unexpected authz header: %q", authz)
-			http.Error(w, "Invalid auth", 401)
+			http.Error(w, "Invalid auth", http.StatusUnauthorized)
 			return
 		}
 
 		if len(review.Request.Object.Raw) == 0 {
-			http.Error(w, err.Error(), 400)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		pod := &corev1.Pod{}
 		if err := json.Unmarshal(review.Request.Object.Raw, pod); err != nil {
-			http.Error(w, err.Error(), 400)
+			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 

--- a/test/integration/apiserver/admissionwebhook/timeout_test.go
+++ b/test/integration/apiserver/admissionwebhook/timeout_test.go
@@ -428,6 +428,9 @@ func newTimeoutWebhookHandler(recorder *timeoutRecorder) http.Handler {
 		}
 
 		timeout, err := time.ParseDuration(r.URL.Query().Get("timeout"))
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		}
 		invocation := invocation{path: r.URL.Path, timeoutSeconds: int(timeout.Round(time.Second) / time.Second)}
 		recorder.RecordInvocation(invocation)
 

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -403,11 +403,9 @@ func TestNameInFieldSelector(t *testing.T) {
 	defer closeFn()
 
 	numNamespaces := 3
-	namespaces := make([]*v1.Namespace, 0, numNamespaces)
 	for i := 0; i < 3; i++ {
 		ns := framework.CreateTestingNamespace(fmt.Sprintf("ns%d", i), s, t)
 		defer framework.DeleteTestingNamespace(ns, s, t)
-		namespaces = append(namespaces, ns)
 
 		_, err := clientSet.CoreV1().Secrets(ns.Name).Create(makeSecret("foo"))
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup

**What this PR does / why we need it**:

Fix static check failures

**Which issue(s) this PR fixes**:

Ref: #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
 
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

 
```docs
admissionwebhook/admission_test.go:714:2: this value of err is never used (SA4006)
admissionwebhook/admission_test.go:1424:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
admissionwebhook/admission_test.go:1431:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
admissionwebhook/client_auth_test.go:264:34: should use constant http.StatusUnauthorized instead of numeric literal 401 (ST1013)
admissionwebhook/timeout_test.go:430:12: this value of err is never used (SA4006)
apiserver_test.go:410:22: this result of append is never used, except maybe in other appends 
(SA4010)
admissionwebhook/admission_test.go:599:14: should use time.Since instead of time.Now().Sub (S1012)
```
