### PR TITLE
feat: make delete protection to namespace kube-node-lease

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -292,6 +292,8 @@ const (
 	NamespaceSystem string = "kube-system"
 	// NamespacePublic is the namespace where we place public info (ConfigMaps)
 	NamespacePublic string = "kube-public"
+	// NamespaceNodeLease is the namespace where we place node lease objects (used for node heartbeats)
+	NamespaceNodeLease = "kube-node-lease"
 )
 
 // OwnerReference contains enough information to let you identify an owning

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle/admission.go
@@ -54,7 +54,7 @@ const (
 // Register registers a plugin
 func Register(plugins *admission.Plugins) {
 	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
-		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic))
+		return NewLifecycle(sets.NewString(metav1.NamespaceDefault, metav1.NamespaceSystem, metav1.NamespacePublic, metav1.NamespaceNodeLease))
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Make delete protection to namespace `kube-node-lease`:

Namespace kube-system, default and kube-public already protected.
```
root@k8sn00:~# kubectl get ns
NAME              STATUS   AGE
default           Active   13d
ingress-nginx     Active   13d
kube-node-lease   Active   13d
kube-public       Active   13d
kube-system       Active   13d
monitoring        Active   13d
root@k8sn00:~# kubectl delete ns kube-system
Error from server (Forbidden): namespaces "kube-system" is forbidden: this namespace may not be deleted
root@k8sn00:~# kubectl delete ns default
Error from server (Forbidden): namespaces "default" is forbidden: this namespace may not be deleted
root@k8sn00:~# kubectl delete ns kube-public
Error from server (Forbidden): namespaces "kube-public" is forbidden: this namespace may not be deleted
```
We should alse protect `kube-node-lease` from deletion since if we delete it, the cluster become unstable, and later the namespace will be recreated.
```
root@k8sn00:~# kubectl delete ns kube-node-lease
namespace "kube-node-lease" deleted
root@k8sn00:~# kubectl get node -w
NAME     STATUS   ROLES    AGE   VERSION
k8sn00   Ready    master   13d   v1.15.4
k8sn01   Ready    <none>   13d   v1.15.4
k8sn02   Ready    <none>   13d   v1.15.4
k8sn01   NotReady   <none>   13d   v1.15.4
k8sn01   NotReady   <none>   13d   v1.15.4
k8sn00   NotReady   master   13d   v1.15.4
k8sn00   NotReady   master   13d   v1.15.4
k8sn02   NotReady   <none>   13d   v1.15.4
k8sn02   NotReady   <none>   13d   v1.15.4
k8sn01   NotReady   <none>   13d   v1.15.4
k8sn01   Ready      <none>   13d   v1.15.4
k8sn01   Ready      <none>   13d   v1.15.4
k8sn01   Ready      <none>   13d   v1.15.4
k8sn00   Ready      master   13d   v1.15.4
k8sn00   Ready      master   13d   v1.15.4
```
However, in some conditon, delete `kube-node-lease` where stuck in Terminating and the hole cluster will become unrecoverable at all.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Namespace `kube-node-lease` are not allowed to be deleted by user.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
