### PR TITLE
Make cloud provider caching TTL configurable

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -174,6 +174,22 @@ type Config struct {
 	// LoadBalancerResourceGroup determines the specific resource group of the load balancer user want to use, working
 	// with LoadBalancerName
 	LoadBalancerResourceGroup string `json:"loadBalancerResourceGroup,omitempty" yaml:"loadBalancerResourceGroup,omitempty"`
+
+	// AvailabilitySetNodesCacheTTL sets the Cache TTL for availabilitySetNodesCache
+	// if not set, will use default value
+	AvailabilitySetNodesCacheTTL int `json:"availabilitySetNodesCacheTTL,omitempty" yaml:"availabilitySetNodesCacheTTL,omitempty"`
+	// VmssCacheTTL sets the cache TTL for VMSS
+	VmssCacheTTL int `json:"vmssCacheTTL,omitempty" yaml:"vmssCacheTTL,omitempty"`
+	// VmssVirtualMachinesCacheTTL sets the cache TTL for vmssVirtualMachines
+	VmssVirtualMachinesCacheTTL int `json:"vmssVirtualMachinesCacheTTL,omitempty" yaml:"vmssVirtualMachinesCacheTTL,omitempty"`
+	// VmCacheTTL sets the cache TTL for vm
+	VMCacheTTL int `json:"vmCacheTTL,omitempty" yaml:"vmCacheTTL,omitempty"`
+	// LbCacheTTL sets the cache TTL for load balancer
+	LbCacheTTL int `json:"lbCacheTTL,omitempty" yaml:"lbcacheTTL,omitempty"`
+	// NsgCacheTTL sets the cache TTL for network security group
+	NsgCacheTTL int `json:"nsgCacheTTL,omityempty" yaml:"nsgCacheTTL,omitempty"`
+	// RtCacheTTL sets the cache TTL for route table
+	RtCacheTTL int `json:"rtCacheTTL,omitempty" yaml:"rtCacheTTL,omitempty"`
 }
 
 var _ cloudprovider.Interface = (*Cloud)(nil)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -175,21 +175,21 @@ type Config struct {
 	// with LoadBalancerName
 	LoadBalancerResourceGroup string `json:"loadBalancerResourceGroup,omitempty" yaml:"loadBalancerResourceGroup,omitempty"`
 
-	// AvailabilitySetNodesCacheTTL sets the Cache TTL for availabilitySetNodesCache
+	// AvailabilitySetNodesCacheTTLInSeconds sets the Cache TTL for availabilitySetNodesCache
 	// if not set, will use default value
-	AvailabilitySetNodesCacheTTL int `json:"availabilitySetNodesCacheTTL,omitempty" yaml:"availabilitySetNodesCacheTTL,omitempty"`
-	// VmssCacheTTL sets the cache TTL for VMSS
-	VmssCacheTTL int `json:"vmssCacheTTL,omitempty" yaml:"vmssCacheTTL,omitempty"`
-	// VmssVirtualMachinesCacheTTL sets the cache TTL for vmssVirtualMachines
-	VmssVirtualMachinesCacheTTL int `json:"vmssVirtualMachinesCacheTTL,omitempty" yaml:"vmssVirtualMachinesCacheTTL,omitempty"`
-	// VmCacheTTL sets the cache TTL for vm
-	VMCacheTTL int `json:"vmCacheTTL,omitempty" yaml:"vmCacheTTL,omitempty"`
-	// LbCacheTTL sets the cache TTL for load balancer
-	LbCacheTTL int `json:"lbCacheTTL,omitempty" yaml:"lbcacheTTL,omitempty"`
-	// NsgCacheTTL sets the cache TTL for network security group
-	NsgCacheTTL int `json:"nsgCacheTTL,omityempty" yaml:"nsgCacheTTL,omitempty"`
-	// RtCacheTTL sets the cache TTL for route table
-	RtCacheTTL int `json:"rtCacheTTL,omitempty" yaml:"rtCacheTTL,omitempty"`
+	AvailabilitySetNodesCacheTTLInSeconds int `json:"availabilitySetNodesCacheTTLInSeconds,omitempty" yaml:"availabilitySetNodesCacheTTLInSeconds,omitempty"`
+	// VmssCacheTTLInSeconds sets the cache TTL for VMSS
+	VmssCacheTTLInSeconds int `json:"vmssCacheTTLInSeconds,omitempty" yaml:"vmssCacheTTLInSeconds,omitempty"`
+	// VmssVirtualMachinesCacheTTLInSeconds sets the cache TTL for vmssVirtualMachines
+	VmssVirtualMachinesCacheTTLInSeconds int `json:"vmssVirtualMachinesCacheTTLInSeconds,omitempty" yaml:"vmssVirtualMachinesCacheTTLInSeconds,omitempty"`
+	// VmCacheTTLInSeconds sets the cache TTL for vm
+	VMCacheTTLInSeconds int `json:"vmCacheTTLInSeconds,omitempty" yaml:"vmCacheTTLInSeconds,omitempty"`
+	// LoadBalancerCacheTTLInSeconds sets the cache TTL for load balancer
+	LoadBalancerCacheTTLInSeconds int `json:"loadBalancerCacheTTLInSeconds,omitempty" yaml:"loadBalancerCacheTTLInSeconds,omitempty"`
+	// NsgCacheTTLInSeconds sets the cache TTL for network security group
+	NsgCacheTTLInSeconds int `json:"nsgCacheTTLInSeconds,omitempty" yaml:"nsgCacheTTLInSeconds,omitempty"`
+	// RouteTableCacheTTLInSeconds sets the cache TTL for route table
+	RouteTableCacheTTLInSeconds int `json:"routeTableCacheTTLInSeconds,omitempty" yaml:"routeTableCacheTTLInSeconds,omitempty"`
 }
 
 var _ cloudprovider.Interface = (*Cloud)(nil)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -59,6 +59,13 @@ func TestParseConfig(t *testing.T) {
 		"CloudProviderRateLimitBucketWrite": 1,
 		"cloudProviderRateLimitQPS": 1,
 		"CloudProviderRateLimitQPSWrite": 1,
+		"availabilitySetNodesCacheTTL": 100,
+		"vmssCacheTTL": 100,
+		"vmssVirtualMachinesCacheTTL": 100,
+		"vmCacheTTL": 100,
+		"lbCacheTTL": 100,
+		"nsgCacheTTL": 100,
+		"rtCacheTTL": 100,
 		"location": "location",
 		"maximumLoadBalancerRuleCount": 1,
 		"primaryAvailabilitySetName": "primaryAvailabilitySetName",
@@ -97,6 +104,13 @@ func TestParseConfig(t *testing.T) {
 		CloudProviderRateLimitBucketWrite: 1,
 		CloudProviderRateLimitQPS:         1,
 		CloudProviderRateLimitQPSWrite:    1,
+		AvailabilitySetNodesCacheTTL:      100,
+		VmssCacheTTL:                      100,
+		VmssVirtualMachinesCacheTTL:       100,
+		VMCacheTTL:                        100,
+		LbCacheTTL:                        100,
+		NsgCacheTTL:                       100,
+		RtCacheTTL:                        100,
 		Location:                          "location",
 		MaximumLoadBalancerRuleCount:      1,
 		PrimaryAvailabilitySetName:        "primaryAvailabilitySetName",
@@ -1572,7 +1586,14 @@ func TestNewCloudFromJSON(t *testing.T) {
 		"cloudProviderBackoff": true,
 		"cloudProviderRatelimit": true,
 		"cloudProviderRateLimitQPS": 0.5,
-		"cloudProviderRateLimitBucket": 5
+		"cloudProviderRateLimitBucket": 5,
+		"availabilitySetNodesCacheTTL": 100,
+		"vmssCacheTTL": 100,
+		"vmssVirtualMachinesCacheTTL": 100,
+		"vmCacheTTL": 100,
+		"lbCacheTTL": 100,
+		"nsgCacheTTL": 100,
+		"rtCacheTTL": 100,
 	}`
 	validateConfig(t, config)
 }
@@ -1622,6 +1643,13 @@ cloudProviderBackoffJitter: 1.0
 cloudProviderRatelimit: true
 cloudProviderRateLimitQPS: 0.5
 cloudProviderRateLimitBucket: 5
+availabilitySetNodesCacheTTL: 100
+vmssCacheTTL: 100
+vmssVirtualMachinesCacheTTL: 100
+vmCacheTTL: 100
+lbCacheTTL: 100
+nsgCacheTTL: 100
+rtCacheTTL: 100
 `
 	validateConfig(t, config)
 }
@@ -1694,6 +1722,27 @@ func validateConfig(t *testing.T, config string) {
 	}
 	if azureCloud.CloudProviderRateLimitBucket != 5 {
 		t.Errorf("got incorrect value for CloudProviderRateLimitBucket")
+	}
+	if azureCloud.AvailabilitySetNodesCacheTTL != 100 {
+		t.Errorf("got incorrect value for availabilitySetNodesCacheTTL")
+	}
+	if azureCloud.VmssCacheTTL != 100 {
+		t.Errorf("got incorrect value for vmssCacheTTL")
+	}
+	if azureCloud.VmssVirtualMachinesCacheTTL != 100 {
+		t.Errorf("got incorrect value for vmssVirtualMachinesCacheTTL")
+	}
+	if azureCloud.VMCacheTTL != 100 {
+		t.Errorf("got incorrect value for vmCacheTTL")
+	}
+	if azureCloud.LbCacheTTL != 100 {
+		t.Errorf("got incorrect value for lbCacheTTL")
+	}
+	if azureCloud.NsgCacheTTL != 100 {
+		t.Errorf("got incorrect value for nsgCacheTTL")
+	}
+	if azureCloud.RtCacheTTL != 100 {
+		t.Errorf("got incorrect value for rtCacheTTL")
 	}
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -59,13 +59,13 @@ func TestParseConfig(t *testing.T) {
 		"CloudProviderRateLimitBucketWrite": 1,
 		"cloudProviderRateLimitQPS": 1,
 		"CloudProviderRateLimitQPSWrite": 1,
-		"availabilitySetNodesCacheTTL": 100,
-		"vmssCacheTTL": 100,
-		"vmssVirtualMachinesCacheTTL": 100,
-		"vmCacheTTL": 100,
-		"lbCacheTTL": 100,
-		"nsgCacheTTL": 100,
-		"rtCacheTTL": 100,
+		"availabilitySetNodesCacheTTLInSeconds": 100,
+		"vmssCacheTTLInSeconds": 100,
+		"vmssVirtualMachinesCacheTTLInSeconds": 100,
+		"vmCacheTTLInSeconds": 100,
+		"loadBalancerCacheTTLInSeconds": 100,
+		"nsgCacheTTLInSeconds": 100,
+		"routeTableCacheTTLInSeconds": 100,
 		"location": "location",
 		"maximumLoadBalancerRuleCount": 1,
 		"primaryAvailabilitySetName": "primaryAvailabilitySetName",
@@ -94,36 +94,36 @@ func TestParseConfig(t *testing.T) {
 			TenantID:                    "tenantId",
 			UseManagedIdentityExtension: true,
 		},
-		CloudProviderBackoff:              true,
-		CloudProviderBackoffDuration:      1,
-		CloudProviderBackoffExponent:      1,
-		CloudProviderBackoffJitter:        1,
-		CloudProviderBackoffRetries:       1,
-		CloudProviderRateLimit:            true,
-		CloudProviderRateLimitBucket:      1,
-		CloudProviderRateLimitBucketWrite: 1,
-		CloudProviderRateLimitQPS:         1,
-		CloudProviderRateLimitQPSWrite:    1,
-		AvailabilitySetNodesCacheTTL:      100,
-		VmssCacheTTL:                      100,
-		VmssVirtualMachinesCacheTTL:       100,
-		VMCacheTTL:                        100,
-		LbCacheTTL:                        100,
-		NsgCacheTTL:                       100,
-		RtCacheTTL:                        100,
-		Location:                          "location",
-		MaximumLoadBalancerRuleCount:      1,
-		PrimaryAvailabilitySetName:        "primaryAvailabilitySetName",
-		PrimaryScaleSetName:               "primaryScaleSetName",
-		ResourceGroup:                     "resourcegroup",
-		RouteTableName:                    "routeTableName",
-		RouteTableResourceGroup:           "routeTableResourceGroup",
-		SecurityGroupName:                 "securityGroupName",
-		SubnetName:                        "subnetName",
-		UseInstanceMetadata:               true,
-		VMType:                            "standard",
-		VnetName:                          "vnetName",
-		VnetResourceGroup:                 "vnetResourceGroup",
+		CloudProviderBackoff:                  true,
+		CloudProviderBackoffDuration:          1,
+		CloudProviderBackoffExponent:          1,
+		CloudProviderBackoffJitter:            1,
+		CloudProviderBackoffRetries:           1,
+		CloudProviderRateLimit:                true,
+		CloudProviderRateLimitBucket:          1,
+		CloudProviderRateLimitBucketWrite:     1,
+		CloudProviderRateLimitQPS:             1,
+		CloudProviderRateLimitQPSWrite:        1,
+		AvailabilitySetNodesCacheTTLInSeconds: 100,
+		VmssCacheTTLInSeconds:                 100,
+		VmssVirtualMachinesCacheTTLInSeconds:  100,
+		VMCacheTTLInSeconds:                   100,
+		LoadBalancerCacheTTLInSeconds:         100,
+		NsgCacheTTLInSeconds:                  100,
+		RouteTableCacheTTLInSeconds:           100,
+		Location:                              "location",
+		MaximumLoadBalancerRuleCount:          1,
+		PrimaryAvailabilitySetName:            "primaryAvailabilitySetName",
+		PrimaryScaleSetName:                   "primaryScaleSetName",
+		ResourceGroup:                         "resourcegroup",
+		RouteTableName:                        "routeTableName",
+		RouteTableResourceGroup:               "routeTableResourceGroup",
+		SecurityGroupName:                     "securityGroupName",
+		SubnetName:                            "subnetName",
+		UseInstanceMetadata:                   true,
+		VMType:                                "standard",
+		VnetName:                              "vnetName",
+		VnetResourceGroup:                     "vnetResourceGroup",
 	}
 
 	buffer := bytes.NewBufferString(azureConfig)
@@ -1587,13 +1587,13 @@ func TestNewCloudFromJSON(t *testing.T) {
 		"cloudProviderRatelimit": true,
 		"cloudProviderRateLimitQPS": 0.5,
 		"cloudProviderRateLimitBucket": 5,
-		"availabilitySetNodesCacheTTL": 100,
-		"vmssCacheTTL": 100,
-		"vmssVirtualMachinesCacheTTL": 100,
-		"vmCacheTTL": 100,
-		"lbCacheTTL": 100,
-		"nsgCacheTTL": 100,
-		"rtCacheTTL": 100,
+		"availabilitySetNodesCacheTTLInSeconds": 100,
+		"vmssCacheTTLInSeconds": 100,
+		"vmssVirtualMachinesCacheTTLInSeconds": 100,
+		"vmCacheTTLInSeconds": 100,
+		"loadBalancerCacheTTLInSeconds": 100,
+		"nsgCacheTTLInSeconds": 100,
+		"routeTableCacheTTLInSeconds": 100,
 	}`
 	validateConfig(t, config)
 }
@@ -1643,13 +1643,13 @@ cloudProviderBackoffJitter: 1.0
 cloudProviderRatelimit: true
 cloudProviderRateLimitQPS: 0.5
 cloudProviderRateLimitBucket: 5
-availabilitySetNodesCacheTTL: 100
-vmssCacheTTL: 100
-vmssVirtualMachinesCacheTTL: 100
-vmCacheTTL: 100
-lbCacheTTL: 100
-nsgCacheTTL: 100
-rtCacheTTL: 100
+availabilitySetNodesCacheTTLInSeconds: 100
+vmssCacheTTLInSeconds: 100
+vmssVirtualMachinesCacheTTLInSeconds: 100
+vmCacheTTLInSeconds: 100
+loadBalancerCacheTTLInSeconds: 100
+nsgCacheTTLInSeconds: 100
+routeTableCacheTTLInSeconds: 100
 `
 	validateConfig(t, config)
 }
@@ -1723,26 +1723,26 @@ func validateConfig(t *testing.T, config string) {
 	if azureCloud.CloudProviderRateLimitBucket != 5 {
 		t.Errorf("got incorrect value for CloudProviderRateLimitBucket")
 	}
-	if azureCloud.AvailabilitySetNodesCacheTTL != 100 {
-		t.Errorf("got incorrect value for availabilitySetNodesCacheTTL")
+	if azureCloud.AvailabilitySetNodesCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for availabilitySetNodesCacheTTLInSeconds")
 	}
-	if azureCloud.VmssCacheTTL != 100 {
-		t.Errorf("got incorrect value for vmssCacheTTL")
+	if azureCloud.VmssCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for vmssCacheTTLInSeconds")
 	}
-	if azureCloud.VmssVirtualMachinesCacheTTL != 100 {
-		t.Errorf("got incorrect value for vmssVirtualMachinesCacheTTL")
+	if azureCloud.VmssVirtualMachinesCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for vmssVirtualMachinesCacheTTLInSeconds")
 	}
-	if azureCloud.VMCacheTTL != 100 {
-		t.Errorf("got incorrect value for vmCacheTTL")
+	if azureCloud.VMCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for vmCacheTTLInSeconds")
 	}
-	if azureCloud.LbCacheTTL != 100 {
-		t.Errorf("got incorrect value for lbCacheTTL")
+	if azureCloud.LoadBalancerCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for loadBalancerCacheTTLInSeconds")
 	}
-	if azureCloud.NsgCacheTTL != 100 {
-		t.Errorf("got incorrect value for nsgCacheTTL")
+	if azureCloud.NsgCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for nsgCacheTTLInSeconds")
 	}
-	if azureCloud.RtCacheTTL != 100 {
-		t.Errorf("got incorrect value for rtCacheTTL")
+	if azureCloud.RouteTableCacheTTLInSeconds != 100 {
+		t.Errorf("got incorrect value for routeTableCacheTTLInSeconds")
 	}
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
@@ -38,9 +38,9 @@ var (
 	vmssVirtualMachinesKey  = "k8svmssVirtualMachinesKey"
 	availabilitySetNodesKey = "k8sAvailabilitySetNodesKey"
 
-	availabilitySetNodesCacheTTLDefault = 900 // in seconds
-	vmssCacheTTLDefault                 = 600 // in seconds
-	vmssVirtualMachinesCacheTTLDefault  = 600 // in seconds
+	availabilitySetNodesCacheTTLDefaultInSeconds = 900
+	vmssCacheTTLDefaultInSeconds                 = 600
+	vmssVirtualMachinesCacheTTLDefaultInSeconds  = 600
 )
 
 type vmssVirtualMachinesEntry struct {
@@ -87,10 +87,10 @@ func (ss *scaleSet) newVMSSCache() (*timedCache, error) {
 		return localCache, nil
 	}
 
-	if ss.Config.VmssCacheTTL == 0 {
-		return newTimedcache(time.Duration(vmssCacheTTLDefault)*time.Second, getter)
+	if ss.Config.VmssCacheTTLInSeconds == 0 {
+		ss.Config.VmssCacheTTLInSeconds = vmssCacheTTLDefaultInSeconds
 	}
-	return newTimedcache(time.Duration(ss.Config.VmssCacheTTL)*time.Second, getter)
+	return newTimedcache(time.Duration(ss.Config.VmssCacheTTLInSeconds)*time.Second, getter)
 }
 
 func extractVmssVMName(name string) (string, string, error) {
@@ -150,10 +150,10 @@ func (ss *scaleSet) newVMSSVirtualMachinesCache() (*timedCache, error) {
 		return localCache, nil
 	}
 
-	if ss.Config.VmssVirtualMachinesCacheTTL == 0 {
-		return newTimedcache(time.Duration(vmssVirtualMachinesCacheTTLDefault)*time.Second, getter)
+	if ss.Config.VmssVirtualMachinesCacheTTLInSeconds == 0 {
+		ss.Config.VmssVirtualMachinesCacheTTLInSeconds = vmssVirtualMachinesCacheTTLDefaultInSeconds
 	}
-	return newTimedcache(time.Duration(ss.Config.VmssVirtualMachinesCacheTTL)*time.Second, getter)
+	return newTimedcache(time.Duration(ss.Config.VmssVirtualMachinesCacheTTLInSeconds)*time.Second, getter)
 }
 
 func (ss *scaleSet) deleteCacheForNode(nodeName string) error {
@@ -192,10 +192,10 @@ func (ss *scaleSet) newAvailabilitySetNodesCache() (*timedCache, error) {
 		return localCache, nil
 	}
 
-	if ss.Config.AvailabilitySetNodesCacheTTL == 0 {
-		return newTimedcache(time.Duration(availabilitySetNodesCacheTTLDefault)*time.Second, getter)
+	if ss.Config.AvailabilitySetNodesCacheTTLInSeconds == 0 {
+		ss.Config.AvailabilitySetNodesCacheTTLInSeconds = availabilitySetNodesCacheTTLDefaultInSeconds
 	}
-	return newTimedcache(time.Duration(ss.Config.AvailabilitySetNodesCacheTTL)*time.Second, getter)
+	return newTimedcache(time.Duration(ss.Config.AvailabilitySetNodesCacheTTLInSeconds)*time.Second, getter)
 }
 
 func (ss *scaleSet) isNodeManagedByAvailabilitySet(nodeName string, crt cacheReadType) (bool, error) {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_cache.go
@@ -38,9 +38,9 @@ var (
 	vmssVirtualMachinesKey  = "k8svmssVirtualMachinesKey"
 	availabilitySetNodesKey = "k8sAvailabilitySetNodesKey"
 
-	availabilitySetNodesCacheTTL = 15 * time.Minute
-	vmssTTL                      = 10 * time.Minute
-	vmssVirtualMachinesTTL       = 10 * time.Minute
+	availabilitySetNodesCacheTTLDefault = 900 // in seconds
+	vmssCacheTTLDefault                 = 600 // in seconds
+	vmssVirtualMachinesCacheTTLDefault  = 600 // in seconds
 )
 
 type vmssVirtualMachinesEntry struct {
@@ -87,7 +87,10 @@ func (ss *scaleSet) newVMSSCache() (*timedCache, error) {
 		return localCache, nil
 	}
 
-	return newTimedcache(vmssTTL, getter)
+	if ss.Config.VmssCacheTTL == 0 {
+		return newTimedcache(time.Duration(vmssCacheTTLDefault)*time.Second, getter)
+	}
+	return newTimedcache(time.Duration(ss.Config.VmssCacheTTL)*time.Second, getter)
 }
 
 func extractVmssVMName(name string) (string, string, error) {
@@ -147,7 +150,10 @@ func (ss *scaleSet) newVMSSVirtualMachinesCache() (*timedCache, error) {
 		return localCache, nil
 	}
 
-	return newTimedcache(vmssVirtualMachinesTTL, getter)
+	if ss.Config.VmssVirtualMachinesCacheTTL == 0 {
+		return newTimedcache(time.Duration(vmssVirtualMachinesCacheTTLDefault)*time.Second, getter)
+	}
+	return newTimedcache(time.Duration(ss.Config.VmssVirtualMachinesCacheTTL)*time.Second, getter)
 }
 
 func (ss *scaleSet) deleteCacheForNode(nodeName string) error {
@@ -186,7 +192,10 @@ func (ss *scaleSet) newAvailabilitySetNodesCache() (*timedCache, error) {
 		return localCache, nil
 	}
 
-	return newTimedcache(availabilitySetNodesCacheTTL, getter)
+	if ss.Config.AvailabilitySetNodesCacheTTL == 0 {
+		return newTimedcache(time.Duration(availabilitySetNodesCacheTTLDefault)*time.Second, getter)
+	}
+	return newTimedcache(time.Duration(ss.Config.AvailabilitySetNodesCacheTTL)*time.Second, getter)
 }
 
 func (ss *scaleSet) isNodeManagedByAvailabilitySet(nodeName string, crt cacheReadType) (bool, error) {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
@@ -35,10 +35,10 @@ import (
 )
 
 var (
-	vmCacheTTL  = time.Minute
-	lbCacheTTL  = 2 * time.Minute
-	nsgCacheTTL = 2 * time.Minute
-	rtCacheTTL  = 2 * time.Minute
+	vmCacheTTLDefault  = 60  // in seconds
+	lbCacheTTLDefault  = 120 // in seconds
+	nsgCacheTTLDefault = 120 // in seconds
+	rtCacheTTLDefault  = 120 // in seconds
 
 	azureNodeProviderIDRE    = regexp.MustCompile(`^azure:///subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Compute/(?:.*)`)
 	azureResourceGroupNameRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/(?:.*)`)
@@ -228,7 +228,10 @@ func (az *Cloud) newVMCache() (*timedCache, error) {
 		return &vm, nil
 	}
 
-	return newTimedcache(vmCacheTTL, getter)
+	if az.VMCacheTTL == 0 {
+		return newTimedcache(time.Duration(vmCacheTTLDefault)*time.Second, getter)
+	}
+	return newTimedcache(time.Duration(az.VMCacheTTL)*time.Second, getter)
 }
 
 func (az *Cloud) newLBCache() (*timedCache, error) {
@@ -250,7 +253,10 @@ func (az *Cloud) newLBCache() (*timedCache, error) {
 		return &lb, nil
 	}
 
-	return newTimedcache(lbCacheTTL, getter)
+	if az.LbCacheTTL == 0 {
+		return newTimedcache(time.Duration(lbCacheTTLDefault)*time.Second, getter)
+	}
+	return newTimedcache(time.Duration(az.LbCacheTTL)*time.Second, getter)
 }
 
 func (az *Cloud) newNSGCache() (*timedCache, error) {
@@ -271,7 +277,10 @@ func (az *Cloud) newNSGCache() (*timedCache, error) {
 		return &nsg, nil
 	}
 
-	return newTimedcache(nsgCacheTTL, getter)
+	if az.NsgCacheTTL == 0 {
+		return newTimedcache(time.Duration(nsgCacheTTLDefault)*time.Second, getter)
+	}
+	return newTimedcache(time.Duration(az.NsgCacheTTL)*time.Second, getter)
 }
 
 func (az *Cloud) newRouteTableCache() (*timedCache, error) {
@@ -292,7 +301,10 @@ func (az *Cloud) newRouteTableCache() (*timedCache, error) {
 		return &rt, nil
 	}
 
-	return newTimedcache(rtCacheTTL, getter)
+	if az.RtCacheTTL == 0 {
+		return newTimedcache(time.Duration(rtCacheTTLDefault)*time.Second, getter)
+	}
+	return newTimedcache(time.Duration(az.RtCacheTTL)*time.Second, getter)
 }
 
 func (az *Cloud) useStandardLoadBalancer() bool {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
@@ -35,10 +35,10 @@ import (
 )
 
 var (
-	vmCacheTTLDefault  = 60  // in seconds
-	lbCacheTTLDefault  = 120 // in seconds
-	nsgCacheTTLDefault = 120 // in seconds
-	rtCacheTTLDefault  = 120 // in seconds
+	vmCacheTTLDefaultInSeconds           = 60
+	loadBalancerCacheTTLDefaultInSeconds = 120
+	nsgCacheTTLDefaultInSeconds          = 120
+	routeTableCacheTTLDefaultInSeconds   = 120
 
 	azureNodeProviderIDRE    = regexp.MustCompile(`^azure:///subscriptions/(?:.*)/resourceGroups/(?:.*)/providers/Microsoft.Compute/(?:.*)`)
 	azureResourceGroupNameRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/(?:.*)`)
@@ -228,10 +228,10 @@ func (az *Cloud) newVMCache() (*timedCache, error) {
 		return &vm, nil
 	}
 
-	if az.VMCacheTTL == 0 {
-		return newTimedcache(time.Duration(vmCacheTTLDefault)*time.Second, getter)
+	if az.VMCacheTTLInSeconds == 0 {
+		az.VMCacheTTLInSeconds = vmCacheTTLDefaultInSeconds
 	}
-	return newTimedcache(time.Duration(az.VMCacheTTL)*time.Second, getter)
+	return newTimedcache(time.Duration(az.VMCacheTTLInSeconds)*time.Second, getter)
 }
 
 func (az *Cloud) newLBCache() (*timedCache, error) {
@@ -253,10 +253,10 @@ func (az *Cloud) newLBCache() (*timedCache, error) {
 		return &lb, nil
 	}
 
-	if az.LbCacheTTL == 0 {
-		return newTimedcache(time.Duration(lbCacheTTLDefault)*time.Second, getter)
+	if az.LoadBalancerCacheTTLInSeconds == 0 {
+		az.LoadBalancerCacheTTLInSeconds = loadBalancerCacheTTLDefaultInSeconds
 	}
-	return newTimedcache(time.Duration(az.LbCacheTTL)*time.Second, getter)
+	return newTimedcache(time.Duration(az.LoadBalancerCacheTTLInSeconds)*time.Second, getter)
 }
 
 func (az *Cloud) newNSGCache() (*timedCache, error) {
@@ -277,10 +277,10 @@ func (az *Cloud) newNSGCache() (*timedCache, error) {
 		return &nsg, nil
 	}
 
-	if az.NsgCacheTTL == 0 {
-		return newTimedcache(time.Duration(nsgCacheTTLDefault)*time.Second, getter)
+	if az.NsgCacheTTLInSeconds == 0 {
+		az.NsgCacheTTLInSeconds = nsgCacheTTLDefaultInSeconds
 	}
-	return newTimedcache(time.Duration(az.NsgCacheTTL)*time.Second, getter)
+	return newTimedcache(time.Duration(az.NsgCacheTTLInSeconds)*time.Second, getter)
 }
 
 func (az *Cloud) newRouteTableCache() (*timedCache, error) {
@@ -301,10 +301,10 @@ func (az *Cloud) newRouteTableCache() (*timedCache, error) {
 		return &rt, nil
 	}
 
-	if az.RtCacheTTL == 0 {
-		return newTimedcache(time.Duration(rtCacheTTLDefault)*time.Second, getter)
+	if az.RouteTableCacheTTLInSeconds == 0 {
+		az.RouteTableCacheTTLInSeconds = routeTableCacheTTLDefaultInSeconds
 	}
-	return newTimedcache(time.Duration(az.RtCacheTTL)*time.Second, getter)
+	return newTimedcache(time.Duration(az.RouteTableCacheTTLInSeconds)*time.Second, getter)
 }
 
 func (az *Cloud) useStandardLoadBalancer() bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
<!-- > Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind flake
-->
/kind feature


**What this PR does / why we need it**:
The PR will make cloud provider caching TTL configurable, instead of only using static default value.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure cloud provider cache TTL is configurable, list of the azure cloud provider is as following:
- "availabilitySetNodesCacheTTLInSeconds"
- "vmssCacheTTLInSeconds"
- "vmssVirtualMachinesCacheTTLInSeconds"
- "vmCacheTTLInSeconds"
- "loadBalancerCacheTTLInSeconds"
- "nsgCacheTTLInSeconds"
- "routeTableCacheTTLInSeconds"

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [Usage]: 
add settings at cloud provider config file, eg:
                 "availabilitySetNodesCacheTTLInSeconds": 100,
		"vmssCacheTTLInSeconds": 100,
		"vmssVirtualMachinesCacheTTLInSeconds": 100,
		"vmCacheTTLInSeconds": 100,
		"loadBalancerCacheTTLInSeconds": 100,
		"nsgCacheTTLInSeconds": 100,
		"routeTableCacheTTLInSeconds": 100,
```
