### PR TITLE
[WIP] kms: check healthz less often when the plugin is working

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope.go
@@ -41,6 +41,13 @@ type Service interface {
 	Decrypt(data []byte) ([]byte, error)
 	// Encrypt bytes to a ciphertext.
 	Encrypt(data []byte) ([]byte, error)
+
+	// FailedSinceLastRecordPassingHealthz must return true if either Encrypt or Decrypt
+	// has returned a non-nil error since the last time RecordPassingHealthz was called.
+	FailedSinceLastRecordPassingHealthz() bool
+	// RecordPassingHealthz allows an external healthz checker to record that this Service
+	// is working as expected (i.e. both Encrypt and Decrypt are returning nil errors).
+	RecordPassingHealthz()
 }
 
 type envelopeTransformer struct {

--- a/test/integration/master/kms_transformation_test.go
+++ b/test/integration/master/kms_transformation_test.go
@@ -240,6 +240,7 @@ resources:
 	// Stage 2 - kms-plugin for provider-1 is down. Therefore, expect the health check for provider-1
 	// to fail, but provider-2 should still be OK
 	pluginMock1.EnterFailedState()
+	_, _ = test.createSecret(testSecret+"-0", testNamespace) // probe the API to invoke the KMS plugin otherwise it will stay healthy
 	mustBeUnHealthy(t, "kms-provider-0", test.kubeAPIServer.ClientConfig)
 	mustBeHealthy(t, "kms-provider-1", test.kubeAPIServer.ClientConfig)
 	pluginMock1.ExitFailedState()
@@ -249,6 +250,7 @@ resources:
 	// Need to sleep since health check chases responses for 3 seconds.
 	pluginMock2.EnterFailedState()
 	mustBeHealthy(t, "kms-provider-0", test.kubeAPIServer.ClientConfig)
+	// TODO this test will fail until we seed data into etcd that would use this plugin for a read
 	mustBeUnHealthy(t, "kms-provider-1", test.kubeAPIServer.ClientConfig)
 }
 


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

This is WIP alternative to #86368 that does not involve exposing config to end users.  It uses failures during encryption and decryption to "unset" the cached KMS healthz response.  The positive healthz cache is increased to an hour.  This means that if the KAS does not invoke the plugin (large cache, not many secrets, idle cluster, etc), it may take an hour for the plugin to report unhealthy.  This may be an okay tradeoff since it means that the KAS is working without issue during that hour.

I have left most of the unit tests alone at this point as the change is invasive and I would like to get feedback on the approach.  If anyone has ideas on other approaches that do not involve exposing config to users, I would like to hear them.

/kind bug
/sig auth
/priority important-longterm
/milestone v1.18

```release-note
NONE
```

/assign @immutableT @awly @liggitt 
@kubernetes/sig-auth-pr-reviews