### PR TITLE
[v1.17.1] cherry pick of #86395 : Allocate map when out points to nil map

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/v1/conversion.go
@@ -31,6 +31,9 @@ func Convert_Slice_v1_NamedCluster_To_Map_string_To_Pointer_api_Cluster(in *[]Na
 		if err := Convert_v1_Cluster_To_api_Cluster(&curr.Cluster, newCluster, s); err != nil {
 			return err
 		}
+		if *out == nil {
+			*out = make(map[string]*api.Cluster)
+		}
 		if (*out)[curr.Name] == nil {
 			(*out)[curr.Name] = newCluster
 		} else {
@@ -64,6 +67,9 @@ func Convert_Slice_v1_NamedAuthInfo_To_Map_string_To_Pointer_api_AuthInfo(in *[]
 		newAuthInfo := api.NewAuthInfo()
 		if err := Convert_v1_AuthInfo_To_api_AuthInfo(&curr.AuthInfo, newAuthInfo, s); err != nil {
 			return err
+		}
+		if *out == nil {
+			*out = make(map[string]*api.AuthInfo)
 		}
 		if (*out)[curr.Name] == nil {
 			(*out)[curr.Name] = newAuthInfo
@@ -99,6 +105,9 @@ func Convert_Slice_v1_NamedContext_To_Map_string_To_Pointer_api_Context(in *[]Na
 		if err := Convert_v1_Context_To_api_Context(&curr.Context, newContext, s); err != nil {
 			return err
 		}
+		if *out == nil {
+			*out = make(map[string]*api.Context)
+		}
 		if (*out)[curr.Name] == nil {
 			(*out)[curr.Name] = newContext
 		} else {
@@ -132,6 +141,9 @@ func Convert_Slice_v1_NamedExtension_To_Map_string_To_runtime_Object(in *[]Named
 		var newExtension runtime.Object
 		if err := runtime.Convert_runtime_RawExtension_To_runtime_Object(&curr.Extension, &newExtension, s); err != nil {
 			return err
+		}
+		if *out == nil {
+			*out = make(map[string]runtime.Object)
 		}
 		if (*out)[curr.Name] == nil {
 			(*out)[curr.Name] = newExtension

--- a/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/loader_test.go
@@ -78,6 +78,32 @@ var (
 	}
 )
 
+func TestNilOutMap(t *testing.T) {
+	var fakeKubeconfigData = `apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: UEhPTlkK
+    server: https://1.1.1.1
+  name: production
+contexts:
+- context:
+    cluster: production
+    user: production
+  name: production
+current-context: production
+users:
+- name: production
+  user:
+    auth-provider:
+      name: gcp`
+
+	_, _, err := clientcmdlatest.Codec.Decode([]byte(fakeKubeconfigData), nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestNonExistentCommandLineFile(t *testing.T) {
 	loadingRules := ClientConfigLoadingRules{
 		ExplicitPath: "bogus_file",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR allocates map when the out parameter of Convert_Slice_v1_NamedCluster_To_Map_string_To_Pointer_api_Cluster points to nil map.

**Which issue(s) this PR fixes**:
Fixes #86394

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
