### PR TITLE
Increasing LoadBalancerPollTimeout from 15 to 22 minutes

### DIFF
--- a/test/e2e/framework/service/const.go
+++ b/test/e2e/framework/service/const.go
@@ -66,7 +66,7 @@ const (
 
 	// LoadBalancerPollTimeout is the time required by the loadbalancer to poll.
 	// On average it takes ~6 minutes for a single backend to come online in GCE.
-	LoadBalancerPollTimeout = 15 * time.Minute
+	LoadBalancerPollTimeout = 22 * time.Minute
 	// LoadBalancerPollInterval is the interval value in which the loadbalancer polls.
 	LoadBalancerPollInterval = 30 * time.Second
 


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Some related tests (https://testgrid.k8s.io/sig-release-1.17-blocking#gce-cos-k8sbeta-ingress) were flaking as a result of GCP LBs potentially taking longer to update than 15 minutes.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority critical-urgent
/cc @MrHohn @alenkacz 