### PR TITLE
fix kubectl run help image name

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -68,13 +68,13 @@ var (
 		kubectl run nginx --image=nginx
 
 		# Start a single instance of hazelcast and let the container expose port 5701 .
-		kubectl run hazelcast --image=hazelcast --port=5701
+		kubectl run hazelcast --image=hazelcast/hazelcast --port=5701
 
 		# Start a single instance of hazelcast and set environment variables "DNS_DOMAIN=cluster" and "POD_NAMESPACE=default" in the container.
-		kubectl run hazelcast --image=hazelcast --env="DNS_DOMAIN=cluster" --env="POD_NAMESPACE=default"
+		kubectl run hazelcast --image=hazelcast/hazelcast --env="DNS_DOMAIN=cluster" --env="POD_NAMESPACE=default"
 
 		# Start a single instance of hazelcast and set labels "app=hazelcast" and "env=prod" in the container.
-		kubectl run hazelcast --image=hazelcast --labels="app=hazelcast,env=prod"
+		kubectl run hazelcast --image=hazelcast/hazelcast --labels="app=hazelcast,env=prod"
 
 		# Start a replicated instance of nginx.
 		kubectl run nginx --image=nginx --replicas=5


### PR DESCRIPTION
**What type of PR is this?**

/sig cli
/area kubectl
/kind documentation

**What this PR does / why we need it**:

Currently, `kubectl run help` provides the wrong image name which doesn't work when you try to execute that example. This PR fixes the wrong image name in the example.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```