### PR TITLE
Add an interface to return scheduler framework instance

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -141,6 +141,9 @@ type ScheduleAlgorithm interface {
 	// for cluster autoscaler integration.
 	// TODO(#85691): remove this once CA migrates to creating a Framework instead of a full scheduler.
 	Snapshot() error
+	// Framework returns the scheduler framework instance. This is needed  for cluster autoscaler integration.
+	// TODO(#85691): remove this once CA migrates to creating a Framework instead of a full scheduler.
+	Framework() framework.Framework
 }
 
 // ScheduleResult represents the result of one pod scheduled. It will contain
@@ -174,14 +177,20 @@ type genericScheduler struct {
 	nextStartNodeIndex       int
 }
 
-// snapshot snapshots scheduler cache and node infos for all fit and priority
+// Snapshot snapshots scheduler cache and node infos for all fit and priority
 // functions.
 func (g *genericScheduler) Snapshot() error {
 	// Used for all fit and priority funcs.
 	return g.cache.UpdateNodeInfoSnapshot(g.nodeInfoSnapshot)
 }
 
-// GetPredicateMetadataProducer returns the predicate metadata producer. This is needed
+// Framework returns the framework instance.
+func (g *genericScheduler) Framework() framework.Framework {
+	// Used for all fit and priority funcs.
+	return g.framework
+}
+
+// PredicateMetadataProducer returns the predicate metadata producer. This is needed
 // for cluster autoscaler integration.
 func (g *genericScheduler) PredicateMetadataProducer() predicates.MetadataProducer {
 	return g.predicateMetaProducer

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -180,6 +180,10 @@ func (es mockScheduler) Snapshot() error {
 	return nil
 
 }
+func (es mockScheduler) Framework() framework.Framework {
+	return nil
+
+}
 
 func TestSchedulerCreation(t *testing.T) {
 	client := clientsetfake.NewSimpleClientset()


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Adds a method to ```SchedulerAlgorithm``` interface to return the framework instance. This is needed by the Cluster Autoscaler to run Filter and PreFilter plugins.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @losipiuk @MaciekPytel 