### PR TITLE
Fix: describe of statefulset prints pointer not value

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe.go
@@ -3187,7 +3187,7 @@ func describeStatefulSet(ps *appsv1.StatefulSet, selector labels.Selector, event
 		if ps.Spec.UpdateStrategy.RollingUpdate != nil {
 			ru := ps.Spec.UpdateStrategy.RollingUpdate
 			if ru.Partition != nil {
-				w.Write(LEVEL_1, "Partition:\t%d\n", ru.Partition)
+				w.Write(LEVEL_1, "Partition:\t%d\n", *ru.Partition)
 			}
 		}
 

--- a/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/versioned/describe_test.go
@@ -3544,7 +3544,7 @@ func TestDescribeNode(t *testing.T) {
 }
 
 func TestDescribeStatefulSet(t *testing.T) {
-	var partition int32 = 2
+	var partition int32 = 2672
 	var replicas int32 = 1
 	fake := fake.NewSimpleClientset(&appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -3575,7 +3575,7 @@ func TestDescribeStatefulSet(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 	expectedOutputs := []string{
-		"bar", "foo", "Containers:", "mytest-image:latest", "Update Strategy", "RollingUpdate", "Partition",
+		"bar", "foo", "Containers:", "mytest-image:latest", "Update Strategy", "RollingUpdate", "Partition", "2672",
 	}
 	for _, o := range expectedOutputs {
 		if !strings.Contains(out, o) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, if you use `kubectl describe statefulsets.apps` on a `StatefulSet` which uses e.g. `spec.updateStrategy.rollingUpdate.partition = 2` you will see something like this (on amd64):
```bash
        Update Strategy:    RollingUpdate
          Partition:        824633996052
```
Because `kubectl` prints the pointer and not the actual value.

**Which issue(s) this PR fixes**:
The issue described above.


**Special notes for your reviewer**:
Is it worth a release note?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
"kubectl describe statefulsets.apps" prints garbage for rolling update partition
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
