### PR TITLE
Fix IPv6 addresses lost issue in pure ipv6 vsphere environment

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go
@@ -572,7 +572,7 @@ func getLocalIP() ([]v1.NodeAddress, error) {
 		} else {
 			for _, addr := range localAddrs {
 				if ipnet, ok := addr.(*net.IPNet); ok {
-					if ipnet.IP.To4() != nil {
+					if !ipnet.IP.IsLinkLocalUnicast() {
 						// Filter external IP by MAC address OUIs from vCenter and from ESX
 						vmMACAddr := strings.ToLower(i.HardwareAddr.String())
 						// Making sure that the MAC address is long enough
@@ -683,7 +683,7 @@ func (vs *VSphere) NodeAddresses(ctx context.Context, nodeName k8stypes.NodeName
 	for _, v := range vmMoList[0].Guest.Net {
 		if vs.cfg.Network.PublicNetwork == v.Network {
 			for _, ip := range v.IpAddress {
-				if net.ParseIP(ip).To4() != nil {
+				if !net.ParseIP(ip).IsLinkLocalUnicast() {
 					nodehelpers.AddToNodeAddresses(&addrs,
 						v1.NodeAddress{
 							Type:    v1.NodeExternalIP,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind bug

**What this PR does / why we need it**:
with this bug fix, k8s could get both ipv6/ipv4 addresses from vsphere platform, meanwhile k8s could ignore link-local addresses while retrieves VM’s IP.

VMware tools can collect IP addresses on VM, and provide them to k8s.
those IP addresses contain both ipv4/ipv6 addresses, and some useless link-local addresses
e.g.
![70368878-72c33b80-18eb-11ea-8349-5aef9103c088](https://user-images.githubusercontent.com/16233859/76823379-04c5d300-684f-11ea-908f-09ad9d7c51d9.png)
From the code
https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere.go#L682-L700
we can know that while the provider retrieves VM’s IP, It uses To4() function for all IP addresses from vsphere platform, this function will ignore all ipv6 address, and can't filter out ipv4 link-local addresses.
![70368733-b321ba00-18e9-11ea-8200-dcdb89fec0b9](https://user-images.githubusercontent.com/16233859/76823420-26bf5580-684f-11ea-862b-79b3b2e121cb.png)
It will cause IPv6 addresses lost in node status.
```
[root@henry-c1 ~]# kubectl get nodes -o wide
NAME        STATUS   ROLES    AGE    VERSION   INTERNAL-IP   EXTERNAL-IP   OS-IMAGE                                      KERNEL-VERSION               CONTAINER-RUNTIME
henry-c1    Ready    <none>   6h9m   v1.15.4   <none>        <none>        Red Hat Enterprise Linux Server 7.6 (Maipo)   3.10.0-1062.1.2.el7.x86_64   docker://1.13.1
```
and we can't use helm in a vsphere pure ipv6 env
```
[root@henry-c1 ~]# helm install
Error: forwarding ports: error upgrading connection: no preferred addresses found; known addresses: []
```

In this PR, we use  !ParseIP(ip).IsLinkLocalUnicast() to retrieves VM’s IP
![70368813-8621d700-18ea-11ea-8bd1-ef4b90ef0a4d](https://user-images.githubusercontent.com/16233859/76823455-3dfe4300-684f-11ea-8012-d2f75062a98f.png)
we can get ipv6 address in node status by this fix, and can use helm in a pure ipv6 vsphere env 
```
[root@henry-c1 ~]# kubectl get nodes -o wide
NAME        STATUS   ROLES    AGE    VERSION                                  INTERNAL-IP         EXTERNAL-IP         OS-IMAGE                                      KERNEL-VERSION               CONTAINER-RUNTIME
henry-c1    Ready    <none>   2d9h   v1.15.7-beta.0.16+6be749574d9801-dirty   2650:1:87:96::113   2650:1:87:96::113   Red Hat Enterprise Linux Server 7.6 (Maipo)   3.10.0-1062.1.2.el7.x86_64   docker://1.13.1
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85886 #83584

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
Fix IPv6 addresses lost issue in pure ipv6 vsphere environment
```

