### PR TITLE
Add simple reference to synopsis of kube-scheduler

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -81,7 +81,8 @@ and capacity. The scheduler needs to take into account individual and collective
 resource requirements, quality of service requirements, hardware/software/policy
 constraints, affinity and anti-affinity specifications, data locality, inter-workload
 interference, deadlines, and so on. Workload-specific requirements will be exposed
-through the API as necessary.`,
+through the API as necessary. See [scheduling](https://kubernetes.io/docs/concepts/scheduling/)
+for more information about scheduling and the kube-scheduler component.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := runCommand(cmd, args, opts, registryOptions...); err != nil {
 				fmt.Fprintf(os.Stderr, "%v\n", err)


### PR DESCRIPTION
**What type of PR is this?**
 /kind documentation

**What this PR does / why we need it**:
Address the https://github.com/kubernetes/website/issues/17170
The objective is making the document into more polite for user.

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/website/issues/17170

**Special notes for your reviewer**:
Would you please inform me if some required steps are missing?

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
NONE
