### PR TITLE
Replace deprecated grpc.WithDialer

### DIFF
--- a/pkg/kubelet/cm/devicemanager/endpoint.go
+++ b/pkg/kubelet/cm/devicemanager/endpoint.go
@@ -177,8 +177,8 @@ func dial(unixSocketPath string) (pluginapi.DevicePluginClient, *grpc.ClientConn
 	defer cancel()
 
 	c, err := grpc.DialContext(ctx, unixSocketPath, grpc.WithInsecure(), grpc.WithBlock(),
-		grpc.WithDialer(func(addr string, timeout time.Duration) (net.Conn, error) {
-			return net.DialTimeout("unix", addr, timeout)
+		grpc.WithContextDialer(func(ctx context.Context, addr string) (net.Conn, error) {
+			return net.DialUnix("unix", nil, &net.UnixAddr{Name: addr})
 		}),
 	)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
grpc.WithDialer is deprecated.

This PR replaces it using WithContextDialer.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
