### PR TITLE
Interactive filter pods in logs command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/BUILD
@@ -11,6 +11,8 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",
+        "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/polymorphichelpers:go_default_library",
@@ -30,9 +32,12 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -475,12 +475,7 @@ func getSelectedPod(builder resource.Builder, resourceLike string, io io.Writer)
 		return resourceLike
 	}
 
-	allErrs := []error{}
-	err := addContextHeaders(out)
-	if err != nil {
-		allErrs = append(allErrs, err)
-	}
-
+	addContextHeaders(out)
 	addPrintContext(filteredPods, out)
 	out.Flush()
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -795,7 +794,7 @@ func TestPromptPodList(t *testing.T) {
 		in, _ := ioutil.TempFile("", "")
 		defer in.Close()
 		io.WriteString(in, "2")
-		in.Seek(0, os.SEEK_SET)
+		in.Seek(0, io.SeekStart)
 		selectedIndex, _ := promptPodList(4, in)
 		if selectedIndex != 2 {
 			t.Errorf("unexpected promp response")
@@ -806,7 +805,7 @@ func TestPromptPodList(t *testing.T) {
 		in, _ := ioutil.TempFile("", "")
 		defer in.Close()
 		io.WriteString(in, "foo")
-		in.Seek(0, os.SEEK_SET)
+		in.Seek(0, io.SeekStart)
 		_, err := promptPodList(4, in)
 		if err == nil {
 			t.Errorf("unexpected error promp response")


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**why we need it:**

In order to get pod logs we need exact name is required and the namespace as well, something like:

1) `kubectl get pods -n <namespace>`

2) `kubectl logs -f <pod name> ...`

This is less efficient and can be done in a more user friendly way.
 
**What this PR does:**

I would like to create a new flag that will allow fuzzy searching of some pod name and see the logs easier.

I have added a new flag (--like) into kubectl logs subcommand, by default the flag is false (to preserve backwards behavior )

**For example:**

This is the result of` kubectl get pods`

![image](https://user-images.githubusercontent.com/1224389/70074453-66956080-1603-11ea-96f6-898fc0ce2daa.png)


We want to only access pods of the deployment:  **foo-deployment**

Then:
`kubectl logs --like foo`

The result of the command will present a table with all the pod's that matches the query `-like <query>`

![image](https://user-images.githubusercontent.com/1224389/70074528-917fb480-1603-11ea-96d1-1a5ae4618d9d.png)

**Special notes for your reviewer**:
I have added unit-tests for the new logic, please let me know if further modification are required  

**Does this PR introduce a user-facing change?**:
```release-note
kubectl/logs new flag: --like (off by default) allows for fuzzy search of pods and quick logs access. Action required: upgrade kubectl 

kubectl logs --like foo
```