### PR TITLE
ipset: remove unneccesary judgement in IsNotFoundError() and fix comm…

### DIFF
--- a/pkg/util/ipset/ipset.go
+++ b/pkg/util/ipset/ipset.go
@@ -467,14 +467,13 @@ func validateHashFamily(family string) bool {
 func IsNotFoundError(err error) bool {
 	es := err.Error()
 	if strings.Contains(es, "does not exist") {
-		// set with the same name already exists
-		// xref: https://github.com/Olipro/ipset/blob/master/lib/errcode.c#L32-L33
+		// set with the given name does not exist
+		// xref: https://github.com/Olipro/ipset/blob/c3ad11037681e46fb5f3096c5c824f3e3556522a/lib/errcode.c#L24-L25
 		return true
 	}
-	if strings.Contains(es, "element is missing") {
-		// entry is missing from the set
-		// xref: https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1904
-		// https://github.com/Olipro/ipset/blob/master/lib/parse.c#L1925
+	if strings.Contains(es, "it's not added") {
+		// entry that does not exist in set cannot be deleted
+		// https://github.com/Olipro/ipset/blob/c3ad11037681e46fb5f3096c5c824f3e3556522a/lib/errcode.c#L84
 		return true
 	}
 	return false


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
1. the judgement `strings.Contains(es, "element is missing")` can only tell a `ipset` command is missing some params, but can't tell whether a set or entry exists.  An example is shown as below.
```
[HP chen]# ipset create foo hash:ip,port,net # create a set named `foo`
[HP chen]# ipset add foo 192.168.1.1,80,10.0.0.0/24 # add an entry
[HP chen]# ipset add foo 192.168.1.1 # try to add an entry with params missing
ipset v7.3: Syntax error: Second element is missing from 192.168.1.1.
[HP chen]# ipset add foo 192.168.1.1,22  # try to add an entry with params missing
ipset v7.3: Syntax error: Third element is missing from 192.168.1.1,22.
```
2. fix comments about `does not exist` and make xref link  permanent

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
