### PR TITLE
Fix Azure VMSS instance ID parsing

### DIFF
--- a/pkg/cloudprovider/providers/azure/azure_vmss_test.go
+++ b/pkg/cloudprovider/providers/azure/azure_vmss_test.go
@@ -163,25 +163,32 @@ func TestGetScaleSetVMInstanceID(t *testing.T) {
 		machineName        string
 		expectError        bool
 		expectedInstanceID string
-	}{{
-		msg:         "invalid vmss instance name",
-		machineName: "vmvm",
-		expectError: true,
-	},
+	}{
+		{
+			msg:         "invalid vmss instance name",
+			machineName: "vmvm",
+			expectError: true,
+		},
 		{
 			msg:                "valid vmss instance name",
 			machineName:        "vm00000Z",
 			expectError:        false,
 			expectedInstanceID: "35",
 		},
+		{
+			msg:                "valid vmss instance name",
+			machineName:        "vm_13",
+			expectError:        false,
+			expectedInstanceID: "13",
+		},
 	}
 
 	for i, test := range tests {
 		instanceID, err := getScaleSetVMInstanceID(test.machineName)
 		if test.expectError {
-			assert.Error(t, err, fmt.Sprintf("TestCase[%d]: %s", i, test.msg))
+			assert.Error(t, err, fmt.Sprintf("TestCase[%d]: %s -> %s", i, test.msg, instanceID))
 		} else {
-			assert.Equal(t, test.expectedInstanceID, instanceID, fmt.Sprintf("TestCase[%d]: %s", i, test.msg))
+			assert.Equal(t, test.expectedInstanceID, instanceID, fmt.Sprintf("TestCase[%d]: %s -> %s", i, test.msg, instanceID))
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

It fixes errors when  the machine name does not use the expected format:

```
E1128 13:29:22.165430       1 attacher.go:276] failed to detach azure disk "/subscriptions/xxxxxxxxx/resourceGroups/prod-RG/providers/Microsoft.Compute/disks/prod-dynamic-pvc-50d28937-1031-11ea-803c-000d3a494d17", err failed to get azure instance id for node "prod-agentzone1-vmss_2" (not a vmss instance)
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix Azure VMSS instance ID parsing
```
