### PR TITLE
add extra group and usage check for bootstraptoken

### DIFF
--- a/test/e2e_kubeadm/bootstrap_token_test.go
+++ b/test/e2e_kubeadm/bootstrap_token_test.go
@@ -20,6 +20,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	bootstrapapi "k8s.io/cluster-bootstrap/token/api"
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/onsi/ginkgo"
@@ -54,8 +55,12 @@ var _ = Describe("bootstrap token", func() {
 
 		tokenNum := 0
 		for _, s := range secrets.Items {
-			if s.Type == corev1.SecretTypeBootstrapToken {
-				//TODO: might be we want to further check tokens  (auth-extra-groups, usage etc)
+			// check extra group and usage of token, make sure at least one token exist
+			if s.Type == corev1.SecretTypeBootstrapToken && string(s.Data[bootstrapapi.BootstrapTokenExtraGroupsKey]) == bootstrapTokensGroup {
+				usageBootstrapAuthentication := string(s.Data[bootstrapapi.BootstrapTokenUsageAuthentication])
+				usageBootstrapSigning := string(s.Data[bootstrapapi.BootstrapTokenUsageSigningKey])
+				gomega.Expect(usageBootstrapAuthentication).Should(gomega.Equal("true"), "the bootstrap token should be able to be used for authentication")
+				gomega.Expect(usageBootstrapSigning).Should(gomega.Equal("true"), "the bootstrap token should be able to be used for signing")
 				tokenNum++
 			}
 		}


### PR DESCRIPTION
kubeadm creates the bootstrap token with extra group
, system:bootstrappers:kubeadm:default-node-token,
should be able to be used for authentication and
signing.

Signed-off-by: Howard Zhang <howard.zhang@arm.com>

**What type of PR is this?**
/kind cleanup
/sig testing
