### PR TITLE
client-go/util/retry: Add "AlwaysRetry" retriable function

### DIFF
--- a/staging/src/k8s.io/client-go/util/retry/util.go
+++ b/staging/src/k8s.io/client-go/util/retry/util.go
@@ -42,6 +42,11 @@ var DefaultBackoff = wait.Backoff{
 	Jitter:   0.1,
 }
 
+// AlwaysRetry when passed to OnError, allows it to keep trying regardless of the error.
+func AlwaysRetry(err error) bool {
+	return true
+}
+
 // OnError allows the caller to retry fn in case the error returned by fn is retriable
 // according to the provided function. backoff defines the maximum retries and the wait
 // interval between two retries.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This enables the OnError call to keep trying until the limit is reached,
regardless of the error gotten. Errors can still be logged as they're
received on the OnError `fn`.

While small, it's a small enhancement so folks don't have to write the retriable every time.

**Does this PR introduce a user-facing change?**:
NONE
```release-note
Adds a AlwaysRetriable function which tells the OnError retry function to keep trying regardless of the error.
```
