### PR TITLE
Cleanup scheduler's in-tree plugins registry naming

### DIFF
--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -587,7 +587,7 @@ func newConfigFactoryWithFrameworkRegistry(
 func newConfigFactory(
 	client clientset.Interface, hardPodAffinitySymmetricWeight int32, stopCh <-chan struct{}) *Configurator {
 	return newConfigFactoryWithFrameworkRegistry(client, hardPodAffinitySymmetricWeight, stopCh,
-		frameworkplugins.NewDefaultRegistry(&frameworkplugins.RegistryArgs{}), frameworkplugins.NewDefaultConfigProducerRegistry())
+		frameworkplugins.NewInTreeRegistry(&frameworkplugins.RegistryArgs{}), frameworkplugins.NewConfigProducerRegistry())
 }
 
 type fakeExtender struct {

--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -2,7 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["default_registry.go"],
+    srcs = ["registry.go"],
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins",
     visibility = ["//visibility:public"],
     deps = [
@@ -72,7 +72,7 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["default_registry_test.go"],
+    srcs = ["registry_test.go"],
     embed = [":go_default_library"],
     deps = [
         "//pkg/scheduler/apis/config:go_default_library",

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -52,10 +52,10 @@ type RegistryArgs struct {
 	VolumeBinder *volumebinder.VolumeBinder
 }
 
-// NewDefaultRegistry builds the default registry with all the in-tree plugins.
-// This is the registry that Kubernetes default scheduler uses. A scheduler that runs out of tree
-// plugins can register additional plugins through the WithFrameworkOutOfTreeRegistry option.
-func NewDefaultRegistry(args *RegistryArgs) framework.Registry {
+// NewInTreeRegistry builds the registry with all the in-tree plugins.
+// A scheduler that runs out of tree plugins can register additional plugins
+// through the WithFrameworkOutOfTreeRegistry option.
+func NewInTreeRegistry(args *RegistryArgs) framework.Registry {
 	return framework.Registry{
 		defaultpodtopologyspread.Name:        defaultpodtopologyspread.New,
 		imagelocality.Name:                   imagelocality.New,
@@ -115,8 +115,8 @@ type ConfigProducerRegistry struct {
 	PriorityToConfigProducer  map[string]ConfigProducer
 }
 
-// NewDefaultConfigProducerRegistry creates a new producer registry.
-func NewDefaultConfigProducerRegistry() *ConfigProducerRegistry {
+// NewConfigProducerRegistry creates a new producer registry.
+func NewConfigProducerRegistry() *ConfigProducerRegistry {
 	registry := &ConfigProducerRegistry{
 		PredicateToConfigProducer: make(map[string]ConfigProducer),
 		PriorityToConfigProducer:  make(map[string]ConfigProducer),

--- a/pkg/scheduler/framework/plugins/registry_test.go
+++ b/pkg/scheduler/framework/plugins/registry_test.go
@@ -41,7 +41,7 @@ func produceConfig(keys []string, producersMap map[string]ConfigProducer, args C
 }
 
 func TestRegisterConfigProducers(t *testing.T) {
-	registry := NewDefaultConfigProducerRegistry()
+	registry := NewConfigProducerRegistry()
 	testPredicateName1 := "testPredicate1"
 	testFilterName1 := "testFilter1"
 	registry.RegisterPredicate(testPredicateName1,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -141,9 +141,9 @@ type schedulerOptions struct {
 	bindTimeoutSeconds             int64
 	podInitialBackoffSeconds       int64
 	podMaxBackoffSeconds           int64
-	// Default registry contains all in-tree plugins
-	frameworkDefaultRegistry framework.Registry
-	// This registry contains out of tree plugins to be merged with default registry.
+	// Contains all in-tree plugins.
+	frameworkInTreeRegistry framework.Registry
+	// This registry contains out of tree plugins to be merged with the in-tree registry.
 	frameworkOutOfTreeRegistry      framework.Registry
 	frameworkConfigProducerRegistry *frameworkplugins.ConfigProducerRegistry
 	frameworkPlugins                *schedulerapi.Plugins
@@ -195,10 +195,10 @@ func WithBindTimeoutSeconds(bindTimeoutSeconds int64) Option {
 	}
 }
 
-// WithFrameworkDefaultRegistry sets the framework's default registry. This is only used in integration tests.
-func WithFrameworkDefaultRegistry(registry framework.Registry) Option {
+// WithFrameworkInTreeRegistry sets the framework's in-tree registry. This is only used in integration tests.
+func WithFrameworkInTreeRegistry(registry framework.Registry) Option {
 	return func(o *schedulerOptions) {
-		o.frameworkDefaultRegistry = registry
+		o.frameworkInTreeRegistry = registry
 	}
 }
 
@@ -256,7 +256,7 @@ var defaultSchedulerOptions = schedulerOptions{
 	bindTimeoutSeconds:              BindTimeoutSeconds,
 	podInitialBackoffSeconds:        int64(internalqueue.DefaultPodInitialBackoffDuration.Seconds()),
 	podMaxBackoffSeconds:            int64(internalqueue.DefaultPodMaxBackoffDuration.Seconds()),
-	frameworkConfigProducerRegistry: frameworkplugins.NewDefaultConfigProducerRegistry(),
+	frameworkConfigProducerRegistry: frameworkplugins.NewConfigProducerRegistry(),
 	// The plugins and pluginConfig options are currently nil because we currently don't have
 	// "default" plugins. All plugins that we run through the framework currently come from two
 	// sources: 1) specified in component config, in which case those two options should be
@@ -297,9 +297,9 @@ func New(client clientset.Interface,
 		time.Duration(options.bindTimeoutSeconds)*time.Second,
 	)
 
-	registry := options.frameworkDefaultRegistry
+	registry := options.frameworkInTreeRegistry
 	if registry == nil {
-		registry = frameworkplugins.NewDefaultRegistry(&frameworkplugins.RegistryArgs{
+		registry = frameworkplugins.NewInTreeRegistry(&frameworkplugins.RegistryArgs{
 			VolumeBinder: volumeBinder,
 		})
 	}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -203,7 +203,7 @@ func TestSchedulerCreation(t *testing.T) {
 
 	// Test case for when a plugin name in frameworkOutOfTreeRegistry already exist in defaultRegistry.
 	fakeFrameworkPluginName := ""
-	for name := range frameworkplugins.NewDefaultRegistry(&frameworkplugins.RegistryArgs{}) {
+	for name := range frameworkplugins.NewInTreeRegistry(&frameworkplugins.RegistryArgs{}) {
 		fakeFrameworkPluginName = name
 		break
 	}

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -483,7 +483,7 @@ func TestPreFilterPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "prefilter-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -554,7 +554,7 @@ func TestScorePlugin(t *testing.T) {
 
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "score-plugin", nil), 10,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for i, fail := range []bool{false, true} {
@@ -612,7 +612,7 @@ func TestNormalizeScorePlugin(t *testing.T) {
 	}
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "score-plugin", nil), 10,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 
 	defer cleanupTest(t, context)
 
@@ -657,7 +657,7 @@ func TestReservePlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "reserve-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for _, fail := range []bool{false, true} {
@@ -709,7 +709,7 @@ func TestPrebindPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "prebind-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -792,7 +792,7 @@ func TestUnreservePlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "unreserve-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -882,7 +882,7 @@ func TestBindPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerWithOptions(t, testContext, false, nil, time.Second,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry),
+		scheduler.WithFrameworkInTreeRegistry(registry),
 		scheduler.WithFrameworkConfigProducerRegistry(nil))
 	defer cleanupTest(t, context)
 
@@ -1043,7 +1043,7 @@ func TestPostBindPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "postbind-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -1099,7 +1099,7 @@ func TestPermitPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "permit-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -1187,7 +1187,7 @@ func TestMultiplePermitPlugins(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "multi-permit-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	// Both permit plugins will return Wait for permitting
@@ -1242,7 +1242,7 @@ func TestPermitPluginsCancelled(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "permit-plugins", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	// Both permit plugins will return Wait for permitting
@@ -1283,7 +1283,7 @@ func TestCoSchedulingWithPermitPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "permit-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	tests := []struct {
@@ -1364,7 +1364,7 @@ func TestFilterPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "filter-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for _, fail := range []bool{false, true} {
@@ -1415,7 +1415,7 @@ func TestPostFilterPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "post-filter-plugin", nil), 2,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	for _, fail := range []bool{false, true} {
@@ -1460,7 +1460,7 @@ func TestPreemptWithPermitPlugin(t *testing.T) {
 	// Create the master and the scheduler with the test plugin set.
 	context := initTestSchedulerForFrameworkTest(t, initTestMaster(t, "preempt-with-permit-plugin", nil), 0,
 		scheduler.WithFrameworkPlugins(plugins),
-		scheduler.WithFrameworkDefaultRegistry(registry))
+		scheduler.WithFrameworkInTreeRegistry(registry))
 	defer cleanupTest(t, context)
 
 	// Add one node.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Renames the plugin registry from DefaultRegistry to InTreeRegistry. This should help clarify the difference between the DefaultProvider plugins (which is what we initially meant by the default registry in the framework KEP) and the registry of in-tree plugins (which includes all in-tree plugins and is more than what the set of plugins that the DefaultProvider configures the scheduler with).

**Which issue(s) this PR fixes**:
Part of #86162

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @draveness 