### PR TITLE
publishing: Update to go@1.13.4 for kubernetes-1.16

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -20,7 +20,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/code-generator
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/code-generator
@@ -42,7 +42,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/apimachinery
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/apimachinery
@@ -70,7 +70,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/api
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
       - repository: apimachinery
         branch: release-1.16
@@ -108,7 +108,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/client-go
     name: release-13.0
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
       - repository: apimachinery
         branch: release-1.16
@@ -154,7 +154,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/component-base
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -208,7 +208,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/apiserver
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -273,7 +273,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -350,7 +350,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -426,7 +426,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-controller
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -502,7 +502,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -572,7 +572,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/metrics
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -626,7 +626,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: api
       branch: release-1.16
@@ -680,7 +680,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: api
       branch: release-1.16
@@ -734,7 +734,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -784,7 +784,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kubelet
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -830,7 +830,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -884,7 +884,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -934,7 +934,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -980,7 +980,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1034,7 +1034,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1100,7 +1100,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1170,7 +1170,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/node-api
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1210,7 +1210,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cri-api
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/cri-api
@@ -1247,7 +1247,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kubectl
     name: release-1.16
-    go: 1.12.12
+    go: 1.13.4
     dependencies:
     - repository: api
       branch: release-1.16


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For 1.16: https://github.com/kubernetes/kubernetes/blob/release-1.16/build/dependencies.yaml#L36-L37

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
