### PR TITLE
Automated cherry pick of #85610: Bump Cluster Autoscaler version to 1.17.0

### DIFF
--- a/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
+++ b/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
@@ -6,6 +6,14 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
 rules:
   # leader election
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    resourceNames: ["cluster-autoscaler"]
+    verbs: ["get", "update", "patch", "delete"]
+  # TODO: remove in 1.18; CA uses lease objects for leader election since 1.17
   - apiGroups: [""]
     resources: ["endpoints"]
     verbs: ["create"]

--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.16.2",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.17.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Cherry pick of #85610 on release-1.17.

#85610: Bump Cluster Autoscaler version to 1.17.0

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.