### PR TITLE
scheduler should exit when pod UID in cache is corrupted

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -502,7 +502,7 @@ func (cache *schedulerCache) UpdatePod(oldPod, newPod *v1.Pod) error {
 	// An assumed pod won't have Update/Remove event. It needs to have Add event
 	// before Update event, in which case the state would change from Assumed to Added.
 	case ok && !cache.assumedPods[key]:
-		if currState.pod.Spec.NodeName != newPod.Spec.NodeName || currState.Pod.UID != newPod.UID {
+		if currState.pod.Spec.NodeName != newPod.Spec.NodeName || currState.pod.UID != newPod.UID {
 			klog.Errorf("Pod %v updated on a different node or UID changed to %s.", key, newPod.UID)
 			klog.Fatalf("Schedulercache is corrupted and can badly affect scheduling decisions")
 		}

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -502,8 +502,8 @@ func (cache *schedulerCache) UpdatePod(oldPod, newPod *v1.Pod) error {
 	// An assumed pod won't have Update/Remove event. It needs to have Add event
 	// before Update event, in which case the state would change from Assumed to Added.
 	case ok && !cache.assumedPods[key]:
-		if currState.pod.Spec.NodeName != newPod.Spec.NodeName {
-			klog.Errorf("Pod %v updated on a different node than previously added to.", key)
+		if currState.pod.Spec.NodeName != newPod.Spec.NodeName || currState.Pod.UID != newPod.UID {
+			klog.Errorf("Pod %v updated on a different node or UID changed to %s.", key, newPod.UID)
 			klog.Fatalf("Schedulercache is corrupted and can badly affect scheduling decisions")
 		}
 		if err := cache.updatePod(oldPod, newPod); err != nil {


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
sheduler should exit when received pod update notification with pod's UID changed

Which issue(s) this PR fixes:
https://github.com/kubernetes/kubernetes/issues/85726

