### PR TITLE
Make e2e scale updates unconditional

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -787,6 +787,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 			framework.ExpectEqual(scale.Status.Replicas, int32(1))
 
 			ginkgo.By("updating a scale subresource")
+			scale.ResourceVersion = "" // indicate the scale update should be unconditional
 			scale.Spec.Replicas = 2
 			scaleResult, err := c.AppsV1().StatefulSets(ns).UpdateScale(ssName, scale)
 			if err != nil {

--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -680,6 +680,7 @@ func (j *TestJig) Scale(replicas int) error {
 		return fmt.Errorf("failed to get scale for RC %q: %v", rc, err)
 	}
 
+	scale.ResourceVersion = "" // indicate the scale update should be unconditional
 	scale.Spec.Replicas = int32(replicas)
 	_, err = j.Client.CoreV1().ReplicationControllers(j.Namespace).UpdateScale(rc, scale)
 	if err != nil {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -350,6 +350,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				scale, err := f.ClientSet.AppsV1().Deployments(ns).GetScale(name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				if scale.Spec.Replicas != int32(num) {
+					scale.ResourceVersion = "" // indicate the scale update should be unconditional
 					scale.Spec.Replicas = int32(num)
 					_, err = f.ClientSet.AppsV1().Deployments(ns).UpdateScale(name, scale)
 					framework.ExpectNoError(err)
@@ -400,6 +401,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 			ginkgo.By(fmt.Sprintf("Scale backend replicas to %d", replicas))
 			scale, err := f.ClientSet.AppsV1().Deployments(ns).GetScale(name, metav1.GetOptions{})
 			framework.ExpectNoError(err)
+			scale.ResourceVersion = "" // indicate the scale update should be unconditional
 			scale.Spec.Replicas = int32(replicas)
 			_, err = f.ClientSet.AppsV1().Deployments(ns).UpdateScale(name, scale)
 			framework.ExpectNoError(err)
@@ -448,6 +450,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				scale, err := f.ClientSet.AppsV1().Deployments(ns).GetScale(name, metav1.GetOptions{})
 				framework.ExpectNoError(err)
 				if scale.Spec.Replicas != int32(num) {
+					scale.ResourceVersion = "" // indicate the scale update should be unconditional
 					scale.Spec.Replicas = int32(num)
 					_, err = f.ClientSet.AppsV1().Deployments(ns).UpdateScale(name, scale)
 					framework.ExpectNoError(err)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind flake
/area deflake

**What this PR does / why we need it**:
Makes scale subresource updates done during e2e tests unconditional (by clearing resourceVersion). This fixes flakes in tests that are expecting scale requests to succeed unconditionally.

**Which issue(s) this PR fixes**:
```
[sig-apps] StatefulSet [k8s.io] Basic StatefulSet functionality [StatefulSetBasic] should have a working scale subresource [Conformance]
test/e2e/framework/framework.go:685 Dec 16 19:31:30.252: Failed to put scale subresource: Operation cannot be fulfilled on statefulsets.apps "ss": the object has been modified; please apply your changes to the latest version and try again test/e2e/apps/statefulset.go:793
```

Seen at https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/86315/pull-kubernetes-e2e-gce/1206654179796324355/

```release-note
NONE
```