### PR TITLE
Register nodeports and noderesources prefilters 

### DIFF
--- a/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
+++ b/pkg/scheduler/algorithmprovider/defaults/defaults_test.go
@@ -104,6 +104,8 @@ func TestCompatibility(t *testing.T) {
 			name: "No Provider specified",
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodeResourcesFit"},
+					{Name: "NodePorts"},
 					{Name: "InterPodAffinity"},
 				},
 				"FilterPlugin": {
@@ -139,6 +141,8 @@ func TestCompatibility(t *testing.T) {
 			provider: config.SchedulerDefaultProviderName,
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodeResourcesFit"},
+					{Name: "NodePorts"},
 					{Name: "InterPodAffinity"},
 				},
 				"FilterPlugin": {
@@ -174,6 +178,8 @@ func TestCompatibility(t *testing.T) {
 			provider: ClusterAutoscalerProvider,
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodeResourcesFit"},
+					{Name: "NodePorts"},
 					{Name: "InterPodAffinity"},
 				},
 				"FilterPlugin": {

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -64,6 +64,10 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
                   ]
 		}`,
 			wantPlugins: map[string][]config.Plugin{
+				"PreFilterPlugin": {
+					{Name: "NodeResourcesFit"},
+					{Name: "NodePorts"},
+				},
 				"FilterPlugin": {
 					{Name: "NodeUnschedulable"},
 					{Name: "NodeResourcesFit"},
@@ -118,6 +122,7 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 				},
 				"FilterPlugin": {
@@ -164,6 +169,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 				},
 				"FilterPlugin": {
@@ -219,6 +226,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 				},
 				"FilterPlugin": {
@@ -283,6 +292,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -351,6 +362,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -430,6 +443,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -520,6 +535,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -611,6 +628,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -706,6 +725,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -813,6 +834,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -922,6 +945,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -1031,6 +1056,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},
@@ -1145,6 +1172,8 @@ func TestCompatibility_v1_Scheduler(t *testing.T) {
 			wantPredicates: sets.NewString(),
 			wantPlugins: map[string][]config.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodePorts"},
+					{Name: "NodeResourcesFit"},
 					{Name: "ServiceAffinity"},
 					{Name: "InterPodAffinity"},
 				},

--- a/pkg/scheduler/framework/plugins/default_registry.go
+++ b/pkg/scheduler/framework/plugins/default_registry.go
@@ -124,9 +124,11 @@ func NewDefaultConfigProducerRegistry() *ConfigProducerRegistry {
 		func(args ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
 			// GeneralPredicate is a combination of predicates.
 			plugins.Filter = appendToPluginSet(plugins.Filter, noderesources.FitName, nil)
+			plugins.PreFilter = appendToPluginSet(plugins.PreFilter, noderesources.FitName, nil)
 			pluginConfig = append(pluginConfig, makePluginConfig(noderesources.FitName, args.NodeResourcesFitArgs))
 			plugins.Filter = appendToPluginSet(plugins.Filter, nodename.Name, nil)
 			plugins.Filter = appendToPluginSet(plugins.Filter, nodeports.Name, nil)
+			plugins.PreFilter = appendToPluginSet(plugins.PreFilter, nodeports.Name, nil)
 			plugins.Filter = appendToPluginSet(plugins.Filter, nodeaffinity.Name, nil)
 			return
 		})
@@ -138,6 +140,7 @@ func NewDefaultConfigProducerRegistry() *ConfigProducerRegistry {
 	registry.RegisterPredicate(predicates.PodFitsResourcesPred,
 		func(args ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
 			plugins.Filter = appendToPluginSet(plugins.Filter, noderesources.FitName, nil)
+			plugins.PreFilter = appendToPluginSet(plugins.PreFilter, noderesources.FitName, nil)
 			pluginConfig = append(pluginConfig, makePluginConfig(noderesources.FitName, args.NodeResourcesFitArgs))
 			return
 		})
@@ -149,6 +152,7 @@ func NewDefaultConfigProducerRegistry() *ConfigProducerRegistry {
 	registry.RegisterPredicate(predicates.PodFitsHostPortsPred,
 		func(_ ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
 			plugins.Filter = appendToPluginSet(plugins.Filter, nodeports.Name, nil)
+			plugins.PreFilter = appendToPluginSet(plugins.PreFilter, nodeports.Name, nil)
 			return
 		})
 	registry.RegisterPredicate(predicates.MatchNodeSelectorPred,

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -126,6 +126,8 @@ func TestSchedulerCreationFromConfigMap(t *testing.T) {
 			}`,
 			expectedPlugins: map[string][]kubeschedulerconfig.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodeResourcesFit"},
+					{Name: "NodePorts"},
 					{Name: "InterPodAffinity"},
 				},
 				"FilterPlugin": {
@@ -200,6 +202,8 @@ kind: Policy
 `,
 			expectedPlugins: map[string][]kubeschedulerconfig.Plugin{
 				"PreFilterPlugin": {
+					{Name: "NodeResourcesFit"},
+					{Name: "NodePorts"},
 					{Name: "InterPodAffinity"},
 				},
 				"FilterPlugin": {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Registers NodeResources and NodePorts prefilters, which we missed to do when refactoring predicate metadata calculation.

**Which issue(s) this PR fixes**:
Fixes #86302

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @Huang-Wei 