### PR TITLE
Expose configuration options to control the frequency of kms-plugin's health checks.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
@@ -96,4 +96,23 @@ type KMSConfiguration struct {
 	// Timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration
+	// cacheHealthyTTL is the duration of time, after the last successful health check, during which
+	// kube-apiserver will not recheck the health status of the kms-plugin and will continue to
+	// return healthy status.
+	// By default this value is set to 20 seconds.
+	// Increasing this value may reduce operating costs of the plugin (especially in environments
+	// where calls to KMS are billable operations). However, doing so may delay the
+	// discovery of plugin's failure (ex. via a healthz probe).
+	// Setting this value to zero will disable caching of positive health check results.
+	// +optional
+	CacheHealthyTTL *metav1.Duration
+	// cacheUnHealthyTTL is the duration of time, after the last failed health check, during which
+	// kube-apiserver will not recheck the health status of the kms-plugin and will continue to
+	// return failed status.
+	// By default this value is set to 3 seconds.
+	// Reducing this value may lead to an earlier discovery in state changes of the plugin (ex. when
+	// the plugin is coming online).
+	// Setting this value to zero will disable caching of negative health check results.
+	// +optional
+	CacheUnHealthyTTL *metav1.Duration
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
@@ -24,8 +24,10 @@ import (
 )
 
 var (
-	defaultTimeout         = &metav1.Duration{Duration: 3 * time.Second}
-	defaultCacheSize int32 = 1000
+	defaultCacheSize         int32 = 1000
+	defaultTimeout                 = &metav1.Duration{Duration: 3 * time.Second}
+	defaultCacheHealthyTTL         = &metav1.Duration{Duration: 20 * time.Second}
+	defaultCacheUnHealthyTTL       = &metav1.Duration{Duration: 3 * time.Second}
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -40,5 +42,13 @@ func SetDefaults_KMSConfiguration(obj *KMSConfiguration) {
 
 	if obj.CacheSize == nil {
 		obj.CacheSize = &defaultCacheSize
+	}
+
+	if obj.CacheHealthyTTL == nil {
+		obj.CacheHealthyTTL = defaultCacheHealthyTTL
+	}
+
+	if obj.CacheUnHealthyTTL == nil {
+		obj.CacheUnHealthyTTL = defaultCacheUnHealthyTTL
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
@@ -34,12 +34,22 @@ func TestKMSProviderTimeoutDefaults(t *testing.T) {
 		{
 			desc: "timeout not supplied",
 			in:   &KMSConfiguration{},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:           defaultTimeout,
+				CacheSize:         &defaultCacheSize,
+				CacheHealthyTTL:   defaultCacheHealthyTTL,
+				CacheUnHealthyTTL: defaultCacheUnHealthyTTL,
+			},
 		},
 		{
 			desc: "timeout supplied",
 			in:   &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}},
-			want: &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:           &v1.Duration{Duration: 1 * time.Minute},
+				CacheSize:         &defaultCacheSize,
+				CacheHealthyTTL:   defaultCacheHealthyTTL,
+				CacheUnHealthyTTL: defaultCacheUnHealthyTTL,
+			},
 		},
 	}
 
@@ -67,17 +77,88 @@ func TestKMSProviderCacheDefaults(t *testing.T) {
 		{
 			desc: "cache size not supplied",
 			in:   &KMSConfiguration{},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:           defaultTimeout,
+				CacheSize:         &defaultCacheSize,
+				CacheHealthyTTL:   defaultCacheHealthyTTL,
+				CacheUnHealthyTTL: defaultCacheUnHealthyTTL,
+			},
 		},
 		{
 			desc: "cache of zero size supplied",
 			in:   &KMSConfiguration{CacheSize: &zero},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &zero},
+			want: &KMSConfiguration{
+				Timeout:           defaultTimeout,
+				CacheSize:         &zero,
+				CacheHealthyTTL:   defaultCacheHealthyTTL,
+				CacheUnHealthyTTL: defaultCacheUnHealthyTTL,
+			},
 		},
 		{
 			desc: "positive cache size supplied",
 			in:   &KMSConfiguration{CacheSize: &ten},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &ten},
+			want: &KMSConfiguration{
+				Timeout:           defaultTimeout,
+				CacheSize:         &ten,
+				CacheHealthyTTL:   defaultCacheHealthyTTL,
+				CacheUnHealthyTTL: defaultCacheUnHealthyTTL,
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			SetDefaults_KMSConfiguration(tt.in)
+			if d := cmp.Diff(tt.want, tt.in); d != "" {
+				t.Fatalf("KMS Provider mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func TestKMSProviderHealthCacheTTLDefaults(t *testing.T) {
+	zeroDuration := &v1.Duration{Duration: 0}
+	positiveDuration := &v1.Duration{Duration: 1 * time.Second}
+	testCases := []struct {
+		desc string
+		in   *KMSConfiguration
+		want *KMSConfiguration
+	}{
+		{
+			desc: "ttl cache duration not supplied",
+			in:   &KMSConfiguration{},
+			want: &KMSConfiguration{
+				Timeout:           defaultTimeout,
+				CacheSize:         &defaultCacheSize,
+				CacheHealthyTTL:   defaultCacheHealthyTTL,
+				CacheUnHealthyTTL: defaultCacheUnHealthyTTL,
+			},
+		},
+		{
+			desc: "ttl cache of zero duration is supplied",
+			in: &KMSConfiguration{
+				CacheHealthyTTL:   zeroDuration,
+				CacheUnHealthyTTL: zeroDuration,
+			},
+			want: &KMSConfiguration{
+				Timeout:           defaultTimeout,
+				CacheSize:         &defaultCacheSize,
+				CacheHealthyTTL:   zeroDuration,
+				CacheUnHealthyTTL: zeroDuration,
+			},
+		},
+		{
+			desc: "ttl cache of positive duration is supplied",
+			in: &KMSConfiguration{
+				CacheHealthyTTL:   positiveDuration,
+				CacheUnHealthyTTL: positiveDuration,
+			},
+			want: &KMSConfiguration{
+				Timeout:           defaultTimeout,
+				CacheSize:         &defaultCacheSize,
+				CacheHealthyTTL:   positiveDuration,
+				CacheUnHealthyTTL: positiveDuration,
+			},
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
@@ -96,4 +96,23 @@ type KMSConfiguration struct {
 	// Timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+	// cacheHealthyTTL is the duration of time, after the last successful health check, during which
+	// kube-apiserver will not recheck the health status of the kms-plugin and will continue to
+	// return healthy status.
+	// By default this value is set to 20 seconds.
+	// Increasing this value may reduce operating costs of the plugin (especially in environments
+	// where calls to KMS are billable operations). However, doing so may delay the
+	// discovery of plugin's failure (ex. via a healthz probe).
+	// Setting this value to zero will disable caching of positive health check results.
+	// +optional
+	CacheHealthyTTL *metav1.Duration `json:"CacheHealthyTTL,omitempty"`
+	// cacheUnHealthyTTL is the duration of time, after the last failed health check, during which
+	// kube-apiserver will not recheck the health status of the kms-plugin and will continue to
+	// return failed status.
+	// By default this value is set to 3 seconds.
+	// Reducing this value may lead to an earlier discovery in state changes of the plugin (ex. when
+	// the plugin is coming online).
+	// Setting this value to zero will disable caching of negative health check results.
+	// +optional
+	CacheUnHealthyTTL *metav1.Duration `json:"CacheHealthyTTL,omitempty"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.conversion.go
@@ -182,6 +182,8 @@ func autoConvert_v1_KMSConfiguration_To_config_KMSConfiguration(in *KMSConfigura
 	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
 	out.Endpoint = in.Endpoint
 	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	out.CacheHealthyTTL = (*metav1.Duration)(unsafe.Pointer(in.CacheHealthyTTL))
+	out.CacheUnHealthyTTL = (*metav1.Duration)(unsafe.Pointer(in.CacheUnHealthyTTL))
 	return nil
 }
 
@@ -195,6 +197,8 @@ func autoConvert_config_KMSConfiguration_To_v1_KMSConfiguration(in *config.KMSCo
 	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
 	out.Endpoint = in.Endpoint
 	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	out.CacheHealthyTTL = (*metav1.Duration)(unsafe.Pointer(in.CacheHealthyTTL))
+	out.CacheUnHealthyTTL = (*metav1.Duration)(unsafe.Pointer(in.CacheUnHealthyTTL))
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.deepcopy.go
@@ -107,6 +107,16 @@ func (in *KMSConfiguration) DeepCopyInto(out *KMSConfiguration) {
 		*out = new(metav1.Duration)
 		**out = **in
 	}
+	if in.CacheHealthyTTL != nil {
+		in, out := &in.CacheHealthyTTL, &out.CacheHealthyTTL
+		*out = new(metav1.Duration)
+		**out = **in
+	}
+	if in.CacheUnHealthyTTL != nil {
+		in, out := &in.CacheUnHealthyTTL, &out.CacheUnHealthyTTL
+		*out = new(metav1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
@@ -179,6 +179,8 @@ func validateKMSConfiguration(c *config.KMSConfiguration, fieldPath *field.Path)
 	allErrs = append(allErrs, validateKMSTimeout(c, fieldPath.Child("timeout"))...)
 	allErrs = append(allErrs, validateKMSEndpoint(c, fieldPath.Child("endpoint"))...)
 	allErrs = append(allErrs, validateKMSCacheSize(c, fieldPath.Child("cachesize"))...)
+	allErrs = append(allErrs, validateKMSCacheHealthyTTL(c, fieldPath.Child("cacheHealthyTTL"))...)
+	allErrs = append(allErrs, validateKMSCacheUnHealthyTTL(c, fieldPath.Child("cacheUnHealthyTTL"))...)
 	return allErrs
 }
 
@@ -186,6 +188,24 @@ func validateKMSCacheSize(c *config.KMSConfiguration, fieldPath *field.Path) fie
 	allErrs := field.ErrorList{}
 	if *c.CacheSize <= 0 {
 		allErrs = append(allErrs, field.Invalid(fieldPath, *c.CacheSize, fmt.Sprintf(zeroOrNegativeErrFmt, "cachesize")))
+	}
+
+	return allErrs
+}
+
+func validateKMSCacheHealthyTTL(c *config.KMSConfiguration, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if c.CacheHealthyTTL.Duration < 0 {
+		allErrs = append(allErrs, field.Invalid(fieldPath, c.CacheHealthyTTL, fmt.Sprintf(negativeValueErrFmt, "cacheHealthyTTL")))
+	}
+
+	return allErrs
+}
+
+func validateKMSCacheUnHealthyTTL(c *config.KMSConfiguration, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if c.CacheUnHealthyTTL.Duration < 0 {
+		allErrs = append(allErrs, field.Invalid(fieldPath, c.CacheUnHealthyTTL, fmt.Sprintf(negativeValueErrFmt, "cacheUnHealthyTTL")))
 	}
 
 	return allErrs

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation_test.go
@@ -266,6 +266,86 @@ func TestKMSProviderTimeout(t *testing.T) {
 	}
 }
 
+func TestKMSProviderHealthyTTL(t *testing.T) {
+	healthyTTLField := field.NewPath("resource").Index(0).Child("provider").Index(0).Child("kms").Child("cacheHealthyTTL")
+	positiveTTL := &metav1.Duration{Duration: 1 * time.Minute}
+	negativeTTL := &metav1.Duration{Duration: -1 * time.Minute}
+	zeroTTL := &metav1.Duration{Duration: 0 * time.Minute}
+
+	testCases := []struct {
+		desc string
+		in   *config.KMSConfiguration
+		want field.ErrorList
+	}{
+		{
+			desc: "positive ttl",
+			in:   &config.KMSConfiguration{CacheHealthyTTL: positiveTTL},
+			want: field.ErrorList{},
+		},
+		{
+			desc: "negative ttl",
+			in:   &config.KMSConfiguration{CacheHealthyTTL: negativeTTL},
+			want: field.ErrorList{
+				field.Invalid(healthyTTLField, negativeTTL, fmt.Sprintf(negativeValueErrFmt, "cacheHealthyTTL")),
+			},
+		},
+		{
+			desc: "zero ttl",
+			in:   &config.KMSConfiguration{CacheHealthyTTL: zeroTTL},
+			want: field.ErrorList{},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := validateKMSCacheHealthyTTL(tt.in, healthyTTLField)
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Fatalf("KMS Provider validation mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func TestKMSProviderUnHealthyTTL(t *testing.T) {
+	unHealthyTTLField := field.NewPath("resource").Index(0).Child("provider").Index(0).Child("kms").Child("cacheUnHealthyTTL")
+	positiveTTL := &metav1.Duration{Duration: 1 * time.Minute}
+	negativeTTL := &metav1.Duration{Duration: -1 * time.Minute}
+	zeroTTL := &metav1.Duration{Duration: 0 * time.Minute}
+
+	testCases := []struct {
+		desc string
+		in   *config.KMSConfiguration
+		want field.ErrorList
+	}{
+		{
+			desc: "positive ttl",
+			in:   &config.KMSConfiguration{CacheUnHealthyTTL: positiveTTL},
+			want: field.ErrorList{},
+		},
+		{
+			desc: "negative ttl",
+			in:   &config.KMSConfiguration{CacheUnHealthyTTL: negativeTTL},
+			want: field.ErrorList{
+				field.Invalid(unHealthyTTLField, negativeTTL, fmt.Sprintf(negativeValueErrFmt, "cacheUnHealthyTTL")),
+			},
+		},
+		{
+			desc: "zero ttl",
+			in:   &config.KMSConfiguration{CacheUnHealthyTTL: zeroTTL},
+			want: field.ErrorList{},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			got := validateKMSCacheUnHealthyTTL(tt.in, unHealthyTTLField)
+			if d := cmp.Diff(tt.want, got); d != "" {
+				t.Fatalf("KMS Provider validation mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
+
 func TestKMSEndpoint(t *testing.T) {
 	endpointField := field.NewPath("Resource").Index(0).Child("Provider").Index(0).Child("kms").Child("endpoint")
 	testCases := []struct {

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/zz_generated.deepcopy.go
@@ -107,6 +107,16 @@ func (in *KMSConfiguration) DeepCopyInto(out *KMSConfiguration) {
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.CacheHealthyTTL != nil {
+		in, out := &in.CacheHealthyTTL, &out.CacheHealthyTTL
+		*out = new(v1.Duration)
+		**out = **in
+	}
+	if in.CacheUnHealthyTTL != nil {
+		in, out := &in.CacheUnHealthyTTL, &out.CacheUnHealthyTTL
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind api-change
 /kind feature

/priority important-longterm
/milestone v1.18

**What this PR does / why we need it**:
The frequency of at which to perform health checks of kms-plugin may be very greatly based on the the environment.
Concretely, the cost (both monetary and performance) of performing crypto operations against an external KMS may greatly influence how often such checks should be performed.
Thus, this PR exposes the option of configuring the frequency of checks at cluster deployment time.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 Yes, users will be able to control the cache TTL of kms-plugin's health check results.

Need to update:
- https://kubernetes.io/docs/tasks/administer-cluster/kms-provider/
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
