### PR TITLE
Clean up kube-apiserver reference document

### DIFF
--- a/pkg/kubeapiserver/options/authentication.go
+++ b/pkg/kubeapiserver/options/authentication.go
@@ -196,7 +196,7 @@ func (s *BuiltInAuthenticationOptions) AddFlags(fs *pflag.FlagSet) {
 		"Identifiers of the API. The service account token authenticator will validate that "+
 		"tokens used against the API are bound to at least one of these audiences. If the "+
 		"--service-account-issuer flag is configured and this flag is not, this field "+
-		"defaults to a single element list containing the issuer URL .")
+		"defaults to a single element list containing the issuer URL.")
 
 	if s.Anonymous != nil {
 		fs.BoolVar(&s.Anonymous.Allow, "anonymous-auth", s.Anonymous.Allow, ""+

--- a/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
@@ -184,7 +184,7 @@ func (s *ServerRunOptions) AddUniversalFlags(fs *pflag.FlagSet) {
 
 	deprecatedMasterServiceNamespace := metav1.NamespaceDefault
 	fs.StringVar(&deprecatedMasterServiceNamespace, "master-service-namespace", deprecatedMasterServiceNamespace, ""+
-		"DEPRECATED: the namespace from which the kubernetes master services should be injected into pods.")
+		"DEPRECATED: the namespace from which the Kubernetes master services should be injected into pods.")
 
 	fs.IntVar(&s.MaxRequestsInFlight, "max-requests-inflight", s.MaxRequestsInFlight, ""+
 		"The maximum number of non-mutating requests in flight at a given time. When the server exceeds this, "+

--- a/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/serving.go
@@ -147,9 +147,9 @@ func (s *SecureServingOptions) AddFlags(fs *pflag.FlagSet) {
 
 	desc := "The port on which to serve HTTPS with authentication and authorization."
 	if s.Required {
-		desc += "It cannot be switched off with 0."
+		desc += " It cannot be switched off with 0."
 	} else {
-		desc += "If 0, don't serve HTTPS at all."
+		desc += " If 0, don't serve HTTPS at all."
 	}
 	fs.IntVar(&s.BindPort, "secure-port", s.BindPort, desc)
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Clean up kube-apiserver reference document(https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).

I modified three places.
- 1: pkg/kubeapiserver/options/authentication.go 
  - I removed unnecessary space.
- 2: staging/src/k8s.io/apiserver/pkg/server/options/server_run_options.go
  - I fixed orthographic variants(The kubernetes -> The Kubernetes).
- 3: staging/src/k8s.io/apiserver/pkg/server/options/serving.go
  - I added necessary space. (Need to add space when joining two sentences)

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
