### PR TITLE
Fix golint errors in pkg/registry/scheduling/rest

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -187,7 +187,6 @@ pkg/registry/rbac/rolebinding
 pkg/registry/rbac/rolebinding/policybased
 pkg/registry/rbac/validation
 pkg/registry/registrytest
-pkg/registry/scheduling/rest
 pkg/registry/settings/rest
 pkg/registry/storage/rest
 pkg/registry/storage/storageclass


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>


/kind cleanup


**What this PR does / why we need it**:
Fix golint errors in pkg/registry/scheduling/rest

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
errors from golint:
pkg/registry/scheduling/rest/storage_scheduling.go:42:7: exported const PostStartHookName should have comment or be unexported
pkg/registry/scheduling/rest/storage_scheduling.go:44:6: exported type RESTStorageProvider should have comment or be unexported
pkg/registry/scheduling/rest/storage_scheduling.go:44:6: type name will be used as rest.RESTStorageProvider by other packages, and that stutters; consider calling this StorageProvider
pkg/registry/scheduling/rest/storage_scheduling.go:48:1: exported method RESTStorageProvider.NewRESTStorage should have comment or be unexported
pkg/registry/scheduling/rest/storage_scheduling.go:54:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/registry/scheduling/rest/storage_scheduling.go:61:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/registry/scheduling/rest/storage_scheduling.go:68:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/registry/scheduling/rest/storage_scheduling.go:80:9: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its
own line if necessary)
pkg/registry/scheduling/rest/storage_scheduling.go:91:9: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its
own line if necessary)
pkg/registry/scheduling/rest/storage_scheduling.go:103:9: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/registry/scheduling/rest/storage_scheduling.go:110:1: exported method RESTStorageProvider.PostStartHook should have comment or be unexported
pkg/registry/scheduling/rest/storage_scheduling.go:114:1: exported function AddSystemPriorityClasses should have comment or be unexported
pkg/registry/scheduling/rest/storage_scheduling.go:132:14: if block ends with a return statement, so drop this else and outdent its block
pkg/registry/scheduling/rest/storage_scheduling.go:153:1: exported method RESTStorageProvider.GroupName should have comment or be unexported
```
