### PR TITLE
Let RemoveObjectManagedFields return error

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -119,8 +119,12 @@ func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (o
 		}
 	}
 
-	internal.RemoveObjectManagedFields(liveObj)
-	internal.RemoveObjectManagedFields(newObj)
+	if err = internal.RemoveObjectManagedFields(liveObj); err != nil {
+		return nil, err
+	}
+	if err = internal.RemoveObjectManagedFields(newObj); err != nil {
+		return nil, err
+	}
 
 	if object, managed, err = f.fieldManager.Update(liveObj, newObj, managed, manager); err != nil {
 		return nil, err
@@ -147,7 +151,9 @@ func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, manager strin
 		return nil, fmt.Errorf("failed to decode managed fields: %v", err)
 	}
 
-	internal.RemoveObjectManagedFields(liveObj)
+	if err = internal.RemoveObjectManagedFields(liveObj); err != nil {
+		return nil, err
+	}
 
 	if object, managed, err = f.fieldManager.Apply(liveObj, patch, managed, manager, force); err != nil {
 		return nil, err

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
@@ -65,12 +65,13 @@ func NewManaged(f fieldpath.ManagedFields, t map[string]*metav1.Time) ManagedInt
 // RemoveObjectManagedFields removes the ManagedFields from the object
 // before we merge so that it doesn't appear in the ManagedFields
 // recursively.
-func RemoveObjectManagedFields(obj runtime.Object) {
+func RemoveObjectManagedFields(obj runtime.Object) error {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
-		panic(fmt.Sprintf("couldn't get accessor: %v", err))
+		return fmt.Errorf("couldn't get accessor: %v", err)
 	}
 	accessor.SetManagedFields(nil)
+	return nil
 }
 
 // DecodeObjectManagedFields extracts and converts the objects ManagedFields into a fieldpath.ManagedFields.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In RemoveObjectManagedFields, if we couldn't get accessor, return error.
The callers of RemoveObjectManagedFields check the error return.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
