### PR TITLE
Fix(kubectl): the fields of history controllerrevision will be covered with daemonset

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
@@ -348,20 +348,20 @@ func statefulSetHistory(
 
 // applyDaemonSetHistory returns a specific revision of DaemonSet by applying the given history to a copy of the given DaemonSet
 func applyDaemonSetHistory(ds *appsv1.DaemonSet, history *appsv1.ControllerRevision) (*appsv1.DaemonSet, error) {
-	clone := ds.DeepCopy()
-	cloneBytes, err := json.Marshal(clone)
+	dsBytes, err := json.Marshal(ds)
 	if err != nil {
 		return nil, err
 	}
-	patched, err := strategicpatch.StrategicMergePatch(cloneBytes, history.Data.Raw, clone)
+	patched, err := strategicpatch.StrategicMergePatch(dsBytes, history.Data.Raw, ds)
 	if err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(patched, clone)
+	result := &appsv1.DaemonSet{}
+	err = json.Unmarshal(patched, result)
 	if err != nil {
 		return nil, err
 	}
-	return clone, nil
+	return result, nil
 }
 
 // TODO: copied here until this becomes a describer

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package polymorphichelpers
 
 import (
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -104,4 +106,124 @@ func TestViewHistory(t *testing.T) {
 		t.Fatalf("unexpected output  (%v was expected but got %v)", expected, result)
 	}
 
+}
+
+func TestApplyDaemonSetHistory(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   *appsv1.DaemonSet
+		expected *appsv1.DaemonSet
+	}{
+		{
+			"test_less",
+			&appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"version": "v3"},
+						},
+						Spec: corev1.PodSpec{
+							InitContainers:   []corev1.Container{{Name: "i0"}},
+							Containers:       []corev1.Container{{Name: "c0"}},
+							Volumes:          []corev1.Volume{{Name: "v0"}},
+							NodeSelector:     map[string]string{"1dsa": "n0"},
+							ImagePullSecrets: []corev1.LocalObjectReference{{Name: "ips0"}},
+							Tolerations:      []corev1.Toleration{{Key: "t0"}},
+							HostAliases:      []corev1.HostAlias{{IP: "h0"}},
+							ReadinessGates:   []corev1.PodReadinessGate{{ConditionType: corev1.PodScheduled}},
+						},
+					},
+				},
+			},
+			&appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "c1"}},
+							// keep diversity field, eg: nil or empty slice
+							InitContainers: []corev1.Container{},
+						},
+					},
+				},
+			},
+		},
+		{
+			"test_more",
+			&appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{{Name: "i0"}},
+						},
+					},
+				},
+			},
+			&appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"version": "v3"},
+						},
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{{Name: "i1"}},
+							Containers:     []corev1.Container{{Name: "c1"}},
+							Volumes:        []corev1.Volume{{Name: "v1"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			"test_equal",
+			&appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"version": "v0"},
+						},
+						Spec: corev1.PodSpec{
+							Containers:     []corev1.Container{{Name: "c1"}},
+							InitContainers: []corev1.Container{{Name: "i0"}},
+							Volumes:        []corev1.Volume{{Name: "v0"}},
+						},
+					},
+				},
+			},
+			&appsv1.DaemonSet{
+				Spec: appsv1.DaemonSetSpec{
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Annotations: map[string]string{"version": "v1"},
+						},
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{{Name: "i1"}},
+							Containers:     []corev1.Container{{Name: "c1"}},
+							Volumes:        []corev1.Volume{{Name: "v1"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			patch, err := getDaemonSetPatch(tt.expected)
+			if err != nil {
+				t.Errorf("getDaemonSetPatch failed : %v", err)
+			}
+			cr := &appsv1.ControllerRevision{
+				Data: runtime.RawExtension{
+					Raw: patch,
+				},
+			}
+			tt.source, err = applyDaemonSetHistory(tt.source, cr)
+			if err != nil {
+				t.Errorf("applyDaemonSetHistory failed : %v", err)
+			}
+			if !apiequality.Semantic.DeepEqual(tt.source, tt.expected) {
+				t.Errorf("expected out [%v]  but get [%v]", tt.expected, tt.source)
+			}
+		})
+	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/rollback.go
@@ -392,16 +392,16 @@ var appsCodec = scheme.Codecs.LegacyCodec(appsv1.SchemeGroupVersion)
 // applyRevision returns a new StatefulSet constructed by restoring the state in revision to set. If the returned error
 // is nil, the returned StatefulSet is valid.
 func applyRevision(set *appsv1.StatefulSet, revision *appsv1.ControllerRevision) (*appsv1.StatefulSet, error) {
-	clone := set.DeepCopy()
-	patched, err := strategicpatch.StrategicMergePatch([]byte(runtime.EncodeOrDie(appsCodec, clone)), revision.Data.Raw, clone)
+	patched, err := strategicpatch.StrategicMergePatch([]byte(runtime.EncodeOrDie(appsCodec, set)), revision.Data.Raw, set)
 	if err != nil {
 		return nil, err
 	}
-	err = json.Unmarshal(patched, clone)
+	result := &appsv1.StatefulSet{}
+	err = json.Unmarshal(patched, result)
 	if err != nil {
 		return nil, err
 	}
-	return clone, nil
+	return result, nil
 }
 
 // statefulsetMatch check if the given StatefulSet's template matches the template stored in the given history.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind bug


**What this PR does / why we need it**:

When I use `kubectl rollout history` command, the fields of history controllerrevision will be covered with daemonset when the fields don't exist in controllerrevision but  exist in daemonset.

First i apply the daemonset with the yaml:
```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: fluentd-elasticsearch
  namespace: kube-system
spec:
  selector:
    matchLabels:
      name: fluentd-elasticsearch
  template:
    metadata:
      labels:
        name: fluentd-elasticsearch
    spec:
      tolerations:
      - key: node-role.kubernetes.io/master
        effect: NoSchedule
      containers:
      - name: fluentd-elasticsearch
        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
        resources:
          limits:
            memory: 200Mi
          requests:
            cpu: 100m
            memory: 200Mi
```

I will get the content after performing the command `kubectl rollout history daemonset.v1.apps/fluentd-elasticsearch -n kube-system --revision=1`:

```
Pod Template:
  Labels:       name=fluentd-elasticsearch
  Containers:
   fluentd-elasticsearch:
    Image:      quay.io/fluentd_elasticsearch/fluentd:v2.5.2
    Port:       <none>
    Host Port:  <none>
    Limits:
      memory:   200Mi
    Requests:
      cpu:      100m
      memory:   200Mi
    Environment:        <none>
    Mounts:     <none>
  Volumes:      <none>
```
Than i change the yaml file to below and apply again.

```
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: fluentd-elasticsearch
  namespace: kube-system
spec:
  selector:
    matchLabels:
      name: fluentd-elasticsearch
  template:
    metadata:
      labels:
        name: fluentd-elasticsearch
    spec:
      tolerations:
      - key: node-role.kubernetes.io/master
        effect: NoSchedule
      containers:
      - name: fluentd-elasticsearch
        image: quay.io/fluentd_elasticsearch/fluentd:v2.5.2
        resources:
          limits:
            memory: 200Mi
          requests:
            cpu: 100m
            memory: 200Mi
        volumeMounts:
        - name: varlog
          mountPath: /var/log
        - name: varlibdockercontainers
          mountPath: /var/lib/docker/containers
          readOnly: true
      terminationGracePeriodSeconds: 30
      volumes:
      - name: varlog
        hostPath:
          path: /var/log
      - name: varlibdockercontainers
        hostPath:
          path: /var/lib/docker/containers

```

The result of the command `kubectl rollout history daemonset.v1.apps/fluentd-elasticsearch -n kube-system --revision=1` change to this:
```
daemonset.apps/fluentd-elasticsearch with revision #1
Pod Template:
  Labels:       name=fluentd-elasticsearch
  Containers:
   fluentd-elasticsearch:
    Image:      quay.io/fluentd_elasticsearch/fluentd:v2.5.2
    Port:       <none>
    Host Port:  <none>
    Limits:
      memory:   200Mi
    Requests:
      cpu:      100m
      memory:   200Mi
    Environment:        <none>
    Mounts:
      /var/lib/docker/containers from varlibdockercontainers (ro)
      /var/log from varlog (rw)
  Volumes:
   varlog:
    Type:       HostPath (bare host directory volume)
    Path:       /var/log
    HostPathType:
   varlibdockercontainers:
    Type:       HostPath (bare host directory volume)
    Path:       /var/lib/docker/containers
    HostPathType:
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
