### PR TITLE
Export scheduler.Snapshot function

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -132,8 +132,12 @@ type ScheduleAlgorithm interface {
 	Extenders() []algorithm.SchedulerExtender
 	// GetPredicateMetadataProducer returns the predicate metadata producer. This is needed
 	// for cluster autoscaler integration.
-	// TODO(ahg-g): remove this once CA migrates to creating a Framework instead of a full scheduler.
+	// TODO(#85691): remove this once CA migrates to creating a Framework instead of a full scheduler.
 	PredicateMetadataProducer() predicates.MetadataProducer
+	// Snapshot snapshots scheduler cache and node infos. This is needed
+	// for cluster autoscaler integration.
+	// TODO(#85691): remove this once CA migrates to creating a Framework instead of a full scheduler.
+	Snapshot() error
 }
 
 // ScheduleResult represents the result of one pod scheduled. It will contain
@@ -169,7 +173,7 @@ type genericScheduler struct {
 
 // snapshot snapshots scheduler cache and node infos for all fit and priority
 // functions.
-func (g *genericScheduler) snapshot() error {
+func (g *genericScheduler) Snapshot() error {
 	// Used for all fit and priority funcs.
 	return g.cache.UpdateNodeInfoSnapshot(g.nodeInfoSnapshot)
 }
@@ -192,7 +196,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 	}
 	trace.Step("Basic checks done")
 
-	if err := g.snapshot(); err != nil {
+	if err := g.Snapshot(); err != nil {
 		return result, err
 	}
 	trace.Step("Snapshoting scheduler cache and node infos done")

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -2176,7 +2176,7 @@ func TestPreempt(t *testing.T) {
 				schedulerapi.DefaultPercentageOfNodesToScore,
 				true)
 			state := framework.NewCycleState()
-			scheduler.(*genericScheduler).snapshot()
+			scheduler.Snapshot()
 			// Call Preempt and check the expected results.
 			failedPredMap := defaultFailedPredMap
 			if test.failedPredMap != nil {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -156,7 +156,6 @@ func (es mockScheduler) PredicateMetadataProducer() predicates.MetadataProducer 
 	return nil
 
 }
-
 func (es mockScheduler) Schedule(ctx context.Context, state *framework.CycleState, pod *v1.Pod) (core.ScheduleResult, error) {
 	return es.result, es.err
 }
@@ -170,9 +169,12 @@ func (es mockScheduler) Prioritizers() []priorities.PriorityConfig {
 func (es mockScheduler) Extenders() []algorithm.SchedulerExtender {
 	return nil
 }
-
 func (es mockScheduler) Preempt(ctx context.Context, state *framework.CycleState, pod *v1.Pod, scheduleErr error) (*v1.Node, []*v1.Pod, []*v1.Pod, error) {
 	return nil, nil, nil, nil
+}
+func (es mockScheduler) Snapshot() error {
+	return nil
+
 }
 
 func TestSchedulerCreation(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

CA needs to update the snapshot now that predicates list nodes/pods from the snapshot rather than the scheduler cache. 

For CA to be able to do that, we need to export scheduler.snapshot function. 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @alculquicondor 