### PR TITLE
fix flakiness on e2e test TCP CLOSE_WAIT timeout

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -26,11 +26,11 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	"k8s.io/kubernetes/test/images/agnhost/net/nat"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
@@ -42,10 +42,10 @@ var kubeProxyE2eImage = imageutils.GetE2EImage(imageutils.Agnhost)
 
 var _ = SIGDescribe("Network", func() {
 	const (
-		testDaemonHTTPPort    = 11301
-		testDaemonTCPPort     = 11302
-		timeoutSeconds        = 10
-		postFinTimeoutSeconds = 5
+		testDaemonHTTPPort     = 11301
+		testDaemonTCPPort      = 11302
+		deadlineTimeoutSeconds = 10
+		postFinTimeoutSeconds  = 30
 	)
 
 	fr := framework.NewDefaultFramework("network")
@@ -81,16 +81,63 @@ var _ = SIGDescribe("Network", func() {
 
 		zero := int64(0)
 
+		// Create a pod to check the conntrack entries on the host node
+		// It mounts the host /proc/net folder to be able to access
+		// the nf_conntrack file with the host conntrack entries
+		privileged := true
+
+		hostExecPod := &v1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "e2e-net-exec",
+				Namespace: fr.Namespace.Name,
+				Labels:    map[string]string{"app": "e2e-net-exec"},
+			},
+			Spec: v1.PodSpec{
+				HostNetwork: true,
+				NodeName:    clientNodeInfo.name,
+				Containers: []v1.Container{
+					{
+						Name:            "e2e-net-exec",
+						Image:           kubeProxyE2eImage,
+						ImagePullPolicy: "Always",
+						Args:            []string{"pause"},
+						VolumeMounts: []v1.VolumeMount{
+							{
+								Name:      "proc-net",
+								MountPath: "/rootfs/proc/net",
+								ReadOnly:  true,
+							},
+						},
+						SecurityContext: &v1.SecurityContext{
+							Privileged: &privileged,
+						},
+					},
+				},
+				Volumes: []v1.Volume{
+					{
+						Name: "proc-net",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: "/proc/net",
+							},
+						},
+					},
+				},
+				TerminationGracePeriodSeconds: &zero,
+			},
+		}
+		fr.PodClient().CreateSync(hostExecPod)
+
 		// Some distributions (Ubuntu 16.04 etc.) don't support the proc file.
-		_, err = e2essh.IssueSSHCommandWithResult(
-			"ls /proc/net/nf_conntrack",
-			framework.TestContext.Provider,
-			clientNodeInfo.node)
+		_, err = framework.RunHostCmd(fr.Namespace.Name, "e2e-net-exec",
+			"ls /rootfs/proc/net/nf_conntrack")
 		if err != nil && strings.Contains(err.Error(), "No such file or directory") {
-			framework.Skipf("The node %s does not support /proc/net/nf_conntrack", clientNodeInfo.name)
+			framework.Skipf("The node %s does not support /proc/net/nf_conntrack",
+				clientNodeInfo.name)
 		}
 		framework.ExpectNoError(err)
 
+		// Create the client and server pods
 		clientPodSpec := &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "e2e-net-client",
@@ -105,7 +152,7 @@ var _ = SIGDescribe("Network", func() {
 						Image:           kubeProxyE2eImage,
 						ImagePullPolicy: "Always",
 						Args: []string{
-							"net", "--serve", fmt.Sprintf("0.0.0.0:%d", testDaemonHTTPPort),
+							"net", "--serve", fmt.Sprintf(":%d", testDaemonHTTPPort),
 						},
 					},
 				},
@@ -130,7 +177,7 @@ var _ = SIGDescribe("Network", func() {
 							"net",
 							"--runner", "nat-closewait-server",
 							"--options",
-							fmt.Sprintf(`{"LocalAddr":"0.0.0.0:%v", "PostFindTimeoutSeconds":%v}`,
+							fmt.Sprintf(`{"LocalAddr":":%v", "PostFinTimeoutSeconds":%v}`,
 								testDaemonTCPPort,
 								postFinTimeoutSeconds),
 						},
@@ -166,8 +213,8 @@ var _ = SIGDescribe("Network", func() {
 		options := nat.CloseWaitClientOptions{
 			RemoteAddr: fmt.Sprintf("%v:%v",
 				serverNodeInfo.nodeIP, testDaemonTCPPort),
-			TimeoutSeconds:        timeoutSeconds,
-			PostFinTimeoutSeconds: 0,
+			TimeoutSeconds:        deadlineTimeoutSeconds,
+			PostFinTimeoutSeconds: postFinTimeoutSeconds,
 			LeakConnection:        true,
 		}
 
@@ -179,47 +226,52 @@ var _ = SIGDescribe("Network", func() {
 				`'%v' 2>/dev/null`,
 			testDaemonHTTPPort,
 			string(jsonBytes))
-		framework.RunHostCmdOrDie(fr.Namespace.Name, "e2e-net-client", cmd)
+		// Run the closewait command in a subroutine so it keeps waiting during postFinTimeoutSeconds
+		// otherwise the pod is deleted and the connection is closed loosing the conntrack entry
+		go func() {
+			framework.RunHostCmdOrDie(fr.Namespace.Name, "e2e-net-client", cmd)
+		}()
 
 		<-time.After(time.Duration(1) * time.Second)
 
 		ginkgo.By("Checking /proc/net/nf_conntrack for the timeout")
-		// If test flakes occur here, then this check should be performed
-		// in a loop as there may be a race with the client connecting.
-		e2essh.IssueSSHCommandWithResult(
-			fmt.Sprintf("sudo cat /proc/net/nf_conntrack | grep 'dport=%v'",
-				testDaemonTCPPort),
-			framework.TestContext.Provider,
-			clientNodeInfo.node)
-
-		// Timeout in seconds is available as the fifth column from
-		// /proc/net/nf_conntrack.
-		result, err := e2essh.IssueSSHCommandWithResult(
-			fmt.Sprintf(
-				"sudo cat /proc/net/nf_conntrack "+
-					"| grep 'CLOSE_WAIT.*dst=%v.*dport=%v' "+
-					"| tail -n 1"+
-					"| awk '{print $5}' ",
-				serverNodeInfo.nodeIP,
-				testDaemonTCPPort),
-			framework.TestContext.Provider,
-			clientNodeInfo.node)
-		framework.ExpectNoError(err)
-
-		timeoutSeconds, err := strconv.Atoi(strings.TrimSpace(result.Stdout))
-		framework.ExpectNoError(err)
-
 		// These must be synchronized from the default values set in
 		// pkg/apis/../defaults.go ConntrackTCPCloseWaitTimeout. The
 		// current defaults are hidden in the initialization code.
 		const epsilonSeconds = 60
 		const expectedTimeoutSeconds = 60 * 60
-
-		framework.Logf("conntrack entry timeout was: %v, expected: %v",
-			timeoutSeconds, expectedTimeoutSeconds)
-
-		gomega.Expect(math.Abs(float64(timeoutSeconds - expectedTimeoutSeconds))).Should(
-			gomega.BeNumerically("<", (epsilonSeconds)))
+		// Obtain the corresponding conntrack entry on the host checking
+		// the nf_conntrack file from the pod e2e-net-exec.
+		// It retries in a loop if the entry is not found.
+		cmd = fmt.Sprintf("cat /rootfs/proc/net/nf_conntrack "+
+			"| grep -m 1 'CLOSE_WAIT.*dst=%v.*dport=%v' ",
+			serverNodeInfo.nodeIP,
+			testDaemonTCPPort)
+		if err := wait.PollImmediate(5*time.Second, 30*time.Second, func() (bool, error) {
+			result, err := framework.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
+			// retry if we can't obtain the conntrack entry
+			if err != nil {
+				framework.Logf("failed to obtain conntrack entry: %v %v", result, err)
+				return false, nil
+			}
+			framework.Logf("conntrack entry for node %v and port %v:  %v", serverNodeInfo.nodeIP, testDaemonTCPPort, result)
+			// Timeout in seconds is available as the fifth column of
+			// the matched entry in /proc/net/nf_conntrack.
+			line := strings.Fields(result)
+			if len(line) < 5 {
+				return false, fmt.Errorf("conntrack entry does not have a timeout field: %v", line)
+			}
+			timeoutSeconds, err := strconv.Atoi(line[4])
+			if err != nil {
+				return false, fmt.Errorf("failed to convert matched timeout %s to integer: %v", line[4], err)
+			}
+			if math.Abs(float64(timeoutSeconds-expectedTimeoutSeconds)) < epsilonSeconds {
+				return true, nil
+			}
+			return false, fmt.Errorf("wrong TCP CLOSE_WAIT timeout: %v expected: %v", timeoutSeconds, expectedTimeoutSeconds)
+		}); err != nil {
+			framework.Failf("no conntrack entry for port %d on node %s", testDaemonTCPPort, serverNodeInfo.nodeIP)
+		}
 	})
 
 	// Regression test for #74839, where:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

The e2e test "Network should set TCP CLOSE_WAIT timeout"
was not using correctly the option to keep the connection
on the close_wait status, hence it was flake depending on
how fast it checked the conntrack table it may find the entry.

This PR also removes the need to use ssh, using a pod to check 
the conntrack entries and adding a retry loop will avoid flakiness 
related to ssh or race conditions checking the conntrack file.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #71565

**Special notes for your reviewer**:

The failing tests shows that the first ssh command gives the right output, however, the second time the output is empty. This means that the test will not fail if uses the result obtained from the first command or, maybe, if we retry.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
