### PR TITLE
e2e: support long CSI driver names

### DIFF
--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -171,7 +171,6 @@ func skipUnsupportedTest(driver TestDriver, pattern testpatterns.TestPattern) {
 type VolumeResource struct {
 	Config    *PerTestConfig
 	Pattern   testpatterns.TestPattern
-	VolType   string
 	VolSource *v1.VolumeSource
 	Pvc       *v1.PersistentVolumeClaim
 	Pv        *v1.PersistentVolume
@@ -199,7 +198,6 @@ func CreateVolumeResource(driver TestDriver, config *PerTestConfig, pattern test
 		framework.Logf("Creating resource for inline volume")
 		if iDriver, ok := driver.(InlineVolumeTestDriver); ok {
 			r.VolSource = iDriver.GetVolumeSource(false, pattern.FsType, r.Volume)
-			r.VolType = dInfo.Name
 		}
 	case testpatterns.PreprovisionedPV:
 		framework.Logf("Creating resource for pre-provisioned PV")
@@ -209,7 +207,6 @@ func CreateVolumeResource(driver TestDriver, config *PerTestConfig, pattern test
 				r.Pv, r.Pvc = createPVCPV(f, dInfo.Name, pvSource, volumeNodeAffinity, pattern.VolMode, dInfo.RequiredAccessModes)
 				r.VolSource = createVolumeSource(r.Pvc.Name, false /* readOnly */)
 			}
-			r.VolType = fmt.Sprintf("%s-preprovisionedPV", dInfo.Name)
 		}
 	case testpatterns.DynamicPV:
 		framework.Logf("Creating resource for dynamic PV")
@@ -238,12 +235,10 @@ func CreateVolumeResource(driver TestDriver, config *PerTestConfig, pattern test
 					f, dInfo.Name, claimSize, r.Sc, pattern.VolMode, dInfo.RequiredAccessModes)
 				r.VolSource = createVolumeSource(r.Pvc.Name, false /* readOnly */)
 			}
-			r.VolType = fmt.Sprintf("%s-dynamicPV", dInfo.Name)
 		}
 	case testpatterns.CSIInlineVolume:
 		framework.Logf("Creating resource for CSI ephemeral inline volume")
 		if eDriver, ok := driver.(EphemeralTestDriver); ok {
-			r.VolType = fmt.Sprintf("%s-ephemeral", dInfo.Name)
 			attributes, _, _ := eDriver.GetVolume(config, 0)
 			r.VolSource = &v1.VolumeSource{
 				CSI: &v1.CSIVolumeSource{

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -148,7 +148,7 @@ func (s *subPathTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 		}
 
 		subPath := f.Namespace.Name
-		l.pod = SubpathTestPod(f, subPath, l.resource.VolType, l.resource.VolSource, true)
+		l.pod = SubpathTestPod(f, subPath, string(volType), l.resource.VolSource, true)
 		l.pod.Spec.NodeName = l.config.ClientNodeName
 		l.pod.Spec.NodeSelector = l.config.ClientNodeSelector
 
@@ -185,6 +185,8 @@ func (s *subPathTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 
 		validateMigrationVolumeOpCounts(f.ClientSet, driver.GetDriverInfo().InTreePluginName, l.intreeOps, l.migratedOps)
 	}
+
+	driverName := driver.GetDriverInfo().Name
 
 	ginkgo.It("should support non-existent path", func() {
 		init()
@@ -348,9 +350,9 @@ func (s *subPathTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 		init()
 		defer cleanup()
 
-		if strings.HasPrefix(l.resource.VolType, "hostPath") || strings.HasPrefix(l.resource.VolType, "csi-hostpath") {
+		if strings.HasPrefix(driverName, "hostPath") {
 			// TODO: This skip should be removed once #61446 is fixed
-			framework.Skipf("%s volume type does not support reconstruction, skipping", l.resource.VolType)
+			framework.Skipf("Driver %s does not support reconstruction, skipping", driverName)
 		}
 
 		testSubpathReconstruction(f, l.hostExec, l.pod, true)
@@ -390,7 +392,7 @@ func (s *subPathTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 		init()
 		defer cleanup()
 		if l.roVolSource == nil {
-			framework.Skipf("Volume type %v doesn't support readOnly source", l.resource.VolType)
+			framework.Skipf("Driver %s on volume type %s doesn't support readOnly source", driverName, pattern.VolType)
 		}
 
 		origpod := l.pod.DeepCopy()
@@ -418,7 +420,7 @@ func (s *subPathTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 		init()
 		defer cleanup()
 		if l.roVolSource == nil {
-			framework.Skipf("Volume type %v doesn't support readOnly source", l.resource.VolType)
+			framework.Skipf("Driver %s on volume type %s doesn't support readOnly source", driverName, pattern.VolType)
 		}
 
 		// Format the volume while it's writable

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -193,7 +193,7 @@ func (t *volumesTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 			init()
 			defer cleanup()
 
-			testScriptInPod(f, l.resource.VolType, l.resource.VolSource, l.config)
+			testScriptInPod(f, string(pattern.VolType), l.resource.VolSource, l.config)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The storage e2e test suite uses given CSI driver names as pod names. For pod names that also get enriched by a prefix and suffix, it is very easy to exceed the 63 character limit that pod names are subject to, thereby causing tests to fail. This is already the case for moderately sized CSI driver names like `dobs.csi.digitalocean.com` that we employ for DigitalOcean's CSI driver: about ~15 tests were failing on us due to this problem.

This change fixes the described problem by omitting the driver name from the pod name suffix.

It also allows us to drop VolumeResource.VolType.

~This change runs CSI driver names through a shortening function that reduces each domain name label of the driver name to its first letter. For all practical purposes, this should prevent pod name character length violations.~ (Original approach that was changed along the review.)

**Special notes for your reviewer**:

I discussed the matter with @msau42 a couple of days ago [on Slack](https://kubernetes.slack.com/archives/C09QZFCE5/p1575074013442500). We concluded that truncating or short name usage would make sense.

I did not implement either of the two directly because of the following reasons:

- Truncating means removing/shortening either the prefix or the (randomly generated) suffix of a pod name, with the implications that pods are harder to associate to tests or could cause collisions with other pod names, respectively. Neither seemed ideal.
- The short name is currently not part of the interface that is passed to individual tests. Unless we were willing to do some rather nasty type assertions, we would have to extend the interface used to retrieve test driver details from. This seemed like a rather invasive change.
- Finally, the proposed solution of shortening by domain name labels is effective while still allowing to identify involved CSI drivers (with a bit of a squint).

**Does this PR introduce a user-facing change?**:

-->
```release-note
NONE
```