### PR TITLE
kubeadm: re-enable kubelet version check test in preflight

### DIFF
--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -671,11 +671,6 @@ func restoreEnv(e map[string]string) {
 }
 
 func TestKubeletVersionCheck(t *testing.T) {
-	// TODO: Re-enable this test
-	// fakeexec.FakeCmd supports only combined output.
-	// Hence .Output() returns a "not supported" error and we cannot use it for the test ATM.
-	t.Skip()
-
 	cases := []struct {
 		kubeletVersion string
 		k8sVersion     string
@@ -694,7 +689,7 @@ func TestKubeletVersionCheck(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.kubeletVersion, func(t *testing.T) {
 			fcmd := fakeexec.FakeCmd{
-				CombinedOutputScript: []fakeexec.FakeAction{
+				OutputScript: []fakeexec.FakeAction{
 					func() ([]byte, []byte, error) { return []byte("Kubernetes " + tc.kubeletVersion), nil, nil },
 				},
 			}

--- a/cmd/kubeadm/app/preflight/utils_test.go
+++ b/cmd/kubeadm/app/preflight/utils_test.go
@@ -26,11 +26,6 @@ import (
 )
 
 func TestGetKubeletVersion(t *testing.T) {
-	// TODO: Re-enable this test
-	// fakeexec.FakeCmd supports only combined output.
-	// Hence .Output() returns a "not supported" error and we cannot use it for the test ATM.
-	t.Skip()
-
 	cases := []struct {
 		output   string
 		expected string
@@ -47,7 +42,7 @@ func TestGetKubeletVersion(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.output, func(t *testing.T) {
 			fcmd := fakeexec.FakeCmd{
-				CombinedOutputScript: []fakeexec.FakeAction{
+				OutputScript: []fakeexec.FakeAction{
 					func() ([]byte, []byte, error) { return []byte(tc.output), nil, tc.err },
 				},
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
kubeadm: re-enable kubelet version check test in preflight

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#1925

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
