### PR TITLE
stop spamming the log on failures with full objects

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -158,7 +158,7 @@ func (i *Info) ObjectName() string {
 
 // String returns the general purpose string representation
 func (i *Info) String() string {
-	basicInfo := fmt.Sprintf("Name: %q, Namespace: %q\nObject: %+q", i.Name, i.Namespace, i.Object)
+	basicInfo := fmt.Sprintf("Name: %q, Namespace: %q", i.Name, i.Namespace)
 	if i.Mapping != nil {
 		mappingInfo := fmt.Sprintf("Resource: %q, GroupVersionKind: %q", i.Mapping.Resource.String(),
 			i.Mapping.GroupVersionKind.String())


### PR DESCRIPTION
The caller can save the input it's sending either way. Sometimes this content can also include sensitive information (secrets as one example, though conceptually any sensitive resource).  It's not normally needed for debugging since the input is provided on the client-side and the client can save the value however they wish.

```
Error from server (Forbidden): error when retrieving current configuration of:
Resource: "/v1, Resource=secrets", GroupVersionKind: "/v1, Kind=Secret"
Name: "app-cert", Namespace: "openshift-ingress"
Object: &{map["apiVersion":"v1" "data":map["tls.crt":"LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZqRENDQkhTZ0F3SUJBZ0lTQStaaGx3TXRkK2FsKy8zTURBQ01OR0lOTUEwR0NTcUdTSWIzRFFFQkN3VUEKTUVveEN6QUpCZ05WQkFZVEFsVlRNUll3RkFZRFZRUUtFdzFNWlhRbmN5QkZibU55ZVhCME1TTXdJUVlEVlFRRApFeHBNWlhRbmN5QkZibU55ZVhCMElFRjFkR2h2Y21sMGVTQllNekFlRncweE9URXhNamN5TURRd05USmFGdzB5Ck1EQXlNalV5TURRd05USmFNRFV4TXpBeEJnTlZCQU1NS2lvdVlYQndjeTVpZFdsc1pEQXhMbU5wTG1SbGRtTnMKZFhOMFpYSXViM0J
```
as an example

/kind bug
/priority important-soon
@kubernetes/sig-cli-maintainers 

```release-note
NONE
```