### PR TITLE
Automated cherry pick of #83777: Fixed bug in TopologyManager with SingleNUMANode Policy

### DIFF
--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
@@ -37,7 +37,7 @@ func (p *singleNumaNodePolicy) Name() string {
 }
 
 func (p *singleNumaNodePolicy) CanAdmitPodResult(hint *TopologyHint) lifecycle.PodAdmitResult {
-	if !hint.Preferred || hint.NUMANodeAffinity.Count() > 1 {
+	if !hint.Preferred {
 		return lifecycle.PodAdmitResult{
 			Admit:   false,
 			Reason:  "Topology Affinity Error",

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
@@ -31,16 +31,6 @@ func TestPolicySingleNumaNodeCanAdmitPodResult(t *testing.T) {
 			hint:     TopologyHint{nil, false},
 			expected: false,
 		},
-		{
-			name:     "NUMANodeAffinity has multiple NUMA Nodes masked in topology hints",
-			hint:     TopologyHint{NewTestSocketMask(0, 1), true},
-			expected: false,
-		},
-		{
-			name:     "NUMANodeAffinity has one NUMA Node masked in topology hints",
-			hint:     TopologyHint{NewTestSocketMask(0), true},
-			expected: true,
-		},
 	}
 
 	for _, tc := range tcases {

--- a/pkg/kubelet/cm/topologymanager/topology_manager_test.go
+++ b/pkg/kubelet/cm/topologymanager/topology_manager_test.go
@@ -858,6 +858,24 @@ func TestAdmit(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "QOSClass set as BestEffort. single-numa-node Policy. No Hints.",
+			qosClass: v1.PodQOSBestEffort,
+			policy:   NewRestrictedPolicy(),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
+			expected: true,
+		},
+		{
+			name:     "QOSClass set as BestEffort. Restricted Policy. No Hints.",
+			qosClass: v1.PodQOSBestEffort,
+			policy:   NewRestrictedPolicy(),
+			hp: []HintProvider{
+				&mockHintProvider{},
+			},
+			expected: true,
+		},
+		{
 			name:     "QOSClass set as Guaranteed. BestEffort Policy. Preferred Affinity.",
 			qosClass: v1.PodQOSGuaranteed,
 			policy:   NewBestEffortPolicy(),


### PR DESCRIPTION
Cherry pick of #83777 on release-1.16.

#83777: Fixed bug in TopologyManager with SingleNUMANode Policy

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.