### PR TITLE
Automated cherry pick of #85687: fix: padded base64 encoded docker auth field

### DIFF
--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -287,8 +287,7 @@ func decodeDockerConfigFieldAuth(field string) (username, password string, err e
 
 	// StdEncoding can only decode padded string
 	// RawStdEncoding can only decode unpadded string
-	// a string is correctly padded if and only if its length is a multiple of 4
-	if (len(field) % 4) == 0 {
+	if strings.HasSuffix(strings.TrimSpace(field), "=") {
 		// decode padded data
 		decoded, err = base64.StdEncoding.DecodeString(field)
 	} else {

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -214,6 +214,13 @@ func TestDecodeDockerConfigFieldAuth(t *testing.T) {
 			password: "bar",
 		},
 
+		// some test as before but with new line characters
+		{
+			input:    "Zm9vOm\nJhcg==\n",
+			username: "foo",
+			password: "bar",
+		},
+
 		// standard encoding (with padding)
 		{
 			input:    base64.StdEncoding.EncodeToString([]byte("foo:bar")),
@@ -238,6 +245,12 @@ func TestDecodeDockerConfigFieldAuth(t *testing.T) {
 		// good base64 data, but no colon separating username & password
 		{
 			input: "cGFudHM=",
+			fail:  true,
+		},
+
+		// only new line characters are ignored
+		{
+			input: "Zm9vOmJhcg== ",
 			fail:  true,
 		},
 


### PR DESCRIPTION
Cherry pick of #85687 on release-1.17.

#85687: fix: padded base64 encoded docker auth field

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.