### PR TITLE
kms: use negative cachesize value to disable caching

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
@@ -88,12 +88,13 @@ type IdentityConfiguration struct{}
 type KMSConfiguration struct {
 	// name is the name of the KMS plugin to be used.
 	Name string
-	// cacheSize is the maximum number of secrets which are cached in memory. The default value is 1000.
+	// cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
+	// Set to a negative value to disable caching.
 	// +optional
 	CacheSize *int32
 	// endpoint is the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".
 	Endpoint string
-	// Timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
+	// timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
@@ -88,12 +88,13 @@ type IdentityConfiguration struct{}
 type KMSConfiguration struct {
 	// name is the name of the KMS plugin to be used.
 	Name string `json:"name"`
-	// cacheSize is the maximum number of secrets which are cached in memory. The default value is 1000.
+	// cachesize is the maximum number of secrets which are cached in memory. The default value is 1000.
+	// Set to a negative value to disable caching.
 	// +optional
 	CacheSize *int32 `json:"cachesize,omitempty"`
 	// endpoint is the gRPC server listening address, for example "unix:///var/run/kms-provider.sock".
 	Endpoint string `json:"endpoint"`
-	// Timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
+	// timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
@@ -34,7 +34,7 @@ const (
 	mandatoryFieldErrFmt     = "%s is a mandatory field for a %s"
 	base64EncodingErr        = "secrets must be base64 encoded"
 	zeroOrNegativeErrFmt     = "%s should be a positive value"
-	negativeValueErrFmt      = "%s can't be negative"
+	nonZeroErrFmt            = "%s should be a positive value, or negative to disable"
 	encryptionConfigNilErr   = "EncryptionConfiguration can't be nil"
 )
 
@@ -184,8 +184,8 @@ func validateKMSConfiguration(c *config.KMSConfiguration, fieldPath *field.Path)
 
 func validateKMSCacheSize(c *config.KMSConfiguration, fieldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
-	if *c.CacheSize <= 0 {
-		allErrs = append(allErrs, field.Invalid(fieldPath, *c.CacheSize, fmt.Sprintf(zeroOrNegativeErrFmt, "cachesize")))
+	if *c.CacheSize == 0 {
+		allErrs = append(allErrs, field.Invalid(fieldPath, *c.CacheSize, fmt.Sprintf(nonZeroErrFmt, "cachesize")))
 	}
 
 	return allErrs

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
@@ -331,15 +331,13 @@ func TestKMSProviderCacheSize(t *testing.T) {
 			desc: "invalid zero cache size",
 			in:   &config.KMSConfiguration{CacheSize: &zeroCacheSize},
 			want: field.ErrorList{
-				field.Invalid(cacheField, int32(0), fmt.Sprintf(zeroOrNegativeErrFmt, "cachesize")),
+				field.Invalid(cacheField, int32(0), fmt.Sprintf(nonZeroErrFmt, "cachesize")),
 			},
 		},
 		{
-			desc: "negative caches size",
+			desc: "valid negative caches size",
 			in:   &config.KMSConfiguration{CacheSize: &negativeCacheSize},
-			want: field.ErrorList{
-				field.Invalid(cacheField, negativeCacheSize, fmt.Sprintf(zeroOrNegativeErrFmt, "cachesize")),
-			},
+			want: field.ErrorList{},
 		},
 	}
 


### PR DESCRIPTION
This change relaxes the KMS config cache size validation to allow for negative values.  The KMS code already treats all values <= 0 to mean that the cache is disabled (zero is still a validation error).

Signed-off-by: Monis Khan <mok@vmware.com>

/kind api-change
/priority important-longterm
/milestone v1.18
/assign @immutableT @liggitt 

xref: #85363

```release-note
Kubernetes KMS provider for data encryption now supports disabling the in-memory data encryption key (DEK) cache by setting cachesize to a negative value.
```

```docs
Need to update:
- https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/
- https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/
```
