### PR TITLE
code-gen: fix argument type for plural exceptions

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/args/args.go
@@ -83,7 +83,7 @@ func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet, inputBase string) {
 	pflag.BoolVar(&ca.ClientsetOnly, "clientset-only", ca.ClientsetOnly, "when set, client-gen only generates the clientset shell, without generating the individual typed clients")
 	pflag.BoolVar(&ca.FakeClient, "fake-clientset", ca.FakeClient, "when set, client-gen will generate the fake clientset that can be used in tests")
 
-	fs.StringArrayVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType form")
+	fs.StringSliceVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType form")
 
 	// support old flags
 	fs.SetNormalizeFunc(mapFlagName("clientset-path", "output-package", fs.GetNormalizeFunc()))

--- a/staging/src/k8s.io/code-generator/cmd/informer-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/informer-gen/args/args.go
@@ -62,7 +62,7 @@ func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&ca.VersionedClientSetPackage, "versioned-clientset-package", ca.VersionedClientSetPackage, "the full package name for the versioned clientset to use")
 	fs.StringVar(&ca.ListersPackage, "listers-package", ca.ListersPackage, "the full package name for the listers to use")
 	fs.BoolVar(&ca.SingleDirectory, "single-directory", ca.SingleDirectory, "if true, omit the intermediate \"internalversion\" and \"externalversions\" subdirectories")
-	fs.StringArrayVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType format")
+	fs.StringSliceVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType format")
 }
 
 // Validate checks the given arguments.

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/args/args.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/args/args.go
@@ -49,7 +49,7 @@ func NewDefaults() (*args.GeneratorArgs, *CustomArgs) {
 
 // AddFlags add the generator flags to the flag set.
 func (ca *CustomArgs) AddFlags(fs *pflag.FlagSet) {
-	fs.StringArrayVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType format")
+	fs.StringSliceVar(&ca.PluralExceptions, "plural-exceptions", ca.PluralExceptions, "list of comma separated plural exception definitions in Type:PluralizedType format")
 }
 
 // Validate checks the given arguments.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The plural exception list flag for code generator was incorrectly using `StrnigArrayVar` instead of `StringSliceVar` which resulted in that flag to misinterpret its value.

```release-note
NONE
```