### PR TITLE
kube-proxy: add some interface type assertions

### DIFF
--- a/pkg/proxy/config/config.go
+++ b/pkg/proxy/config/config.go
@@ -97,6 +97,8 @@ func (*NoopEndpointSliceHandler) OnEndpointSliceDelete(endpointSlice *discovery.
 // OnEndpointSlicesSynced is a noop handler for EndpointSlice syncs.
 func (*NoopEndpointSliceHandler) OnEndpointSlicesSynced() {}
 
+var _ EndpointSliceHandler = &NoopEndpointSliceHandler{}
+
 // EndpointsConfig tracks a set of endpoints configurations.
 type EndpointsConfig struct {
 	listerSynced  cache.InformerSynced
@@ -402,6 +404,8 @@ func (*NoopNodeHandler) OnNodeDelete(node *v1.Node) {}
 
 // OnNodeSynced is a noop handler for Node syncs.
 func (*NoopNodeHandler) OnNodeSynced() {}
+
+var _ NodeHandler = &NoopNodeHandler{}
 
 // NodeConfig tracks a set of node configurations.
 // It accepts "set", "add" and "remove" operations of node via channels, and invokes registered handlers on change.

--- a/pkg/proxy/healthcheck/proxier_health.go
+++ b/pkg/proxy/healthcheck/proxier_health.go
@@ -44,6 +44,8 @@ type ProxierHealthUpdater interface {
 	Updated()
 }
 
+var _ ProxierHealthUpdater = &ProxierHealthServer{}
+
 // ProxierHealthServer returns 200 "OK" by default. It verifies that the delay between
 // QueuedUpdate() calls and Updated() calls never exceeds healthTimeout.
 type ProxierHealthServer struct {

--- a/pkg/proxy/iptables/proxier.go
+++ b/pkg/proxy/iptables/proxier.go
@@ -91,6 +91,8 @@ func CanUseIPTablesProxier(kcompat KernelCompatTester) (bool, error) {
 	return true, nil
 }
 
+var _ KernelCompatTester = LinuxKernelCompatTester{}
+
 // LinuxKernelCompatTester is the Linux implementation of KernelCompatTester
 type LinuxKernelCompatTester struct{}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
It is a good programming practice to check whether an object implements an interface at compile time, which helps to find problems faster.
This PR adds some interface type assertions.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
