### PR TITLE
change kubemark from ReplicationController to Deployment

### DIFF
--- a/test/kubemark/iks/startup.sh
+++ b/test/kubemark/iks/startup.sh
@@ -21,8 +21,8 @@ KUBEMARK_DIRECTORY="${KUBE_ROOT}/test/kubemark"
 RESOURCE_DIRECTORY="${KUBEMARK_DIRECTORY}/resources"
 
 # Generate secret and configMap for the hollow-node pods to work, prepare
-# manifests of the hollow-node and heapster replication controllers from
-# templates, and finally create these resources through kubectl.
+# manifests of the hollow-node and heapster deployments from templates,
+# and finally create these resources through kubectl.
 function create-kube-hollow-node-resources {
   # Create kubeconfig for Kubelet.
   KUBELET_KUBECONFIG_CONTENTS="$(cat <<EOF
@@ -225,7 +225,7 @@ EOF
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/addons" --namespace="kubemark"
   set-registry-secrets
 
-  # Create the replication controller for hollow-nodes.
+  # Create the deployment for hollow-nodes.
   # We allow to override the NUM_REPLICAS when running Cluster Autoscaler.
   NUM_REPLICAS=${NUM_REPLICAS:-${KUBEMARK_NUM_NODES}}
   sed "s/{{numreplicas}}/${NUM_REPLICAS}/g" "${RESOURCE_DIRECTORY}/hollow-node_template.yaml" > "${RESOURCE_DIRECTORY}/hollow-node.yaml"
@@ -250,7 +250,7 @@ EOF
   sed -i'' -e "s'{{kubemark_mig_config}}'${KUBEMARK_MIG_CONFIG:-}'g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/hollow-node.yaml" --namespace="kubemark"
 
-  echo "Created secrets, configMaps, replication-controllers required for hollow-nodes."
+  echo "Created secrets, configMaps, deployments required for hollow-nodes."
 }
 
 # Wait until all hollow-nodes are running or there is a timeout.

--- a/test/kubemark/resources/heapster_template.json
+++ b/test/kubemark/resources/heapster_template.json
@@ -1,6 +1,6 @@
 {
-	"kind": "ReplicationController",
-	"apiVersion": "v1",
+	"kind": "Deployment",
+	"apiVersion": "apps/v1",
 	"metadata": {
 		"name": "heapster-v1.3.0",
 		"labels": {
@@ -11,8 +11,9 @@
 	"spec": {
 		"replicas": 1,
 		"selector": {
-			"k8s-app": "heapster",
-			"version": "v1.3.0"
+			"matchLabels":
+				"k8s-app": "heapster",
+				"version": "v1.3.0"
 		},
 		"template": {
 			"metadata": {

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: hollow-node
   labels:
@@ -8,7 +8,8 @@ metadata:
 spec:
   replicas: {{numreplicas}}
   selector:
-    name: hollow-node
+    matchLabels:
+      name: hollow-node
   template:
     metadata:
       labels:

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -82,8 +82,8 @@ function delete-kubemark-image {
 }
 
 # Generate secret and configMap for the hollow-node pods to work, prepare
-# manifests of the hollow-node and heapster replication controllers from
-# templates, and finally create these resources through kubectl.
+# manifests of the hollow-node and heapster deployments from templates,
+# and finally create these resources through kubectl.
 function create-kube-hollow-node-resources {
   # Create kubemark namespace.
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/kubemark-ns.json"
@@ -142,7 +142,7 @@ function create-kube-hollow-node-resources {
 
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/addons" --namespace="kubemark"
 
-  # Create the replication controller for hollow-nodes.
+  # Create the deployment for hollow-nodes.
   # We allow to override the NUM_REPLICAS when running Cluster Autoscaler.
   NUM_REPLICAS=${NUM_REPLICAS:-${NUM_NODES}}
   sed "s@{{numreplicas}}@${NUM_REPLICAS}@g" "${RESOURCE_DIRECTORY}/hollow-node_template.yaml" > "${RESOURCE_DIRECTORY}/hollow-node.yaml"
@@ -174,7 +174,7 @@ function create-kube-hollow-node-resources {
   sed -i'' -e "s@{{kubemark_mig_config}}@${KUBEMARK_MIG_CONFIG:-}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/hollow-node.yaml" --namespace="kubemark"
 
-  echo "Created secrets, configMaps, replication-controllers required for hollow-nodes."
+  echo "Created secrets, configMaps, deployments required for hollow-nodes."
 }
 
 # Wait until all hollow-nodes are running or there is a timeout.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind api-change
/kind cleanup

**What this PR does / why we need it**:

As far as I know, the `ReplicationController` has been replaced by `ReplicationSet` and `Deployment`, the new version is no longer recommended to use `ReplicationController`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```