### PR TITLE
Migrate OWNERS file to apply the area/provider/gcp label

### DIFF
--- a/cluster/addons/addon-manager/OWNERS
+++ b/cluster/addons/addon-manager/OWNERS
@@ -5,4 +5,4 @@ reviewers:
 approvers:
 - mrhohn
 labels:
-- sig/gcp
+- area/provider/gcp

--- a/cluster/addons/fluentd-gcp/OWNERS
+++ b/cluster/addons/fluentd-gcp/OWNERS
@@ -6,5 +6,5 @@ approvers:
 reviewers:
 - sig-instrumentation-reviewers
 labels:
-- sig/gcp
+- area/provider/gcp
 - sig/instrumentation

--- a/cluster/gce/manifests/OWNERS
+++ b/cluster/gce/manifests/OWNERS
@@ -7,4 +7,4 @@ approvers:
 - tallclair
 - MrHohn
 labels:
-- sig/gcp
+- area/provider/gcp

--- a/cluster/gce/windows/OWNERS
+++ b/cluster/gce/windows/OWNERS
@@ -11,4 +11,4 @@ approvers:
   - yujuhong
   - yliaog
 labels:
-  - sig/gcp
+- area/provider/gcp


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`sig/gcp` label no longer exists.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85919

**Special notes for your reviewer**:
/assign @tallclair @x13n @mtaufen
/cc @fejta


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
