### PR TITLE
Move added info and status stack trace to the end of line.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/httplog/httplog.go
@@ -158,7 +158,7 @@ func (rl *respLogger) Log() {
 	latency := time.Since(rl.startTime)
 	if klog.V(3) {
 		if !rl.hijacked {
-			klog.InfoDepth(1, fmt.Sprintf("%s %s: (%v) %v%v%v [%s %s]", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.statusStack, rl.addedInfo, rl.req.UserAgent(), rl.req.RemoteAddr))
+			klog.InfoDepth(1, fmt.Sprintf("%s %s: (%v) %v [%s %s]%v%v", rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.req.UserAgent(), rl.req.RemoteAddr, rl.statusStack, rl.addedInfo))
 		} else {
 			klog.InfoDepth(1, fmt.Sprintf("%s %s: (%v) hijacked [%s %s]", rl.req.Method, rl.req.RequestURI, latency, rl.req.UserAgent(), rl.req.RemoteAddr))
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In the http log, `rl.req.Method, rl.req.RequestURI, latency, rl.status, rl.req.UserAgent(), rl.req.RemoteAddr` are common messages which would be printed whether `logStacktracePred` returns true or not. But, `rl.statusStack, rl.addedInfo` looks optional and there are `\n`s before these messages.

When the optional messages are printed, the rl.req.UserAgent() will be printed tons of lines after  stack trace and added info, it would be a bit more difficult to analyze log and find out the client.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
