### PR TITLE
Fix internal loadbalancer configuration failure when subnet name too long

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -405,7 +405,7 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 		return nil, nil
 	}
 	isInternal := requiresInternalLoadBalancer(service)
-	lbFrontendIPConfigName := az.getFrontendIPConfigName(service, subnet(service))
+	lbFrontendIPConfigName := az.getFrontendIPConfigName(service)
 	serviceName := getServiceName(service)
 	for _, ipConfiguration := range *lb.FrontendIPConfigurations {
 		if lbFrontendIPConfigName == *ipConfiguration.Name {
@@ -693,7 +693,7 @@ func (az *Cloud) reconcileLoadBalancer(clusterName string, service *v1.Service, 
 	}
 	lbName := *lb.Name
 	klog.V(2).Infof("reconcileLoadBalancer for service(%s): lb(%s) wantLb(%t) resolved load balancer name", serviceName, lbName, wantLb)
-	lbFrontendIPConfigName := az.getFrontendIPConfigName(service, subnet(service))
+	lbFrontendIPConfigName := az.getFrontendIPConfigName(service)
 	lbFrontendIPConfigID := az.getFrontendIPConfigID(lbName, lbFrontendIPConfigName)
 	lbBackendPoolName := getBackendPoolName(az.ipv6DualStackEnabled, clusterName, service)
 	lbBackendPoolID := az.getBackendPoolID(lbName, lbBackendPoolName)
@@ -1026,7 +1026,7 @@ func (az *Cloud) reconcileLoadBalancerRule(
 		}
 
 		for _, protocol := range protocols {
-			lbRuleName := az.getLoadBalancerRuleName(service, protocol, port.Port, subnet(service))
+			lbRuleName := az.getLoadBalancerRuleName(service, protocol, port.Port)
 			klog.V(2).Infof("reconcileLoadBalancerRule lb name (%s) rule name (%s)", lbName, lbRuleName)
 
 			transportProto, _, probeProto, err := getProtocolsFromKubernetesProtocol(protocol)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer_test.go
@@ -1627,7 +1627,7 @@ func TestGetServiceLoadBalancerStatus(t *testing.T) {
 		},
 		{
 			desc: "getServiceLoadBalancerStatus shall return nil if lb.FrontendIPConfigurations.name != " +
-				"az.getFrontendIPConfigName(service, subnet(service))",
+				"az.getFrontendIPConfigName(service)",
 			service: &internalService,
 			lb:      &lb3,
 		},

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -273,12 +273,21 @@ func getBackendPoolName(ipv6DualStackEnabled bool, clusterName string, service *
 	return clusterName
 }
 
-func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protocol, port int32, subnetName *string) string {
+func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protocol, port int32) string {
 	prefix := az.getRulePrefix(service)
-	if subnetName == nil {
-		return fmt.Sprintf("%s-%s-%d", prefix, protocol, port)
+	ruleName := fmt.Sprintf("%s-%s-%d", prefix, protocol, port)
+	subnet := subnet(service)
+	if subnet == nil {
+		return ruleName
 	}
-	return fmt.Sprintf("%s-%s-%s-%d", prefix, *subnetName, protocol, port)
+
+	// Load balancer rule name must be less or equal to 80 charactors, so excluding the hyphen two segments cannot exceed 79
+	subnetSegment := *subnet
+	if len(ruleName) + len(subnetSegment) > 79 {
+		subnetSegment = subnetSegment[:79 - len(ruleName)]
+	}
+
+	return fmt.Sprintf("%s-%s-%s-%d", prefix, subnetSegment, protocol, port)
 }
 
 func (az *Cloud) getSecurityRuleName(service *v1.Service, port v1.ServicePort, sourceAddrPrefix string) string {
@@ -316,10 +325,17 @@ func (az *Cloud) serviceOwnsFrontendIP(fip network.FrontendIPConfiguration, serv
 	return strings.HasPrefix(*fip.Name, baseName)
 }
 
-func (az *Cloud) getFrontendIPConfigName(service *v1.Service, subnetName *string) string {
+func (az *Cloud) getFrontendIPConfigName(service *v1.Service) string {
 	baseName := az.GetLoadBalancerName(context.TODO(), "", service)
+	subnetName := subnet(service)
 	if subnetName != nil {
-		return fmt.Sprintf("%s-%s", baseName, *subnetName)
+		ipcName := fmt.Sprintf("%s-%s", baseName, *subnetName)
+		
+		// Azure lb front end configuration name must not exceed 80 charactors
+		if len(ipcName) > 80 {
+			ipcName = ipcName[:80]
+		}
+		return ipcName
 	}
 	return baseName
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -65,7 +65,7 @@ const (
 	nodeLabelRole  = "kubernetes.io/role"
 	nicFailedState = "Failed"
 
-	storageAccountNameMaxLength = 24
+	storageAccountNameMaxLength   = 24
 	frontendIPConfigNameMaxLength = 80
 	loadBalancerRuleNameMaxLength = 80
 )
@@ -283,10 +283,10 @@ func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protoc
 		return ruleName
 	}
 
-	// Load balancer rule name must be less or equal to 80 charactors, so excluding the hyphen two segments cannot exceed 79
+	// Load balancer rule name must be less or equal to 80 characters, so excluding the hyphen two segments cannot exceed 79
 	subnetSegment := *subnet
-	if len(ruleName) + len(subnetSegment) + 1 > loadBalancerRuleNameMaxLength {
-		subnetSegment = subnetSegment[:loadBalancerRuleNameMaxLength - len(ruleName) - 1]
+	if len(ruleName)+len(subnetSegment)+1 > loadBalancerRuleNameMaxLength {
+		subnetSegment = subnetSegment[:loadBalancerRuleNameMaxLength-len(ruleName)-1]
 	}
 
 	return fmt.Sprintf("%s-%s-%s-%d", prefix, subnetSegment, protocol, port)
@@ -332,8 +332,8 @@ func (az *Cloud) getFrontendIPConfigName(service *v1.Service) string {
 	subnetName := subnet(service)
 	if subnetName != nil {
 		ipcName := fmt.Sprintf("%s-%s", baseName, *subnetName)
-		
-		// Azure lb front end configuration name must not exceed 80 charactors
+
+		// Azure lb front end configuration name must not exceed 80 characters
 		if len(ipcName) > frontendIPConfigNameMaxLength {
 			ipcName = ipcName[:frontendIPConfigNameMaxLength]
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -66,6 +66,8 @@ const (
 	nicFailedState = "Failed"
 
 	storageAccountNameMaxLength = 24
+	frontendIPConfigNameMaxLength = 80
+	loadBalancerRuleNameMaxLength = 80
 )
 
 var errNotInVMSet = errors.New("vm is not in the vmset")
@@ -283,8 +285,8 @@ func (az *Cloud) getLoadBalancerRuleName(service *v1.Service, protocol v1.Protoc
 
 	// Load balancer rule name must be less or equal to 80 charactors, so excluding the hyphen two segments cannot exceed 79
 	subnetSegment := *subnet
-	if len(ruleName) + len(subnetSegment) > 79 {
-		subnetSegment = subnetSegment[:79 - len(ruleName)]
+	if len(ruleName) + len(subnetSegment) + 1 > loadBalancerRuleNameMaxLength {
+		subnetSegment = subnetSegment[:loadBalancerRuleNameMaxLength - len(ruleName) - 1]
 	}
 
 	return fmt.Sprintf("%s-%s-%s-%d", prefix, subnetSegment, protocol, port)
@@ -332,8 +334,8 @@ func (az *Cloud) getFrontendIPConfigName(service *v1.Service) string {
 		ipcName := fmt.Sprintf("%s-%s", baseName, *subnetName)
 		
 		// Azure lb front end configuration name must not exceed 80 charactors
-		if len(ipcName) > 80 {
-			ipcName = ipcName[:80]
+		if len(ipcName) > frontendIPConfigNameMaxLength {
+			ipcName = ipcName[:frontendIPConfigNameMaxLength]
 		}
 		return ipcName
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -19,8 +19,8 @@ limitations under the License.
 package azure
 
 import (
-	"testing"
 	"strconv"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 
@@ -261,13 +261,13 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 
 	svc := &v1.Service{
 		ObjectMeta: meta.ObjectMeta{
-			Annotations: map[string]string{ 	},
-			UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
+			Annotations: map[string]string{},
+			UID:         "257b9655-5137-4ad2-b091-ef3f07043ad3",
 		},
 	}
 
 	cases := []struct {
-		description string
+		description   string
 		subnetName    string
 		isInternal    bool
 		useStandardLB bool
@@ -276,49 +276,49 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 		expected      string
 	}{
 		{
-			description: "internal lb should have subnet name on the rule name",
-			subnetName:       "shortsubnet",
-			isInternal: true,
-			useStandardLB:    true,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-shortsubnet-TCP-9000",
+			description:   "internal lb should have subnet name on the rule name",
+			subnetName:    "shortsubnet",
+			isInternal:    true,
+			useStandardLB: true,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-shortsubnet-TCP-9000",
 		},
 		{
-			description: "internal standard lb should have subnet name on the rule name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    true,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
+			description:   "internal standard lb should have subnet name on the rule name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: true,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
 		},
 		{
-			description: "internal basic lb should have subnet name on the rule name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    false,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
+			description:   "internal basic lb should have subnet name on the rule name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: false,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
 		},
 		{
-			description: "external standard lb should not have subnet name on the rule name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    true,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-TCP-9000",
+			description:   "external standard lb should not have subnet name on the rule name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: true,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-TCP-9000",
 		},
 		{
-			description: "external basic lb should not have subnet name on the rule name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    false,
-			protocol: v1.ProtocolTCP,
-			port: 9000,
-			expected: "a257b965551374ad2b091ef3f07043ad-TCP-9000",
+			description:   "external basic lb should not have subnet name on the rule name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: false,
+			protocol:      v1.ProtocolTCP,
+			port:          9000,
+			expected:      "a257b965551374ad2b091ef3f07043ad-TCP-9000",
 		},
 	}
 
@@ -351,46 +351,46 @@ func TestGetFrontendIPConfigName(t *testing.T) {
 	}
 
 	cases := []struct {
-		description string
+		description   string
 		subnetName    string
 		isInternal    bool
 		useStandardLB bool
 		expected      string
 	}{
 		{
-			description: "internal lb should have subnet name on the frontend ip configuration name",
-			subnetName:       "shortsubnet",
-			isInternal: true,
-			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad-shortsubnet",
+			description:   "internal lb should have subnet name on the frontend ip configuration name",
+			subnetName:    "shortsubnet",
+			isInternal:    true,
+			useStandardLB: true,
+			expected:      "a257b965551374ad2b091ef3f07043ad-shortsubnet",
 		},
 		{
-			description: "internal standard lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
+			description:   "internal standard lb should have subnet name on the frontend ip configuration name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: true,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
-			description: "internal basic lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
-			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
-			isInternal: true,
-			useStandardLB:    false,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
+			description:   "internal basic lb should have subnet name on the frontend ip configuration name but truncated to 80 characters",
+			subnetName:    "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal:    true,
+			useStandardLB: false,
+			expected:      "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
-			description: "external standard lb should not have subnet name on the frontend ip configuration name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad",
+			description:   "external standard lb should not have subnet name on the frontend ip configuration name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: true,
+			expected:      "a257b965551374ad2b091ef3f07043ad",
 		},
 		{
-			description: "external basic lb should not have subnet name on the frontend ip configuration name",
-			subnetName:       "shortsubnet",
-			isInternal: false,
-			useStandardLB:    false,
-			expected: "a257b965551374ad2b091ef3f07043ad",
+			description:   "external basic lb should not have subnet name on the frontend ip configuration name",
+			subnetName:    "shortsubnet",
+			isInternal:    false,
+			useStandardLB: false,
+			expected:      "a257b965551374ad2b091ef3f07043ad",
 		},
 	}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -336,7 +336,7 @@ func TestGetLoadBalancingRuleName(t *testing.T) {
 	}
 }
 
-func TestgetFrontendIPConfigName(t *testing.T) {
+func TestGetFrontendIPConfigName(t *testing.T) {
 	az := getTestCloud()
 	az.PrimaryAvailabilitySetName = "primary"
 
@@ -369,14 +369,14 @@ func TestgetFrontendIPConfigName(t *testing.T) {
 			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
 			isInternal: true,
 			useStandardLB:    true,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg",
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
 			description: "internal basic lb should have subnet name on the frontend ip configuration name but truncated to 80 charactors",
 			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
 			isInternal: true,
 			useStandardLB:    false,
-			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg",
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnnggggggggggg",
 		},
 		{
 			description: "external standard lb should not have subnet name on the frontend ip configuration name",
@@ -403,7 +403,7 @@ func TestgetFrontendIPConfigName(t *testing.T) {
 		svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
 		svc.Annotations[ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
 
-		loadbalancerName := az.getFrontendIPConfigName(svc)
-		assert.Equal(t, c.expected, loadbalancerName, c.description)
+		ipconfigName := az.getFrontendIPConfigName(svc)
+		assert.Equal(t, c.expected, ipconfigName, c.description)
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"testing"
+	"strconv"
 
 	"github.com/stretchr/testify/assert"
 
@@ -250,6 +251,90 @@ func TestGetAzureLoadBalancerName(t *testing.T) {
 			az.Config.LoadBalancerSku = loadBalancerSkuBasic
 		}
 		loadbalancerName := az.getAzureLoadBalancerName(c.clusterName, c.vmSet, c.isInternal)
+		assert.Equal(t, c.expected, loadbalancerName, c.description)
+	}
+}
+
+func TestGetLoadBalancingRuleName(t *testing.T) {
+	az := getTestCloud()
+	az.PrimaryAvailabilitySetName = "primary"
+
+	svc := &v1.Service{
+		ObjectMeta: meta.ObjectMeta{
+			Annotations: map[string]string{
+				ServiceAnnotationLoadBalancerInternalSubnet: "subnet",
+				ServiceAnnotationLoadBalancerInternal:       "true",
+			},
+			UID: "257b9655-5137-4ad2-b091-ef3f07043ad3",
+		},
+	}
+
+	cases := []struct {
+		description string
+		subnetName    string
+		isInternal    bool
+		useStandardLB bool
+		protocol      v1.Protocol
+		port          int32
+		expected      string
+	}{
+		{
+			description: "internal lb should have subnet name on the rule name",
+			subnetName:       "shortsubnet",
+			isInternal: true,
+			useStandardLB:    true,
+			protocol: v1.ProtocolTCP,
+			port: 9000,
+			expected: "a257b965551374ad2b091ef3f07043ad-shortsubnet-TCP-9000",
+		},
+		{
+			description: "internal standard lb should have subnet name on the rule name but truncated to 80 charactors",
+			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal: true,
+			useStandardLB:    true,
+			protocol: v1.ProtocolTCP,
+			port: 9000,
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
+		},
+		{
+			description: "internal basic lb should have subnet name on the rule name but truncated to 80 charactors",
+			subnetName:       "averylonnnngggnnnnnnnnnnnnnnnnnnnnnngggggggggggggggggggggggggggggggggggggsubet",
+			isInternal: true,
+			useStandardLB:    false,
+			protocol: v1.ProtocolTCP,
+			port: 9000,
+			expected: "a257b965551374ad2b091ef3f07043ad-averylonnnngggnnnnnnnnnnnnnnnnnnnnnngg-TCP-9000",
+		},
+		{
+			description: "external standard lb should not have subnet name on the rule name",
+			subnetName:       "shortsubnet",
+			isInternal: false,
+			useStandardLB:    true,
+			protocol: v1.ProtocolTCP,
+			port: 9000,
+			expected: "a257b965551374ad2b091ef3f07043ad-TCP-9000",
+		},
+		{
+			description: "external basic lb should not have subnet name on the rule name",
+			subnetName:       "shortsubnet",
+			isInternal: false,
+			useStandardLB:    false,
+			protocol: v1.ProtocolTCP,
+			port: 9000,
+			expected: "a257b965551374ad2b091ef3f07043ad-TCP-9000",
+		},
+	}
+
+	for _, c := range cases {
+		if c.useStandardLB {
+			az.Config.LoadBalancerSku = loadBalancerSkuStandard
+		} else {
+			az.Config.LoadBalancerSku = loadBalancerSkuBasic
+		}
+		svc.Annotations[ServiceAnnotationLoadBalancerInternalSubnet] = c.subnetName
+		svc.Annotations[ServiceAnnotationLoadBalancerInternal] = strconv.FormatBool(c.isInternal)
+
+		loadbalancerName := az.getLoadBalancerRuleName(svc, c.protocol, c.port)
 		assert.Equal(t, c.expected, loadbalancerName, c.description)
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1238,14 +1238,14 @@ func validateLoadBalancer(t *testing.T, loadBalancer *network.LoadBalancer, serv
 		if len(svc.Spec.Ports) > 0 {
 			expectedFrontendIPCount++
 			expectedFrontendIP := ExpectedFrontendIPInfo{
-				Name:   az.getFrontendIPConfigName(&svc, subnet(&svc)),
+				Name:   az.getFrontendIPConfigName(&svc),
 				Subnet: subnet(&svc),
 			}
 			expectedFrontendIPs = append(expectedFrontendIPs, expectedFrontendIP)
 		}
 		for _, wantedRule := range svc.Spec.Ports {
 			expectedRuleCount++
-			wantedRuleName := az.getLoadBalancerRuleName(&svc, wantedRule.Protocol, wantedRule.Port, subnet(&svc))
+			wantedRuleName := az.getLoadBalancerRuleName(&svc, wantedRule.Protocol, wantedRule.Port)
 			foundRule := false
 			for _, actualRule := range *loadBalancer.LoadBalancingRules {
 				if strings.EqualFold(*actualRule.Name, wantedRuleName) &&


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR fixes the mentioned issue and added new test coverage. The issue is that when subnet name is too long, cloud provider will use a long name for frontend IP configuration and load balancing rule name, which may exceed the 80 charactor limit.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #86275

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix internal loadbalancer configuration failure when subnet name too long
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
