### PR TITLE
Remove unreferenced DryRun field

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -54,9 +54,6 @@ type Helper struct {
 	Out                 io.Writer
 	ErrOut              io.Writer
 
-	// TODO(justinsb): unnecessary?
-	DryRun bool
-
 	// OnPodDeletedOrEvicted is called when a pod is evicted/deleted; for printing progress output
 	OnPodDeletedOrEvicted func(pod *corev1.Pod, usingEviction bool)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The DryRun field of Helper is not used anywhere.
This PR removes the field.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
