### PR TITLE
Come out of loop after master role is determined

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1739,6 +1739,7 @@ func (c *Cloud) GetCandidateZonesForDynamicVolume() (sets.String, error) {
 			tagKey := aws.StringValue(tag.Key)
 			if awsTagNameMasterRoles.Has(tagKey) {
 				master = true
+				break
 			}
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In Cloud#GetCandidateZonesForDynamicVolume, when tagKey is found in awsTagNameMasterRoles, we can come out of the inner loop.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
