### PR TITLE
Change patchMergeKey from `port` to `name`.

### DIFF
--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -644,11 +644,10 @@ message Container {
   // accessible from the network.
   // Cannot be updated.
   // +optional
-  // +patchMergeKey=containerPort
+  // +patchMergeKey=name
   // +patchStrategy=merge
   // +listType=map
-  // +listMapKey=containerPort
-  // +listMapKey=protocol
+  // +listMapKey=name
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.
@@ -4619,11 +4618,10 @@ message ServiceProxyOptions {
 message ServiceSpec {
   // The list of ports that are exposed by this service.
   // More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
-  // +patchMergeKey=port
+  // +patchMergeKey=name
   // +patchStrategy=merge
   // +listType=map
-  // +listMapKey=port
-  // +listMapKey=protocol
+  // +listMapKey=name
   repeated ServicePort ports = 1;
 
   // Route service traffic to pods with label keys and values matching this

--- a/staging/src/k8s.io/api/core/v1/generated.proto
+++ b/staging/src/k8s.io/api/core/v1/generated.proto
@@ -644,10 +644,11 @@ message Container {
   // accessible from the network.
   // Cannot be updated.
   // +optional
-  // +patchMergeKey=name
+  // +patchMergeKey=containerPort
   // +patchStrategy=merge
   // +listType=map
-  // +listMapKey=name
+  // +listMapKey=containerPort
+  // +listMapKey=protocol
   repeated ContainerPort ports = 6;
 
   // List of sources to populate environment variables in the container.

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2148,11 +2148,12 @@ type Container struct {
 	// accessible from the network.
 	// Cannot be updated.
 	// +optional
-	// +patchMergeKey=name
+	// +patchMergeKey=containerPort
 	// +patchStrategy=merge
 	// +listType=map
-	// +listMapKey=name
-	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,6,rep,name=ports"`
+	// +listMapKey=containerPort
+	// +listMapKey=protocol
+	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
 	// will be reported as an event when the container is starting. When a key exists in multiple

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2148,12 +2148,11 @@ type Container struct {
 	// accessible from the network.
 	// Cannot be updated.
 	// +optional
-	// +patchMergeKey=containerPort
+	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +listType=map
-	// +listMapKey=containerPort
-	// +listMapKey=protocol
-	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"containerPort" protobuf:"bytes,6,rep,name=ports"`
+	// +listMapKey=name
+	Ports []ContainerPort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,6,rep,name=ports"`
 	// List of sources to populate environment variables in the container.
 	// The keys defined within a source must be a C_IDENTIFIER. All invalid keys
 	// will be reported as an event when the container is starting. When a key exists in multiple
@@ -3836,12 +3835,11 @@ const (
 type ServiceSpec struct {
 	// The list of ports that are exposed by this service.
 	// More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
-	// +patchMergeKey=port
+	// +patchMergeKey=name
 	// +patchStrategy=merge
 	// +listType=map
-	// +listMapKey=port
-	// +listMapKey=protocol
-	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"port" protobuf:"bytes,1,rep,name=ports"`
+	// +listMapKey=name
+	Ports []ServicePort `json:"ports,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,1,rep,name=ports"`
 
 	// Route service traffic to pods with label keys and values matching this
 	// selector. If empty or not present, the service is assumed to have an


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
By using kubectl cannot modify tcp port and dns port expectedly in kube-dns service if they have the same port (53).

For instance, the original kube-dns service is:
```
apiVersion: v1
kind: Service
metadata:
  name: kube-dns
  namespace: kube-system
spec:
  ports:
  - name: dns
    port: 53
    protocol: UDP
    targetPort: 53
  - name: dns-tcp
    port: 53
    protocol: TCP
    targetPort: 53
  selector:
    k8s-app: kube-dns
  sessionAffinity: None
  type: ClusterIP
```

We change both tcp and udp port from 53 to 1053 in yaml manifest:
```
apiVersion: v1
kind: Service
metadata:
  name: kube-dns
  namespace: kube-system
spec:
  ports:
  - name: dns
    port: 53
    protocol: UDP
    targetPort: 1053    # changed from 53
  - name: dns-tcp
    port: 53
    protocol: TCP
    targetPort: 1053    # changed from 53
  selector:
    k8s-app: kube-dns
  sessionAffinity: None
  type: ClusterIP
```

And then use kubectl to apply the changes:
```
kubectl -n kube-system apply -f kube-dns-service.yaml
```

Get the service again. The result shows that only udp targetPort, which is the first element in ports list has changed:
```
apiVersion: v1
kind: Service
metadata:
  name: kube-dns
  namespace: kube-system
spec:
  ports:
  - name: dns
    port: 53
    protocol: UDP
    targetPort: 1053    # only this field is changed to 1053
  - name: dns-tcp
    port: 53
    protocol: TCP
    targetPort: 53    # this field should change to 1053, too
  selector:
    k8s-app: kube-dns
  sessionAffinity: None
  type: ClusterIP
```

This would be reproduced on kubernetes 1.16.
```
kubectl version
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:18:23Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:09:08Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

By reading the kubernetes API (https://github.com/kubernetes/kubernetes/blob/f6337c762483e60e41dd775166afd536b130455e/staging/src/k8s.io/api/core/v1/types.go#L3844) and docs (https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/#notes-on-the-strategic-merge-patch), I found that the root cause is ports list using `port` field for patch merging. If this list has same ports (although different protocol), the patch result will be unexpected. 

Change the patchMergeKey to `name` may fix this issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Change patchMergeKey in service ports and container ports from `port` to `name`.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
