### PR TITLE
[wip] proxy: Simplify ServiceChangeTracker

### DIFF
--- a/pkg/proxy/iptables/proxier_test.go
+++ b/pkg/proxy/iptables/proxier_test.go
@@ -268,8 +268,6 @@ func TestDeleteEndpointConnections(t *testing.T) {
 				svc.Spec.ExternalTrafficPolicy = v1.ServiceExternalTrafficPolicyTypeLocal
 			}),
 		)
-
-		proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
 	}
 
 	// Run the test cases
@@ -288,8 +286,9 @@ func TestDeleteEndpointConnections(t *testing.T) {
 				ServicePortName: svc,
 			},
 		}
+		result := fp.serviceChanges.Commit()
 
-		fp.deleteEndpointConnections(input)
+		fp.deleteEndpointConnections(result.ServiceMap, input)
 
 		// For UDP connections, check the executed conntrack command
 		var expExecs int
@@ -347,7 +346,6 @@ func NewFakeProxier(ipt utiliptables.Interface, endpointSlicesEnabled bool) *Pro
 	// invocation into a Run() method.
 	p := &Proxier{
 		exec:                     &fakeexec.FakeExec{},
-		serviceMap:               make(proxy.ServiceMap),
 		serviceChanges:           proxy.NewServiceChangeTracker(newServiceInfo, nil, nil),
 		endpointsMap:             make(proxy.EndpointsMap),
 		endpointsChanges:         proxy.NewEndpointChangeTracker(testHostname, newEndpointInfo, nil, nil, endpointSlicesEnabled),
@@ -1162,24 +1160,24 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	for i := range services {
 		fp.OnServiceAdd(services[i])
 	}
-	result := proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 10 {
-		t.Errorf("expected service map length 10, got %v", fp.serviceMap)
+	result := fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 10 {
+		t.Errorf("expected service map length 10, got %v", result.ServiceMap)
 	}
 
 	// The only-local-loadbalancer ones get added
-	if len(result.HCServiceNodePorts) != 1 {
-		t.Errorf("expected 1 healthcheck port, got %v", result.HCServiceNodePorts)
+	if len(result.ServiceMap.HCServiceNodePorts()) != 1 {
+		t.Errorf("expected 1 healthcheck port, got %v", result.ServiceMap.HCServiceNodePorts())
 	} else {
 		nsn := makeNSN("somewhere", "only-local-load-balancer")
-		if port, found := result.HCServiceNodePorts[nsn]; !found || port != 345 {
-			t.Errorf("expected healthcheck port [%q]=345: got %v", nsn, result.HCServiceNodePorts)
+		if port, found := result.ServiceMap.HCServiceNodePorts()[nsn]; !found || port != 345 {
+			t.Errorf("expected healthcheck port [%q]=345: got %v", nsn, result.ServiceMap.HCServiceNodePorts())
 		}
 	}
 
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.UDPStaleClusterIPs()) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIPs()))
 	}
 
 	// Remove some stuff
@@ -1195,24 +1193,24 @@ func TestBuildServiceMapAddRemove(t *testing.T) {
 	fp.OnServiceDelete(services[2])
 	fp.OnServiceDelete(services[3])
 
-	result = proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 1 {
-		t.Errorf("expected service map length 1, got %v", fp.serviceMap)
+	result = fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 1 {
+		t.Errorf("expected service map length 1, got %v", result.ServiceMap)
 	}
 
-	if len(result.HCServiceNodePorts) != 0 {
-		t.Errorf("expected 0 healthcheck ports, got %v", result.HCServiceNodePorts)
+	if len(result.ServiceMap.HCServiceNodePorts()) != 0 {
+		t.Errorf("expected 0 healthcheck ports, got %v", result.ServiceMap.HCServiceNodePorts())
 	}
 
 	// All services but one were deleted. While you'd expect only the ClusterIPs
 	// from the three deleted services here, we still have the ClusterIP for
 	// the not-deleted service, because one of it's ServicePorts was deleted.
 	expectedStaleUDPServices := []string{"172.16.55.10", "172.16.55.4", "172.16.55.11", "172.16.55.12"}
-	if len(result.UDPStaleClusterIP) != len(expectedStaleUDPServices) {
-		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.UDPStaleClusterIP.UnsortedList())
+	if len(result.UDPStaleClusterIPs()) != len(expectedStaleUDPServices) {
+		t.Errorf("expected stale UDP services length %d, got %v", len(expectedStaleUDPServices), result.UDPStaleClusterIPs().UnsortedList())
 	}
 	for _, ip := range expectedStaleUDPServices {
-		if !result.UDPStaleClusterIP.Has(ip) {
+		if !result.UDPStaleClusterIPs().Has(ip) {
 			t.Errorf("expected stale UDP service service %s", ip)
 		}
 	}
@@ -1235,18 +1233,18 @@ func TestBuildServiceMapServiceHeadless(t *testing.T) {
 	)
 
 	// Headless service should be ignored
-	result := proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 0 {
-		t.Errorf("expected service map length 0, got %d", len(fp.serviceMap))
+	result := fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 0 {
+		t.Errorf("expected service map length 0, got %d", len(result.ServiceMap))
 	}
 
 	// No proxied services, so no healthchecks
-	if len(result.HCServiceNodePorts) != 0 {
-		t.Errorf("expected healthcheck ports length 0, got %d", len(result.HCServiceNodePorts))
+	if len(result.ServiceMap.HCServiceNodePorts()) != 0 {
+		t.Errorf("expected healthcheck ports length 0, got %d", len(result.ServiceMap.HCServiceNodePorts()))
 	}
 
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+	if len(result.UDPStaleClusterIPs()) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIPs()))
 	}
 }
 
@@ -1263,16 +1261,16 @@ func TestBuildServiceMapServiceTypeExternalName(t *testing.T) {
 		}),
 	)
 
-	result := proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 0 {
-		t.Errorf("expected service map length 0, got %v", fp.serviceMap)
+	result := fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 0 {
+		t.Errorf("expected service map length 0, got %v", result.ServiceMap)
 	}
 	// No proxied services, so no healthchecks
-	if len(result.HCServiceNodePorts) != 0 {
-		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
+	if len(result.ServiceMap.HCServiceNodePorts()) != 0 {
+		t.Errorf("expected healthcheck ports length 0, got %v", result.ServiceMap.HCServiceNodePorts())
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP)
+	if len(result.UDPStaleClusterIPs()) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIPs())
 	}
 }
 
@@ -1303,57 +1301,57 @@ func TestBuildServiceMapServiceUpdate(t *testing.T) {
 
 	fp.OnServiceAdd(servicev1)
 
-	result := proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result := fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", result.ServiceMap)
 	}
-	if len(result.HCServiceNodePorts) != 0 {
-		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
+	if len(result.ServiceMap.HCServiceNodePorts()) != 0 {
+		t.Errorf("expected healthcheck ports length 0, got %v", result.ServiceMap.HCServiceNodePorts())
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.UDPStaleClusterIPs()) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIPs()))
 	}
 
 	// Change service to load-balancer
 	fp.OnServiceUpdate(servicev1, servicev2)
-	result = proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", result.ServiceMap)
 	}
-	if len(result.HCServiceNodePorts) != 1 {
-		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
+	if len(result.ServiceMap.HCServiceNodePorts()) != 1 {
+		t.Errorf("expected healthcheck ports length 1, got %v", result.ServiceMap.HCServiceNodePorts())
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP.UnsortedList())
+	if len(result.UDPStaleClusterIPs()) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIPs().UnsortedList())
 	}
 
 	// No change; make sure the service map stays the same and there are
 	// no health-check changes
 	fp.OnServiceUpdate(servicev2, servicev2)
-	result = proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", result.ServiceMap)
 	}
-	if len(result.HCServiceNodePorts) != 1 {
-		t.Errorf("expected healthcheck ports length 1, got %v", result.HCServiceNodePorts)
+	if len(result.ServiceMap.HCServiceNodePorts()) != 1 {
+		t.Errorf("expected healthcheck ports length 1, got %v", result.ServiceMap.HCServiceNodePorts())
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
-		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIP.UnsortedList())
+	if len(result.UDPStaleClusterIPs()) != 0 {
+		t.Errorf("expected stale UDP services length 0, got %v", result.UDPStaleClusterIPs().UnsortedList())
 	}
 
 	// And back to ClusterIP
 	fp.OnServiceUpdate(servicev2, servicev1)
-	result = proxy.UpdateServiceMap(fp.serviceMap, fp.serviceChanges)
-	if len(fp.serviceMap) != 2 {
-		t.Errorf("expected service map length 2, got %v", fp.serviceMap)
+	result = fp.serviceChanges.Commit()
+	if len(result.ServiceMap) != 2 {
+		t.Errorf("expected service map length 2, got %v", result.ServiceMap)
 	}
-	if len(result.HCServiceNodePorts) != 0 {
-		t.Errorf("expected healthcheck ports length 0, got %v", result.HCServiceNodePorts)
+	if len(result.ServiceMap.HCServiceNodePorts()) != 0 {
+		t.Errorf("expected healthcheck ports length 0, got %v", result.ServiceMap.HCServiceNodePorts())
 	}
-	if len(result.UDPStaleClusterIP) != 0 {
+	if len(result.UDPStaleClusterIPs()) != 0 {
 		// Services only added, so nothing stale yet
-		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIP))
+		t.Errorf("expected stale UDP services length 0, got %d", len(result.UDPStaleClusterIPs()))
 	}
 }
 

--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -25,7 +25,7 @@ import (
 
 	"k8s.io/klog"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
@@ -182,23 +182,23 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 
 type makeServicePortFunc func(*v1.ServicePort, *v1.Service, *BaseServiceInfo) ServicePort
 
-// serviceChange contains all changes to services that happened since proxy rules were synced.  For a single object,
-// changes are accumulated, i.e. previous is state from before applying the changes,
-// current is state after applying all of the changes.
-type serviceChange struct {
-	previous ServiceMap
-	current  ServiceMap
-}
-
-// ServiceChangeTracker carries state about uncommitted changes to an arbitrary number of
-// Services, keyed by their namespace and name.
+// ServiceChangeTracker keeps track of the last-synced state of the world for
+// Services as well as buffering future uncommitted (to, say, iptables) changes.
 type ServiceChangeTracker struct {
-	// lock protects items.
 	lock sync.Mutex
-	// items maps a service to its serviceChange.
-	items map[types.NamespacedName]*serviceChange
+
+	// lastState is the last committed state, with no pending changes applied
+	// it is a map of Service to ServiceMap, so we can quickly look up all
+	// ServicePorts that belong to a given service
+	lastState map[types.NamespacedName]PartialServiceMap
+
+	// pendingChanges is the set of Services (really ServicePorts) that have changed
+	// since the last Commit(). Again, this is per-Service, so it's a PartialServiceMap
+	pendingChanges map[types.NamespacedName]PartialServiceMap
+
 	// makeServiceInfo allows proxier to inject customized information when processing service.
 	makeServiceInfo makeServicePortFunc
+
 	// isIPv6Mode indicates if change tracker is under IPv6/IPv4 mode. Nil means not applicable.
 	isIPv6Mode *bool
 	recorder   record.EventRecorder
@@ -207,85 +207,139 @@ type ServiceChangeTracker struct {
 // NewServiceChangeTracker initializes a ServiceChangeTracker
 func NewServiceChangeTracker(makeServiceInfo makeServicePortFunc, isIPv6Mode *bool, recorder record.EventRecorder) *ServiceChangeTracker {
 	return &ServiceChangeTracker{
-		items:           make(map[types.NamespacedName]*serviceChange),
+		pendingChanges:  make(map[types.NamespacedName]PartialServiceMap),
+		lastState:       make(map[types.NamespacedName]PartialServiceMap),
 		makeServiceInfo: makeServiceInfo,
 		isIPv6Mode:      isIPv6Mode,
 		recorder:        recorder,
 	}
 }
 
-// Update updates given service's change map based on the <previous, current> service pair.  It returns true if items changed,
+// Update updates given service's change map based on the <previous, current> service pair.  It returns true if the Tracker has any pending changes.
 // otherwise return false.  Update can be used to add/update/delete items of ServiceChangeMap.  For example,
 // Add item
 //   - pass <nil, service> as the <previous, current> pair.
 // Update item
-//   - pass <oldService, service> as the <previous, current> pair.
+//   - pass <oldService, service> as the <previous, current> pair. oldService is ignored
 // Delete item
-//   - pass <service, nil> as the <previous, current> pair.
+//  - pass <oldService, nil> as the <previous, current> pair.
 func (sct *ServiceChangeTracker) Update(previous, current *v1.Service) bool {
-	svc := current
-	if svc == nil {
-		svc = previous
+	var nsn types.NamespacedName
+	if current != nil {
+		nsn = types.NamespacedName{Namespace: current.Namespace, Name: current.Name}
+	} else if previous != nil {
+		nsn = types.NamespacedName{Namespace: previous.Namespace, Name: previous.Name}
+	} else {
+		return false // prev, current nil
 	}
-	// previous == nil && current == nil is unexpected, we should return false directly.
-	if svc == nil {
-		return false
-	}
-	metrics.ServiceChangesTotal.Inc()
-	namespacedName := types.NamespacedName{Namespace: svc.Namespace, Name: svc.Name}
 
 	sct.lock.Lock()
 	defer sct.lock.Unlock()
 
-	change, exists := sct.items[namespacedName]
-	if !exists {
-		change = &serviceChange{}
-		change.previous = sct.serviceToServiceMap(previous)
-		sct.items[namespacedName] = change
+	metrics.ServiceChangesTotal.Inc()
+
+	oldState := sct.lastState[nsn]               // may be nil
+	newState := sct.serviceToServiceMap(current) // may be nil
+
+	// if newState == currentState, it means either no change or ABA, so we
+	// can delete this from the list of pending changes
+	if reflect.DeepEqual(oldState, newState) {
+		delete(sct.pendingChanges, nsn)
+	} else {
+		sct.pendingChanges[nsn] = newState
 	}
-	change.current = sct.serviceToServiceMap(current)
-	// if change.previous equal to change.current, it means no change
-	if reflect.DeepEqual(change.previous, change.current) {
-		delete(sct.items, namespacedName)
-	}
-	metrics.ServiceChangesPending.Set(float64(len(sct.items)))
-	return len(sct.items) > 0
+
+	metrics.ServiceChangesPending.Set(float64(len(sct.pendingChanges)))
+	return len(sct.pendingChanges) > 0
 }
 
 // UpdateServiceMapResult is the updated results after applying service changes.
 type UpdateServiceMapResult struct {
-	// HCServiceNodePorts is a map of Service names to node port numbers which indicate the health of that Service on this Node.
-	// The value(uint16) of HCServices map is the service health check node port.
-	HCServiceNodePorts map[types.NamespacedName]uint16
-	// UDPStaleClusterIP holds stale (no longer assigned to a Service) Service IPs that had UDP ports.
-	// Callers can use this to abort timeout-waits or clear connection-tracking information.
-	UDPStaleClusterIP sets.String
+	ServiceMap ServiceMap
+
+	StaleServicePorts []ServicePort
 }
 
-// UpdateServiceMap updates ServiceMap based on the given changes.
-func UpdateServiceMap(serviceMap ServiceMap, changes *ServiceChangeTracker) (result UpdateServiceMapResult) {
-	result.UDPStaleClusterIP = sets.NewString()
-	serviceMap.apply(changes, result.UDPStaleClusterIP)
+// UDPStaleClusterIPs holds stale (no longer assigned to a Service) Service IPs that had UDP ports.
+// Callers can use this to abort timeout-waits or clear connection-tracking information.
+func (smr *UpdateServiceMapResult) UDPStaleClusterIPs() sets.String {
+	result := sets.NewString()
 
-	// TODO: If this will appear to be computationally expensive, consider
-	// computing this incrementally similarly to serviceMap.
-	result.HCServiceNodePorts = make(map[types.NamespacedName]uint16)
-	for svcPortName, info := range serviceMap {
-		if info.HealthCheckNodePort() != 0 {
-			result.HCServiceNodePorts[svcPortName.NamespacedName] = uint16(info.HealthCheckNodePort())
+	for _, staleServicePort := range smr.StaleServicePorts {
+		if staleServicePort.Protocol() == v1.ProtocolUDP {
+			result.Insert(staleServicePort.ClusterIP().String())
 		}
 	}
+	return result
+}
+
+// Commit applies the pending changes to the state. It returns the newly
+// committed state as well as the list of deleted ServicePorts
+func (sct *ServiceChangeTracker) Commit() UpdateServiceMapResult {
+	sct.lock.Lock()
+	defer sct.lock.Unlock()
+
+	result := UpdateServiceMapResult{
+		ServiceMap:        make(ServiceMap, len(sct.lastState)),
+		StaleServicePorts: []ServicePort{},
+	}
+
+	// merge pending changes, compute deleted
+	for serviceNamespacedName, newServicePorts := range sct.pendingChanges {
+		oldServicePorts := sct.lastState[serviceNamespacedName]
+		if len(newServicePorts) == 0 {
+			delete(sct.lastState, serviceNamespacedName)
+		} else {
+			sct.lastState[serviceNamespacedName] = newServicePorts
+		}
+
+		// delete serviceports from old that are also in new, any left over
+		// are stale.
+		for servicePortName := range newServicePorts {
+			delete(oldServicePorts, servicePortName)
+		}
+		for _, staleServicePort := range oldServicePorts {
+			result.StaleServicePorts = append(result.StaleServicePorts, staleServicePort)
+		}
+	}
+
+	// flatten list of PartialServiceMaps to the final result
+	for _, sm := range sct.lastState {
+		for k, v := range sm {
+			result.ServiceMap[k] = v
+		}
+	}
+
+	// clear pending changes
+	sct.pendingChanges = make(map[types.NamespacedName]PartialServiceMap)
+	metrics.ServiceChangesPending.Set(0)
 
 	return result
 }
 
-// ServiceMap maps a service to its ServicePort.
+// ServiceMap is a map of ServicePorts by their names
 type ServiceMap map[ServicePortName]ServicePort
 
-// serviceToServiceMap translates a single Service object to a ServiceMap.
+// PartialServiceMap is the same as a ServiceMap, but with a different type
+// to detect coding errors.
+type PartialServiceMap map[ServicePortName]ServicePort
+
+// HCServiceNodePorts returns a map of Service to healthcheck port
+func (sm ServiceMap) HCServiceNodePorts() map[types.NamespacedName]uint16 {
+	result := make(map[types.NamespacedName]uint16)
+	for svcPortName, info := range sm {
+		if hcp := info.HealthCheckNodePort(); hcp != 0 {
+			result[svcPortName.NamespacedName] = uint16(hcp)
+		}
+	}
+	return result
+}
+
+// serviceToServiceMap translates a single Service object to a PartialServiceMap.
+// The PartialServiceMap is the set of ServicePorts created by this Service.
 //
 // NOTE: service object should NOT be modified.
-func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) ServiceMap {
+func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) PartialServiceMap {
 	if service == nil {
 		return nil
 	}
@@ -303,7 +357,7 @@ func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) Servic
 		}
 	}
 
-	serviceMap := make(ServiceMap)
+	serviceMap := make(PartialServiceMap)
 	for i := range service.Spec.Ports {
 		servicePort := &service.Spec.Ports[i]
 		svcPortName := ServicePortName{NamespacedName: svcName, Port: servicePort.Name, Protocol: servicePort.Protocol}
@@ -315,83 +369,4 @@ func (sct *ServiceChangeTracker) serviceToServiceMap(service *v1.Service) Servic
 		}
 	}
 	return serviceMap
-}
-
-// apply the changes to ServiceMap and update the stale udp cluster IP set. The UDPStaleClusterIP argument is passed in to store the
-// udp protocol service cluster ip when service is deleted from the ServiceMap.
-func (sm *ServiceMap) apply(changes *ServiceChangeTracker, UDPStaleClusterIP sets.String) {
-	changes.lock.Lock()
-	defer changes.lock.Unlock()
-	for _, change := range changes.items {
-		sm.merge(change.current)
-		// filter out the Update event of current changes from previous changes before calling unmerge() so that can
-		// skip deleting the Update events.
-		change.previous.filter(change.current)
-		sm.unmerge(change.previous, UDPStaleClusterIP)
-	}
-	// clear changes after applying them to ServiceMap.
-	changes.items = make(map[types.NamespacedName]*serviceChange)
-	metrics.ServiceChangesPending.Set(0)
-}
-
-// merge adds other ServiceMap's elements to current ServiceMap.
-// If collision, other ALWAYS win. Otherwise add the other to current.
-// In other words, if some elements in current collisions with other, update the current by other.
-// It returns a string type set which stores all the newly merged services' identifier, ServicePortName.String(), to help users
-// tell if a service is deleted or updated.
-// The returned value is one of the arguments of ServiceMap.unmerge().
-// ServiceMap A Merge ServiceMap B will do following 2 things:
-//   * update ServiceMap A.
-//   * produce a string set which stores all other ServiceMap's ServicePortName.String().
-// For example,
-//   - A{}
-//   - B{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
-//     - A updated to be {{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
-//     - produce string set {"ns/cluster-ip:http"}
-//   - A{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 345, "UDP"}}
-//   - B{{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
-//     - A updated to be {{"ns", "cluster-ip", "http"}: {"172.16.55.10", 1234, "TCP"}}
-//     - produce string set {"ns/cluster-ip:http"}
-func (sm *ServiceMap) merge(other ServiceMap) sets.String {
-	// existingPorts is going to store all identifiers of all services in `other` ServiceMap.
-	existingPorts := sets.NewString()
-	for svcPortName, info := range other {
-		// Take ServicePortName.String() as the newly merged service's identifier and put it into existingPorts.
-		existingPorts.Insert(svcPortName.String())
-		_, exists := (*sm)[svcPortName]
-		if !exists {
-			klog.V(1).Infof("Adding new service port %q at %s", svcPortName, info.String())
-		} else {
-			klog.V(1).Infof("Updating existing service port %q at %s", svcPortName, info.String())
-		}
-		(*sm)[svcPortName] = info
-	}
-	return existingPorts
-}
-
-// filter filters out elements from ServiceMap base on given ports string sets.
-func (sm *ServiceMap) filter(other ServiceMap) {
-	for svcPortName := range *sm {
-		// skip the delete for Update event.
-		if _, ok := other[svcPortName]; ok {
-			delete(*sm, svcPortName)
-		}
-	}
-}
-
-// unmerge deletes all other ServiceMap's elements from current ServiceMap.  We pass in the UDPStaleClusterIP strings sets
-// for storing the stale udp service cluster IPs. We will clear stale udp connection base on UDPStaleClusterIP later
-func (sm *ServiceMap) unmerge(other ServiceMap, UDPStaleClusterIP sets.String) {
-	for svcPortName := range other {
-		info, exists := (*sm)[svcPortName]
-		if exists {
-			klog.V(1).Infof("Removing service port %q", svcPortName)
-			if info.Protocol() == v1.ProtocolUDP {
-				UDPStaleClusterIP.Insert(info.ClusterIP().String())
-			}
-			delete(*sm, svcPortName)
-		} else {
-			klog.Errorf("Service port %q doesn't exists", svcPortName)
-		}
-	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

ServiceChangeTracker is not level-triggered, and is susceptible to informer bugs. Specifically, if the informer fails to send an edge, we will ignore subsequent resyncs. This is because we compare the new object against the old one in the informer's store, rather than in our state as we understand it.

The fix is to for the ServiceChangeTracker to keep this state internally, and otherwise ignore the old object as provided by the informer.

This PR refactors the ServiceChangeTracker and simplifies the API. It's not a full code clean-up, but it's a start.

The goal is to refactor the EndpointChangeTracker in the same manner.
**Does this PR introduce a user-facing change?**:
```release-note
NONE
```