### PR TITLE
Ensure that file modes requested are respected for volume sources

### DIFF
--- a/pkg/volume/cephfs/cephfs.go
+++ b/pkg/volume/cephfs/cephfs.go
@@ -361,7 +361,7 @@ func (cephfsVolume *cephfs) execFuseMount(mountpoint string) error {
 		payload[fileName] = fileProjection
 
 		writerContext := fmt.Sprintf("cephfuse:%v.keyring", cephfsVolume.id)
-		writer, err := util.NewAtomicWriter(keyringPath, writerContext)
+		writer, err := util.NewAtomicWriter(keyringPath, writerContext, nil)
 		if err != nil {
 			klog.Errorf("failed to create atomic writer: %v", err)
 			return err

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -244,7 +244,7 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}()
 
 	writerContext := fmt.Sprintf("pod %v/%v volume %v", b.pod.Namespace, b.pod.Name, b.volName)
-	writer, err := volumeutil.NewAtomicWriter(dir, writerContext)
+	writer, err := volumeutil.NewAtomicWriter(dir, writerContext, mounterArgs.FsGroup)
 	if err != nil {
 		klog.Errorf("Error creating atomic writer: %v", err)
 		return err
@@ -256,11 +256,6 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 		return err
 	}
 
-	err = volume.SetVolumeOwnership(b, mounterArgs.FsGroup)
-	if err != nil {
-		klog.Errorf("Error applying volume ownership settings for group: %v", mounterArgs.FsGroup)
-		return err
-	}
 	setupSuccess = true
 	return nil
 }

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -215,7 +215,7 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 	}()
 
 	writerContext := fmt.Sprintf("pod %v/%v volume %v", b.pod.Namespace, b.pod.Name, b.volName)
-	writer, err := volumeutil.NewAtomicWriter(dir, writerContext)
+	writer, err := volumeutil.NewAtomicWriter(dir, writerContext, mounterArgs.FsGroup)
 	if err != nil {
 		klog.Errorf("Error creating atomic writer: %v", err)
 		return err
@@ -224,12 +224,6 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 	err = writer.Write(data)
 	if err != nil {
 		klog.Errorf("Error writing payload to dir: %v", err)
-		return err
-	}
-
-	err = volume.SetVolumeOwnership(b, mounterArgs.FsGroup)
-	if err != nil {
-		klog.Errorf("Error applying volume ownership settings for group: %v", mounterArgs.FsGroup)
 		return err
 	}
 

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -227,7 +227,7 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	}()
 
 	writerContext := fmt.Sprintf("pod %v/%v volume %v", s.pod.Namespace, s.pod.Name, s.volName)
-	writer, err := volumeutil.NewAtomicWriter(dir, writerContext)
+	writer, err := volumeutil.NewAtomicWriter(dir, writerContext, mounterArgs.FsGroup)
 	if err != nil {
 		klog.Errorf("Error creating atomic writer: %v", err)
 		return err
@@ -236,12 +236,6 @@ func (s *projectedVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 	err = writer.Write(data)
 	if err != nil {
 		klog.Errorf("Error writing payload to dir: %v", err)
-		return err
-	}
-
-	err = volume.SetVolumeOwnership(s, mounterArgs.FsGroup)
-	if err != nil {
-		klog.Errorf("Error applying volume ownership settings for group: %v", mounterArgs.FsGroup)
 		return err
 	}
 	setupSuccess = true

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -239,7 +239,7 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 	}()
 
 	writerContext := fmt.Sprintf("pod %v/%v volume %v", b.pod.Namespace, b.pod.Name, b.volName)
-	writer, err := volumeutil.NewAtomicWriter(dir, writerContext)
+	writer, err := volumeutil.NewAtomicWriter(dir, writerContext, mounterArgs.FsGroup)
 	if err != nil {
 		klog.Errorf("Error creating atomic writer: %v", err)
 		return err
@@ -251,11 +251,6 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 		return err
 	}
 
-	err = volume.SetVolumeOwnership(b, mounterArgs.FsGroup)
-	if err != nil {
-		klog.Errorf("Error applying volume ownership settings for group: %v", mounterArgs.FsGroup)
-		return err
-	}
 	setupSuccess = true
 	return nil
 }

--- a/pkg/volume/util/BUILD
+++ b/pkg/volume/util/BUILD
@@ -4,6 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "atomic_writer.go",
+        "atomic_writer_linux.go",
+        "atomic_writer_unsupported.go",
         "attach_limit.go",
         "device_util.go",
         "device_util_linux.go",

--- a/pkg/volume/util/atomic_writer_linux.go
+++ b/pkg/volume/util/atomic_writer_linux.go
@@ -1,0 +1,54 @@
+// +build linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"os"
+	"syscall"
+
+	"k8s.io/klog"
+)
+
+// chown changes the group that owns the given file.
+func (w *AtomicWriter) chown(file string) error {
+	stat, err := os.Stat(file)
+	if err != nil {
+		return err
+	}
+
+	sysStat, ok := stat.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+
+	user := int(sysStat.Uid)
+	group := int(sysStat.Gid)
+	if w.fsGroup != nil {
+		group = int(*w.fsGroup)
+	}
+
+	err = os.Chown(file, user, group)
+	if err != nil {
+		// Replicate the behaviour of `volume.SetVolumeOwnership` which ignores any failure to chown a file.
+		klog.Errorf("%s: error trying to chown %s to %d:%d: %v", w.logContext, file, user, group, err)
+		return nil
+	}
+
+	return nil
+}

--- a/pkg/volume/util/atomic_writer_test.go
+++ b/pkg/volume/util/atomic_writer_test.go
@@ -38,7 +38,7 @@ func TestNewAtomicWriter(t *testing.T) {
 	}
 	defer os.RemoveAll(targetDir)
 
-	_, err = NewAtomicWriter(targetDir, "-test-")
+	_, err = NewAtomicWriter(targetDir, "-test-", nil)
 	if err != nil {
 		t.Fatalf("unexpected error creating writer for existing target dir: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestNewAtomicWriter(t *testing.T) {
 		t.Fatalf("unexpected error ensuring dir %v does not exist: %v", nonExistentDir, err)
 	}
 
-	_, err = NewAtomicWriter(nonExistentDir, "-test-")
+	_, err = NewAtomicWriter(nonExistentDir, "-test-", nil)
 	if err == nil {
 		t.Fatalf("unexpected success creating writer for nonexistent target dir: %v", err)
 	}

--- a/pkg/volume/util/atomic_writer_unsupported.go
+++ b/pkg/volume/util/atomic_writer_unsupported.go
@@ -1,0 +1,23 @@
+// +build !linux
+
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+func (w *AtomicWriter) chown(file string) error {
+	return nil
+}

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -77,6 +77,14 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 		doConfigMapE2EWithoutMappings(f, true, 1001, nil)
 	})
 
+	ginkgo.It("should be consumable from pods in volume with FSGroup with file mode applied [LinuxOnly] [NodeFeature:FSGroup]", func() {
+		// Windows does not support RunAsUser / FSGroup SecurityContext options.
+		framework.SkipIfNodeOSDistroIs("windows")
+
+		mode := int32(0400)
+		doConfigMapE2EWithoutMappings(f, false, 1001, &mode)
+	})
+
 	/*
 		Release : v1.9
 		Testname: ConfigMap Volume, with mapping


### PR DESCRIPTION
Ensure that the file modes specified by `DefaultMode` or `Mode`in volume sources for ConfigMaps, Secrets, Projected, or Downward API rather than enforcing them to have at least `0440` permissions.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR ensures that the file mode requested by the user for files in volumes made from config maps, secrets, projected or downward api are what the user requests rather than being a superset of what was asked for.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #57923

**Special notes for your reviewer**:
All uses of `AtomicWriter.Write` - secrets, configmaps, downward apis, projections & cephfs - either specify a file mode directly, as with cephfs, or the default when the user specifies no modes (i.e. staging/src/k8s.io/api/core/v1/types/SecretVolumeSourceDefaultMode) are all 0644. Also, the behaviour of pkg/volume/SetVolumeOwnership for configmaps, downward apis & projections is to enforce that all files have at least 0440 permissions. This means that the only thing that `AtomicWriter` needs to take care of so the call to `SetVolumeOwnership` can be removed is to `chown` the relevant files & directories.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
