### PR TITLE
update RBAC rules in e2e aggregator test

### DIFF
--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -144,8 +144,8 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 		// role for listing ValidatingWebhookConfiguration/MutatingWebhookConfiguration/Namespaces
 		ObjectMeta: metav1.ObjectMeta{Name: "sample-apiserver-reader"},
 		Rules: []rbacv1.PolicyRule{
-			rbacv1helpers.NewRule("list").Groups("").Resources("namespaces").RuleOrDie(),
-			rbacv1helpers.NewRule("list").Groups("admissionregistration.k8s.io").Resources("*").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch").Groups("").Resources("namespaces").RuleOrDie(),
+			rbacv1helpers.NewRule("get", "list", "watch").Groups("admissionregistration.k8s.io").Resources("*").RuleOrDie(),
 		},
 	})
 	framework.ExpectNoError(err, "creating cluster role %s", "sample-apiserver-reader")


### PR DESCRIPTION
Add the "get" and "watch" verbs to the ClusterRole created
for the sample apiserver.  Without this, the test complains about
"Failed to watch..." the resources in question.

Strictly speaking the "get" verb doesn't seem to be needed, but
this aligns the e2e test with the example at
staging/src/k8s.io/sample-apiserver/artifacts/example/rbac.yaml

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The sample apiserver RBAC verbs listed in staging/src/k8s.io/sample-apiserver/artifacts/example/rbac.yaml don't match the verbs used programmatically in test/e2e/apimachinery/aggregator.go.

This causes the e2e test to emit logs of the form:

E1128 17:49:49.788234       1 reflector.go:322] k8s.io/sample-apiserver/vendor/k8s.io/client-go/informers/factory.go:87: Failed to watch *v1.Namespace: unknown (get namespaces)
E1128 17:49:49.788234       1 reflector.go:322] k8s.io/sample-apiserver/vendor/k8s.io/client-go/informers/factory.go:87: Failed to watch *v1beta1.ValidatingWebhookConfiguration: unknown (get validatingwebhookconfigurations.admissionregistration.k8s.io)
E1128 17:49:49.788235       1 reflector.go:322] k8s.io/sample-apiserver/vendor/k8s.io/client-go/informers/factory.go:87: Failed to watch *v1beta1.MutatingWebhookConfiguration: unknown (get mutatingwebhookconfigurations.admissionregistration.k8s.io)

Adding the RBAC verbs to the e2e test should make these logs go away.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
