### PR TITLE
kubeadm: move taints to the kubelet phases

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/init/kubelet.go
@@ -65,10 +65,8 @@ func runKubeletStart(c workflow.RunData) error {
 		kubeletphase.TryStopKubelet()
 	}
 
-	// Write env file with flags for the kubelet to use. We do not need to write the --register-with-taints for the control-plane,
-	// as we handle that ourselves in the mark-control-plane phase
-	// TODO: Maybe we want to do that some time in the future, in order to remove some logic from the mark-control-plane phase?
-	if err := kubeletphase.WriteKubeletDynamicEnvFile(&data.Cfg().ClusterConfiguration, &data.Cfg().NodeRegistration, false, data.KubeletDir()); err != nil {
+	// Write env file with flags for the kubelet to use.
+	if err := kubeletphase.WriteKubeletDynamicEnvFile(&data.Cfg().ClusterConfiguration, &data.Cfg().NodeRegistration, true, data.KubeletDir()); err != nil {
 		return errors.Wrap(err, "error writing a dynamic environment file for the kubelet")
 	}
 

--- a/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
+++ b/cmd/kubeadm/app/cmd/phases/init/markcontrolplane.go
@@ -61,5 +61,5 @@ func runMarkControlPlane(c workflow.RunData) error {
 	}
 
 	nodeRegistration := data.Cfg().NodeRegistration
-	return markcontrolplanephase.MarkControlPlane(client, nodeRegistration.Name, nodeRegistration.Taints)
+	return markcontrolplanephase.MarkControlPlane(client, nodeRegistration.Name)
 }

--- a/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
+++ b/cmd/kubeadm/app/cmd/phases/join/controlplanejoin.go
@@ -194,8 +194,8 @@ func runMarkControlPlanePhase(c workflow.RunData) error {
 		return err
 	}
 
-	if err := markcontrolplanephase.MarkControlPlane(client, cfg.NodeRegistration.Name, cfg.NodeRegistration.Taints); err != nil {
-		return errors.Wrap(err, "error applying control-plane label and taints")
+	if err := markcontrolplanephase.MarkControlPlane(client, cfg.NodeRegistration.Name); err != nil {
+		return errors.Wrap(err, "error applying control-plane label")
 	}
 
 	return nil

--- a/cmd/kubeadm/app/cmd/phases/join/kubelet.go
+++ b/cmd/kubeadm/app/cmd/phases/join/kubelet.go
@@ -138,11 +138,9 @@ func runKubeletStartJoinPhase(c workflow.RunData) (returnErr error) {
 		return err
 	}
 
-	// Write env file with flags for the kubelet to use. We only want to
-	// register the joining node with the specified taints if the node
-	// is not a control-plane. The mark-control-plane phase will register the taints otherwise.
-	registerTaintsUsingFlags := cfg.ControlPlane == nil
-	if err := kubeletphase.WriteKubeletDynamicEnvFile(&initCfg.ClusterConfiguration, &initCfg.NodeRegistration, registerTaintsUsingFlags, kubeadmconstants.KubeletRunDirectory); err != nil {
+	// Write env file with flags for the kubelet to use.
+	addControlPlaneTaint := cfg.ControlPlane == nil
+	if err := kubeletphase.WriteKubeletDynamicEnvFile(&initCfg.ClusterConfiguration, &initCfg.NodeRegistration, addControlPlaneTaint, kubeadmconstants.KubeletRunDirectory); err != nil {
 		return err
 	}
 

--- a/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
+++ b/cmd/kubeadm/app/phases/markcontrolplane/markcontrolplane.go
@@ -26,41 +26,15 @@ import (
 )
 
 // MarkControlPlane taints the control-plane and sets the control-plane label
-func MarkControlPlane(client clientset.Interface, controlPlaneName string, taints []v1.Taint) error {
+func MarkControlPlane(client clientset.Interface, controlPlaneName string) error {
 
 	fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the label \"%s=''\"\n", controlPlaneName, constants.LabelNodeRoleMaster)
 
-	if len(taints) > 0 {
-		taintStrs := []string{}
-		for _, taint := range taints {
-			taintStrs = append(taintStrs, taint.ToString())
-		}
-		fmt.Printf("[mark-control-plane] Marking the node %s as control-plane by adding the taints %v\n", controlPlaneName, taintStrs)
-	}
-
 	return apiclient.PatchNode(client, controlPlaneName, func(n *v1.Node) {
-		markControlPlaneNode(n, taints)
+		markControlPlaneNode(n)
 	})
 }
 
-func taintExists(taint v1.Taint, taints []v1.Taint) bool {
-	for _, t := range taints {
-		if t == taint {
-			return true
-		}
-	}
-
-	return false
-}
-
-func markControlPlaneNode(n *v1.Node, taints []v1.Taint) {
+func markControlPlaneNode(n *v1.Node) {
 	n.ObjectMeta.Labels[constants.LabelNodeRoleMaster] = ""
-
-	for _, nt := range n.Spec.Taints {
-		if !taintExists(nt, taints) {
-			taints = append(taints, nt)
-		}
-	}
-
-	n.Spec.Taints = taints
 }

--- a/cmd/kubeadm/app/util/config/BUILD
+++ b/cmd/kubeadm/app/util/config/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//cmd/kubeadm/app/util/apiclient:go_default_library",
         "//cmd/kubeadm/app/util/config/strict:go_default_library",
         "//cmd/kubeadm/app/util/runtime:go_default_library",
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -69,7 +68,6 @@ go_test(
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/github.com/lithammer/dedent:go_default_library",
         "//vendor/github.com/pmezard/go-difflib/difflib:go_default_library",
-        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/util/config/initconfiguration.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pkg/errors"
 	"k8s.io/klog"
 
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	netutil "k8s.io/apimachinery/pkg/util/net"
@@ -47,7 +46,7 @@ func SetInitDynamicDefaults(cfg *kubeadmapi.InitConfiguration) error {
 	if err := SetBootstrapTokensDynamicDefaults(&cfg.BootstrapTokens); err != nil {
 		return err
 	}
-	if err := SetNodeRegistrationDynamicDefaults(&cfg.NodeRegistration, true); err != nil {
+	if err := SetNodeRegistrationDynamicDefaults(&cfg.NodeRegistration); err != nil {
 		return err
 	}
 	if err := SetAPIEndpointDynamicDefaults(&cfg.LocalAPIEndpoint); err != nil {
@@ -83,16 +82,11 @@ func SetBootstrapTokensDynamicDefaults(cfg *[]kubeadmapi.BootstrapToken) error {
 }
 
 // SetNodeRegistrationDynamicDefaults checks and sets configuration values for the NodeRegistration object
-func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions, ControlPlaneTaint bool) error {
+func SetNodeRegistrationDynamicDefaults(cfg *kubeadmapi.NodeRegistrationOptions) error {
 	var err error
 	cfg.Name, err = kubeadmutil.GetHostname(cfg.Name)
 	if err != nil {
 		return err
-	}
-
-	// Only if the slice is nil, we should append the control-plane taint. This allows the user to specify an empty slice for no default control-plane taint
-	if ControlPlaneTaint && cfg.Taints == nil {
-		cfg.Taints = []v1.Taint{kubeadmconstants.ControlPlaneTaint}
 	}
 
 	if cfg.CRISocket == "" {

--- a/cmd/kubeadm/app/util/config/initconfiguration_test.go
+++ b/cmd/kubeadm/app/util/config/initconfiguration_test.go
@@ -24,12 +24,7 @@ import (
 	"testing"
 
 	"github.com/pmezard/go-difflib/difflib"
-
-	"k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"sigs.k8s.io/yaml"
 )
 
 func diff(expected, actual []byte) string {
@@ -118,83 +113,6 @@ func TestLoadInitConfigurationFromFile(t *testing.T) {
 				if obj == nil {
 					t.Errorf("Unexpected nil return value")
 				}
-			}
-		})
-	}
-}
-
-func TestDefaultTaintsMarshaling(t *testing.T) {
-	tests := []struct {
-		desc             string
-		cfg              kubeadmapiv1beta2.InitConfiguration
-		expectedTaintCnt int
-	}{
-		{
-			desc: "Uninitialized nodeRegistration field produces a single taint (the master one)",
-			cfg: kubeadmapiv1beta2.InitConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta2",
-					Kind:       constants.InitConfigurationKind,
-				},
-			},
-			expectedTaintCnt: 1,
-		},
-		{
-			desc: "Uninitialized taints field produces a single taint (the master one)",
-			cfg: kubeadmapiv1beta2.InitConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta2",
-					Kind:       constants.InitConfigurationKind,
-				},
-				NodeRegistration: kubeadmapiv1beta2.NodeRegistrationOptions{},
-			},
-			expectedTaintCnt: 1,
-		},
-		{
-			desc: "Forsing taints to an empty slice produces no taints",
-			cfg: kubeadmapiv1beta2.InitConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta2",
-					Kind:       constants.InitConfigurationKind,
-				},
-				NodeRegistration: kubeadmapiv1beta2.NodeRegistrationOptions{
-					Taints: []v1.Taint{},
-				},
-			},
-			expectedTaintCnt: 0,
-		},
-		{
-			desc: "Custom taints are used",
-			cfg: kubeadmapiv1beta2.InitConfiguration{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "kubeadm.k8s.io/v1beta2",
-					Kind:       constants.InitConfigurationKind,
-				},
-				NodeRegistration: kubeadmapiv1beta2.NodeRegistrationOptions{
-					Taints: []v1.Taint{
-						{Key: "taint1"},
-						{Key: "taint2"},
-					},
-				},
-			},
-			expectedTaintCnt: 2,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			b, err := yaml.Marshal(tc.cfg)
-			if err != nil {
-				t.Fatalf("unexpected error while marshalling to YAML: %v", err)
-			}
-
-			cfg, err := BytesToInitConfiguration(b)
-			if err != nil {
-				t.Fatalf("unexpected error of BytesToInitConfiguration: %v\nconfig: %s", err, string(b))
-			}
-
-			if tc.expectedTaintCnt != len(cfg.NodeRegistration.Taints) {
-				t.Fatalf("unexpected taints count\nexpected: %d\ngot: %d\ntaints: %v", tc.expectedTaintCnt, len(cfg.NodeRegistration.Taints), cfg.NodeRegistration.Taints)
 			}
 		})
 	}

--- a/cmd/kubeadm/app/util/config/joinconfiguration.go
+++ b/cmd/kubeadm/app/util/config/joinconfiguration.go
@@ -33,11 +33,7 @@ import (
 
 // SetJoinDynamicDefaults checks and sets configuration values for the JoinConfiguration object
 func SetJoinDynamicDefaults(cfg *kubeadmapi.JoinConfiguration) error {
-	addControlPlaneTaint := false
-	if cfg.ControlPlane != nil {
-		addControlPlaneTaint = true
-	}
-	if err := SetNodeRegistrationDynamicDefaults(&cfg.NodeRegistration, addControlPlaneTaint); err != nil {
+	if err := SetNodeRegistrationDynamicDefaults(&cfg.NodeRegistration); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Pass the Node taints as kubelet flags.
The kubelet configuration does not support these.

This registers the Node taints as early as possible, otherwise
the taints in the mark-control-plane phase happen too late and
workloads can schedule on a control-plane node.

Joining control-planes already use the same logic as
WriteKubeletDynamicEnvFile supports generating the register-with-taints
kubelet flag.

The NodeRegistrationOptions comments about taints need a slight
adjustment for v1beta3.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#1621

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: kubeadm: the mark-control-plane phase now only labels the Node but does not taint it. Taints passed via the kubeadm config and also the "master" taint are now passed to the kubelet via the "--register-with-taints" flag. This prevents scheduling Pods on Nodes before they have the correct taints.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/hold
/kind feature
/priority important-longterm
@kubernetes/sig-cluster-lifecycle-pr-reviews 
cc @yagonobre 