### PR TITLE
Deflake grace period pod deletion e2e

### DIFF
--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -109,8 +109,10 @@ var _ = SIGDescribe("Pods Extended", func() {
 
 			ginkgo.By("verifying the kubelet observed the termination notice")
 
+			// allow up to 2x the grace period (which applies to process termination)
+			// for the kubelet to complete removal of the pod from the API
 			start := time.Now()
-			err = wait.Poll(time.Second*5, time.Second*30, func() (bool, error) {
+			err = wait.Poll(time.Second*5, time.Second*30*2, func() (bool, error) {
 				podList, err := e2ekubelet.GetKubeletPods(f.ClientSet, pod.Spec.NodeName)
 				if err != nil {
 					framework.Logf("Unable to retrieve kubelet pods for node %v: %v", pod.Spec.NodeName, err)


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/area deflake

**What this PR does / why we need it**:
Adds buffer to allow the kubelet time to remove a pod from the API after terminating its container processes.

**Which issue(s) this PR fixes**:
Fixes #85762

**Special notes for your reviewer**:

See analysis of current flakes in https://github.com/kubernetes/kubernetes/issues/85762#issuecomment-567796950

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

@kubernetes/sig-node-test-failures 
/sig node
/cc @smarterclayton 