### PR TITLE
Remove `Stop` from `RateLimiter` interface

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
+++ b/pkg/controller/nodelifecycle/scheduler/rate_limited_queue.go
@@ -304,6 +304,5 @@ func (q *RateLimitedTimedQueue) SwapLimiter(newQPS float32) {
 			newLimiter.TryAccept()
 		}
 	}
-	q.limiter.Stop()
 	q.limiter = newLimiter
 }

--- a/pkg/util/async/bounded_frequency_runner.go
+++ b/pkg/util/async/bounded_frequency_runner.go
@@ -49,7 +49,6 @@ type BoundedFrequencyRunner struct {
 // designed so that flowcontrol.RateLimiter satisfies
 type rateLimiter interface {
 	TryAccept() bool
-	Stop()
 }
 
 type nullLimiter struct{}
@@ -57,8 +56,6 @@ type nullLimiter struct{}
 func (nullLimiter) TryAccept() bool {
 	return true
 }
-
-func (nullLimiter) Stop() {}
 
 var _ rateLimiter = nullLimiter{}
 
@@ -257,7 +254,6 @@ func (bfr *BoundedFrequencyRunner) RetryAfter(interval time.Duration) {
 func (bfr *BoundedFrequencyRunner) stop() {
 	bfr.mu.Lock()
 	defer bfr.mu.Unlock()
-	bfr.limiter.Stop()
 	bfr.timer.Stop()
 }
 

--- a/staging/src/k8s.io/client-go/util/flowcontrol/throttle.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/throttle.go
@@ -31,8 +31,6 @@ type RateLimiter interface {
 	TryAccept() bool
 	// Accept returns once a token becomes available.
 	Accept()
-	// Stop stops the rate limiter, subsequent calls to CanAccept will return false
-	Stop()
 	// QPS returns QPS of this rate limiter
 	QPS() float32
 	// Wait returns nil if a token is taken before the Context is done.
@@ -95,9 +93,6 @@ func (t *tokenBucketRateLimiter) Accept() {
 	t.clock.Sleep(t.limiter.ReserveN(now, 1).DelayFrom(now))
 }
 
-func (t *tokenBucketRateLimiter) Stop() {
-}
-
 func (t *tokenBucketRateLimiter) QPS() float32 {
 	return t.qps
 }
@@ -115,8 +110,6 @@ func NewFakeAlwaysRateLimiter() RateLimiter {
 func (t *fakeAlwaysRateLimiter) TryAccept() bool {
 	return true
 }
-
-func (t *fakeAlwaysRateLimiter) Stop() {}
 
 func (t *fakeAlwaysRateLimiter) Accept() {}
 
@@ -140,10 +133,6 @@ func NewFakeNeverRateLimiter() RateLimiter {
 
 func (t *fakeNeverRateLimiter) TryAccept() bool {
 	return false
-}
-
-func (t *fakeNeverRateLimiter) Stop() {
-	t.wg.Done()
 }
 
 func (t *fakeNeverRateLimiter) Accept() {

--- a/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/throttle_test.go
@@ -146,12 +146,6 @@ func TestNeverFake(t *testing.T) {
 	if finished {
 		t.Error("Accept should block forever in NeverFake.")
 	}
-
-	rl.Stop()
-	wg.Wait()
-	if !finished {
-		t.Error("Stop should make Accept unblock in NeverFake.")
-	}
 }
 
 func TestWait(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove the `Stop` method from the `RateLimiter` interface.

I originally only intended to update the comment (i.e. as `CanAccept` no
longer exists as a method). However, as I was doing so, I noticed a
couple traits of `Stop` which made me want to delete it.

1. Only fake implementations of the `RateLimiter` interface use it in a
meaningful way.
2. Even on fakes, `Stop` method doesn't have a consistent impact, as calling `Stop`
impacts `Accept`, but does not impact `TryAccept` or `Wait`.
3. In general, we want to keep interfaces as concise as possible.

Give the above, I propose we delete the `Stop` method from the
`RateLimiter` interface. We can always add it back if we feel we need
it and that need corresponds with a real use case.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
