### PR TITLE
[Windows] Upload containerd logs to stackdriver

### DIFF
--- a/cluster/gce/windows/k8s-node-setup.psm1
+++ b/cluster/gce/windows/k8s-node-setup.psm1
@@ -1492,7 +1492,7 @@ function Install_Containerd {
 # Register and start containerd service.
 function Start_Containerd {
   Log-Output "Creating containerd service"
-  containerd.exe --register-service
+  containerd.exe --register-service --log-file ${env:LOGS_DIR}/containerd.log
   Log-Output "Starting containerd service"
   Start-Service containerd
 }
@@ -1710,6 +1710,20 @@ $FLUENTD_CONFIG = @'
   path /etc/kubernetes/logs/kube-proxy.log
   pos_file /etc/kubernetes/logs/gcp-kube-proxy.log.pos
   tag kube-proxy
+</source>
+
+# Example:
+# time="2019-12-10T21:27:59.836946700Z" level=info msg="loading plugin \"io.containerd.grpc.v1.cri\"..." type=io.containerd.grpc.v1
+<source>
+  @type tail
+  format multiline
+  multiline_flush_interval 5s
+  format_firstline /^time=/
+  format1 /^time="(?<time>[^ ]*)" level=(?<severity>\w*) (?<message>.*)/
+  time_format %Y-%m-%dT%H:%M:%S.%N%z
+  path /etc/kubernetes/logs/containerd.log
+  pos_file /etc/kubernetes/logs/gcp-containerd.log.pos
+  tag container-runtime
 </source>
 
 <match reform.**>


### PR DESCRIPTION
Log containerd output to a log file `containerd.log`, and upload the log to stackdriver.

Note that we are using the `container-runtime` tag, which matches what we are using on linux https://github.com/kubernetes/kubernetes/blob/master/cluster/addons/fluentd-gcp/fluentd-gcp-configmap.yaml#L274

I've validated the change in my cluster, and the log can be successfully uploaded:
![image](https://user-images.githubusercontent.com/5821883/70744133-fad38780-1cd5-11ea-86f4-7ee6155990ce.png)


/cc @kubernetes/sig-windows-misc @yliaog @pjh 

Signed-off-by: Lantao Liu <lantaol@google.com>

```release-note
none
```