### PR TITLE
Fix staticcheck failures of e2e/storage/drivers e2e/storage/testsuites

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -67,8 +67,6 @@ test/e2e/autoscaling
 test/e2e/instrumentation/logging/stackdriver
 test/e2e/instrumentation/monitoring
 test/e2e/manifest
-test/e2e/storage/drivers
-test/e2e/storage/testsuites
 test/e2e/storage/utils
 test/e2e/storage/vsphere
 test/images/agnhost/dns

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -576,10 +576,6 @@ func (v *rbdVolume) DeleteVolume() {
 
 // Ceph
 type cephFSDriver struct {
-	serverIP  string
-	serverPod *v1.Pod
-	secret    *v1.Secret
-
 	driverInfo testsuites.DriverInfo
 }
 
@@ -690,8 +686,6 @@ func (v *cephVolume) DeleteVolume() {
 
 // Hostpath
 type hostPathDriver struct {
-	node v1.Node
-
 	driverInfo testsuites.DriverInfo
 }
 
@@ -758,8 +752,6 @@ func (h *hostPathDriver) CreateVolume(config *testsuites.PerTestConfig, volType 
 
 // HostPathSymlink
 type hostPathSymlinkDriver struct {
-	node v1.Node
-
 	driverInfo testsuites.DriverInfo
 }
 

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -649,14 +649,6 @@ func getMigrationVolumeOpCounts(cs clientset.Interface, pluginName string) (opCo
 	return opCounts{}, opCounts{}
 }
 
-func getTotOps(ops opCounts) int64 {
-	var tot = int64(0)
-	for _, count := range ops {
-		tot += count
-	}
-	return tot
-}
-
 func validateMigrationVolumeOpCounts(cs clientset.Interface, pluginName string, oldInTreeOps, oldMigratedOps opCounts) {
 	if len(pluginName) == 0 {
 		// This is a native CSI Driver and we don't check ops

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -468,7 +468,7 @@ func (t StorageClassTest) TestBindingWaitForFirstConsumerMultiPVC(claims []*v1.P
 		framework.ExpectNoError(err)
 	}
 	defer func() {
-		var errors map[string]error
+		errors := map[string]error{}
 		for _, claim := range createdClaims {
 			err := e2epv.DeletePersistentVolumeClaim(t.Client, claim.Name, claim.Namespace)
 			if err != nil {

--- a/test/e2e/storage/testsuites/topology.go
+++ b/test/e2e/storage/testsuites/topology.go
@@ -104,7 +104,6 @@ func (t *topologyTestSuite) DefineTests(driver TestDriver, pattern testpatterns.
 	f := framework.NewDefaultFramework("topology")
 
 	init := func() topologyTest {
-		const numTestTopologies = 2
 
 		l := topologyTest{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix staticcheck failures of e2e/storage/drivers e2e/storage/testsuites

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref  #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
