### PR TITLE
Add current chairs to component base approvers

### DIFF
--- a/staging/src/k8s.io/component-base/OWNERS
+++ b/staging/src/k8s.io/component-base/OWNERS
@@ -1,6 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
+- mtaufen
+- stealthybox
 - luxas
 - sttts
 - lavalamp


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Adds current WG Component Standard chairs to k8s.io/component-base approvers

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @sttts @luxas 