### PR TITLE
Azure: use separate rate limiter for VMSS (master)

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -54,10 +54,13 @@ const (
 	CloudProviderName      = "azure"
 	rateLimitQPSDefault    = 1.0
 	rateLimitBucketDefault = 5
-	backoffRetriesDefault  = 6
-	backoffExponentDefault = 1.5
-	backoffDurationDefault = 5 // in seconds
-	backoffJitterDefault   = 1.0
+	// VMSS API limits are 180 queries per 3 minutes & 900 queries per 30 minutes per subscription
+	vmssRateLimitQPSDefault    = 1.0
+	vmssRateLimitBucketDefault = 5
+	backoffRetriesDefault      = 6
+	backoffExponentDefault     = 1.5
+	backoffDurationDefault     = 5 // in seconds
+	backoffJitterDefault       = 1.0
 	// According to https://docs.microsoft.com/en-us/azure/azure-subscription-service-limits#load-balancer.
 	maximumLoadBalancerRuleCount = 250
 
@@ -144,6 +147,10 @@ type Config struct {
 	CloudProviderRateLimitQPS float32 `json:"cloudProviderRateLimitQPS,omitempty" yaml:"cloudProviderRateLimitQPS,omitempty"`
 	// Rate limit Bucket Size
 	CloudProviderRateLimitBucket int `json:"cloudProviderRateLimitBucket,omitempty" yaml:"cloudProviderRateLimitBucket,omitempty"`
+	// VMSS Rate limit QPS
+	CloudProviderVMSSRateLimitQPS float32 `json:"cloudProviderVMSSRateLimitQPS,omitempty" yaml:"cloudProviderVMSSRateLimitQPS,omitempty"`
+	// VMSS Rate limit Bucket Size
+	CloudProviderVMSSRateLimitBucket int `json:"cloudProviderVMSSRateLimitBucket,omitempty" yaml:"cloudProviderVMSSRateLimitBucket,omitempty"`
 	// Rate limit QPS (Write)
 	CloudProviderRateLimitQPSWrite float32 `json:"cloudProviderRateLimitQPSWrite,omitempty" yaml:"cloudProviderRateLimitQPSWrite,omitempty"`
 	// Rate limit Bucket Size
@@ -354,6 +361,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 	// operationPollRateLimiter.Accept() is a no-op if rate limits are configured off.
 	operationPollRateLimiter := flowcontrol.NewFakeAlwaysRateLimiter()
 	operationPollRateLimiterWrite := flowcontrol.NewFakeAlwaysRateLimiter()
+	operationPollVMSSRateLimiter := flowcontrol.NewFakeAlwaysRateLimiter()
 
 	// If reader is provided (and no writer) we will
 	// use the same value for both.
@@ -364,6 +372,12 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 		}
 		if config.CloudProviderRateLimitBucket == 0 {
 			config.CloudProviderRateLimitBucket = rateLimitBucketDefault
+		}
+		if config.CloudProviderVMSSRateLimitQPS == 0 {
+			config.CloudProviderVMSSRateLimitQPS = vmssRateLimitQPSDefault
+		}
+		if config.CloudProviderVMSSRateLimitBucket == 0 {
+			config.CloudProviderRateLimitBucket = vmssRateLimitBucketDefault
 		}
 		if config.CloudProviderRateLimitQPSWrite == 0 {
 			config.CloudProviderRateLimitQPSWrite = rateLimitQPSDefault
@@ -376,13 +390,21 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 			config.CloudProviderRateLimitQPS,
 			config.CloudProviderRateLimitBucket)
 
-		operationPollRateLimiterWrite = flowcontrol.NewTokenBucketRateLimiter(
+		operationPollVMSSRateLimiter = flowcontrol.NewTokenBucketRateLimiter(
+			config.CloudProviderVMSSRateLimitQPS,
+			config.CloudProviderVMSSRateLimitBucket)
+
+		operationPollRateLimiter = flowcontrol.NewTokenBucketRateLimiter(
 			config.CloudProviderRateLimitQPSWrite,
 			config.CloudProviderRateLimitBucketWrite)
 
 		klog.V(2).Infof("Azure cloudprovider (read ops) using rate limit config: QPS=%g, bucket=%d",
 			config.CloudProviderRateLimitQPS,
 			config.CloudProviderRateLimitBucket)
+
+		klog.V(2).Infof("Azure cloudprovider (VMSS ops) using rate limit config: QPS=%g, bucket=%d",
+			config.CloudProviderVMSSRateLimitQPS,
+			config.CloudProviderVMSSRateLimitBucket)
 
 		klog.V(2).Infof("Azure cloudprovider (write ops) using rate limit config: QPS=%g, bucket=%d",
 			config.CloudProviderRateLimitQPSWrite,
@@ -462,7 +484,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 	}
 
 	// Initialize Azure clients.
-	azClientConfig := &azClientConfig{
+	clientConfig := &azClientConfig{
 		subscriptionID:                 config.SubscriptionID,
 		resourceManagerEndpoint:        env.ResourceManagerEndpoint,
 		servicePrincipalToken:          servicePrincipalToken,
@@ -472,20 +494,32 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 		CloudProviderBackoffDuration:   config.CloudProviderBackoffDuration,
 		ShouldOmitCloudProviderBackoff: config.shouldOmitCloudProviderBackoff(),
 	}
-	az.DisksClient = newAzDisksClient(azClientConfig)
-	az.SnapshotsClient = newSnapshotsClient(azClientConfig)
-	az.RoutesClient = newAzRoutesClient(azClientConfig)
-	az.SubnetsClient = newAzSubnetsClient(azClientConfig)
-	az.InterfacesClient = newAzInterfacesClient(azClientConfig)
-	az.RouteTablesClient = newAzRouteTablesClient(azClientConfig)
-	az.LoadBalancerClient = newAzLoadBalancersClient(azClientConfig)
-	az.SecurityGroupsClient = newAzSecurityGroupsClient(azClientConfig)
-	az.StorageAccountClient = newAzStorageAccountClient(azClientConfig)
-	az.VirtualMachinesClient = newAzVirtualMachinesClient(azClientConfig)
-	az.PublicIPAddressesClient = newAzPublicIPAddressesClient(azClientConfig)
-	az.VirtualMachineSizesClient = newAzVirtualMachineSizesClient(azClientConfig)
-	az.VirtualMachineScaleSetsClient = newAzVirtualMachineScaleSetsClient(azClientConfig)
-	az.VirtualMachineScaleSetVMsClient = newAzVirtualMachineScaleSetVMsClient(azClientConfig)
+
+	vmssClientConfig := &azClientConfig{
+		subscriptionID:                 config.SubscriptionID,
+		resourceManagerEndpoint:        env.ResourceManagerEndpoint,
+		servicePrincipalToken:          servicePrincipalToken,
+		rateLimiterReader:              operationPollVMSSRateLimiter,
+		rateLimiterWriter:              operationPollVMSSRateLimiter,
+		CloudProviderBackoffRetries:    config.CloudProviderBackoffRetries,
+		CloudProviderBackoffDuration:   config.CloudProviderBackoffDuration,
+		ShouldOmitCloudProviderBackoff: config.shouldOmitCloudProviderBackoff(),
+	}
+
+	az.DisksClient = newAzDisksClient(clientConfig)
+	az.SnapshotsClient = newSnapshotsClient(clientConfig)
+	az.RoutesClient = newAzRoutesClient(clientConfig)
+	az.SubnetsClient = newAzSubnetsClient(clientConfig)
+	az.InterfacesClient = newAzInterfacesClient(clientConfig)
+	az.RouteTablesClient = newAzRouteTablesClient(clientConfig)
+	az.LoadBalancerClient = newAzLoadBalancersClient(clientConfig)
+	az.SecurityGroupsClient = newAzSecurityGroupsClient(clientConfig)
+	az.StorageAccountClient = newAzStorageAccountClient(clientConfig)
+	az.VirtualMachinesClient = newAzVirtualMachinesClient(clientConfig)
+	az.PublicIPAddressesClient = newAzPublicIPAddressesClient(clientConfig)
+	az.VirtualMachineSizesClient = newAzVirtualMachineSizesClient(clientConfig)
+	az.VirtualMachineScaleSetsClient = newAzVirtualMachineScaleSetsClient(vmssClientConfig)
+	az.VirtualMachineScaleSetVMsClient = newAzVirtualMachineScaleSetVMsClient(vmssClientConfig)
 	az.FileClient = &azureFileClient{env: *env}
 
 	if az.MaximumLoadBalancerRuleCount == 0 {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -169,42 +169,42 @@ type Config struct {
 }
 
 type cloudProviderRateLimiting struct {
-	Enabled bool
+	Enabled bool `json:"enabled,omitempty" yaml:"enabled,omitempty"`
 
 	// QPS are the number of queries per second authorized per client
 	// Once hit, the Rate Limiter will start to throttle queries unless
 	// its associated bucket is greater than 0.
-	RoutesClientQPS                  float32
-	SubnetsClientQPS                 float32
-	InterfacesClientQPS              float32
-	RouteTablesClientQPS             float32
-	LoadBalancerClientQPS            float32
-	PublicIPAddressesClientQPS       float32
-	SecurityGroupsClientQPS          float32
-	VirtualMachinesClientQPS         float32
-	StorageAccountClientQPS          float32
-	DisksClientQPS                   float32
-	SnapshotsClientQPS               float32
-	VirtualMachineScaleSetsClientQPS float32
-	VirtualMachineSizesClientQPS     float32
+	RoutesClientQPS                  float32 `json:"routesClientQPS,omitempty" yaml:"routesClientQPS,omitempty"`
+	SubnetsClientQPS                 float32 `json:"subnetsClientQPS,omitempty" yaml:"subnetsClientQPS,omitempty"`
+	InterfacesClientQPS              float32 `json:"interfacesClientQPS,omitempty" yaml:"interfacesClientQPS,omitempty"`
+	RouteTablesClientQPS             float32 `json:"routeTablesClientQPS,omitempty" yaml:"routeTablesClientQPS,omitempty"`
+	LoadBalancerClientQPS            float32 `json:"loadBalancerClientQPS,omitempty" yaml:"loadBalancerClientQPS,omitempty"`
+	PublicIPAddressesClientQPS       float32 `json:"publicIPAddressesClientQPS,omitempty" yaml:"publicIPAddressesClientQPS,omitempty"`
+	SecurityGroupsClientQPS          float32 `json:"securityGroupsClientQPS,omitempty" yaml:"securityGroupsClientQPS,omitempty"`
+	VirtualMachinesClientQPS         float32 `json:"virtualMachinesClientQPS,omitempty" yaml:"virtualMachinesClientQPS,omitempty"`
+	StorageAccountClientQPS          float32 `json:"storageAccountClientQPS,omitempty" yaml:"storageAccountClientQPS,omitempty"`
+	DisksClientQPS                   float32 `json:"disksClientQPS,omitempty" yaml:"disksClientQPS,omitempty"`
+	SnapshotsClientQPS               float32 `json:"snapshotsClientQPS,omitempty" yaml:"snapshotsClientQPS,omitempty"`
+	VirtualMachineScaleSetsClientQPS float32 `json:"virtualMachineScaleSetsClientQPS,omitempty" yaml:"virtualMachineScaleSetsClientQPS,omitempty"`
+	VirtualMachineSizesClientQPS     float32 `json:"virtualMachineSizesClientQPS,omitempty" yaml:"virtualMachineSizesClientQPS,omitempty"`
 
 	// Buckets (burst) are the number of queries above the QPS that the Rate Limiter
 	// will still allow. Each query made above QPS rate will decrease the bucket and
 	// the rate limiter will start throttle queries when the bucket is depleted. The
-	// buckets are refilled with the unused QPS until it reaches its orginal size.
-	RoutesClientBucket                  int
-	SubnetsClientBucket                 int
-	InterfacesClientBucket              int
-	RouteTablesClientBucket             int
-	LoadBalancerClientBucket            int
-	PublicIPAddressesClientBucket       int
-	SecurityGroupsClientBucket          int
-	VirtualMachinesClientBucket         int
-	StorageAccountClientBucket          int
-	DisksClientBucket                   int
-	SnapshotsClientBucket               int
-	VirtualMachineScaleSetsClientBucket int
-	VirtualMachineSizesClientBucket     int
+	// buckets are refilled with the unused QPS until it reaches its original size.
+	RoutesClientBucket                  int `json:"routesClientBucket,omitempty" yaml:"routesClientBucket,omitempty"`
+	SubnetsClientBucket                 int `json:"subnetsClientBucket,omitempty" yaml:"subnetsClientBucket,omitempty"`
+	InterfacesClientBucket              int `json:"interfacesClientBucket,omitempty" yaml:"interfacesClientBucket,omitempty"`
+	RouteTablesClientBucket             int `json:"routeTablesClientBucket,omitempty" yaml:"routeTablesClientBucket,omitempty"`
+	LoadBalancerClientBucket            int `json:"loadBalancerClientBucket,omitempty" yaml:"loadBalancerClientBucket,omitempty"`
+	PublicIPAddressesClientBucket       int `json:"publicIPAddressesClientBucket,omitempty" yaml:"publicIPAddressesClientBucket,omitempty"`
+	SecurityGroupsClientBucket          int `json:"securityGroupsClientBucket,omitempty" yaml:"securityGroupsClientBucket,omitempty"`
+	VirtualMachinesClientBucket         int `json:"virtualMachinesClientBucket,omitempty" yaml:"virtualMachinesClientBucket,omitempty"`
+	StorageAccountClientBucket          int `json:"storageAccountClientBucket,omitempty" yaml:"storageAccountClientBucket,omitempty"`
+	DisksClientBucket                   int `json:"disksClientBucket,omitempty" yaml:"disksClientBucket,omitempty"`
+	SnapshotsClientBucket               int `json:"snapshotsClientBucket,omitempty" yaml:"snapshotsClientBucket,omitempty"`
+	VirtualMachineScaleSetsClientBucket int `json:"virtualMachineScaleSetsClientBucket,omitempty" yaml:"virtualMachineScaleSetsClientBucket,omitempty"`
+	VirtualMachineSizesClientBucket     int `json:"virtualMachineSizesClientBucket,omitempty" yaml:"virtualMachineSizesClientBucket,omitempty"`
 }
 
 var _ cloudprovider.Interface = (*Cloud)(nil)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -55,8 +55,8 @@ const (
 	rateLimitQPSDefault    = 1.0
 	rateLimitBucketDefault = 5
 	// VMSS API limits are 180 queries per 3 minutes & 900 queries per 30 minutes per subscription
-	vmssRateLimitQPSDefault    = 6.0
-	vmssRateLimitBucketDefault = 20
+	vmssRateLimitQPSDefault    = 1.0
+	vmssRateLimitBucketDefault = 5
 	backoffRetriesDefault      = 6
 	backoffExponentDefault     = 1.5
 	backoffDurationDefault     = 5 // in seconds

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -55,8 +55,8 @@ const (
 	rateLimitQPSDefault    = 1.0
 	rateLimitBucketDefault = 5
 	// VMSS API limits are 180 queries per 3 minutes & 900 queries per 30 minutes per subscription
-	vmssRateLimitQPSDefault    = 1.0
-	vmssRateLimitBucketDefault = 5
+	vmssRateLimitQPSDefault    = 6.0
+	vmssRateLimitBucketDefault = 20
 	backoffRetriesDefault      = 6
 	backoffExponentDefault     = 1.5
 	backoffDurationDefault     = 5 // in seconds

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -394,7 +394,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 			config.CloudProviderVMSSRateLimitQPS,
 			config.CloudProviderVMSSRateLimitBucket)
 
-		operationPollRateLimiter = flowcontrol.NewTokenBucketRateLimiter(
+		operationPollRateLimiterWrite = flowcontrol.NewTokenBucketRateLimiter(
 			config.CloudProviderRateLimitQPSWrite,
 			config.CloudProviderRateLimitBucketWrite)
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -377,7 +377,7 @@ func (az *Cloud) InitializeCloudFromConfig(config *Config, fromSecret bool) erro
 			config.CloudProviderVMSSRateLimitQPS = vmssRateLimitQPSDefault
 		}
 		if config.CloudProviderVMSSRateLimitBucket == 0 {
-			config.CloudProviderRateLimitBucket = vmssRateLimitBucketDefault
+			config.CloudProviderVMSSRateLimitBucket = vmssRateLimitBucketDefault
 		}
 		if config.CloudProviderRateLimitQPSWrite == 0 {
 			config.CloudProviderRateLimitQPSWrite = rateLimitQPSDefault

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -54,11 +54,35 @@ func TestParseConfig(t *testing.T) {
 		"cloudProviderBackoffExponent": 1,
 		"cloudProviderBackoffJitter": 1,
 		"cloudProviderBackoffRetries": 1,
-		"cloudProviderRatelimit": true,
-		"cloudProviderRateLimitBucket": 1,
-		"CloudProviderRateLimitBucketWrite": 1,
-		"cloudProviderRateLimitQPS": 1,
-		"CloudProviderRateLimitQPSWrite": 1,
+		"cloudProviderRateLimiting": {
+			"enabled": true,
+			"routesClientQPS": 2,
+			"subnetsClientQPS": 2,
+			"interfacesClientQPS": 2,
+			"routeTablesClientQPS": 2,
+			"loadBalancerClientQPS": 2,
+			"publicIPAddressesClientQPS": 2,
+			"securityGroupsClientQPS": 2,
+			"virtualMachinesClientQPS": 2,
+			"storageAccountClientQPS": 2,
+			"disksClientQPS": 2,
+			"snapshotsClientQPS": 2,
+			"virtualMachineScaleSetsClientQPS": 2,
+			"virtualMachineSizesClientQPS": 2,
+			"routesClientBucket": 4,
+			"subnetsClientBucket": 4,
+			"interfacesClientBucket": 4,
+			"routeTablesClientBucket": 4,
+			"loadBalancerClientBucket": 4,
+			"publicIPAddressesClientBucket": 4,
+			"securityGroupsClientBucket": 4,
+			"virtualMachinesClientBucket": 4,
+			"storageAccountClientBucket": 4,
+			"disksClientBucket": 4,
+			"snapshotsClientBucket": 4,
+			"virtualMachineScaleSetsClientBucket": 4,
+			"virtualMachineSizesClientBucket": 4
+		},
 		"location": "location",
 		"maximumLoadBalancerRuleCount": 1,
 		"primaryAvailabilitySetName": "primaryAvailabilitySetName",
@@ -87,29 +111,53 @@ func TestParseConfig(t *testing.T) {
 			TenantID:                    "tenantId",
 			UseManagedIdentityExtension: true,
 		},
-		CloudProviderBackoff:              true,
-		CloudProviderBackoffDuration:      1,
-		CloudProviderBackoffExponent:      1,
-		CloudProviderBackoffJitter:        1,
-		CloudProviderBackoffRetries:       1,
-		CloudProviderRateLimit:            true,
-		CloudProviderRateLimitBucket:      1,
-		CloudProviderRateLimitBucketWrite: 1,
-		CloudProviderRateLimitQPS:         1,
-		CloudProviderRateLimitQPSWrite:    1,
-		Location:                          "location",
-		MaximumLoadBalancerRuleCount:      1,
-		PrimaryAvailabilitySetName:        "primaryAvailabilitySetName",
-		PrimaryScaleSetName:               "primaryScaleSetName",
-		ResourceGroup:                     "resourcegroup",
-		RouteTableName:                    "routeTableName",
-		RouteTableResourceGroup:           "routeTableResourceGroup",
-		SecurityGroupName:                 "securityGroupName",
-		SubnetName:                        "subnetName",
-		UseInstanceMetadata:               true,
-		VMType:                            "standard",
-		VnetName:                          "vnetName",
-		VnetResourceGroup:                 "vnetResourceGroup",
+		CloudProviderBackoff:         true,
+		CloudProviderBackoffDuration: 1,
+		CloudProviderBackoffExponent: 1,
+		CloudProviderBackoffJitter:   1,
+		CloudProviderBackoffRetries:  1,
+		CloudProviderRateLimiting: cloudProviderRateLimiting{
+			Enabled:                             true,
+			RoutesClientQPS:                     2,
+			SubnetsClientQPS:                    2,
+			InterfacesClientQPS:                 2,
+			RouteTablesClientQPS:                2,
+			LoadBalancerClientQPS:               2,
+			PublicIPAddressesClientQPS:          2,
+			SecurityGroupsClientQPS:             2,
+			VirtualMachinesClientQPS:            2,
+			StorageAccountClientQPS:             2,
+			DisksClientQPS:                      2,
+			SnapshotsClientQPS:                  2,
+			VirtualMachineScaleSetsClientQPS:    2,
+			VirtualMachineSizesClientQPS:        2,
+			RoutesClientBucket:                  4,
+			SubnetsClientBucket:                 4,
+			InterfacesClientBucket:              4,
+			RouteTablesClientBucket:             4,
+			LoadBalancerClientBucket:            4,
+			PublicIPAddressesClientBucket:       4,
+			SecurityGroupsClientBucket:          4,
+			VirtualMachinesClientBucket:         4,
+			StorageAccountClientBucket:          4,
+			DisksClientBucket:                   4,
+			SnapshotsClientBucket:               4,
+			VirtualMachineScaleSetsClientBucket: 4,
+			VirtualMachineSizesClientBucket:     4,
+		},
+		Location:                     "location",
+		MaximumLoadBalancerRuleCount: 1,
+		PrimaryAvailabilitySetName:   "primaryAvailabilitySetName",
+		PrimaryScaleSetName:          "primaryScaleSetName",
+		ResourceGroup:                "resourcegroup",
+		RouteTableName:               "routeTableName",
+		RouteTableResourceGroup:      "routeTableResourceGroup",
+		SecurityGroupName:            "securityGroupName",
+		SubnetName:                   "subnetName",
+		UseInstanceMetadata:          true,
+		VMType:                       "standard",
+		VnetName:                     "vnetName",
+		VnetResourceGroup:            "vnetResourceGroup",
 	}
 
 	buffer := bytes.NewBufferString(azureConfig)
@@ -1572,9 +1620,9 @@ func TestNewCloudFromJSON(t *testing.T) {
 		"routeTableName": "--route-table-name--",
 		"primaryAvailabilitySetName": "--primary-availability-set-name--",
 		"cloudProviderBackoff": true,
-		"cloudProviderRatelimit": true,
-		"cloudProviderRateLimitQPS": 0.5,
-		"cloudProviderRateLimitBucket": 5
+		"cloudProviderRateLimiting": {
+			"enabled": true
+		}
 	}`
 	validateConfig(t, config)
 }
@@ -1621,9 +1669,8 @@ cloudProviderBackoffRetries: 6
 cloudProviderBackoffExponent: 1.5
 cloudProviderBackoffDuration: 5
 cloudProviderBackoffJitter: 1.0
-cloudProviderRatelimit: true
-cloudProviderRateLimitQPS: 0.5
-cloudProviderRateLimitBucket: 5
+cloudProviderRateLimiting:
+  enabled: true
 `
 	validateConfig(t, config)
 }
@@ -1688,14 +1735,8 @@ func validateConfig(t *testing.T, config string) {
 	if azureCloud.CloudProviderBackoffJitter != 1.0 {
 		t.Errorf("got incorrect value for CloudProviderBackoffJitter")
 	}
-	if azureCloud.CloudProviderRateLimit != true {
-		t.Errorf("got incorrect value for CloudProviderRateLimit")
-	}
-	if azureCloud.CloudProviderRateLimitQPS != 0.5 {
-		t.Errorf("got incorrect value for CloudProviderRateLimitQPS")
-	}
-	if azureCloud.CloudProviderRateLimitBucket != 5 {
-		t.Errorf("got incorrect value for CloudProviderRateLimitBucket")
+	if azureCloud.CloudProviderRateLimiting.Enabled != true {
+		t.Errorf("got incorrect value for CloudProviderRateLimiting.Enabled")
 	}
 }
 
@@ -1717,8 +1758,8 @@ func validateEmptyConfig(t *testing.T, config string) {
 		t.Errorf("got incorrect value for CloudProviderBackoff")
 	}
 	// rate limits should be disabled by default if not explicitly enabled in config
-	if azureCloud.CloudProviderRateLimit != false {
-		t.Errorf("got incorrect value for CloudProviderRateLimit")
+	if azureCloud.CloudProviderRateLimiting.Enabled != false {
+		t.Errorf("got incorrect value for CloudProviderRateLimiting.Enabled")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR is a clone of https://github.com/kubernetes/kubernetes/pull/85942 for master

We need it to fix errors we have when the global rate limiting allows kubernetes to query VMSS API beyond the low limits it enforces.

**Which issue(s) this PR fixes**:

https://github.com/Azure/AKS/issues/1187

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:


```release-note
Azure: Separate VMSS rate limiting
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
