### PR TITLE
change apply signature and move it's decoding into handler

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -70,6 +70,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1beta1/validation:go_default_library",
@@ -104,6 +105,7 @@ go_library(
         "//vendor/golang.org/x/net/websocket:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
@@ -17,7 +17,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal:go_default_library",
@@ -25,7 +24,6 @@ go_library(
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/fieldpath:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/merge:go_default_library",
-        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/buildmanagerinfo.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/buildmanagerinfo.go
@@ -51,12 +51,12 @@ func (f *buildManagerInfoManager) Update(liveObj, newObj runtime.Object, managed
 }
 
 // Apply implements Manager.
-func (f *buildManagerInfoManager) Apply(liveObj runtime.Object, patch []byte, managed Managed, manager string, force bool) (runtime.Object, Managed, error) {
+func (f *buildManagerInfoManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, manager string, force bool) (runtime.Object, Managed, error) {
 	manager, err := f.buildManagerInfo(manager, metav1.ManagedFieldsOperationApply)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to build manager identifier: %v", err)
 	}
-	return f.fieldManager.Apply(liveObj, patch, managed, manager, force)
+	return f.fieldManager.Apply(liveObj, appliedObj, managed, manager, force)
 }
 
 func (f *buildManagerInfoManager) buildManagerInfo(prefix string, operation metav1.ManagedFieldsOperationType) (string, error) {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers.go
@@ -58,8 +58,8 @@ func (f *capManagersManager) Update(liveObj, newObj runtime.Object, managed Mana
 }
 
 // Apply implements Manager.
-func (f *capManagersManager) Apply(liveObj runtime.Object, patch []byte, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error) {
-	return f.fieldManager.Apply(liveObj, patch, managed, fieldManager, force)
+func (f *capManagersManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error) {
+	return f.fieldManager.Apply(liveObj, appliedObj, managed, fieldManager, force)
 }
 
 // capUpdateManagers merges a number of the oldest update entries into versioned buckets,

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers_test.go
@@ -41,7 +41,7 @@ func (*fakeManager) Update(_, newObj runtime.Object, managed fieldmanager.Manage
 	return newObj, managed, nil
 }
 
-func (*fakeManager) Apply(_ runtime.Object, _ []byte, _ fieldmanager.Managed, _ string, force bool) (runtime.Object, fieldmanager.Managed, error) {
+func (*fakeManager) Apply(_, _ runtime.Object, _ fieldmanager.Managed, _ string, force bool) (runtime.Object, fieldmanager.Managed, error) {
 	panic("not implemented")
 	return nil, nil, nil
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -51,7 +51,7 @@ type Manager interface {
 
 	// Apply is used when server-side apply is called, as it merges the
 	// object and updates the managed fields.
-	Apply(liveObj runtime.Object, patch []byte, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error)
+	Apply(liveObj, appliedObj runtime.Object, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error)
 }
 
 // FieldManager updates the managed fields and merge applied
@@ -135,7 +135,7 @@ func (f *FieldManager) Update(liveObj, newObj runtime.Object, manager string) (o
 
 // Apply is used when server-side apply is called, as it merges the
 // object and updates the managed fields.
-func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, manager string, force bool) (object runtime.Object, err error) {
+func (f *FieldManager) Apply(liveObj, appliedObj runtime.Object, manager string, force bool) (object runtime.Object, err error) {
 	// If the object doesn't have metadata, apply isn't allowed.
 	if _, err = meta.Accessor(liveObj); err != nil {
 		return nil, fmt.Errorf("couldn't get accessor: %v", err)
@@ -149,7 +149,7 @@ func (f *FieldManager) Apply(liveObj runtime.Object, patch []byte, manager strin
 
 	internal.RemoveObjectManagedFields(liveObj)
 
-	if object, managed, err = f.fieldManager.Apply(liveObj, patch, managed, manager, force); err != nil {
+	if object, managed, err = f.fieldManager.Apply(liveObj, appliedObj, managed, manager, force); err != nil {
 		return nil, err
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied.go
@@ -51,7 +51,7 @@ func (f *skipNonAppliedManager) Update(liveObj, newObj runtime.Object, managed M
 }
 
 // Apply implements Manager.
-func (f *skipNonAppliedManager) Apply(liveObj runtime.Object, patch []byte, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error) {
+func (f *skipNonAppliedManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, fieldManager string, force bool) (runtime.Object, Managed, error) {
 	if len(managed.Fields()) == 0 {
 		emptyObj, err := f.objectCreater.New(f.gvk)
 		if err != nil {
@@ -62,5 +62,5 @@ func (f *skipNonAppliedManager) Apply(liveObj runtime.Object, patch []byte, mana
 			return nil, nil, fmt.Errorf("failed to create manager for existing fields: %v", err)
 		}
 	}
-	return f.fieldManager.Apply(liveObj, patch, managed, fieldManager, force)
+	return f.fieldManager.Apply(liveObj, appliedObj, managed, fieldManager, force)
 }

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/skipnonapplied_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+	"sigs.k8s.io/yaml"
 )
 
 type fakeObjectCreater struct {
@@ -49,7 +50,8 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 		schema.GroupVersionKind{},
 	)
 
-	if err := f.Apply([]byte(`{
+	appliedObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := yaml.Unmarshal([]byte(`{
 		"apiVersion": "v1",
 		"kind": "Pod",
 		"metadata": {
@@ -62,7 +64,11 @@ func TestNoUpdateBeforeFirstApply(t *testing.T) {
 				"image": "nginx:latest"
 			}]
         }
-	}`), "fieldmanager_test_apply", false); err != nil {
+	}`), &appliedObj.Object); err != nil {
+		t.Fatalf("error decoding YAML: %v", err)
+	}
+
+	if err := f.Apply(appliedObj, "fieldmanager_test_apply", false); err != nil {
 		t.Fatalf("failed to update object: %v", err)
 	}
 
@@ -96,7 +102,8 @@ func TestUpdateBeforeFirstApply(t *testing.T) {
 		t.Fatalf("managedFields were tracked on update only: %v", m)
 	}
 
-	appliedBytes := []byte(`{
+	appliedObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := yaml.Unmarshal([]byte(`{
 		"apiVersion": "v1",
 		"kind": "Pod",
 		"metadata": {
@@ -109,9 +116,11 @@ func TestUpdateBeforeFirstApply(t *testing.T) {
 				"image": "nginx:latest"
 			}]
         }
-	}`)
+	}`), &appliedObj.Object); err != nil {
+		t.Fatalf("error decoding YAML: %v", err)
+	}
 
-	err := f.Apply(appliedBytes, "fieldmanager_test_apply", false)
+	err := f.Apply(appliedObj, "fieldmanager_test_apply", false)
 	apiStatus, _ := err.(apierrors.APIStatus)
 	if err == nil || !apierrors.IsConflict(err) || len(apiStatus.Status().Details.Causes) != 1 {
 		t.Fatalf("Expecting to get one conflict but got %v", err)
@@ -125,7 +134,7 @@ func TestUpdateBeforeFirstApply(t *testing.T) {
 		t.Fatalf("Expecting conflict message to contain %q but got %q: %v", e, a, err)
 	}
 
-	if err := f.Apply(appliedBytes, "fieldmanager_test_apply", true); err != nil {
+	if err := f.Apply(appliedObj, "fieldmanager_test_apply", true); err != nil {
 		t.Fatalf("failed to update object: %v", err)
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/stripmeta.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/stripmeta.go
@@ -64,13 +64,13 @@ func (f *stripMetaManager) Update(liveObj, newObj runtime.Object, managed Manage
 }
 
 // Apply implements Manager.
-func (f *stripMetaManager) Apply(liveObj runtime.Object, patch []byte, managed Managed, manager string, force bool) (runtime.Object, Managed, error) {
-	newObj, managed, err := f.fieldManager.Apply(liveObj, patch, managed, manager, force)
+func (f *stripMetaManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, manager string, force bool) (runtime.Object, Managed, error) {
+	appliedObj, managed, err := f.fieldManager.Apply(liveObj, appliedObj, managed, manager, force)
 	if err != nil {
 		return nil, nil, err
 	}
 	f.stripFields(managed.Fields(), manager)
-	return newObj, managed, nil
+	return appliedObj, managed, nil
 }
 
 // stripFields removes a predefined set of paths found in typed from managed

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/stripmeta.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/stripmeta.go
@@ -65,12 +65,12 @@ func (f *stripMetaManager) Update(liveObj, newObj runtime.Object, managed Manage
 
 // Apply implements Manager.
 func (f *stripMetaManager) Apply(liveObj, appliedObj runtime.Object, managed Managed, manager string, force bool) (runtime.Object, Managed, error) {
-	appliedObj, managed, err := f.fieldManager.Apply(liveObj, appliedObj, managed, manager, force)
+	newObj, managed, err := f.fieldManager.Apply(liveObj, appliedObj, managed, manager, force)
 	if err != nil {
 		return nil, nil, err
 	}
 	f.stripFields(managed.Fields(), manager)
-	return appliedObj, managed, nil
+	return newObj, managed, nil
 }
 
 // stripFields removes a predefined set of paths found in typed from managed

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversionscheme "k8s.io/apimachinery/pkg/apis/meta/internalversion/scheme"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -48,6 +49,7 @@ import (
 	"k8s.io/apiserver/pkg/util/dryrun"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	utiltrace "k8s.io/utils/trace"
+	"sigs.k8s.io/yaml"
 )
 
 const (
@@ -433,7 +435,13 @@ func (p *applyPatcher) applyPatchToCurrentObject(obj runtime.Object) (runtime.Ob
 	if p.fieldManager == nil {
 		panic("FieldManager must be installed to run apply")
 	}
-	return p.fieldManager.Apply(obj, p.patch, p.options.FieldManager, force)
+
+	patchObj := &unstructured.Unstructured{Object: map[string]interface{}{}}
+	if err := yaml.Unmarshal(p.patch, &patchObj.Object); err != nil {
+		return nil, errors.NewBadRequest(fmt.Sprintf("error decoding YAML: %v", err))
+	}
+
+	return p.fieldManager.Apply(obj, patchObj, p.options.FieldManager, force)
 }
 
 func (p *applyPatcher) createNewObject() (runtime.Object, error) {


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

Change the signature of `fieldManager.Apply(liveObj runtime.Object, patchBytes []byte, ...)` to `fieldManager.Apply(liveObj, patchObj runtime.Object, ...)`

This makes it more consistent with `fieldManager.Update` and is a preparation for the fix on status wiping and the implementation of declarative fieldManager.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Required for: https://github.com/kubernetes/enhancements/pull/1123

/sig api-machinery
/wg apply
/cc @apelisse