### PR TITLE
Use expect equal test e2e upgrades

### DIFF
--- a/test/e2e/upgrades/cassandra.go
+++ b/test/e2e/upgrades/cassandra.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -200,19 +199,19 @@ func (t *CassandraUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 	}, 10*time.Millisecond, done)
 	framework.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
 
-	gomega.Expect(lastUserCount >= t.successfulWrites).To(gomega.BeTrue())
+	framework.ExpectEqual(lastUserCount >= t.successfulWrites, true)
 	ratio := float64(success) / float64(success+failures)
 	framework.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
 	ratio = float64(t.successfulWrites) / float64(writeAttempts)
 	framework.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
 	framework.Logf("Errors: %v", errors)
 	// TODO(maisem): tweak this value once we have a few test runs.
-	gomega.Expect(ratio > 0.75).To(gomega.BeTrue())
+	framework.ExpectEqual(ratio > 0.75, true)
 }
 
 // Teardown does one final check of the data's availability.
 func (t *CassandraUpgradeTest) Teardown(f *framework.Framework) {
 	users, err := t.listUsers()
 	framework.ExpectNoError(err)
-	gomega.Expect(len(users) >= t.successfulWrites).To(gomega.BeTrue())
+	framework.ExpectEqual(len(users) >= t.successfulWrites, true)
 }

--- a/test/e2e/upgrades/etcd.go
+++ b/test/e2e/upgrades/etcd.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -188,19 +187,19 @@ func (t *EtcdUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, upg
 	}, 10*time.Millisecond, done)
 	framework.Logf("got %d users; want >=%d", lastUserCount, t.successfulWrites)
 
-	gomega.Expect(lastUserCount >= t.successfulWrites).To(gomega.BeTrue())
+	framework.ExpectEqual(lastUserCount >= t.successfulWrites, true)
 	ratio := float64(success) / float64(success+failures)
 	framework.Logf("Successful gets %d/%d=%v", success, success+failures, ratio)
 	ratio = float64(t.successfulWrites) / float64(writeAttempts)
 	framework.Logf("Successful writes %d/%d=%v", t.successfulWrites, writeAttempts, ratio)
 	framework.Logf("Errors: %v", errors)
 	// TODO(maisem): tweak this value once we have a few test runs.
-	gomega.Expect(ratio > 0.75).To(gomega.BeTrue())
+	framework.ExpectEqual(ratio > 0.75, true)
 }
 
 // Teardown does one final check of the data's availability.
 func (t *EtcdUpgradeTest) Teardown(f *framework.Framework) {
 	users, err := t.listUsers()
 	framework.ExpectNoError(err)
-	gomega.Expect(len(users) >= t.successfulWrites).To(gomega.BeTrue())
+	framework.ExpectEqual(len(users) >= t.successfulWrites, true)
 }

--- a/test/e2e/upgrades/mysql.go
+++ b/test/e2e/upgrades/mysql.go
@@ -26,7 +26,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/version"
@@ -168,7 +167,7 @@ func (t *MySQLUpgradeTest) Test(f *framework.Framework, done <-chan struct{}, up
 func (t *MySQLUpgradeTest) Teardown(f *framework.Framework) {
 	count, err := t.countNames()
 	framework.ExpectNoError(err)
-	gomega.Expect(count >= t.successfulWrites).To(gomega.BeTrue())
+	framework.ExpectEqual(count >= t.successfulWrites, true)
 }
 
 // addName adds a new value to the db.

--- a/test/e2e/upgrades/nvidia-gpu.go
+++ b/test/e2e/upgrades/nvidia-gpu.go
@@ -22,7 +22,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/scheduling"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 const (
@@ -54,7 +53,7 @@ func (t *NvidiaGPUUpgradeTest) Test(f *framework.Framework, done <-chan struct{}
 		// MasterUpgrade should be totally hitless.
 		job, err := jobutil.GetJob(f.ClientSet, f.Namespace.Name, "cuda-add")
 		framework.ExpectNoError(err)
-		gomega.Expect(job.Status.Failed).To(gomega.BeZero(), "Job pods failed during master upgrade: %v", job.Status.Failed)
+		framework.ExpectEqual(job.Status.Failed, 0, "Job pods failed during master upgrade: %v", job.Status.Failed)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
 
/kind cleanup
/priority backlog
/release-note-none
/cc @oomichi 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Ref: #79686

This makes e2e tests use the function under test/e2e/upgrades

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
 
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
