### PR TITLE
staging/publishing: temporarily disable publishing tags

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,3 +1,4 @@
+skip-tags: true
 recursive-delete-patterns:
 - BUILD
 - "*/BUILD"


### PR DESCRIPTION
Ref: https://github.com/kubernetes/publishing-bot/pull/210#discussion_r354891238

To make sure we get enough time to test publishing of `v1.17.0`
(on a test repo) when it is tagged, this commit disables publishing tags.

After testing it, we'll re-enable publishing of tags.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
