### PR TITLE
Remove unnecessary nil check in if statement in nodelease controller

### DIFF
--- a/pkg/kubelet/nodelease/controller.go
+++ b/pkg/kubelet/nodelease/controller.go
@@ -213,7 +213,7 @@ func (c *controller) newLease(base *coordinationv1.Lease) *coordinationv1.Lease 
 	// kubelet.nodeRef.UID. When lease is initially created, it is possible that
 	// the connection between master and node is not ready yet. So try to set
 	// owner reference every time when renewing the lease, until successful.
-	if lease.OwnerReferences == nil || len(lease.OwnerReferences) == 0 {
+	if len(lease.OwnerReferences) == 0 {
 		if node, err := c.client.CoreV1().Nodes().Get(c.holderIdentity, metav1.GetOptions{}); err == nil {
 			lease.OwnerReferences = []metav1.OwnerReference{
 				{


### PR DESCRIPTION
**What type of PR is this?**
Remove unnecessary judgment
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #


```
OwnerReferences []OwnerReferencematches 
so nil len(OwnerReferences) ==0 

change:
 if lease.OwnerReferences == nil || len(lease.OwnerReferences) == 0 ==>if len(lease.OwnerReferences) == 0 
```
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:



