### PR TITLE
Automated cherry pick of #85793: Switch addon resizer to 1.8.7

### DIFF
--- a/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/google/heapster-controller.yaml
@@ -77,7 +77,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:
@@ -113,7 +113,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
+++ b/cluster/addons/cluster-monitoring/googleinfluxdb/heapster-controller-combined.yaml
@@ -78,7 +78,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=gcl
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:
@@ -114,7 +114,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/heapster-rbac.yaml
+++ b/cluster/addons/cluster-monitoring/heapster-rbac.yaml
@@ -27,15 +27,20 @@ rules:
   - ""
   resources:
   - pods
+  - nodes
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
-  - "extensions"
+  - "apps"
   resources:
   - deployments
   verbs:
   - get
   - update
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/influxdb/heapster-controller.yaml
@@ -77,7 +77,7 @@ spec:
             - /eventer
             - --source=kubernetes:''
             - --sink=influxdb:http://monitoring-influxdb:8086
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:
@@ -113,7 +113,7 @@ spec:
             # Specifies the smallest cluster (defined in number of nodes)
             # resources will be scaled to.
             - --minClusterSize={{ heapster_min_cluster_size }}
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: eventer-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/stackdriver/heapster-controller.yaml
@@ -80,7 +80,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
         # END_PROMETHEUS_TO_SD
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
+++ b/cluster/addons/cluster-monitoring/standalone/heapster-controller.yaml
@@ -58,7 +58,7 @@ spec:
           command:
             - /heapster
             - --source=kubernetes.summary_api:''
-        - image: k8s.gcr.io/addon-resizer:1.8.5
+        - image: k8s.gcr.io/addon-resizer:1.8.7
           name: heapster-nanny
           resources:
             limits:

--- a/cluster/addons/fluentd-gcp/scaler-rbac.yaml
+++ b/cluster/addons/fluentd-gcp/scaler-rbac.yaml
@@ -18,6 +18,7 @@ metadata:
 rules:
 - apiGroups:
   - "extensions"
+  - "apps"
   resources:
   - daemonsets
   verbs:

--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -62,7 +62,7 @@ spec:
           name: https
           protocol: TCP
       - name: metrics-server-nanny
-        image: k8s.gcr.io/addon-resizer:1.8.5
+        image: k8s.gcr.io/addon-resizer:1.8.7
         resources:
           limits:
             cpu: 100m

--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -18,6 +18,7 @@ rules:
   - watch
 - apiGroups:
   - "extensions"
+  - "apps"
   resources:
   - deployments
   verbs:

--- a/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
       - name: addon-resizer
-        image: k8s.gcr.io/addon-resizer:1.8.5
+        image: k8s.gcr.io/addon-resizer:1.8.7
         resources:
           limits:
             cpu: 100m

--- a/cluster/addons/prometheus/kube-state-metrics-rbac.yaml
+++ b/cluster/addons/prometheus/kube-state-metrics-rbac.yaml
@@ -30,7 +30,7 @@ rules:
   - namespaces
   - endpoints
   verbs: ["list", "watch"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions","apps"]
   resources:
   - daemonsets
   - deployments
@@ -63,7 +63,7 @@ rules:
   resources:
   - pods
   verbs: ["get"]
-- apiGroups: ["extensions"]
+- apiGroups: ["extensions","apps"]
   resources:
   - deployments
   resourceNames: ["kube-state-metrics"]


### PR DESCRIPTION
Cherry pick of #85793 on release-1.16.

#85793: Switch addon resizer to 1.8.7

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Fixed issue with addon-resizer using deprecated extensions APIs
```

/kind bug
/priority important-soon
/sig cluster-lifecycle