### PR TITLE
[1.17] Update cAdvisor dependency to v0.35.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 	github.com/coredns/corefile-migration v1.0.4
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea
-	github.com/coreos/rkt v1.30.0 // indirect
 	github.com/cpuguy83/go-md2man v1.0.10
 	github.com/cyphar/filepath-securejoin v0.2.2 // indirect
 	github.com/davecgh/go-spew v1.1.1
@@ -64,7 +63,7 @@ require (
 	github.com/gogo/protobuf v1.2.2-0.20190723190241-65acae22fc9d
 	github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903
 	github.com/golang/mock v1.2.0
-	github.com/google/cadvisor v0.34.0
+	github.com/google/cadvisor v0.35.0
 	github.com/google/go-cmp v0.3.0
 	github.com/google/gofuzz v1.0.0
 	github.com/google/uuid v1.1.1
@@ -235,7 +234,6 @@ replace (
 	github.com/coreos/go-semver => github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd => github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/pkg => github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea
-	github.com/coreos/rkt => github.com/coreos/rkt v1.30.0
 	github.com/cpuguy83/go-md2man => github.com/cpuguy83/go-md2man v1.0.10
 	github.com/creack/pty => github.com/creack/pty v1.1.7
 	github.com/cyphar/filepath-securejoin => github.com/cyphar/filepath-securejoin v0.2.2
@@ -318,7 +316,7 @@ replace (
 	github.com/golangplus/fmt => github.com/golangplus/fmt v0.0.0-20150411045040-2a5d6d7d2995
 	github.com/golangplus/testing => github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e
 	github.com/google/btree => github.com/google/btree v1.0.0
-	github.com/google/cadvisor => github.com/google/cadvisor v0.34.0
+	github.com/google/cadvisor => github.com/google/cadvisor v0.35.0
 	github.com/google/go-cmp => github.com/google/go-cmp v0.3.0
 	github.com/google/go-github => github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring => github.com/google/go-querystring v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,6 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea h1:n2Ltr3SrfQlf/9nOna1DoGKxLx3qTSI8Ttl6Xrqp6mw=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
-github.com/coreos/rkt v1.30.0 h1:Kkt6sYeEGKxA3Y7SCrY+nHoXkWed6Jr2BBY42GqMymM=
-github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1hF1U=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
@@ -243,8 +241,8 @@ github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e h1:KhcknUwkWHKZ
 github.com/golangplus/testing v0.0.0-20180327235837-af21d9c3145e/go.mod h1:0AA//k/eakGydO4jKRoRL2j92ZKSzTgj9tclaCrvXHk=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/cadvisor v0.34.0 h1:No7G6U/TasplR9uNqyc5Jj0Bet5VSYsK5xLygOf4pUw=
-github.com/google/cadvisor v0.34.0/go.mod h1:1nql6U13uTHaLYB8rLS5x9IJc2qT6Xd/Tr1sTX6NE48=
+github.com/google/cadvisor v0.35.0 h1:qivoEm+iGqTrd0CKSmQidxfOxUxkNZovvYs/8G6B6ao=
+github.com/google/cadvisor v0.35.0/go.mod h1:1nql6U13uTHaLYB8rLS5x9IJc2qT6Xd/Tr1sTX6NE48=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -309,6 +307,7 @@ github.com/karrick/godirwalk v1.7.5 h1:VbzFqwXwNbAZoA6W5odrLr+hKK197CcENcPh6E/gJ
 github.com/karrick/godirwalk v1.7.5/go.mod h1:2c9FRhkDxdIbgkOnCEvnSWs71Bhugbl46shStcFDJ34=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.4.1 h1:8VMb5+0wMgdBykOV96DwNwKFQ+WTI4pzYURP99CcB9E=
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/vendor/github.com/google/cadvisor/container/common/BUILD
+++ b/vendor/github.com/google/cadvisor/container/common/BUILD
@@ -17,6 +17,7 @@ go_library(
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/github.com/google/cadvisor/utils:go_default_library",
         "//vendor/github.com/karrick/godirwalk:go_default_library",
+        "//vendor/github.com/opencontainers/runc/libcontainer/cgroups:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/inotify:go_default_library",

--- a/vendor/github.com/google/cadvisor/container/container.go
+++ b/vendor/github.com/google/cadvisor/container/container.go
@@ -32,7 +32,6 @@ type ContainerType int
 const (
 	ContainerTypeRaw ContainerType = iota
 	ContainerTypeDocker
-	ContainerTypeRkt
 	ContainerTypeSystemd
 	ContainerTypeCrio
 	ContainerTypeContainerd

--- a/vendor/github.com/google/cadvisor/container/libcontainer/helpers.go
+++ b/vendor/github.com/google/cadvisor/container/libcontainer/helpers.go
@@ -47,6 +47,7 @@ func GetCgroupSubsystems(includedMetrics container.MetricSet) (CgroupSubsystems,
 	//currently we only support disable blkio subsystem
 	if !includedMetrics.Has(container.DiskIOMetrics) {
 		disableCgroups["blkio"] = struct{}{}
+		disableCgroups["io"] = struct{}{}
 	}
 	return getCgroupSubsystemsHelper(allCgroups, disableCgroups)
 }
@@ -109,6 +110,7 @@ var supportedSubsystems map[string]struct{} = map[string]struct{}{
 	"pids":    {},
 	"cpuset":  {},
 	"blkio":   {},
+	"io":      {},
 	"devices": {},
 }
 

--- a/vendor/github.com/google/cadvisor/fs/fs.go
+++ b/vendor/github.com/google/cadvisor/fs/fs.go
@@ -41,7 +41,6 @@ import (
 const (
 	LabelSystemRoot   = "root"
 	LabelDockerImages = "docker-images"
-	LabelRktImages    = "rkt-images"
 	LabelCrioImages   = "crio-images"
 )
 
@@ -118,7 +117,6 @@ func NewFsInfo(context Context) (FsInfo, error) {
 		fsInfo.mounts[mount.Mountpoint] = mount
 	}
 
-	fsInfo.addRktImagesLabel(context, mounts)
 	// need to call this before the log line below printing out the partitions, as this function may
 	// add a "partition" for devicemapper to fsInfo.partitions
 	fsInfo.addDockerImagesLabel(context, mounts)
@@ -167,19 +165,22 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 
 	supportedFsType := map[string]bool{
 		// all ext systems are checked through prefix.
-		"btrfs": true,
-		"tmpfs": true,
-		"xfs":   true,
-		"zfs":   true,
+		"btrfs":   true,
+		"overlay": true,
+		"tmpfs":   true,
+		"xfs":     true,
+		"zfs":     true,
 	}
 
 	for _, mount := range mounts {
 		if !strings.HasPrefix(mount.Fstype, "ext") && !supportedFsType[mount.Fstype] {
 			continue
 		}
-		// Avoid bind mounts.
+		// Avoid bind mounts, exclude tmpfs.
 		if _, ok := partitions[mount.Source]; ok {
-			continue
+			if mount.Fstype != "tmpfs" {
+				continue
+			}
 		}
 
 		hasPrefix := false
@@ -193,6 +194,10 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 			continue
 		}
 
+		// using mountpoint to replace device once fstype it tmpfs
+		if mount.Fstype == "tmpfs" {
+			mount.Source = mount.Mountpoint
+		}
 		// btrfs fix: following workaround fixes wrong btrfs Major and Minor Ids reported in /proc/self/mountinfo.
 		// instead of using values from /proc/self/mountinfo we use stat to get Ids from btrfs mount point
 		if mount.Fstype == "btrfs" && mount.Major == 0 && strings.HasPrefix(mount.Source, "/dev/") {
@@ -203,6 +208,11 @@ func processMounts(mounts []*mount.Info, excludedMountpointPrefixes []string) ma
 				mount.Major = major
 				mount.Minor = minor
 			}
+		}
+
+		// overlay fix: Making mount source unique for all overlay mounts, using the mount's major and minor ids.
+		if mount.Fstype == "overlay" {
+			mount.Source = fmt.Sprintf("%s_%d-%d", mount.Source, mount.Major, mount.Minor)
 		}
 
 		partitions[mount.Source] = partition{
@@ -287,20 +297,6 @@ func (self *RealFsInfo) addCrioImagesLabel(context Context, mounts []*mount.Info
 			crioPath = filepath.Dir(crioPath)
 		}
 		self.updateContainerImagesPath(LabelCrioImages, mounts, crioImagePaths)
-	}
-}
-
-func (self *RealFsInfo) addRktImagesLabel(context Context, mounts []*mount.Info) {
-	if context.RktPath != "" {
-		rktPath := context.RktPath
-		rktImagesPaths := map[string]struct{}{
-			"/": {},
-		}
-		for rktPath != "/" && rktPath != "." {
-			rktImagesPaths[rktPath] = struct{}{}
-			rktPath = filepath.Dir(rktPath)
-		}
-		self.updateContainerImagesPath(LabelRktImages, mounts, rktImagesPaths)
 	}
 }
 

--- a/vendor/github.com/google/cadvisor/fs/types.go
+++ b/vendor/github.com/google/cadvisor/fs/types.go
@@ -20,9 +20,8 @@ import (
 
 type Context struct {
 	// docker root directory.
-	Docker  DockerContext
-	RktPath string
-	Crio    CrioContext
+	Docker DockerContext
+	Crio   CrioContext
 }
 
 type DockerContext struct {

--- a/vendor/github.com/google/cadvisor/info/v1/machine.go
+++ b/vendor/github.com/google/cadvisor/info/v1/machine.go
@@ -38,9 +38,10 @@ type FsInfo struct {
 type Node struct {
 	Id int `json:"node_id"`
 	// Per-node memory
-	Memory uint64  `json:"memory"`
-	Cores  []Core  `json:"cores"`
-	Caches []Cache `json:"caches"`
+	Memory    uint64          `json:"memory"`
+	HugePages []HugePagesInfo `json:"hugepages"`
+	Cores     []Core          `json:"cores"`
+	Caches    []Cache         `json:"caches"`
 }
 
 type Core struct {

--- a/vendor/github.com/google/cadvisor/machine/info.go
+++ b/vendor/github.com/google/cadvisor/machine/info.go
@@ -17,10 +17,8 @@ package machine
 import (
 	"bytes"
 	"flag"
-	"fmt"
 	"io/ioutil"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/docker/docker/pkg/parsers/operatingsystem"
@@ -54,45 +52,6 @@ func getInfoFromFiles(filePaths string) string {
 	return ""
 }
 
-// GetHugePagesInfo returns information about pre-allocated huge pages
-func GetHugePagesInfo() ([]info.HugePagesInfo, error) {
-	var hugePagesInfo []info.HugePagesInfo
-	files, err := ioutil.ReadDir(hugepagesDirectory)
-	if err != nil {
-		// treat as non-fatal since kernels and machine can be
-		// configured to disable hugepage support
-		return hugePagesInfo, nil
-	}
-	for _, st := range files {
-		nameArray := strings.Split(st.Name(), "-")
-		pageSizeArray := strings.Split(nameArray[1], "kB")
-		pageSize, err := strconv.ParseUint(string(pageSizeArray[0]), 10, 64)
-		if err != nil {
-			return hugePagesInfo, err
-		}
-
-		numFile := hugepagesDirectory + st.Name() + "/nr_hugepages"
-		val, err := ioutil.ReadFile(numFile)
-		if err != nil {
-			return hugePagesInfo, err
-		}
-		var numPages uint64
-		// we use sscanf as the file as a new-line that trips up ParseUint
-		// it returns the number of tokens successfully parsed, so if
-		// n != 1, it means we were unable to parse a number from the file
-		n, err := fmt.Sscanf(string(val), "%d", &numPages)
-		if err != nil || n != 1 {
-			return hugePagesInfo, fmt.Errorf("could not parse file %v contents %q", numFile, string(val))
-		}
-
-		hugePagesInfo = append(hugePagesInfo, info.HugePagesInfo{
-			NumPages: numPages,
-			PageSize: pageSize,
-		})
-	}
-	return hugePagesInfo, nil
-}
-
 func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.MachineInfo, error) {
 	rootFs := "/"
 	if !inHostNamespace {
@@ -100,6 +59,9 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 	}
 
 	cpuinfo, err := ioutil.ReadFile(filepath.Join(rootFs, "/proc/cpuinfo"))
+	if err != nil {
+		return nil, err
+	}
 	clockSpeed, err := GetClockSpeed(cpuinfo)
 	if err != nil {
 		return nil, err
@@ -110,7 +72,7 @@ func Info(sysFs sysfs.SysFs, fsInfo fs.FsInfo, inHostNamespace bool) (*info.Mach
 		return nil, err
 	}
 
-	hugePagesInfo, err := GetHugePagesInfo()
+	hugePagesInfo, err := GetHugePagesInfo(hugepagesDirectory)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/google/cadvisor/manager/container.go
+++ b/vendor/github.com/google/cadvisor/manager/container.go
@@ -185,6 +185,9 @@ func (c *containerData) getCgroupPath(cgroups string) (string, error) {
 	if cgroups == "-" {
 		return "/", nil
 	}
+	if strings.HasPrefix(cgroups, "0::") {
+		return cgroups[3:], nil
+	}
 	matches := cgroupPathRegExp.FindSubmatch([]byte(cgroups))
 	if len(matches) != 2 {
 		klog.V(3).Infof("failed to get memory cgroup path from %q", cgroups)

--- a/vendor/github.com/google/cadvisor/utils/cpuload/netlink/reader.go
+++ b/vendor/github.com/google/cadvisor/utils/cpuload/netlink/reader.go
@@ -66,10 +66,10 @@ func (self *NetlinkReader) GetCpuLoad(name string, path string) (info.LoadStats,
 	}
 
 	cfd, err := os.Open(path)
-	defer cfd.Close()
 	if err != nil {
 		return info.LoadStats{}, fmt.Errorf("failed to open cgroup path %s: %q", path, err)
 	}
+	defer cfd.Close()
 
 	stats, err := getLoadStats(self.familyId, cfd, self.conn)
 	if err != nil {

--- a/vendor/github.com/google/cadvisor/watcher/watcher.go
+++ b/vendor/github.com/google/cadvisor/watcher/watcher.go
@@ -28,7 +28,6 @@ type ContainerWatchSource int
 
 const (
 	Raw ContainerWatchSource = iota
-	Rkt
 )
 
 // ContainerEvent represents a

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -342,7 +342,7 @@ github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/btree v1.0.0 => github.com/google/btree v1.0.0
 github.com/google/btree
-# github.com/google/cadvisor v0.34.0 => github.com/google/cadvisor v0.34.0
+# github.com/google/cadvisor v0.35.0 => github.com/google/cadvisor v0.35.0
 github.com/google/cadvisor/accelerators
 github.com/google/cadvisor/cache/memory
 github.com/google/cadvisor/client/v2


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/priority important-soon

**What this PR does / why we need it**:
Update cadvisor dependency
This is the cherrypick of #85698 on the 1.17 branch.  Rather than use the cherrypick tool and risk merge conflicts, I just re-ran the update dependency script.

**Special notes for your reviewer**:
We cut and vendor a cAdvisor release for each kubernetes version.  The v0.35.0 cAdvisor release corresponds with the 1.17 kubernetes release.

**Does this PR introduce a user-facing change?**:
```release-note
None
```

/assign @liggitt @derekwaynecarr 
cc @dims @dchen1107 