### PR TITLE
chore: port azure disk csi code to azure cloud provider

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
@@ -283,4 +284,130 @@ func TestFilteredDetatchingDisks(t *testing.T) {
 	disks = []compute.DataDisk{}
 	filteredDisks = filterDetachingDisks(disks)
 	assert.Equal(t, 0, len(filteredDisks))
+}
+
+func TestGetValidCreationData(t *testing.T) {
+	sourceResourceSnapshotID := "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/snapshots/xxx"
+	sourceResourceVolumeID := "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/disks/xxx"
+
+	tests := []struct {
+		subscriptionID   string
+		resourceGroup    string
+		sourceResourceID string
+		sourceType       string
+		expected1        compute.CreationData
+		expected2        error
+	}{
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "",
+			sourceType:       "",
+			expected1: compute.CreationData{
+				CreateOption: compute.Empty,
+			},
+			expected2: nil,
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/snapshots/xxx",
+			sourceType:       sourceSnapshot,
+			expected1: compute.CreationData{
+				CreateOption:     compute.Copy,
+				SourceResourceID: &sourceResourceSnapshotID,
+			},
+			expected2: nil,
+		},
+		{
+			subscriptionID:   "xxx",
+			resourceGroup:    "xxx",
+			sourceResourceID: "xxx",
+			sourceType:       sourceSnapshot,
+			expected1: compute.CreationData{
+				CreateOption:     compute.Copy,
+				SourceResourceID: &sourceResourceSnapshotID,
+			},
+			expected2: nil,
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "/subscriptions/23/providers/Microsoft.Compute/disks/name",
+			sourceType:       sourceSnapshot,
+			expected1:        compute.CreationData{},
+			expected2:        fmt.Errorf("sourceResourceID(%s) is invalid, correct format: %s", "/subscriptions//resourceGroups//providers/Microsoft.Compute/snapshots//subscriptions/23/providers/Microsoft.Compute/disks/name", diskSnapshotPathRE),
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "http://test.com/vhds/name",
+			sourceType:       sourceSnapshot,
+			expected1:        compute.CreationData{},
+			expected2:        fmt.Errorf("sourceResourceID(%s) is invalid, correct format: %s", "/subscriptions//resourceGroups//providers/Microsoft.Compute/snapshots/http://test.com/vhds/name", diskSnapshotPathRE),
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "/subscriptions/xxx/snapshots/xxx",
+			sourceType:       sourceSnapshot,
+			expected1:        compute.CreationData{},
+			expected2:        fmt.Errorf("sourceResourceID(%s) is invalid, correct format: %s", "/subscriptions//resourceGroups//providers/Microsoft.Compute/snapshots//subscriptions/xxx/snapshots/xxx", diskSnapshotPathRE),
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/snapshots/xxx/snapshots/xxx/snapshots/xxx",
+			sourceType:       sourceSnapshot,
+			expected1:        compute.CreationData{},
+			expected2:        fmt.Errorf("sourceResourceID(%s) is invalid, correct format: %s", "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/snapshots/xxx/snapshots/xxx/snapshots/xxx", diskSnapshotPathRE),
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "xxx",
+			sourceType:       "",
+			expected1: compute.CreationData{
+				CreateOption: compute.Empty,
+			},
+			expected2: nil,
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/disks/xxx",
+			sourceType:       sourceVolume,
+			expected1: compute.CreationData{
+				CreateOption:     compute.Copy,
+				SourceResourceID: &sourceResourceVolumeID,
+			},
+			expected2: nil,
+		},
+		{
+			subscriptionID:   "xxx",
+			resourceGroup:    "xxx",
+			sourceResourceID: "xxx",
+			sourceType:       sourceVolume,
+			expected1: compute.CreationData{
+				CreateOption:     compute.Copy,
+				SourceResourceID: &sourceResourceVolumeID,
+			},
+			expected2: nil,
+		},
+		{
+			subscriptionID:   "",
+			resourceGroup:    "",
+			sourceResourceID: "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/snapshots/xxx",
+			sourceType:       sourceVolume,
+			expected1:        compute.CreationData{},
+			expected2:        fmt.Errorf("sourceResourceID(%s) is invalid, correct format: %s", "/subscriptions//resourceGroups//providers/Microsoft.Compute/disks//subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/snapshots/xxx", managedDiskPathRE),
+		},
+	}
+
+	for _, test := range tests {
+		result, err := getValidCreationData(test.subscriptionID, test.resourceGroup, test.sourceResourceID, test.sourceType)
+		if !reflect.DeepEqual(result, test.expected1) || !reflect.DeepEqual(err, test.expected2) {
+			t.Errorf("input sourceResourceID: %v, sourceType: %v, getValidCreationData result: %v, expected1 : %v, err: %v, expected2: %v", test.sourceResourceID, test.sourceType, result, test.expected1, err, test.expected2)
+		}
+	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -69,6 +69,10 @@ type ManagedDiskOptions struct {
 	DiskIOPSReadWrite string
 	// Throughput Cap (MBps) for UltraSSD disk
 	DiskMBpsReadWrite string
+	// if SourceResourceID is not empty, then it's a disk copy operation(for snapshot)
+	SourceResourceID string
+	// The type of source
+	SourceType string
 	// ResourceId of the disk encryption set to use for enabling encryption at rest.
 	DiskEncryptionSetID string
 }
@@ -99,9 +103,14 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 
 	diskSizeGB := int32(options.SizeGB)
 	diskSku := compute.DiskStorageAccountTypes(options.StorageAccountType)
+
+	creationData, err := getValidCreationData(c.common.subscriptionID, options.ResourceGroup, options.SourceResourceID, options.SourceType)
+	if err != nil {
+		return "", err
+	}
 	diskProperties := compute.DiskProperties{
 		DiskSizeGB:   &diskSizeGB,
-		CreationData: &compute.CreationData{CreateOption: compute.Empty},
+		CreationData: &creationData,
 	}
 
 	if diskSku == compute.UltraSSDLRS {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR ports azure disk csi code to upstream, including create disk from:
 - snapshot
 - disk
Actually it's not supported by in-tree disk driver, only supported by csi driver.
This PR port the csi code to upstream, and then would use upstream code(`CreateManagedDisk` func), fix this issue: https://github.com/kubernetes-sigs/azuredisk-csi-driver/issues/97

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
original azure disk csi code: https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/035c1d6597e73f6c609b4d1dcf7e7cc6dd31e690/pkg/azuredisk/azuredisk.go#L276

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure