### PR TITLE
Use private master IP in GCE kubemark tests

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -40,6 +40,7 @@ function create-kubemark-master {
     export KUBE_TEMP="${KUBE_TEMP}"
 
     export KUBECONFIG="${RESOURCE_DIRECTORY}/kubeconfig.kubemark"
+    export KUBECONFIG_INTERNAL="${RESOURCE_DIRECTORY}/kubeconfig-internal.kubemark"
     export CLUSTER_NAME="${CLUSTER_NAME}-kubemark"
     export KUBE_CREATE_NODES=false
     export KUBE_GCE_INSTANCE_PREFIX="${KUBE_GCE_INSTANCE_PREFIX}-kubemark"
@@ -79,6 +80,33 @@ function create-kubemark-master {
           KUBE_GCE_ZONE="${KUBE_GCE_ZONE}" KUBE_REPLICATE_EXISTING_MASTER=true \
             "${KUBE_ROOT}/hack/e2e-internal/e2e-grow-cluster.sh"
         done
+    fi
+
+    # The e2e-up.sh script is not sourced, so we don't have access to variables that
+    # it sets. Instead, we read data which was written to the KUBE_TEMP directory.
+    # The cluster-location is either ZONE (say us-east1-a) or REGION (say us-east1).
+    # To get REGION from location, only first two parts are matched.
+    REGION=$(grep -o "^[a-z]*-[a-z0-9]*" "${KUBE_TEMP}"/cluster-location.txt)
+    MASTER_NAME="${KUBE_GCE_INSTANCE_PREFIX}"-master
+
+    MASTER_INTERNAL_IP=$(gcloud compute addresses describe "${MASTER_NAME}-internal-ip" \
+        --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')
+    MASTER_IP=$(gcloud compute addresses describe "${MASTER_NAME}-ip" \
+        --project "${PROJECT}" --region "${REGION}" -q --format='value(address)')
+
+    # If cluster uses private master IP, two kubeconfigs are created:
+    # - kubeconfig with public IP, which will be used to connect to the cluster
+    #     from outside of the cluster network
+    # - kubeconfig with private IP (called internal kubeconfig), which will be
+    #      used to create hollow nodes.
+    #
+    # Note that hollow nodes might use either of these kubeconfigs, but
+    # using internal one is better from performance and cost perspective, since
+    # traffic does not need to go through Cloud NAT.
+    if [[ -n "${MASTER_INTERNAL_IP:-}" ]]; then
+      echo "Writing internal kubeconfig to '${KUBECONFIG_INTERNAL}'"
+      ip_regexp=${MASTER_IP//./\\.} # escape ".", so that sed won't treat it as "any char"
+      sed "s/${ip_regexp}/${MASTER_INTERNAL_IP}/g" "${KUBECONFIG}" > "${KUBECONFIG_INTERNAL}"
     fi
     )
 }

--- a/test/kubemark/skeleton/util.sh
+++ b/test/kubemark/skeleton/util.sh
@@ -26,6 +26,10 @@ function authenticate-docker {
 
 # This function should create kubemark master and write kubeconfig to
 # "${RESOURCE_DIRECTORY}/kubeconfig.kubemark".
+# If a cluster uses private master IP, create-kubemark-master might also write
+# a second kubeconfig to "${RESOURCE_DIRECTORY}/kubeconfig-internal.kubemark".
+# The difference between these two kubeconfigs is that the internal one uses
+# private master IP, which might be better suited for setting up hollow nodes.
 function create-kubemark-master {
   echo "Creating cluster..."
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently hollow nodes communicate with kubemark master using public
master IP, which results in each call going through cloud NAT. Cloud NAT
limitations become performance bottleneck (see kubernetes/perf-tests/issues/874).

**Which issue(s) this PR fixes**:
kubernetes/perf-tests/issues/874

**Special notes for your reviewer**:
See commit message for more detailed description.

**Does this PR introduce a user-facing change?**:
NONE

```release-note
NONE
```