### PR TITLE
Use alpine as sample-apiserver base image

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/artifacts/simple-image/Dockerfile
+++ b/staging/src/k8s.io/sample-apiserver/artifacts/simple-image/Dockerfile
@@ -12,6 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM fedora
+FROM alpine
 ADD kube-sample-apiserver /
 ENTRYPOINT ["/kube-sample-apiserver"]

--- a/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
+++ b/staging/src/k8s.io/sample-apiserver/docs/minikube-walkthrough.md
@@ -22,6 +22,7 @@ cd $GOPATH/src
 mkdir -p k8s.io
 cd k8s.io
 git clone https://github.com/kubernetes/sample-apiserver.git
+cd sample-apiserver
 ```
 
 ## Build the binary
@@ -30,7 +31,7 @@ Next we will want to create a new binary to both test we can build the server an
 
 From the root of this repo, where ```main.go``` is located, run the following command:
 ```
-export GOOS=linux; go build .
+GOOS=linux go build .
 ```
 if everything went well, you should have a binary called ```sample-apiserver``` present in your current directory.
 
@@ -46,7 +47,7 @@ docker build -t <YOUR_DOCKERHUB_USER>/kube-sample-apiserver:latest ./artifacts/s
 docker push <YOUR_DOCKERHUB_USER>/kube-sample-apiserver
 ```
 
-## Modify the replication controller
+## Modify the deployment
 
 You need to modify the [artifacts/example/deployment.yaml](/artifacts/example/deployment.yaml) file to change the ```imagePullPolicy``` to ```Always``` or ```IfNotPresent```.
 
@@ -82,7 +83,7 @@ kubectl create -f artifacts/example/auth-reader.yaml -n kube-system
 kubectl create -f artifacts/example/rbac.yaml
 kubectl create -f artifacts/example/rbac-bind.yaml
 
-# create the service and replication controller
+# create the service and deployment
 kubectl create -f artifacts/example/deployment.yaml -n wardle
 kubectl create -f artifacts/example/service.yaml -n wardle
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Use alpine as sample-apiserver base image to reduce the image size. With `fedora` as base image the image size is ~300Mb, with `alpine` as base image - ~60Mb. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

