### PR TITLE
WIP: kubectl in-cluster config e2e test is flaky

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -744,7 +744,7 @@ var _ = SIGDescribe("Kubectl client", func() {
 			}
 		})
 
-		ginkgo.It("should handle in-cluster config", func() {
+		ginkgo.It("should handle in-cluster config [Flaky]", func() {
 			ginkgo.By("adding rbac permissions")
 			// grant the view permission widely to allow inspection of the `invalid` namespace and the default namespace
 			err := auth.BindClusterRole(f.ClientSet.RbacV1(), "view", f.Namespace.Name,


### PR DESCRIPTION
* Mark test `should handle in-cluster config` flaky

/kind cleanup
/sig cli
/area kubectl
/priority important-soon

```release-note
NONE
```
