### PR TITLE
Add support for hugepages in downward API

### DIFF
--- a/pkg/api/pod/BUILD
+++ b/pkg/api/pod/BUILD
@@ -12,9 +12,13 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/api/pod",
     deps = [
         "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/helper:go_default_library",
+        "//pkg/apis/core/v1/helper:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
     ],
 )

--- a/pkg/api/testing/BUILD
+++ b/pkg/api/testing/BUILD
@@ -98,6 +98,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/api/legacyscheme:go_default_library",
+        "//pkg/api/pod:go_default_library",
         "//pkg/api/testing/compat:go_default_library",
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/apps/v1:go_default_library",

--- a/pkg/api/testing/backward_compatibility_test.go
+++ b/pkg/api/testing/backward_compatibility_test.go
@@ -19,14 +19,14 @@ package testing
 import (
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	podutil "k8s.io/kubernetes/pkg/api/pod"
 	"k8s.io/kubernetes/pkg/api/testing/compat"
 	api "k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/apis/core/validation"
-
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
+	"k8s.io/kubernetes/pkg/apis/core/validation"
 )
 
 func TestCompatibility_v1_PodSecurityContext(t *testing.T) {
@@ -159,7 +159,8 @@ func TestCompatibility_v1_PodSecurityContext(t *testing.T) {
 	}
 
 	validator := func(obj runtime.Object) field.ErrorList {
-		return validation.ValidatePodSpec(&(obj.(*api.Pod).Spec), &(obj.(*api.Pod).ObjectMeta), field.NewPath("spec"))
+		opts := podutil.GetValidationOptionsFromPodSpec(&(obj.(*api.Pod).Spec), nil)
+		return validation.ValidatePodSpec(&(obj.(*api.Pod).Spec), &(obj.(*api.Pod).ObjectMeta), field.NewPath("spec"), opts)
 	}
 
 	for _, tc := range cases {

--- a/pkg/apis/apps/validation/BUILD
+++ b/pkg/apis/apps/validation/BUILD
@@ -32,6 +32,7 @@ go_test(
     deps = [
         "//pkg/apis/apps:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/apis/apps/validation/validation.go
+++ b/pkg/apis/apps/validation/validation.go
@@ -241,17 +241,17 @@ func ValidateControllerRevisionUpdate(newHistory, oldHistory *apps.ControllerRev
 }
 
 // ValidateDaemonSet tests if required fields in the DaemonSet are set.
-func ValidateDaemonSet(ds *apps.DaemonSet) field.ErrorList {
+func ValidateDaemonSet(ds *apps.DaemonSet, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMeta(&ds.ObjectMeta, true, ValidateDaemonSetName, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateDaemonSetSpec(&ds.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateDaemonSetSpec(&ds.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
 // ValidateDaemonSetUpdate tests if required fields in the DaemonSet are set.
-func ValidateDaemonSetUpdate(ds, oldDS *apps.DaemonSet) field.ErrorList {
+func ValidateDaemonSetUpdate(ds, oldDS *apps.DaemonSet, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&ds.ObjectMeta, &oldDS.ObjectMeta, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateDaemonSetSpecUpdate(&ds.Spec, &oldDS.Spec, field.NewPath("spec"))...)
-	allErrs = append(allErrs, ValidateDaemonSetSpec(&ds.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateDaemonSetSpec(&ds.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
@@ -307,7 +307,7 @@ func ValidateDaemonSetStatusUpdate(ds, oldDS *apps.DaemonSet) field.ErrorList {
 }
 
 // ValidateDaemonSetSpec tests if required fields in the DaemonSetSpec are set.
-func ValidateDaemonSetSpec(spec *apps.DaemonSetSpec, fldPath *field.Path) field.ErrorList {
+func ValidateDaemonSetSpec(spec *apps.DaemonSetSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(spec.Selector, fldPath.Child("selector"))...)
@@ -320,7 +320,7 @@ func ValidateDaemonSetSpec(spec *apps.DaemonSetSpec, fldPath *field.Path) field.
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "empty selector is invalid for daemonset"))
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(&spec.Template, fldPath.Child("template"))...)
+	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(&spec.Template, fldPath.Child("template"), opts)...)
 	// Daemons typically run on more than one node, so mark Read-Write persistent disks as invalid.
 	allErrs = append(allErrs, apivalidation.ValidateReadOnlyPersistentDisks(spec.Template.Spec.Volumes, fldPath.Child("template", "spec", "volumes"))...)
 	// RestartPolicy has already been first-order validated as per ValidatePodTemplateSpec().
@@ -474,7 +474,7 @@ func ValidateRollback(rollback *apps.RollbackConfig, fldPath *field.Path) field.
 }
 
 // ValidateDeploymentSpec validates given deployment spec.
-func ValidateDeploymentSpec(spec *apps.DeploymentSpec, fldPath *field.Path) field.ErrorList {
+func ValidateDeploymentSpec(spec *apps.DeploymentSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(spec.Replicas), fldPath.Child("replicas"))...)
 
@@ -491,7 +491,7 @@ func ValidateDeploymentSpec(spec *apps.DeploymentSpec, fldPath *field.Path) fiel
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "invalid label selector"))
 	} else {
-		allErrs = append(allErrs, ValidatePodTemplateSpecForReplicaSet(&spec.Template, selector, spec.Replicas, fldPath.Child("template"))...)
+		allErrs = append(allErrs, ValidatePodTemplateSpecForReplicaSet(&spec.Template, selector, spec.Replicas, fldPath.Child("template"), opts)...)
 	}
 
 	allErrs = append(allErrs, ValidateDeploymentStrategy(&spec.Strategy, fldPath.Child("strategy"))...)
@@ -541,9 +541,9 @@ func ValidateDeploymentStatus(status *apps.DeploymentStatus, fldPath *field.Path
 }
 
 // ValidateDeploymentUpdate tests if an update to a Deployment is valid.
-func ValidateDeploymentUpdate(update, old *apps.Deployment) field.ErrorList {
+func ValidateDeploymentUpdate(update, old *apps.Deployment, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&update.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateDeploymentSpec(&update.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateDeploymentSpec(&update.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
@@ -564,9 +564,9 @@ func ValidateDeploymentStatusUpdate(update, old *apps.Deployment) field.ErrorLis
 }
 
 // ValidateDeployment validates a given Deployment.
-func ValidateDeployment(obj *apps.Deployment) field.ErrorList {
+func ValidateDeployment(obj *apps.Deployment, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMeta(&obj.ObjectMeta, true, ValidateDeploymentName, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateDeploymentSpec(&obj.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateDeploymentSpec(&obj.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
@@ -587,17 +587,17 @@ func ValidateDeploymentRollback(obj *apps.DeploymentRollback) field.ErrorList {
 var ValidateReplicaSetName = apimachineryvalidation.NameIsDNSSubdomain
 
 // ValidateReplicaSet tests if required fields in the ReplicaSet are set.
-func ValidateReplicaSet(rs *apps.ReplicaSet) field.ErrorList {
+func ValidateReplicaSet(rs *apps.ReplicaSet, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMeta(&rs.ObjectMeta, true, ValidateReplicaSetName, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateReplicaSetSpec(&rs.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateReplicaSetSpec(&rs.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
 // ValidateReplicaSetUpdate tests if required fields in the ReplicaSet are set.
-func ValidateReplicaSetUpdate(rs, oldRs *apps.ReplicaSet) field.ErrorList {
+func ValidateReplicaSetUpdate(rs, oldRs *apps.ReplicaSet, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&rs.ObjectMeta, &oldRs.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateReplicaSetSpec(&rs.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateReplicaSetSpec(&rs.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
@@ -634,7 +634,7 @@ func ValidateReplicaSetStatus(status apps.ReplicaSetStatus, fldPath *field.Path)
 }
 
 // ValidateReplicaSetSpec tests if required fields in the ReplicaSet spec are set.
-func ValidateReplicaSetSpec(spec *apps.ReplicaSetSpec, fldPath *field.Path) field.ErrorList {
+func ValidateReplicaSetSpec(spec *apps.ReplicaSetSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(spec.Replicas), fldPath.Child("replicas"))...)
@@ -653,13 +653,13 @@ func ValidateReplicaSetSpec(spec *apps.ReplicaSetSpec, fldPath *field.Path) fiel
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("selector"), spec.Selector, "invalid label selector"))
 	} else {
-		allErrs = append(allErrs, ValidatePodTemplateSpecForReplicaSet(&spec.Template, selector, spec.Replicas, fldPath.Child("template"))...)
+		allErrs = append(allErrs, ValidatePodTemplateSpecForReplicaSet(&spec.Template, selector, spec.Replicas, fldPath.Child("template"), opts)...)
 	}
 	return allErrs
 }
 
 // ValidatePodTemplateSpecForReplicaSet validates the given template and ensures that it is in accordance with the desired selector and replicas.
-func ValidatePodTemplateSpecForReplicaSet(template *api.PodTemplateSpec, selector labels.Selector, replicas int32, fldPath *field.Path) field.ErrorList {
+func ValidatePodTemplateSpecForReplicaSet(template *api.PodTemplateSpec, selector labels.Selector, replicas int32, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if template == nil {
 		allErrs = append(allErrs, field.Required(fldPath, ""))
@@ -671,7 +671,7 @@ func ValidatePodTemplateSpecForReplicaSet(template *api.PodTemplateSpec, selecto
 				allErrs = append(allErrs, field.Invalid(fldPath.Child("metadata", "labels"), template.Labels, "`selector` does not match template `labels`"))
 			}
 		}
-		allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(template, fldPath)...)
+		allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(template, fldPath, opts)...)
 		if replicas > 1 {
 			allErrs = append(allErrs, apivalidation.ValidateReadOnlyPersistentDisks(template.Spec.Volumes, fldPath.Child("spec", "volumes"))...)
 		}

--- a/pkg/apis/apps/validation/validation_test.go
+++ b/pkg/apis/apps/validation/validation_test.go
@@ -30,6 +30,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/apps"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 )
 
@@ -1552,7 +1553,7 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 		if len(successCase.old.ObjectMeta.ResourceVersion) == 0 || len(successCase.update.ObjectMeta.ResourceVersion) == 0 {
 			t.Errorf("%q has incorrect test setup with no resource version set", testName)
 		}
-		if errs := ValidateDaemonSetUpdate(&successCase.update, &successCase.old); len(errs) != 0 {
+		if errs := ValidateDaemonSetUpdate(&successCase.update, &successCase.old, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("%q expected no error, but got: %v", testName, errs)
 		}
 	}
@@ -1770,7 +1771,7 @@ func TestValidateDaemonSetUpdate(t *testing.T) {
 			t.Errorf("%q has incorrect test setup with no resource version set", testName)
 		}
 		// Run the tests
-		if errs := ValidateDaemonSetUpdate(&errorCase.update, &errorCase.old); len(errs) != errorCase.expectedErrNum {
+		if errs := ValidateDaemonSetUpdate(&errorCase.update, &errorCase.old, corevalidation.PodValidationOptions{}); len(errs) != errorCase.expectedErrNum {
 			t.Errorf("%q expected %d errors, but got %d error: %v", testName, errorCase.expectedErrNum, len(errs), errs)
 		} else {
 			t.Logf("(PASS) %q got errors %v", testName, errs)
@@ -1829,7 +1830,7 @@ func TestValidateDaemonSet(t *testing.T) {
 		},
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateDaemonSet(&successCase); len(errs) != 0 {
+		if errs := ValidateDaemonSet(&successCase, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -1973,7 +1974,7 @@ func TestValidateDaemonSet(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		errs := ValidateDaemonSet(&v)
+		errs := ValidateDaemonSet(&v, corevalidation.PodValidationOptions{})
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		}
@@ -2049,7 +2050,7 @@ func TestValidateDeployment(t *testing.T) {
 		validDeployment(),
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateDeployment(successCase); len(errs) != 0 {
+		if errs := ValidateDeployment(successCase, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -2142,7 +2143,7 @@ func TestValidateDeployment(t *testing.T) {
 	errorCases["ephemeral containers not allowed"] = invalidEphemeralContainersDeployment
 
 	for k, v := range errorCases {
-		errs := ValidateDeployment(v)
+		errs := ValidateDeployment(v, corevalidation.PodValidationOptions{})
 		if len(errs) == 0 {
 			t.Errorf("[%s] expected failure", k)
 		} else if !strings.Contains(errs[0].Error(), k) {
@@ -2671,7 +2672,7 @@ func TestValidateReplicaSetUpdate(t *testing.T) {
 	for _, successCase := range successCases {
 		successCase.old.ObjectMeta.ResourceVersion = "1"
 		successCase.update.ObjectMeta.ResourceVersion = "1"
-		if errs := ValidateReplicaSetUpdate(&successCase.update, &successCase.old); len(errs) != 0 {
+		if errs := ValidateReplicaSetUpdate(&successCase.update, &successCase.old, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -2746,7 +2747,7 @@ func TestValidateReplicaSetUpdate(t *testing.T) {
 		},
 	}
 	for testName, errorCase := range errorCases {
-		if errs := ValidateReplicaSetUpdate(&errorCase.update, &errorCase.old); len(errs) == 0 {
+		if errs := ValidateReplicaSetUpdate(&errorCase.update, &errorCase.old, corevalidation.PodValidationOptions{}); len(errs) == 0 {
 			t.Errorf("expected failure: %s", testName)
 		}
 	}
@@ -2816,7 +2817,7 @@ func TestValidateReplicaSet(t *testing.T) {
 		},
 	}
 	for _, successCase := range successCases {
-		if errs := ValidateReplicaSet(&successCase); len(errs) != 0 {
+		if errs := ValidateReplicaSet(&successCase, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("expected success: %v", errs)
 		}
 	}
@@ -2948,7 +2949,7 @@ func TestValidateReplicaSet(t *testing.T) {
 		},
 	}
 	for k, v := range errorCases {
-		errs := ValidateReplicaSet(&v)
+		errs := ValidateReplicaSet(&v, corevalidation.PodValidationOptions{})
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		}

--- a/pkg/apis/batch/validation/BUILD
+++ b/pkg/apis/batch/validation/BUILD
@@ -30,6 +30,7 @@ go_test(
     deps = [
         "//pkg/apis/batch:go_default_library",
         "//pkg/apis/core:go_default_library",
+        "//pkg/apis/core/validation:go_default_library",
         "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/apis/batch/validation/validation.go
+++ b/pkg/apis/batch/validation/validation.go
@@ -76,17 +76,17 @@ func ValidateGeneratedSelector(obj *batch.Job) field.ErrorList {
 }
 
 // ValidateJob validates a Job and returns an ErrorList with any errors.
-func ValidateJob(job *batch.Job) field.ErrorList {
+func ValidateJob(job *batch.Job, opts apivalidation.PodValidationOptions) field.ErrorList {
 	// Jobs and rcs have the same name validation
 	allErrs := apivalidation.ValidateObjectMeta(&job.ObjectMeta, true, apivalidation.ValidateReplicationControllerName, field.NewPath("metadata"))
 	allErrs = append(allErrs, ValidateGeneratedSelector(job)...)
-	allErrs = append(allErrs, ValidateJobSpec(&job.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateJobSpec(&job.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
 // ValidateJobSpec validates a JobSpec and returns an ErrorList with any errors.
-func ValidateJobSpec(spec *batch.JobSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := validateJobSpec(spec, fldPath)
+func ValidateJobSpec(spec *batch.JobSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
+	allErrs := validateJobSpec(spec, fldPath, opts)
 
 	if spec.Selector == nil {
 		allErrs = append(allErrs, field.Required(fldPath.Child("selector"), ""))
@@ -104,7 +104,7 @@ func ValidateJobSpec(spec *batch.JobSpec, fldPath *field.Path) field.ErrorList {
 	return allErrs
 }
 
-func validateJobSpec(spec *batch.JobSpec, fldPath *field.Path) field.ErrorList {
+func validateJobSpec(spec *batch.JobSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if spec.Parallelism != nil {
@@ -123,7 +123,7 @@ func validateJobSpec(spec *batch.JobSpec, fldPath *field.Path) field.ErrorList {
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.TTLSecondsAfterFinished), fldPath.Child("ttlSecondsAfterFinished"))...)
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(&spec.Template, fldPath.Child("template"))...)
+	allErrs = append(allErrs, apivalidation.ValidatePodTemplateSpec(&spec.Template, fldPath.Child("template"), opts)...)
 	if spec.Template.Spec.RestartPolicy != api.RestartPolicyOnFailure &&
 		spec.Template.Spec.RestartPolicy != api.RestartPolicyNever {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("template", "spec", "restartPolicy"),
@@ -142,9 +142,9 @@ func ValidateJobStatus(status *batch.JobStatus, fldPath *field.Path) field.Error
 }
 
 // ValidateJobUpdate validates an update to a Job and returns an ErrorList with any errors.
-func ValidateJobUpdate(job, oldJob *batch.Job) field.ErrorList {
+func ValidateJobUpdate(job, oldJob *batch.Job, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&job.ObjectMeta, &oldJob.ObjectMeta, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateJobSpecUpdate(job.Spec, oldJob.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateJobSpecUpdate(job.Spec, oldJob.Spec, field.NewPath("spec"), opts)...)
 	return allErrs
 }
 
@@ -156,9 +156,9 @@ func ValidateJobUpdateStatus(job, oldJob *batch.Job) field.ErrorList {
 }
 
 // ValidateJobSpecUpdate validates an update to a JobSpec and returns an ErrorList with any errors.
-func ValidateJobSpecUpdate(spec, oldSpec batch.JobSpec, fldPath *field.Path) field.ErrorList {
+func ValidateJobSpecUpdate(spec, oldSpec batch.JobSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, ValidateJobSpec(&spec, fldPath)...)
+	allErrs = append(allErrs, ValidateJobSpec(&spec, fldPath, opts)...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Completions, oldSpec.Completions, fldPath.Child("completions"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Selector, oldSpec.Selector, fldPath.Child("selector"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(spec.Template, oldSpec.Template, fldPath.Child("template"))...)
@@ -173,10 +173,10 @@ func ValidateJobStatusUpdate(status, oldStatus batch.JobStatus) field.ErrorList 
 }
 
 // ValidateCronJob validates a CronJob and returns an ErrorList with any errors.
-func ValidateCronJob(cronJob *batch.CronJob) field.ErrorList {
+func ValidateCronJob(cronJob *batch.CronJob, opts apivalidation.PodValidationOptions) field.ErrorList {
 	// CronJobs and rcs have the same name validation
 	allErrs := apivalidation.ValidateObjectMeta(&cronJob.ObjectMeta, true, apivalidation.ValidateReplicationControllerName, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateCronJobSpec(&cronJob.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateCronJobSpec(&cronJob.Spec, field.NewPath("spec"), opts)...)
 	if len(cronJob.ObjectMeta.Name) > apimachineryvalidation.DNS1035LabelMaxLength-11 {
 		// The cronjob controller appends a 11-character suffix to the cronjob (`-$TIMESTAMP`) when
 		// creating a job. The job name length limit is 63 characters.
@@ -188,16 +188,16 @@ func ValidateCronJob(cronJob *batch.CronJob) field.ErrorList {
 }
 
 // ValidateCronJobUpdate validates an update to a CronJob and returns an ErrorList with any errors.
-func ValidateCronJobUpdate(job, oldJob *batch.CronJob) field.ErrorList {
+func ValidateCronJobUpdate(job, oldJob *batch.CronJob, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := apivalidation.ValidateObjectMetaUpdate(&job.ObjectMeta, &oldJob.ObjectMeta, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateCronJobSpec(&job.Spec, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateCronJobSpec(&job.Spec, field.NewPath("spec"), opts)...)
 	// skip the 52-character name validation limit on update validation
 	// to allow old cronjobs with names > 52 chars to be updated/deleted
 	return allErrs
 }
 
 // ValidateCronJobSpec validates a CronJobSpec and returns an ErrorList with any errors.
-func ValidateCronJobSpec(spec *batch.CronJobSpec, fldPath *field.Path) field.ErrorList {
+func ValidateCronJobSpec(spec *batch.CronJobSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if len(spec.Schedule) == 0 {
@@ -209,7 +209,7 @@ func ValidateCronJobSpec(spec *batch.CronJobSpec, fldPath *field.Path) field.Err
 		allErrs = append(allErrs, apivalidation.ValidateNonnegativeField(int64(*spec.StartingDeadlineSeconds), fldPath.Child("startingDeadlineSeconds"))...)
 	}
 	allErrs = append(allErrs, validateConcurrencyPolicy(&spec.ConcurrencyPolicy, fldPath.Child("concurrencyPolicy"))...)
-	allErrs = append(allErrs, ValidateJobTemplateSpec(&spec.JobTemplate, fldPath.Child("jobTemplate"))...)
+	allErrs = append(allErrs, ValidateJobTemplateSpec(&spec.JobTemplate, fldPath.Child("jobTemplate"), opts)...)
 
 	if spec.SuccessfulJobsHistoryLimit != nil {
 		// zero is a valid SuccessfulJobsHistoryLimit
@@ -248,16 +248,16 @@ func validateScheduleFormat(schedule string, fldPath *field.Path) field.ErrorLis
 }
 
 // ValidateJobTemplate validates a JobTemplate and returns an ErrorList with any errors.
-func ValidateJobTemplate(job *batch.JobTemplate) field.ErrorList {
+func ValidateJobTemplate(job *batch.JobTemplate, opts apivalidation.PodValidationOptions) field.ErrorList {
 	// this method should be identical to ValidateJob
 	allErrs := apivalidation.ValidateObjectMeta(&job.ObjectMeta, true, apivalidation.ValidateReplicationControllerName, field.NewPath("metadata"))
-	allErrs = append(allErrs, ValidateJobTemplateSpec(&job.Template, field.NewPath("template"))...)
+	allErrs = append(allErrs, ValidateJobTemplateSpec(&job.Template, field.NewPath("template"), opts)...)
 	return allErrs
 }
 
 // ValidateJobTemplateSpec validates a JobTemplateSpec and returns an ErrorList with any errors.
-func ValidateJobTemplateSpec(spec *batch.JobTemplateSpec, fldPath *field.Path) field.ErrorList {
-	allErrs := validateJobSpec(&spec.Spec, fldPath.Child("spec"))
+func ValidateJobTemplateSpec(spec *batch.JobTemplateSpec, fldPath *field.Path, opts apivalidation.PodValidationOptions) field.ErrorList {
+	allErrs := validateJobSpec(&spec.Spec, fldPath.Child("spec"), opts)
 
 	// jobtemplate will always have the selector automatically generated
 	if spec.Spec.Selector != nil {

--- a/pkg/apis/batch/validation/validation_test.go
+++ b/pkg/apis/batch/validation/validation_test.go
@@ -26,6 +26,7 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/batch"
 	api "k8s.io/kubernetes/pkg/apis/core"
+	corevalidation "k8s.io/kubernetes/pkg/apis/core/validation"
 	"k8s.io/kubernetes/pkg/features"
 )
 
@@ -99,7 +100,7 @@ func TestValidateJob(t *testing.T) {
 		},
 	}
 	for k, v := range successCases {
-		if errs := ValidateJob(&v); len(errs) != 0 {
+		if errs := ValidateJob(&v, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("expected success for %s: %v", k, errs)
 		}
 	}
@@ -238,7 +239,7 @@ func TestValidateJob(t *testing.T) {
 		}
 
 		for k, v := range errorCases {
-			errs := ValidateJob(&v)
+			errs := ValidateJob(&v, corevalidation.PodValidationOptions{})
 			if len(errs) == 0 {
 				t.Errorf("expected failure for %s", k)
 			} else {
@@ -368,7 +369,7 @@ func TestValidateCronJob(t *testing.T) {
 		},
 	}
 	for k, v := range successCases {
-		if errs := ValidateCronJob(&v); len(errs) != 0 {
+		if errs := ValidateCronJob(&v, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("expected success for %s: %v", k, errs)
 		}
 
@@ -376,7 +377,7 @@ func TestValidateCronJob(t *testing.T) {
 		// copy to avoid polluting the testcase object, set a resourceVersion to allow validating update, and test a no-op update
 		v = *v.DeepCopy()
 		v.ResourceVersion = "1"
-		if errs := ValidateCronJobUpdate(&v, &v); len(errs) != 0 {
+		if errs := ValidateCronJobUpdate(&v, &v, corevalidation.PodValidationOptions{}); len(errs) != 0 {
 			t.Errorf("expected success for %s: %v", k, errs)
 		}
 	}
@@ -629,7 +630,7 @@ func TestValidateCronJob(t *testing.T) {
 	}
 
 	for k, v := range errorCases {
-		errs := ValidateCronJob(&v)
+		errs := ValidateCronJob(&v, corevalidation.PodValidationOptions{})
 		if len(errs) == 0 {
 			t.Errorf("expected failure for %s", k)
 		} else {
@@ -644,7 +645,7 @@ func TestValidateCronJob(t *testing.T) {
 		// copy to avoid polluting the testcase object, set a resourceVersion to allow validating update, and test a no-op update
 		v = *v.DeepCopy()
 		v.ResourceVersion = "1"
-		errs = ValidateCronJobUpdate(&v, &v)
+		errs = ValidateCronJobUpdate(&v, &v, corevalidation.PodValidationOptions{})
 		if len(errs) == 0 {
 			if k == "metadata.name: must be no more than 52 characters" {
 				continue

--- a/pkg/apis/core/resource.go
+++ b/pkg/apis/core/resource.go
@@ -26,40 +26,33 @@ func (rn ResourceName) String() string {
 
 // CPU returns the CPU limit if specified.
 func (rl *ResourceList) CPU() *resource.Quantity {
-	if val, ok := (*rl)[ResourceCPU]; ok {
-		return &val
-	}
-	return &resource.Quantity{Format: resource.DecimalSI}
+	return rl.Name(ResourceCPU, resource.DecimalSI)
 }
 
 // Memory returns the Memory limit if specified.
 func (rl *ResourceList) Memory() *resource.Quantity {
-	if val, ok := (*rl)[ResourceMemory]; ok {
-		return &val
-	}
-	return &resource.Quantity{Format: resource.BinarySI}
+	return rl.Name(ResourceMemory, resource.BinarySI)
 }
 
 // Storage returns the Storage limit if specified.
 func (rl *ResourceList) Storage() *resource.Quantity {
-	if val, ok := (*rl)[ResourceStorage]; ok {
-		return &val
-	}
-	return &resource.Quantity{Format: resource.BinarySI}
+	return rl.Name(ResourceStorage, resource.BinarySI)
 }
 
 // Pods returns the list of pods
 func (rl *ResourceList) Pods() *resource.Quantity {
-	if val, ok := (*rl)[ResourcePods]; ok {
-		return &val
-	}
-	return &resource.Quantity{}
+	return rl.Name(ResourcePods, resource.DecimalSI)
 }
 
 // StorageEphemeral returns the list of ephemeral storage volumes, if any
 func (rl *ResourceList) StorageEphemeral() *resource.Quantity {
-	if val, ok := (*rl)[ResourceEphemeralStorage]; ok {
+	return rl.Name(ResourceEphemeralStorage, resource.BinarySI)
+}
+
+// Name returns the resource with name if specified, otherwise it returns a nil quantity with default format.
+func (rl *ResourceList) Name(name ResourceName, defaultFormat resource.Format) *resource.Quantity {
+	if val, ok := (*rl)[name]; ok {
 		return &val
 	}
-	return &resource.Quantity{}
+	return &resource.Quantity{Format: defaultFormat}
 }

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -588,6 +588,12 @@ const (
 	//        medium: HugePages-1Gi
 	HugePageStorageMediumSize featuregate.Feature = "HugePageStorageMediumSize"
 
+	// owner: @derekwaynecarr
+	// alpha: v1.20
+	//
+	// Enables usage of hugepages-<size> in downward API.
+	DownwardAPIHugePages featuregate.Feature = "DownwardAPIHugePages"
+
 	// owner: @freehan
 	// GA: v1.18
 	//
@@ -757,6 +763,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceAppProtocol:                             {Default: true, PreRelease: featuregate.Beta},
 	ImmutableEphemeralVolumes:                      {Default: true, PreRelease: featuregate.Beta},
 	HugePageStorageMediumSize:                      {Default: true, PreRelease: featuregate.Beta},
+	DownwardAPIHugePages:                           {Default: false, PreRelease: featuregate.Alpha},
 	ExternalPolicyForExternalIP:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.22
 	AnyVolumeDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
 	DefaultPodTopologySpread:                       {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/quota/v1/evaluator/core/pods.go
+++ b/pkg/quota/v1/evaluator/core/pods.go
@@ -57,7 +57,7 @@ var podResources = []corev1.ResourceName{
 }
 
 // podResourcePrefixes are the set of prefixes for resources (Hugepages, and other
-// potential extended reources with specific prefix) managed by quota associated with pods.
+// potential extended resources with specific prefix) managed by quota associated with pods.
 var podResourcePrefixes = []string{
 	corev1.ResourceHugePagesPrefix,
 	corev1.ResourceRequestsHugePagesPrefix,

--- a/pkg/registry/apps/deployment/strategy.go
+++ b/pkg/registry/apps/deployment/strategy.go
@@ -79,7 +79,8 @@ func (deploymentStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obje
 // Validate validates a new deployment.
 func (deploymentStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	deployment := obj.(*apps.Deployment)
-	return validation.ValidateDeployment(deployment)
+	opts := pod.GetValidationOptionsFromPodTemplate(&deployment.Spec.Template, nil)
+	return validation.ValidateDeployment(deployment, opts)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -112,7 +113,9 @@ func (deploymentStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime
 func (deploymentStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newDeployment := obj.(*apps.Deployment)
 	oldDeployment := old.(*apps.Deployment)
-	allErrs := validation.ValidateDeploymentUpdate(newDeployment, oldDeployment)
+
+	opts := pod.GetValidationOptionsFromPodTemplate(&newDeployment.Spec.Template, &oldDeployment.Spec.Template)
+	allErrs := validation.ValidateDeploymentUpdate(newDeployment, oldDeployment, opts)
 
 	// Update is not allowed to set Spec.Selector for all groups/versions except extensions/v1beta1.
 	// If RequestInfo is nil, it is better to revert to old behavior (i.e. allow update to set Spec.Selector)

--- a/pkg/registry/batch/cronjob/strategy.go
+++ b/pkg/registry/batch/cronjob/strategy.go
@@ -83,7 +83,8 @@ func (cronJobStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Ob
 // Validate validates a new scheduled job.
 func (cronJobStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	cronJob := obj.(*batch.CronJob)
-	return validation.ValidateCronJob(cronJob)
+	opts := pod.GetValidationOptionsFromPodTemplate(&cronJob.Spec.JobTemplate.Spec.Template, nil)
+	return validation.ValidateCronJob(cronJob, opts)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -103,7 +104,9 @@ func (cronJobStrategy) AllowCreateOnUpdate() bool {
 func (cronJobStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	newCronJob := obj.(*batch.CronJob)
 	oldCronJob := old.(*batch.CronJob)
-	return validation.ValidateCronJobUpdate(newCronJob, oldCronJob)
+
+	opts := pod.GetValidationOptionsFromPodTemplate(&newCronJob.Spec.JobTemplate.Spec.Template, &oldCronJob.Spec.JobTemplate.Spec.Template)
+	return validation.ValidateCronJobUpdate(newCronJob, oldCronJob, opts)
 }
 
 type cronJobStatusStrategy struct {

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -103,7 +103,8 @@ func (jobStrategy) Validate(ctx context.Context, obj runtime.Object) field.Error
 	if job.Spec.ManualSelector == nil || *job.Spec.ManualSelector == false {
 		generateSelector(job)
 	}
-	return validation.ValidateJob(job)
+	opts := pod.GetValidationOptionsFromPodTemplate(&job.Spec.Template, nil)
+	return validation.ValidateJob(job, opts)
 }
 
 // generateSelector adds a selector to a job and labels to its template
@@ -173,8 +174,10 @@ func (jobStrategy) AllowCreateOnUpdate() bool {
 func (jobStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	job := obj.(*batch.Job)
 	oldJob := old.(*batch.Job)
-	validationErrorList := validation.ValidateJob(job)
-	updateErrorList := validation.ValidateJobUpdate(job, oldJob)
+
+	opts := pod.GetValidationOptionsFromPodTemplate(&job.Spec.Template, &oldJob.Spec.Template)
+	validationErrorList := validation.ValidateJob(job, opts)
+	updateErrorList := validation.ValidateJobUpdate(job, oldJob, opts)
 	return append(validationErrorList, updateErrorList...)
 }
 

--- a/pkg/registry/core/podtemplate/strategy.go
+++ b/pkg/registry/core/podtemplate/strategy.go
@@ -53,7 +53,8 @@ func (podTemplateStrategy) PrepareForCreate(ctx context.Context, obj runtime.Obj
 // Validate validates a new pod template.
 func (podTemplateStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	template := obj.(*api.PodTemplate)
-	return corevalidation.ValidatePodTemplate(template)
+	opts := pod.GetValidationOptionsFromPodTemplate(&template.Template, nil)
+	return corevalidation.ValidatePodTemplate(template, opts)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -77,7 +78,10 @@ func (podTemplateStrategy) PrepareForUpdate(ctx context.Context, obj, old runtim
 func (podTemplateStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
 	template := obj.(*api.PodTemplate)
 	oldTemplate := old.(*api.PodTemplate)
-	return corevalidation.ValidatePodTemplateUpdate(template, oldTemplate)
+
+	// Allow downward api usage of hugepages on pod update if feature is enabled or if the old pod already had used them.
+	opts := pod.GetValidationOptionsFromPodTemplate(&template.Template, &oldTemplate.Template)
+	return corevalidation.ValidatePodTemplateUpdate(template, oldTemplate, opts)
 }
 
 func (podTemplateStrategy) AllowUnconditionalUpdate() bool {

--- a/pkg/registry/core/replicationcontroller/strategy.go
+++ b/pkg/registry/core/replicationcontroller/strategy.go
@@ -108,7 +108,8 @@ func (rcStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object)
 // Validate validates a new replication controller.
 func (rcStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	controller := obj.(*api.ReplicationController)
-	return validation.ValidateReplicationController(controller)
+	opts := pod.GetValidationOptionsFromPodTemplate(controller.Spec.Template, nil)
+	return validation.ValidateReplicationController(controller, opts)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -126,8 +127,9 @@ func (rcStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) f
 	oldRc := old.(*api.ReplicationController)
 	newRc := obj.(*api.ReplicationController)
 
-	validationErrorList := validation.ValidateReplicationController(newRc)
-	updateErrorList := validation.ValidateReplicationControllerUpdate(newRc, oldRc)
+	opts := pod.GetValidationOptionsFromPodTemplate(newRc.Spec.Template, oldRc.Spec.Template)
+	validationErrorList := validation.ValidateReplicationController(newRc, opts)
+	updateErrorList := validation.ValidateReplicationControllerUpdate(newRc, oldRc, opts)
 	errs := append(validationErrorList, updateErrorList...)
 
 	for key, value := range helper.NonConvertibleFields(oldRc.Annotations) {

--- a/staging/src/k8s.io/api/core/v1/resource.go
+++ b/staging/src/k8s.io/api/core/v1/resource.go
@@ -25,40 +25,35 @@ func (rn ResourceName) String() string {
 	return string(rn)
 }
 
-// Returns the CPU limit if specified.
+// Cpu returns the Cpu limit if specified.
 func (rl *ResourceList) Cpu() *resource.Quantity {
-	if val, ok := (*rl)[ResourceCPU]; ok {
-		return &val
-	}
-	return &resource.Quantity{Format: resource.DecimalSI}
+	return rl.Name(ResourceCPU, resource.DecimalSI)
 }
 
-// Returns the Memory limit if specified.
+// Memory returns the Memory limit if specified.
 func (rl *ResourceList) Memory() *resource.Quantity {
-	if val, ok := (*rl)[ResourceMemory]; ok {
-		return &val
-	}
-	return &resource.Quantity{Format: resource.BinarySI}
+	return rl.Name(ResourceMemory, resource.BinarySI)
 }
 
-// Returns the Storage limit if specified.
+// Storage returns the Storage limit if specified.
 func (rl *ResourceList) Storage() *resource.Quantity {
-	if val, ok := (*rl)[ResourceStorage]; ok {
-		return &val
-	}
-	return &resource.Quantity{Format: resource.BinarySI}
+	return rl.Name(ResourceStorage, resource.BinarySI)
 }
 
+// Pods returns the list of pods
 func (rl *ResourceList) Pods() *resource.Quantity {
-	if val, ok := (*rl)[ResourcePods]; ok {
-		return &val
-	}
-	return &resource.Quantity{}
+	return rl.Name(ResourcePods, resource.DecimalSI)
 }
 
+// StorageEphemeral returns the list of ephemeral storage volumes, if any
 func (rl *ResourceList) StorageEphemeral() *resource.Quantity {
-	if val, ok := (*rl)[ResourceEphemeralStorage]; ok {
+	return rl.Name(ResourceEphemeralStorage, resource.BinarySI)
+}
+
+// Name returns the resource with name if specified, otherwise it returns a nil quantity with default format.
+func (rl *ResourceList) Name(name ResourceName, defaultFormat resource.Format) *resource.Quantity {
+	if val, ok := (*rl)[name]; ok {
 		return &val
 	}
-	return &resource.Quantity{}
+	return &resource.Quantity{Format: defaultFormat}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_resolve.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/env/env_resolve.go
@@ -199,7 +199,20 @@ func extractContainerResourceValue(fs *corev1.ResourceFieldSelector, container *
 	case "requests.ephemeral-storage":
 		return convertResourceEphemeralStorageToString(container.Resources.Requests.StorageEphemeral(), divisor)
 	}
-
+	// handle extended standard resources with dynamic names
+	// example: requests.hugepages-<pageSize> or limits.hugepages-<pageSize>
+	if strings.HasPrefix(fs.Resource, "requests.") {
+		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "requests."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Requests.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
+	if strings.HasPrefix(fs.Resource, "limits.") {
+		resourceName := corev1.ResourceName(strings.TrimPrefix(fs.Resource, "limits."))
+		if IsHugePageResourceName(resourceName) {
+			return convertResourceHugePagesToString(container.Resources.Limits.Name(resourceName, resource.BinarySI), divisor)
+		}
+	}
 	return "", fmt.Errorf("Unsupported container resource : %v", fs.Resource)
 }
 
@@ -214,6 +227,13 @@ func convertResourceCPUToString(cpu *resource.Quantity, divisor resource.Quantit
 // ceiling of the value.
 func convertResourceMemoryToString(memory *resource.Quantity, divisor resource.Quantity) (string, error) {
 	m := int64(math.Ceil(float64(memory.Value()) / float64(divisor.Value())))
+	return strconv.FormatInt(m, 10), nil
+}
+
+// convertResourceHugePagesToString converts hugepages value to the format of divisor and returns
+// ceiling of the value.
+func convertResourceHugePagesToString(hugePages *resource.Quantity, divisor resource.Quantity) (string, error) {
+	m := int64(math.Ceil(float64(hugePages.Value()) / float64(divisor.Value())))
 	return strconv.FormatInt(m, 10), nil
 }
 
@@ -268,4 +288,10 @@ func GetEnvVarRefString(from *corev1.EnvVarSource) string {
 	}
 
 	return "invalid valueFrom"
+}
+
+// IsHugePageResourceName returns true if the resource name has the huge page
+// resource prefix.
+func IsHugePageResourceName(name corev1.ResourceName) bool {
+	return strings.HasPrefix(string(name), corev1.ResourceHugePagesPrefix)
 }

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -261,7 +261,6 @@ var _ = ginkgo.Describe("[sig-storage] Downward API volume", func() {
 
 		f.TestContainerOutputRegexp("downward API volume plugin", pod, 0, []string{"[1-9]"})
 	})
-
 })
 
 func downwardAPIVolumePodForModeTest(name, filePath string, itemMode, defaultMode *int32) *v1.Pod {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add the ability to project `hugepages-<pagesize>` container resource requirements via downward API

Fixes https://github.com/kubernetes/kubernetes/issues/85148

**Special notes for your reviewer**:
Adds `requests.hugepages-<pagesize>` and `limits.hugepages-<pagesize>` to downward API consistent with cpu, memory, and ephemeral storage.

**Does this PR introduce a user-facing change?**:
```release-note
Add support for hugepages to downward API
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
