### PR TITLE
Fix ensureStaticIP if name for existed address was changed

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external.go
@@ -1060,6 +1060,18 @@ func ensureStaticIP(s CloudAddressService, name, serviceName, region, existingIP
 		existed = true
 	}
 
+	// If address exists, get it by IP, because name might be different.
+	// This can specifically happen if the IP was changed from ephemeral to static,
+	// which results in a new name for the IP.
+	if existingIP != "" {
+		addr, err := s.GetRegionAddressByIP(region, existingIP)
+		if err != nil {
+			return "", false, fmt.Errorf("error getting static IP address: %v", err)
+		}
+		return addr.Address, existed, nil
+	}
+
+	// Otherwise, get address by name
 	addr, err := s.GetRegionAddress(name, region)
 	if err != nil {
 		return "", false, fmt.Errorf("error getting static IP address: %v", err)

--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
@@ -63,6 +63,13 @@ func TestEnsureStaticIP(t *testing.T) {
 	if err != nil || !existed || ip != ipPrime {
 		t.Fatalf(`ensureStaticIP(%v, %v, %v, %v, %v) = %v, %v, %v; want %v, true, nil`, gce, ipName, serviceName, gce.region, ip, ipPrime, existed, err, ip)
 	}
+
+	// Ensure call with different name
+	ipName = "another-name-for-static-ip"
+	ipPrime, existed, err = ensureStaticIP(gce, ipName, serviceName, gce.region, ip, cloud.NetworkTierDefault)
+	if err != nil || !existed || ip != ipPrime {
+		t.Fatalf(`ensureStaticIP(%v, %v, %v, %v, %v) = %v, %v, %v; want %v, true, nil`, gce, ipName, serviceName, gce.region, ip, ipPrime, existed, err, ip)
+	}
 }
 
 func TestEnsureStaticIPWithTier(t *testing.T) {


### PR DESCRIPTION
It might happen when we change external IP address from ephemeral to
static and give it a custom name.
In this case GetRegionAddress with given name will return Not Found

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes error in `ensureStaticIP` when ip already exists but with different name.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/53475 
Fixes https://github.com/kubernetes/kubernetes/issues/51668

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
