### PR TITLE
apt install and purge dependencies failed

### DIFF
--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/install.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/install.sh
@@ -28,7 +28,7 @@ BUILD_DEPS="make gcc g++ libc6-dev ruby-dev libffi-dev"
 
 # apt install
 apt-get update
-apt-get install -y --no-install-recommends "${BUILD_DEPS}" ca-certificates libjemalloc2 ruby
+apt-get install -y --no-install-recommends ${BUILD_DEPS} ca-certificates libjemalloc2 ruby
 
 # ruby install
 echo 'gem: --no-document' >> /etc/gemrc 

--- a/cluster/addons/fluentd-elasticsearch/fluentd-es-image/install.sh
+++ b/cluster/addons/fluentd-elasticsearch/fluentd-es-image/install.sh
@@ -35,7 +35,7 @@ echo 'gem: --no-document' >> /etc/gemrc
 gem install --file Gemfile
 
 # cleanup
-apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false "${BUILD_DEPS}"
+apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false ${BUILD_DEPS}
 apt-get clean -y
 rm -rf \
    /var/cache/debconf/* \


### PR DESCRIPTION
Step 4/9 : RUN chmod +x /tmp/install.sh &&     /bin/bash -l -c /tmp/install.sh &&     rm /tmp/*
 ---> Running in 6337abb6402a
Get:1 http://security-cdn.debian.org/debian-security buster/updates InRelease [65.4 kB]
Get:2 http://security-cdn.debian.org/debian-security buster/updates/main amd64 Packages [163 kB]
Get:3 http://deb.debian.org/debian buster InRelease [122 kB]
Get:4 http://deb.debian.org/debian buster-updates InRelease [49.3 kB]
Get:5 http://deb.debian.org/debian buster/main amd64 Packages [7908 kB]
Get:6 http://deb.debian.org/debian buster-updates/main amd64 Packages [5792 B]
Fetched 8313 kB in 1min 35s (87.1 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
E: Unable to locate package make gcc g++ libc6-dev ruby-dev libffi-dev
E: Couldn't find any package by regex 'make gcc g++ libc6-dev ruby-dev libffi-dev'

/kind bug
