### PR TITLE
Be more agressive acquiring the iptables lock

### DIFF
--- a/pkg/util/iptables/iptables.go
+++ b/pkg/util/iptables/iptables.go
@@ -163,6 +163,9 @@ var RandomFullyMinVersion = utilversion.MustParseGeneric("1.6.2")
 // WaitMinVersion a minimum iptables versions supporting the -w and -w<seconds> flags
 var WaitMinVersion = utilversion.MustParseGeneric("1.4.20")
 
+// WaitIntervalMinVersion a minimum iptables versions supporting the wait interval useconds
+var WaitIntervalMinVersion = utilversion.MustParseGeneric("1.6.1")
+
 // WaitSecondsMinVersion a minimum iptables versions supporting the wait seconds
 var WaitSecondsMinVersion = utilversion.MustParseGeneric("1.4.22")
 
@@ -174,6 +177,12 @@ const WaitString = "-w"
 
 // WaitSecondsValue a constant for specifying the default wait seconds
 const WaitSecondsValue = "5"
+
+// WaitIntervalString a constant for specifying the wait interval flag
+const WaitIntervalString = "-W"
+
+// WaitIntervalUsecondsValue a constant for specifying the default wait interval useconds
+const WaitIntervalUsecondsValue = "100000"
 
 // LockfilePath16x is the iptables lock file acquired by any process that's making any change in the iptable rule
 const LockfilePath16x = "/run/xtables.lock"
@@ -638,6 +647,8 @@ func getIPTablesVersion(exec utilexec.Interface, protocol Protocol) (*utilversio
 // Checks if iptables version has a "wait" flag
 func getIPTablesWaitFlag(version *utilversion.Version) []string {
 	switch {
+	case version.AtLeast(WaitIntervalMinVersion):
+		return []string{WaitString, WaitSecondsValue, WaitIntervalString, WaitIntervalUsecondsValue}
 	case version.AtLeast(WaitSecondsMinVersion):
 		return []string{WaitString, WaitSecondsValue}
 	case version.AtLeast(WaitMinVersion):
@@ -650,7 +661,7 @@ func getIPTablesWaitFlag(version *utilversion.Version) []string {
 // Checks if iptables-restore has a "wait" flag
 func getIPTablesRestoreWaitFlag(version *utilversion.Version, exec utilexec.Interface, protocol Protocol) []string {
 	if version.AtLeast(WaitRestoreMinVersion) {
-		return []string{WaitString, WaitSecondsValue}
+		return []string{WaitString, WaitSecondsValue, WaitIntervalString, WaitIntervalUsecondsValue}
 	}
 
 	// Older versions may have backported features; if iptables-restore supports

--- a/pkg/util/iptables/monitor_test.go
+++ b/pkg/util/iptables/monitor_test.go
@@ -100,12 +100,12 @@ func (mfc *monitorFakeCmd) CombinedOutput() ([]byte, error) {
 		return []byte("iptables v1.6.2"), nil
 	}
 
-	if len(mfc.args) != 6 || mfc.args[0] != WaitString || mfc.args[1] != WaitSecondsValue || mfc.args[4] != "-t" {
+	if len(mfc.args) != 8 || mfc.args[0] != WaitString || mfc.args[1] != WaitSecondsValue || mfc.args[2] != WaitIntervalString || mfc.args[3] != WaitIntervalUsecondsValue || mfc.args[6] != "-t" {
 		panic(fmt.Sprintf("bad args %#v", mfc.args))
 	}
-	op := operation(mfc.args[2])
-	chainName := mfc.args[3]
-	tableName := mfc.args[5]
+	op := operation(mfc.args[4])
+	chainName := mfc.args[5]
+	tableName := mfc.args[7]
 
 	mfc.mfe.Lock()
 	defer mfc.mfe.Unlock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

if kube-proxy is not able to get the lock it means a maximum penalty of 35 sec, 5 secs waiting to get the lock and 30 secs to retry

```
2019-11-30T16:47:27.528166227Z stderr F I1130 16:47:27.526891       1 proxier.go:784] Sync failed; retrying in 30s
2019-11-30T16:47:32.576137313Z stderr F E1130 16:47:32.574934       1 proxier.go:792] Failed to ensure that filter chain KUBE-EXTERNAL-SERVICES exists: error creating chain "KUBE-EXTERNAL-SERVICES": exit status 4: Another app is currently holding the xtables lock. Stopped waiting after 5s.
```

Currently, kubernetes uses the iptables -w 5 option, waiting 5 seconds to acquire the lock

```
  --wait        -w [seconds]    maximum wait to acquire xtables lock before give up
  --wait-interval -W [usecs]    wait time to try to acquire xtables lock
                                interval to wait for xtables lock
                                default is 1 second

```
We can be more aggressive trying to acquire the lock using an smaller interval

We can reproduce this situation using flock to hold the lock

#### acquire the lock in iptables
```
exec 3> /run/xtables.lock
flock -x 3
```

#### observe iptables behaviour with -W = 100000
```
root@kind-worker:/# ip6tables -L -w 5 -W 100000
Another app is currently holding the xtables lock; still 4s 100000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 100000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 100000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 100000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 100000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock. Stopped waiting after 5s.

```
#### observe iptables behaviour with -W = 10000

```

root@kind-worker:/# ip6tables -L -w 5 -W 10000
Another app is currently holding the xtables lock; still 4s 910000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 810000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 710000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 610000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 510000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 410000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 310000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 210000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 110000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 4s 10000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 910000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 810000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 710000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 610000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 510000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 410000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 310000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 210000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 110000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 3s 10000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 910000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 810000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 710000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 610000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 510000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 410000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 310000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 210000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 110000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 2s 10000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 910000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 810000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 710000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 610000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 510000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 410000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 310000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 210000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 110000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 1s 10000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 910000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 810000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 710000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 610000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 510000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 410000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 310000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 210000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 110000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock; still 0s 10000us time ahead to have a chance to grab the lock...
Another app is currently holding the xtables lock. Stopped waiting after 5s.

```
#### remove the lock
`exec 3>&-`


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Seems this was the previous behaviour based on
https://github.com/kubernetes/kubernetes/blob/650c797d3faedcbd3ad60cad065cabf305bb49a1/pkg/util/iptables/iptables_linux.go#L74

and the one implemented for flushing the chains
https://github.com/kubernetes/kubernetes/blob/650c797d3faedcbd3ad60cad065cabf305bb49a1/pkg/util/iptables/iptables.go#L528-L533

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubernetes will try to acquire the iptables lock every 100 msec during 5 seconds instead of every second. This specially useful for environments using kube-proxy in iptables mode with a high churn rate of services.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
