### PR TITLE
Automated cherry pick of #86258: Fix build break - Hyperkube image needs kubelet/kubectl

### DIFF
--- a/build/release-images.sh
+++ b/build/release-images.sh
@@ -30,6 +30,9 @@ if [[ "${KUBE_BUILD_CONFORMANCE}" =~ [yY] ]]; then
     CMD_TARGETS="${CMD_TARGETS} ${KUBE_CONFORMANCE_IMAGE_TARGETS[*]}"
 fi
 
+# TODO(dims): Remove this when we get rid of hyperkube image
+CMD_TARGETS="${CMD_TARGETS} cmd/kubelet cmd/kubectl"
+
 kube::build::verify_prereqs
 kube::build::build_image
 kube::build::run_build_command make all WHAT="${CMD_TARGETS}" KUBE_BUILD_PLATFORMS="${KUBE_SERVER_PLATFORMS[*]}"


### PR DESCRIPTION
Cherry pick of #86258 on release-1.17.

#86258: Fix build break - Hyperkube image needs kubelet/kubectl

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.