### PR TITLE
return success if cordon node by replace

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/drain/default.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/default.go
@@ -58,11 +58,11 @@ func RunCordonOrUncordon(drainer *Helper, node *corev1.Node, desired bool) error
 	}
 
 	err, patchErr := c.PatchOrReplace(drainer.Client, false)
-	if patchErr != nil {
-		return patchErr
-	}
 	if err != nil {
-		return err
+		if patchErr != nil {
+			return fmt.Errorf("cordon error: %s; merge patch error: %s", err.Error(), patchErr.Error())
+		}
+		return fmt.Errorf("cordon error: %s", err.Error())
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The function is run cordon or uncordon api with patch and replace.
In current situation, we use replace api if create merge patch failed, then will return error whatever replace is success.
The expect behavior is return success when one of patch and replace are success.

**Does this PR introduce a user-facing change?**:
return success whatever cordon node by replace or patch

```release-note

```
