### PR TITLE
sts: rollout history will show the details of the sts if the revision is specfied

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/BUILD
@@ -95,6 +95,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//staging/src/k8s.io/client-go/testing:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go
@@ -192,6 +192,8 @@ func (h *DaemonSetHistoryViewer) ViewHistory(namespace, name string, revision in
 	})
 }
 
+// printHistory returns the podTemplate of the given revision if it is non-zero
+// else returns the overall revisions
 func printHistory(history []*appsv1.ControllerRevision, revision int64, getPodTemplate func(history *appsv1.ControllerRevision) (*corev1.PodTemplateSpec, error)) (string, error) {
 	historyInfo := make(map[int64]*appsv1.ControllerRevision)
 	for _, history := range history {

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
@@ -105,8 +105,8 @@ func TestViewHistory(t *testing.T) {
 			t.Fatalf("error getting ViewHistory for a StatefulSets moons: %v", err)
 		}
 
-		expected := `REVISION
-1
+		expected := `REVISION  CHANGE-CAUSE
+1         <none>
 `
 
 		if result != expected {

--- a/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history_test.go
@@ -54,73 +54,74 @@ func TestHistoryViewerFor(t *testing.T) {
 
 func TestViewHistory(t *testing.T) {
 
-	var (
-		trueVar  = true
-		replicas = int32(1)
+	t.Run("for statefulSet", func(t *testing.T) {
+		var (
+			trueVar  = true
+			replicas = int32(1)
 
-		podStub = corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
-			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test", Image: "nginx"}}},
-		}
+			podStub = corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test", Image: "nginx"}}},
+			}
 
-		ssStub = &appsv1.StatefulSet{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "moons",
-				Namespace: "default",
-				UID:       "1993",
-				Labels:    map[string]string{"foo": "bar"},
-			},
-			Spec: appsv1.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: podStub.ObjectMeta.Labels}, Replicas: &replicas, Template: podStub},
-		}
-	)
-	stsRawData, err := json.Marshal(ssStub)
-	if err != nil {
-		t.Fatalf("error creating sts raw data: %v", err)
-	}
-	ssStub1 := &appsv1.ControllerRevision{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            "moons",
-			Namespace:       "default",
-			Labels:          map[string]string{"foo": "bar"},
-			OwnerReferences: []metav1.OwnerReference{{"apps/v1", "StatefulSet", "moons", "1993", &trueVar, nil}},
-		},
-		Data:     runtime.RawExtension{Raw: stsRawData},
-		TypeMeta: metav1.TypeMeta{Kind: "StatefulSet", APIVersion: "apps/v1"},
-		Revision: 1,
-	}
-
-	fakeClientSet := fake.NewSimpleClientset(ssStub)
-	_, err = fakeClientSet.AppsV1().ControllerRevisions("default").Create(context.TODO(), ssStub1, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("create controllerRevisions error %v occurred ", err)
-	}
-
-	var sts = &StatefulSetHistoryViewer{
-		fakeClientSet,
-	}
-
-	t.Run("should show revisions list if the revision is not specified", func(t *testing.T) {
-		result, err := sts.ViewHistory("default", "moons", 0)
+			ssStub = &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moons",
+					Namespace: "default",
+					UID:       "1993",
+					Labels:    map[string]string{"foo": "bar"},
+				},
+				Spec: appsv1.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: podStub.ObjectMeta.Labels}, Replicas: &replicas, Template: podStub},
+			}
+		)
+		stsRawData, err := json.Marshal(ssStub)
 		if err != nil {
-			t.Fatalf("error getting ViewHistory for a StatefulSets moons: %v", err)
+			t.Fatalf("error creating sts raw data: %v", err)
+		}
+		ssStub1 := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "moons",
+				Namespace:       "default",
+				Labels:          map[string]string{"foo": "bar"},
+				OwnerReferences: []metav1.OwnerReference{{"apps/v1", "StatefulSet", "moons", "1993", &trueVar, nil}},
+			},
+			Data:     runtime.RawExtension{Raw: stsRawData},
+			TypeMeta: metav1.TypeMeta{Kind: "StatefulSet", APIVersion: "apps/v1"},
+			Revision: 1,
 		}
 
-		expected := `REVISION  CHANGE-CAUSE
+		fakeClientSet := fake.NewSimpleClientset(ssStub)
+		_, err = fakeClientSet.AppsV1().ControllerRevisions("default").Create(context.TODO(), ssStub1, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("create controllerRevisions error %v occurred ", err)
+		}
+
+		var sts = &StatefulSetHistoryViewer{
+			fakeClientSet,
+		}
+
+		t.Run("should show revisions list if the revision is not specified", func(t *testing.T) {
+			result, err := sts.ViewHistory("default", "moons", 0)
+			if err != nil {
+				t.Fatalf("error getting ViewHistory for a StatefulSets moons: %v", err)
+			}
+
+			expected := `REVISION  CHANGE-CAUSE
 1         <none>
 `
 
-		if result != expected {
-			t.Fatalf("unexpected output  (%v was expected but got %v)", expected, result)
-		}
-	})
+			if result != expected {
+				t.Fatalf("unexpected output  (%v was expected but got %v)", expected, result)
+			}
+		})
 
-	t.Run("should describe the revision if revision is specified", func(t *testing.T) {
-		result, err := sts.ViewHistory("default", "moons", 1)
-		if err != nil {
-			t.Fatalf("error getting ViewHistory for a StatefulSets moons: %v", err)
-		}
+		t.Run("should describe the revision if revision is specified", func(t *testing.T) {
+			result, err := sts.ViewHistory("default", "moons", 1)
+			if err != nil {
+				t.Fatalf("error getting ViewHistory for a StatefulSets moons: %v", err)
+			}
 
-		expected := `Pod Template:
+			expected := `Pod Template:
   Labels:	foo=bar
   Containers:
    test:
@@ -132,9 +133,96 @@ func TestViewHistory(t *testing.T) {
   Volumes:	<none>
 `
 
-		if result != expected {
-			t.Fatalf("unexpected output  (%v was expected but got %v)", expected, result)
+			if result != expected {
+				t.Fatalf("unexpected output  (%v was expected but got %v)", expected, result)
+			}
+		})
+
+	})
+
+	t.Run("for daemonSet", func(t *testing.T) {
+		var (
+			trueVar = true
+			podStub = corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"foo": "bar"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "test", Image: "nginx"}}},
+			}
+
+			daemonSetStub = &appsv1.DaemonSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "moons",
+					Namespace: "default",
+					UID:       "1993",
+					Labels:    map[string]string{"foo": "bar"},
+				},
+				Spec: appsv1.DaemonSetSpec{Selector: &metav1.LabelSelector{MatchLabels: podStub.ObjectMeta.Labels}, Template: podStub},
+			}
+		)
+
+		daemonSetRaw, err := json.Marshal(daemonSetStub)
+		if err != nil {
+			t.Fatalf("error creating sts raw data: %v", err)
 		}
+		daemonSetControllerRevision := &appsv1.ControllerRevision{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            "moons",
+				Namespace:       "default",
+				Labels:          map[string]string{"foo": "bar"},
+				OwnerReferences: []metav1.OwnerReference{{"apps/v1", "DaemonSet", "moons", "1993", &trueVar, nil}},
+			},
+			Data:     runtime.RawExtension{Raw: daemonSetRaw},
+			TypeMeta: metav1.TypeMeta{Kind: "StatefulSet", APIVersion: "apps/v1"},
+			Revision: 1,
+		}
+
+		fakeClientSet := fake.NewSimpleClientset(daemonSetStub)
+		_, err = fakeClientSet.AppsV1().ControllerRevisions("default").Create(context.TODO(), daemonSetControllerRevision, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("create controllerRevisions error %v occurred ", err)
+		}
+
+		var daemonSetHistoryViewer = &DaemonSetHistoryViewer{
+			fakeClientSet,
+		}
+
+		t.Run("should show revisions list if the revision is not specified", func(t *testing.T) {
+			result, err := daemonSetHistoryViewer.ViewHistory("default", "moons", 0)
+			if err != nil {
+				t.Fatalf("error getting ViewHistory for a StatefulSets moons: %v", err)
+			}
+
+			expected := `REVISION  CHANGE-CAUSE
+1         <none>
+`
+
+			if result != expected {
+				t.Fatalf("unexpected output  (%v was expected but got %v)", expected, result)
+			}
+		})
+
+		t.Run("should describe the revision if revision is specified", func(t *testing.T) {
+			result, err := daemonSetHistoryViewer.ViewHistory("default", "moons", 1)
+			if err != nil {
+				t.Fatalf("error getting ViewHistory for a StatefulSets moons: %v", err)
+			}
+
+			expected := `Pod Template:
+  Labels:	foo=bar
+  Containers:
+   test:
+    Image:	nginx
+    Port:	<none>
+    Host Port:	<none>
+    Environment:	<none>
+    Mounts:	<none>
+  Volumes:	<none>
+`
+
+			if result != expected {
+				t.Fatalf("unexpected output  (%v was expected but got %v)", expected, result)
+			}
+		})
+
 	})
 }
 


### PR DESCRIPTION
Signed-off-by: Dinesh <dineshudt17@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently, `kubectl rollout history sts/sts-name --revision=some-revision` shows
```bash
statefulset.apps/sts-name with revision #some-version
REVISION
0
0
0
2
3
```
`Expected:` We **have to show the detailed view of the revision if revision is specified**
and there is a [TODO](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/kubectl/pkg/polymorphichelpers/history.go#L235) to fix this.

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubernetes/issues/82612
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Does this PR introduce a user-facing change?**:
```release-note
kubectl rollout history sts/sts-name --revision=some-revision will start showing the detailed view of  the sts on that specified revision
```
There is no change with respect to input command. Going forward, user will see the detailed pod template for the given revision of the statefulset (which is expected).