### PR TITLE
Remove todos for verification of “allowed to post CSR” and "allowed to auto approve CSR" for bootstraptoken group

### DIFF
--- a/test/e2e_kubeadm/bootstrap_token_test.go
+++ b/test/e2e_kubeadm/bootstrap_token_test.go
@@ -68,7 +68,6 @@ var _ = Describe("bootstrap token", func() {
 			rbacv1.GroupKind, bootstrapTokensGroup,
 			bootstrapTokensAllowPostCSRClusterRoleName,
 		)
-		//TODO: check if possible to verify "allowed to post CSR" using subject asses review as well
 	})
 
 	ginkgo.It("should be allowed to auto approve CSR for kubelet certificates on joining nodes", func() {
@@ -77,6 +76,5 @@ var _ = Describe("bootstrap token", func() {
 			rbacv1.GroupKind, bootstrapTokensGroup,
 			bootstrapTokensCSRAutoApprovalClusterRoleName,
 		)
-		//TODO: check if possible to verify "allowed to auto approve CSR" using subject asses review as well
 	})
 })


### PR DESCRIPTION
verify if group _system:bootstrappers:kubeadm:default-node-token_
can create resource _certificatesigningrequests_ and _certificatesigningrequests/nodeclient_

**What type of PR is this?**
/kind cleanup
/sig testing
