### PR TITLE
Require client / server protocols

### DIFF
--- a/pkg/client/tests/remotecommand_test.go
+++ b/pkg/client/tests/remotecommand_test.go
@@ -185,33 +185,6 @@ func TestStream(t *testing.T) {
 			ClientProtocols: []string{remotecommandconsts.StreamProtocolV2Name},
 			ServerProtocols: []string{remotecommandconsts.StreamProtocolV2Name},
 		},
-		{
-			// 1.0 kubectl, 1.0 kubelet
-			TestName:        "unversioned client, unversioned server",
-			Stdout:          "b",
-			Stderr:          "c",
-			MessageCount:    1,
-			ClientProtocols: []string{},
-			ServerProtocols: []string{},
-		},
-		{
-			// 1.0 kubectl, 1.1+ kubelet
-			TestName:        "unversioned client, versioned server",
-			Stdout:          "b",
-			Stderr:          "c",
-			MessageCount:    1,
-			ClientProtocols: []string{},
-			ServerProtocols: []string{remotecommandconsts.StreamProtocolV2Name, remotecommandconsts.StreamProtocolV1Name},
-		},
-		{
-			// 1.1+ kubectl, 1.0 kubelet
-			TestName:        "versioned client, unversioned server",
-			Stdout:          "b",
-			Stderr:          "c",
-			MessageCount:    1,
-			ClientProtocols: []string{remotecommandconsts.StreamProtocolV2Name, remotecommandconsts.StreamProtocolV1Name},
-			ServerProtocols: []string{},
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/pkg/kubelet/server/server_test.go
+++ b/pkg/kubelet/server/server_test.go
@@ -1011,6 +1011,16 @@ func TestContainerLogsWithInvalidTail(t *testing.T) {
 	}
 }
 
+func makeReq(t *testing.T, method, url, clientProtocol string) *http.Request {
+	req, err := http.NewRequest(method, url, nil)
+	if err != nil {
+		t.Fatalf("error creating request: %v", err)
+	}
+	req.Header.Set("Content-Type", "")
+	req.Header.Add("X-Stream-Protocol-Version", clientProtocol)
+	return req
+}
+
 func TestServeExecInContainerIdleTimeout(t *testing.T) {
 	ss, err := newTestStreamingServer(100 * time.Millisecond)
 	require.NoError(t, err)
@@ -1027,7 +1037,7 @@ func TestServeExecInContainerIdleTimeout(t *testing.T) {
 	upgradeRoundTripper := spdy.NewSpdyRoundTripper(nil, true, true)
 	c := &http.Client{Transport: upgradeRoundTripper}
 
-	resp, err := c.Post(url, "", nil)
+	resp, err := c.Do(makeReq(t, "POST", url, "v4.channel.k8s.io"))
 	if err != nil {
 		t.Fatalf("Got error POSTing: %v", err)
 	}
@@ -1063,7 +1073,6 @@ func testExecAttach(t *testing.T, verb string) {
 		"stdout":                       {stdout: true, responseStatusCode: http.StatusSwitchingProtocols},
 		"stderr":                       {stderr: true, responseStatusCode: http.StatusSwitchingProtocols},
 		"stdout and stderr":            {stdout: true, stderr: true, responseStatusCode: http.StatusSwitchingProtocols},
-		"stdout stderr and tty":        {stdout: true, stderr: true, tty: true, responseStatusCode: http.StatusSwitchingProtocols},
 		"stdin stdout and stderr":      {stdin: true, stdout: true, stderr: true, responseStatusCode: http.StatusSwitchingProtocols},
 		"stdin stdout stderr with uid": {stdin: true, stdout: true, stderr: true, responseStatusCode: http.StatusSwitchingProtocols, uid: true},
 		"stdout with redirect":         {stdout: true, responseStatusCode: http.StatusFound, redirect: true},
@@ -1194,7 +1203,7 @@ func testExecAttach(t *testing.T, verb string) {
 				c = &http.Client{Transport: upgradeRoundTripper}
 			}
 
-			resp, err = c.Post(url, "", nil)
+			resp, err = c.Do(makeReq(t, "POST", url, "v4.channel.k8s.io"))
 			require.NoError(t, err, "POSTing")
 			defer resp.Body.Close()
 
@@ -1290,7 +1299,8 @@ func TestServePortForwardIdleTimeout(t *testing.T) {
 	upgradeRoundTripper := spdy.NewRoundTripper(nil, true, true)
 	c := &http.Client{Transport: upgradeRoundTripper}
 
-	resp, err := c.Post(url, "", nil)
+	req := makeReq(t, "POST", url, "portforward.k8s.io")
+	resp, err := c.Do(req)
 	if err != nil {
 		t.Fatalf("Got error POSTing: %v", err)
 	}
@@ -1398,7 +1408,8 @@ func TestServePortForward(t *testing.T) {
 				c = &http.Client{Transport: upgradeRoundTripper}
 			}
 
-			resp, err := c.Post(url, "", nil)
+			req := makeReq(t, "POST", url, "portforward.k8s.io")
+			resp, err := c.Do(req)
 			require.NoError(t, err, "POSTing")
 			defer resp.Body.Close()
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
@@ -123,15 +123,11 @@ func negotiateProtocol(clientProtocols, serverProtocols []string) string {
 func Handshake(req *http.Request, w http.ResponseWriter, serverProtocols []string) (string, error) {
 	clientProtocols := req.Header[http.CanonicalHeaderKey(HeaderProtocolVersion)]
 	if len(clientProtocols) == 0 {
-		// Kube 1.0 clients didn't support subprotocol negotiation.
-		// TODO require clientProtocols once Kube 1.0 is no longer supported
-		return "", nil
+		return "", fmt.Errorf("unable to upgrade: %s is required", HeaderProtocolVersion)
 	}
 
 	if len(serverProtocols) == 0 {
-		// Kube 1.0 servers didn't support subprotocol negotiation. This is mainly for testing.
-		// TODO require serverProtocols once Kube 1.0 is no longer supported
-		return "", nil
+		panic(fmt.Errorf("unable to upgrade: serverProtocols is required"))
 	}
 
 	negotiatedProtocol := negotiateProtocol(clientProtocols, serverProtocols)

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
@@ -52,11 +52,6 @@ func TestHandshake(t *testing.T) {
 		expectedProtocol string
 		expectError      bool
 	}{
-		"no client protocols": {
-			clientProtocols:  []string{},
-			serverProtocols:  []string{"a", "b"},
-			expectedProtocol: "",
-		},
 		"no common protocol": {
 			clientProtocols:  []string{"c"},
 			serverProtocols:  []string{"a", "b"},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR addresses TODO in staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go

**Which issue(s) this PR fixes**:
Fixes #

```release-note
For subprotocol negotiation, both client and server protocol is required now.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
