### PR TITLE
Change volume expand could not find plugin event to be type Normal

### DIFF
--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -279,11 +279,7 @@ func (expc *expandController) syncHandler(key string) error {
 	if err != nil || volumePlugin == nil {
 		msg := fmt.Errorf("didn't find a plugin capable of expanding the volume; " +
 			"waiting for an external controller to process this PVC")
-		eventType := v1.EventTypeNormal
-		if err != nil {
-			eventType = v1.EventTypeWarning
-		}
-		expc.recorder.Event(pvc, eventType, events.ExternalExpanding, fmt.Sprintf("Ignoring the PVC: %v.", msg))
+		expc.recorder.Event(pvc, v1.EventTypeNormal, events.ExternalExpanding, fmt.Sprintf("Ignoring the PVC: %v.", msg))
 		klog.Infof("Ignoring the PVC %q (uid: %q) : %v.", util.GetPersistentVolumeClaimQualifiedName(pvc), pvc.UID, msg)
 		// If we are expecting that an external plugin will handle resizing this volume then
 		// is no point in requeuing this PVC.


### PR DESCRIPTION
Signed-off-by: Grant Griffiths <grant@portworx.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Changes the "could not find volume plugin" event to be "Normal" instead of a "Warning". This a normal event because a CSI driver might pick up this work.

**Which issue(s) this PR fixes**:
Fixes #86200

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
n/a

/sig storage
