### PR TITLE
Perform linear compelxity deduplication

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -1761,20 +1761,22 @@ func sortScalars(s []interface{}) []interface{} {
 }
 
 func deduplicateScalars(s []interface{}) []interface{} {
-	// Clever algorithm to deduplicate.
-	length := len(s) - 1
-	for i := 0; i < length; i++ {
-		for j := i + 1; j <= length; j++ {
-			if s[i] == s[j] {
-				s[j] = s[length]
-				s = s[0:length]
-				length--
-				j--
-			}
-		}
+	m := make(map[interface{}]bool)
+	for _, item := range s {
+		m[item] = true
 	}
-
-	return s
+	l := len(m)
+	if l == len(s) {
+		// there is no duplicate
+		return s
+	}
+	deduped := make([]interface{}, l, l)
+	idx := 0
+	for item := range m {
+		deduped[idx] = item
+		idx++
+	}
+	return deduped
 }
 
 type SortableSliceOfScalars struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
deduplicateScalars is not efficient in the sense that the complexity is O(N^2).

This PR replaces the nested loop with the introduction of map, resulting in linear complexity dedup.

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
