### PR TITLE
clientcmd: add error wrapping to loader

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader.go
@@ -212,7 +212,7 @@ func (rules *ClientConfigLoadingRules) Load() (*clientcmdapi.Config, error) {
 		}
 
 		if err != nil {
-			errlist = append(errlist, fmt.Errorf("error loading config file \"%s\": %v", filename, err))
+			errlist = append(errlist, fmt.Errorf("error loading config file \"%s\": %w", filename, err))
 			continue
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We are currently getting rid of the very nice os package
typed errors and turning them into strings due to
our `fmt.Errorf` call. This uses go error wrapping
to make sure we can use the nice error matchers in the
os package like `is.PermissionDenied`.

**Special notes for your reviewer**:
This takes advantage of the error wrapping verb `%w` which means we'd need to only build this with go `1.13+`. If we'd like to take advantage of this but be backward compatible with more go versions I can tweak the approach to either:

1) remove the wrapping completely and just save the raw error types returned
2) add a custom error that will make sure to not drop the type info but have a pretty printed message.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
