### PR TITLE
fix: replace TrimLeft with TrimPrefix and TrimRight with TrimSuffix

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
+++ b/staging/src/k8s.io/apiserver/pkg/audit/policy/checker.go
@@ -185,11 +185,11 @@ func ruleMatchesResource(r *audit.PolicyRule, attrs authorizer.Attributes) bool 
 						return true
 					}
 					// match "*/subresource"
-					if len(subresource) > 0 && strings.HasPrefix(res, "*/") && subresource == strings.TrimLeft(res, "*/") {
+					if len(subresource) > 0 && strings.HasPrefix(res, "*/") && subresource == strings.TrimPrefix(res, "*/") {
 						return true
 					}
 					// match "resource/*"
-					if strings.HasSuffix(res, "/*") && resource == strings.TrimRight(res, "/*") {
+					if strings.HasSuffix(res, "/*") && resource == strings.TrimSuffix(res, "/*") {
 						return true
 					}
 				}


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In string based trim scenario, we shall always use string based TrimPrefix/TrimSuffix instead of char based TrimLeft/TrimRight.
See the diff here: https://play.golang.org/p/S7cBaoIxPQy

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
