### PR TITLE
stop defaulting kubeconfig to http://localhost:8080

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -35,22 +35,13 @@ import (
 var (
 	// ClusterDefaults has the same behavior as the old EnvVar and DefaultCluster fields
 	// DEPRECATED will be replaced
-	ClusterDefaults = clientcmdapi.Cluster{Server: getDefaultServer()}
+	ClusterDefaults = clientcmdapi.Cluster{Server: os.Getenv("KUBERNETES_MASTER")}
 	// DefaultClientConfig represents the legacy behavior of this package for defaulting
 	// DEPRECATED will be replace
 	DefaultClientConfig = DirectClientConfig{*clientcmdapi.NewConfig(), "", &ConfigOverrides{
 		ClusterDefaults: ClusterDefaults,
 	}, nil, NewDefaultClientConfigLoadingRules(), promptedCredentials{}}
 )
-
-// getDefaultServer returns a default setting for DefaultClientConfig
-// DEPRECATED
-func getDefaultServer() string {
-	if server := os.Getenv("KUBERNETES_MASTER"); len(server) > 0 {
-		return server
-	}
-	return "http://localhost:8080"
-}
 
 // ClientConfig is used to make it easy to get an api server client
 type ClientConfig interface {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -30,7 +30,7 @@ import (
 
 var (
 	ErrNoContext   = errors.New("no context chosen")
-	ErrEmptyConfig = errors.New("no configuration has been provided")
+	ErrEmptyConfig = errors.New("no configuration has been provided, try setting KUBERNETES_MASTER environment variable")
 	// message is for consistency with old behavior
 	ErrEmptyCluster = errors.New("cluster has no server defined")
 )

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -325,6 +325,7 @@ runTests() {
     exit 1
   fi
   kube::log::status "Checking kubectl version"
+  export KUBERNETES_MASTER=http://127.0.0.1:${API_PORT}
   kubectl version
 
   # Generate a random namespace name, based on the current time (to make


### PR DESCRIPTION
This is reviewing https://github.com/kubernetes/kubernetes/pull/62469

This default reflects a discouraged path (http, not https), that hasn't correspond to the default clusters being stood up for years (we changed default to https).

Potential places this might have an impact are insecure servers exposed and used/managed via a local script.  Making this change now provides immediate feedback about a potentially risky situation from a location that will not see a warning added for humans.

If you own one of these legacy clusters, you are *strongly* encouraged to secure your server.  If you cannot secure your server, you can set  `KUBERNETES_MASTER`.

@kubernetes/sig-api-machinery-pr-reviews 
/assign @liggitt @deads2k 

```release-note
action required: `kubectl` no longer defaults to `http://localhost:8080`.  If you own one of these legacy clusters, you are *strongly* encouraged to secure your server.   If you cannot secure your server, you can set `KUBERNETES_MASTER` if you were relying on that behavior and you're client-go user. Set `--server`, `--kubeconfig` or `KUBECONFIG` to make it work in `kubectl`. 
```