### PR TITLE
Don't paginate in listwatch

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/listwatch.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listwatch.go
@@ -17,14 +17,11 @@ limitations under the License.
 package cache
 
 import (
-	"context"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	restclient "k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/pager"
 )
 
 // Lister is any object that knows how to perform an initial list.
@@ -102,9 +99,8 @@ func NewFilteredListWatchFromClient(c Getter, resource string, namespace string,
 
 // List a set of apiserver resources
 func (lw *ListWatch) List(options metav1.ListOptions) (runtime.Object, error) {
-	if !lw.DisableChunking {
-		return pager.New(pager.SimplePageFunc(lw.ListFunc)).List(context.TODO(), options)
-	}
+	// ListWatch is used in Reflector, which already supports pagination.
+	// Don't paginate here to avoid duplication.
 	return lw.ListFunc(options)
 }
 


### PR DESCRIPTION
Ref #86483

As found while working on https://github.com/kubernetes/kubernetes/pull/86430 we now have double-pagination in reflector when using listwatch, which doesn't make any sense.

```release-note
NONE
```