### PR TITLE
Revert "Merge pull request #86376 from xieyanker/kubemark_deployment"

### DIFF
--- a/test/kubemark/iks/startup.sh
+++ b/test/kubemark/iks/startup.sh
@@ -21,8 +21,8 @@ KUBEMARK_DIRECTORY="${KUBE_ROOT}/test/kubemark"
 RESOURCE_DIRECTORY="${KUBEMARK_DIRECTORY}/resources"
 
 # Generate secret and configMap for the hollow-node pods to work, prepare
-# manifests of the hollow-node and heapster deployments from templates,
-# and finally create these resources through kubectl.
+# manifests of the hollow-node and heapster replication controllers from
+# templates, and finally create these resources through kubectl.
 function create-kube-hollow-node-resources {
   # Create kubeconfig for Kubelet.
   KUBELET_KUBECONFIG_CONTENTS="$(cat <<EOF
@@ -225,7 +225,7 @@ EOF
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/addons" --namespace="kubemark"
   set-registry-secrets
 
-  # Create the deployment for hollow-nodes.
+  # Create the replication controller for hollow-nodes.
   # We allow to override the NUM_REPLICAS when running Cluster Autoscaler.
   NUM_REPLICAS=${NUM_REPLICAS:-${KUBEMARK_NUM_NODES}}
   sed "s/{{numreplicas}}/${NUM_REPLICAS}/g" "${RESOURCE_DIRECTORY}/hollow-node_template.yaml" > "${RESOURCE_DIRECTORY}/hollow-node.yaml"
@@ -250,7 +250,7 @@ EOF
   sed -i'' -e "s'{{kubemark_mig_config}}'${KUBEMARK_MIG_CONFIG:-}'g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/hollow-node.yaml" --namespace="kubemark"
 
-  echo "Created secrets, configMaps, deployments required for hollow-nodes."
+  echo "Created secrets, configMaps, replication-controllers required for hollow-nodes."
 }
 
 # Wait until all hollow-nodes are running or there is a timeout.

--- a/test/kubemark/resources/heapster_template.json
+++ b/test/kubemark/resources/heapster_template.json
@@ -1,6 +1,6 @@
 {
-	"kind": "Deployment",
-	"apiVersion": "apps/v1",
+	"kind": "ReplicationController",
+	"apiVersion": "v1",
 	"metadata": {
 		"name": "heapster-v1.3.0",
 		"labels": {
@@ -11,9 +11,8 @@
 	"spec": {
 		"replicas": 1,
 		"selector": {
-			"matchLabels":
-				"k8s-app": "heapster",
-				"version": "v1.3.0"
+			"k8s-app": "heapster",
+			"version": "v1.3.0"
 		},
 		"template": {
 			"metadata": {

--- a/test/kubemark/resources/hollow-node_template.yaml
+++ b/test/kubemark/resources/hollow-node_template.yaml
@@ -1,5 +1,5 @@
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: v1
+kind: ReplicationController
 metadata:
   name: hollow-node
   labels:
@@ -8,8 +8,7 @@ metadata:
 spec:
   replicas: {{numreplicas}}
   selector:
-    matchLabels:
-      name: hollow-node
+    name: hollow-node
   template:
     metadata:
       labels:

--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -82,8 +82,8 @@ function delete-kubemark-image {
 }
 
 # Generate secret and configMap for the hollow-node pods to work, prepare
-# manifests of the hollow-node and heapster deployments from templates,
-# and finally create these resources through kubectl.
+# manifests of the hollow-node and heapster replication controllers from
+# templates, and finally create these resources through kubectl.
 function create-kube-hollow-node-resources {
   # Create kubemark namespace.
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/kubemark-ns.json"
@@ -142,7 +142,7 @@ function create-kube-hollow-node-resources {
 
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/addons" --namespace="kubemark"
 
-  # Create the deployment for hollow-nodes.
+  # Create the replication controller for hollow-nodes.
   # We allow to override the NUM_REPLICAS when running Cluster Autoscaler.
   NUM_REPLICAS=${NUM_REPLICAS:-${NUM_NODES}}
   sed "s@{{numreplicas}}@${NUM_REPLICAS}@g" "${RESOURCE_DIRECTORY}/hollow-node_template.yaml" > "${RESOURCE_DIRECTORY}/hollow-node.yaml"
@@ -174,7 +174,7 @@ function create-kube-hollow-node-resources {
   sed -i'' -e "s@{{kubemark_mig_config}}@${KUBEMARK_MIG_CONFIG:-}@g" "${RESOURCE_DIRECTORY}/hollow-node.yaml"
   "${KUBECTL}" create -f "${RESOURCE_DIRECTORY}/hollow-node.yaml" --namespace="kubemark"
 
-  echo "Created secrets, configMaps, deployments required for hollow-nodes."
+  echo "Created secrets, configMaps, replication-controllers required for hollow-nodes."
 }
 
 # Wait until all hollow-nodes are running or there is a timeout.


### PR DESCRIPTION
This reverts commit 661a08daf6acb99374401b68639d82e8b3509f04 from https://github.com/kubernetes/kubernetes/pull/86376, reversing changes made to 8cd87842894464bdf7bc25378fc4824ba1cb37bb.

That PR changed kubemark to use a deployment.

kubemark-up was already red when that PR merged, due to https://github.com/kubernetes/kubernetes/issues/86423 (reverted in https://github.com/kubernetes/kubernetes/pull/86425), but even with that reverted, kubemark-up did not go green again. It is possible this injected a second failure.

**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
Speculative revert to get the kubemark job green again

```release-note
NONE
```