### PR TITLE
Change PDB tests to use pod conditions instead of phase

### DIFF
--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
+	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -314,8 +315,9 @@ func waitForPodsOrDie(cs kubernetes.Interface, ns string, n int) {
 			return false, nil
 		}
 		ready := 0
-		for i := 0; i < n; i++ {
-			if pods.Items[i].Status.Phase == v1.PodRunning {
+		for i := range pods.Items {
+			pod := pods.Items[i]
+			if podutil.IsPodReady(&pod) {
 				ready++
 			}
 		}
@@ -373,8 +375,9 @@ func locateRunningPod(cs kubernetes.Interface, ns string) (pod *v1.Pod, err erro
 		}
 
 		for i := range podList.Items {
-			if podList.Items[i].Status.Phase == v1.PodRunning {
-				pod = &podList.Items[i]
+			p := podList.Items[i]
+			if podutil.IsPodReady(&p) {
+				pod = &p
 				return true, nil
 			}
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
The PDB test is flaky as described in #86358. I think this is caused by an issue where the e2e tests checks the pod phase to determine if a pod is ready while the pdb controller actually use the pod `Ready` condition for this. This updates the test to use the same check as the PDB controller.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/sig apps
@kubernetes/sig-apps-pr-reviews 
