### PR TITLE
Remixes the GCE master-naming firewall test from arbitrary specificity

### DIFF
--- a/test/e2e/framework/providers/gce/firewall.go
+++ b/test/e2e/framework/providers/gce/firewall.go
@@ -93,7 +93,7 @@ func ConstructHealthCheckFirewallForLBService(clusterID string, svc *v1.Service,
 // From cluster/gce/config-test.sh, master name is set up using below format:
 // MASTER_NAME="${INSTANCE_PREFIX}-master"
 func GetInstancePrefix(masterName string) (string, error) {
-	if !strings.HasSuffix(masterName, "-master") {
+	if !strings.Contains(masterName, "master") {
 		return "", fmt.Errorf("unexpected master name format: %v", masterName)
 	}
 	return masterName[:len(masterName)-7], nil


### PR DESCRIPTION
/kind bug
/kind failing-test

**What this PR does / why we need it**
kops sets the names of the masters in a slightly different format than this test expects. This PR attempts to adjust the formula so that it doesn't cause failures during E2E tests. I don't think that requiring the suffix `-master` on masters is a strict security requirement; it seems to be more like a naming preference. This PR should continue to :+1: on the same naming scheme as before, but should also be happier with the way kops is allocating names. 

**Which issue(s) this PR fixes**:
should fix https://github.com/kubernetes/kops/issues/8181

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE
```release-note
NONE
```

