### PR TITLE
Isolate kubectl test-cmd plugin tests

### DIFF
--- a/test/cmd/plugins.sh
+++ b/test/cmd/plugins.sh
@@ -24,24 +24,28 @@ run_plugins_tests() {
 
   kube::log::status "Testing kubectl plugins"
 
+  # Create a folder which only contains our kubectl executable
+  TEMP_PATH=$(mktemp -d /tmp/tmp-kubectl-path-XXXXX)
+  ln -s "$(which kubectl)" "${TEMP_PATH}/kubectl"
+
   # test plugins that overwrite existing kubectl commands
-  output_message=$(! PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/version" kubectl plugin list 2>&1)
+  output_message=$(! PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/version" kubectl plugin list 2>&1)
   kube::test::if_has_string "${output_message}" 'kubectl-version overwrites existing command: "kubectl version"'
 
   # test plugins that overwrite similarly-named plugins
-  output_message=$(! PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins:test/fixtures/pkg/kubectl/plugins/foo" kubectl plugin list 2>&1)
+  output_message=$(! PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins:test/fixtures/pkg/kubectl/plugins/foo" kubectl plugin list 2>&1)
   kube::test::if_has_string "${output_message}" 'test/fixtures/pkg/kubectl/plugins/foo/kubectl-foo is overshadowed by a similarly named plugin'
 
   # test plugins with no warnings
-  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins" kubectl plugin list 2>&1)
+  output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins" kubectl plugin list 2>&1)
   kube::test::if_has_string "${output_message}" 'plugins are available'
 
   # no plugins
-  output_message=$(! PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/empty" kubectl plugin list 2>&1)
+  output_message=$(! PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/empty" kubectl plugin list 2>&1)
   kube::test::if_has_string "${output_message}" 'unable to find any kubectl plugins in your PATH'
 
   # attempt to run a plugin in the user's PATH
-  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins" kubectl foo)
+  output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins" kubectl foo)
   kube::test::if_has_string "${output_message}" 'plugin foo'
 
   # check arguments passed to the plugin
@@ -49,9 +53,11 @@ run_plugins_tests() {
   kube::test::if_has_string "${output_message}" 'test/fixtures/pkg/kubectl/plugins/bar/kubectl-bar arg1'
 
   # ensure that a kubectl command supersedes a plugin that overshadows it
-  output_message=$(PATH=${PATH}:"test/fixtures/pkg/kubectl/plugins/version" kubectl version)
+  output_message=$(PATH=${TEMP_PATH}:"test/fixtures/pkg/kubectl/plugins/version" kubectl version --client)
   kube::test::if_has_string "${output_message}" 'Client Version'
   kube::test::if_has_not_string "${output_message}" 'overshadows an existing plugin'
+
+  rm -fr "${TEMP_PATH}"
 
   set +o nounset
   set +o errexit


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Makes the test-cmd plugins test work even if you have a plugin-like binary in your PATH. I have per-version `kubectl-$version` binaries in my local bin path for regression testing, and this test fails because the command that is expected to return `unable to find any kubectl plugins in your PATH` instead lists my versioned kubectl binaries.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cli
/cc @seans3 