### PR TITLE
[kubeadm]: Bump CoreDNS version to 1.6.7

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -69,7 +69,7 @@ dependencies:
       match: k8s.gcr.io/coredns
 
   - name: "coredns-kubeadm"
-    version: 1.6.5
+    version: 1.6.7
     refPaths:
     - path: cmd/kubeadm/app/constants/constants.go
       match: CoreDNSVersion =

--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -338,7 +338,7 @@ const (
 	KubeDNSVersion = "1.14.13"
 
 	// CoreDNSVersion is the version of CoreDNS to be deployed if it is used
-	CoreDNSVersion = "1.6.5"
+	CoreDNSVersion = "1.6.7"
 
 	// ClusterConfigurationKind is the string kind value for the ClusterConfiguration struct
 	ClusterConfigurationKind = "ClusterConfiguration"

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	github.com/containerd/containerd v1.0.2 // indirect
 	github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20 // indirect
 	github.com/containernetworking/cni v0.7.1
-	github.com/coredns/corefile-migration v1.0.4
+	github.com/coredns/corefile-migration v1.0.6
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
 	github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea
 	github.com/cpuguy83/go-md2man v1.0.10
@@ -232,7 +232,7 @@ replace (
 	github.com/containerd/containerd => github.com/containerd/containerd v1.0.2
 	github.com/containerd/typeurl => github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20
 	github.com/containernetworking/cni => github.com/containernetworking/cni v0.7.1
-	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.4
+	github.com/coredns/corefile-migration => github.com/coredns/corefile-migration v1.0.6
 	github.com/coreos/etcd => github.com/coreos/etcd v3.3.10+incompatible
 	github.com/coreos/go-etcd => github.com/coreos/go-etcd v2.0.0+incompatible
 	github.com/coreos/go-oidc => github.com/coreos/go-oidc v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20 h1:14r0i3IeJj6z
 github.com/containerd/typeurl v0.0.0-20190228175220-2a93cfde8c20/go.mod h1:Cm3kwCdlkCfMSHURc+r6fwoGH6/F1hH3S4sg0rLFWPc=
 github.com/containernetworking/cni v0.7.1 h1:fE3r16wpSEyaqY4Z4oFrLMmIGfBYIKpPrHK31EJ9FzE=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
-github.com/coredns/corefile-migration v1.0.4 h1:GpAwsgzgLA9HOnt3+Z69xsMVLl0doNnyVfBX79d/P5A=
-github.com/coredns/corefile-migration v1.0.4/go.mod h1:OFwBp/Wc9dJt5cAZzHWMNhK1r5L0p0jDwIBc6j8NC8E=
+github.com/coredns/corefile-migration v1.0.6 h1:hB6vclp2g/KeXe9n1oz/PafgieUahsOYeHMQA+RJ4Hg=
+github.com/coredns/corefile-migration v1.0.6/go.mod h1:OFwBp/Wc9dJt5cAZzHWMNhK1r5L0p0jDwIBc6j8NC8E=
 github.com/coreos/etcd v3.3.10+incompatible h1:jFneRYjIvLMLhDLCzuTuU4rSJUjRplcJQ7pD7MnhC04=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=

--- a/vendor/github.com/coredns/corefile-migration/migration/BUILD
+++ b/vendor/github.com/coredns/corefile-migration/migration/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "migrate.go",
         "notice.go",
+        "plugins.go",
         "versions.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/github.com/coredns/corefile-migration/migration",

--- a/vendor/github.com/coredns/corefile-migration/migration/corefile/corefile.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/corefile/corefile.go
@@ -152,7 +152,7 @@ NextPlugin:
 }
 
 func (o *Option) FindMatch(def []*Option) (*Option, bool) {
-NextPlugin:
+NextOption:
 	for _, oDef := range def {
 		if oDef.Name != o.Name {
 			continue
@@ -165,7 +165,7 @@ NextPlugin:
 				return oDef, true
 			}
 			if i >= len(o.Args) || arg != o.Args[i] {
-				continue NextPlugin
+				continue NextOption
 			}
 		}
 		if len(oDef.Args) != len(o.Args) {

--- a/vendor/github.com/coredns/corefile-migration/migration/migrate.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/migrate.go
@@ -7,6 +7,7 @@ package migration
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 
 	"github.com/coredns/corefile-migration/migration/corefile"
@@ -43,17 +44,14 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 		for _, s := range cf.Servers {
 			for _, p := range s.Plugins {
 				vp, present := Versions[v].plugins[p.Name]
-				if status == unsupported {
-					if present {
-						continue
-					}
+				if status == unsupported && !present {
 					notices = append(notices, Notice{Plugin: p.Name, Severity: status, Version: v})
 					continue
 				}
 				if !present {
 					continue
 				}
-				if vp.status != "" && vp.status != newdefault {
+				if vp.status != "" && vp.status != newdefault && status != unsupported {
 					notices = append(notices, Notice{
 						Plugin:     p.Name,
 						Severity:   vp.status,
@@ -64,18 +62,16 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 					continue
 				}
 				for _, o := range p.Options {
-					vo, present := Versions[v].plugins[p.Name].options[o.Name]
+					vo, present := matchOption(o.Name, Versions[v].plugins[p.Name])
 					if status == unsupported {
 						if present {
 							continue
 						}
 						notices = append(notices, Notice{
-							Plugin:     p.Name,
-							Option:     o.Name,
-							Severity:   status,
-							Version:    v,
-							ReplacedBy: vo.replacedBy,
-							Additional: vo.additional,
+							Plugin:   p.Name,
+							Option:   o.Name,
+							Severity: status,
+							Version:  v,
 						})
 						continue
 					}
@@ -89,7 +85,7 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 				}
 				if status != unsupported {
 				CheckForNewOptions:
-					for name, vo := range Versions[v].plugins[p.Name].options {
+					for name, vo := range Versions[v].plugins[p.Name].namedOptions {
 						if vo.status != newdefault {
 							continue
 						}
@@ -156,19 +152,9 @@ func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecati
 					newPlugs = append(newPlugs, p)
 					continue
 				}
-				if vp.action != nil {
-					p, err := vp.action(p)
-					if err != nil {
-						return "", err
-					}
-					if p == nil {
-						// remove plugin, skip options processing
-						continue
-					}
-				}
 				newOpts := []*corefile.Option{}
 				for _, o := range p.Options {
-					vo, present := Versions[v].plugins[p.Name].options[o.Name]
+					vo, present := matchOption(o.Name, Versions[v].plugins[p.Name])
 					if !present {
 						newOpts = append(newOpts, o)
 						continue
@@ -191,13 +177,23 @@ func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecati
 					}
 					newOpts = append(newOpts, o)
 				}
+				if vp.action != nil {
+					p, err := vp.action(p)
+					if err != nil {
+						return "", err
+					}
+					if p == nil {
+						// remove plugin, skip options processing
+						continue
+					}
+				}
 				newPlug := &corefile.Plugin{
 					Name:    p.Name,
 					Args:    p.Args,
 					Options: newOpts,
 				}
 			CheckForNewOptions:
-				for name, vo := range Versions[v].plugins[p.Name].options {
+				for name, vo := range Versions[v].plugins[p.Name].namedOptions {
 					if vo.status != newdefault {
 						continue
 					}
@@ -294,7 +290,7 @@ func MigrateDown(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) (stri
 
 				newOpts := []*corefile.Option{}
 				for _, o := range p.Options {
-					vo, present := Versions[v].plugins[p.Name].options[o.Name]
+					vo, present := matchOption(o.Name, Versions[v].plugins[p.Name])
 					if !present {
 						newOpts = append(newOpts, o)
 						continue
@@ -445,4 +441,23 @@ func validDownMigration(fromCoreDNSVersion, toCoreDNSVersion string) error {
 		return nil
 	}
 	return fmt.Errorf("cannot migrate down to '%v' from '%v'", toCoreDNSVersion, fromCoreDNSVersion)
+}
+
+func matchOption(oName string, p plugin) (*option, bool) {
+	o, exists := p.namedOptions[oName]
+	if exists {
+		o.name = oName
+		return &o, exists
+	}
+	for pattern, o := range p.patternOptions {
+		matched, err := regexp.MatchString(pattern, oName)
+		if err != nil {
+			continue
+		}
+		if matched {
+			o.name = oName
+			return &o, true
+		}
+	}
+	return nil, false
 }

--- a/vendor/github.com/coredns/corefile-migration/migration/plugins.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/plugins.go
@@ -1,0 +1,499 @@
+package migration
+
+import (
+	"errors"
+
+	"github.com/coredns/corefile-migration/migration/corefile"
+)
+
+type plugin struct {
+	status         string
+	replacedBy     string
+	additional     string
+	namedOptions   map[string]option
+	patternOptions map[string]option
+	action         pluginActionFn // action affecting this plugin only
+	add            serverActionFn // action to add a new plugin to the server block
+	downAction     pluginActionFn // downgrade action affecting this plugin only
+}
+
+type option struct {
+	name       string
+	status     string
+	replacedBy string
+	additional string
+	action     optionActionFn // action affecting this option only
+	add        pluginActionFn // action to add the option to the plugin
+	downAction optionActionFn // downgrade action affecting this option only
+}
+
+type corefileAction func(*corefile.Corefile) (*corefile.Corefile, error)
+type serverActionFn func(*corefile.Server) (*corefile.Server, error)
+type pluginActionFn func(*corefile.Plugin) (*corefile.Plugin, error)
+type optionActionFn func(*corefile.Option) (*corefile.Option, error)
+
+// plugins holds a map of plugin names and their migration rules per "version".  "Version" here is meaningless outside
+// of the context of this code. Each change in options or migration actions for a plugin requires a new "version"
+// containing those new/removed options and migration actions. Plugins in CoreDNS are not versioned.
+var plugins = map[string]map[string]plugin{
+	"kubernetes": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod":       {},
+				"endpoint":           {},
+				"tls":                {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream":           {},
+				"ttl":                {},
+				"noendpoints":        {},
+				"transfer":           {},
+				"fallthrough":        {},
+				"ignore":             {},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod":       {},
+				"endpoint":           {},
+				"tls":                {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream":           {},
+				"ttl":                {},
+				"noendpoints":        {},
+				"transfer":           {},
+				"fallthrough":        {},
+				"ignore":             {},
+				"kubeconfig":         {}, // new option
+			},
+		},
+		"v3": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": {},
+				"endpoint": { // new deprecation
+					status: deprecated,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream":           {},
+				"ttl":                {},
+				"noendpoints":        {},
+				"transfer":           {},
+				"fallthrough":        {},
+				"ignore":             {},
+			},
+		},
+		"v4": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": {},
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": { // new deprecation
+					status: deprecated,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+		"v5": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": { // new deprecation
+					status: deprecated,
+					action: removeOption,
+				},
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": {
+					status: ignored,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+		"v6": plugin{
+			namedOptions: map[string]option{
+				"resyncperiod": { // new removal
+					status: removed,
+					action: removeOption,
+				},
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": {
+					status: ignored,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+		"v7": plugin{
+			namedOptions: map[string]option{
+				// resyncperiod removed
+				"endpoint": {
+					status: ignored,
+					action: useFirstArgumentOnly,
+				},
+				"tls":                {},
+				"kubeconfig":         {},
+				"namespaces":         {},
+				"labels":             {},
+				"pods":               {},
+				"endpoint_pod_names": {},
+				"upstream": {
+					status: ignored,
+					action: removeOption,
+				},
+				"ttl":         {},
+				"noendpoints": {},
+				"transfer":    {},
+				"fallthrough": {},
+				"ignore":      {},
+			},
+		},
+	},
+
+	"errors": {
+		"v1": plugin{},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"consolidate": {},
+			},
+		},
+	},
+
+	"health": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"lameduck": {},
+			},
+		},
+		"v1 add lameduck": plugin{
+			namedOptions: map[string]option{
+				"lameduck": {
+					status: newdefault,
+					add: func(c *corefile.Plugin) (*corefile.Plugin, error) {
+						return addOptionToPlugin(c, &corefile.Option{Name: "lameduck 5s"})
+					},
+					downAction: removeOption,
+				},
+			},
+		},
+	},
+
+	"hosts": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"ttl":         {},
+				"no_reverse":  {},
+				"reload":      {},
+				"fallthrough": {},
+			},
+			patternOptions: map[string]option{
+				`\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}`:              {}, // close enough
+				`[0-9A-Fa-f]{1,4}:[:0-9A-Fa-f]+:[0-9A-Fa-f]{1,4}`: {}, // less close, but still close enough
+			},
+		},
+	},
+
+	"rewrite": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"type":        {},
+				"class":       {},
+				"name":        {},
+				"answer name": {},
+				"edns0":       {},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"type":        {},
+				"class":       {},
+				"name":        {},
+				"answer name": {},
+				"edns0":       {},
+				"ttl":         {}, // new option
+			},
+		},
+	},
+
+	"log": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"class": {},
+			},
+		},
+	},
+
+	"cache": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"success":  {},
+				"denial":   {},
+				"prefetch": {},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"success":     {},
+				"denial":      {},
+				"prefetch":    {},
+				"serve_stale": {}, // new option
+			},
+		},
+	},
+
+	"forward": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"except":         {},
+				"force_tcp":      {},
+				"expire":         {},
+				"max_fails":      {},
+				"tls":            {},
+				"tls_servername": {},
+				"policy":         {},
+				"health_check":   {},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"except":         {},
+				"force_tcp":      {},
+				"prefer_udp":     {},
+				"expire":         {},
+				"max_fails":      {},
+				"tls":            {},
+				"tls_servername": {},
+				"policy":         {},
+				"health_check":   {},
+			},
+		},
+	},
+
+	"k8s_external": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"apex": {},
+				"ttl":  {},
+			},
+		},
+	},
+
+	"proxy": {
+		"v1": plugin{
+			namedOptions: map[string]option{
+				"policy":       {},
+				"fail_timeout": {},
+				"max_fails":    {},
+				"health_check": {},
+				"except":       {},
+				"spray":        {},
+				"protocol": { // https_google option ignored
+					status: ignored,
+					action: proxyRemoveHttpsGoogleProtocol,
+				},
+			},
+		},
+		"v2": plugin{
+			namedOptions: map[string]option{
+				"policy":       {},
+				"fail_timeout": {},
+				"max_fails":    {},
+				"health_check": {},
+				"except":       {},
+				"spray":        {},
+				"protocol": { // https_google option removed
+					status: removed,
+					action: proxyRemoveHttpsGoogleProtocol,
+				},
+			},
+		},
+		"deprecation": plugin{ // proxy -> forward deprecation migration
+			status:       deprecated,
+			replacedBy:   "forward",
+			action:       proxyToForwardPluginAction,
+			namedOptions: proxyToForwardOptionsMigrations,
+		},
+		"removal": plugin{ // proxy -> forward forced migration
+			status:       removed,
+			replacedBy:   "forward",
+			action:       proxyToForwardPluginAction,
+			namedOptions: proxyToForwardOptionsMigrations,
+		},
+	},
+}
+
+func removePlugin(*corefile.Plugin) (*corefile.Plugin, error) { return nil, nil }
+func removeOption(*corefile.Option) (*corefile.Option, error) { return nil, nil }
+
+func renamePlugin(p *corefile.Plugin, to string) (*corefile.Plugin, error) {
+	p.Name = to
+	return p, nil
+}
+
+func addToServerBlockWithPlugins(sb *corefile.Server, newPlugin *corefile.Plugin, with []string) (*corefile.Server, error) {
+	if len(with) == 0 {
+		// add to all blocks
+		sb.Plugins = append(sb.Plugins, newPlugin)
+		return sb, nil
+	}
+	for _, p := range sb.Plugins {
+		for _, w := range with {
+			if w == p.Name {
+				// add to this block
+				sb.Plugins = append(sb.Plugins, newPlugin)
+				return sb, nil
+			}
+		}
+	}
+	return sb, nil
+}
+
+func addToKubernetesServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlockWithPlugins(sb, newPlugin, []string{"kubernetes"})
+}
+
+func addToForwardingServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlockWithPlugins(sb, newPlugin, []string{"forward", "proxy"})
+}
+
+func addToAllServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlockWithPlugins(sb, newPlugin, []string{})
+}
+
+func addOptionToPlugin(pl *corefile.Plugin, newOption *corefile.Option) (*corefile.Plugin, error) {
+	pl.Options = append(pl.Options, newOption)
+	return pl, nil
+}
+
+var proxyToForwardOptionsMigrations = map[string]option{
+	"policy": {
+		action: func(o *corefile.Option) (*corefile.Option, error) {
+			if len(o.Args) == 1 && o.Args[0] == "least_conn" {
+				o.Name = "force_tcp"
+				o.Args = nil
+			}
+			return o, nil
+		},
+	},
+	"except":       {},
+	"fail_timeout": {action: removeOption},
+	"max_fails":    {action: removeOption},
+	"health_check": {action: removeOption},
+	"spray":        {action: removeOption},
+	"protocol": {
+		action: func(o *corefile.Option) (*corefile.Option, error) {
+			if len(o.Args) >= 2 && o.Args[0] == "force_tcp" {
+				o.Name = "force_tcp"
+				o.Args = nil
+				return o, nil
+			}
+			return nil, nil
+		},
+	},
+}
+
+var proxyToForwardPluginAction = func(p *corefile.Plugin) (*corefile.Plugin, error) {
+	return renamePlugin(p, "forward")
+}
+
+var useFirstArgumentOnly = func(o *corefile.Option) (*corefile.Option, error) {
+	if len(o.Args) < 1 {
+		return o, nil
+	}
+	o.Args = o.Args[:1]
+	return o, nil
+}
+
+var proxyRemoveHttpsGoogleProtocol = func(o *corefile.Option) (*corefile.Option, error) {
+	if len(o.Args) > 0 && o.Args[0] == "https_google" {
+		return nil, nil
+	}
+	return o, nil
+}
+
+func breakForwardStubDomainsIntoServerBlocks(cf *corefile.Corefile) (*corefile.Corefile, error) {
+	for _, sb := range cf.Servers {
+		for j, fwd := range sb.Plugins {
+			if fwd.Name != "forward" {
+				continue
+			}
+			if len(fwd.Args) == 0 {
+				return nil, errors.New("found invalid forward plugin declaration")
+			}
+			if fwd.Args[0] == "." {
+				// dont move the default upstream
+				continue
+			}
+			if len(sb.DomPorts) != 1 {
+				return cf, errors.New("unhandled migration of multi-domain/port server block")
+			}
+			if sb.DomPorts[0] != "." && sb.DomPorts[0] != ".:53" {
+				return cf, errors.New("unhandled migration of non-default domain/port server block")
+			}
+
+			newSb := &corefile.Server{}                // create a new server block
+			newSb.DomPorts = []string{fwd.Args[0]}     // copy the forward zone to the server block domain
+			fwd.Args[0] = "."                          // the plugin's zone changes to "." for brevity
+			newSb.Plugins = append(newSb.Plugins, fwd) // add the plugin to its new server block
+
+			// Add appropriate addtl plugins to new server block
+			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "loop"})
+			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "errors"})
+			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "cache", Args: []string{"30"}})
+
+			//add new server block to corefile
+			cf.Servers = append(cf.Servers, newSb)
+
+			//remove the forward plugin from the original server block
+			sb.Plugins = append(sb.Plugins[:j], sb.Plugins[j+1:]...)
+		}
+	}
+	return cf, nil
+}

--- a/vendor/github.com/coredns/corefile-migration/migration/versions.go
+++ b/vendor/github.com/coredns/corefile-migration/migration/versions.go
@@ -1,35 +1,16 @@
 package migration
 
 import (
-	"errors"
 	"github.com/coredns/corefile-migration/migration/corefile"
 )
 
-type plugin struct {
-	status     string
-	replacedBy string
-	additional string
-	options    map[string]option
-	action     pluginActionFn // action affecting this plugin only
-	add        serverActionFn // action to add a new plugin to the server block
-	downAction pluginActionFn // downgrade action affecting this plugin only
-}
-
-type option struct {
-	status     string
-	replacedBy string
-	additional string
-	action     optionActionFn // action affecting this option only
-	add        pluginActionFn // action to add the option to the plugin
-	downAction optionActionFn // downgrade action affecting this option only
-}
-
+// release holds information pertaining to a single CoreDNS release
 type release struct {
-	k8sReleases    []string
-	nextVersion    string
-	priorVersion   string
-	dockerImageSHA string
-	plugins        map[string]plugin // list of plugins with deprecation status and migration actions
+	k8sReleases    []string          // a list of K8s versions that deploy this CoreDNS release by default
+	nextVersion    string            // the next CoreDNS version
+	priorVersion   string            // the prior CoreDNS version
+	dockerImageSHA string            // the docker image SHA for this release
+	plugins        map[string]plugin // map of plugins with deprecation status and migration actions for this release
 
 	// postProcess is a post processing action to take on the corefile as a whole.  Used for complex migration
 	//   tasks that dont fit well into the modular plugin/option migration framework. For example, when the
@@ -41,71 +22,25 @@ type release struct {
 	// Wildcards are used for fuzzy matching:
 	//   "*"   matches exactly one token
 	//   "***" matches 0 all remaining tokens on the line
-	// Order of server blocks, plugins, and options does not matter.
+	// Order of server blocks, plugins, and namedOptions does not matter.
 	// Order of arguments does matter.
 	defaultConf string
 }
 
-type corefileAction func(*corefile.Corefile) (*corefile.Corefile, error)
-type serverActionFn func(*corefile.Server) (*corefile.Server, error)
-type pluginActionFn func(*corefile.Plugin) (*corefile.Plugin, error)
-type optionActionFn func(*corefile.Option) (*corefile.Option, error)
-
-func removePlugin(*corefile.Plugin) (*corefile.Plugin, error) { return nil, nil }
-func removeOption(*corefile.Option) (*corefile.Option, error) { return nil, nil }
-
-func renamePlugin(p *corefile.Plugin, to string) (*corefile.Plugin, error) {
-	p.Name = to
-	return p, nil
-}
-
-func addToServerBlockWithPlugins(sb *corefile.Server, newPlugin *corefile.Plugin, with []string) (*corefile.Server, error) {
-	if len(with) == 0 {
-		// add to all blocks
-		sb.Plugins = append(sb.Plugins, newPlugin)
-		return sb, nil
-	}
-	for _, p := range sb.Plugins {
-		for _, w := range with {
-			if w == p.Name {
-				// add to this block
-				sb.Plugins = append(sb.Plugins, newPlugin)
-				return sb, nil
-			}
-		}
-	}
-	return sb, nil
-}
-
-func addToKubernetesServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
-	return addToServerBlockWithPlugins(sb, newPlugin, []string{"kubernetes"})
-}
-
-func addToForwardingServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
-	return addToServerBlockWithPlugins(sb, newPlugin, []string{"forward", "proxy"})
-}
-
-func addToAllServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
-	return addToServerBlockWithPlugins(sb, newPlugin, []string{})
-}
-
-func addOptionToPlugin(pl *corefile.Plugin, newOption *corefile.Option) (*corefile.Plugin, error) {
-	pl.Options = append(pl.Options, newOption)
-	return pl, nil
-}
-
+// Versions holds a map of plugin/option migrations per CoreDNS release (since 1.1.4)
 var Versions = map[string]release{
-	"1.6.5": {
-		priorVersion:   "1.6.4",
-		dockerImageSHA: "7ec975f167d815311a7136c32e70735f0d00b73781365df1befd46ed35bd4fe7",
+	"1.6.7": {
+		priorVersion:   "1.6.6",
+		k8sReleases:    []string{"1.18"},
+		dockerImageSHA: "2c8d61c46f484d881db43b34d13ca47a269336e576c81cf007ca740fa9ec0800",
 		defaultConf: `.:53 {
     errors
     health {
         lameduck 5s
     }
+    ready
     kubernetes * *** {
         pods insecure
-        upstream
         fallthrough in-addr.arpa ip6.arpa
         ttl 30
     }
@@ -117,82 +52,84 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health": {
-				options: map[string]option{
-					"lameduck": {
-						status: newdefault,
-						add: func(c *corefile.Plugin) (*corefile.Plugin, error) {
-							return addOptionToPlugin(c, &corefile.Option{Name: "lameduck 5s"})
-						},
-						downAction: removeOption,
-					},
-				},
-			},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v2"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
+		},
+	},
+	"1.6.6": {
+		nextVersion:    "1.6.7",
+		priorVersion:   "1.6.5",
+		dockerImageSHA: "41bee6992c2ed0f4628fcef75751048927bcd6b1cee89c79f6acb63ca5474d5a",
+		plugins: map[string]plugin{
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v2"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
+		},
+	},
+	"1.6.5": {
+		nextVersion:    "1.6.6",
+		priorVersion:   "1.6.4",
+		k8sReleases:    []string{"1.17"},
+		dockerImageSHA: "7ec975f167d815311a7136c32e70735f0d00b73781365df1befd46ed35bd4fe7",
+		defaultConf: `.:53 {
+    errors
+    health {
+        lameduck 5s
+    }
+    ready
+    kubernetes * *** {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+        ttl 30
+    }
+    prometheus :9153
+    forward . *
+    cache 30
+    loop
+    reload
+    loadbalance
+}`,
+		plugins: map[string]plugin{
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1 add lameduck"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.6.4": {
@@ -200,72 +137,21 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.3",
 		dockerImageSHA: "493ee88e1a92abebac67cbd4b5658b4730e0f33512461442d8d9214ea6734a9b",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.6.3": {
@@ -273,84 +159,34 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.2",
 		dockerImageSHA: "cfa7236dab4e3860881fdf755880ff8361e42f6cba2e3775ae48e2d46d22f7ba",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.6.2": {
 		nextVersion:    "1.6.3",
 		priorVersion:   "1.6.1",
+		k8sReleases:    []string{"1.16"},
 		dockerImageSHA: "12eb885b8685b1b13a04ecf5c23bc809c2e57917252fd7b0be9e9c00644e8ee5",
 		defaultConf: `.:53 {
     errors
     health
+    ready
     kubernetes * *** {
         pods insecure
-        upstream
         fallthrough in-addr.arpa ip6.arpa
         ttl 30
     }
@@ -362,72 +198,21 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.6.1": {
@@ -435,72 +220,21 @@ var Versions = map[string]release{
 		priorVersion:   "1.6.0",
 		dockerImageSHA: "9ae3b6fcac4ee821362277de6bd8fd2236fa7d3e19af2ef0406d80b595620a7a",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v7"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.6.0": {
@@ -508,76 +242,21 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.2",
 		dockerImageSHA: "263d03f2b889a75a0b91e035c2a14d45d7c1559c53444c5f7abf3a76014b779d",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod": {
-						status: removed,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v6"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.5.2": {
@@ -585,76 +264,21 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.1",
 		dockerImageSHA: "586d15ec14911ee680ac9c5af20ff24b9d1412fbbf0e05862ee1f5c37baa65b2",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v5"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.5.1": {
@@ -662,76 +286,21 @@ var Versions = map[string]release{
 		priorVersion:   "1.5.0",
 		dockerImageSHA: "451817637035535ae1fc8639753b453fa4b781d0dea557d5da5cb3c131e62ef5",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"ready":    {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"ready":        {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v5"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.5.0": {
@@ -739,17 +308,9 @@ var Versions = map[string]release{
 		priorVersion:   "1.4.0",
 		dockerImageSHA: "e83beb5e43f8513fa735e77ffc5859640baea30a882a11cc75c4c3244a737d3c",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health": {},
+			"errors": plugins["errors"]["v2"],
+			"log":    plugins["log"]["v1"],
+			"health": plugins["health"]["v1"],
 			"ready": {
 				status: newdefault,
 				add: func(c *corefile.Server) (*corefile.Server, error) {
@@ -757,70 +318,18 @@ var Versions = map[string]release{
 				},
 				downAction: removePlugin,
 			},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: ignored,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				status:     removed,
-				replacedBy: "forward",
-				action:     proxyToForwardPluginAction,
-				options:    proxyToForwardOptionsMigrations,
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v5"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["removal"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 		postProcess: breakForwardStubDomainsIntoServerBlocks,
 	},
@@ -829,78 +338,21 @@ var Versions = map[string]release{
 		priorVersion:   "1.3.1",
 		dockerImageSHA: "70a92e9f6fc604f9b629ca331b6135287244a86612f550941193ec7e12759417",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod": {},
-					"endpoint": {
-						status: ignored,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream": {
-						status: deprecated,
-						action: removeOption,
-					},
-					"ttl":         {},
-					"noendpoints": {},
-					"transfer":    {},
-					"fallthrough": {},
-					"ignore":      {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				status:     deprecated,
-				replacedBy: "forward",
-				action:     proxyToForwardPluginAction,
-				options:    proxyToForwardOptionsMigrations,
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v4"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["deprecation"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 		postProcess: breakForwardStubDomainsIntoServerBlocks,
 	},
@@ -926,80 +378,21 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod": {},
-					"endpoint": {
-						status: deprecated,
-						action: useFirstArgumentOnly,
-					},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"k8s_external": {
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v3"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["v2"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.3.0": {
@@ -1007,78 +400,21 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.6",
 		dockerImageSHA: "e030773c7fee285435ed7fc7623532ee54c4c1c4911fb24d95cd0170a8a768bc",
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"k8s_external": {
-				downAction: removePlugin,
-				options: map[string]option{
-					"apex": {},
-					"ttl":  {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"loop":        {},
-			"reload":      {},
-			"loadbalance": {},
+			"errors":       plugins["errors"]["v2"],
+			"log":          plugins["log"]["v1"],
+			"health":       plugins["health"]["v1"],
+			"autopath":     {},
+			"kubernetes":   plugins["kubernetes"]["v2"],
+			"k8s_external": plugins["k8s_external"]["v1"],
+			"prometheus":   {},
+			"proxy":        plugins["proxy"]["v2"],
+			"forward":      plugins["forward"]["v2"],
+			"cache":        plugins["cache"]["v1"],
+			"loop":         {},
+			"reload":       {},
+			"loadbalance":  {},
+			"hosts":        plugins["hosts"]["v1"],
+			"rewrite":      plugins["rewrite"]["v2"],
 		},
 	},
 	"1.2.6": {
@@ -1102,71 +438,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {
-				options: map[string]option{
-					"consolidate": {},
-				},
-			},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"errors":      plugins["errors"]["v2"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v2"],
 		},
 	},
 	"1.2.5": {
@@ -1174,67 +459,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.4",
 		dockerImageSHA: "33c8da20b887ae12433ec5c40bfddefbbfa233d5ce11fb067122e68af30291d6",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v2"],
 		},
 	},
 	"1.2.4": {
@@ -1242,67 +480,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.3",
 		dockerImageSHA: "a0d40ad961a714c699ee7b61b77441d165f6252f9fb84ac625d04a8d8554c0ec",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v2"],
 		},
 	},
 	"1.2.3": {
@@ -1310,67 +501,20 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.2",
 		dockerImageSHA: "12f3cab301c826978fac736fd40aca21ac023102fd7f4aa6b4341ae9ba89e90e",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"kubeconfig":         {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v2"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v2"],
 		},
 	},
 	"1.2.2": {
@@ -1394,66 +538,20 @@ var Versions = map[string]release{
     loadbalance
 }`,
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v1"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v1"],
 		},
 	},
 	"1.2.1": {
@@ -1461,63 +559,15 @@ var Versions = map[string]release{
 		priorVersion:   "1.2.0",
 		dockerImageSHA: "fb129c6a7c8912bc6d9cc4505e1f9007c5565ceb1aa6369750e60cc79771a244",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
+			"errors":     plugins["errors"]["v1"],
+			"log":        plugins["log"]["v1"],
+			"health":     plugins["health"]["v1"],
+			"autopath":   {},
+			"kubernetes": plugins["kubernetes"]["v1"],
 			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol":     {},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"proxy":      plugins["proxy"]["v2"],
+			"forward":    plugins["forward"]["v2"],
+			"cache":      plugins["cache"]["v1"],
 			"loop": {
 				status: newdefault,
 				add: func(s *corefile.Server) (*corefile.Server, error) {
@@ -1527,6 +577,8 @@ var Versions = map[string]release{
 			},
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v1"],
 		},
 	},
 	"1.2.0": {
@@ -1534,68 +586,19 @@ var Versions = map[string]release{
 		priorVersion:   "1.1.4",
 		dockerImageSHA: "ae69a32f8cc29a3e2af9628b6473f24d3e977950a2cb62ce8911478a61215471",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol": {
-						status: removed,
-						action: proxyRemoveHttpsGoogleProtocol,
-					},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"prefer_udp":     {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v1"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v2"],
+			"forward":     plugins["forward"]["v2"],
+			"cache":       plugins["cache"]["v1"],
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v1"],
 		},
 	},
 	"1.1.4": {
@@ -1603,67 +606,19 @@ var Versions = map[string]release{
 		priorVersion:   "1.1.3",
 		dockerImageSHA: "463c7021141dd3bfd4a75812f4b735ef6aadc0253a128f15ffe16422abe56e50",
 		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy": {
-				options: map[string]option{
-					"policy":       {},
-					"fail_timeout": {},
-					"max_fails":    {},
-					"health_check": {},
-					"except":       {},
-					"spray":        {},
-					"protocol": {
-						status: ignored,
-						action: proxyRemoveHttpsGoogleProtocol,
-					},
-				},
-			},
-			"forward": {
-				options: map[string]option{
-					"except":         {},
-					"force_tcp":      {},
-					"expire":         {},
-					"max_fails":      {},
-					"tls":            {},
-					"tls_servername": {},
-					"policy":         {},
-					"health_check":   {},
-				},
-			},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
+			"errors":      plugins["errors"]["v1"],
+			"log":         plugins["log"]["v1"],
+			"health":      plugins["health"]["v1"],
+			"autopath":    {},
+			"kubernetes":  plugins["kubernetes"]["v1"],
+			"prometheus":  {},
+			"proxy":       plugins["proxy"]["v1"],
+			"forward":     plugins["forward"]["v1"],
+			"cache":       plugins["cache"]["v1"],
 			"reload":      {},
 			"loadbalance": {},
+			"hosts":       plugins["hosts"]["v1"],
+			"rewrite":     plugins["rewrite"]["v1"],
 		},
 	},
 	"1.1.3": {
@@ -1683,90 +638,4 @@ var Versions = map[string]release{
     cache 30
     reload
 }`},
-}
-
-var proxyToForwardOptionsMigrations = map[string]option{
-	"policy": {
-		action: func(o *corefile.Option) (*corefile.Option, error) {
-			if len(o.Args) == 2 && o.Args[1] == "least_conn" {
-				o.Name = "force_tcp"
-				o.Args = nil
-			}
-			return o, nil
-		},
-	},
-	"except":       {},
-	"fail_timeout": {action: removeOption},
-	"max_fails":    {action: removeOption},
-	"health_check": {action: removeOption},
-	"spray":        {action: removeOption},
-	"protocol": {
-		action: func(o *corefile.Option) (*corefile.Option, error) {
-			if len(o.Args) >= 2 && o.Args[1] == "force_tcp" {
-				o.Name = "force_tcp"
-				o.Args = nil
-				return o, nil
-			}
-			return nil, nil
-		},
-	},
-}
-
-var proxyToForwardPluginAction = func(p *corefile.Plugin) (*corefile.Plugin, error) {
-	return renamePlugin(p, "forward")
-}
-
-var useFirstArgumentOnly = func(o *corefile.Option) (*corefile.Option, error) {
-	if len(o.Args) < 1 {
-		return o, nil
-	}
-	o.Args = o.Args[:1]
-	return o, nil
-}
-
-var proxyRemoveHttpsGoogleProtocol = func(o *corefile.Option) (*corefile.Option, error) {
-	if len(o.Args) > 0 && o.Args[0] == "https_google" {
-		return nil, nil
-	}
-	return o, nil
-}
-
-func breakForwardStubDomainsIntoServerBlocks(cf *corefile.Corefile) (*corefile.Corefile, error) {
-	for _, sb := range cf.Servers {
-		for j, fwd := range sb.Plugins {
-			if fwd.Name != "forward" {
-				continue
-			}
-			if len(fwd.Args) == 0 {
-				return nil, errors.New("found invalid forward plugin declaration")
-			}
-			if fwd.Args[0] == "." {
-				// dont move the default upstream
-				continue
-			}
-			if len(sb.DomPorts) != 1 {
-				return cf, errors.New("unhandled migration of multi-domain/port server block")
-			}
-			if sb.DomPorts[0] != "." && sb.DomPorts[0] != ".:53" {
-				return cf, errors.New("unhandled migration of non-default domain/port server block")
-			}
-
-			newSb := &corefile.Server{}                // create a new server block
-			newSb.DomPorts = []string{fwd.Args[0]}     // copy the forward zone to the server block domain
-			fwd.Args[0] = "."                          // the plugin's zone changes to "." for brevity
-			newSb.Plugins = append(newSb.Plugins, fwd) // add the plugin to its new server block
-
-			// Add appropriate addtl plugins to new server block
-			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "loop"})
-			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "errors"})
-			newSb.Plugins = append(newSb.Plugins, &corefile.Plugin{Name: "cache", Args: []string{"30"}})
-
-			//add new server block to corefile
-			cf.Servers = append(cf.Servers, newSb)
-
-			//remove the forward plugin from the original server block
-			sb.Plugins = append(sb.Plugins[:j], sb.Plugins[j+1:]...)
-		}
-	}
-	return cf, nil
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -186,7 +186,7 @@ github.com/containernetworking/cni/pkg/types
 github.com/containernetworking/cni/pkg/types/020
 github.com/containernetworking/cni/pkg/types/current
 github.com/containernetworking/cni/pkg/version
-# github.com/coredns/corefile-migration v1.0.4 => github.com/coredns/corefile-migration v1.0.4
+# github.com/coredns/corefile-migration v1.0.6 => github.com/coredns/corefile-migration v1.0.6
 github.com/coredns/corefile-migration/migration
 github.com/coredns/corefile-migration/migration/corefile
 # github.com/coreos/go-oidc v2.1.0+incompatible => github.com/coreos/go-oidc v2.1.0+incompatible


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Bumps CoreDNS version to 1.6.7
Also updates the [migration library to 1.0.6](https://github.com/coredns/corefile-migration/releases/tag/v1.0.6) which supports coredns v1.6.7

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubeadm now includes CoreDNS version 1.6.7
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
