### PR TITLE
Azure cloud provider should not retry on bad request

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error.go
@@ -125,8 +125,9 @@ func getHTTPStatusCode(resp *http.Response) int {
 // shouldRetryHTTPRequest determines if the request is retriable.
 func shouldRetryHTTPRequest(resp *http.Response, err error) bool {
 	if resp != nil {
-		// HTTP 412 (StatusPreconditionFailed) means etag mismatch, hence we shouldn't retry.
-		if resp.StatusCode == http.StatusPreconditionFailed {
+		// HTTP 412 (StatusPreconditionFailed) means etag mismatch
+		// HTTP 400 (BadRequest) means the request cannot be accepted, hence we shouldn't retry.
+		if resp.StatusCode == http.StatusPreconditionFailed || resp.StatusCode == http.StatusBadRequest {
 			return false
 		}
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error_test.go
@@ -54,7 +54,7 @@ func TestGetError(t *testing.T) {
 		{
 			code: http.StatusBadRequest,
 			expected: &Error{
-				Retriable:      true,
+				Retriable:      false,
 				HTTPStatusCode: http.StatusBadRequest,
 				RawError:       fmt.Errorf("HTTP response: 400"),
 			},
@@ -136,7 +136,7 @@ func TestGetStatusNotFoundAndForbiddenIgnoredError(t *testing.T) {
 		{
 			code: http.StatusBadRequest,
 			expected: &Error{
-				Retriable:      true,
+				Retriable:      false,
 				HTTPStatusCode: http.StatusBadRequest,
 				RawError:       fmt.Errorf("HTTP response: 400"),
 			},
@@ -191,7 +191,7 @@ func TestShouldRetryHTTPRequest(t *testing.T) {
 	}{
 		{
 			code:     http.StatusBadRequest,
-			expected: true,
+			expected: false,
 		},
 		{
 			code:     http.StatusInternalServerError,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR excludes 400 response from Azure for inline retries. The reason is that, if we set 400 as retry-able error, the cloud provider may stuck on one operation for days. E.g. if you reference a Basic IP in a standard load balancer cluster, the reconcile LB will response something like below:

```json
{
    "error": {
        "codd": "PublicIPAndLBSkuDoNotMatch",
        "message": "Standard sku load balancer /subscriptions/xxxx/resourceGroups/xxx-group/providers/Microsoft.Network/loadBalancers/kubernetes cannot reference Basic sku publicIP /subscriptions/xxx/resourceGroups/xxx-group/providers/Microsoft.Network/publicIPAddresses/a-basic-IP.",
        "details": []
    }
}
```

Since we would always retry on 400, the inline retryer will keep going for days, and this error from Azure will not be surfaced to user as an event on svc. It does show up in controller manager logs but it's not super visible.

So the proposal here is to not retry on 400 specifically and surface that error immediately.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #86686

**Special notes for your reviewer**:
Please let me know if there is a reason we need inline retry on 400. If that's the case we can parse the error code.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
