### PR TITLE
drop KUBE_TIMEOUT in test/cmd/kubeadm.sh

### DIFF
--- a/test/cmd/kubeadm.sh
+++ b/test/cmd/kubeadm.sh
@@ -28,12 +28,9 @@ run_kubeadm_tests() {
   # comment this out to save yourself from needlessly building here.
   make -C "${KUBE_ROOT}" WHAT=cmd/kubeadm
 
-  #TODO(runyontr): Remove the KUBE_TIMEOUT override when 
-  # kubernetes/kubeadm/issues/1430 is fixed
   make -C "${KUBE_ROOT}" test \
   WHAT=k8s.io/kubernetes/cmd/kubeadm/test/cmd \
-  KUBE_TEST_ARGS="--kubeadm-path '${KUBEADM_PATH}'" \
-  KUBE_TIMEOUT="--timeout=600s"
+  KUBE_TEST_ARGS="--kubeadm-path '${KUBEADM_PATH}'"
   set +o nounset
   set +o errexit
 }


### PR DESCRIPTION
As [runyontr remarked in test/cmd/kubeadm.sh](https://github.com/kubernetes/kubernetes/pull/74807/files#diff-aa7a425ed5ca1cb87690c2637abeb3e6): when https://github.com/kubernetes/kubeadm/issues/1430 is closed, the `KUBE_TIMEOUT` work-around can be removed.

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
It removes a workaround that apparently is not necessary any more.

**Special notes for your reviewer**:
I tried testing this locally, but `make test-cmd WHAT="kubeadm"` failed for me, for current `master` too. Maybe my local setup needs changes(?).