### PR TITLE
Remove daemonset controller's dependency on scheduler metadata

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1318,9 +1318,9 @@ func NewPod(ds *apps.DaemonSet, nodeName string) *v1.Pod {
 //   - PodFitsHost: checks pod's NodeName against node
 //   - PodMatchNodeSelector: checks pod's NodeSelector and NodeAffinity against node
 //   - PodToleratesNodeTaints: exclude tainted node unless pod has specific toleration
-func checkNodeFitness(pod *v1.Pod, meta predicates.Metadata, nodeInfo *schedulernodeinfo.NodeInfo) (bool, []predicates.PredicateFailureReason, error) {
+func checkNodeFitness(pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) (bool, []predicates.PredicateFailureReason, error) {
 	var predicateFails []predicates.PredicateFailureReason
-	fit, reasons, err := predicates.PodFitsHost(pod, meta, nodeInfo)
+	fit, reasons, err := predicates.PodFitsHost(pod, nil, nodeInfo)
 	if err != nil {
 		return false, predicateFails, err
 	}
@@ -1328,7 +1328,7 @@ func checkNodeFitness(pod *v1.Pod, meta predicates.Metadata, nodeInfo *scheduler
 		predicateFails = append(predicateFails, reasons...)
 	}
 
-	fit, reasons, err = predicates.PodMatchNodeSelector(pod, meta, nodeInfo)
+	fit, reasons, err = predicates.PodMatchNodeSelector(pod, nil, nodeInfo)
 	if err != nil {
 		return false, predicateFails, err
 	}
@@ -1351,7 +1351,7 @@ func checkNodeFitness(pod *v1.Pod, meta predicates.Metadata, nodeInfo *scheduler
 func Predicates(pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) (bool, []predicates.PredicateFailureReason, error) {
 	var predicateFails []predicates.PredicateFailureReason
 
-	fit, reasons, err := checkNodeFitness(pod, nil, nodeInfo)
+	fit, reasons, err := checkNodeFitness(pod, nodeInfo)
 	if err != nil {
 		return false, predicateFails, err
 	}


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Removes daemonset controller's dependency on scheduler's predicates.Metadata which is getting deprecated.

**Which issue(s) this PR fixes**:
Part of #85822

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

