### PR TITLE
code-generator: expose pluralExceptions via flag

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -49,6 +49,9 @@ type CustomArgs struct {
 	ClientsetOnly bool
 	// FakeClient determines if client-gen generates the fake clients.
 	FakeClient bool
+	// PluralExceptions specify list of exceptions used when pluralizing certain types.
+	// For example 'Endpoints:Endpoints', otherwise the pluralizer will generate 'Endpointes'.
+	PluralExceptions []string
 }
 
 func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
@@ -58,6 +61,7 @@ func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 		ClientsetAPIPath: "/apis",
 		ClientsetOnly:    false,
 		FakeClient:       true,
+		PluralExceptions: []string{"Endpoints:Endpoints"},
 	}
 	genericArgs.CustomArgs = customArgs
 	genericArgs.InputDirs = DefaultInputDirs
@@ -78,6 +82,8 @@ func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet, inputBase string) {
 	pflag.StringVarP(&ca.ClientsetAPIPath, "clientset-api-path", "", ca.ClientsetAPIPath, "the value of default API HTTP path, starting with / and without trailing /.")
 	pflag.BoolVar(&ca.ClientsetOnly, "clientset-only", ca.ClientsetOnly, "when set, client-gen only generates the clientset shell, without generating the individual typed clients")
 	pflag.BoolVar(&ca.FakeClient, "fake-clientset", ca.FakeClient, "when set, client-gen will generate the fake clientset that can be used in tests")
+
+	fs.StringArrayVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType form")
 
 	// support old flags
 	fs.SetNormalizeFunc(mapFlagName("clientset-path", "output-package", fs.GetNormalizeFunc()))

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/client_generator.go
@@ -37,10 +37,7 @@ import (
 )
 
 // NameSystems returns the name system used by the generators in this package.
-func NameSystems() namer.NameSystems {
-	pluralExceptions := map[string]string{
-		"Endpoints": "Endpoints",
-	}
+func NameSystems(pluralExceptions map[string]string) namer.NameSystems {
 	lowercaseNamer := namer.NewAllLowercasePluralNamer(pluralExceptions)
 
 	publicNamer := &ExceptionNamer{

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/main.go
@@ -57,7 +57,7 @@ func main() {
 	}
 
 	if err := genericArgs.Execute(
-		generators.NameSystems(),
+		generators.NameSystems(util.PluralExceptionListToMapOrDie(customArgs.PluralExceptions)),
 		generators.DefaultNameSystem(),
 		generators.Packages,
 	); err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/args/args.go
@@ -31,13 +31,18 @@ type CustomArgs struct {
 	InternalClientSetPackage  string
 	ListersPackage            string
 	SingleDirectory           bool
+
+	// PluralExceptions define a list of pluralizer exceptions in Type:PluralType format.
+	// The default list is "Endpoints:Endpoints"
+	PluralExceptions []string
 }
 
 // NewDefaults returns default arguments for the generator.
 func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 	genericArgs := args.Default().WithoutDefaultFlagParsing()
 	customArgs := &CustomArgs{
-		SingleDirectory: false,
+		SingleDirectory:  false,
+		PluralExceptions: []string{"Endpoints:Endpoints"},
 	}
 	genericArgs.CustomArgs = customArgs
 
@@ -57,6 +62,7 @@ func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&ca.VersionedClientSetPackage, "versioned-clientset-package", ca.VersionedClientSetPackage, "the full package name for the versioned clientset to use")
 	fs.StringVar(&ca.ListersPackage, "listers-package", ca.ListersPackage, "the full package name for the listers to use")
 	fs.BoolVar(&ca.SingleDirectory, "single-directory", ca.SingleDirectory, "if true, omit the intermediate \"internalversion\" and \"externalversions\" subdirectories")
+	fs.StringArrayVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType format")
 }
 
 // Validate checks the given arguments.

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//staging/src/k8s.io/code-generator/cmd/client-gen/types:go_default_library",
         "//staging/src/k8s.io/code-generator/cmd/informer-gen/args:go_default_library",
         "//staging/src/k8s.io/code-generator/pkg/namer:go_default_library",
+        "//staging/src/k8s.io/code-generator/pkg/util:go_default_library",
         "//vendor/k8s.io/gengo/args:go_default_library",
         "//vendor/k8s.io/gengo/generator:go_default_library",
         "//vendor/k8s.io/gengo/namer:go_default_library",

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/generic.go
@@ -35,6 +35,7 @@ type genericGenerator struct {
 	imports              namer.ImportTracker
 	groupVersions        map[string]clientgentypes.GroupVersions
 	groupGoNames         map[string]string
+	pluralExceptions     map[string]string
 	typesForGroupVersion map[clientgentypes.GroupVersion][]*types.Type
 	filtered             bool
 }
@@ -50,14 +51,11 @@ func (g *genericGenerator) Filter(c *generator.Context, t *types.Type) bool {
 }
 
 func (g *genericGenerator) Namers(c *generator.Context) namer.NameSystems {
-	pluralExceptions := map[string]string{
-		"Endpoints": "Endpoints",
-	}
 	return namer.NameSystems{
 		"raw":                namer.NewRawNamer(g.outputPackage, g.imports),
-		"allLowercasePlural": namer.NewAllLowercasePluralNamer(pluralExceptions),
-		"publicPlural":       namer.NewPublicPluralNamer(pluralExceptions),
-		"resource":           codegennamer.NewTagOverrideNamer("resourceName", namer.NewAllLowercasePluralNamer(pluralExceptions)),
+		"allLowercasePlural": namer.NewAllLowercasePluralNamer(g.pluralExceptions),
+		"publicPlural":       namer.NewPublicPluralNamer(g.pluralExceptions),
+		"resource":           codegennamer.NewTagOverrideNamer("resourceName", namer.NewAllLowercasePluralNamer(g.pluralExceptions)),
 	}
 }
 

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/generators/packages.go
@@ -31,13 +31,11 @@ import (
 	"k8s.io/code-generator/cmd/client-gen/generators/util"
 	clientgentypes "k8s.io/code-generator/cmd/client-gen/types"
 	informergenargs "k8s.io/code-generator/cmd/informer-gen/args"
+	genutil "k8s.io/code-generator/pkg/util"
 )
 
 // NameSystems returns the name system used by the generators in this package.
-func NameSystems() namer.NameSystems {
-	pluralExceptions := map[string]string{
-		"Endpoints": "Endpoints",
-	}
+func NameSystems(pluralExceptions map[string]string) namer.NameSystems {
 	return namer.NameSystems{
 		"public":             namer.NewPublicNamer(0),
 		"private":            namer.NewPrivateNamer(0),
@@ -208,7 +206,9 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 	if len(externalGroupVersions) != 0 {
 		packageList = append(packageList, factoryInterfacePackage(externalVersionPackagePath, boilerplate, customArgs.VersionedClientSetPackage))
-		packageList = append(packageList, factoryPackage(externalVersionPackagePath, boilerplate, groupGoNames, externalGroupVersions, customArgs.VersionedClientSetPackage, typesForGroupVersion))
+		packageList = append(packageList, factoryPackage(externalVersionPackagePath, boilerplate, groupGoNames, genutil.PluralExceptionListToMapOrDie(customArgs.PluralExceptions), externalGroupVersions,
+			customArgs.VersionedClientSetPackage,
+			typesForGroupVersion))
 		for _, gvs := range externalGroupVersions {
 			packageList = append(packageList, groupPackage(externalVersionPackagePath, gvs, boilerplate))
 		}
@@ -216,7 +216,7 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 
 	if len(internalGroupVersions) != 0 {
 		packageList = append(packageList, factoryInterfacePackage(internalVersionPackagePath, boilerplate, customArgs.InternalClientSetPackage))
-		packageList = append(packageList, factoryPackage(internalVersionPackagePath, boilerplate, groupGoNames, internalGroupVersions, customArgs.InternalClientSetPackage, typesForGroupVersion))
+		packageList = append(packageList, factoryPackage(internalVersionPackagePath, boilerplate, groupGoNames, genutil.PluralExceptionListToMapOrDie(customArgs.PluralExceptions), internalGroupVersions, customArgs.InternalClientSetPackage, typesForGroupVersion))
 		for _, gvs := range internalGroupVersions {
 			packageList = append(packageList, groupPackage(internalVersionPackagePath, gvs, boilerplate))
 		}
@@ -225,7 +225,8 @@ func Packages(context *generator.Context, arguments *args.GeneratorArgs) generat
 	return packageList
 }
 
-func factoryPackage(basePackage string, boilerplate []byte, groupGoNames map[string]string, groupVersions map[string]clientgentypes.GroupVersions, clientSetPackage string, typesForGroupVersion map[clientgentypes.GroupVersion][]*types.Type) generator.Package {
+func factoryPackage(basePackage string, boilerplate []byte, groupGoNames, pluralExceptions map[string]string, groupVersions map[string]clientgentypes.GroupVersions, clientSetPackage string,
+	typesForGroupVersion map[clientgentypes.GroupVersion][]*types.Type) generator.Package {
 	return &generator.DefaultPackage{
 		PackageName: filepath.Base(basePackage),
 		PackagePath: basePackage,
@@ -250,6 +251,7 @@ func factoryPackage(basePackage string, boilerplate []byte, groupGoNames map[str
 				outputPackage:        basePackage,
 				imports:              generator.NewImportTracker(),
 				groupVersions:        groupVersions,
+				pluralExceptions:     pluralExceptions,
 				typesForGroupVersion: typesForGroupVersion,
 				groupGoNames:         groupGoNames,
 			})

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/main.go
@@ -53,7 +53,7 @@ func main() {
 
 	// Run it.
 	if err := genericArgs.Execute(
-		generators.NameSystems(),
+		generators.NameSystems(util.PluralExceptionListToMapOrDie(customArgs.PluralExceptions)),
 		generators.DefaultNameSystem(),
 		generators.Packages,
 	); err != nil {

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/args/args.go
@@ -26,12 +26,18 @@ import (
 )
 
 // CustomArgs is used by the gengo framework to pass args specific to this generator.
-type CustomArgs struct{}
+type CustomArgs struct {
+	// PluralExceptions specify list of exceptions used when pluralizing certain types.
+	// For example 'Endpoints:Endpoints', otherwise the pluralizer will generate 'Endpointes'.
+	PluralExceptions []string
+}
 
 // NewDefaults returns default arguments for the generator.
 func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 	genericArgs := args.Default().WithoutDefaultFlagParsing()
-	customArgs := &CustomArgs{}
+	customArgs := &CustomArgs{
+		PluralExceptions: []string{"Endpoints:Endpoints"},
+	}
 	genericArgs.CustomArgs = customArgs
 
 	if pkg := codegenutil.CurrentPackage(); len(pkg) != 0 {
@@ -42,7 +48,9 @@ func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 }
 
 // AddFlags add the generator flags to the flag set.
-func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {}
+func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {
+	fs.StringArrayVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType format")
+}
 
 // Validate checks the given arguments.
 func Validate(genericArgs *args.GeneratorArgs) error {

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -34,10 +34,7 @@ import (
 )
 
 // NameSystems returns the name system used by the generators in this package.
-func NameSystems() namer.NameSystems {
-	pluralExceptions := map[string]string{
-		"Endpoints": "Endpoints",
-	}
+func NameSystems(pluralExceptions map[string]string) namer.NameSystems {
 	return namer.NameSystems{
 		"public":             namer.NewPublicNamer(0),
 		"private":            namer.NewPrivateNamer(0),

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Run it.
 	if err := genericArgs.Execute(
-		generators.NameSystems(),
+		generators.NameSystems(util.PluralExceptionListToMapOrDie(customArgs.PluralExceptions)),
 		generators.DefaultNameSystem(),
 		generators.Packages,
 	); err != nil {

--- a/staging/src/k8s.io/code-generator/pkg/util/BUILD
+++ b/staging/src/k8s.io/code-generator/pkg/util/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["build.go"],
+    srcs = [
+        "build.go",
+        "plural_exceptions.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/code-generator/pkg/util",
     importpath = "k8s.io/code-generator/pkg/util",
     visibility = ["//visibility:public"],

--- a/staging/src/k8s.io/code-generator/pkg/util/plural_exceptions.go
+++ b/staging/src/k8s.io/code-generator/pkg/util/plural_exceptions.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+)
+
+// PluralExceptionListToMapOrDie converts the list in "Type:PluralType" to map[string]string.
+// This is used for pluralizer.
+// If the format is wrong, this function will panic.
+func PluralExceptionListToMapOrDie(pluralExceptions []string) map[string]string {
+	pluralExceptionMap := make(map[string]string, len(pluralExceptions))
+	for i := range pluralExceptions {
+		parts := strings.Split(pluralExceptions[i], ":")
+		if len(parts) != 2 {
+			panic(fmt.Sprintf("invalid plural exception definition: %s", pluralExceptions[i]))
+		}
+		pluralExceptionMap[parts[0]] = parts[1]
+	}
+	return pluralExceptionMap
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

The plural exception list is hardcoded in client-gen, informer-gen and lister-gen and it lists only `Endpoints:Endpoints`.

Downstream project that use these generators might have more exceptions, in OpenShift this is namely `DNSs:DNSs` or `SecurityContextConstraints: SecurityContextConstraints`. With this fix, downstream project would be able to specify comma separated list of their exceptions.

```release-note
NONE
```