### PR TITLE
Add error handler for rlimit.RlimitNumFiles

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1100,7 +1100,9 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	}
 	podCfg := kubeDeps.PodConfig
 
-	rlimit.RlimitNumFiles(uint64(kubeServer.MaxOpenFiles))
+	if err := rlimit.RlimitNumFiles(uint64(kubeServer.MaxOpenFiles)); err != nil {
+		klog.Warningf("Failed to set open file handler limit: %v", err)
+	}
 
 	// process pods and exit.
 	if runOnce {

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -1101,7 +1101,7 @@ func RunKubelet(kubeServer *options.KubeletServer, kubeDeps *kubelet.Dependencie
 	podCfg := kubeDeps.PodConfig
 
 	if err := rlimit.RlimitNumFiles(uint64(kubeServer.MaxOpenFiles)); err != nil {
-		klog.Warningf("Failed to set open file handler limit: %v", err)
+		klog.Errorf("Failed to set rlimit on max file handles: %v", err)
 	}
 
 	// process pods and exit.

--- a/pkg/util/rlimit/rlimit_linux.go
+++ b/pkg/util/rlimit/rlimit_linux.go
@@ -22,6 +22,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func RlimitNumFiles(maxOpenFiles uint64) {
-	unix.Setrlimit(unix.RLIMIT_NOFILE, &unix.Rlimit{Max: maxOpenFiles, Cur: maxOpenFiles})
+func RlimitNumFiles(maxOpenFiles uint64) error {
+	return unix.Setrlimit(unix.RLIMIT_NOFILE, &unix.Rlimit{Max: maxOpenFiles, Cur: maxOpenFiles})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`rlimit.RlimitNumFiles` should not silently ignore the error of `unix.Setrlimit`, which may cause bigger problems.

We already handle error here: https://github.com/kubernetes/kubernetes/blob/master/pkg/util/rlimit/rlimit_unsupported.go#L25


This PR adds error handler for `rlimit.RlimitNumFiles`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
