### PR TITLE
WIP - Consider whether a type can be encoded as protobuf when negotiating a serializer

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/interfaces.go
@@ -128,6 +128,9 @@ type SerializerInfo struct {
 	// StreamSerializer, if set, describes the streaming serialization format
 	// for this media type.
 	StreamSerializer *StreamSerializerInfo
+	// SupportsObject is used to determine if this serializer supports serializing the specified object.
+	// If SupportsObject is nil, all objects are assumed to be supported.
+	SupportsObject func(Object) bool
 }
 
 // StreamSerializerInfo contains information about a specific stream serialization format

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation/negotiate_test.go
@@ -302,8 +302,8 @@ func BenchmarkNegotiateMediaTypeOptions(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		options, _ := NegotiateMediaTypeOptions(header, accepted, DefaultEndpointRestrictions)
-		if options.Accepted != accepted[1] {
-			b.Errorf("Unexpected result")
+		if a, e := options.Accepted, accepted[1]; a.MediaType != e.MediaType || a.MediaTypeType != e.MediaTypeType || a.MediaTypeSubType != e.MediaTypeSubType {
+			b.Errorf("Unexpected result; got %#v, expected %#v", a, e)
 		}
 	}
 }

--- a/test/integration/examples/BUILD
+++ b/test/integration/examples/BUILD
@@ -23,6 +23,7 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/apis/audit:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Improves API server support for serving types that do not support protobuf encoding

**Which issue(s) this PR fixes**:
Fixes #86253

**Does this PR introduce a user-facing change?**:
```release-note
sample-apiserver now gracefully handles Accept headers that indicate a preference for protobuf but fall back to application/json
```

/cc @smarterclayton 
/sig api-machinery