### PR TITLE
Remove alwaysCheckAllPredicates from NewGenericScheduler

### DIFF
--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -593,7 +593,6 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 				informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
 				informerFactory.Policy().V1beta1().PodDisruptionBudgets().Lister(),
 				false,
-				false,
 				schedulerapi.DefaultPercentageOfNodesToScore,
 				false)
 			podIgnored := &v1.Pod{}

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -157,7 +157,6 @@ type genericScheduler struct {
 	prioritizers             []priorities.PriorityConfig
 	framework                framework.Framework
 	extenders                []algorithm.SchedulerExtender
-	alwaysCheckAllPredicates bool
 	nodeInfoSnapshot         *nodeinfosnapshot.Snapshot
 	volumeBinder             *volumebinder.VolumeBinder
 	pvcLister                corelisters.PersistentVolumeClaimLister
@@ -1134,7 +1133,7 @@ func podPassesBasicChecks(pod *v1.Pod, pvcLister corelisters.PersistentVolumeCla
 }
 
 // NewGenericScheduler creates a genericScheduler object.
-// TODO(Huang-Wei): remove 'predicates' and 'alwaysCheckAllPredicates'.
+// TODO(Huang-Wei): remove 'predicates'.
 func NewGenericScheduler(
 	cache internalcache.Cache,
 	podQueue internalqueue.SchedulingQueue,
@@ -1146,7 +1145,6 @@ func NewGenericScheduler(
 	volumeBinder *volumebinder.VolumeBinder,
 	pvcLister corelisters.PersistentVolumeClaimLister,
 	pdbLister policylisters.PodDisruptionBudgetLister,
-	alwaysCheckAllPredicates bool,
 	disablePreemption bool,
 	percentageOfNodesToScore int32,
 	enableNonPreempting bool) ScheduleAlgorithm {
@@ -1161,7 +1159,6 @@ func NewGenericScheduler(
 		volumeBinder:             volumeBinder,
 		pvcLister:                pvcLister,
 		pdbLister:                pdbLister,
-		alwaysCheckAllPredicates: alwaysCheckAllPredicates,
 		disablePreemption:        disablePreemption,
 		percentageOfNodesToScore: percentageOfNodesToScore,
 		enableNonPreempting:      enableNonPreempting,

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -370,15 +370,14 @@ func TestGenericScheduler(t *testing.T) {
 	defer algorithmpredicates.SetPredicatesOrderingDuringTest(order)()
 
 	tests := []struct {
-		name                     string
-		registerPlugins          []st.RegisterPluginFunc
-		alwaysCheckAllPredicates bool
-		nodes                    []string
-		pvcs                     []v1.PersistentVolumeClaim
-		pod                      *v1.Pod
-		pods                     []*v1.Pod
-		expectedHosts            sets.String
-		wErr                     error
+		name            string
+		registerPlugins []st.RegisterPluginFunc
+		nodes           []string
+		pvcs            []v1.PersistentVolumeClaim
+		pod             *v1.Pod
+		pods            []*v1.Pod
+		expectedHosts   sets.String
+		wErr            error
 	}{
 		{
 			registerPlugins: []st.RegisterPluginFunc{
@@ -789,7 +788,6 @@ func TestGenericScheduler(t *testing.T) {
 				cache,
 				internalqueue.NewSchedulingQueue(nil),
 				nil,
-				// test.prioritizers,
 				priorities.EmptyMetadataProducer,
 				snapshot,
 				fwk,
@@ -797,7 +795,6 @@ func TestGenericScheduler(t *testing.T) {
 				nil,
 				pvcLister,
 				informerFactory.Policy().V1beta1().PodDisruptionBudgets().Lister(),
-				test.alwaysCheckAllPredicates,
 				false,
 				schedulerapi.DefaultPercentageOfNodesToScore,
 				false)
@@ -839,7 +836,7 @@ func makeScheduler(nodes []*v1.Node, fns ...st.RegisterPluginFunc) *genericSched
 		priorities.EmptyMetadataProducer,
 		emptySnapshot,
 		fwk,
-		nil, nil, nil, nil, false, false,
+		nil, nil, nil, nil, false,
 		schedulerapi.DefaultPercentageOfNodesToScore, false)
 	cache.UpdateNodeInfoSnapshot(s.(*genericScheduler).nodeInfoSnapshot)
 	return s.(*genericScheduler)
@@ -967,7 +964,7 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 			priorities.EmptyMetadataProducer,
 			emptySnapshot,
 			fwk,
-			nil, nil, nil, nil, false, false,
+			nil, nil, nil, nil, false,
 			schedulerapi.DefaultPercentageOfNodesToScore, false).(*genericScheduler)
 		cache.UpdateNodeInfoSnapshot(scheduler.nodeInfoSnapshot)
 		queue.UpdateNominatedPodForNode(&v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: types.UID("nominated")}, Spec: v1.PodSpec{Priority: &midPriority}}, "1")
@@ -1167,7 +1164,6 @@ func TestZeroRequest(t *testing.T) {
 				nil,
 				nil,
 				nil,
-				false,
 				false,
 				schedulerapi.DefaultPercentageOfNodesToScore,
 				false).(*genericScheduler)
@@ -1614,7 +1610,6 @@ func TestSelectNodesForPreemption(t *testing.T) {
 				nil,
 				nil,
 				informerFactory.Policy().V1beta1().PodDisruptionBudgets().Lister(),
-				false,
 				false,
 				schedulerapi.DefaultPercentageOfNodesToScore,
 				false)
@@ -2362,7 +2357,6 @@ func TestPreempt(t *testing.T) {
 				nil,
 				informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
 				informerFactory.Policy().V1beta1().PodDisruptionBudgets().Lister(),
-				false,
 				false,
 				schedulerapi.DefaultPercentageOfNodesToScore,
 				true)

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -86,9 +86,6 @@ type Configurator struct {
 	// Handles volume binding decisions
 	volumeBinder *volumebinder.VolumeBinder
 
-	// Always check all predicates even if the middle of one predicate fails.
-	alwaysCheckAllPredicates bool
-
 	// Disable pod preemption or not.
 	disablePreemption bool
 
@@ -204,11 +201,6 @@ func (c *Configurator) CreateFromConfig(policy schedulerapi.Policy) (*Scheduler,
 	if policy.HardPodAffinitySymmetricWeight != 0 {
 		c.hardPodAffinitySymmetricWeight = policy.HardPodAffinitySymmetricWeight
 	}
-	// When AlwaysCheckAllPredicates is set to true, scheduler checks all the configured
-	// predicates even after one or more of them fails.
-	if policy.AlwaysCheckAllPredicates {
-		c.alwaysCheckAllPredicates = policy.AlwaysCheckAllPredicates
-	}
 
 	return c.CreateFromKeys(predicateKeys, priorityKeys, extenders)
 }
@@ -289,7 +281,6 @@ func (c *Configurator) CreateFromKeys(predicateKeys, priorityKeys sets.String, e
 		c.volumeBinder,
 		c.informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
 		GetPodDisruptionBudgetLister(c.informerFactory),
-		c.alwaysCheckAllPredicates,
 		c.disablePreemption,
 		c.percentageOfNodesToScore,
 		c.enableNonPreempting,

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -695,7 +695,6 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 		informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
 		informerFactory.Policy().V1beta1().PodDisruptionBudgets().Lister(),
 		false,
-		false,
 		schedulerapi.DefaultPercentageOfNodesToScore,
 		false,
 	)
@@ -751,7 +750,6 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 		nil,
 		informerFactory.Core().V1().PersistentVolumeClaims().Lister(),
 		informerFactory.Policy().V1beta1().PodDisruptionBudgets().Lister(),
-		false,
 		false,
 		schedulerapi.DefaultPercentageOfNodesToScore,
 		false,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

~~`AlwaysCheckAllPredicates` used to serve as a debug option in scheduler Policy API, but it's seldom used. Now scheduler has (almost) migrated to the new framework, it doesn't make much sense to still support this option. This PR invalidate this option, and mark it as DEPRECATED in API.~~

`alwaysCheckAllPredicates` doesn't fit in `NewGenericScheduler` any more, instead, we will plumb this option in framework to ensure it works in RunFilterPlugins.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
`AlwaysCheckAllPredicates` is deprecated in scheduler Policy API.
```

/cc @ahg-g @liggitt 