### PR TITLE
AWS: Don't report deletion of attached volume as warning

### DIFF
--- a/staging/src/k8s.io/cloud-provider/volume/errors/errors.go
+++ b/staging/src/k8s.io/cloud-provider/volume/errors/errors.go
@@ -65,3 +65,13 @@ func NewDanglingError(msg string, node k8stypes.NodeName, devicePath string) err
 		DevicePath:  devicePath,
 	}
 }
+
+// IsDanglingError returns true if an error is DanglingAttachError
+func IsDanglingError(err error) bool {
+	switch err.(type) {
+	case *DanglingAttachError:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Deletion of still attached volume is part of normal cluster operation. When a pod and PVC are deleted at the same time (e.g. because of the whole namespace was deleted), PV controller may try to delete a volume that is still detached.

From:
```
  Warning  VolumeFailedDelete  39s   persistentvolume-controller  Error deleting EBS volume "vol-0ec8ebb98d96d2edd" since volume is currently attached to "i-0234d7ee96518d229"
```

To:
```
  Normal  VolumeDelete  11s   persistentvolume-controller  error deleting EBS volume "vol-0836f17128e12a6bb" since volume is currently attached to "i-0234d7ee96518d229"
```

/sig storage
@gnufied @wongma7, PTAL

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
