### PR TITLE
Utilize Context with timeout in gce_instances.go

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go
@@ -111,7 +111,7 @@ func (g *Cloud) NodeAddresses(_ context.Context, _ types.NodeName) ([]v1.NodeAdd
 // NodeAddressesByProviderID will not be called from the node that is requesting this ID.
 // i.e. metadata service and other local methods cannot be used here
 func (g *Cloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]v1.NodeAddress, error) {
-	timeoutCtx, cancel := cloud.ContextWithCallTimeout()
+	timeoutCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
 	_, zone, name, err := splitProviderID(providerID)
@@ -229,7 +229,7 @@ func (g *Cloud) InstanceType(ctx context.Context, nodeName types.NodeName) (stri
 // AddSSHKeyToAllInstances adds an SSH public key as a legal identity for all instances
 // expected format for the key is standard ssh-keygen format: <protocol> <blob>
 func (g *Cloud) AddSSHKeyToAllInstances(ctx context.Context, user string, keyData []byte) error {
-	ctx, cancel := cloud.ContextWithCallTimeout()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 
 	return wait.Poll(2*time.Second, 30*time.Second, func() (bool, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR creates Context with 1 hour timeout.

Ref #81874

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
