### PR TITLE
Do not swallow timeout in manageReplicas

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -957,16 +957,6 @@ func (dsc *DaemonSetsController) syncNodes(ds *apps.DaemonSet, podsToDelete, nod
 						// this error since all subsequent creations will fail.
 						return
 					}
-					if errors.IsTimeout(err) {
-						// Pod is created but its initialization has timed out.
-						// If the initialization is successful eventually, the
-						// controller will observe the creation via the informer.
-						// If the initialization fails, or if the pod keeps
-						// uninitialized for a long time, the informer will not
-						// receive any update, and the controller will create a new
-						// pod when the expectation expires.
-						return
-					}
 				}
 				if err != nil {
 					klog.V(2).Infof("Failed creation, decrementing expectations for set %q/%q", ds.Namespace, ds.Name)

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -777,16 +777,6 @@ func (jm *JobController) manageJob(activePods []*v1.Pod, succeeded int32, job *b
 							// this error since all subsequent creations will fail.
 							return
 						}
-						if errors.IsTimeout(err) {
-							// Pod is created but its initialization has timed out.
-							// If the initialization is successful eventually, the
-							// controller will observe the creation via the informer.
-							// If the initialization fails, or if the pod keeps
-							// uninitialized for a long time, the informer will not
-							// receive any update, and the controller will create a new
-							// pod when the expectation expires.
-							return
-						}
 					}
 					if err != nil {
 						defer utilruntime.HandleError(err)

--- a/pkg/controller/replicaset/replica_set.go
+++ b/pkg/controller/replicaset/replica_set.go
@@ -575,16 +575,6 @@ func (rsc *ReplicaSetController) manageReplicas(filteredPods []*v1.Pod, rs *apps
 					// anything because any creation will fail
 					return nil
 				}
-				if errors.IsTimeout(err) {
-					// Pod is created but its initialization has timed out.
-					// If the initialization is successful eventually, the
-					// controller will observe the creation via the informer.
-					// If the initialization fails, or if the pod keeps
-					// uninitialized for a long time, the informer will not
-					// receive any update, and the controller will create a new
-					// pod when the expectation expires.
-					return nil
-				}
 			}
 			return err
 		})


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes #67662 by not swallowing timeout

**Which issue(s) this PR fixes**:
Fixes #67662

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
