### PR TITLE
exclude kmsplugin from readiness probe

### DIFF
--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -45,7 +45,7 @@
         "scheme": "HTTPS",
         "host": "127.0.0.1",
         "port": {{secure_port}},
-        "path": "/healthz"
+        "path": "/healthz?exclude=kms-provider-0&exclude=kms-provider-1"
       },
       "periodSeconds": 1,
       "timeoutSeconds": 15


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
we only need healthz check in gke

**Which issue(s) this PR fixes**:
Fixes # b/144707780

```release-note
NONE
```