### PR TITLE
kubectl apply refactor

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
@@ -7,6 +7,7 @@ go_library(
         "apply_edit_last_applied.go",
         "apply_set_last_applied.go",
         "apply_view_last_applied.go",
+        "patcher.go",
         "prune.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/apply",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
@@ -7,6 +7,7 @@ go_library(
         "apply_edit_last_applied.go",
         "apply_set_last_applied.go",
         "apply_view_last_applied.go",
+        "prune.go",
     ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/kubectl/pkg/cmd/apply",
     importpath = "k8s.io/kubectl/pkg/cmd/apply",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"time"
 
 	"github.com/jonboulle/clockwork"
@@ -282,6 +281,13 @@ func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 		return err
 	}
 
+	if o.Prune {
+		o.PruneResources, err = parsePruneResources(o.Mapper, o.PruneWhitelist)
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
@@ -300,37 +306,6 @@ func validatePruneAll(prune, all bool, selector string) error {
 		return fmt.Errorf("all resources selected for prune without explicitly passing --all. To prune all resources, pass the --all flag. If you did not mean to prune all resources, specify a label selector")
 	}
 	return nil
-}
-
-func parsePruneResources(mapper meta.RESTMapper, gvks []string) ([]pruneResource, error) {
-	pruneResources := []pruneResource{}
-	for _, groupVersionKind := range gvks {
-		gvk := strings.Split(groupVersionKind, "/")
-		if len(gvk) != 3 {
-			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
-		}
-
-		if gvk[0] == "core" {
-			gvk[0] = ""
-		}
-		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
-		if err != nil {
-			return pruneResources, err
-		}
-		var namespaced bool
-		namespaceScope := mapping.Scope.Name()
-		switch namespaceScope {
-		case meta.RESTScopeNameNamespace:
-			namespaced = true
-		case meta.RESTScopeNameRoot:
-			namespaced = false
-		default:
-			return pruneResources, fmt.Errorf("Unknown namespace scope: %q", namespaceScope)
-		}
-
-		pruneResources = append(pruneResources, pruneResource{gvk[0], gvk[1], gvk[2], namespaced})
-	}
-	return pruneResources, nil
 }
 
 func isIncompatibleServerError(err error) bool {
@@ -385,14 +360,6 @@ func (o *ApplyOptions) Run() error {
 	dryRunVerifier := &DryRunVerifier{
 		Finder:        cmdutil.NewCRDFinder(cmdutil.CRDFromDynamic(o.DynamicClient)),
 		OpenAPIGetter: o.DiscoveryClient,
-	}
-
-	var err error
-	if o.Prune {
-		o.PruneResources, err = parsePruneResources(o.Mapper, o.PruneWhitelist)
-		if err != nil {
-			return err
-		}
 	}
 
 	visitedUids := sets.NewString()
@@ -606,46 +573,9 @@ See http://k8s.io/docs/reference/using-api/api-concepts/#conflicts`, err)
 		return err
 	}
 
-	if !o.Prune {
-		return nil
-	}
-
-	p := pruner{
-		mapper:        o.Mapper,
-		dynamicClient: o.DynamicClient,
-
-		labelSelector: o.Selector,
-		visitedUids:   visitedUids,
-
-		cascade:      o.DeleteOptions.Cascade,
-		dryRun:       o.DryRun,
-		serverDryRun: o.ServerDryRun,
-		gracePeriod:  o.DeleteOptions.GracePeriod,
-
-		toPrinter: o.ToPrinter,
-
-		out: o.Out,
-	}
-
-	namespacedRESTMappings, nonNamespacedRESTMappings, err := getRESTMappings(o.Mapper, &(o.PruneResources))
-	if err != nil {
-		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
-	}
-
-	for n := range visitedNamespaces {
-		if len(o.Namespace) != 0 && n != o.Namespace {
-			continue
-		}
-		for _, m := range namespacedRESTMappings {
-			if err := p.prune(n, m); err != nil {
-				return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)
-			}
-		}
-	}
-	for _, m := range nonNamespacedRESTMappings {
-		if err := p.prune(metav1.NamespaceNone, m); err != nil {
-			return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
-		}
+	if o.Prune {
+		p := newPruner(o, visitedUids, visitedNamespaces)
+		return p.pruneAll(o)
 	}
 
 	return nil
@@ -704,140 +634,6 @@ func (o *ApplyOptions) printObjects() error {
 	}
 
 	return nil
-}
-
-type pruneResource struct {
-	group      string
-	version    string
-	kind       string
-	namespaced bool
-}
-
-func (pr pruneResource) String() string {
-	return fmt.Sprintf("%v/%v, Kind=%v, Namespaced=%v", pr.group, pr.version, pr.kind, pr.namespaced)
-}
-
-func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
-	if len(*pruneResources) == 0 {
-		// default whitelist
-		// TODO: need to handle the older api versions - e.g. v1beta1 jobs. Github issue: #35991
-		*pruneResources = []pruneResource{
-			{"", "v1", "ConfigMap", true},
-			{"", "v1", "Endpoints", true},
-			{"", "v1", "Namespace", false},
-			{"", "v1", "PersistentVolumeClaim", true},
-			{"", "v1", "PersistentVolume", false},
-			{"", "v1", "Pod", true},
-			{"", "v1", "ReplicationController", true},
-			{"", "v1", "Secret", true},
-			{"", "v1", "Service", true},
-			{"batch", "v1", "Job", true},
-			{"batch", "v1beta1", "CronJob", true},
-			{"extensions", "v1beta1", "Ingress", true},
-			{"apps", "v1", "DaemonSet", true},
-			{"apps", "v1", "Deployment", true},
-			{"apps", "v1", "ReplicaSet", true},
-			{"apps", "v1", "StatefulSet", true},
-		}
-	}
-
-	for _, resource := range *pruneResources {
-		addedMapping, err := mapper.RESTMapping(schema.GroupKind{Group: resource.group, Kind: resource.kind}, resource.version)
-		if err != nil {
-			return nil, nil, fmt.Errorf("invalid resource %v: %v", resource, err)
-		}
-		if resource.namespaced {
-			namespaced = append(namespaced, addedMapping)
-		} else {
-			nonNamespaced = append(nonNamespaced, addedMapping)
-		}
-	}
-
-	return namespaced, nonNamespaced, nil
-}
-
-type pruner struct {
-	mapper        meta.RESTMapper
-	dynamicClient dynamic.Interface
-
-	visitedUids   sets.String
-	labelSelector string
-	fieldSelector string
-
-	cascade      bool
-	serverDryRun bool
-	dryRun       bool
-	gracePeriod  int
-
-	toPrinter func(string) (printers.ResourcePrinter, error)
-
-	out io.Writer
-}
-
-func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
-	objList, err := p.dynamicClient.Resource(mapping.Resource).
-		Namespace(namespace).
-		List(metav1.ListOptions{
-			LabelSelector: p.labelSelector,
-			FieldSelector: p.fieldSelector,
-		})
-	if err != nil {
-		return err
-	}
-
-	objs, err := meta.ExtractList(objList)
-	if err != nil {
-		return err
-	}
-
-	for _, obj := range objs {
-		metadata, err := meta.Accessor(obj)
-		if err != nil {
-			return err
-		}
-		annots := metadata.GetAnnotations()
-		if _, ok := annots[corev1.LastAppliedConfigAnnotation]; !ok {
-			// don't prune resources not created with apply
-			continue
-		}
-		uid := metadata.GetUID()
-		if p.visitedUids.Has(string(uid)) {
-			continue
-		}
-		name := metadata.GetName()
-		if !p.dryRun {
-			if err := p.delete(namespace, name, mapping); err != nil {
-				return err
-			}
-		}
-
-		printer, err := p.toPrinter("pruned")
-		if err != nil {
-			return err
-		}
-		printer.PrintObj(obj, p.out)
-	}
-	return nil
-}
-
-func (p *pruner) delete(namespace, name string, mapping *meta.RESTMapping) error {
-	return runDelete(namespace, name, mapping, p.dynamicClient, p.cascade, p.gracePeriod, p.serverDryRun)
-}
-
-func runDelete(namespace, name string, mapping *meta.RESTMapping, c dynamic.Interface, cascade bool, gracePeriod int, serverDryRun bool) error {
-	options := &metav1.DeleteOptions{}
-	if gracePeriod >= 0 {
-		options = metav1.NewDeleteOptions(int64(gracePeriod))
-	}
-	if serverDryRun {
-		options.DryRun = []string{metav1.DryRunAll}
-	}
-	policy := metav1.DeletePropagationForeground
-	if !cascade {
-		policy = metav1.DeletePropagationOrphan
-	}
-	options.PropagationPolicy = &policy
-	return c.Resource(mapping.Resource).Namespace(namespace).Delete(name, options)
 }
 
 func (p *Patcher) delete(namespace, name string) error {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/jsonmergepatch"
+	"k8s.io/apimachinery/pkg/util/mergepatch"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
+	oapi "k8s.io/kube-openapi/pkg/util/proto"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/scheme"
+	"k8s.io/kubectl/pkg/util"
+	"k8s.io/kubectl/pkg/util/openapi"
+)
+
+const (
+	// maxPatchRetry is the maximum number of conflicts retry for during a patch operation before returning failure
+	maxPatchRetry = 5
+	// backOffPeriod is the period to back off when apply patch results in error.
+	backOffPeriod = 1 * time.Second
+	// how many times we can retry before back off
+	triesBeforeBackOff = 1
+)
+
+// Patcher defines options to patch OpenAPI objects.
+type Patcher struct {
+	Mapping       *meta.RESTMapping
+	Helper        *resource.Helper
+	DynamicClient dynamic.Interface
+
+	Overwrite bool
+	BackOff   clockwork.Clock
+
+	Force        bool
+	Cascade      bool
+	Timeout      time.Duration
+	GracePeriod  int
+	ServerDryRun bool
+
+	// If set, forces the patch against a specific resourceVersion
+	ResourceVersion *string
+
+	// Number of retries to make if the patch fails with conflict
+	Retries int
+
+	OpenapiSchema openapi.Resources
+}
+
+func newPatcher(o *ApplyOptions, info *resource.Info) *Patcher {
+	var openapiSchema openapi.Resources
+	if o.OpenAPIPatch {
+		openapiSchema = o.OpenAPISchema
+	}
+
+	helper := resource.NewHelper(info.Client, info.Mapping)
+	return &Patcher{
+		Mapping:       info.Mapping,
+		Helper:        helper,
+		DynamicClient: o.DynamicClient,
+		Overwrite:     o.Overwrite,
+		BackOff:       clockwork.NewRealClock(),
+		Force:         o.DeleteOptions.ForceDeletion,
+		Cascade:       o.DeleteOptions.Cascade,
+		Timeout:       o.DeleteOptions.Timeout,
+		GracePeriod:   o.DeleteOptions.GracePeriod,
+		ServerDryRun:  o.ServerDryRun,
+		OpenapiSchema: openapiSchema,
+		Retries:       maxPatchRetry,
+	}
+}
+
+func (p *Patcher) delete(namespace, name string) error {
+	return runDelete(namespace, name, p.Mapping, p.DynamicClient, p.Cascade, p.GracePeriod, p.ServerDryRun)
+}
+
+func (p *Patcher) patchSimple(obj runtime.Object, modified []byte, source, namespace, name string, errOut io.Writer) ([]byte, runtime.Object, error) {
+	// Serialize the current configuration of the object from the server.
+	current, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
+	if err != nil {
+		return nil, nil, cmdutil.AddSourceToErr(fmt.Sprintf("serializing current configuration from:\n%v\nfor:", obj), source, err)
+	}
+
+	// Retrieve the original configuration of the object from the annotation.
+	original, err := util.GetOriginalConfiguration(obj)
+	if err != nil {
+		return nil, nil, cmdutil.AddSourceToErr(fmt.Sprintf("retrieving original configuration from:\n%v\nfor:", obj), source, err)
+	}
+
+	var patchType types.PatchType
+	var patch []byte
+	var lookupPatchMeta strategicpatch.LookupPatchMeta
+	var schema oapi.Schema
+	createPatchErrFormat := "creating patch with:\noriginal:\n%s\nmodified:\n%s\ncurrent:\n%s\nfor:"
+
+	// Create the versioned struct from the type defined in the restmapping
+	// (which is the API version we'll be submitting the patch to)
+	versionedObject, err := scheme.Scheme.New(p.Mapping.GroupVersionKind)
+	switch {
+	case runtime.IsNotRegisteredError(err):
+		// fall back to generic JSON merge patch
+		patchType = types.MergePatchType
+		preconditions := []mergepatch.PreconditionFunc{mergepatch.RequireKeyUnchanged("apiVersion"),
+			mergepatch.RequireKeyUnchanged("kind"), mergepatch.RequireMetadataKeyUnchanged("name")}
+		patch, err = jsonmergepatch.CreateThreeWayJSONMergePatch(original, modified, current, preconditions...)
+		if err != nil {
+			if mergepatch.IsPreconditionFailed(err) {
+				return nil, nil, fmt.Errorf("%s", "At least one of apiVersion, kind and name was changed")
+			}
+			return nil, nil, cmdutil.AddSourceToErr(fmt.Sprintf(createPatchErrFormat, original, modified, current), source, err)
+		}
+	case err != nil:
+		return nil, nil, cmdutil.AddSourceToErr(fmt.Sprintf("getting instance of versioned object for %v:", p.Mapping.GroupVersionKind), source, err)
+	case err == nil:
+		// Compute a three way strategic merge patch to send to server.
+		patchType = types.StrategicMergePatchType
+
+		// Try to use openapi first if the openapi spec is available and can successfully calculate the patch.
+		// Otherwise, fall back to baked-in types.
+		if p.OpenapiSchema != nil {
+			if schema = p.OpenapiSchema.LookupResource(p.Mapping.GroupVersionKind); schema != nil {
+				lookupPatchMeta = strategicpatch.PatchMetaFromOpenAPI{Schema: schema}
+				if openapiPatch, err := strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, p.Overwrite); err != nil {
+					fmt.Fprintf(errOut, "warning: error calculating patch from openapi spec: %v\n", err)
+				} else {
+					patchType = types.StrategicMergePatchType
+					patch = openapiPatch
+				}
+			}
+		}
+
+		if patch == nil {
+			lookupPatchMeta, err = strategicpatch.NewPatchMetaFromStruct(versionedObject)
+			if err != nil {
+				return nil, nil, cmdutil.AddSourceToErr(fmt.Sprintf(createPatchErrFormat, original, modified, current), source, err)
+			}
+			patch, err = strategicpatch.CreateThreeWayMergePatch(original, modified, current, lookupPatchMeta, p.Overwrite)
+			if err != nil {
+				return nil, nil, cmdutil.AddSourceToErr(fmt.Sprintf(createPatchErrFormat, original, modified, current), source, err)
+			}
+		}
+	}
+
+	if string(patch) == "{}" {
+		return patch, obj, nil
+	}
+
+	if p.ResourceVersion != nil {
+		patch, err = addResourceVersion(patch, *p.ResourceVersion)
+		if err != nil {
+			return nil, nil, cmdutil.AddSourceToErr("Failed to insert resourceVersion in patch", source, err)
+		}
+	}
+
+	options := metav1.PatchOptions{}
+	if p.ServerDryRun {
+		options.DryRun = []string{metav1.DryRunAll}
+	}
+
+	patchedObj, err := p.Helper.Patch(namespace, name, patchType, patch, &options)
+	return patch, patchedObj, err
+}
+
+// Patch tries to patch an OpenAPI resource. On success, returns the merge patch as well
+// the final patched object. On failure, returns an error.
+func (p *Patcher) Patch(current runtime.Object, modified []byte, source, namespace, name string, errOut io.Writer) ([]byte, runtime.Object, error) {
+	var getErr error
+	patchBytes, patchObject, err := p.patchSimple(current, modified, source, namespace, name, errOut)
+	if p.Retries == 0 {
+		p.Retries = maxPatchRetry
+	}
+	for i := 1; i <= p.Retries && errors.IsConflict(err); i++ {
+		if i > triesBeforeBackOff {
+			p.BackOff.Sleep(backOffPeriod)
+		}
+		current, getErr = p.Helper.Get(namespace, name, false)
+		if getErr != nil {
+			return nil, nil, getErr
+		}
+		patchBytes, patchObject, err = p.patchSimple(current, modified, source, namespace, name, errOut)
+	}
+	if err != nil && (errors.IsConflict(err) || errors.IsInvalid(err)) && p.Force {
+		patchBytes, patchObject, err = p.deleteAndCreate(current, modified, namespace, name)
+	}
+	return patchBytes, patchObject, err
+}
+
+func (p *Patcher) deleteAndCreate(original runtime.Object, modified []byte, namespace, name string) ([]byte, runtime.Object, error) {
+	if err := p.delete(namespace, name); err != nil {
+		return modified, nil, err
+	}
+	// TODO: use wait
+	if err := wait.PollImmediate(1*time.Second, p.Timeout, func() (bool, error) {
+		if _, err := p.Helper.Get(namespace, name, false); !errors.IsNotFound(err) {
+			return false, err
+		}
+		return true, nil
+	}); err != nil {
+		return modified, nil, err
+	}
+	versionedObject, _, err := unstructured.UnstructuredJSONScheme.Decode(modified, nil, nil)
+	if err != nil {
+		return modified, nil, err
+	}
+	options := metav1.CreateOptions{}
+	if p.ServerDryRun {
+		options.DryRun = []string{metav1.DryRunAll}
+	}
+	createdObject, err := p.Helper.Create(namespace, true, versionedObject, &options)
+	if err != nil {
+		// restore the original object if we fail to create the new one
+		// but still propagate and advertise error to user
+		recreated, recreateErr := p.Helper.Create(namespace, true, original, &options)
+		if recreateErr != nil {
+			err = fmt.Errorf("An error occurred force-replacing the existing object with the newly provided one:\n\n%v.\n\nAdditionally, an error occurred attempting to restore the original object:\n\n%v", err, recreateErr)
+		} else {
+			createdObject = recreated
+		}
+	}
+	return modified, createdObject, err
+}
+
+func addResourceVersion(patch []byte, rv string) ([]byte, error) {
+	var patchMap map[string]interface{}
+	err := json.Unmarshal(patch, &patchMap)
+	if err != nil {
+		return nil, err
+	}
+	u := unstructured.Unstructured{Object: patchMap}
+	a, err := meta.Accessor(&u)
+	if err != nil {
+		return nil, err
+	}
+	a.SetResourceVersion(rv)
+
+	return json.Marshal(patchMap)
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -49,14 +49,14 @@ type pruner struct {
 	out io.Writer
 }
 
-func newPruner(o *ApplyOptions, visitedUids sets.String, visitedNamespaces sets.String) pruner {
+func newPruner(o *ApplyOptions) pruner {
 	return pruner{
 		mapper:        o.Mapper,
 		dynamicClient: o.DynamicClient,
 
 		labelSelector:     o.Selector,
-		visitedUids:       visitedUids,
-		visitedNamespaces: visitedNamespaces,
+		visitedUids:       o.VisitedUids,
+		visitedNamespaces: o.VisitedNamespaces,
 
 		cascade:      o.DeleteOptions.Cascade,
 		dryRun:       o.DryRun,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apply
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/dynamic"
+)
+
+type pruner struct {
+	mapper        meta.RESTMapper
+	dynamicClient dynamic.Interface
+
+	visitedUids       sets.String
+	visitedNamespaces sets.String
+	labelSelector     string
+	fieldSelector     string
+
+	cascade      bool
+	serverDryRun bool
+	dryRun       bool
+	gracePeriod  int
+
+	toPrinter func(string) (printers.ResourcePrinter, error)
+
+	out io.Writer
+}
+
+func newPruner(o *ApplyOptions, visitedUids sets.String, visitedNamespaces sets.String) pruner {
+	return pruner{
+		mapper:        o.Mapper,
+		dynamicClient: o.DynamicClient,
+
+		labelSelector:     o.Selector,
+		visitedUids:       visitedUids,
+		visitedNamespaces: visitedNamespaces,
+
+		cascade:      o.DeleteOptions.Cascade,
+		dryRun:       o.DryRun,
+		serverDryRun: o.ServerDryRun,
+		gracePeriod:  o.DeleteOptions.GracePeriod,
+
+		toPrinter: o.ToPrinter,
+
+		out: o.Out,
+	}
+}
+
+func (p *pruner) pruneAll(o *ApplyOptions) error {
+
+	namespacedRESTMappings, nonNamespacedRESTMappings, err := getRESTMappings(o.Mapper, &(o.PruneResources))
+	if err != nil {
+		return fmt.Errorf("error retrieving RESTMappings to prune: %v", err)
+	}
+
+	for n := range p.visitedNamespaces {
+		if len(o.Namespace) != 0 && n != o.Namespace {
+			continue
+		}
+		for _, m := range namespacedRESTMappings {
+			if err := p.prune(n, m); err != nil {
+				return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)
+			}
+		}
+	}
+	for _, m := range nonNamespacedRESTMappings {
+		if err := p.prune(metav1.NamespaceNone, m); err != nil {
+			return fmt.Errorf("error pruning nonNamespaced object %v: %v", m.GroupVersionKind, err)
+		}
+	}
+
+	return nil
+}
+
+func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
+	objList, err := p.dynamicClient.Resource(mapping.Resource).
+		Namespace(namespace).
+		List(metav1.ListOptions{
+			LabelSelector: p.labelSelector,
+			FieldSelector: p.fieldSelector,
+		})
+	if err != nil {
+		return err
+	}
+
+	objs, err := meta.ExtractList(objList)
+	if err != nil {
+		return err
+	}
+
+	for _, obj := range objs {
+		metadata, err := meta.Accessor(obj)
+		if err != nil {
+			return err
+		}
+		annots := metadata.GetAnnotations()
+		if _, ok := annots[corev1.LastAppliedConfigAnnotation]; !ok {
+			// don't prune resources not created with apply
+			continue
+		}
+		uid := metadata.GetUID()
+		if p.visitedUids.Has(string(uid)) {
+			continue
+		}
+		name := metadata.GetName()
+		if !p.dryRun {
+			if err := p.delete(namespace, name, mapping); err != nil {
+				return err
+			}
+		}
+
+		printer, err := p.toPrinter("pruned")
+		if err != nil {
+			return err
+		}
+		printer.PrintObj(obj, p.out)
+	}
+	return nil
+}
+
+func (p *pruner) delete(namespace, name string, mapping *meta.RESTMapping) error {
+	return runDelete(namespace, name, mapping, p.dynamicClient, p.cascade, p.gracePeriod, p.serverDryRun)
+}
+
+func runDelete(namespace, name string, mapping *meta.RESTMapping, c dynamic.Interface, cascade bool, gracePeriod int, serverDryRun bool) error {
+	options := &metav1.DeleteOptions{}
+	if gracePeriod >= 0 {
+		options = metav1.NewDeleteOptions(int64(gracePeriod))
+	}
+	if serverDryRun {
+		options.DryRun = []string{metav1.DryRunAll}
+	}
+	policy := metav1.DeletePropagationForeground
+	if !cascade {
+		policy = metav1.DeletePropagationOrphan
+	}
+	options.PropagationPolicy = &policy
+	return c.Resource(mapping.Resource).Namespace(namespace).Delete(name, options)
+}
+
+type pruneResource struct {
+	group      string
+	version    string
+	kind       string
+	namespaced bool
+}
+
+func (pr pruneResource) String() string {
+	return fmt.Sprintf("%v/%v, Kind=%v, Namespaced=%v", pr.group, pr.version, pr.kind, pr.namespaced)
+}
+
+func getRESTMappings(mapper meta.RESTMapper, pruneResources *[]pruneResource) (namespaced, nonNamespaced []*meta.RESTMapping, err error) {
+	if len(*pruneResources) == 0 {
+		// default whitelist
+		// TODO: need to handle the older api versions - e.g. v1beta1 jobs. Github issue: #35991
+		*pruneResources = []pruneResource{
+			{"", "v1", "ConfigMap", true},
+			{"", "v1", "Endpoints", true},
+			{"", "v1", "Namespace", false},
+			{"", "v1", "PersistentVolumeClaim", true},
+			{"", "v1", "PersistentVolume", false},
+			{"", "v1", "Pod", true},
+			{"", "v1", "ReplicationController", true},
+			{"", "v1", "Secret", true},
+			{"", "v1", "Service", true},
+			{"batch", "v1", "Job", true},
+			{"batch", "v1beta1", "CronJob", true},
+			{"extensions", "v1beta1", "Ingress", true},
+			{"apps", "v1", "DaemonSet", true},
+			{"apps", "v1", "Deployment", true},
+			{"apps", "v1", "ReplicaSet", true},
+			{"apps", "v1", "StatefulSet", true},
+		}
+	}
+
+	for _, resource := range *pruneResources {
+		addedMapping, err := mapper.RESTMapping(schema.GroupKind{Group: resource.group, Kind: resource.kind}, resource.version)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid resource %v: %v", resource, err)
+		}
+		if resource.namespaced {
+			namespaced = append(namespaced, addedMapping)
+		} else {
+			nonNamespaced = append(nonNamespaced, addedMapping)
+		}
+	}
+
+	return namespaced, nonNamespaced, nil
+}
+
+func parsePruneResources(mapper meta.RESTMapper, gvks []string) ([]pruneResource, error) {
+	pruneResources := []pruneResource{}
+	for _, groupVersionKind := range gvks {
+		gvk := strings.Split(groupVersionKind, "/")
+		if len(gvk) != 3 {
+			return nil, fmt.Errorf("invalid GroupVersionKind format: %v, please follow <group/version/kind>", groupVersionKind)
+		}
+
+		if gvk[0] == "core" {
+			gvk[0] = ""
+		}
+		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gvk[0], Kind: gvk[2]}, gvk[1])
+		if err != nil {
+			return pruneResources, err
+		}
+		var namespaced bool
+		namespaceScope := mapping.Scope.Name()
+		switch namespaceScope {
+		case meta.RESTScopeNameNamespace:
+			namespaced = true
+		case meta.RESTScopeNameRoot:
+			namespaced = false
+		default:
+			return pruneResources, fmt.Errorf("Unknown namespace scope: %q", namespaceScope)
+		}
+
+		pruneResources = append(pruneResources, pruneResource{gvk[0], gvk[1], gvk[2], namespaced})
+	}
+	return pruneResources, nil
+}


### PR DESCRIPTION
* Refactors kubectl apply away from a single massive `Run()` function.
* Does NOT change functionality.
* Changes the builder `Visit()` pattern to retrieve all the objects to apply using the builder `Infos()` method. This will allow future pre-processing/post-processing of resources to apply.
* Moves the prune and patch functionality (unchanged) to their own files.
* Attempts to clean up common printing functionality.
* Moves visitedUids/visitedNamespaces (used for pruning) into ApplyOptions.
* Adds Pre/Post Process functions before and after all objects are applied. The standard PostProcessor function prints and prunes, which is the current functionality.

/kind cleanup
/sig cli
/area kubectl
/priority longterm-important

```release-note
NONE
```