### PR TITLE
Deflake kubectl custom printing test

### DIFF
--- a/test/e2e/kubectl/BUILD
+++ b/test/e2e/kubectl/BUILD
@@ -33,6 +33,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
+        "//staging/src/k8s.io/client-go/discovery:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Tolerates discovery errors unrelated to the API groups we care about in the kubectl printing test. We run this test parallel with lots of other tests that add/remove API groups dynamically, so this test should be robust to that.

Would fix failures like https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/batch/pull-kubernetes-e2e-gce/1202646121160118273/

xref similar change done in https://github.com/kubernetes/kubernetes/pull/63597/files

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig testing
/assign @robscott 