### PR TITLE
Add kind/deprecation to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,7 @@ https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-k
 > /kind api-change
 > /kind bug
 > /kind cleanup
+> /kind deprecation
 > /kind design
 > /kind documentation
 > /kind failing-test


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

With the merge of https://github.com/kubernetes/test-infra/pull/15040,
we're now able to use the kind/deprecation label for PRs as well. This
label will be consumed by the release notes generation tool.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```
