### PR TITLE
Drop PersistentVolumes GCEPD involving deletion of namespace

### DIFF
--- a/test/e2e/storage/persistent_volumes-gce.go
+++ b/test/e2e/storage/persistent_volumes-gce.go
@@ -147,18 +147,4 @@ var _ = utils.SIGDescribe("PersistentVolumes GCEPD", func() {
 		ginkgo.By("Verifying Persistent Disk detaches")
 		framework.ExpectNoError(waitForPDDetach(diskName, node), "PD ", diskName, " did not detach")
 	})
-
-	// Test that a Pod and PVC attached to a GCEPD successfully unmounts and detaches when the encompassing Namespace is deleted.
-	ginkgo.It("should test that deleting the Namespace of a PVC and Pod causes the successful detach of Persistent Disk [Flaky]", func() {
-
-		ginkgo.By("Deleting the Namespace")
-		err := c.CoreV1().Namespaces().Delete(ns, nil)
-		framework.ExpectNoError(err)
-
-		err = framework.WaitForNamespacesDeleted(c, []string{ns}, framework.DefaultNamespaceDeletionTimeout)
-		framework.ExpectNoError(err)
-
-		ginkgo.By("Verifying Persistent Disk detaches")
-		framework.ExpectNoError(waitForPDDetach(diskName, node), "PD ", diskName, " did not detach")
-	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As @msau42 commented in https://github.com/kubernetes/kubernetes/issues/86181#issuecomment-567718454, we can remove the test involving deletion of namespace.

**Which issue(s) this PR fixes**:
Fixes #86181

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
