### PR TITLE
Add build support for riscv64 arch

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -27,6 +27,7 @@ readonly KUBE_SUPPORTED_SERVER_PLATFORMS=(
   linux/arm64
   linux/s390x
   linux/ppc64le
+  linux/riscv64
 )
 
 # The node platforms we build for
@@ -36,6 +37,7 @@ readonly KUBE_SUPPORTED_NODE_PLATFORMS=(
   linux/arm64
   linux/s390x
   linux/ppc64le
+  linux/riscv64
   windows/amd64
 )
 
@@ -48,6 +50,7 @@ readonly KUBE_SUPPORTED_CLIENT_PLATFORMS=(
   linux/arm64
   linux/s390x
   linux/ppc64le
+  linux/riscv64
   darwin/amd64
   darwin/386
   windows/amd64
@@ -62,6 +65,7 @@ readonly KUBE_SUPPORTED_TEST_PLATFORMS=(
   linux/arm64
   linux/s390x
   linux/ppc64le
+  linux/riscv64
   darwin/amd64
   windows/amd64
 )


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds support to build Kubernetes binaries for riscv64 architecture by using makefiles as:

```
make WHAT=./cmd/binary KUBE_BUILD_PLATFORMS=linux/riscv64
```

Output dir:

```
❯ ll _output/local/bin/linux/riscv64
total 1.1G
-rwxr-xr-x 1 carlosedp carlosedp 5.6M Dec  6 14:17 linkcheck*
-rwxr-xr-x 1 carlosedp carlosedp  43M Dec  6 14:17 kube-scheduler*
-rwxr-xr-x 1 carlosedp carlosedp 1.9M Dec  6 14:17 mounter*
-rwxr-xr-x 1 carlosedp carlosedp 108M Dec  6 14:17 kubelet*
-rwxr-xr-x 1 carlosedp carlosedp 154M Dec  6 14:17 genman*
-rwxr-xr-x 1 carlosedp carlosedp 107M Dec  6 14:17 kubemark*
-rwxr-xr-x 1 carlosedp carlosedp  40M Dec  6 14:17 kubeadm*
-rwxr-xr-x 1 carlosedp carlosedp 147M Dec  6 14:17 genkubedocs*
-rwxr-xr-x 1 carlosedp carlosedp  43M Dec  6 14:17 gendocs*
-rwxr-xr-x 1 carlosedp carlosedp 2.2M Dec  6 14:17 go-runner*
-rwxr-xr-x 1 carlosedp carlosedp  38M Dec  6 14:18 kube-proxy*
-rwxr-xr-x 1 carlosedp carlosedp  44M Dec  6 14:18 kubectl*
-rwxr-xr-x 1 carlosedp carlosedp 116M Dec  6 14:18 kube-apiserver*
-rwxr-xr-x 1 carlosedp carlosedp 8.5M Dec  6 14:18 genswaggertypedocs*
-rwxr-xr-x 1 carlosedp carlosedp 8.9M Dec  6 14:18 ginkgo*
-rwxr-xr-x 1 carlosedp carlosedp  47M Dec  6 14:18 apiextensions-apiserver*
-rwxr-xr-x 1 carlosedp carlosedp  43M Dec  6 14:18 genyaml*
-rwxr-xr-x 1 carlosedp carlosedp 106M Dec  6 14:18 kube-controller-manager*

❯ ./_output/local/bin/linux/riscv64/kubectl version
Client Version: version.Info{Major:"1", Minor:"18+", GitVersion:"v1.18.0-alpha.0.1512+616fce7839b16d-dirty", GitCommit:"616fce7839b16dc61c9079cbae3b0ce1e47060f7", GitTreeState:"dirty", BuildDate:"2019-12-06T19:03:17Z", GoVersion:"devel +1c193b20a6 3 weeks ago", Compiler:"gc", Platform:"linux/riscv64"}
```

**Special notes for your reviewer**:

Ginkgo has been bumped after PR https://github.com/onsi/ginkgo/pull/632 was merged to be able to build on riscv64.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```