### PR TITLE
kubeadm: set cluster name on the controller manager

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -324,6 +324,11 @@ func getControllerManagerCommand(cfg *kubeadmapi.ClusterConfiguration) []string 
 		}
 	}
 
+	// Set cluster name
+	if cfg.ClusterName != "" {
+		defaultArguments["cluster-name"] = cfg.ClusterName
+	}
+
 	// TODO: The following code should be remvoved after dual-stack is GA.
 	// Note: The user still retains the ability to explicitly set feature-gates and that value will overwrite this base value.
 	enabled, present := cfg.FeatureGates[features.IPv6DualStack]

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -580,6 +580,31 @@ func TestGetControllerManagerCommand(t *testing.T) {
 		expected []string
 	}{
 		{
+			name: "custom cluster name for " + cpVersion,
+			cfg: &kubeadmapi.ClusterConfiguration{
+				KubernetesVersion: cpVersion,
+				CertificatesDir:   testCertsDir,
+				ClusterName:       "some-other-cluster-name",
+			},
+			expected: []string{
+				"kube-controller-manager",
+				"--bind-address=127.0.0.1",
+				"--leader-elect=true",
+				"--kubeconfig=" + kubeadmconstants.KubernetesDir + "/controller-manager.conf",
+				"--root-ca-file=" + testCertsDir + "/ca.crt",
+				"--service-account-private-key-file=" + testCertsDir + "/sa.key",
+				"--cluster-signing-cert-file=" + testCertsDir + "/ca.crt",
+				"--cluster-signing-key-file=" + testCertsDir + "/ca.key",
+				"--use-service-account-credentials=true",
+				"--controllers=*,bootstrapsigner,tokencleaner",
+				"--authentication-kubeconfig=" + kubeadmconstants.KubernetesDir + "/controller-manager.conf",
+				"--authorization-kubeconfig=" + kubeadmconstants.KubernetesDir + "/controller-manager.conf",
+				"--client-ca-file=" + testCertsDir + "/ca.crt",
+				"--requestheader-client-ca-file=" + testCertsDir + "/front-proxy-ca.crt",
+				"--cluster-name=some-other-cluster-name",
+			},
+		},
+		{
 			name: "custom certs dir for " + cpVersion,
 			cfg: &kubeadmapi.ClusterConfiguration{
 				CertificatesDir:   testCertsDir,


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
On kubeadm's configuration it's possible to set up the cluster
name. Forward this information to the controller manager's
`--cluster-name` argument.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubeadm/issues/1951

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: Forward cluster name to the controller-manager arguments
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews 