### PR TITLE
Add instructions about how to bring up e2e test cluster

### DIFF
--- a/cluster/gce/windows/README-GCE-Windows-kube-up.md
+++ b/cluster/gce/windows/README-GCE-Windows-kube-up.md
@@ -78,9 +78,9 @@ export KUBERNETES_NODE_PLATFORM=windows
 export LOGGING_STACKDRIVER_RESOURCE_TYPES=new
 ```
 
-Now bring up a cluster using kube-up script:
+Now bring up a cluster using one of the following two methods:
 
-#### 2. Create a regular Kubernetes cluster
+#### 2a. Create a regular Kubernetes cluster
 
 ```
 # Invoke kube-up.sh with these environment variables:
@@ -94,6 +94,44 @@ To teardown the cluster run:
 ```
 PROJECT=${CLOUDSDK_CORE_PROJECT} KUBERNETES_SKIP_CONFIRM=y ./cluster/kube-down.sh
 ```
+
+#### 2b. Create a Kubernetes end-to-end (E2E) test cluster	
+
+Install or update `kubetest` as follows:
+```
+go get -u k8s.io/test-infra/kubetest
+```
+*   If you see the error below, it's due to `github.com/Azure/go-autorest` dependencies are incompatible between different versions of go modules: 
+
+    ```
+    build k8s.io/test-infra/kubetest: cannot load github.com/Azure/go-autorest/autorest: ambiguous import: found github.com/Azure/go-autorest/autorest in multiple modules:
+            github.com/Azure/go-autorest v11.1.2+incompatible (/usr/local/google/home/yluu/go/pkg/mod/github.com/!azure/go-autorest@v11.1.2+incompatible/autorest)
+            github.com/Azure/go-autorest/autorest v0.9.0 (/usr/local/google/home/yluu/go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.9.0)
+    ```
+
+    Add `github.com/Azure/go-autorest v12.2.0+incompatible` into require block of `go.mod` and try again.
+
+If you have built your own release binaries following step 1, run the following	
+command:	
+```	
+PROJECT=${CLOUDSDK_CORE_PROJECT} $GOPATH/bin/kubetest --up	
+```	
+
+Otherwise, you can specify what branch from which to get the release artifacts:	
+```	
+# Get the latest build from the stable1 branch	
+PROJECT=${CLOUDSDK_CORE_PROJECT} $GOPATH/bin/kubetest --up --extract=ci/k8s-stable1	
+# Or Get the latest build from master	
+PROJECT=${CLOUDSDK_CORE_PROJECT} $GOPATH/bin/kubetest --up --extract=ci-cross/latest	
+```
+
+This command, by default, tears down any existing E2E cluster and creates a new	
+one. To teardown the cluster run the same command with `--down` instead of	
+`--up`.	
+
+No matter what type of cluster you chose to create, the result should be a	
+Kubernetes cluster with one Linux master node, `NUM_NODES` Linux worker nodes	
+and `NUM_WINDOWS_NODES` Windows worker nodes.	
 
 ## Validating the cluster
 

--- a/cluster/gce/windows/README-GCE-Windows-kube-up.md
+++ b/cluster/gce/windows/README-GCE-Windows-kube-up.md
@@ -56,9 +56,8 @@ make quick-release
 
 ### 2. Create a Kubernetes cluster
 
-You can create a regular Kubernetes cluster or an end-to-end test cluster.
-End-to-end test clusters support running the Kubernetes e2e tests and enable
-some debugging features such as SSH access on the Windows nodes.
+You can create a regular Kubernetes cluster or an end-to-end test cluster.<br />
+Only end-to-end test clusters support running the Kubernetes e2e tests (as both [e2e cluster creation](https://github.com/kubernetes/kubernetes/blob/b632eaddbaad9dc1430d214d506b72750bbb9f69/hack/e2e-internal/e2e-up.sh#L24) and [e2e test scripts](https://github.com/kubernetes/kubernetes/blob/b632eaddbaad9dc1430d214d506b72750bbb9f69/hack/ginkgo-e2e.sh#L42) are setup based on `cluster/gce/config-test.sh`), also enables some debugging features such as SSH access on the Windows nodes. 
 
 Please make sure you set the environment variables properly following the
 instructions in the previous section.
@@ -96,38 +95,16 @@ PROJECT=${CLOUDSDK_CORE_PROJECT} KUBERNETES_SKIP_CONFIRM=y ./cluster/kube-down.s
 ```
 
 #### 2b. Create a Kubernetes end-to-end (E2E) test cluster	
-
-Install or update `kubetest` as follows:
-```
-go get -u k8s.io/test-infra/kubetest
-```
-*   If you see the error below, it's due to `github.com/Azure/go-autorest` dependencies are incompatible between different versions of go modules: 
-
-    ```
-    build k8s.io/test-infra/kubetest: cannot load github.com/Azure/go-autorest/autorest: ambiguous import: found github.com/Azure/go-autorest/autorest in multiple modules:
-            github.com/Azure/go-autorest v11.1.2+incompatible (/usr/local/google/home/yluu/go/pkg/mod/github.com/!azure/go-autorest@v11.1.2+incompatible/autorest)
-            github.com/Azure/go-autorest/autorest v0.9.0 (/usr/local/google/home/yluu/go/pkg/mod/github.com/!azure/go-autorest/autorest@v0.9.0)
-    ```
-
-    Add `github.com/Azure/go-autorest v12.2.0+incompatible` into require block of `go.mod` and try again.
-
 If you have built your own release binaries following step 1, run the following	
 command:	
 ```	
-PROJECT=${CLOUDSDK_CORE_PROJECT} $GOPATH/bin/kubetest --up	
+PROJECT=${CLOUDSDK_CORE_PROJECT} ./hack/e2e-internal/e2e-up.sh	
 ```	
 
-Otherwise, you can specify what branch from which to get the release artifacts:	
+If any e2e cluster exists already, this command will prompt you whether tears down and creates a new	one. To teardown existing e2e cluster only, run the command:
 ```	
-# Get the latest build from the stable1 branch	
-PROJECT=${CLOUDSDK_CORE_PROJECT} $GOPATH/bin/kubetest --up --extract=ci/k8s-stable1	
-# Or Get the latest build from master	
-PROJECT=${CLOUDSDK_CORE_PROJECT} $GOPATH/bin/kubetest --up --extract=ci-cross/latest	
-```
-
-This command, by default, tears down any existing E2E cluster and creates a new	
-one. To teardown the cluster run the same command with `--down` instead of	
-`--up`.	
+PROJECT=${CLOUDSDK_CORE_PROJECT} ./hack/e2e-internal/e2e-down.sh	
+```	
 
 No matter what type of cluster you chose to create, the result should be a	
 Kubernetes cluster with one Linux master node, `NUM_NODES` Linux worker nodes	


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind documentation

**What this PR does / why we need it**:
Add instructions about how to bring up e2e test cluster.  `./cluster/kube-up.sh` can bring up a cluster but not work with e2e test script, instead `./hack/e2e-internal/e2e-up.sh` works. kubetest also works, but due to some go module incompatible issues in kubetest, need to do some walkaround to update kubetest binary. Although kubetest can extract different versions of k8s binaries, but for local test, it seems not necessary. So `./hack/e2e-internal/e2e-up.sh` should be the best way.

**Special notes for your reviewer**:
Some discussions about build kubetest: 
https://github.com/Azure/go-autorest/issues/414
https://github.com/Azure/go-autorest/issues/481

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add instructions about how to bring up e2e test cluster
```
