### PR TITLE
rename _count to _total in a few metrics

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/stats.go
+++ b/staging/src/k8s.io/apiserver/pkg/authentication/token/cache/stats.go
@@ -37,7 +37,7 @@ var (
 		&metrics.CounterOpts{
 			Namespace:      "authentication",
 			Subsystem:      "token_cache",
-			Name:           "request_count",
+			Name:           "request_total",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"status"},
@@ -46,7 +46,7 @@ var (
 		&metrics.GaugeOpts{
 			Namespace:      "authentication",
 			Subsystem:      "token_cache",
-			Name:           "fetch_count",
+			Name:           "fetch_total",
 			StabilityLevel: metrics.ALPHA,
 		},
 		[]string{"status"},


### PR DESCRIPTION
request_total is fully accumulating, fetch_total is mostly accumulating
except for the active label. These metrics are brand new so we can rename them.

```release-note
NONE
```

/sig auth
/kind cleanup