### PR TITLE
Automated cherry pick of #86412: It fixes a bug where AAD token obtained by kubectl is

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
@@ -287,7 +287,7 @@ func (ts *azureTokenSource) refreshToken(token *azureToken) (*azureToken, error)
 		return nil, err
 	}
 
-	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, token.tenantID)
+	oauthConfig, err := adal.NewOAuthConfigWithAPIVersion(env.ActiveDirectoryEndpoint, token.tenantID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building the OAuth configuration for token refresh: %v", err)
 	}
@@ -344,7 +344,7 @@ func newAzureTokenSourceDeviceCode(environment azure.Environment, clientID strin
 }
 
 func (ts *azureTokenSourceDeviceCode) Token() (*azureToken, error) {
-	oauthConfig, err := adal.NewOAuthConfig(ts.environment.ActiveDirectoryEndpoint, ts.tenantID)
+	oauthConfig, err := adal.NewOAuthConfigWithAPIVersion(ts.environment.ActiveDirectoryEndpoint, ts.tenantID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("building the OAuth configuration for device code authentication: %v", err)
 	}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/auth/azure_auth.go
@@ -90,7 +90,7 @@ func GetServicePrincipalToken(config *AzureAuthConfig, env *azure.Environment) (
 			env.ServiceManagementEndpoint)
 	}
 
-	oauthConfig, err := adal.NewOAuthConfig(env.ActiveDirectoryEndpoint, tenantID)
+	oauthConfig, err := adal.NewOAuthConfigWithAPIVersion(env.ActiveDirectoryEndpoint, tenantID, nil)
 	if err != nil {
 		return nil, fmt.Errorf("creating the OAuth config: %v", err)
 	}


### PR DESCRIPTION
Cherry pick of #86412 on release-1.16.

#86412: It fixes a bug where AAD token obtained by kubectl is

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.