### PR TITLE
Fix: kubectl top --sort-by option bug

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_printer.go
@@ -64,6 +64,7 @@ func (n *NodeMetricsSorter) Len() int {
 
 func (n *NodeMetricsSorter) Swap(i, j int) {
 	n.metrics[i], n.metrics[j] = n.metrics[j], n.metrics[i]
+	n.usages[i], n.usages[j] = n.usages[j], n.usages[i]
 }
 
 func (n *NodeMetricsSorter) Less(i, j int) bool {
@@ -71,7 +72,7 @@ func (n *NodeMetricsSorter) Less(i, j int) bool {
 	case "cpu":
 		qi := n.usages[i][v1.ResourceCPU]
 		qj := n.usages[j][v1.ResourceCPU]
-		return qi.Value() > qj.Value()
+		return qi.ScaledValue(-3) > qj.ScaledValue(-3)
 	case "memory":
 		qi := n.usages[i][v1.ResourceMemory]
 		qj := n.usages[j][v1.ResourceMemory]
@@ -109,6 +110,7 @@ func (p *PodMetricsSorter) Len() int {
 
 func (p *PodMetricsSorter) Swap(i, j int) {
 	p.metrics[i], p.metrics[j] = p.metrics[j], p.metrics[i]
+	p.podMetrics[i], p.podMetrics[j] = p.podMetrics[j], p.podMetrics[i]
 }
 
 func (p *PodMetricsSorter) Less(i, j int) bool {
@@ -116,7 +118,7 @@ func (p *PodMetricsSorter) Less(i, j int) bool {
 	case "cpu":
 		qi := p.podMetrics[i][v1.ResourceCPU]
 		qj := p.podMetrics[j][v1.ResourceCPU]
-		return qi.Value() > qj.Value()
+		return qi.ScaledValue(-3) > qj.ScaledValue(-3)
 	case "memory":
 		qi := p.podMetrics[i][v1.ResourceMemory]
 		qj := p.podMetrics[j][v1.ResourceMemory]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

> /kind bug

**What this PR does / why we need it**:

This PR fixes the kubectl top --sort-by option bug.

**Which issue(s) this PR fixes**: 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/86401

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

Before fix, sort by memeory
```shell
chenjiandongx@cloud-test001 ~]$ kubectl top pods --sort-by=memory
NAME                                        CPU(cores)   MEMORY(bytes)
conveyor-es-l8g7h                           4m           38Mi
kafka-kafka-2                               23m          1241Mi
kafka-kafka-0                               22m          1076Mi
xbi-address-56c6bf8664-89mqh                7m           13Mi
mongo-sh-configsvr-1                        21m          105Mi
flink-jobmanager-6b8fc8dc9b-dmc5f           9m           782Mi
kafka-zookeeper-1                           13m          161Mi
flink-taskmanager-86c87cb4b-6gwxf           5m           1180Mi
mongo-sh-configsvr-2                        24m          77Mi
mongo-sh-configsvr-0                        24m          117Mi
conveyor-es-nk4vx                           5m           27Mi
apollo-77b4fdb7d7-p6prh                     10m          812Mi
kubedb-operator-76dc8bb479-q26bh            2m           36Mi
flink-taskmanager-86c87cb4b-26b49           5m           1173Mi
xbi-jc-6986f9bd8c-r42nx                     0m           14Mi
mysql-0                                     2m           216Mi
strimzi-cluster-operator-76bc64bc59-8lgx2   2m           251Mi
kafka-zookeeper-2                           17m          138Mi
kafka-zookeeper-0                           17m          155Mi
conveyor-es-nrrgj                           4m           21Mi
kafka-kafka-1                               24m          663Mi
mongo-sh-shard0-0                           22m          111Mi
xiot-657694c765-mxqkw                       1m           12Mi
ngx-85b4f77f5b-mldhb                        0m           1Mi
nginx-59f555cbf9-k7hct                      0m           1Mi
ngx-85b4f77f5b-4mjq5                        0m           1Mi
ngx-85b4f77f5b-l8kk2                        0m           1Mi
kafka-entity-operator-595bf8d698-2f8sg      4m           377Mi
nginx-59f555cbf9-tmx75                      0m           1Mi
bbox-57fcffb7cc-zmhr2                       0m           0Mi
nginx-59f555cbf9-v6zfm                      0m           1Mi
ngx-85b4f77f5b-cfqzp                        0m           1Mi
mongo-sh-mongos-7695c7896b-nmzfx            20m          10Mi
kafkamannager-7798b6c554-rbqb2              0m           8Mi
```

Before fix, sort by cpu
```shell
[chenjiandongx@cloud-test001 ~]$ kubectl top pods --sort-by=cpu
NAME                                        CPU(cores)   MEMORY(bytes)
kafka-kafka-0                               22m          1076Mi
xbi-address-56c6bf8664-89mqh                7m           13Mi
mongo-sh-configsvr-2                        24m          76Mi
xiot-657694c765-mxqkw                       1m           12Mi
flink-taskmanager-86c87cb4b-26b49           5m           1173Mi
kubedb-operator-76dc8bb479-q26bh            2m           36Mi
conveyor-es-nk4vx                           6m           27Mi
conveyor-es-nrrgj                           4m           21Mi
mongo-sh-shard0-0                           22m          111Mi
kafka-kafka-1                               25m          663Mi
kafka-zookeeper-0                           16m          155Mi
mongo-sh-configsvr-0                        24m          117Mi
kafka-entity-operator-595bf8d698-2f8sg      6m           377Mi
mongo-sh-configsvr-1                        23m          105Mi
kafka-kafka-2                               23m          1241Mi
kafka-zookeeper-2                           15m          138Mi
kafka-zookeeper-1                           14m          161Mi
conveyor-es-l8g7h                           4m           39Mi
flink-taskmanager-86c87cb4b-6gwxf           5m           1180Mi
mongo-sh-mongos-7695c7896b-nmzfx            17m          10Mi
apollo-77b4fdb7d7-p6prh                     10m          812Mi
nginx-59f555cbf9-tmx75                      0m           1Mi
mysql-0                                     1m           216Mi
nginx-59f555cbf9-v6zfm                      0m           1Mi
ngx-85b4f77f5b-l8kk2                        0m           1Mi
nginx-59f555cbf9-k7hct                      0m           1Mi
strimzi-cluster-operator-76bc64bc59-8lgx2   0m           251Mi
xbi-jc-6986f9bd8c-r42nx                     0m           14Mi
ngx-85b4f77f5b-4mjq5                        0m           1Mi
bbox-57fcffb7cc-zmhr2                       0m           0Mi
kafkamannager-7798b6c554-rbqb2              0m           8Mi
ngx-85b4f77f5b-mldhb                        0m           1Mi
flink-jobmanager-6b8fc8dc9b-dmc5f           9m           783Mi
ngx-85b4f77f5b-cfqzp                        0m           1Mi
```

The reason of this problem is a mistake with the sorting algorithm. After fix, sort by memory
```shell
NAME                                        CPU(cores)   MEMORY(bytes)
kafka-kafka-2                               23m          1237Mi
flink-taskmanager-86c87cb4b-26b49           6m           1196Mi
flink-taskmanager-86c87cb4b-6gwxf           5m           1180Mi
kafka-kafka-0                               22m          1075Mi
apollo-77b4fdb7d7-p6prh                     10m          812Mi
flink-jobmanager-6b8fc8dc9b-dmc5f           9m           790Mi
kafka-kafka-1                               24m          658Mi
kafka-entity-operator-595bf8d698-2f8sg      5m           377Mi
strimzi-cluster-operator-76bc64bc59-8lgx2   0m           251Mi
mysql-0                                     2m           216Mi
kafka-zookeeper-1                           14m          161Mi
kafka-zookeeper-0                           17m          155Mi
kafka-zookeeper-2                           17m          140Mi
mongo-sh-configsvr-0                        25m          111Mi
mongo-sh-shard0-0                           23m          105Mi
mongo-sh-configsvr-1                        21m          101Mi
mongo-sh-configsvr-2                        25m          76Mi
conveyor-es-l8g7h                           4m           38Mi
kubedb-operator-76dc8bb479-q26bh            2m           37Mi
conveyor-es-nk4vx                           6m           28Mi
conveyor-es-nrrgj                           4m           21Mi
xbi-jc-6986f9bd8c-r42nx                     0m           14Mi
xbi-address-56c6bf8664-89mqh                7m           13Mi
xiot-657694c765-mxqkw                       1m           11Mi
mongo-sh-mongos-7695c7896b-nmzfx            18m          10Mi
kafkamannager-7798b6c554-rbqb2              0m           7Mi
ngx-85b4f77f5b-mldhb                        0m           1Mi
ngx-85b4f77f5b-4mjq5                        0m           1Mi
nginx-59f555cbf9-tmx75                      0m           1Mi
nginx-59f555cbf9-k7hct                      0m           1Mi
ngx-85b4f77f5b-cfqzp                        0m           1Mi
nginx-59f555cbf9-v6zfm                      0m           1Mi
ngx-85b4f77f5b-l8kk2                        0m           1Mi
bbox-57fcffb7cc-zmhr2                       0m           0Mi
```

After fix, sort by cpu
```shell
NAME                                        CPU(cores)   MEMORY(bytes)
mongo-sh-configsvr-0                        27m          112Mi
mongo-sh-configsvr-2                        25m          76Mi
kafka-kafka-1                               25m          658Mi
kafka-kafka-2                               23m          1237Mi
mongo-sh-configsvr-1                        23m          101Mi
mongo-sh-shard0-0                           23m          105Mi
kafka-kafka-0                               21m          1075Mi
mongo-sh-mongos-7695c7896b-nmzfx            19m          10Mi
kafka-zookeeper-0                           18m          155Mi
kafka-zookeeper-2                           16m          140Mi
kafka-zookeeper-1                           14m          161Mi
apollo-77b4fdb7d7-p6prh                     11m          812Mi
flink-jobmanager-6b8fc8dc9b-dmc5f           9m           790Mi
xbi-address-56c6bf8664-89mqh                7m           13Mi
kafka-entity-operator-595bf8d698-2f8sg      6m           377Mi
conveyor-es-nk4vx                           6m           28Mi
flink-taskmanager-86c87cb4b-26b49           6m           1196Mi
flink-taskmanager-86c87cb4b-6gwxf           5m           1180Mi
conveyor-es-nrrgj                           4m           21Mi
conveyor-es-l8g7h                           4m           38Mi
mysql-0                                     3m           216Mi
kubedb-operator-76dc8bb479-q26bh            2m           37Mi
strimzi-cluster-operator-76bc64bc59-8lgx2   2m           251Mi
xiot-657694c765-mxqkw                       1m           11Mi
bbox-57fcffb7cc-zmhr2                       0m           0Mi
nginx-59f555cbf9-v6zfm                      0m           1Mi
ngx-85b4f77f5b-cfqzp                        0m           1Mi
ngx-85b4f77f5b-mldhb                        0m           1Mi
kafkamannager-7798b6c554-rbqb2              0m           7Mi
ngx-85b4f77f5b-l8kk2                        0m           1Mi
nginx-59f555cbf9-tmx75                      0m           1Mi
nginx-59f555cbf9-k7hct                      0m           1Mi
xbi-jc-6986f9bd8c-r42nx                     0m           14Mi
ngx-85b4f77f5b-4mjq5                        0m           1Mi
```

