### PR TITLE
increase LRU cache size 8x for authorization webhook

### DIFF
--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -95,7 +95,7 @@ func New(kubeConfigFile string, version string, authorizedTTL, unauthorizedTTL t
 func newWithBackoff(subjectAccessReview subjectAccessReviewer, authorizedTTL, unauthorizedTTL, initialBackoff time.Duration) (*WebhookAuthorizer, error) {
 	return &WebhookAuthorizer{
 		subjectAccessReview: subjectAccessReview,
-		responseCache:       cache.NewLRUExpireCache(1024),
+		responseCache:       cache.NewLRUExpireCache(8192),
 		authorizedTTL:       authorizedTTL,
 		unauthorizedTTL:     unauthorizedTTL,
 		initialBackoff:      initialBackoff,


### PR DESCRIPTION
1024 seems absurdly small for any normal deployment. At our 10000 byte
entry size limit, this will consume max ~80 MB of memory. More realistic
entry sizes are going to be far less than a kB amounting to less than <8MB
of memory consumption.

/sig auth
/kind bug
Ref: #85855

```release-note
NONE
```