### PR TITLE
Come out of loop when omitempty is true

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -256,6 +256,7 @@ func fieldInfoFromField(structType reflect.Type, field int) *fieldInfo {
 		for i := range items {
 			if items[i] == "omitempty" {
 				info.omitempty = true
+				break
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In fieldInfoFromField, when "omitempty" is seen, we can break out of the loop.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
