### PR TITLE
Validate ingressrule http is not nil

### DIFF
--- a/pkg/apis/networking/validation/validation.go
+++ b/pkg/apis/networking/validation/validation.go
@@ -266,10 +266,10 @@ func validateIngressRules(ingressRules []networking.IngressRule, fldPath *field.
 
 func validateIngressRuleValue(ingressRule *networking.IngressRuleValue, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if ingressRule.HTTP != nil {
-		allErrs = append(allErrs, validateHTTPIngressRuleValue(ingressRule.HTTP, fldPath.Child("http"))...)
+	if ingressRule.HTTP == nil {
+		return append(allErrs, field.Required(fldPath.Child("http"), ""))
 	}
-	return allErrs
+	return append(allErrs, validateHTTPIngressRuleValue(ingressRule.HTTP, fldPath.Child("http"))...)
 }
 
 func validateHTTPIngressRuleValue(httpIngressRuleValue *networking.HTTPIngressRuleValue, fldPath *field.Path) field.ErrorList {


### PR DESCRIPTION
Co-authored-by: anencore94 <ssarang520@gmail.com>
Signed-off-by: Woohyung Han <techhanx@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently we can create following ingress with there's no meaning.

```go
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:
  name: test-ingress
spec:
  rules:
  - http:
```

if we create the ingress and try to check rule, nil pointer exception occurs because there is no http rule. This should be checked in validation section. (https://github.com/kubevirt/containerized-data-importer/blob/f948406c5461b3a750203e84fff14d4142152b8e/pkg/controller/config-controller.go#L153)

```go
		for _, rule := range ing.Spec.Rules {
                        // here, I print rule variable but this is nil
                       // so following line throw an nil pointer exception
			for _, path := range rule.HTTP.Paths {
				if path.Backend.ServiceName == c.uploadProxyServiceName {
					c.enqueueCDIConfig(config)
					return
				}
			}
		}
```



**Which issue(s) this PR fixes**:
Fixes #85982 

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```