### PR TITLE
Metrics stability framework cleanup

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/metric.go
+++ b/staging/src/k8s.io/component-base/metrics/metric.go
@@ -188,6 +188,8 @@ func (c *selfCollector) Collect(ch chan<- prometheus.Metric) {
 // no-op vecs for convenience
 var noopCounterVec = &prometheus.CounterVec{}
 var noopHistogramVec = &prometheus.HistogramVec{}
+
+// lint:ignore U1000 Keep it for future use
 var noopSummaryVec = &prometheus.SummaryVec{}
 var noopGaugeVec = &prometheus.GaugeVec{}
 var noopObserverVec = &noopObserverVector{}

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -31,7 +31,6 @@ import (
 
 var (
 	v115         = semver.MustParse("1.15.0")
-	v114         = semver.MustParse("1.14.0")
 	alphaCounter = NewCounter(
 		&CounterOpts{
 			Namespace:      "some_namespace",
@@ -240,6 +239,7 @@ func TestShowHiddenMetric(t *testing.T) {
 	registry.MustRegister(alphaHiddenCounter)
 
 	ms, err := registry.Gather()
+	assert.Nil(t, err, "Gather failed %v", err)
 	assert.Equalf(t, expectedMetricCount, len(ms), "Got %v metrics, Want: %v metrics", len(ms), expectedMetricCount)
 
 	showHidden.Store(true)
@@ -257,9 +257,8 @@ func TestShowHiddenMetric(t *testing.T) {
 	expectedMetricCount = 1
 
 	ms, err = registry.Gather()
-	assert.Equalf(t, expectedMetricCount, len(ms), "Got %v metrics, Want: %v metrics", len(ms), expectedMetricCount)
 	assert.Nil(t, err, "Gather failed %v", err)
-
+	assert.Equalf(t, expectedMetricCount, len(ms), "Got %v metrics, Want: %v metrics", len(ms), expectedMetricCount)
 }
 
 func TestValidateShowHiddenMetricsVersion(t *testing.T) {

--- a/staging/src/k8s.io/component-base/metrics/registry_test.go
+++ b/staging/src/k8s.io/component-base/metrics/registry_test.go
@@ -99,7 +99,6 @@ func TestRegister(t *testing.T) {
 	var tests = []struct {
 		desc                    string
 		metrics                 []*Counter
-		registryVersion         *semver.Version
 		expectedErrors          []error
 		expectedIsCreatedValues []bool
 		expectedIsDeprecated    []bool
@@ -108,7 +107,6 @@ func TestRegister(t *testing.T) {
 		{
 			desc:                    "test alpha metric",
 			metrics:                 []*Counter{alphaCounter},
-			registryVersion:         &v115,
 			expectedErrors:          []error{nil},
 			expectedIsCreatedValues: []bool{true},
 			expectedIsDeprecated:    []bool{false},
@@ -117,7 +115,6 @@ func TestRegister(t *testing.T) {
 		{
 			desc:                    "test registering same metric multiple times",
 			metrics:                 []*Counter{alphaCounter, alphaCounter},
-			registryVersion:         &v115,
 			expectedErrors:          []error{nil, prometheus.AlreadyRegisteredError{}},
 			expectedIsCreatedValues: []bool{true, true},
 			expectedIsDeprecated:    []bool{false, false},
@@ -126,7 +123,6 @@ func TestRegister(t *testing.T) {
 		{
 			desc:                    "test alpha deprecated metric",
 			metrics:                 []*Counter{alphaDeprecatedCounter},
-			registryVersion:         &v115,
 			expectedErrors:          []error{nil},
 			expectedIsCreatedValues: []bool{true},
 			expectedIsDeprecated:    []bool{true},
@@ -135,7 +131,6 @@ func TestRegister(t *testing.T) {
 		{
 			desc:                    "test alpha hidden metric",
 			metrics:                 []*Counter{alphaHiddenCounter},
-			registryVersion:         &v115,
 			expectedErrors:          []error{nil},
 			expectedIsCreatedValues: []bool{false},
 			expectedIsDeprecated:    []bool{true},
@@ -152,7 +147,7 @@ func TestRegister(t *testing.T) {
 			})
 			for i, m := range test.metrics {
 				err := registry.Register(m)
-				if err != test.expectedErrors[i] && err.Error() != test.expectedErrors[i].Error() {
+				if err != nil && err.Error() != test.expectedErrors[i].Error() {
 					t.Errorf("Got unexpected error %v, wanted %v", err, test.expectedErrors[i])
 				}
 				if m.IsCreated() != test.expectedIsCreatedValues[i] {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixed some static check failures which are mostly based on #82006 (@Zhuzhenghao).

Thanks @Zhuzhenghao 's contribution.

There is still one failure which I'd like to deal with later, maybe we need to bump some dependency.
```
vendor/k8s.io/component-base/metrics/processstarttime.go:57:18: p.NewStat is deprecated: use NewStat() instead  (SA1019)
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority backlog