### PR TITLE
Remove no longer needed `modifyContainerPIDNamespaceOverrides`

### DIFF
--- a/pkg/kubelet/dockershim/helpers_linux.go
+++ b/pkg/kubelet/dockershim/helpers_linux.go
@@ -120,7 +120,6 @@ func (ds *dockerService) updateCreateConfig(
 		if err := applyContainerSecurityContext(lc, podSandboxID, createConfig.Config, createConfig.HostConfig, securityOptSep); err != nil {
 			return fmt.Errorf("failed to apply container security context for container %q: %v", config.Metadata.Name, err)
 		}
-		modifyContainerPIDNamespaceOverrides(apiVersion, createConfig.HostConfig, podSandboxID)
 	}
 
 	// Apply cgroupsParent derived from the sandbox config.

--- a/pkg/kubelet/dockershim/security_context.go
+++ b/pkg/kubelet/dockershim/security_context.go
@@ -19,9 +19,7 @@ package dockershim
 import (
 	"fmt"
 	"strconv"
-	"strings"
 
-	"github.com/blang/semver"
 	dockercontainer "github.com/docker/docker/api/types/container"
 
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
@@ -202,16 +200,5 @@ func modifyHostOptionsForContainer(nsOpts *runtimeapi.NamespaceOption, podSandbo
 
 	if nsOpts.GetNetwork() == runtimeapi.NamespaceMode_NODE {
 		hc.UTSMode = namespaceModeHost
-	}
-}
-
-// modifyPIDNamespaceOverrides implements a temporary override for the default PID namespace sharing for Docker:
-//     1. Docker engine prior to API Version 1.24 doesn't support attaching to another container's
-//        PID namespace, and it didn't stabilize until 1.26. This check can be removed when Kubernetes'
-//        minimum Docker version is at least 1.13.1 (API version 1.26).
-// TODO(verb): remove entirely once these two conditions are satisfied
-func modifyContainerPIDNamespaceOverrides(version *semver.Version, hc *dockercontainer.HostConfig, podSandboxID string) {
-	if version.LT(semver.Version{Major: 1, Minor: 26}) && strings.HasPrefix(string(hc.PidMode), "container:") {
-		hc.PidMode = ""
 	}
 }

--- a/pkg/kubelet/dockershim/security_context_test.go
+++ b/pkg/kubelet/dockershim/security_context_test.go
@@ -21,7 +21,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/blang/semver"
 	dockercontainer "github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 
@@ -401,56 +400,6 @@ func TestModifyContainerNamespaceOptions(t *testing.T) {
 		dockerCfg := &dockercontainer.HostConfig{}
 		modifyContainerNamespaceOptions(tc.nsOpt, sandboxID, dockerCfg)
 		assert.Equal(t, tc.expected, dockerCfg, "[Test case %q]", tc.name)
-	}
-}
-
-func TestModifyContainerNamespacePIDOverride(t *testing.T) {
-	cases := []struct {
-		name            string
-		version         *semver.Version
-		input, expected dockercontainer.PidMode
-	}{
-		{
-			name:     "mode:CONTAINER docker:NEW",
-			version:  &semver.Version{Major: 1, Minor: 26},
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "mode:CONTAINER docker:OLD",
-			version:  &semver.Version{Major: 1, Minor: 25},
-			input:    "",
-			expected: "",
-		},
-		{
-			name:     "mode:HOST docker:NEW",
-			version:  &semver.Version{Major: 1, Minor: 26},
-			input:    "host",
-			expected: "host",
-		},
-		{
-			name:     "mode:HOST docker:OLD",
-			version:  &semver.Version{Major: 1, Minor: 25},
-			input:    "host",
-			expected: "host",
-		},
-		{
-			name:     "mode:POD docker:NEW",
-			version:  &semver.Version{Major: 1, Minor: 26},
-			input:    "container:sandbox",
-			expected: "container:sandbox",
-		},
-		{
-			name:     "mode:POD docker:OLD",
-			version:  &semver.Version{Major: 1, Minor: 25},
-			input:    "container:sandbox",
-			expected: "",
-		},
-	}
-	for _, tc := range cases {
-		dockerCfg := &dockercontainer.HostConfig{PidMode: tc.input}
-		modifyContainerPIDNamespaceOverrides(tc.version, dockerCfg, "sandbox")
-		assert.Equal(t, tc.expected, dockerCfg.PidMode, "[Test case %q]", tc.name)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
As of https://github.com/kubernetes/kubernetes/pull/72831/, the minimum
kubernetes version is now 1.13.1. As a result, this function becomes a
no-op. As the TODO indicates, we should delete it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @verb (author of the TODO)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
