### PR TITLE
Return all scheduler predicate failures instead of the first one

### DIFF
--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -103,15 +103,14 @@ var unresolvablePredicateFailureErrors = map[PredicateFailureReason]struct{}{
 	ErrVolumeBindConflict:      {},
 }
 
-// UnresolvablePredicateExists checks if there is at least one unresolvable predicate failure reason, if true
-// returns the first one in the list.
-func UnresolvablePredicateExists(reasons []PredicateFailureReason) PredicateFailureReason {
+// UnresolvablePredicateExists checks if there is at least one unresolvable predicate failure reason.
+func UnresolvablePredicateExists(reasons []PredicateFailureReason) bool {
 	for _, r := range reasons {
 		if _, ok := unresolvablePredicateFailureErrors[r]; ok {
-			return r
+			return true
 		}
 	}
-	return nil
+	return false
 }
 
 // InsufficientResourceError is an error type that indicates what kind of resource limit is

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -96,7 +96,9 @@ func (f *FitError) Error() string {
 	}
 
 	for _, status := range f.FilteredNodesStatuses {
-		reasons[status.Message()]++
+		for _, reason := range status.Reasons() {
+			reasons[reason]++
+		}
 	}
 
 	sortReasonsHistogram := func() []string {
@@ -1207,7 +1209,7 @@ func nodesWherePreemptionMightHelp(nodeNameToInfo map[string]*schedulernodeinfo.
 		// to rely less on such assumptions in the code when checking does not impose
 		// significant overhead.
 		// Also, we currently assume all failures returned by extender as resolvable.
-		if predicates.UnresolvablePredicateExists(failedPredicates) == nil {
+		if !predicates.UnresolvablePredicateExists(failedPredicates) {
 			klog.V(3).Infof("Node %v is a potential node for preemption.", name)
 			potentialNodes = append(potentialNodes, node.Node())
 		}

--- a/pkg/scheduler/framework/plugins/migration/utils.go
+++ b/pkg/scheduler/framework/plugins/migration/utils.go
@@ -41,12 +41,17 @@ func PredicateResultToFrameworkStatus(reasons []predicates.PredicateFailureReaso
 		return nil
 	}
 
-	if r := predicates.UnresolvablePredicateExists(reasons); r != nil {
-		return framework.NewStatus(framework.UnschedulableAndUnresolvable, r.GetReason())
+	code := framework.Unschedulable
+	if predicates.UnresolvablePredicateExists(reasons) {
+		code = framework.UnschedulableAndUnresolvable
 	}
 
-	// We will just use the first reason.
-	return framework.NewStatus(framework.Unschedulable, reasons[0].GetReason())
+	// We will keep all failure reasons.
+	var failureReasons []string
+	for _, reason := range reasons {
+		failureReasons = append(failureReasons, reason.GetReason())
+	}
+	return framework.NewStatus(code, failureReasons...)
 }
 
 // ErrorToFrameworkStatus converts an error to a framework status.

--- a/pkg/scheduler/framework/plugins/migration/utils_test.go
+++ b/pkg/scheduler/framework/plugins/migration/utils_test.go
@@ -54,7 +54,7 @@ func TestPredicateResultToFrameworkStatus(t *testing.T) {
 		{
 			name:       "Unschedulable and Unresolvable",
 			reasons:    []predicates.PredicateFailureReason{predicates.ErrDiskConflict, predicates.ErrNodeSelectorNotMatch},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't match node selector"),
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) had no available disk", "node(s) didn't match node selector"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -109,8 +109,12 @@ func TestNodeResourcesFit(t *testing.T) {
 			pod: newResourcePod(schedulernodeinfo.Resource{MilliCPU: 1, Memory: 1}),
 			nodeInfo: schedulernodeinfo.NewNodeInfo(
 				newResourcePod(schedulernodeinfo.Resource{MilliCPU: 10, Memory: 20})),
-			name:       "too many resources fails",
-			wantStatus: framework.NewStatus(framework.Unschedulable, predicates.NewInsufficientResourceError(v1.ResourceCPU, 2, 10, 10).GetReason()),
+			name: "too many resources fails",
+			wantStatus: framework.NewStatus(
+				framework.Unschedulable,
+				predicates.NewInsufficientResourceError(v1.ResourceCPU, 2, 10, 10).GetReason(),
+				predicates.NewInsufficientResourceError(v1.ResourceMemory, 2, 10, 10).GetReason(),
+			),
 		},
 		{
 			pod: newResourceInitPod(newResourcePod(schedulernodeinfo.Resource{MilliCPU: 1, Memory: 1}), schedulernodeinfo.Resource{MilliCPU: 3, Memory: 1}),

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -1031,7 +1031,7 @@ func TestRejectWaitingPod(t *testing.T) {
 		f.RejectWaitingPod(pod.UID)
 	}()
 	permitStatus := f.RunPermitPlugins(context.Background(), nil, pod, "")
-	if permitStatus.message != "pod \"pod\" rejected while waiting at permit: removed" {
+	if permitStatus.Message() != "pod \"pod\" rejected while waiting at permit: removed" {
 		t.Fatalf("RejectWaitingPod failed, permitStatus: %v", permitStatus)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig scheduling

**What this PR does / why we need it**:

Scheduled used to report all failure reasons upon a predicate failure. For example, if a Pod requests  excessive cpu and memory, running `kubectl describe pod <pod name>` will get message:

```
Events:
  Type     Reason            Age              From               Message
  ----     ------            ----             ----               -------
  Warning  FailedScheduling  8s (x2 over 8s)  default-scheduler  0/1 nodes are available: 1 Insufficient cpu, 1 Insufficient memory.
```

However, in 1.17, we introduced changes which **only returns the first failure reason**. For the above example, it reports:

```
Events:
  Type     Reason            Age        From               Message
  ----     ------            ----       ----               -------
  Warning  FailedScheduling  <unknown>  default-scheduler  0/1 nodes are available: 1 Insufficient cpu.
```

It's not appropriate since:
1. users get less error info and may have to resolve the failure several rounds to get it resolved eventually; however, they can get a full failure picture in one glance in the before
1. internally, scheduler still keeps the logic to calculate all failure reasons; only returns the first failure doesn't help to reduce the memory footprint.

**Which issue(s) this PR fixes**:

Part of #85918.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fixed an issue that the scheduler only returns the first failure reason.
```

/cc @ahg-g