### PR TITLE
interactive filter exex pod

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go
@@ -442,7 +442,7 @@ func addPrintContext(pods []string, w io.Writer) {
 	}
 }
 
-// promptPodList prompt to user selection question to select number between 0 - maxSelect given field
+// promptPodList prompt to user selection question to select number between 0-maxSelect given field
 func promptPodList(maxSelect int, in *os.File) (int, error) {
 	if in == nil {
 		in = os.Stdin

--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
@@ -31,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	kfake "k8s.io/client-go/kubernetes/fake"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/rest/fake"
 	"k8s.io/client-go/tools/remotecommand"
@@ -403,5 +405,107 @@ func TestSetupTTY(t *testing.T) {
 	}
 	if tty.Out != o.Out {
 		t.Errorf("attach stdin, TTY, is a terminal: tty.Out should equal o.Out")
+	}
+}
+
+func TestFilterPods(t *testing.T) {
+
+	pods := []corev1.Pod{
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo",
+			},
+		},
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "foo-1",
+			},
+		},
+		corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "none",
+			},
+		},
+	}
+
+	response := filterPods(pods, "foo")
+
+	if len(response) != 2 {
+		t.Errorf("unexpected pod filter count, got %d expected %d", len(response), 2)
+	}
+
+}
+
+func TestPrintContext(t *testing.T) {
+
+	pods := []string{"foo", "foo-1"}
+	buf := new(bytes.Buffer)
+	addPrintContext(pods, buf)
+
+	expected := `1	foo	
+2	foo-1	
+`
+
+	if expected != buf.String() {
+		t.Errorf("unexpected table content")
+	}
+}
+
+func TestContextHeaders(t *testing.T) {
+
+	buf := new(bytes.Buffer)
+	addContextHeaders(buf)
+
+	expected := `#	NAME
+`
+	if expected != buf.String() {
+		t.Errorf("unexpected table header content")
+	}
+
+}
+
+func TestPromptPodList(t *testing.T) {
+
+	t.Run("valid_number", func(t *testing.T) {
+		in, _ := ioutil.TempFile("", "")
+		defer in.Close()
+		io.WriteString(in, "2")
+		in.Seek(0, os.SEEK_SET)
+		selectedIndex, _ := promptPodList(4, in)
+		if selectedIndex != 2 {
+			t.Errorf("unexpected promp response")
+		}
+	})
+
+	t.Run("invalid_number", func(t *testing.T) {
+		in, _ := ioutil.TempFile("", "")
+		defer in.Close()
+		io.WriteString(in, "foo")
+		in.Seek(0, os.SEEK_SET)
+		_, err := promptPodList(4, in)
+		if err == nil {
+			t.Errorf("unexpected error promp response")
+		}
+
+	})
+
+}
+func TestSelectResourceName(t *testing.T) {
+
+	client := kfake.NewSimpleClientset()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "foo-pod",
+		},
+	}
+
+	client.CoreV1().Pods("").Create(pod)
+
+	buf := new(bytes.Buffer)
+	podResourceName := selectPod(client.CoreV1(), buf, "foo", "")
+
+	if podResourceName != "foo-pod" {
+		t.Errorf("unexpected pod resource selection")
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**why we need it **:

In order to SSH into a pod the exact name is required and the namespace as well, something like:

1) `kubectl get pods -n <namespace>`

2) `kubectl exec -it <pod name> ...`

This is less efficient and can be done in a more user friendly way.
 
**What this PR does **:

I would like to create a new flag that will allow fuzzy searching of some pod name and ssh/see logs easier.

I have added a new flag (--like, -l) into EXEC subcommand, on default the flag is false (to maintain regular behavior)

**For example,  :**

This is the result of` k get pods`

![image](https://user-images.githubusercontent.com/1224389/69786334-e619ce80-11c2-11ea-8d76-654fb3f1e94d.png)


We want to access a **foo-deployment** pod.

Then:
`kubectl exec -it --like foo sh`

The result of the command will present a table with all the pod's that matches the query 

![image](https://user-images.githubusercontent.com/1224389/69786507-401a9400-11c3-11ea-86d3-632cecca70f0.png)


**Special notes for your reviewer**:
I have added unit-tests for the new logic, please let me know if further modification are required  

**Does this PR introduce a user-facing change?**:
```release-note
kubectl/exec new flag: --like (off by default) allows for fuzzy search of pods and quick SSH access. Action required: upgrade kubectl 


kubectl exec -it --like foo sh
```

Thank you for taking the time and reviewing this PR.
