### PR TITLE
[WIP] kubeadm: Carry over new component config versions

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/BUILD
+++ b/cmd/kubeadm/app/componentconfigs/BUILD
@@ -26,6 +26,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/kube-proxy/config/v1alpha1:go_default_library",
         "//staging/src/k8s.io/kubelet/config/v1beta1:go_default_library",

--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -56,7 +56,11 @@ var kubeletHandler = handler{
 	GroupVersion: kubeletconfig.SchemeGroupVersion,
 	AddToScheme:  kubeletconfig.AddToScheme,
 	CreateEmpty: func() kubeadmapi.ComponentConfig {
-		return &kubeletConfig{}
+		return &kubeletConfig{
+			configBase: configBase{
+				GroupVersion: kubeletconfig.SchemeGroupVersion,
+			},
+		}
 	},
 	fromCluster: kubeletConfigFromCluster,
 }
@@ -74,21 +78,23 @@ func kubeletConfigFromCluster(h *handler, clientset clientset.Interface, cluster
 
 // kubeletConfig implements the kubeadmapi.ComponentConfig interface for kubelet
 type kubeletConfig struct {
+	configBase
 	config kubeletconfig.KubeletConfiguration
 }
 
 func (kc *kubeletConfig) DeepCopy() kubeadmapi.ComponentConfig {
 	result := &kubeletConfig{}
+	kc.configBase.DeepCopyInto(&result.configBase)
 	kc.config.DeepCopyInto(&result.config)
 	return result
 }
 
 func (kc *kubeletConfig) Marshal() ([]byte, error) {
-	return kubeletHandler.Marshal(&kc.config)
+	return kc.configBase.Marshal(&kc.config)
 }
 
 func (kc *kubeletConfig) Unmarshal(docmap kubeadmapi.DocumentMap) error {
-	return kubeletHandler.Unmarshal(docmap, &kc.config)
+	return kc.configBase.Unmarshal(docmap, &kc.config)
 }
 
 func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubeadmapi.APIEndpoint) {

--- a/cmd/kubeadm/app/componentconfigs/kubeproxy.go
+++ b/cmd/kubeadm/app/componentconfigs/kubeproxy.go
@@ -41,7 +41,11 @@ var kubeProxyHandler = handler{
 	GroupVersion: kubeproxyconfig.SchemeGroupVersion,
 	AddToScheme:  kubeproxyconfig.AddToScheme,
 	CreateEmpty: func() kubeadmapi.ComponentConfig {
-		return &kubeProxyConfig{}
+		return &kubeProxyConfig{
+			configBase: configBase{
+				GroupVersion: kubeproxyconfig.SchemeGroupVersion,
+			},
+		}
 	},
 	fromCluster: kubeProxyConfigFromCluster,
 }
@@ -52,21 +56,23 @@ func kubeProxyConfigFromCluster(h *handler, clientset clientset.Interface, _ *ku
 
 // kubeProxyConfig implements the kubeadmapi.ComponentConfig interface for kube-proxy
 type kubeProxyConfig struct {
+	configBase
 	config kubeproxyconfig.KubeProxyConfiguration
 }
 
 func (kp *kubeProxyConfig) DeepCopy() kubeadmapi.ComponentConfig {
 	result := &kubeProxyConfig{}
+	kp.configBase.DeepCopyInto(&result.configBase)
 	kp.config.DeepCopyInto(&result.config)
 	return result
 }
 
 func (kp *kubeProxyConfig) Marshal() ([]byte, error) {
-	return kubeProxyHandler.Marshal(&kp.config)
+	return kp.configBase.Marshal(&kp.config)
 }
 
 func (kp *kubeProxyConfig) Unmarshal(docmap kubeadmapi.DocumentMap) error {
-	return kubeProxyHandler.Unmarshal(docmap, &kp.config)
+	return kp.configBase.Unmarshal(docmap, &kp.config)
 }
 
 func kubeProxyDefaultBindAddress(localAdvertiseAddress string) string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Although group based, kubeadm's component configs support is still fixed to
support only a single version. Hence, it doesn't matter if the loaded component
config version is older or newer - kubeadm would always bail out with an error.

Forcing users to the latest version of a component config format would also
mean that for many of them a manual migration would be required (while the old
version is still loadable by the component in question).

Hence, if kubeadm does not require any new features of the config, it does not
need to force users to update their config.

With that in mind, many users may actually want to provide configs in the new
format. Hence, to enable that without bailing out with an error, kubeadm needs
to tolerate newer component config versions without explicitly understanding
that format.

This change allows for that to happen by treating newer config versions as
blobs of YAML. As a consequence, newer configs are not defaulted (patched with
kubeadm preferred values) and are not guaranteed to work at all.

It is a requirement to the user to verify that correct config settings are
supplied or the component in question may not work.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs:
- kubernetes/kubeadm#1940
- kubernetes/enhancements#1381

**Special notes for your reviewer**:

This PR is part of the implementation of the new kubeadm component config management scheme KEP (see link below).

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/priority important-longterm
/assign @timothysc @fabriziopandini @neolit123 @ereslibre 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm now allows for component configs in newer unsupported by it formats to be used by treating them as YAML blobs
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cluster-lifecycle/kubeadm/20190925-component-configs.md
```
