### PR TITLE
Add DynamicPluginProber for startVolumeExpandController in release 1.17

### DIFF
--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -358,6 +358,8 @@ func startVolumeExpandController(ctx ControllerContext) (http.Handler, bool, err
 		if err != nil {
 			return nil, true, fmt.Errorf("failed to probe volume plugins when starting volume expand controller: %v", err)
 		}
+
+		prober := GetDynamicPluginProber(ctx.ComponentConfig.PersistentVolumeBinderController.VolumeConfiguration)
 		csiTranslator := csitrans.New()
 		expandController, expandControllerErr := expand.NewExpandController(
 			ctx.ClientBuilder.ClientOrDie("expand-controller"),
@@ -366,6 +368,7 @@ func startVolumeExpandController(ctx ControllerContext) (http.Handler, bool, err
 			ctx.InformerFactory.Storage().V1().StorageClasses(),
 			ctx.Cloud,
 			plugins,
+			prober,
 			csiTranslator,
 			csimigration.NewPluginManager(csiTranslator))
 

--- a/pkg/controller/volume/expand/expand_controller.go
+++ b/pkg/controller/volume/expand/expand_controller.go
@@ -112,6 +112,7 @@ func NewExpandController(
 	scInformer storageclassinformer.StorageClassInformer,
 	cloud cloudprovider.Interface,
 	plugins []volume.VolumePlugin,
+	prober volume.DynamicPluginProber,
 	translator CSINameTranslator,
 	csiMigratedPluginManager csimigration.PluginManager) (ExpandController, error) {
 
@@ -129,7 +130,7 @@ func NewExpandController(
 		csiMigratedPluginManager: csiMigratedPluginManager,
 	}
 
-	if err := expc.volumePluginMgr.InitPlugins(plugins, nil, expc); err != nil {
+	if err := expc.volumePluginMgr.InitPlugins(plugins, prober, expc); err != nil {
 		return nil, fmt.Errorf("could not initialize volume plugins for Expand Controller : %+v", err)
 	}
 

--- a/pkg/controller/volume/expand/expand_controller_test.go
+++ b/pkg/controller/volume/expand/expand_controller_test.go
@@ -126,7 +126,7 @@ func TestSyncHandler(t *testing.T) {
 			informerFactory.Storage().V1().StorageClasses().Informer().GetIndexer().Add(tc.storageClass)
 		}
 		translator := csitrans.New()
-		expc, err := NewExpandController(fakeKubeClient, pvcInformer, pvInformer, storageClassInformer, nil, allPlugins, translator, csimigration.NewPluginManager(translator))
+		expc, err := NewExpandController(fakeKubeClient, pvcInformer, pvInformer, storageClassInformer, nil, allPlugins, nil, translator, csimigration.NewPluginManager(translator))
 		if err != nil {
 			t.Fatalf("error creating expand controller : %v", err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

Add DynamicPluginProber for VolumeExpandController to enable volumeExpand feature of flexvolume plugins.

**Which issue(s) this PR fixes**:

Fixes #85504

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix a bug in PVC resize when using flexvolume for release 1.17:
Add DynamicPluginProber for VolumeExpandController to enable volumeExpand feature of flexvolume plugins.
```

