### PR TITLE
Add some necessary metrics for scheduler

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -48,13 +48,6 @@ const (
 	// E2eScheduling - e2e scheduling operation label value
 )
 
-// Variables used by some metrics
-var (
-	CurrentHostName string
-	BeginRunTime    time.Time
-	BeginInitTime   time.Time
-)
-
 // All the histogram based metrics have 1ms as size for the smallest bucket.
 var (
 	scheduleAttempts = metrics.NewCounterVec(
@@ -308,27 +301,27 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"type"})
 
-	ReadyTime = metrics.NewGaugeVec(
+	LeaderReadyTime = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      "ready_time",
+			Name:      "leader_ready_time",
 			Help:      "Ready time for leader-scheduler to work.",
 		}, []string{"hostname"},
 	)
 
-	StartLatency = metrics.NewGaugeVec(
+	LeaderReadyLatency = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      "start_latency",
-			Help:      "Latency in microseconds for leader-scheduler to be ready after init.",
+			Name:      "leader_ready_latency_seconds",
+			Help:      "Latency in seconds for leader-scheduler to be ready after init.",
 		}, []string{"hostname"},
 	)
 
-	InitLatency = metrics.NewGaugeVec(
+	CacheInitLatency = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      "init_latency",
-			Help:      "Latency in microseconds for scheduler to be pod cache populated.",
+			Name:      "cache_init_latency_seconds",
+			Help:      "Latency in seconds for scheduler to be pod cache populated.",
 		}, []string{"hostname"},
 	)
 
@@ -367,10 +360,10 @@ var (
 		SchedulerGoroutines,
 		PermitWaitDuration,
 		CacheSize,
-		StartLatency,
-		InitLatency,
+		LeaderReadyLatency,
+		CacheInitLatency,
 		HasLeader,
-		ReadyTime,
+		LeaderReadyTime,
 	}
 )
 

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -46,20 +46,14 @@ const (
 	// Binding - binding operation label value
 	Binding = "binding"
 	// E2eScheduling - e2e scheduling operation label value
-
-	StartLatencyKey = "start_latency"
-	InitLatencyKey  = "init_latency"
-	HasLeaderKey    = "has_leader"
-	ReadyTimeKey    = "ready_time"
 )
 
-
+// Variables used by some metrics
 var (
 	CurrentHostName string
 	BeginRunTime    time.Time
 	BeginInitTime   time.Time
 )
-
 
 // All the histogram based metrics have 1ms as size for the smallest bucket.
 var (
@@ -317,7 +311,7 @@ var (
 	ReadyTime = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      ReadyTimeKey,
+			Name:      "ready_time",
 			Help:      "Ready time for leader-scheduler to work.",
 		}, []string{"hostname"},
 	)
@@ -325,15 +319,15 @@ var (
 	StartLatency = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      StartLatencyKey,
+			Name:      "start_latency",
 			Help:      "Latency in microseconds for leader-scheduler to be ready after init.",
-		},[]string{"hostname"},
+		}, []string{"hostname"},
 	)
 
 	InitLatency = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      InitLatencyKey,
+			Name:      "init_latency",
 			Help:      "Latency in microseconds for scheduler to be pod cache populated.",
 		}, []string{"hostname"},
 	)
@@ -341,7 +335,7 @@ var (
 	HasLeader = metrics.NewGaugeVec(
 		&metrics.GaugeOpts{
 			Subsystem: SchedulerSubsystem,
-			Name:      HasLeaderKey,
+			Name:      "has_leader",
 			Help:      "Whether or not leader-scheduler exists.1 is existence, 0 is not.",
 		}, []string{"hostname"},
 	)

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -46,7 +46,20 @@ const (
 	// Binding - binding operation label value
 	Binding = "binding"
 	// E2eScheduling - e2e scheduling operation label value
+
+	StartLatencyKey = "start_latency"
+	InitLatencyKey  = "init_latency"
+	HasLeaderKey    = "has_leader"
+	ReadyTimeKey    = "ready_time"
 )
+
+
+var (
+	CurrentHostName string
+	BeginRunTime    time.Time
+	BeginInitTime   time.Time
+)
+
 
 // All the histogram based metrics have 1ms as size for the smallest bucket.
 var (
@@ -301,6 +314,38 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"type"})
 
+	ReadyTime = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      ReadyTimeKey,
+			Help:      "Ready time for leader-scheduler to work.",
+		}, []string{"hostname"},
+	)
+
+	StartLatency = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      StartLatencyKey,
+			Help:      "Latency in microseconds for leader-scheduler to be ready after init.",
+		},[]string{"hostname"},
+	)
+
+	InitLatency = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      InitLatencyKey,
+			Help:      "Latency in microseconds for scheduler to be pod cache populated.",
+		}, []string{"hostname"},
+	)
+
+	HasLeader = metrics.NewGaugeVec(
+		&metrics.GaugeOpts{
+			Subsystem: SchedulerSubsystem,
+			Name:      HasLeaderKey,
+			Help:      "Whether or not leader-scheduler exists.1 is existence, 0 is not.",
+		}, []string{"hostname"},
+	)
+
 	metricsList = []metrics.Registerable{
 		scheduleAttempts,
 		SchedulingLatency,
@@ -328,6 +373,10 @@ var (
 		SchedulerGoroutines,
 		PermitWaitDuration,
 		CacheSize,
+		StartLatency,
+		InitLatency,
+		HasLeader,
+		ReadyTime,
 	}
 )
 


### PR DESCRIPTION
**What type of PR is this?**
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
From the actual usage, existed metrics are not enough. So I add four necessary metrics for kube-scheduler:
1.  `scheduler_has_leader`: which one is leader-scheduler
2. `scheduler_ready_time`: ready time for leader-scheduler to schedule
3. `scheduler_init_latency`: latency for scheduler to be cache populated
4. `scheduler_start_latency`: latency for leader-scheduler to be ready after init

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
