### PR TITLE
hack/local-up-cluster: modify cloud provider launch to work with aws

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -696,7 +696,11 @@ function start_kubelet {
     cloud_config_arg=("--cloud-provider=${CLOUD_PROVIDER}" "--cloud-config=${CLOUD_CONFIG}")
     if [[ "${EXTERNAL_CLOUD_PROVIDER:-}" == "true" ]]; then
        cloud_config_arg=("--cloud-provider=external")
-       cloud_config_arg+=("--provider-id=$(hostname)")
+       if [[ "${CLOUD_PROVIDER:-}" == "aws" ]]; then
+         cloud_config_arg+=("--provider-id=$(curl http://169.254.169.254/latest/meta-data/instance-id)")
+       else
+         cloud_config_arg+=("--provider-id=$(hostname)")
+       fi
     fi
 
     mkdir -p "/var/lib/kubelet" &>/dev/null || sudo mkdir -p "/var/lib/kubelet"


### PR DESCRIPTION
This commit updates the local-up-cluster script to set the proper provider id when the aws cloud provider is used.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug



**What this PR does / why we need it**:
This PR allows the usage of /hack/local-cluster-up.sh when using the AWS cloud provider. This makes it easier to test and develop on the AWS cloud provider.

**Which issue(s) this PR fixes**:
This PR fixes a bug when trying to spawn up a cluster using the `hack/local-up-cluster.sh` script with external cloud provider set as AWS.

```
E1220 06:57:37.402311    4217 node_controller.go:319] NodeAddress: Error fetching by providerID: Invalid format for AWS instance (ip-172-31-33-150) Error fetching by NodeName: getInstanceByNodeName failed for "i-0db5bc1926ffb5fc1" with "instance not found"
```

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Intend to create a PR within the aws cloud provider repo for instructions on properly using the aws provider. 


On an ec2 instance, the following variables will have you up and running with a single node cluster using the aws cloud provider.

```
export CLOUD_PROVIDER=aws
export EXTERNAL_CLOUD_PROVIDER=true
export CLOUD_CONFIG=$(pwd)/cloudconfig
export HOSTNAME_OVERRIDE=<your instance ID>
export EXTERNAL_CLOUD_PROVIDER_BINARY=/home/<user>/go/src/k8s.io/cloud-provider-aws/aws-cloud-controller-manager
```

Also be sure to tag your ec2 instance with `KubernetesCluster:<randomname>` and that your EC2 instance has typical EKS node permissions. 

For the cloudconfig, the file just contains the following
```
[Global]
RoleARN=""
```

This is telling the provide to use credentials from ec2 metadata. 


