### PR TITLE
fix: add space in front of url in command desc

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
+++ b/staging/src/k8s.io/kubectl/pkg/util/templates/markdown.go
@@ -133,6 +133,7 @@ func (r *ASCIIRenderer) Table(out *bytes.Buffer, header []byte, body []byte, col
 }
 
 func (r *ASCIIRenderer) Link(out *bytes.Buffer, link []byte, title []byte, content []byte) {
+	out.WriteString(" ")
 	r.fw(out, link)
 }
 


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When run command help in kubectl

```
# kubectl drain -h
Drain node in preparation for maintenance.

 The given node will be marked unschedulable to prevent new pods from arriving. 'drain' evicts the pods if the APIServer
supportshttp://kubernetes.io/docs/admin/disruptions/ . Otherwise, 
```

See the `supportshttp://kubernetes.io/docs` are bad formed, url should have space in front, like this:

```
Drain node in preparation for maintenance.

 The given node will be marked unschedulable to prevent new pods from arriving. 'drain' evicts the pods if the APIServer
supports http://kubernetes.io/docs/admin/disruptions/ . Otherwise, 
```

this pr fix this and here: https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#drain

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
