### PR TITLE
Worker probe 80431

### DIFF
--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -17,10 +17,9 @@ limitations under the License.
 package prober
 
 import (
-	"math/rand"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/metrics"
 	"k8s.io/klog"
@@ -126,12 +125,10 @@ func newWorker(
 
 // run periodically probes the container.
 func (w *worker) run() {
+	initialDelayPeriod := time.Duration(w.spec.InitialDelaySeconds) * time.Second
+	time.Sleep(initialDelayPeriod)
+
 	probeTickerPeriod := time.Duration(w.spec.PeriodSeconds) * time.Second
-
-	// If kubelet restarted the probes could be started in rapid succession.
-	// Let the worker wait for a random portion of tickerPeriod before probing.
-	time.Sleep(time.Duration(rand.Float64() * float64(probeTickerPeriod)))
-
 	probeTicker := time.NewTicker(probeTickerPeriod)
 
 	defer func() {

--- a/pkg/kubelet/prober/worker.go
+++ b/pkg/kubelet/prober/worker.go
@@ -219,11 +219,6 @@ func (w *worker) doProbe() (keepGoing bool) {
 			w.pod.Spec.RestartPolicy != v1.RestartPolicyNever
 	}
 
-	// Probe disabled for InitialDelaySeconds.
-	if int32(time.Since(c.State.Running.StartedAt.Time).Seconds()) < w.spec.InitialDelaySeconds {
-		return true
-	}
-
 	if c.Started != nil && *c.Started {
 		// Stop probing for startup once container has started.
 		if w.probeType == startup {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Kubernetes users run into this bug when running “watch -n X kubectl describe pods”. They would see that, although the pod is running, the “Ready” status does not update from 0/1 to 1/1. Meaning that kubelet has not issued a probe although the pod is ready. Previously, the prober’s first probe timing was inconsistent, not using the “initialDelaySeconds” or “periodSeconds” of the pod probe specification properly. 

The probe relied on `time.Sleep(time.Duration(rand.Float64() * float64(probeTickerPeriod)))` with probeTickerPeriod coming from periodSeconds. This behavior originated from the idea that if kubelet restarted the probes could be started in rapid succession. Therefore the worker should wait a random period before probing.

The random call makes the probe times inconsistent and if periodSeconds is defined as a larger value the initial probe will take longer than expected. There are cases when this random call also causes the first probe to be outside of periodSeconds.

The status would eventually get updated, but not in an unknown timing window. This PR fixes this timing issue of the kubelet prober when adding a new pod to a worker node. This PR corrects this bug and guarantees that if someone specifies a “initialDelaySeconds” in their pod specification, the probe timing behaves as expected. By defining the time.Sleep by initialDelaySeconds instead of a random portion of the periodSeconds we are creating a consistent time for the probe to be issued. 

As reference to some of the data points taken from issue #80431 here are the timing results we had when the change was made.

Before:

| periodSeconds | initialDelaySeconds | first probe completes |
|---------------|---------------------|-----------------------|
| 120           | 15                  | 86                    |
| 120           | 15                  | 86                    |
| 180           | 15                  | 60                    |
| 180           | 15                  | 198                   |
| 180           | 15                  | 55                    |
| 240           | 15                  | 180                   |
| 240           | 15                  | 159                   |

After:


| periodSeconds | initialDelaySeconds | first probe completes |
|---------------|---------------------|-----------------------|
| 120           | 15                  | 15                    |
| 120           | 15                  | 15                    |
| 180           | 15                  | 15                    |
| 180           | 15                  | 15                    |
| 180           | 15                  | 15                    |
| 240           | 15                  | 15                    |
| 240           | 15                  | 15                    |

**Which issue(s) this PR fixes**:
Fixes #80431

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

