### PR TITLE
Provide a mechanism to enable hidden metrics in stable collector

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/collector.go
+++ b/staging/src/k8s.io/component-base/metrics/collector.go
@@ -38,6 +38,9 @@ type StableCollector interface {
 	// Create will initialize all Desc and it intends to be called by registry.
 	Create(version *semver.Version, self StableCollector) bool
 
+	// ClearState will clear all the states marked by Create.
+	ClearState()
+
 	// HiddenMetrics tells the list of hidden metrics with fqName.
 	HiddenMetrics() []string
 }
@@ -160,6 +163,18 @@ func (bsc *BaseStableCollector) Create(version *semver.Version, self StableColle
 	}
 
 	return false
+}
+
+// ClearState will clear all the states marked by Create.
+// It intends to be used for re-register a hidden metric.
+func (bsc *BaseStableCollector) ClearState() {
+	for _, d := range bsc.descriptors {
+		d.ClearState()
+	}
+
+	bsc.descriptors = nil
+	bsc.registrable = nil
+	bsc.hidden = nil
 }
 
 // HiddenMetrics tells the list of hidden metrics with fqName.

--- a/staging/src/k8s.io/component-base/metrics/collector.go
+++ b/staging/src/k8s.io/component-base/metrics/collector.go
@@ -37,6 +37,9 @@ type StableCollector interface {
 
 	// Create will initialize all Desc and it intends to be called by registry.
 	Create(version *semver.Version, self StableCollector) bool
+
+	// HiddenMetrics tells the list of hidden metrics with fqName.
+	HiddenMetrics() []string
 }
 
 // BaseStableCollector which implements almost all of the methods defined by StableCollector
@@ -157,6 +160,14 @@ func (bsc *BaseStableCollector) Create(version *semver.Version, self StableColle
 	}
 
 	return false
+}
+
+// HiddenMetrics tells the list of hidden metrics with fqName.
+func (bsc *BaseStableCollector) HiddenMetrics() (fqNames []string) {
+	for i := range bsc.hidden {
+		fqNames = append(fqNames, bsc.hidden[i].fqName)
+	}
+	return
 }
 
 // Check if our BaseStableCollector implements necessary interface

--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -83,6 +83,7 @@ func SetShowHidden() {
 		// re-register collectors that has been hidden in phase of last registry.
 		for _, r := range registries {
 			r.enableHiddenCollectors()
+			r.enableHiddenStableCollectors()
 		}
 	})
 }
@@ -120,7 +121,7 @@ type KubeRegistry interface {
 	CustomMustRegister(cs ...StableCollector)
 	Register(Registerable) error
 	MustRegister(...Registerable)
-	Unregister(Registerable) bool
+	Unregister(collector Collector) bool
 	Gather() ([]*dto.MetricFamily, error)
 }
 
@@ -216,7 +217,7 @@ func (kr *kubeRegistry) RawMustRegister(cs ...prometheus.Collector) {
 // returns whether a Collector was unregistered. Note that an unchecked
 // Collector cannot be unregistered (as its Describe method does not
 // yield any descriptor).
-func (kr *kubeRegistry) Unregister(collector Registerable) bool {
+func (kr *kubeRegistry) Unregister(collector Collector) bool {
 	return kr.PromRegistry.Unregister(collector)
 }
 
@@ -249,14 +250,44 @@ func (kr *kubeRegistry) trackStableCollectors(cs ...StableCollector) {
 
 // enableHiddenCollectors will re-register all of the hidden collectors.
 func (kr *kubeRegistry) enableHiddenCollectors() {
+	if len(kr.hiddenCollectors) == 0 {
+		return
+	}
+
 	kr.hiddenCollectorsLock.Lock()
-	defer kr.hiddenCollectorsLock.Unlock()
+	cs := make([]Registerable, 0, len(kr.hiddenCollectors))
 
 	for _, c := range kr.hiddenCollectors {
 		c.ClearState()
-		kr.MustRegister(c)
+		cs = append(cs, c)
 	}
+
 	kr.hiddenCollectors = nil
+	kr.hiddenCollectorsLock.Unlock()
+	kr.MustRegister(cs...)
+}
+
+// enableHiddenStableCollectors will re-register the stable collectors if there is one or more hidden metrics in it.
+// Since we can not register a metrics twice, so we have to unregister first then register again.
+func (kr *kubeRegistry) enableHiddenStableCollectors() {
+	if len(kr.stableCollectors) == 0 {
+		return
+	}
+
+	kr.stableCollectorsLock.Lock()
+
+	cs := make([]StableCollector, 0, len(kr.stableCollectors))
+	for _, c := range kr.stableCollectors {
+		if len(c.HiddenMetrics()) > 0 {
+			kr.Unregister(c) // unregister must happens before clear state, otherwise no metrics would be unregister
+			c.ClearState()
+			cs = append(cs, c)
+		}
+	}
+
+	kr.stableCollectors = nil
+	kr.stableCollectorsLock.Unlock()
+	kr.CustomMustRegister(cs...)
 }
 
 func newKubeRegistry(v apimachineryversion.Info) *kubeRegistry {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
For now, only normal metrics can be enabled again by flag `--show-hidden-metrics-for-version`.
(It is enough for v1.17 since we haven't deprecated any metrics from a custom collector.)

This PR provided a mechanism to enable hidden metrics from the custom collector.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/milestone v1.18
/priority important-soon