### PR TITLE
remove redundant definition of the defaultProvider in the scheduler

### DIFF
--- a/pkg/scheduler/algorithm_factory.go
+++ b/pkg/scheduler/algorithm_factory.go
@@ -81,11 +81,6 @@ var (
 	predicateMetadataProducerFactory PredicateMetadataProducerFactory
 )
 
-const (
-	// DefaultProvider defines the default algorithm provider name.
-	DefaultProvider = "DefaultProvider"
-)
-
 // AlgorithmProviderConfig is used to store the configuration of algorithm providers.
 type AlgorithmProviderConfig struct {
 	FitPredicateKeys     sets.String

--- a/pkg/scheduler/algorithmprovider/BUILD
+++ b/pkg/scheduler/algorithmprovider/BUILD
@@ -17,7 +17,10 @@ go_test(
     name = "go_default_test",
     srcs = ["plugins_test.go"],
     embed = [":go_default_library"],
-    deps = ["//pkg/scheduler:go_default_library"],
+    deps = [
+        "//pkg/scheduler:go_default_library",
+        "//pkg/scheduler/apis/config:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/scheduler/algorithmprovider/defaults/BUILD
+++ b/pkg/scheduler/algorithmprovider/defaults/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/scheduler/algorithm:go_default_library",
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/algorithm/priorities:go_default_library",
+        "//pkg/scheduler/apis/config:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/scheduler/algorithmprovider/defaults/defaults.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
 const (
@@ -93,7 +94,7 @@ func ApplyFeatureGates() (restore func()) {
 func registerAlgorithmProvider(predSet, priSet sets.String) {
 	// Registers algorithm providers. By default we use 'DefaultProvider', but user can specify one to be used
 	// by specifying flag.
-	scheduler.RegisterAlgorithmProvider(scheduler.DefaultProvider, predSet, priSet)
+	scheduler.RegisterAlgorithmProvider(schedulerapi.SchedulerDefaultProviderName, predSet, priSet)
 	// Cluster autoscaler friendly scheduling algorithm.
 	scheduler.RegisterAlgorithmProvider(ClusterAutoscalerProvider, predSet,
 		copyAndReplace(priSet, priorities.LeastRequestedPriority, priorities.MostRequestedPriority))

--- a/pkg/scheduler/algorithmprovider/plugins_test.go
+++ b/pkg/scheduler/algorithmprovider/plugins_test.go
@@ -21,16 +21,17 @@ import (
 	"testing"
 
 	"k8s.io/kubernetes/pkg/scheduler"
+	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
 )
 
 var (
 	algorithmProviderNames = []string{
-		scheduler.DefaultProvider,
+		schedulerapi.SchedulerDefaultProviderName,
 	}
 )
 
 func TestDefaultConfigExists(t *testing.T) {
-	p, err := scheduler.GetAlgorithmProvider(scheduler.DefaultProvider)
+	p, err := scheduler.GetAlgorithmProvider(schedulerapi.SchedulerDefaultProviderName)
 	if err != nil {
 		t.Errorf("error retrieving default provider: %v", err)
 	}

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -119,7 +119,7 @@ func (c *Configurator) GetHardPodAffinitySymmetricWeight() int32 {
 
 // Create creates a scheduler with the default algorithm provider.
 func (c *Configurator) Create() (*Scheduler, error) {
-	return c.CreateFromProvider(DefaultProvider)
+	return c.CreateFromProvider(schedulerapi.SchedulerDefaultProviderName)
 }
 
 // CreateFromProvider creates a scheduler from the name of a registered algorithm provider.
@@ -143,8 +143,8 @@ func (c *Configurator) CreateFromConfig(policy schedulerapi.Policy) (*Scheduler,
 
 	predicateKeys := sets.NewString()
 	if policy.Predicates == nil {
-		klog.V(2).Infof("Using predicates from algorithm provider '%v'", DefaultProvider)
-		provider, err := GetAlgorithmProvider(DefaultProvider)
+		klog.V(2).Infof("Using predicates from algorithm provider '%v'", schedulerapi.SchedulerDefaultProviderName)
+		provider, err := GetAlgorithmProvider(schedulerapi.SchedulerDefaultProviderName)
 		if err != nil {
 			return nil, err
 		}
@@ -158,8 +158,8 @@ func (c *Configurator) CreateFromConfig(policy schedulerapi.Policy) (*Scheduler,
 
 	priorityKeys := sets.NewString()
 	if policy.Priorities == nil {
-		klog.V(2).Infof("Using priorities from algorithm provider '%v'", DefaultProvider)
-		provider, err := GetAlgorithmProvider(DefaultProvider)
+		klog.V(2).Infof("Using priorities from algorithm provider '%v'", schedulerapi.SchedulerDefaultProviderName)
+		provider, err := GetAlgorithmProvider(schedulerapi.SchedulerDefaultProviderName)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -240,7 +240,7 @@ func TestCreateFromConfigWithUnspecifiedPredicatesOrPriorities(t *testing.T) {
 	RegisterFitPredicate("PredicateOne", PredicateFunc)
 	RegisterPriorityMapReduceFunction("PriorityOne", PriorityFunc, nil, 1)
 
-	RegisterAlgorithmProvider(DefaultProvider, sets.NewString("PredicateOne"), sets.NewString("PriorityOne"))
+	RegisterAlgorithmProvider(schedulerapi.SchedulerDefaultProviderName, sets.NewString("PredicateOne"), sets.NewString("PriorityOne"))
 
 	configData := []byte(`{
 		"kind" : "Policy",
@@ -256,10 +256,10 @@ func TestCreateFromConfigWithUnspecifiedPredicatesOrPriorities(t *testing.T) {
 		t.Fatalf("Failed to create scheduler from configuration: %v", err)
 	}
 	if _, found := c.Algorithm.Predicates()["PredicateOne"]; !found {
-		t.Errorf("Expected predicate PredicateOne from %q", DefaultProvider)
+		t.Errorf("Expected predicate PredicateOne from %q", schedulerapi.SchedulerDefaultProviderName)
 	}
 	if len(c.Algorithm.Prioritizers()) != 1 || c.Algorithm.Prioritizers()[0].Name != "PriorityOne" {
-		t.Errorf("Expected priority PriorityOne from %q", DefaultProvider)
+		t.Errorf("Expected priority PriorityOne from %q", schedulerapi.SchedulerDefaultProviderName)
 	}
 }
 
@@ -275,7 +275,7 @@ func TestCreateFromConfigWithEmptyPredicatesOrPriorities(t *testing.T) {
 	RegisterFitPredicate("PredicateOne", PredicateFunc)
 	RegisterPriorityMapReduceFunction("PriorityOne", PriorityFunc, nil, 1)
 
-	RegisterAlgorithmProvider(DefaultProvider, sets.NewString("PredicateOne"), sets.NewString("PriorityOne"))
+	RegisterAlgorithmProvider(schedulerapi.SchedulerDefaultProviderName, sets.NewString("PredicateOne"), sets.NewString("PriorityOne"))
 
 	configData := []byte(`{
 		"kind" : "Policy",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

"DefaultProvider" constant is defined in two places, this PR cleans that up.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @liu-cong 