### PR TITLE
Fix staticcheck failures of test/integration/scale test/integration/serviceaccount test/integration/serving test/integration/volume

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -76,12 +76,8 @@ test/integration/framework
 test/integration/garbagecollector
 test/integration/master
 test/integration/replicationcontroller
-test/integration/scale
 test/integration/scheduler_perf
-test/integration/serviceaccount
-test/integration/serving
 test/integration/ttlcontroller
-test/integration/volume
 vendor/k8s.io/apimachinery/pkg/api/meta
 vendor/k8s.io/apimachinery/pkg/api/resource
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured

--- a/test/integration/scale/scale_test.go
+++ b/test/integration/scale/scale_test.go
@@ -35,11 +35,6 @@ import (
 	"k8s.io/kubernetes/test/integration/framework"
 )
 
-type subresourceTest struct {
-	resource schema.GroupVersionResource
-	kind     schema.GroupVersionKind
-}
-
 func makeGVR(group, version, resource string) schema.GroupVersionResource {
 	return schema.GroupVersionResource{Group: group, Version: version, Resource: resource}
 }
@@ -58,7 +53,7 @@ func TestScaleSubresources(t *testing.T) {
 	})
 	defer tearDown()
 
-	resourceLists, err := clientSet.Discovery().ServerResources()
+	_, resourceLists, err := clientSet.Discovery().ServerGroupsAndResources()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,10 +200,6 @@ var (
 		Spec:       appsv1.StatefulSetSpec{Selector: &metav1.LabelSelector{MatchLabels: podStub.Labels}, Replicas: &replicas, Template: podStub},
 	}
 )
-
-func setup(t *testing.T) (client kubernetes.Interface, tearDown func()) {
-	return setupWithOptions(t, nil, nil)
-}
 
 func setupWithOptions(t *testing.T, instanceOptions *apitesting.TestServerInstanceOptions, flags []string) (client kubernetes.Interface, tearDown func()) {
 	result := apitesting.StartTestServerOrDie(t, instanceOptions, flags, framework.SharedEtcd())

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -115,7 +115,7 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	}
 
 	// Create service account
-	serviceAccount, err := c.CoreV1().ServiceAccounts(ns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}})
+	_, err = c.CoreV1().ServiceAccounts(ns).Create(&v1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: name}})
 	if err != nil {
 		t.Fatalf("Service Account not created: %v", err)
 	}
@@ -145,7 +145,7 @@ func TestServiceAccountTokenAutoCreate(t *testing.T) {
 	}
 
 	// Trigger creation of a new referenced token
-	serviceAccount, err = c.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
+	serviceAccount, err := c.CoreV1().ServiceAccounts(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -292,6 +292,9 @@ func testComponent(t *testing.T, tester componentTester, kubeconfig, brokenKubec
 				}
 
 				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read response body: %v", err)
+				}
 				defer r.Body.Close()
 				if got, expected := r.StatusCode, *tt.wantSecureCode; got != expected {
 					t.Fatalf("expected http %d at %s of component, got: %d %q", expected, tt.path, got, string(body))
@@ -307,6 +310,9 @@ func testComponent(t *testing.T, tester componentTester, kubeconfig, brokenKubec
 					t.Fatalf("failed to GET %s from component: %v", tt.path, err)
 				}
 				body, err := ioutil.ReadAll(r.Body)
+				if err != nil {
+					t.Fatalf("failed to read response body: %v", err)
+				}
 				defer r.Body.Close()
 				if got, expected := r.StatusCode, *tt.wantInsecureCode; got != expected {
 					t.Fatalf("expected http %d at %s of component, got: %d %q", expected, tt.path, got, string(body))

--- a/test/integration/volume/attach_detach_test.go
+++ b/test/integration/volume/attach_detach_test.go
@@ -132,8 +132,6 @@ func fakePodWithPVC(name, pvcName, namespace string) (*v1.Pod, *v1.PersistentVol
 	return fakePod, fakePVC
 }
 
-type podCountFunc func(int) bool
-
 var defaultTimerConfig = attachdetach.TimerConfig{
 	ReconcilerLoopPeriod:                              100 * time.Millisecond,
 	ReconcilerMaxWaitForUnmountDuration:               6 * time.Second,

--- a/test/integration/volume/persistent_volumes_test.go
+++ b/test/integration/volume/persistent_volumes_test.go
@@ -666,11 +666,10 @@ func TestPersistentVolumeMultiPVsPVCs(t *testing.T) {
 
 			select {
 			case <-stopCh:
-				break
+				return
 			default:
 				continue
 			}
-
 		}
 	}()
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix staticcheck failures of test/integration/scale test/integration/serviceaccount test/integration/serving test/integration/volume

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
