### PR TITLE
Adding in missing Registry unit tests.

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/registry_test.go
+++ b/pkg/scheduler/framework/v1alpha1/registry_test.go
@@ -32,7 +32,7 @@ func TestDecodeInto(t *testing.T) {
 	tests := []struct {
 		name            string
 		schedulerConfig string
-		expeted         PluginFooConfig
+		expected        PluginFooConfig
 	}{
 		{
 			name: "test decode for JSON config",
@@ -57,7 +57,7 @@ func TestDecodeInto(t *testing.T) {
 					}
 				]
 			}`,
-			expeted: PluginFooConfig{
+			expected: PluginFooConfig{
 				FooTest: "test decode",
 			},
 		},
@@ -74,25 +74,28 @@ pluginConfig:
   - name: foo
     args:
       foo_test: "test decode"`,
-			expeted: PluginFooConfig{
+			expected: PluginFooConfig{
 				FooTest: "test decode",
 			},
 		},
 	}
-	for i, test := range tests {
-		schedulerConf, err := loadConfig([]byte(test.schedulerConfig))
-		if err != nil {
-			t.Errorf("Test #%v(%s): failed to load scheduler config: %v", i, test.name, err)
-		}
-		var pluginFooConf PluginFooConfig
-		if err := DecodeInto(&schedulerConf.PluginConfig[0].Args, &pluginFooConf); err != nil {
-			t.Errorf("Test #%v(%s): failed to decode args %+v: %v",
-				i, test.name, schedulerConf.PluginConfig[0].Args, err)
-		}
-		if !reflect.DeepEqual(pluginFooConf, test.expeted) {
-			t.Errorf("Test #%v(%s): failed to decode plugin config, expected: %+v, got: %+v",
-				i, test.name, test.expeted, pluginFooConf)
-		}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			schedulerConf, err := loadConfig([]byte(test.schedulerConfig))
+			if err != nil {
+				t.Errorf("loadConfig(): failed to load scheduler config: %v", err)
+			}
+			var pluginFooConf PluginFooConfig
+			if err := DecodeInto(&schedulerConf.PluginConfig[0].Args, &pluginFooConf); err != nil {
+				t.Errorf("DecodeInto(): failed to decode args %+v: %v",
+					schedulerConf.PluginConfig[0].Args, err)
+			}
+			if !reflect.DeepEqual(test.expected, pluginFooConf) {
+				t.Errorf("DecodeInto(): failed to decode plugin config, expected: %+v, got: %+v",
+					test.expected, pluginFooConf)
+			}
+		})
 	}
 }
 
@@ -103,4 +106,188 @@ func loadConfig(data []byte) (*config.KubeSchedulerConfiguration, error) {
 	}
 
 	return configObj, nil
+}
+
+// isRegistryEqual compares two registries for equality. This function is used in place of
+// reflect.DeepEqual() and cmp() as they don't compare function values.
+func isRegistryEqual(registryX, registryY Registry) bool {
+	for name, pluginFactory := range registryY {
+		if val, ok := registryX[name]; ok {
+			if reflect.ValueOf(pluginFactory) != reflect.ValueOf(val) {
+				// pluginFactory functions are not the same.
+				return false
+			}
+		} else {
+			// registryY contains an entry that is not present in registryX
+			return false
+		}
+	}
+
+	for name := range registryX {
+		if _, ok := registryY[name]; !ok {
+			// registryX contains an entry that is not present in registryY
+			return false
+		}
+	}
+
+	return true
+}
+
+type mockNoopPlugin struct{}
+
+func (p *mockNoopPlugin) Name() string {
+	return "MockNoop"
+}
+
+func NewMockNoopPluginFactory() PluginFactory {
+	return func(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
+		return &mockNoopPlugin{}, nil
+	}
+}
+
+func TestMerge(t *testing.T) {
+	tests := []struct {
+		name            string
+		primaryRegistry Registry
+		registryToMerge Registry
+		expected        Registry
+		shouldError     bool
+	}{
+		{
+			name: "valid Merge",
+			primaryRegistry: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+			},
+			registryToMerge: Registry{
+				"pluginFactory2": NewMockNoopPluginFactory(),
+			},
+			expected: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory2": NewMockNoopPluginFactory(),
+			},
+			shouldError: false,
+		},
+		{
+			name: "Merge duplicate factories",
+			primaryRegistry: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+			},
+			registryToMerge: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+			},
+			expected: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, scenario := range tests {
+		t.Run(scenario.name, func(t *testing.T) {
+			err := scenario.primaryRegistry.Merge(scenario.registryToMerge)
+
+			if (err == nil) == scenario.shouldError {
+				t.Errorf("Merge() shouldError is: %v, however err is: %v.", scenario.shouldError, err)
+				return
+			}
+
+			if !isRegistryEqual(scenario.expected, scenario.primaryRegistry) {
+				t.Errorf("Merge(). Expected %v. Got %v instead.", scenario.expected, scenario.primaryRegistry)
+			}
+		})
+	}
+}
+
+func TestRegister(t *testing.T) {
+	tests := []struct {
+		name              string
+		registry          Registry
+		nameToRegister    string
+		factoryToRegister PluginFactory
+		expected          Registry
+		shouldError       bool
+	}{
+		{
+			name:              "valid Register",
+			registry:          Registry{},
+			nameToRegister:    "pluginFactory1",
+			factoryToRegister: NewMockNoopPluginFactory(),
+			expected: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+			},
+			shouldError: false,
+		},
+		{
+			name: "Register duplicate factories",
+			registry: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+			},
+			nameToRegister:    "pluginFactory1",
+			factoryToRegister: NewMockNoopPluginFactory(),
+			expected: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, scenario := range tests {
+		t.Run(scenario.name, func(t *testing.T) {
+			err := scenario.registry.Register(scenario.nameToRegister, scenario.factoryToRegister)
+
+			if (err == nil) == scenario.shouldError {
+				t.Errorf("Register() shouldError is: %v however err is: %v.", scenario.shouldError, err)
+				return
+			}
+
+			if !isRegistryEqual(scenario.expected, scenario.registry) {
+				t.Errorf("Register(). Expected %v. Got %v instead.", scenario.expected, scenario.registry)
+			}
+		})
+	}
+}
+
+func TestUnregister(t *testing.T) {
+	tests := []struct {
+		name             string
+		registry         Registry
+		nameToUnregister string
+		expected         Registry
+		shouldError      bool
+	}{
+		{
+			name: "valid Unregister",
+			registry: Registry{
+				"pluginFactory1": NewMockNoopPluginFactory(),
+				"pluginFactory2": NewMockNoopPluginFactory(),
+			},
+			nameToUnregister: "pluginFactory1",
+			expected: Registry{
+				"pluginFactory2": NewMockNoopPluginFactory(),
+			},
+			shouldError: false,
+		},
+		{
+			name:             "Unregister non-existent plugin factory",
+			registry:         Registry{},
+			nameToUnregister: "pluginFactory1",
+			expected:         Registry{},
+			shouldError:      true,
+		},
+	}
+
+	for _, scenario := range tests {
+		t.Run(scenario.name, func(t *testing.T) {
+			err := scenario.registry.Unregister(scenario.nameToUnregister)
+
+			if (err == nil) == scenario.shouldError {
+				t.Errorf("Unregister() shouldError is: %v however err is: %v.", scenario.shouldError, err)
+				return
+			}
+
+			if !isRegistryEqual(scenario.expected, scenario.registry) {
+				t.Errorf("Unregister(). Expected %v. Got %v instead.", scenario.expected, scenario.registry)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> 
/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR adds in unit tests that were missing for the Registry type.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
I attempted to use reflect.DeepEqual() to compare Registries but couldn't get it to work no matter what I tried. And I find that weird since the Registries are maps and those maps were effectively equal.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
