### PR TITLE
Revert "staging/publishing: temporarily disable publishing tags"

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -1,4 +1,3 @@
-skip-tags: true
 recursive-delete-patterns:
 - BUILD
 - "*/BUILD"


### PR DESCRIPTION
This reverts commit 2bba8dac7fae5d933e62df47cf6fb6810a81f836.

Reverts https://github.com/kubernetes/kubernetes/pull/86008 so that we can sync tags again. :rocket: 

/kind cleanup
/assign @sttts @liggitt 

/hold
until https://github.com/kubernetes/publishing-bot/pull/210 has been merged and deployed

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
