### PR TITLE
Allow users to choose between AESCBC and AESGCM when configuring envelope encryption.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
@@ -84,6 +84,17 @@ func (k Key) String() string {
 // IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.
 type IdentityConfiguration struct{}
 
+// EnvelopeDataEncryptionTransformer defines supported transformers used for encrypting the data section of an envelope.
+type EnvelopeDataEncryptionTransformer string
+
+// Supported data encryption algorithms.
+const (
+	// AESCBC, see  https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go#L93 for details.
+	AESCBC EnvelopeDataEncryptionTransformer = "AESCBC"
+	// AESGCM, see https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go#L51 for details.
+	AESGCM EnvelopeDataEncryptionTransformer = "AESGCM"
+)
+
 // KMSConfiguration contains the name, cache size and path to configuration file for a KMS based envelope transformer.
 type KMSConfiguration struct {
 	// name is the name of the KMS plugin to be used.
@@ -96,4 +107,7 @@ type KMSConfiguration struct {
 	// Timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration
+	// DataEncryptionAlgorithm specifies the crypto algorithm to use for encrypting the data section of the envelope.
+	// +optional
+	DataEncryptionAlgorithm EnvelopeDataEncryptionTransformer
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	defaultTimeout         = &metav1.Duration{Duration: 3 * time.Second}
-	defaultCacheSize int32 = 1000
+	defaultTimeout                       = &metav1.Duration{Duration: 3 * time.Second}
+	defaultCacheSize               int32 = 1000
+	defaultDataEncryptionAlgorithm       = AESCBC
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -40,5 +41,9 @@ func SetDefaults_KMSConfiguration(obj *KMSConfiguration) {
 
 	if obj.CacheSize == nil {
 		obj.CacheSize = &defaultCacheSize
+	}
+
+	if obj.DataEncryptionAlgorithm == "" {
+		obj.DataEncryptionAlgorithm = defaultDataEncryptionAlgorithm
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
@@ -25,6 +25,34 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+func TestKMSProviderAlgorithmDefaults(t *testing.T) {
+	testCases := []struct {
+		desc string
+		in   *KMSConfiguration
+		want *KMSConfiguration
+	}{
+		{
+			desc: "algorithm not supplied",
+			in:   &KMSConfiguration{},
+			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize, DataEncryptionAlgorithm: defaultDataEncryptionAlgorithm},
+		},
+		{
+			desc: "algorithm supplied",
+			in:   &KMSConfiguration{DataEncryptionAlgorithm: AESGCM},
+			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize, DataEncryptionAlgorithm: AESGCM},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			SetDefaults_KMSConfiguration(tt.in)
+			if d := cmp.Diff(tt.want, tt.in); d != "" {
+				t.Fatalf("KMS Provider mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
+
 func TestKMSProviderTimeoutDefaults(t *testing.T) {
 	testCases := []struct {
 		desc string
@@ -34,12 +62,22 @@ func TestKMSProviderTimeoutDefaults(t *testing.T) {
 		{
 			desc: "timeout not supplied",
 			in:   &KMSConfiguration{},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:                 defaultTimeout,
+				CacheSize:               &defaultCacheSize,
+				DataEncryptionAlgorithm: defaultDataEncryptionAlgorithm,
+			},
 		},
 		{
 			desc: "timeout supplied",
-			in:   &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}},
-			want: &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, CacheSize: &defaultCacheSize},
+			in: &KMSConfiguration{
+				Timeout: &v1.Duration{Duration: 1 * time.Minute},
+			},
+			want: &KMSConfiguration{
+				Timeout:                 &v1.Duration{Duration: 1 * time.Minute},
+				CacheSize:               &defaultCacheSize,
+				DataEncryptionAlgorithm: defaultDataEncryptionAlgorithm,
+			},
 		},
 	}
 
@@ -67,17 +105,33 @@ func TestKMSProviderCacheDefaults(t *testing.T) {
 		{
 			desc: "cache size not supplied",
 			in:   &KMSConfiguration{},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:                 defaultTimeout,
+				CacheSize:               &defaultCacheSize,
+				DataEncryptionAlgorithm: defaultDataEncryptionAlgorithm,
+			},
 		},
 		{
 			desc: "cache of zero size supplied",
-			in:   &KMSConfiguration{CacheSize: &zero},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &zero},
+			in: &KMSConfiguration{
+				CacheSize: &zero,
+			},
+			want: &KMSConfiguration{
+				Timeout:                 defaultTimeout,
+				CacheSize:               &zero,
+				DataEncryptionAlgorithm: defaultDataEncryptionAlgorithm,
+			},
 		},
 		{
 			desc: "positive cache size supplied",
-			in:   &KMSConfiguration{CacheSize: &ten},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &ten},
+			in: &KMSConfiguration{
+				CacheSize: &ten,
+			},
+			want: &KMSConfiguration{
+				Timeout:                 defaultTimeout,
+				CacheSize:               &ten,
+				DataEncryptionAlgorithm: defaultDataEncryptionAlgorithm,
+			},
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
@@ -84,6 +84,17 @@ func (k Key) String() string {
 // IdentityConfiguration is an empty struct to allow identity transformer in provider configuration.
 type IdentityConfiguration struct{}
 
+// EnvelopeDataEncryptionTransformer defines supported transformers used for encrypting the data section of an envelope.
+type EnvelopeDataEncryptionTransformer string
+
+// Supported data encryption algorithms.
+const (
+	// AESCBC, see  https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go#L93 for details.
+	AESCBC EnvelopeDataEncryptionTransformer = "AESCBC"
+	// AESGCM, see https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go#L51 for details.
+	AESGCM EnvelopeDataEncryptionTransformer = "AESGCM"
+)
+
 // KMSConfiguration contains the name, cache size and path to configuration file for a KMS based envelope transformer.
 type KMSConfiguration struct {
 	// name is the name of the KMS plugin to be used.
@@ -96,4 +107,7 @@ type KMSConfiguration struct {
 	// Timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+	// DataEncryptionAlgorithm specifies the crypto algorithm to use for encrypting the data section of the envelope.
+	// +optional
+	DataEncryptionAlgorithm EnvelopeDataEncryptionTransformer `json:"dataEncryptionAlgorithm,omitempty"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.conversion.go
@@ -182,6 +182,7 @@ func autoConvert_v1_KMSConfiguration_To_config_KMSConfiguration(in *KMSConfigura
 	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
 	out.Endpoint = in.Endpoint
 	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	out.DataEncryptionAlgorithm = config.EnvelopeDataEncryptionTransformer(in.DataEncryptionAlgorithm)
 	return nil
 }
 
@@ -195,6 +196,7 @@ func autoConvert_config_KMSConfiguration_To_v1_KMSConfiguration(in *config.KMSCo
 	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
 	out.Endpoint = in.Endpoint
 	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	out.DataEncryptionAlgorithm = EnvelopeDataEncryptionTransformer(in.DataEncryptionAlgorithm)
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
@@ -34,8 +34,8 @@ const (
 	mandatoryFieldErrFmt     = "%s is a mandatory field for a %s"
 	base64EncodingErr        = "secrets must be base64 encoded"
 	zeroOrNegativeErrFmt     = "%s should be a positive value"
-	negativeValueErrFmt      = "%s can't be negative"
 	encryptionConfigNilErr   = "EncryptionConfiguration can't be nil"
+	unsupportedAlgorithm     = "%q is not a supported cryptographic algorithm, only AESCBC and AESGCM are supported"
 )
 
 var (
@@ -179,6 +179,15 @@ func validateKMSConfiguration(c *config.KMSConfiguration, fieldPath *field.Path)
 	allErrs = append(allErrs, validateKMSTimeout(c, fieldPath.Child("timeout"))...)
 	allErrs = append(allErrs, validateKMSEndpoint(c, fieldPath.Child("endpoint"))...)
 	allErrs = append(allErrs, validateKMSCacheSize(c, fieldPath.Child("cachesize"))...)
+	allErrs = append(allErrs, validateKMSDataEncryptionAlgorithm(c, fieldPath.Child("dataEncryptionAlgorithm"))...)
+	return allErrs
+}
+
+func validateKMSDataEncryptionAlgorithm(c *config.KMSConfiguration, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if c.DataEncryptionAlgorithm != config.AESCBC && c.DataEncryptionAlgorithm != config.AESGCM {
+		allErrs = append(allErrs, field.Invalid(fieldPath, c.DataEncryptionAlgorithm, fmt.Sprintf(unsupportedAlgorithm, c.DataEncryptionAlgorithm)))
+	}
 	return allErrs
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
@@ -352,3 +352,38 @@ func TestKMSProviderCacheSize(t *testing.T) {
 		})
 	}
 }
+
+func TestKMSProviderDataEncryptionAlgorithm(t *testing.T) {
+	var (
+		invalidAlg config.EnvelopeDataEncryptionTransformer = "foo"
+		algField                                            = root.Index(0).Child("kms").Child("dataEncryptionAlgorithm")
+	)
+
+	testCases := []struct {
+		desc string
+		in   *config.KMSConfiguration
+		want field.ErrorList
+	}{
+		{
+			desc: "valid positive cache size",
+			in:   &config.KMSConfiguration{DataEncryptionAlgorithm: config.AESCBC},
+			want: field.ErrorList{},
+		},
+		{
+			desc: "unsupported algorithm",
+			in:   &config.KMSConfiguration{DataEncryptionAlgorithm: invalidAlg},
+			want: field.ErrorList{
+				field.Invalid(algField, invalidAlg, fmt.Sprintf(unsupportedAlgorithm, invalidAlg)),
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := validateKMSDataEncryptionAlgorithm(tt.in, algField)
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Fatalf("KMS Provider validation mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -97,10 +97,11 @@ func TestLegacyConfig(t *testing.T) {
 						},
 					}},
 					{KMS: &apiserverconfig.KMSConfiguration{
-						Name:      "testprovider",
-						Endpoint:  "unix:///tmp/testprovider.sock",
-						CacheSize: &cacheSize,
-						Timeout:   &metav1.Duration{Duration: 3 * time.Second},
+						Name:                    "testprovider",
+						Endpoint:                "unix:///tmp/testprovider.sock",
+						CacheSize:               &cacheSize,
+						Timeout:                 &metav1.Duration{Duration: 3 * time.Second},
+						DataEncryptionAlgorithm: "AESCBC",
 					}},
 					{AESCBC: &apiserverconfig.AESConfiguration{
 						Keys: []apiserverconfig.Key{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind api-change
/kind feature

**What this PR does / why we need it**:
This PR allows users to choose AESGCM protocol (as opposed to currently set by default AESCBC) while configuring KMS Provider.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
#81127
**Special notes for your reviewer**:
I will follow-up with a PR to update documentation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Users will be able to supply either AESGCM or AESCBC as the data encryption algorithm.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
