### PR TITLE
deprecate scheduling_algorithm_predicate_evaluation_seconds and sched…

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -218,7 +218,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 		}
 	}
 	trace.Step("Running postfilter plugins done")
-	metrics.SchedulingAlgorithmPredicateEvaluationDuration.Observe(metrics.SinceInSeconds(startPredicateEvalTime))
+	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPredicateEvalTime))
 	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPredicateEvalTime))
 	metrics.SchedulingLatency.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
 	metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
@@ -226,7 +226,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 	startPriorityEvalTime := time.Now()
 	// When only one node after predicate, just use it.
 	if len(filteredNodes) == 1 {
-		metrics.SchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
+		metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 		metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
 		return ScheduleResult{
 			SuggestedHost:  filteredNodes[0].Name,
@@ -241,7 +241,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 		return result, err
 	}
 
-	metrics.SchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
+	metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 	metrics.DeprecatedSchedulingAlgorithmPriorityEvaluationDuration.Observe(metrics.SinceInMicroseconds(startPriorityEvalTime))
 	metrics.SchedulingLatency.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))
 	metrics.DeprecatedSchedulingLatency.WithLabelValues(metrics.PriorityEvaluation).Observe(metrics.SinceInSeconds(startPriorityEvalTime))

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -126,13 +126,14 @@ var (
 			DeprecatedVersion: "1.14.0",
 		},
 	)
-	SchedulingAlgorithmPredicateEvaluationDuration = metrics.NewHistogram(
+	DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration = metrics.NewHistogram(
 		&metrics.HistogramOpts{
-			Subsystem:      SchedulerSubsystem,
-			Name:           "scheduling_algorithm_predicate_evaluation_seconds",
-			Help:           "Scheduling algorithm predicate evaluation duration in seconds",
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         SchedulerSubsystem,
+			Name:              "scheduling_algorithm_predicate_evaluation_seconds",
+			Help:              "Scheduling algorithm predicate evaluation duration in seconds",
+			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.18.0",
 		},
 	)
 	DeprecatedSchedulingAlgorithmPredicateEvaluationDuration = metrics.NewHistogram(
@@ -145,13 +146,14 @@ var (
 			DeprecatedVersion: "1.14.0",
 		},
 	)
-	SchedulingAlgorithmPriorityEvaluationDuration = metrics.NewHistogram(
+	DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration = metrics.NewHistogram(
 		&metrics.HistogramOpts{
-			Subsystem:      SchedulerSubsystem,
-			Name:           "scheduling_algorithm_priority_evaluation_seconds",
-			Help:           "Scheduling algorithm priority evaluation duration in seconds",
-			Buckets:        metrics.ExponentialBuckets(0.001, 2, 15),
-			StabilityLevel: metrics.ALPHA,
+			Subsystem:         SchedulerSubsystem,
+			Name:              "scheduling_algorithm_priority_evaluation_seconds",
+			Help:              "Scheduling algorithm priority evaluation duration in seconds",
+			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
+			StabilityLevel:    metrics.ALPHA,
+			DeprecatedVersion: "1.18.0",
 		},
 	)
 	DeprecatedSchedulingAlgorithmPriorityEvaluationDuration = metrics.NewHistogram(
@@ -311,9 +313,9 @@ var (
 		DeprecatedSchedulingAlgorithmLatency,
 		BindingLatency,
 		DeprecatedBindingLatency,
-		SchedulingAlgorithmPredicateEvaluationDuration,
+		DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration,
 		DeprecatedSchedulingAlgorithmPredicateEvaluationDuration,
-		SchedulingAlgorithmPriorityEvaluationDuration,
+		DeprecatedSchedulingAlgorithmPriorityEvaluationSecondsDuration,
 		DeprecatedSchedulingAlgorithmPriorityEvaluationDuration,
 		SchedulingAlgorithmPreemptionEvaluationDuration,
 		DeprecatedSchedulingAlgorithmPreemptionEvaluationDuration,


### PR DESCRIPTION
…uling_algorithm_priority_evaluation_seconds

**What type of PR is this?**

/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
- scheduling_algorithm_predicate_evaluation_seconds, replaced by framework_extension_point_duration_seconds[extenstion_point="Filter"]
- scheduling_algorithm_priority_evaluation_seconds, replaced by framework_extension_point_duration_seconds[extenstion_point="Score"]

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref # https://github.com/kubernetes/kubernetes/issues/86391

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Marked scheduler's metrics scheduling_algorithm_predicate_evaluation_seconds and
scheduling_algorithm_priority_evaluation_seconds as deprecated. Those are replaced by framework_extension_point_duration_seconds[extenstion_point="Filter"] and framework_extension_point_duration_seconds[extenstion_point="Score"] respectively.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig scheduling
/assign @liu-cong 