### PR TITLE
Automated cherry pick of #85793: Switch addon resizer to 1.8.7

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -77,7 +77,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:
@@ -113,7 +113,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -78,7 +78,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:
@@ -114,7 +114,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/heapster-rbac.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-rbac.yaml
@@ -27,15 +27,20 @@ rules:
   - ""
   resources:
   - pods
+  - nodes
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
-  - "extensions"
+  - "apps"
   resources:
   - deployments
   verbs:
   - get
   - update
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -77,7 +77,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:
@@ -113,7 +113,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -80,7 +80,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         # END_PROMETHEUS_TO_SD
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -58,7 +58,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: k8s.gcr.io/addon-resizer:1.8.6
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: k8s.gcr.io/addon-resizer:1.8.6
+        image: k8s.gcr.io/addon-resizer:1.8.7
         resources:
           limits:
             cpu: 100m


### PR DESCRIPTION
Cherry pick of #85793 on release-1.17.

#85793: Switch addon resizer to 1.8.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed issue with addon-resizer using deprecated extensions APIs
```

/kind bug
/priority important-soon
/sig cluster-lifecycle