### PR TITLE
fix golint check in test/e2e_node/runner/remote

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -520,5 +520,4 @@ staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer
 staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder
 test/e2e/common
 test/e2e/storage/vsphere
-test/e2e_node/runner/remote
 test/utils

--- a/test/e2e_node/runner/remote/run_remote.go
+++ b/test/e2e_node/runner/remote/run_remote.go
@@ -105,12 +105,14 @@ var (
 	suite          remote.TestSuite
 )
 
+// Archive contains path info in the archive.
 type Archive struct {
 	sync.Once
 	path string
 	err  error
 }
 
+// TestResult contains some information about the test results.
 type TestResult struct {
 	output string
 	err    error
@@ -129,22 +131,24 @@ type TestResult struct {
 //         project: gce-image-project
 //         machine: for benchmark only, the machine type (GCE instance) to run test
 //         tests: for benchmark only, a list of ginkgo focus strings to match tests
-
 // TODO(coufon): replace 'image' with 'node' in configurations
 // and we plan to support testing custom machines other than GCE by specifying host
 type ImageConfig struct {
 	Images map[string]GCEImage `json:"images"`
 }
 
+// Accelerator contains type and count about resource.
 type Accelerator struct {
 	Type  string `json:"type,omitempty"`
 	Count int64  `json:"count,omitempty"`
 }
 
+// Resources contains accelerators array.
 type Resources struct {
 	Accelerators []Accelerator `json:"accelerators,omitempty"`
 }
 
+// GCEImage contains some information about CGE Image.
 type GCEImage struct {
 	Image      string `json:"image,omitempty"`
 	ImageDesc  string `json:"image_description,omitempty"`
@@ -428,23 +432,23 @@ func testHost(host string, deleteFiles bool, imageDesc, junitFilePrefix, ginkgoF
 		}
 	}
 	if strings.ToUpper(instance.Status) != "RUNNING" {
-		err = fmt.Errorf("instance %s not in state RUNNING, was %s.", host, instance.Status)
+		err = fmt.Errorf("instance %s not in state RUNNING, was %s", host, instance.Status)
 		return &TestResult{
 			err:    err,
 			host:   host,
 			exitOk: false,
 		}
 	}
-	externalIp := getExternalIp(instance)
-	if len(externalIp) > 0 {
-		remote.AddHostnameIP(host, externalIp)
+	externalIP := getExternalIP(instance)
+	if len(externalIP) > 0 {
+		remote.AddHostnameIP(host, externalIP)
 	}
 
 	path, err := arc.getArchive()
 	if err != nil {
 		// Don't log fatal because we need to do any needed cleanup contained in "defer" statements
 		return &TestResult{
-			err: fmt.Errorf("unable to create test archive: %v.", err),
+			err: fmt.Errorf("unable to create test archive: %v", err),
 		}
 	}
 
@@ -643,12 +647,12 @@ func createInstance(imageConfig *internalGCEImage) (string, error) {
 			continue
 		}
 		if strings.ToUpper(instance.Status) != "RUNNING" {
-			err = fmt.Errorf("instance %s not in state RUNNING, was %s.", name, instance.Status)
+			err = fmt.Errorf("instance %s not in state RUNNING, was %s", name, instance.Status)
 			continue
 		}
-		externalIp := getExternalIp(instance)
-		if len(externalIp) > 0 {
-			remote.AddHostnameIP(name, externalIp)
+		externalIP := getExternalIP(instance)
+		if len(externalIP) > 0 {
+			remote.AddHostnameIP(name, externalIP)
 		}
 		// TODO(random-liu): Remove the docker version check. Use some other command to check
 		// instance readiness.
@@ -699,7 +703,7 @@ func isCloudInitUsed(metadata *compute.Metadata) bool {
 	return false
 }
 
-func getExternalIp(instance *compute.Instance) string {
+func getExternalIP(instance *compute.Instance) string {
 	for i := range instance.NetworkInterfaces {
 		ni := instance.NetworkInterfaces[i]
 		for j := range ni.AccessConfigs {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Fix golint issues in  test/e2e_node/runner/remote

**Which issue(s) this PR fixes**:
 
Ref #68026

**Special notes for your reviewer**:

/cc @oomichi 

**Does this PR introduce a user-facing change?**:
 
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
 
```
test/e2e_node/runner/remote/run_remote.go:108:6: exported type Archive should have comment or be unexported
test/e2e_node/runner/remote/run_remote.go:114:6: exported type TestResult should have comment or be unexported
test/e2e_node/runner/remote/run_remote.go:133:1: comment on exported type ImageConfig should be of the form "ImageConfig ..." (with optional leading article)
test/e2e_node/runner/remote/run_remote.go:139:6: exported type Accelerator should have comment or be unexported
test/e2e_node/runner/remote/run_remote.go:144:6: exported type Resources should have comment or be unexported
test/e2e_node/runner/remote/run_remote.go:148:6: exported type GCEImage should have comment or be unexported
test/e2e_node/runner/remote/run_remote.go:431:20: error strings should not be capitalized or end with punctuation or a newline
test/e2e_node/runner/remote/run_remote.go:438:2: var externalIp should be externalIP
test/e2e_node/runner/remote/run_remote.go:447:20: error strings should not be capitalized or end with punctuation or a newline
test/e2e_node/runner/remote/run_remote.go:646:21: error strings should not be capitalized or end with punctuation or a newline
test/e2e_node/runner/remote/run_remote.go:649:3: var externalIp should be externalIP
test/e2e_node/runner/remote/run_remote.go:702:6: func getExternalIp should be getExternalIP
```

