### PR TITLE
Run all csi-hostpath containers as privileged

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
@@ -44,6 +44,11 @@ spec:
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           volumeMounts:
           - mountPath: /csi
             name: socket-dir

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -46,6 +46,9 @@ spec:
             - --csi-address=/csi/csi.sock
             - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
           securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
             privileged: true
           env:
             - name: KUBE_NODE_NAME

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
@@ -46,6 +46,11 @@ spec:
             - -v=5
             - --csi-address=/csi/csi.sock
             - --connection-timeout=15s
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           volumeMounts:
             - mountPath: /csi
               name: socket-dir

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
@@ -37,6 +37,11 @@ spec:
           env:
             - name: ADDRESS
               value: /csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
           imagePullPolicy: Always
           volumeMounts:
             - mountPath: /csi

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
@@ -38,6 +38,11 @@ spec:
         env:
         - name: ADDRESS
           value: /csi/csi.sock
+        securityContext:
+          # This is necessary only for systems with SELinux, where
+          # non-privileged sidecar containers cannot access unix domain socket
+          # created by privileged CSI driver container.
+          privileged: true
         imagePullPolicy: Always
         volumeMounts:
         - name: socket-dir


### PR DESCRIPTION
On systems with SELinux enabled, non-privileged containers can't access data of privileged containers. Since the CSI driver socket is exposed by a privileged container, all sidecars must be privileged too.

/kind flake
E2e tests don't run on RHEL / CentOS

It's sort-of cherry pick of https://github.com/kubernetes-csi/csi-driver-host-path/pull/123

```release-note
NONE
```

```docs

```

/assign @msau42 