### PR TITLE
swap over kube-apiserver manifest to use livez and readyz

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -35,7 +35,7 @@
         "scheme": "HTTPS",
         "host": "127.0.0.1",
         "port": {{secure_port}},
-        "path": "/healthz?exclude=etcd&exclude=kms-provider-0&exclude=kms-provider-1"
+        "path": "/livez?exclude=etcd&exclude=kms-provider-0&exclude=kms-provider-1"
       },
       "initialDelaySeconds": {{liveness_probe_initial_delay}},
       "timeoutSeconds": 15
@@ -45,7 +45,7 @@
         "scheme": "HTTPS",
         "host": "127.0.0.1",
         "port": {{secure_port}},
-        "path": "/healthz"
+        "path": "/readyz"
       },
       "periodSeconds": 1,
       "timeoutSeconds": 15


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

Fixes #79108

**What this PR does / why we need it**:

We need this to migrate the GCE kube-apiserver setup to use the new livez/readyz endpoints. Currently they use the older healthz endpoint. 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```