### PR TITLE
Optimize error messages when updating openapi spec

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -79,7 +79,7 @@ APISERVER_PID=$!
 if ! kube::util::wait_for_url "${API_HOST}:${API_PORT}/healthz" "apiserver: "; then
   kube::log::error "Here are the last 10 lines from kube-apiserver (${API_LOGFILE})"
   kube::log::error "=== BEGIN OF LOG ==="
-  tail -10 "${API_LOGFILE}" || :
+  tail -10 "${API_LOGFILE}" >&2 || :
   kube::log::error "=== END OF LOG ==="
   exit 1
 fi


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Currently, when update openapi spec we may found this logs in silent mode.
```
Running update-openapi-spec
!!! [1220 15:57:01] Timed out waiting for apiserver:  to answer at 127.0.0.1:8050/healthz; tried 30 waiting 1 between each
!!! [1220 14:35:50] Here are the last 10 lines from kube-apiserver (/tmp/openapi-api-server.log)
!!! [1220 14:35:50] === BEGIN OF LOG ===
!!! [1220 14:35:50] === END OF LOG ===
!!! [1220 14:35:50] Call tree:
```
Seems like the `/tmp/openapi-api-server.log` is empty from upon message. It will confusing users.

It's not so convenient for us to echo `/tmp/openapi-api-server.log` to error logs.  
https://github.com/kubernetes/kubernetes/blob/aab1bef8c6e442ec6e423587b8951c3f23c4e5eb/hack/update-openapi-spec.sh#L82

So, I suggest moving surrounding code to info too. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: