### PR TITLE
optimize some log config

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
+++ b/cluster/addons/fluentd-elasticsearch/es-statefulset.yaml
@@ -86,6 +86,16 @@ spec:
         - containerPort: 9300
           name: transport
           protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: transport
+          initialDelaySeconds: 5
+          timeoutSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: transport
+          initialDelaySeconds: 5
+          timeoutSeconds: 10
         volumeMounts:
         - name: elasticsearch-logging
           mountPath: /data

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
@@ -473,7 +473,7 @@ data:
         retry_forever
         retry_max_interval 30
         chunk_limit_size 2M
-        total_limit_size 2G
+        total_limit_size 500M
         overflow_action block
       </buffer>
     </match>

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-configmap.yaml
@@ -473,7 +473,7 @@ data:
         retry_forever
         retry_max_interval 30
         chunk_limit_size 2M
-        queue_limit_length 8
+        total_limit_size 2G
         overflow_action block
       </buffer>
     </match>

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-ds.yaml
@@ -89,6 +89,20 @@ spec:
           readOnly: true
         - name: config-volume
           mountPath: /etc/fluent/config.d
+        ports:
+        - containerPort: 24231
+          name: prometheus
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: prometheus
+          initialDelaySeconds: 5
+          timeoutSeconds: 10
+        readinessProbe:
+          tcpSocket:
+            port: prometheus
+          initialDelaySeconds: 5
+          timeoutSeconds: 10
       terminationGracePeriodSeconds: 30
       volumes:
       - name: varlog


### PR DESCRIPTION
/kind bug
I commit some changes about log and monitor, now monitor has been removed from kubernetes, but log config is saved, So I commit some bug for log config like elasticsearch and fluentd #85195
