### PR TITLE
Support AlwaysCheckAllPredicates in the scheduler framework.

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -89,6 +89,9 @@ type Configurator struct {
 	// Disable pod preemption or not.
 	disablePreemption bool
 
+	// Always check all predicates even if the middle of one predicate fails.
+	alwaysCheckAllPredicates bool
+
 	// percentageOfNodesToScore specifies percentage of all nodes to score in each scheduling cycle.
 	percentageOfNodesToScore int32
 
@@ -202,6 +205,11 @@ func (c *Configurator) CreateFromConfig(policy schedulerapi.Policy) (*Scheduler,
 		c.hardPodAffinitySymmetricWeight = policy.HardPodAffinitySymmetricWeight
 	}
 
+	// When AlwaysCheckAllPredicates is set to true, scheduler checks all the configured
+	// predicates even after one or more of them fails.
+	if policy.AlwaysCheckAllPredicates {
+		c.alwaysCheckAllPredicates = policy.AlwaysCheckAllPredicates
+	}
 	return c.CreateFromKeys(predicateKeys, priorityKeys, extenders)
 }
 
@@ -250,6 +258,7 @@ func (c *Configurator) CreateFromKeys(predicateKeys, priorityKeys sets.String, e
 		framework.WithClientSet(c.client),
 		framework.WithInformerFactory(c.informerFactory),
 		framework.WithSnapshotSharedLister(c.nodeInfoSnapshot),
+		framework.WithRunAllFilters(c.alwaysCheckAllPredicates),
 	)
 	if err != nil {
 		klog.Fatalf("error initializing the scheduling framework: %v", err)

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -78,6 +78,10 @@ type framework struct {
 	informerFactory informers.SharedInformerFactory
 
 	metricsRecorder *metricsRecorder
+
+	// Indicates that RunFilterPlugins should accumulate all failed statuses and not return
+	// after the first failure.
+	runAllFilters bool
 }
 
 // extensionPoint encapsulates desired and applied set of plugins at a specific extension
@@ -112,6 +116,7 @@ type frameworkOptions struct {
 	informerFactory      informers.SharedInformerFactory
 	snapshotSharedLister schedulerlisters.SharedLister
 	metricsRecorder      *metricsRecorder
+	runAllFilters        bool
 }
 
 // Option for the framework.
@@ -135,6 +140,14 @@ func WithInformerFactory(informerFactory informers.SharedInformerFactory) Option
 func WithSnapshotSharedLister(snapshotSharedLister schedulerlisters.SharedLister) Option {
 	return func(o *frameworkOptions) {
 		o.snapshotSharedLister = snapshotSharedLister
+	}
+}
+
+// WithRunAllFilters sets the runAllFilters flag, which means RunFilterPlugins accumulates
+// all failure Statuses.
+func WithRunAllFilters(runAllFilters bool) Option {
+	return func(o *frameworkOptions) {
+		o.runAllFilters = runAllFilters
 	}
 }
 
@@ -166,6 +179,7 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 		clientSet:             options.clientSet,
 		informerFactory:       options.informerFactory,
 		metricsRecorder:       options.metricsRecorder,
+		runAllFilters:         options.runAllFilters,
 	}
 	if plugins == nil {
 		return f, nil
@@ -395,27 +409,37 @@ func (f *framework) RunFilterPlugins(
 	state *CycleState,
 	pod *v1.Pod,
 	nodeInfo *schedulernodeinfo.NodeInfo,
-) (status *Status) {
+) (finalStatus *Status) {
 	if state.ShouldRecordFrameworkMetrics() {
 		startTime := time.Now()
 		defer func() {
-			f.metricsRecorder.observeExtensionPointDurationAsync(filter, status, metrics.SinceInSeconds(startTime))
+			f.metricsRecorder.observeExtensionPointDurationAsync(filter, finalStatus, metrics.SinceInSeconds(startTime))
 		}()
 	}
 	for _, pl := range f.filterPlugins {
-		status = f.runFilterPlugin(ctx, pl, state, pod, nodeInfo)
-		if !status.IsSuccess() {
-			if !status.IsUnschedulable() {
-				errMsg := fmt.Sprintf("error while running %q filter plugin for pod %q: %v",
-					pl.Name(), pod.Name, status.Message())
-				klog.Error(errMsg)
-				return NewStatus(Error, errMsg)
+		pluginStatus := f.runFilterPlugin(ctx, pl, state, pod, nodeInfo)
+		if !pluginStatus.IsSuccess() {
+			if !pluginStatus.IsUnschedulable() {
+				// Filter plugins are not supposed to return any status other than
+				// Success or Unschedulable.
+				return NewStatus(Error, fmt.Sprintf("running %q filter plugin for pod %q: %v", pl.Name(), pod.Name, pluginStatus.Message()))
 			}
-			return status
+			if !f.runAllFilters {
+				// Exit early if we don't need to run all filters.
+				return pluginStatus
+			}
+			// We need to continue and run all filters.
+			if finalStatus.IsSuccess() {
+				// This is the first failed plugin.
+				finalStatus = pluginStatus
+				continue
+			}
+			// We get here only if more than one Filter return unschedulable and runAllFilters is true.
+			finalStatus.reasons = append(finalStatus.reasons, pluginStatus.reasons...)
 		}
 	}
 
-	return nil
+	return finalStatus
 }
 
 func (f *framework) runFilterPlugin(ctx context.Context, pl FilterPlugin, state *CycleState, pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) *Status {

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -379,12 +379,10 @@ type Framework interface {
 	RunPreFilterPlugins(ctx context.Context, state *CycleState, pod *v1.Pod) *Status
 
 	// RunFilterPlugins runs the set of configured filter plugins for pod on
-	// the given node. It returns directly if any of the filter plugins
-	// return any status other than "Success". Note that for the node being
-	// evaluated, the passed nodeInfo reference could be different from the
-	// one in NodeInfoSnapshot map (e.g., pods considered to be running on
-	// the node could be different). For example, during preemption, we may
-	// pass a copy of the original nodeInfo object that has some pods
+	// the given node. Note that for the node being evaluated, the passed nodeInfo
+	// reference could be different from the one in NodeInfoSnapshot map (e.g., pods
+	// considered to be running on the node could be different). For example, during
+	// preemption, we may pass a copy of the original nodeInfo object that has some pods
 	// removed from it to evaluate the possibility of preempting them to
 	// schedule the target pod.
 	RunFilterPlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) *Status

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -897,7 +897,7 @@ func TestSchedulerWithVolumeBinding(t *testing.T) {
 				FindErr: findErr,
 			},
 			eventReason: "FailedScheduling",
-			expectError: fmt.Errorf("error while running %q filter plugin for pod %q: %v", volumebinding.Name, "foo", findErr),
+			expectError: fmt.Errorf("running %q filter plugin for pod %q: %v", volumebinding.Name, "foo", findErr),
 		},
 		{
 			name: "assume error",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds support for AlwaysCheckAllPredicates flag in the scheduling framework.

**Does this PR introduce a user-facing change?**:
```release-note
Adds back support for AlwaysCheckAllPredicates flag.
```

/cc @Huang-Wei 