### PR TITLE
make test framework easier to re-use

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -162,7 +162,9 @@ func NewFramework(baseName string, options Options, client clientset.Interface) 
 			return
 		}
 		if !f.SkipNamespaceCreation {
-			DumpAllNamespaceInfo(f.ClientSet, f.Namespace.Name)
+			for _, ns := range f.namespacesToDelete {
+				DumpAllNamespaceInfo(f.ClientSet, ns.Name)
+			}
 		}
 	})
 


### PR DESCRIPTION
Fixes a few issues for extenders of the test Framework

1. adds the ability to add AfterEach functions to be run every test.  This is very useful for custom gathering scripts.
2. fix the existing namespace dump info to include all namespaces involved in a test
3. add ability to get a kubeconfig that contacts the kube-apiserver to make it easier to build custom generated clients in built-on code.

/kind cleanup
/priority important-soon
@kubernetes/sig-testing-pr-reviews 

```release-note
NONE
```