### PR TITLE
Move WaitForFailure() to the test

### DIFF
--- a/test/e2e/framework/pods.go
+++ b/test/e2e/framework/pods.go
@@ -208,23 +208,6 @@ func (c *PodClient) WaitForSuccess(name string, timeout time.Duration) {
 	)).To(gomega.Succeed(), "wait for pod %q to success", name)
 }
 
-// WaitForFailure waits for pod to fail.
-func (c *PodClient) WaitForFailure(name string, timeout time.Duration) {
-	f := c.f
-	gomega.Expect(e2epod.WaitForPodCondition(f.ClientSet, f.Namespace.Name, name, "success or failure", timeout,
-		func(pod *v1.Pod) (bool, error) {
-			switch pod.Status.Phase {
-			case v1.PodFailed:
-				return true, nil
-			case v1.PodSucceeded:
-				return true, fmt.Errorf("pod %q successed with reason: %q, message: %q", name, pod.Status.Reason, pod.Status.Message)
-			default:
-				return false, nil
-			}
-		},
-	)).To(gomega.Succeed(), "wait for pod %q to fail", name)
-}
-
 // WaitForFinish waits for pod to finish running, regardless of success or failure.
 func (c *PodClient) WaitForFinish(name string, timeout time.Duration) {
 	f := c.f


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

WaitForFailure() is used at a single e2e test.
So this moves the function to the specific test file for the cleanup.
This is one of effort to reduce e2epod subpackage usage in the e2e core framework.

Ref: https://github.com/kubernetes/kubernetes/issues/81245

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
