### PR TITLE
Initial behavior examples for conformance

### DIFF
--- a/test/conformance/behaviors/sig-network/service-spec.yaml
+++ b/test/conformance/behaviors/sig-network/service-spec.yaml
@@ -1,0 +1,30 @@
+suite: service/spec
+description: Base suite for services
+behaviors:
+- id: service/basic-create/selector
+  description: When a Service resource is created with type "ClusterIP", "NodePort", or "LoadBalancer",
+    and a selector is specified, an Endpoints object is generated based with the IPs of pods with
+    label keys and values matching the selector.
+- id: service/basic-create/no-selector
+  description: When a Service resource is created and a no selector is specified, no changes are made
+    to any corresponding Endpoints object.
+- id: service/type/ClusterIP/empty
+  description: When the Service type is specified as "ClusterIP" and the clusterIP
+    field is empty, a cluster-internal IP address for load-balancing to endpoints is
+    allocated.
+- id: service/type/ClusterIP/static
+  description: When the Service type is specified as "ClusterIP" and the clusterIP
+    field is specified as an IP address in the cluster service range, and that IP is
+    not already assigned to another service, that IP is be allocated as a cluster-internal
+    IP address for load-balancing to endpoints.
+- id: service/type/ClusterIP/None
+  description: When the Service type is specified as "ClusterIP" and the clusterIP
+    field is "None", no virtual IP is allocated and the endpoints are published as a
+    set of endpoints rather than a stable IP.
+- id: service/type/NodePort
+  description: When the Service type is specified as "NodePort" , a cluster-internal
+    IP address for load-balancing to endpoints is allocated as for type "ClusterIP".
+    Additionally, a cluster-wide port is allocated on every node, routing to the clusterIP.
+- id: service/type/ExternalName
+  description: When the Service type is specified as "ExternalName", the cluster DNS provider
+    publishes a CNAME pointing from the service to the specified external name.

--- a/test/conformance/behaviors/sig-node/pod-readiness-gates.yaml
+++ b/test/conformance/behaviors/sig-node/pod-readiness-gates.yaml
@@ -1,0 +1,7 @@
+suite: pod/readinessGates
+description: Suite for pod readiness gates
+behaviors:
+- id: pod/readinessGates/single
+  description: If a readinessGate is specified and the corresponding condition is not "True", then the Pod Ready condition MUST be "False", even if all containers are Ready.
+- id: pod/readinessGates/multiple
+  description: If multiple readinessGates are specified and the corresponding condition is not "True" for one or more of these, then the Pod Ready condition MUST be "False", even if all containers are Ready.

--- a/test/conformance/behaviors/sig-node/pod-spec.yaml
+++ b/test/conformance/behaviors/sig-node/pod-spec.yaml
@@ -1,0 +1,43 @@
+suite: pod/spec
+description: Base suite for pods
+behaviors:
+- id: pod/basic-create
+  description: When a Pod resource is created with a single container and sufficient resources, a Pod MUST be created on a node with the specified container image.
+- id: pod/basic-delete
+  description: When a Pod resource is delete, the Pod containers must receive a TERM signal and the Pod MUST be deleted.
+- id: pod/hostname
+  description: When the hostname field is set, a container running in the Pod MUST report the hostname as the specified value.
+- id: pod/subdomain
+  description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
+    namespace>.svc.<cluster domain>". If not specified, the pod will not have a
+    domainname at all.
+- id: pod/terminationGracePeriodSeconds/in-spec
+  description: When the terminationGracePeriodSeconds is specified in the spec,
+    processes running in the Pod MUST NOT receive a hard termination signal for at
+    least that number of seconds after a delete request.
+- id: pod/terminationGracePeriodSeconds/in-delete
+  description: When the terminationGracePeriodSeconds is specified in a delete request,
+    processes running in the Pod MUST NOT receive a hard termination signal for at
+    least that number of seconds after the delete request.
+- id: pod/activeDeadlineSeconds
+  description: Optional duration in seconds the pod may be active on the node relative
+    to StartTime before the system will actively try to mark it failed and kill
+    associated containers. Value must be a positive integer.
+- id: pod/hostNetwork/true
+  description: When hostNetwork is set to true, the Pod MUST use the host's network
+    namespace.
+- id: pod/hostNetwork/false
+  description: When hostNetwork is set to false, the Pod MUST NOT use the host's network
+    namespace.
+- id: pod/hostPID/true
+  description: When hostPID is set to true, the Pod MUST use the host's process
+    namespace.
+- id: pod/hostPID/false
+  description: When hostPID is set to false, the Pod MUST NOT use the host's process
+    namespace.
+- id: pod/hostIPC/true
+  description: When hostIPC is set to true, the Pod MUST use the host's inter-process
+    communication namespace.
+- id: pod/hostIPC/false
+  description: When hostIPC is set to false, the Pod MUST NOT use the host's inter-process
+    communication namespace.


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates to the conformance tooling as defined in this [KEP].

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This is a work-in-progress, the spec.yaml and readiness-gates.yaml are the furthest along.

The initial files were generated with `kubetestgen` and from there I re-oraganized and tweaked them. Files in this format will eventually become the standard description of what conformant Kubernetes is, and the tests will just validate these behaviors. Behaviors may be flagged with a Provisional status, to indicate that they are desired behaviors but we do not yet have a test that covers them. This will be helpful during the transition, although it likely will be needed for quite some time as we backfill tests.

The KEP describes linking the tests and the behaviors throught a `tests.yaml` file, but instead I think it will be easier just to add a section to the conformance test meta-data:

```
 /*
  Testname: Create and Delete a Pod with a Single Container and Default Values
  Description: This test creates a pod with a single container in and otherwise default PodSpec values, then deletes it. The Pod must be scheduled to a node and the container enter Running state. The Pod must be deleted and the terminationGracePeriod default of 30 seconds respected.
  Behaviors:
   - pods/basic-create
   - pods/basic-delete
*/
```

The test runner then can emit the covered behaviors, simplifying producing a report of whether a given cluster is conformant. All non-provisional behaviors must be hit in the test run; this avoids "missing" tests going undetected.

We should consider how to divide the meta-data between the YAML and the test comment. For example, "version" in the YAML would apply to what Kubernetes version expects that behavior. Version in the test comment may refer to when the test was added, if we believe we need it at all.

The expectation is that we can define the list of behaviors up front, much more rapidly than we can define and write the tests themselves. We must therefore decide whether clusters that pass all existing tests *but demonstrably do not meet Provisional behaviors* are conformant. I would suggest they are not. 

We still need the manual review process for any tests that claims to be hitting conformance behaviors. The reviewers must be careful to ensure that any *implicit* behaviors that are relied upon by a conformance test are also conformant. I don't see any way to automate that. However, the pool of reviewers/approvers for those tests can be much wider than the pool of reviewers/approvers for the behaviors themselves.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

- [KEP]

[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/20190412-conformance-behaviors.md

```docs

```
