### PR TITLE
Add debugging message to know the pod status

### DIFF
--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -184,10 +184,13 @@ func podRunningAndReady(c clientset.Interface, podName, namespace string) wait.C
 		}
 		switch pod.Status.Phase {
 		case v1.PodFailed, v1.PodSucceeded:
+			e2elog.Logf("The status of Pod %s is %s which is unexpected", podName, pod.Status.Phase)
 			return false, conditions.ErrPodCompleted
 		case v1.PodRunning:
+			e2elog.Logf("The status of Pod %s is %s (Ready = %v)", podName, pod.Status.Phase, podutil.IsPodReady(pod))
 			return podutil.IsPodReady(pod), nil
 		}
+		e2elog.Logf("The status of Pod %s is %s, waiting for it to be Running (with Ready = true)", podName, pod.Status.Phase)
 		return false, nil
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:

The log of a flake test says
`Pod did not start running: timed out waiting for the condition`
but it is hard to know what is actual status of the pod.
So this adds debugging message to know that.

Ref: https://github.com/kubernetes/kubernetes/issues/86678

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
