### PR TITLE
Automated cherry pick of #85968: Fix bug in apiserver service cluster cidr split

### DIFF
--- a/cmd/kube-apiserver/app/BUILD
+++ b/cmd/kube-apiserver/app/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -98,4 +98,10 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    embed = [":go_default_library"],
 )

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -572,8 +572,10 @@ func Complete(s *options.ServerRunOptions) (completedServerRunOptions, error) {
 
 	// process s.ServiceClusterIPRange from list to Primary and Secondary
 	// we process secondary only if provided by user
-
-	serviceClusterIPRangeList := strings.Split(s.ServiceClusterIPRanges, ",")
+	serviceClusterIPRangeList := []string{}
+	if s.ServiceClusterIPRanges != "" {
+		serviceClusterIPRangeList = strings.Split(s.ServiceClusterIPRanges, ",")
+	}
 
 	var apiServerServiceIP net.IP
 	var serviceIPRange net.IPNet

--- a/cmd/kube-apiserver/app/server_test.go
+++ b/cmd/kube-apiserver/app/server_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"testing"
+)
+
+func TestGetServiceIPAndRanges(t *testing.T) {
+	tests := []struct {
+		body                    string
+		apiServerServiceIP      string
+		primaryServiceIPRange   string
+		secondaryServiceIPRange string
+		expectedError           bool
+	}{
+		{"", "10.0.0.1", "10.0.0.0/24", "<nil>", false},
+		{"192.0.2.1/24", "192.0.2.1", "192.0.2.0/24", "<nil>", false},
+		{"192.0.2.1/24,192.168.128.0/17", "192.0.2.1", "192.0.2.0/24", "192.168.128.0/17", false},
+		{"192.0.2.1/30,192.168.128.0/17", "<nil>", "<nil>", "<nil>", true},
+	}
+
+	for _, test := range tests {
+		apiServerServiceIP, primaryServiceIPRange, secondaryServiceIPRange, err := getServiceIPAndRanges(test.body)
+
+		if apiServerServiceIP.String() != test.apiServerServiceIP {
+			t.Errorf("expected apiServerServiceIP: %s, got: %s", test.apiServerServiceIP, apiServerServiceIP.String())
+		}
+
+		if primaryServiceIPRange.String() != test.primaryServiceIPRange {
+			t.Errorf("expected primaryServiceIPRange: %s, got: %s", test.primaryServiceIPRange, primaryServiceIPRange.String())
+		}
+
+		if secondaryServiceIPRange.String() != test.secondaryServiceIPRange {
+			t.Errorf("expected secondaryServiceIPRange: %s, got: %s", test.secondaryServiceIPRange, secondaryServiceIPRange.String())
+		}
+
+		if (err == nil) == test.expectedError {
+			t.Errorf("expected err to be: %t, but it was %t", test.expectedError, !test.expectedError)
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick of #85968 on release-1.17.

#85968: Fix bug in apiserver service cluster cidr split

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.