### PR TITLE
Sync the status of static Pods

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	"k8s.io/kubernetes/pkg/kubelet/config"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	kubelettypes "k8s.io/kubernetes/pkg/kubelet/types"
 	utilnode "k8s.io/kubernetes/pkg/util/node"
 )
 
@@ -167,8 +168,11 @@ func (kl *Kubelet) GetPods() []*v1.Pod {
 	// a kubelet running without apiserver requires an additional
 	// update of the static pod status. See #57106
 	for _, p := range pods {
-		if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
-			p.Status = status
+		if kubelettypes.IsStaticPod(p) {
+			if status, ok := kl.statusManager.GetPodStatus(p.UID); ok {
+				klog.V(2).Infof("status for pod %v updated to %v", p.Name, status)
+				p.Status = status
+			}
 		}
 	}
 	return pods


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This refines the change introduced by #77661.
This PR sync's status for static pods.

**Which issue(s) this PR fixes**:
Fixes #84931

```release-note
Fixed a regression where the kubelet would fail to update the ready status of pods.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
