### PR TITLE
Replace the hostname in the fluentd config file even if the file exists

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1525,15 +1525,12 @@ function Install-LoggingAgent {
 function Configure-LoggingAgent {
   $fluentd_config_dir = "$STACKDRIVER_ROOT\LoggingAgent\config.d"
   $fluentd_config_file = "$fluentd_config_dir\k8s_containers.conf"
-  if (-not (ShouldWrite-File $fluentd_config_file)) {
-    Log-Output ("Skip: fluentd logging config $fluentd_config_file already " +
-                "exists")
-  } else {
-     # Create a configuration file for kubernetes containers.
-     # The config.d directory should have already been created automatically, but
-     # try creating again just in case.
-     New-Item $fluentd_config_dir -ItemType 'directory' -Force | Out-Null
-  }
+  
+  # Create a configuration file for kubernetes containers.
+  # The config.d directory should have already been created automatically, but
+  # try creating again just in case.
+  New-Item $fluentd_config_dir -ItemType 'directory' -Force | Out-Null
+  
   $config = $FLUENTD_CONFIG.replace('NODE_NAME', (hostname))
   $config | Out-File -FilePath $fluentd_config_file -Encoding ASCII
   Log-Output "Wrote fluentd logging config to $fluentd_config_file"

--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1528,13 +1528,12 @@ function Configure-LoggingAgent {
   if (-not (ShouldWrite-File $fluentd_config_file)) {
     Log-Output ("Skip: fluentd logging config $fluentd_config_file already " +
                 "exists")
-    return
+  } else {
+     # Create a configuration file for kubernetes containers.
+     # The config.d directory should have already been created automatically, but
+     # try creating again just in case.
+     New-Item $fluentd_config_dir -ItemType 'directory' -Force | Out-Null
   }
-
-  # Create a configuration file for kubernetes containers.
-  # The config.d directory should have already been created automatically, but
-  # try creating again just in case.
-  New-Item $fluentd_config_dir -ItemType 'directory' -Force | Out-Null
   $config = $FLUENTD_CONFIG.replace('NODE_NAME', (hostname))
   $config | Out-File -FilePath $fluentd_config_file -Encoding ASCII
   Log-Output "Wrote fluentd logging config to $fluentd_config_file"


### PR DESCRIPTION
Startup script did not replace the hostname when the image come preinstalled with stackdriver agent (config file exists). This caused the wrong hostname (hostname at buildtime) to show up in the stackdriver logs.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
This PR fixes stackdriver config to have the correct hostname.

**Which issue(s) this PR fixes:**

**Special notes for your reviewer:**

**Does this PR introduce a user-facing change?:**
No