### PR TITLE
OpenStack: Cloud provider: Allow to get AWS compatible metadata

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/metadata.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/metadata.go
@@ -39,8 +39,9 @@ const (
 	// It's a hardcoded IPv4 link-local address as documented in "OpenStack Cloud
 	// Administrator Guide", chapter Compute - Networking with nova-network.
 	//https://docs.openstack.org/nova/latest/admin/networking-nova.html#metadata-service
-	defaultMetadataVersion = "2012-08-10"
-	metadataURLTemplate    = "http://169.254.169.254/openstack/%s/meta_data.json"
+	defaultOpenStackMetadataVersion = "2016-06-30"
+	defaultEC2MetadataVersion       = "2009-04-04"
+	metadataURLTemplate             = "http://169.254.169.254/openstack/%s/meta_data.json"
 
 	// metadataID is used as an identifier on the metadata search order configuration.
 	metadataID = "metadataService"
@@ -48,11 +49,27 @@ const (
 	// Config drive is defined as an iso9660 or vfat (deprecated) drive
 	// with the "config-2" label.
 	//https://docs.openstack.org/nova/latest/user/config-drive.html
-	configDriveLabel        = "config-2"
-	configDrivePathTemplate = "openstack/%s/meta_data.json"
+	configDriveLabel          = "config-2"
+	openstackMetadataFileName = "meta_data.json"
+	ec2MetadataFileName       = "meta-data.json"
+	configDrivePathTemplate   = "%s/%s/%s"
 
 	// configDriveID is used as an identifier on the metadata search order configuration.
 	configDriveID = "configDrive"
+
+	openstackPlatform = "openstack"
+	ec2Plataform      = "ec2"
+
+	// Next URLs are used to get values from AWS compatible metadata service as a plain text.
+
+	// instanceTypeURLTemplate  contains url to get the instance type from metadata server.
+	instanceTypeURLTemplate = "http://169.254.169.254/%s/meta-data/instance-type"
+
+	// localAddressURLTemplate  contains url to get the instance local ip address from metadata server.
+	localAddressURLTemplate = "http://169.254.169.254/%s/meta-data/local-ipv4"
+
+	// publicAddressURLTemplate  contains url to get the instance public ip address from metadata server.
+	publicAddressURLTemplate = "http://169.254.169.254/%s/meta-data/public-ipv4"
 )
 
 // ErrBadMetadata is used to indicate a problem parsing data from metadata server
@@ -67,6 +84,13 @@ type DeviceMetadata struct {
 	// .. and other fields.
 }
 
+type ec2Metadata struct {
+	PublicIP     string `json:"public-ipv4"`
+	LocalIP      string `json:"local-ipv4"`
+	InstanceType string `json:"instance-type"`
+	// .. and other fields we don't care about.  Expand as necessary.
+}
+
 // Metadata has the information fetched from OpenStack metadata service or
 // config drives. Assumes the "2012-08-10" meta_data.json format.
 // See http://docs.openstack.org/user-guide/cli_config_drive.html
@@ -76,6 +100,10 @@ type Metadata struct {
 	AvailabilityZone string           `json:"availability_zone"`
 	Devices          []DeviceMetadata `json:"devices,omitempty"`
 	// .. and other fields we don't care about.  Expand as necessary.
+
+	// We have to use AWS compatible metadata for the next fields, because OpenStack doesn't
+	// provide this information.
+	ec2Metadata
 }
 
 // parseMetadata reads JSON from OpenStack metadata server and parses
@@ -98,11 +126,11 @@ func getMetadataURL(metadataVersion string) string {
 	return fmt.Sprintf(metadataURLTemplate, metadataVersion)
 }
 
-func getConfigDrivePath(metadataVersion string) string {
-	return fmt.Sprintf(configDrivePathTemplate, metadataVersion)
+func getConfigDrivePath(platform, metadataVersion, fileName string) string {
+	return fmt.Sprintf(configDrivePathTemplate, platform, metadataVersion, fileName)
 }
 
-func getMetadataFromConfigDrive(metadataVersion string) (*Metadata, error) {
+func getMetadataFromConfigDrive() (*Metadata, error) {
 	// Try to read instance UUID from config drive.
 	dev := "/dev/disk/by-label/" + configDriveLabel
 	if _, err := os.Stat(dev); os.IsNotExist(err) {
@@ -137,20 +165,42 @@ func getMetadataFromConfigDrive(metadataVersion string) (*Metadata, error) {
 
 	klog.V(4).Infof("Configdrive mounted on %s", mntdir)
 
-	configDrivePath := getConfigDrivePath(metadataVersion)
-	f, err := os.Open(
-		filepath.Join(mntdir, configDrivePath))
+	// Get OpenStack metadata
+	configDrivePath := getConfigDrivePath(openstackPlatform, defaultOpenStackMetadataVersion, openstackMetadataFileName)
+	openstackMetadataFile, err := os.Open(filepath.Join(mntdir, configDrivePath))
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s on config drive: %v", configDrivePath, err)
 	}
-	defer f.Close()
+	defer openstackMetadataFile.Close()
 
-	return parseMetadata(f)
+	metadata, err := parseMetadata(openstackMetadataFile)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing OpenStack metadata: %v", err)
+	}
+
+	// Get AWS compatible metadata
+	configDrivePath = getConfigDrivePath(ec2Plataform, defaultEC2MetadataVersion, ec2MetadataFileName)
+	ec2MetadataFile, err := os.Open(filepath.Join(mntdir, configDrivePath))
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s on config drive: %v", configDrivePath, err)
+	}
+	defer ec2MetadataFile.Close()
+
+	var ec2 ec2Metadata
+	json := json.NewDecoder(ec2MetadataFile)
+	if err := json.Decode(&ec2); err != nil {
+		return nil, fmt.Errorf("error parsing AWS compatible metadata: %v", err)
+	}
+
+	// Combine them together
+	metadata.ec2Metadata = ec2
+
+	return metadata, nil
 }
 
-func getMetadataFromMetadataService(metadataVersion string) (*Metadata, error) {
+func getMetadataFromMetadataService() (*Metadata, error) {
 	// Try to get JSON from metadata server.
-	metadataURL := getMetadataURL(metadataVersion)
+	metadataURL := getMetadataURL(defaultOpenStackMetadataVersion)
 	klog.V(4).Infof("Attempting to fetch metadata from %s", metadataURL)
 	resp, err := http.Get(metadataURL)
 	if err != nil {
@@ -163,7 +213,79 @@ func getMetadataFromMetadataService(metadataVersion string) (*Metadata, error) {
 		return nil, err
 	}
 
-	return parseMetadata(resp.Body)
+	// Get OpenStack metadata
+	metadata, err := parseMetadata(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing OpenStack metadata: %v", err)
+	}
+
+	// Get AWS compatible metadata
+	localAddressURL := fmt.Sprintf(localAddressURLTemplate, defaultEC2MetadataVersion)
+	localIP, err := getNodeAddress(localAddressURL)
+	if err != nil {
+		return nil, fmt.Errorf("error getting local ip address: %v", err)
+	}
+
+	publicAddressURL := fmt.Sprintf(publicAddressURLTemplate, defaultEC2MetadataVersion)
+	publicIP, err := getNodeAddress(publicAddressURL)
+	if err != nil {
+		return nil, fmt.Errorf("error getting public ip address: %v", err)
+	}
+
+	instanceTypeURL := fmt.Sprintf(instanceTypeURLTemplate, defaultEC2MetadataVersion)
+	instanceType, err := getIntanceType(instanceTypeURL)
+	if err != nil {
+		return nil, fmt.Errorf("error getting instance type: %v", err)
+	}
+
+	// Combine them together
+	metadata.ec2Metadata = ec2Metadata{
+		InstanceType: instanceType,
+		LocalIP:      localIP,
+		PublicIP:     publicIP,
+	}
+
+	return metadata, nil
+}
+
+func getIntanceType(instanceTypeURL string) (string, error) {
+	klog.V(4).Infof("Attempting to fetch instance type from %s", instanceTypeURL)
+	resp, err := http.Get(instanceTypeURL)
+	if err != nil {
+		return "", fmt.Errorf("error fetching %s: %v", instanceTypeURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("unexpected status code when reading instance type from %s: %s", instanceTypeURL, resp.Status)
+		return "", err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cannot read the response body %s: %v", instanceTypeURL, err)
+	}
+
+	return string(body), nil
+}
+
+func getNodeAddress(url string) (string, error) {
+	klog.V(4).Infof("Attempting to fetch instance address from %s", url)
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("error fetching %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		err = fmt.Errorf("unexpected status code when reading instance address from %s: %s", url, resp.Status)
+		return "", err
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("cannot read the response body %s: %v", url, err)
+	}
+
+	return string(body), nil
 }
 
 // Metadata is fixed for the current host, so cache the value process-wide
@@ -179,9 +301,9 @@ func getMetadata(order string) (*Metadata, error) {
 			id = strings.TrimSpace(id)
 			switch id {
 			case configDriveID:
-				md, err = getMetadataFromConfigDrive(defaultMetadataVersion)
+				md, err = getMetadataFromConfigDrive()
 			case metadataID:
-				md, err = getMetadataFromMetadataService(defaultMetadataVersion)
+				md, err = getMetadataFromMetadataService()
 			default:
 				err = fmt.Errorf("%s is not a valid metadata search order option. Supported options are %s and %s", id, configDriveID, metadataID)
 			}

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -105,11 +105,6 @@ const (
 	volumeInUseStatus     = "in-use"
 	volumeDeletedStatus   = "deleted"
 	volumeErrorStatus     = "error"
-
-	// On some environments, we need to query the metadata service in order
-	// to locate disks. We'll use the Newton version, which includes device
-	// metadata.
-	newtonMetadataVersion = "2016-06-30"
 )
 
 func (volumes *VolumesV1) createVolume(opts volumeCreateOpts) (string, string, error) {
@@ -515,11 +510,7 @@ func (os *OpenStack) getDevicePathFromInstanceMetadata(volumeID string) string {
 	// volumes, we're querying the metadata service. Note that the Hyper-V
 	// driver will include device metadata for untagged volumes as well.
 	//
-	// We're avoiding using cached metadata (or the configdrive),
-	// relying on the metadata service.
-	instanceMetadata, err := getMetadataFromMetadataService(
-		newtonMetadataVersion)
-
+	instanceMetadata, err := getMetadata(os.metadataOpts.SearchOrder)
 	if err != nil {
 		klog.V(4).Infof(
 			"Could not retrieve instance metadata. Error: %v", err)


### PR DESCRIPTION
This PR allows to read the instance type and node addresses from the metadata without making additional calls to Nova.
We can't obtain the values from OpenStack metadata, because they are not available there, and we have to use AWS compatible metadata for that.

/kind feature

```release-note
NONE
```