### PR TITLE
[v1.17.1] cherry pick of #86277: Check FileInfo against nil during walk of container dir path

### DIFF
--- a/pkg/volume/util/subpath/subpath_linux.go
+++ b/pkg/volume/util/subpath/subpath_linux.go
@@ -240,7 +240,8 @@ func doCleanSubPaths(mounter mount.Interface, podDir string, volumeName string) 
 				return err
 			}
 
-			if info.IsDir() {
+			// We need to check that info is not nil. This may happen when the incoming err is not nil due to stale mounts or permission errors.
+			if info != nil && info.IsDir() {
 				// skip subdirs of the volume: it only matters the first level to unmount, otherwise it would try to unmount subdir of the volume
 				return filepath.SkipDir
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When checking kubelet log under https://gcsweb.k8s.io/gcs/kubernetes-jenkins/pr-logs/pull/86271/pull-kubernetes-e2e-gce/1205989922050150403/artifacts/e2e-41a80d25d0-674b9-minion-group-vrmw/ , I saw the following:
```
I1214 23:54:03.413009    1331 operation_generator.go:713] UnmountVolume.TearDown succeeded for volume "kubernetes.io/secret/7525fe3b-e6fa-4d02-87df-2a08ff0c9f50-default-token-rssv4" (OuterVolumeSpecName: "default-token-rssv4") pod "7525fe3b-e6fa-4d02-87df-2a08ff0c9f50" (UID: "7525fe3b-e6fa-4d02-87df-2a08ff0c9f50"). InnerVolumeSpecName "default-token-rssv4". PluginName "kubernetes.io/secret", VolumeGidValue ""
E1214 23:54:03.413115    1331 nestedpendingoperations.go:270] Operation for "\"kubernetes.io/nfs/8e4f2439-71a4-4102-a049-ba0bb42378ce-pvc-e2e1b57c-fdc0-46d9-a47d-d7ca4555e1c7\" (\"8e4f2439-71a4-4102-a049-ba0bb42378ce\")" failed. No retries permitted until 2019-12-14 23:54:03.912383421 +0000 UTC m=+1573.953851145 (durationBeforeRetry 500ms). Error: "recovered from panic \"runtime error: invalid memory address or nil pointer dereference\". (err=<nil>) Call stack:
goroutine 118595 [running]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.RecoverFromPanic(0xc002b0c310)
\tstaging/src/k8s.io/apimachinery/pkg/util/runtime/runtime.go:158 +0xb5
panic(0x3a2ad60, 0x6d31df0)
\tGOROOT/src/runtime/panic.go:679 +0x1b2
k8s.io/kubernetes/pkg/volume/util/subpath.doCleanSubPaths.func1(0xc002930f00, 0x9f, 0x0, 0x0, 0x497d8a0, 0xc000b34150, 0x0, 0x0)
\tpkg/volume/util/subpath/subpath_linux.go:243 +0xbd
path/filepath.walk(0xc002930be0, 0x9d, 0x4a37a00, 0xc001f2a270, 0xc000ab3ba8, 0x0, 0x9d)
\tGOROOT/src/path/filepath/path.go:378 +0x20c
```
This PR adds check against nil before dereferencing FileInfo

This is cherry pick of #86277

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
