### PR TITLE
kubeadm: use bind-address instead of address to configure the http probes

### DIFF
--- a/cmd/kubeadm/app/util/staticpod/utils.go
+++ b/cmd/kubeadm/app/util/staticpod/utils.go
@@ -38,11 +38,11 @@ import (
 )
 
 const (
-	// kubeControllerManagerAddressArg represents the address argument of the kube-controller-manager configuration.
-	kubeControllerManagerAddressArg = "address"
+	// kubeControllerManagerBindAddressArg represents the bind-address argument of the kube-controller-manager configuration.
+	kubeControllerManagerBindAddressArg = "bind-address"
 
-	// kubeSchedulerAddressArg represents the address argument of the kube-scheduler configuration.
-	kubeSchedulerAddressArg = "address"
+	// kubeSchedulerBindAddressArg represents the bind-address argument of the kube-scheduler configuration.
+	kubeSchedulerBindAddressArg = "bind-address"
 )
 
 // ComponentPod returns a Pod object from the container and volume specifications
@@ -252,7 +252,7 @@ func GetAPIServerProbeAddress(endpoint *kubeadmapi.APIEndpoint) string {
 
 // GetControllerManagerProbeAddress returns the kubernetes controller manager probe address
 func GetControllerManagerProbeAddress(cfg *kubeadmapi.ClusterConfiguration) string {
-	if addr, exists := cfg.ControllerManager.ExtraArgs[kubeControllerManagerAddressArg]; exists {
+	if addr, exists := cfg.ControllerManager.ExtraArgs[kubeControllerManagerBindAddressArg]; exists {
 		return addr
 	}
 	return "127.0.0.1"
@@ -260,7 +260,7 @@ func GetControllerManagerProbeAddress(cfg *kubeadmapi.ClusterConfiguration) stri
 
 // GetSchedulerProbeAddress returns the kubernetes scheduler probe address
 func GetSchedulerProbeAddress(cfg *kubeadmapi.ClusterConfiguration) string {
-	if addr, exists := cfg.Scheduler.ExtraArgs[kubeSchedulerAddressArg]; exists {
+	if addr, exists := cfg.Scheduler.ExtraArgs[kubeSchedulerBindAddressArg]; exists {
 		return addr
 	}
 	return "127.0.0.1"

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -72,6 +72,20 @@ func TestGetAPIServerProbeAddress(t *testing.T) {
 			},
 			expected: "2001:abcd:bcda::1",
 		},
+		{
+			desc: "filled in 0.0.0.0 AdvertiseAddress endpoint returns empty",
+			endpoint: &kubeadmapi.APIEndpoint{
+				AdvertiseAddress: "0.0.0.0",
+			},
+			expected: "",
+		},
+		{
+			desc: "filled in :: AdvertiseAddress endpoint returns empty",
+			endpoint: &kubeadmapi.APIEndpoint{
+				AdvertiseAddress: "::",
+			},
+			expected: "",
+		},
 	}
 
 	for _, test := range tests {
@@ -121,6 +135,28 @@ func TestGetControllerManagerProbeAddress(t *testing.T) {
 			},
 			expected: "2001:abcd:bcda::1",
 		},
+		{
+			desc: "setting controller manager extra address arg to 0.0.0.0 returns empty",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ControllerManager: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: map[string]string{
+						kubeControllerManagerBindAddressArg: "0.0.0.0",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			desc: "setting controller manager extra ipv6 address arg to :: returns empty",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				ControllerManager: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: map[string]string{
+						kubeControllerManagerBindAddressArg: "::",
+					},
+				},
+			},
+			expected: "",
+		},
 	}
 
 	for _, test := range tests {
@@ -133,6 +169,76 @@ func TestGetControllerManagerProbeAddress(t *testing.T) {
 	}
 }
 
+func TestGetSchedulerProbeAddress(t *testing.T) {
+	tests := []struct {
+		desc     string
+		cfg      *kubeadmapi.ClusterConfiguration
+		expected string
+	}{
+		{
+			desc: "no scheduler extra args leads to 127.0.0.1 being used",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				Scheduler: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: map[string]string{},
+				},
+			},
+			expected: "127.0.0.1",
+		},
+		{
+			desc: "setting scheduler extra address arg to something acknowledges it",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				Scheduler: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: map[string]string{
+						kubeSchedulerBindAddressArg: "10.10.10.10",
+					},
+				},
+			},
+			expected: "10.10.10.10",
+		},
+		{
+			desc: "setting scheduler extra ipv6 address arg to something acknowledges it",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				Scheduler: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: map[string]string{
+						kubeSchedulerBindAddressArg: "2001:abcd:bcda::1",
+					},
+				},
+			},
+			expected: "2001:abcd:bcda::1",
+		},
+		{
+			desc: "setting scheduler extra ipv6 address arg to 0.0.0.0 returns empty",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				Scheduler: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: map[string]string{
+						kubeSchedulerBindAddressArg: "0.0.0.0",
+					},
+				},
+			},
+			expected: "",
+		},
+		{
+			desc: "setting scheduler extra ipv6 address arg to :: returns empty",
+			cfg: &kubeadmapi.ClusterConfiguration{
+				Scheduler: kubeadmapi.ControlPlaneComponent{
+					ExtraArgs: map[string]string{
+						kubeSchedulerBindAddressArg: "::",
+					},
+				},
+			},
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			actual := GetSchedulerProbeAddress(test.cfg)
+			if actual != test.expected {
+				t.Errorf("Unexpected result from GetSchedulerProbeAddress:\n\texpected: %s\n\tactual: %s", test.expected, actual)
+			}
+		})
+	}
+}
 func TestGetEtcdProbeEndpoint(t *testing.T) {
 	var tests = []struct {
 		name             string

--- a/cmd/kubeadm/app/util/staticpod/utils_test.go
+++ b/cmd/kubeadm/app/util/staticpod/utils_test.go
@@ -104,7 +104,7 @@ func TestGetControllerManagerProbeAddress(t *testing.T) {
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ControllerManager: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: map[string]string{
-						kubeControllerManagerAddressArg: "10.10.10.10",
+						kubeControllerManagerBindAddressArg: "10.10.10.10",
 					},
 				},
 			},
@@ -115,7 +115,7 @@ func TestGetControllerManagerProbeAddress(t *testing.T) {
 			cfg: &kubeadmapi.ClusterConfiguration{
 				ControllerManager: kubeadmapi.ControlPlaneComponent{
 					ExtraArgs: map[string]string{
-						kubeControllerManagerAddressArg: "2001:abcd:bcda::1",
+						kubeControllerManagerBindAddressArg: "2001:abcd:bcda::1",
 					},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

kubeadm removed the deprecated "--address" flag for controller-manager
and scheduler in favor of "--bind-address" in #71973

We should use bind-address to configure the manifest probe addresses.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Found this in https://github.com/kubernetes-sigs/kind/pull/1195

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: use bind-address option to configure the kube-controller-manager and kube-scheduler http probes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
