### PR TITLE
get-kube-binaries.sh: Remove awk dependency

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -131,16 +131,18 @@ function md5sum_file() {
   if which md5 >/dev/null 2>&1; then
     md5 -q "$1"
   else
-    md5sum "$1" | awk '{ print $1 }'
+    tmp=$(md5sum "$1")
+    echo ${tmp%%[[:blank:]]*}
   fi
 }
 
 function sha1sum_file() {
   if which sha1sum >/dev/null 2>&1; then
-    sha1sum "$1" | awk '{ print $1 }'
+    tmp=$(sha1sum "$1")
   else
-    shasum -a1 "$1" | awk '{ print $1 }'
+    tmp=$(shasum -a1 "$1")
   fi
+  echo ${tmp%%[[:blank:]]*}
 }
 
 # Get default service account credentials of the VM.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Using shell script built-in functionality instead of awk make get-kube-binaries.sh run properly also on targets that do not have awk.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
