### PR TITLE
Automated cherry pick of #82678: skip e2e tests that run on multi node cluster and require

### DIFF
--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -86,7 +86,7 @@ var _ testsuites.SnapshottableTestDriver = &hostpathCSIDriver{}
 func InitHostPathCSIDriver() testsuites.TestDriver {
 	return initHostPathCSIDriver("csi-hostpath",
 		map[testsuites.Capability]bool{testsuites.CapPersistence: true, testsuites.CapDataSource: true,
-			testsuites.CapMultiPODs: true, testsuites.CapBlock: true},
+			testsuites.CapMultiPODs: true, testsuites.CapBlock: true, testsuites.CapSingleNodeVolume: true},
 		"test/e2e/testing-manifests/storage-csi/driver-registrar/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-attacher/rbac.yaml",
 		"test/e2e/testing-manifests/storage-csi/external-provisioner/rbac.yaml",

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -696,7 +696,8 @@ func InitHostPathDriver() testsuites.TestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapPersistence: true,
+				testsuites.CapPersistence:      true,
+				testsuites.CapSingleNodeVolume: true,
 			},
 		},
 	}
@@ -769,7 +770,8 @@ func InitHostPathSymlinkDriver() testsuites.TestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapPersistence: true,
+				testsuites.CapPersistence:      true,
+				testsuites.CapSingleNodeVolume: true,
 			},
 		},
 	}
@@ -910,7 +912,8 @@ func InitEmptydirDriver() testsuites.TestDriver {
 				"", // Default fsType
 			),
 			Capabilities: map[testsuites.Capability]bool{
-				testsuites.CapExec: true,
+				testsuites.CapExec:             true,
+				testsuites.CapSingleNodeVolume: true,
 			},
 		},
 	}
@@ -1619,17 +1622,19 @@ type localVolume struct {
 var (
 	// capabilities
 	defaultLocalVolumeCapabilities = map[testsuites.Capability]bool{
-		testsuites.CapPersistence: true,
-		testsuites.CapFsGroup:     true,
-		testsuites.CapBlock:       false,
-		testsuites.CapExec:        true,
+		testsuites.CapPersistence:      true,
+		testsuites.CapFsGroup:          true,
+		testsuites.CapBlock:            false,
+		testsuites.CapExec:             true,
+		testsuites.CapSingleNodeVolume: true,
 	}
 	localVolumeCapabitilies = map[utils.LocalVolumeType]map[testsuites.Capability]bool{
 		utils.LocalVolumeBlock: {
-			testsuites.CapPersistence: true,
-			testsuites.CapFsGroup:     true,
-			testsuites.CapBlock:       true,
-			testsuites.CapExec:        true,
+			testsuites.CapPersistence:      true,
+			testsuites.CapFsGroup:          true,
+			testsuites.CapBlock:            true,
+			testsuites.CapExec:             true,
+			testsuites.CapSingleNodeVolume: true,
 		},
 	}
 	// fstype

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -156,6 +156,9 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		defer cleanup()
 
 		// Check different-node test requirement
+		if l.driver.GetDriverInfo().Capabilities[CapSingleNodeVolume] {
+			framework.Skipf("Driver %s only supports %v -- skipping", l.driver.GetDriverInfo().Name, CapSingleNodeVolume)
+		}
 		nodes := framework.GetReadySchedulableNodesOrDie(l.cs)
 		if len(nodes.Items) < 2 {
 			framework.Skipf("Number of available nodes is less than 2 - skipping")
@@ -236,6 +239,9 @@ func (t *multiVolumeTestSuite) defineTests(driver TestDriver, pattern testpatter
 		defer cleanup()
 
 		// Check different-node test requirement
+		if l.driver.GetDriverInfo().Capabilities[CapSingleNodeVolume] {
+			framework.Skipf("Driver %s only supports %v -- skipping", l.driver.GetDriverInfo().Name, CapSingleNodeVolume)
+		}
 		nodes := framework.GetReadySchedulableNodesOrDie(l.cs)
 		if len(nodes.Items) < 2 {
 			framework.Skipf("Number of available nodes is less than 2 - skipping")

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -187,6 +187,10 @@ func (p *provisioningTestSuite) defineTests(driver TestDriver, pattern testpatte
 			framework.Skipf("Driver %q only supports testing on one node - skipping", dInfo.Name)
 		}
 
+		if dInfo.Capabilities[CapSingleNodeVolume] {
+			framework.Skipf("Driver %q only supports testing on one node - skipping", dInfo.Name)
+		}
+
 		// Ensure that we actually have more than one node.
 		nodes := framework.GetReadySchedulableNodesOrDie(l.cs)
 		if len(nodes.Items) <= 1 {

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -17,7 +17,7 @@ limitations under the License.
 package testsuites
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -126,7 +126,8 @@ const (
 	// - NodeStageVolume in the spec
 	CapMultiPODs Capability = "multipods"
 
-	CapRWX Capability = "RWX" // support ReadWriteMany access modes
+	CapRWX              Capability = "RWX"              // support ReadWriteMany access modes
+	CapSingleNodeVolume Capability = "singleNodeVolume" // support volume that can run on single node (like hostpath)
 )
 
 // DriverInfo represents static information about a TestDriver.


### PR DESCRIPTION
Cherry pick of #82678 on release-1.15.

#82678: skip e2e tests that run on multi node cluster and require

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.