### PR TITLE
Ensuring kube-proxy does not mutate shared EndpointSlices

### DIFF
--- a/pkg/proxy/BUILD
+++ b/pkg/proxy/BUILD
@@ -70,6 +70,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/discovery/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",

--- a/pkg/proxy/endpointslicecache.go
+++ b/pkg/proxy/endpointslicecache.go
@@ -108,11 +108,13 @@ func newEndpointSliceTracker() *endpointSliceTracker {
 // newEndpointSliceInfo generates endpointSliceInfo from an EndpointSlice.
 func newEndpointSliceInfo(endpointSlice *discovery.EndpointSlice, remove bool) *endpointSliceInfo {
 	esInfo := &endpointSliceInfo{
-		Ports:     endpointSlice.Ports,
+		Ports:     make([]discovery.EndpointPort, len(endpointSlice.Ports)),
 		Endpoints: []*endpointInfo{},
 		Remove:    remove,
 	}
 
+	// copy here to avoid mutating shared EndpointSlice object.
+	copy(esInfo.Ports, endpointSlice.Ports)
 	sort.Sort(byPort(esInfo.Ports))
 
 	if !remove {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fixes a bug that resulted in kube-proxy modifying shared EndpointSlices when it was sorting ports for diffing. This adds tests to ensure future bugs like this will not happen.

**Special notes for your reviewer**:
This copies the `cacheMutationCheck` from the EndpointSlice controller tests added in https://github.com/kubernetes/kubernetes/pull/85368. If there's a good place to share code between controller and proxy, I'm very open to moving this code to a shared location.

**Does this PR introduce a user-facing change?**:
```release-note
kube-proxy no longer modifies shared EndpointSlices.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
/sig network
/priority important-soon
/cc @freehan @liggitt 