### PR TITLE
Deduplicate sorted scalars

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1750,8 +1750,24 @@ func (ss SortableSliceOfMaps) Swap(i, j int) {
 }
 
 func deduplicateAndSortScalars(s []interface{}) []interface{} {
-	s = deduplicateScalars(s)
-	return sortScalars(s)
+	s = sortScalars(s)
+	return deduplicateSortedScalars(s)
+}
+
+// the passed in slice is sorted
+func deduplicateSortedScalars(s []interface{}) []interface{} {
+	length := len(s)
+	lastIdx := 0
+	for i := 1; i < length; i++ {
+		if s[lastIdx] != s[i] {
+			lastIdx++
+			s[lastIdx] = s[i]
+		}
+	}
+	if lastIdx < length-1 {
+		s = s[0 : lastIdx+1]
+	}
+	return s
 }
 
 func sortScalars(s []interface{}) []interface{} {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
deduplicateAndSortScalars performs dedup which is O(N^2) operation followed by sorting.

We can perform sorting first - O(N logN), followed by dedup which is linear.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
