### PR TITLE
Split cronjob tests, so they don't interfere

### DIFF
--- a/test/e2e/apps/cronjob.go
+++ b/test/e2e/apps/cronjob.go
@@ -229,71 +229,70 @@ var _ = SIGDescribe("CronJob", func() {
 		framework.ExpectNoError(err, "Failed to remove %s cronjob in namespace %s", cronJob.Name, f.Namespace.Name)
 	})
 
-	// cleanup of successful/failed finished jobs, with successfulJobsHistoryLimit and failedJobsHistoryLimit
-	ginkgo.It("should delete successful/failed finished jobs with limit of one job [Flaky]", func() {
+	// cleanup of successful finished jobs, with limit of one successful job
+	ginkgo.It("should delete successful finished jobs with limit of one successful job", func() {
+		ginkgo.By("Creating an AllowConcurrent cronjob with custom history limit")
+		successLimit := int32(1)
+		failedLimit := int32(0)
+		cronJob := newTestCronJob("successful-jobs-history-limit", "*/1 * * * ?", batchv1beta1.AllowConcurrent,
+			successCommand, &successLimit, &failedLimit)
 
-		testCases := []struct {
-			description  string
-			command      []string
-			successLimit int32
-			failedLimit  int32
-		}{
-			{
-				description:  "successful-jobs-history-limit",
-				command:      successCommand,
-				successLimit: 1, // keep one successful job
-				failedLimit:  0, // keep none failed job
-			},
-			{
-				description:  "failed-jobs-history-limit",
-				command:      failureCommand,
-				successLimit: 0, // keep none succcessful job
-				failedLimit:  1, // keep one failed job
-			},
-		}
-
-		for _, t := range testCases {
-			ginkgo.By(fmt.Sprintf("Creating a AllowConcurrent cronjob with custom %s", t.description))
-			cronJob := newTestCronJob(t.description, "*/1 * * * ?", batchv1beta1.AllowConcurrent,
-				t.command, &t.successLimit, &t.failedLimit)
-			cronJob, err := createCronJob(f.ClientSet, f.Namespace.Name, cronJob)
-			framework.ExpectNoError(err, "Failed to create allowconcurrent cronjob with custom history limits in namespace %s", f.Namespace.Name)
-
-			// Job is going to complete instantly: do not check for an active job
-			// as we are most likely to miss it
-
-			ginkgo.By("Ensuring a finished job exists")
-			err = waitForAnyFinishedJob(f.ClientSet, f.Namespace.Name)
-			framework.ExpectNoError(err, "Failed to ensure a finished cronjob exists in namespace %s", f.Namespace.Name)
-
-			ginkgo.By("Ensuring a finished job exists by listing jobs explicitly")
-			jobs, err := f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(metav1.ListOptions{})
-			framework.ExpectNoError(err, "Failed to ensure a finished cronjob exists by listing jobs explicitly in namespace %s", f.Namespace.Name)
-			activeJobs, finishedJobs := filterActiveJobs(jobs)
-			if len(finishedJobs) != 1 {
-				framework.Logf("Expected one finished job in namespace %s; activeJobs=%v; finishedJobs=%v", f.Namespace.Name, activeJobs, finishedJobs)
-				framework.ExpectEqual(len(finishedJobs), 1)
-			}
-
-			// Job should get deleted when the next job finishes the next minute
-			ginkgo.By("Ensuring this job and its pods does not exist anymore")
-			err = waitForJobToDisappear(f.ClientSet, f.Namespace.Name, finishedJobs[0])
-			framework.ExpectNoError(err, "Failed to ensure that job does not exists anymore in namespace %s", f.Namespace.Name)
-			err = waitForJobsPodToDisappear(f.ClientSet, f.Namespace.Name, finishedJobs[0])
-			framework.ExpectNoError(err, "Failed to ensure that pods for job does not exists anymore in namespace %s", f.Namespace.Name)
-
-			ginkgo.By("Ensuring there is 1 finished job by listing jobs explicitly")
-			jobs, err = f.ClientSet.BatchV1().Jobs(f.Namespace.Name).List(metav1.ListOptions{})
-			framework.ExpectNoError(err, "Failed to ensure there is one finished job by listing job explicitly in namespace %s", f.Namespace.Name)
-			_, finishedJobs = filterActiveJobs(jobs)
-			framework.ExpectEqual(len(finishedJobs), 1)
-
-			ginkgo.By("Removing cronjob")
-			err = deleteCronJob(f.ClientSet, f.Namespace.Name, cronJob.Name)
-			framework.ExpectNoError(err, "Failed to remove the %s cronjob in namespace %s", cronJob.Name, f.Namespace.Name)
-		}
+		ensureHistoryLimits(f.ClientSet, f.Namespace.Name, cronJob)
 	})
+
+	// cleanup of failed finished jobs, with limit of one failed job
+	ginkgo.It("should delete failed finished jobs with limit of one job", func() {
+		ginkgo.By("Creating an AllowConcurrent cronjob with custom history limit")
+		successLimit := int32(0)
+		failedLimit := int32(1)
+		cronJob := newTestCronJob("failed-jobs-history-limit", "*/1 * * * ?", batchv1beta1.AllowConcurrent,
+			failureCommand, &successLimit, &failedLimit)
+
+		ensureHistoryLimits(f.ClientSet, f.Namespace.Name, cronJob)
+	})
+
 })
+
+func ensureHistoryLimits(c clientset.Interface, ns string, cronJob *batchv1beta1.CronJob) {
+	cronJob, err := createCronJob(c, ns, cronJob)
+	framework.ExpectNoError(err, "Failed to create allowconcurrent cronjob with custom history limits in namespace %s", ns)
+
+	// Job is going to complete instantly: do not check for an active job
+	// as we are most likely to miss it
+
+	ginkgo.By("Ensuring a finished job exists")
+	err = waitForAnyFinishedJob(c, ns)
+	framework.ExpectNoError(err, "Failed to ensure a finished cronjob exists in namespace %s", ns)
+
+	ginkgo.By("Ensuring a finished job exists by listing jobs explicitly")
+	jobs, err := c.BatchV1().Jobs(ns).List(metav1.ListOptions{})
+	framework.ExpectNoError(err, "Failed to ensure a finished cronjob exists by listing jobs explicitly in namespace %s", ns)
+	activeJobs, finishedJobs := filterActiveJobs(jobs)
+	if len(finishedJobs) != 1 {
+		framework.Logf("Expected one finished job in namespace %s; activeJobs=%v; finishedJobs=%v", ns, activeJobs, finishedJobs)
+		framework.ExpectEqual(len(finishedJobs), 1)
+	}
+
+	// Job should get deleted when the next job finishes the next minute
+	ginkgo.By("Ensuring this job and its pods does not exist anymore")
+	err = waitForJobToDisappear(c, ns, finishedJobs[0])
+	framework.ExpectNoError(err, "Failed to ensure that job does not exists anymore in namespace %s", ns)
+	err = waitForJobsPodToDisappear(c, ns, finishedJobs[0])
+	framework.ExpectNoError(err, "Failed to ensure that pods for job does not exists anymore in namespace %s", ns)
+
+	ginkgo.By("Ensuring there is 1 finished job by listing jobs explicitly")
+	jobs, err = c.BatchV1().Jobs(ns).List(metav1.ListOptions{})
+	framework.ExpectNoError(err, "Failed to ensure there is one finished job by listing job explicitly in namespace %s", ns)
+	activeJobs, finishedJobs = filterActiveJobs(jobs)
+	if len(finishedJobs) != 1 {
+		framework.Logf("Expected one finished job in namespace %s; activeJobs=%v; finishedJobs=%v", ns, activeJobs, finishedJobs)
+		framework.ExpectEqual(len(finishedJobs), 1)
+	}
+
+	ginkgo.By("Removing cronjob")
+	err = deleteCronJob(c, ns, cronJob.Name)
+	framework.ExpectNoError(err, "Failed to remove the %s cronjob in namespace %s", cronJob.Name, ns)
+}
 
 // newTestCronJob returns a cronjob which does one of several testing behaviors.
 func newTestCronJob(name, schedule string, concurrencyPolicy batchv1beta1.ConcurrencyPolicy,


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:

**Problem**
https://github.com/kubernetes/kubernetes/pull/78245 added a new test for `failedJobsHistoryLimit` parameter, but instead of creating a new test it changed pre-existing test to use a loop. This caused the flake from #86179, because the 2nd iteration of that loop might (about 20% of time) stumbled on artifacts from the previous loop. The reason for that is that during execution this test waits for any job in a given namespace. 

**Solution**
There are two possible fixes here:
1. Add a wait at the end of the loop to ensure nothing exists after a cronjob is removed, but that will extend the time needed to run this test.
2. Split it to two separate tests (using a common method for the shared code path), which will ensure the artifacts from one run do not affect the other one. Another benefit of that is we can parallelize execution. This is the approach taken in this PR.

**Which issue(s) this PR fixes**:
Fixes #86179

**Special notes for your reviewer**:
/assign @liggitt @tnozicka 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
