### PR TITLE
Refactor and optimize preferred (anti) pod affinity 

### DIFF
--- a/pkg/scheduler/algorithm/priorities/BUILD
+++ b/pkg/scheduler/algorithm/priorities/BUILD
@@ -45,6 +45,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/listers/apps/v1:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Optimize preferred (anti) pod affinity by removing redundant creation of Selectors during metadata calculation, and eliminates unnecessary and excessive nodeinfo map lookups. Gain is roughly 25% on 5k clusters.

before
```
ahg@ahg1:~/go/src/k8s.io/kubernetes$ tail /tmp/affinity-master 
I1205 13:56:33.337355  222356 etcd.go:81] etcd already running at http://127.0.0.1:2379
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/test/integration/scheduler_perf
BenchmarkSchedulingPreferredPodAffinity/500Nodes/500Pods-12                 1000           2099450 ns/op
BenchmarkSchedulingPreferredPodAffinity/5000Nodes/15000Pods-12              1000          13419954 ns/op
PASS
ok      k8s.io/kubernetes/test/integration/scheduler_perf       204.199s
+++ [1205 13:59:57] Cleaning up etcd
+++ [1205 13:59:57] Integration test cleanup complete
ahg@ahg1:~/go/src/k8s.io/kubernetes$ 
```

after
```
ahg@ahg1:~/go/src/k8s.io/kubernetes$ tail /tmp/affinity-opt
I1205 14:04:00.566016  225809 etcd.go:81] etcd already running at http://127.0.0.1:2379
goos: linux
goarch: amd64
pkg: k8s.io/kubernetes/test/integration/scheduler_perf
BenchmarkSchedulingPreferredPodAffinity/500Nodes/500Pods-12                 1000           1909800 ns/op
BenchmarkSchedulingPreferredPodAffinity/5000Nodes/15000Pods-12              1000          10676680 ns/op
PASS
ok      k8s.io/kubernetes/test/integration/scheduler_perf       182.283s
+++ [1205 14:07:02] Cleaning up etcd
+++ [1205 14:07:02] Integration test cleanup complete

```
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @Huang-Wei 