### PR TITLE
Add code check gomega.Expect(bool).To(gomega.BeTrue(),explain)

### DIFF
--- a/hack/verify-test-code.sh
+++ b/hack/verify-test-code.sh
@@ -51,6 +51,30 @@ do
     fi
 done
 
+errors_expect_be_bool=()
+for file in "${all_e2e_files[@]}"
+do
+    if grep -E "gomega\.Expect\(.*\)\.(To|NotTo)\(gomega\.(BeTrue|BeFalse)\(\)" "${file}" > /dev/null
+    then
+        errors_expect_be_bool+=( "${file}" )
+    fi
+done
+
+if [ ${#errors_expect_be_bool[@]} -ne 0 ]; then
+  {
+    echo "Errors:"
+    for err in "${errors_expect_be_bool[@]}"; do
+      echo "$err"
+    done
+    echo
+    echo 'The above files need to use framework.ExpectEqual(foo, true, explain) or '
+    echo 'framework.ExpectEqual(foo, false, explain) instead of '
+    echo 'gomega.Expect(foo).To(gomega.BeTrue(), explain) or gomega.Expect(foo).To(gomega.BeFalse(), explain)'
+    echo
+  } >&2
+  exit 1
+fi
+
 if [ ${#errors_expect_no_error[@]} -ne 0 ]; then
   {
     echo "Errors:"

--- a/test/e2e_kubeadm/kubeadm_certs_test.go
+++ b/test/e2e_kubeadm/kubeadm_certs_test.go
@@ -66,7 +66,7 @@ var _ = Describe("kubeadm-certs [copy-certs]", func() {
 		gomega.Expect(s.OwnerReferences).To(gomega.HaveLen(1), "%s should have one owner reference", kubeadmCertsSecretName)
 		ownRef := s.OwnerReferences[0]
 		framework.ExpectEqual(ownRef.Kind, "Secret", "%s should be owned by a secret", kubeadmCertsSecretName)
-		gomega.Expect(*ownRef.BlockOwnerDeletion).To(gomega.BeTrue(), "%s should be deleted on owner deletion", kubeadmCertsSecretName)
+		framework.ExpectEqual(*ownRef.BlockOwnerDeletion, true, "%s should be deleted on owner deletion", kubeadmCertsSecretName)
 
 		o := GetSecret(f.ClientSet, kubeSystemNamespace, ownRef.Name)
 		framework.ExpectEqual(o.Type, corev1.SecretTypeBootstrapToken, "%s should have an owner reference that refers to a bootstrap-token", kubeadmCertsSecretName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This pr adds code check to check 

```
gomega.Expect(bool).To(gomega.BeTrue(),explain)  
gomega.Expect(bool).To(gomega.BeFalse(),explain)  
```
 in e2e tests.

Remid that we should use framework.Equal(bool,true(or false),explain...)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
