### PR TITLE
Add kind/flake issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/failing-test.md
+++ b/.github/ISSUE_TEMPLATE/failing-test.md
@@ -1,11 +1,11 @@
 ---
 name: Failing Test
-about: Report test failures in Kubernetes CI jobs
+about: Report continuously failing tests or jobs in Kubernetes CI
 labels: kind/failing-test
 
 ---
 
-<!-- Please only use this template for submitting reports about failing tests in Kubernetes CI jobs -->
+<!-- Please only use this template for submitting reports about continuously failing tests or jobs in Kubernetes CI -->
 
 **Which jobs are failing**:
 

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -1,0 +1,20 @@
+---
+name: Flaking Test
+about: Report flaky tests or jobs in Kubernetes CI
+labels: kind/flake
+
+---
+
+<!-- Please only use this template for submitting reports about flaky tests or jobs (pass or fail with no underlying change in code) in Kubernetes CI -->
+
+**Which jobs are flaking**:
+
+**Which test(s) are flaking**:
+
+**Testgrid link**:
+
+**Reason for failure**:
+
+**Anything else we need to know**:
+- links to go.k8s.io/triage appreciated
+- links to specific failures in spyglass appreciated


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

The `kind/failing-test` label should only be used for tests or jobs that
are continuously failing. Today, it's being used for test failures of
any kind, which means flakes are getting under-reported for those who
search the `kind/flake` label.

This PR adds a new template that uses the `kind/flake` label to motivate
reporting test flakes. I'm updating docs on how to report test flakes and
would like to be able to point to this issue template.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```
NONE
```

/priority important-soon
/sig release
cc @kubernetes/ci-signal
because of CI signal
/sig contributor-experience
because issue templates
/sig testing
because flakes