### PR TITLE
fix: padded base64 encoded docker auth field

### DIFF
--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -287,8 +287,7 @@ func decodeDockerConfigFieldAuth(field string) (username, password string, err e
 
 	// StdEncoding can only decode padded string
 	// RawStdEncoding can only decode unpadded string
-	// a string is correctly padded if and only if its length is a multiple of 4
-	if (len(field) % 4) == 0 {
+	if strings.HasSuffix(strings.TrimSpace(field), "=") {
 		// decode padded data
 		decoded, err = base64.StdEncoding.DecodeString(field)
 	} else {

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -214,6 +214,13 @@ func TestDecodeDockerConfigFieldAuth(t *testing.T) {
 			password: "bar",
 		},
 
+		// some test as before but with new line characters
+		{
+			input:    "Zm9vOm\nJhcg==\n",
+			username: "foo",
+			password: "bar",
+		},
+
 		// standard encoding (with padding)
 		{
 			input:    base64.StdEncoding.EncodeToString([]byte("foo:bar")),
@@ -238,6 +245,12 @@ func TestDecodeDockerConfigFieldAuth(t *testing.T) {
 		// good base64 data, but no colon separating username & password
 		{
 			input: "cGFudHM=",
+			fail:  true,
+		},
+
+		// only new line characters are ignored
+		{
+			input: "Zm9vOmJhcg== ",
 			fail:  true,
 		},
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
base64 allows usage of new line characters and some tools use them. As a result, the length of the encoded string cannot be used to determine whether it's padded or not.

**Which issue(s) this PR fixes**:
This patch fixes the regression after #82148.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
