### PR TITLE
Fix staticcheck failures of pkg/volume/iscsi pkg/volume/portworx/

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -41,9 +41,7 @@ pkg/volume/fc
 pkg/volume/flexvolume
 pkg/volume/flocker
 pkg/volume/hostpath
-pkg/volume/iscsi
 pkg/volume/local
-pkg/volume/portworx
 pkg/volume/quobyte
 pkg/volume/rbd
 pkg/volume/scaleio

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -496,7 +496,7 @@ func TestGetISCSICHAP(t *testing.T) {
 		},
 	}
 	for _, testcase := range tests {
-		resultDiscoveryCHAP, _ := getISCSIDiscoveryCHAPInfo(testcase.spec)
+		resultDiscoveryCHAP, err := getISCSIDiscoveryCHAPInfo(testcase.spec)
 		resultSessionCHAP, err := getISCSISessionCHAPInfo(testcase.spec)
 		switch testcase.name {
 		case "no volume":

--- a/pkg/volume/iscsi/iscsi_test.go
+++ b/pkg/volume/iscsi/iscsi_test.go
@@ -91,9 +91,7 @@ func TestGetAccessModes(t *testing.T) {
 }
 
 type fakeDiskManager struct {
-	tmpDir       string
-	attachCalled bool
-	detachCalled bool
+	tmpDir string
 }
 
 func NewFakeDiskManager() *fakeDiskManager {
@@ -498,7 +496,7 @@ func TestGetISCSICHAP(t *testing.T) {
 		},
 	}
 	for _, testcase := range tests {
-		resultDiscoveryCHAP, err := getISCSIDiscoveryCHAPInfo(testcase.spec)
+		resultDiscoveryCHAP, _ := getISCSIDiscoveryCHAPInfo(testcase.spec)
 		resultSessionCHAP, err := getISCSISessionCHAPInfo(testcase.spec)
 		switch testcase.name {
 		case "no volume":

--- a/pkg/volume/iscsi/iscsi_util.go
+++ b/pkg/volume/iscsi/iscsi_util.go
@@ -362,7 +362,7 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 				}
 
 				// in case of node failure/restart, explicitly set to manual login so it doesn't hang on boot
-				out, err = execWithLog(b, "iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-o", "update", "-n", "node.startup", "-v", "manual")
+				_, err = execWithLog(b, "iscsiadm", "-m", "node", "-p", tp, "-T", b.Iqn, "-o", "update", "-n", "node.startup", "-v", "manual")
 				if err != nil {
 					// don't fail if we can't set startup mode, but log warning so there is a clue
 					klog.Warningf("Warning: Failed to set iSCSI login mode to manual. Error: %v", err)

--- a/pkg/volume/iscsi/iscsi_util_test.go
+++ b/pkg/volume/iscsi/iscsi_util_test.go
@@ -157,6 +157,9 @@ func TestWaitForPathToExist(t *testing.T) {
 	}
 
 	exist = waitForPathToExistInternal(&devicePath[1], 1, "fake_iface", os.Stat, fakeFilepathGlob2)
+	if exist == false {
+		t.Errorf("waitForPathToExist: could not find path %s", devicePath[1])
+	}
 	if devicePath[1] != fpath {
 		t.Errorf("waitForPathToExist: wrong code path called for %s", devicePath[1])
 	}

--- a/pkg/volume/portworx/portworx.go
+++ b/pkg/volume/portworx/portworx.go
@@ -383,8 +383,7 @@ func (d *portworxVolumeDeleter) Delete() error {
 
 type portworxVolumeProvisioner struct {
 	*portworxVolume
-	options   volume.VolumeOptions
-	namespace string
+	options volume.VolumeOptions
 }
 
 var _ volume.Provisioner = &portworxVolumeProvisioner{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind cleanup


**What this PR does / why we need it**:
Fix staticcheck failures of pkg/volume/iscsi pkg/volume/portworx/
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
