### PR TITLE
Optimize UpdateNodeInfoSnapshot

### DIFF
--- a/pkg/scheduler/nodeinfo/node_info.go
+++ b/pkg/scheduler/nodeinfo/node_info.go
@@ -548,11 +548,21 @@ func (n *NodeInfo) RemovePod(pod *v1.Pod) error {
 			n.UpdateUsedPorts(pod, false)
 
 			n.generation = nextGeneration()
-
+			n.resetSlicesIfEmpty()
 			return nil
 		}
 	}
 	return fmt.Errorf("no corresponding pod %s in pods of node %s", pod.Name, n.node.Name)
+}
+
+// resets the slices to nil so that we can do DeepEqual in unit tests.
+func (n *NodeInfo) resetSlicesIfEmpty() {
+	if len(n.podsWithAffinity) == 0 {
+		n.podsWithAffinity = nil
+	}
+	if len(n.pods) == 0 {
+		n.pods = nil
+	}
 }
 
 func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64) {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -62,7 +62,6 @@ var (
 	// emptyFramework is an empty framework used in tests.
 	// Note: If the test runs in goroutine, please don't use this variable to avoid a race condition.
 	emptyFramework, _ = framework.NewFramework(emptyPluginRegistry, nil, nil)
-	emptySnapshot     = nodeinfosnapshot.NewEmptySnapshot()
 )
 
 type fakeBinder struct {
@@ -652,7 +651,7 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 		predicates.EmptyMetadataProducer,
 		[]priorities.PriorityConfig{},
 		priorities.EmptyMetadataProducer,
-		emptySnapshot,
+		nodeinfosnapshot.NewEmptySnapshot(),
 		emptyFramework,
 		[]algorithm.SchedulerExtender{},
 		nil,
@@ -703,7 +702,7 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 		predicates.EmptyMetadataProducer,
 		[]priorities.PriorityConfig{},
 		priorities.EmptyMetadataProducer,
-		emptySnapshot,
+		nodeinfosnapshot.NewEmptySnapshot(),
 		emptyFramework,
 		[]algorithm.SchedulerExtender{},
 		nil,


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Optimizes UpdateNodeInfoSnapshot, which is invoked at the beginning of each scheduling cycle. Profiling 5k cluster benchmarks shows that UpdateNodeInfoSnapshot is one of the most significant overheads. 

Specifically, instead of creating the NodeInfoList every time we schedule a pod, we create it only when a node is added or deleted.

On a test with 5K nodes, 15k existing pods and scheduling 150k pods (which mimics the gce-5000 scalability test),  we get 1.7x performance improvement.

before
```
BenchmarkSchedulingV/5000Nodes/15000Pods-12               150000           8087332 ns/op

BenchmarkScheduling/5000Nodes/1000Pods-12           1000           2233893 ns/op
BenchmarkSchedulingPodAntiAffinity/5000Nodes/1000Pods-12                    1000           5557518 ns/op
BenchmarkSchedulingSecrets/5000Nodes/1000Pods-12                            1000           2441967 ns/op
BenchmarkSchedulingInTreePVs/5000Nodes/1000Pods-12                          1000           4666502 ns/op
BenchmarkSchedulingMigratedInTreePVs/5000Nodes/1000Pods-12                  1000           4144397 ns/op
BenchmarkSchedulingCSIPVs/5000Nodes/1000Pods-12                             1000           3531045 ns/op
BenchmarkSchedulingPodAffinity/5000Nodes/1000Pods-12                        1000           7063378 ns/op
BenchmarkSchedulingNodeAffinity/5000Nodes/1000Pods-12                       1000           3117295 ns/op
```


after:
```
BenchmarkSchedulingV/5000Nodes/15000Pods-12               150000           4717456 ns/op

BenchmarkScheduling/5000Nodes/1000Pods-12           1000           1675125 ns/op
BenchmarkSchedulingPodAntiAffinity/5000Nodes/1000Pods-12                    1000           4741884 ns/op
BenchmarkSchedulingSecrets/5000Nodes/1000Pods-12                            1000           1750429 ns/op
BenchmarkSchedulingInTreePVs/5000Nodes/1000Pods-12                          1000           3656064 ns/op
BenchmarkSchedulingMigratedInTreePVs/5000Nodes/1000Pods-12                  1000           3137824 ns/op
BenchmarkSchedulingCSIPVs/5000Nodes/1000Pods-12                             1000           2657050 ns/op
BenchmarkSchedulingPodAffinity/5000Nodes/1000Pods-12                        1000           6063679 ns/op
BenchmarkSchedulingNodeAffinity/5000Nodes/1000Pods-12                       1000           2366480 ns/op

```


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

This was a result of a joint investigation session with @liu-cong 

/cc @liu-cong 