### PR TITLE
Kubelet cert TTL via GaugeFunc

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/BUILD
@@ -41,7 +41,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/pkg/apis/clientauthentication:go_default_library",
         "//staging/src/k8s.io/client-go/tools/clientcmd/api:go_default_library",
-        "//staging/src/k8s.io/client-go/tools/metrics:go_default_library",
         "//staging/src/k8s.io/client-go/transport:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -262,7 +262,6 @@ func (a *Authenticator) cert() (*tls.Certificate, error) {
 func (a *Authenticator) getCreds() (*credentials, error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
-	defer expirationMetrics.report(time.Now)
 
 	if a.cachedCreds != nil && !a.credsExpired() {
 		return a.cachedCreds, nil

--- a/staging/src/k8s.io/client-go/tools/metrics/metrics.go
+++ b/staging/src/k8s.io/client-go/tools/metrics/metrics.go
@@ -31,9 +31,9 @@ type DurationMetric interface {
 	Observe(duration time.Duration)
 }
 
-// TTLMetric sets the time to live of something.
-type TTLMetric interface {
-	Set(ttl *time.Duration)
+// ExpiryMetric sets some time of expiry. If nil, assume not relevant.
+type ExpiryMetric interface {
+	Set(expiry *time.Time)
 }
 
 // LatencyMetric observes client latency partitioned by verb and url.
@@ -47,8 +47,8 @@ type ResultMetric interface {
 }
 
 var (
-	// ClientCertTTL is the time to live of a client certificate
-	ClientCertTTL TTLMetric = noopTTL{}
+	// ClientCertExpiry is the expiry time of a client certificate
+	ClientCertExpiry ExpiryMetric = noopExpiry{}
 	// ClientCertRotationAge is the age of a certificate that has just been rotated.
 	ClientCertRotationAge DurationMetric = noopDuration{}
 	// RequestLatency is the latency metric that rest clients will update.
@@ -59,7 +59,7 @@ var (
 
 // RegisterOpts contains all the metrics to register. Metrics may be nil.
 type RegisterOpts struct {
-	ClientCertTTL         TTLMetric
+	ClientCertExpiry      ExpiryMetric
 	ClientCertRotationAge DurationMetric
 	RequestLatency        LatencyMetric
 	RequestResult         ResultMetric
@@ -69,8 +69,8 @@ type RegisterOpts struct {
 // only be called once.
 func Register(opts RegisterOpts) {
 	registerMetrics.Do(func() {
-		if opts.ClientCertTTL != nil {
-			ClientCertTTL = opts.ClientCertTTL
+		if opts.ClientCertExpiry != nil {
+			ClientCertExpiry = opts.ClientCertExpiry
 		}
 		if opts.ClientCertRotationAge != nil {
 			ClientCertRotationAge = opts.ClientCertRotationAge
@@ -88,9 +88,9 @@ type noopDuration struct{}
 
 func (noopDuration) Observe(time.Duration) {}
 
-type noopTTL struct{}
+type noopExpiry struct{}
 
-func (noopTTL) Set(*time.Duration) {}
+func (noopExpiry) Set(*time.Time) {}
 
 type noopLatency struct{}
 

--- a/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
+++ b/staging/src/k8s.io/client-go/util/certificate/certificate_manager_test.go
@@ -200,7 +200,6 @@ func TestSetRotationDeadline(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			g := metricMock{}
 			m := manager{
 				cert: &tls.Certificate{
 					Leaf: &x509.Certificate{
@@ -208,10 +207,9 @@ func TestSetRotationDeadline(t *testing.T) {
 						NotAfter:  tc.notAfter,
 					},
 				},
-				getTemplate:           func() *x509.CertificateRequest { return &x509.CertificateRequest{} },
-				usages:                []certificates.KeyUsage{},
-				certificateExpiration: &g,
-				now:                   func() time.Time { return now },
+				getTemplate: func() *x509.CertificateRequest { return &x509.CertificateRequest{} },
+				usages:      []certificates.KeyUsage{},
+				now:         func() time.Time { return now },
 			}
 			jitteryDuration = func(float64) time.Duration { return time.Duration(float64(tc.notAfter.Sub(tc.notBefore)) * 0.7) }
 			lowerBound := tc.notBefore.Add(time.Duration(float64(tc.notAfter.Sub(tc.notBefore)) * 0.7))
@@ -224,12 +222,6 @@ func TestSetRotationDeadline(t *testing.T) {
 					tc.notAfter,
 					deadline,
 					lowerBound)
-			}
-			if g.calls != 1 {
-				t.Errorf("%d metrics were recorded, wanted %d", g.calls, 1)
-			}
-			if g.lastValue != float64(tc.notAfter.Unix()) {
-				t.Errorf("%f value for metric was recorded, wanted %d", g.lastValue, tc.notAfter.Unix())
 			}
 		})
 	}


### PR DESCRIPTION
Rewrote the Kubelet client and serving certificate packages to use a GaugeFunc instead of a traditional Gauge. This allows them both to accurately report the TTL of their certificates at read time rather than arbitrary setting the TTL in unrelated threads.

The metric `certificate_manager_server_expiration_seconds` has been renamed to `certificate_manager_server_ttl_seconds` and its behavior has changed from reporting an absolute time, to reporting the seconds remaining e.g. date seconds since epoch like `1257894000` -> remaining seconds like `1234`.

The behavior of `rest_client_exec_plugin_ttl_seconds` remains the same it has just become more accurate when read. 

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
Building off of new client cert metrics (#84382), new serving cert metrics (#84534), and a GaugeFunc implementation (#83830). We now have accurate insights into Kubetlet certificate rotations and TTL. This provides visibility towards efforts of shortening certificate lifetimes. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
- Renamed Kubelet metric certificate_manager_server_expiration_seconds to certificate_manager_server_ttl_seconds and changed to report the second until expiration at read time rather than absolute time of expiry.
- Improved accuracy of Kubelet metric rest_client_exec_plugin_ttl_seconds.
```
/assign @awly @logicalhan @liggitt 