### PR TITLE
Automated cherry pick of #85962: Include cloud/gcp in e2e.test

### DIFF
--- a/test/e2e/cloud/BUILD
+++ b/test/e2e/cloud/BUILD
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "framework.go",
+        "imports.go",
         "nodes.go",
     ],
     importpath = "k8s.io/kubernetes/test/e2e/cloud",
@@ -13,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//test/e2e/cloud/gcp:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",

--- a/test/e2e/cloud/imports.go
+++ b/test/e2e/cloud/imports.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cloud
+
+import (
+	// ensure these packages are scanned by ginkgo for e2e tests
+	_ "k8s.io/kubernetes/test/e2e/cloud/gcp"
+)


### PR DESCRIPTION
Cherry pick of #85962 on release-1.17.

#85962: Include cloud/gcp in e2e.test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.