### PR TITLE
cleanup(kubelet): remove unreachable code, and unnecessary statement

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -832,11 +832,7 @@ func (p *Parser) parseExactValue() (sets.String, error) {
 //  (5) A requirement with just !KEY requires that the KEY not exist.
 //
 func Parse(selector string) (Selector, error) {
-	parsedSelector, err := parse(selector)
-	if err == nil {
-		return parsedSelector, nil
-	}
-	return nil, err
+	return parse(selector)
 }
 
 // parse parses the string representation of the selector and returns the internalSelector struct.
@@ -850,7 +846,7 @@ func parse(selector string) (internalSelector, error) {
 		return nil, err
 	}
 	sort.Sort(ByKey(items)) // sort to grant determistic parsing
-	return internalSelector(items), err
+	return items, err
 }
 
 func validateLabelKey(k string) error {

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector_test.go
@@ -518,8 +518,10 @@ func TestSetSelectorParser(t *testing.T) {
 			t.Errorf("Parse(%s) => %v expected no error", ssp.In, err)
 		} else if err == nil && !ssp.Valid {
 			t.Errorf("Parse(%s) => %+v expected error", ssp.In, sel)
-		} else if ssp.Match && !reflect.DeepEqual(sel, ssp.Out) {
+		} else if ssp.Match && ssp.Out != nil && !reflect.DeepEqual(sel, ssp.Out) {
 			t.Errorf("Parse(%s) => parse output '%#v' doesn't match '%#v' expected match", ssp.In, sel, ssp.Out)
+		} else if ssp.Match && ssp.Out == nil && !reflect.ValueOf(sel).IsNil() {
+			t.Errorf("Parse(%s) => %v expected nil", ssp.In, sel)
 		}
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -357,7 +357,7 @@ func waitForDelete(params waitForDeleteParams) ([]corev1.Pod, error) {
 			default:
 				return false, nil
 			}
-			return false, nil
+
 		}
 		return true, nil
 	})


### PR DESCRIPTION
cleanup(kubelet): remove unnecessary code

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

 /kind cleanup

**What this PR does / why we need it**:
cleanup(kubelet): remove unreachable code, and unnecessary statement
**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

