### PR TITLE
Partial cherry pick of #85396: Move hostdns.conf out of CNI config directory.

### DIFF
--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -873,7 +873,7 @@ function construct-windows-kubelet-flags {
   flags+=" --logtostderr=false"
 
   # Configure the file path for host dns configuration
-  flags+=" --resolv-conf=${WINDOWS_CNI_CONFIG_DIR}\hostdns.conf"
+  flags+=" --resolv-conf=${WINDOWS_CNI_DIR}\hostdns.conf"
 
   # Both --cgroups-per-qos and --enforce-node-allocatable should be disabled on
   # windows; the latter requires the former to be enabled to work.

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -990,7 +990,9 @@ function Configure-HostDnsConf {
 	$conf = $conf + "nameserver $ip`r`n"
   }
   $conf = $conf + "search $search_list"
-  $hostdns_conf = "${env:CNI_CONFIG_DIR}\hostdns.conf"
+  # Do not put hostdns.conf into the CNI config directory so as to
+  # avoid the container runtime treating it as CNI config.
+  $hostdns_conf = "${env:CNI_DIR}\hostdns.conf"
   New-Item -Force -ItemType file ${hostdns_conf} | Out-Null
   Set-Content ${hostdns_conf} $conf
   Log-Output "HOST dns conf:`n$(Get-Content -Raw ${hostdns_conf})"


### PR DESCRIPTION
Partial cherry pick of #85396 on release-1.17.

#85396: Move hostdns.conf out of CNI config directory.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fix hostdns.conf parsing error in kubelet log on GCE windows node.
```