### PR TITLE
Repair smoke-test for Windows GCE clusters

### DIFF
--- a/cluster/gce/windows/smoke-test.sh
+++ b/cluster/gce/windows/smoke-test.sh
@@ -40,7 +40,7 @@
 # Override this to use a different kubectl binary.
 kubectl=kubectl
 linux_deployment_timeout=60
-windows_deployment_timeout=180
+windows_deployment_timeout=300
 output_file=/tmp/k8s-smoke-test.out
 
 function check_windows_nodes_are_ready {
@@ -458,9 +458,9 @@ function test_linux_pod_to_internet {
   echo "TEST: ${FUNCNAME[0]}"
   local linux_command_pod
   linux_command_pod="$(get_linux_command_pod_name)"
-  local internet_ip="8.8.8.8"  # Google DNS
+  # A stable (hopefully) HTTP server provided by Cloudflare.
+  local internet_ip="1.1.1.1"
 
-  # This is expected to return 404 (not found).
   if ! $kubectl exec "$linux_command_pod" -- curl -m 20 \
       "http://$internet_ip" > $output_file; then
     cleanup_deployments
@@ -474,7 +474,7 @@ function test_linux_pod_to_k8s_service {
   echo "TEST: ${FUNCNAME[0]}"
   local linux_command_pod
   linux_command_pod="$(get_linux_command_pod_name)"
-  local service="heapster"
+  local service="metrics-server"
   local service_ip
   service_ip=$($kubectl get service --namespace kube-system $service \
     -o jsonpath='{.spec.clusterIP}')
@@ -483,8 +483,8 @@ function test_linux_pod_to_k8s_service {
     -o jsonpath='{.spec.ports[?(@.protocol=="TCP")].port}')
   echo "curl-ing $service address from Linux pod: $service_ip:$service_port"
 
-  # curl-ing the heapster service results in an expected 404 response code. The
-  # curl command does not set a failure return code in this case.
+  # curl-ing the metrics-server service downloads 14 bytes of unprintable binary
+  # data and sets a return code of success (0).
   if ! $kubectl exec "$linux_command_pod" -- \
       curl -m 20 "http://$service_ip:$service_port" &> $output_file; then
     cleanup_deployments
@@ -547,26 +547,12 @@ function test_windows_pod_to_internet {
   echo "TEST: ${FUNCNAME[0]}"
   local windows_command_pod
   windows_command_pod="$(get_windows_command_pod_name)"
-  local internet_ip="8.8.8.8"
+  # A stable (hopefully) HTTP server provided by Cloudflare. If this ever stops
+  # working, we can request from 8.8.8.8 (Google DNS) using https instead.
+  local internet_ip="1.1.1.1"
 
-  # This snippet tests Internet connectivity without depending on DNS by
-  # attempting to curl Google's well-known DNS IP, 8.8.8.8. On success we expect
-  # to get back a 404 status code; on failure the response object will have a
-  # status code of 0 or some other HTTP code.
   if ! $kubectl exec "$windows_command_pod" -- powershell.exe \
-      "\$response = try { \`
-         (curl -UseBasicParsing http://$internet_ip \`
-            -ErrorAction Stop).BaseResponse \`
-       } catch [System.Net.WebException] { \`
-         \$_.Exception.Response \`
-       }; \`
-       \$statusCodeInt = [int]\$response.StatusCode; \`
-       if (\$statusCodeInt -eq 404) { \`
-         exit 0 \`
-       } else { \`
-         Write-Host \"curl $internet_ip got unexpected status code \$statusCodeInt\"
-         exit 1 \`
-       }" > $output_file; then
+      "curl -UseBasicParsing http://$internet_ip" > $output_file; then
     cleanup_deployments
     echo "Failing output: $(cat $output_file)"
     echo "FAILED: ${FUNCNAME[0]}"
@@ -578,7 +564,7 @@ function test_windows_pod_to_k8s_service {
   echo "TEST: ${FUNCNAME[0]}"
   local windows_command_pod
   windows_command_pod="$(get_windows_command_pod_name)"
-  local service="heapster"
+  local service="metrics-server"
   local service_ip
   service_ip=$($kubectl get service --namespace kube-system $service \
     -o jsonpath='{.spec.clusterIP}')
@@ -588,21 +574,25 @@ function test_windows_pod_to_k8s_service {
   local service_address="$service_ip:$service_port"
 
   echo "curl-ing $service address from Windows pod: $service_address"
-  # Performing a web request to the heapster service results in an expected 404
-  # response; this code snippet filters out the expected 404 from other status
-  # codes that indicate failure.
+  # curl-ing the metrics-server service results in a ServerProtocolViolation
+  # ("The server committed a protocol violation. Section=ResponseStatusLine")
+  # exception. Since we don't care about what the metrics-server actually gives
+  # back to us, just that we can reach it, we check that we get the expected
+  # exception code and not some other exception code.
+  # TODO: it might be less fragile to check that we don't get the "Unable to
+  # connect to the remote server" exception code (2) instead of specifically
+  # expecting the protocol-violation exception code (11).
   if ! $kubectl exec "$windows_command_pod" -- powershell.exe \
-      "\$response = try { \`
-         (curl -UseBasicParsing http://$service_address \`
-            -ErrorAction Stop).BaseResponse \`
+      "\$result = try { \`
+         curl -UseBasicParsing http://$service_address -ErrorAction Stop \`
        } catch [System.Net.WebException] { \`
-         \$_.Exception.Response \`
+         \$_ \`
        }; \`
-       \$statusCodeInt = [int]\$response.StatusCode; \`
-       if (\$statusCodeInt -eq 404) { \`
+       if ([int]\$result.Exception.Status -eq 11) { \`
+         Write-Host \"curl $service_address got expected exception\"
          exit 0 \`
        } else { \`
-         Write-Host \"curl $service_address got unexpected status code \$statusCodeInt\"
+         Write-Host \"curl $service_address got unexpected result/exception: \$result\"
          exit 1 \`
        }" > $output_file; then
     cleanup_deployments


### PR DESCRIPTION
/kind bug

Several tests in the Windows cluster smoke test script have been broken for some time - this PR fixes them. Also increases the timeout for the Windows pod deployments; currently the first test run in a cluster pretty much always fails due to the amount of time it takes to pull + extract the Windows test container.

```release-note
NONE
```