### PR TITLE
Fixing regex for kubernetes version in kubeadm

### DIFF
--- a/cmd/kubeadm/app/util/version.go
+++ b/cmd/kubeadm/app/util/version.go
@@ -40,7 +40,7 @@ const (
 var (
 	kubeReleaseBucketURL  = "https://dl.k8s.io"
 	kubeReleaseRegex      = regexp.MustCompile(`^v?(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)([-0-9a-zA-Z_\.+]*)?$`)
-	kubeReleaseLabelRegex = regexp.MustCompile(`^[[:lower:]]+(-[-\w_\.]+)?$`)
+	kubeReleaseLabelRegex = regexp.MustCompile(`(k8s-master|((latest|stable)+(-[1-9](\.[1-9]([0-9])?)?)?))\z`)
 	kubeBucketPrefixes    = regexp.MustCompile(`^((release|ci|ci-cross)/)?([-\w_\.+]+)$`)
 )
 
@@ -61,6 +61,7 @@ var (
 //  latest      (latest release, including alpha/beta)
 //  latest-1    (latest release in 1.x, including alpha/beta)
 //  latest-1.0  (and similarly 1.1, 1.2, 1.3, ...)
+//  k8s-master  (latest cross build)
 func KubernetesReleaseVersion(version string) (string, error) {
 	return kubernetesReleaseVersion(version, fetchFromURL)
 }

--- a/cmd/kubeadm/app/util/version_test.go
+++ b/cmd/kubeadm/app/util/version_test.go
@@ -116,14 +116,13 @@ func TestVersionFromNetwork(t *testing.T) {
 	currentVersion := normalizedBuildVersion(constants.CurrentKubernetesVersion.String())
 
 	cases := map[string]T{
-		"stable":     {"stable-1", "v1.4.6", false, false}, // recursive pointer to stable-1
-		"stable-1":   {"v1.4.6", "v1.4.6", false, false},
-		"stable-1.3": {"v1.3.10", "v1.3.10", false, false},
-		"latest":     {"v1.6.0-alpha.0", "v1.6.0-alpha.0", false, false},
-		"latest-1.3": {"v1.3.11-beta.0", "v1.3.11-beta.0", false, false},
-		"empty":      {"", currentVersion, true, false},
-		"garbage":    {"<?xml version='1.0'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message></Error>", currentVersion, true, false},
-		"unknown":    {"The requested URL was not found on this server.", currentVersion, true, false},
+		"stable":          {"stable-1", "v1.4.6", false, false}, // recursive pointer to stable-1
+		"stable-1":        {"v1.4.6", "v1.4.6", false, false},
+		"stable-1.3":      {"v1.3.10", "v1.3.10", false, false},
+		"latest":          {"v1.6.0-alpha.0", "v1.6.0-alpha.0", false, false},
+		"latest-1.3":      {"v1.3.11-beta.0", "v1.3.11-beta.0", false, false},
+		"latest-1.5":      {"", currentVersion, true, false}, // fallback to currentVersion on fetcher error
+		"invalid-version": {"", "", false, true},             // invalid version cannot be parsed
 	}
 
 	for k, v := range cases {
@@ -195,11 +194,10 @@ func TestSplitVersion(t *testing.T) {
 		{"v1.8.0-alpha.2.1231+afabd012389d53a", "https://dl.k8s.io/release", "v1.8.0-alpha.2.1231+afabd012389d53a", true},
 		{"release/v1.7.0", "https://dl.k8s.io/release", "v1.7.0", true},
 		{"release/latest-1.7", "https://dl.k8s.io/release", "latest-1.7", true},
-		// CI builds area, lookup actual builds at ci-cross/*.txt
+		// CI builds area
 		{"ci/latest", "https://dl.k8s.io/ci", "latest", true},
-		{"ci-cross/latest", "https://dl.k8s.io/ci-cross", "latest", true},
+		{"ci/k8s-master", "https://dl.k8s.io/ci", "k8s-master", true},
 		{"ci/latest-1.7", "https://dl.k8s.io/ci", "latest-1.7", true},
-		{"ci-cross/latest-1.7", "https://dl.k8s.io/ci-cross", "latest-1.7", true},
 		// unknown label in default (release) area: splitVersion validate only areas.
 		{"unknown-1", "https://dl.k8s.io/release", "unknown-1", true},
 		// unknown area, not valid input.
@@ -238,9 +236,8 @@ func TestKubernetesIsCIVersion(t *testing.T) {
 		{"release/v1.0.0", false},
 		// CI builds
 		{"ci/latest-1", true},
-		{"ci-cross/latest", true},
+		{"ci/k8s-master", true},
 		{"ci/v1.9.0-alpha.1.123+acbcbfd53bfa0a", true},
-		{"ci-cross/v1.9.0-alpha.1.123+acbcbfd53bfa0a", true},
 	}
 
 	for _, tc := range cases {
@@ -269,9 +266,7 @@ func TestCIBuildVersion(t *testing.T) {
 		{"release/0invalid", "", false},
 		// CI or custom builds
 		{"ci/v1.9.0-alpha.1.123+acbcbfd53bfa0a", "v1.9.0-alpha.1.123+acbcbfd53bfa0a", true},
-		{"ci-cross/v1.9.0-alpha.1.123+acbcbfd53bfa0a", "v1.9.0-alpha.1.123+acbcbfd53bfa0a", true},
 		{"ci/1.9.0-alpha.1.123+acbcbfd53bfa0a", "v1.9.0-alpha.1.123+acbcbfd53bfa0a", true},
-		{"ci-cross/1.9.0-alpha.1.123+acbcbfd53bfa0a", "v1.9.0-alpha.1.123+acbcbfd53bfa0a", true},
 		{"ci/0invalid", "", false},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Since https://github.com/kubernetes/test-infra/pull/14030 got merged, the marker for cross builds has moved from ci-cross/latest to ci/k8s-master. While providing the marker to kubeadm via --kubernetes-version flag, ci/k8s-master fails with:

```
version "ci/k8s-master" doesn't match patterns for neither semantic version nor labels
```

This PR fixes the release label regex so that kubeadm can recognize ci/k8s-master marker.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: add support for the "ci/k8s-master" version label as a replacement for "ci-cross/*", which no longer exists.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```