### PR TITLE
Kubelet: add a metric to observe time since PLEG last seen

### DIFF
--- a/pkg/kubelet/metrics/metrics.go
+++ b/pkg/kubelet/metrics/metrics.go
@@ -44,6 +44,7 @@ const (
 	PLEGRelistDurationKey                = "pleg_relist_duration_seconds"
 	PLEGDiscardEventsKey                 = "pleg_discard_events"
 	PLEGRelistIntervalKey                = "pleg_relist_interval_seconds"
+	PLEGLastSeenKey                      = "pleg_last_seen_seconds"
 	EvictionsKey                         = "evictions"
 	EvictionStatsAgeKey                  = "eviction_stats_age_seconds"
 	PreemptionsKey                       = "preemptions"
@@ -184,6 +185,16 @@ var (
 			Name:           PLEGRelistIntervalKey,
 			Help:           "Interval in seconds between relisting in PLEG.",
 			Buckets:        metrics.DefBuckets,
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
+	// PLEGLastSeen is a Gauge giving the Unix timestamp when the Kubelet's
+	// Pod Lifecycle Event Generator (PLEG) was last seen active.
+	PLEGLastSeen = metrics.NewGauge(
+		&metrics.GaugeOpts{
+			Subsystem:      KubeletSubsystem,
+			Name:           PLEGLastSeenKey,
+			Help:           "Timestamp in seconds when PLEG was last seen active.",
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
@@ -523,6 +534,7 @@ func Register(containerCache kubecontainer.RuntimeCache, collectors ...metrics.S
 		legacyregistry.MustRegister(PLEGRelistDuration)
 		legacyregistry.MustRegister(PLEGDiscardEvents)
 		legacyregistry.MustRegister(PLEGRelistInterval)
+		legacyregistry.MustRegister(PLEGLastSeen)
 		legacyregistry.MustRegister(RuntimeOperations)
 		legacyregistry.MustRegister(RuntimeOperationsDuration)
 		legacyregistry.MustRegister(RuntimeOperationsErrors)

--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -138,6 +138,8 @@ func (g *GenericPLEG) Healthy() (bool, error) {
 	if relistTime.IsZero() {
 		return false, fmt.Errorf("pleg has yet to be successful")
 	}
+	// Expose as metric so you can alert on `time()-pleg_last_seen_seconds > nn`
+	metrics.PLEGLastSeen.Set(float64(relistTime.Unix()))
 	elapsed := g.clock.Since(relistTime)
 	if elapsed > relistThreshold {
 		return false, fmt.Errorf("pleg was last seen active %v ago; threshold is %v", elapsed, relistThreshold)


### PR DESCRIPTION
/sig node
/kind feature

**What this PR does / why we need it**:

Expose the measurement that kubelet uses to judge that "PLEG is unhealthy". 
If we can observe the measurement growing then we can alert before the node goes unhealthy.

Note that the existing metrics `PLEGRelistInterval` and `PLEGRelistDuration` are no good for this, because when `relist()` gets stuck they are never updated.

**Which issue(s) this PR fixes**:

Not a fix, but relates to #45419, #72533, #77728, etc

**Does this PR introduce a user-facing change?**:
```release-note
New metric kubelet_pleg_last_seen_seconds to aid diagnosis of PLEG not healthy issues.
```