### PR TITLE
make kubelet sysctl constants private

### DIFF
--- a/pkg/kubelet/sysctl/namespace.go
+++ b/pkg/kubelet/sysctl/namespace.go
@@ -25,28 +25,28 @@ type Namespace string
 
 const (
 	// the Linux IPC namespace
-	IpcNamespace = Namespace("ipc")
+	ipcNamespace = Namespace("ipc")
 
 	// the network namespace
-	NetNamespace = Namespace("net")
+	netNamespace = Namespace("net")
 
 	// the zero value if no namespace is known
-	UnknownNamespace = Namespace("")
+	unknownNamespace = Namespace("")
 )
 
 var namespaces = map[string]Namespace{
-	"kernel.sem": IpcNamespace,
+	"kernel.sem": ipcNamespace,
 }
 
 var prefixNamespaces = map[string]Namespace{
-	"kernel.shm": IpcNamespace,
-	"kernel.msg": IpcNamespace,
-	"fs.mqueue.": IpcNamespace,
-	"net.":       NetNamespace,
+	"kernel.shm": ipcNamespace,
+	"kernel.msg": ipcNamespace,
+	"fs.mqueue.": ipcNamespace,
+	"net.":       netNamespace,
 }
 
 // NamespacedBy returns the namespace of the Linux kernel for a sysctl, or
-// UnknownNamespace if the sysctl is not known to be namespaced.
+// unknownNamespace if the sysctl is not known to be namespaced.
 func NamespacedBy(val string) Namespace {
 	if ns, found := namespaces[val]; found {
 		return ns
@@ -56,5 +56,5 @@ func NamespacedBy(val string) Namespace {
 			return ns
 		}
 	}
-	return UnknownNamespace
+	return unknownNamespace
 }

--- a/pkg/kubelet/sysctl/namespace_test.go
+++ b/pkg/kubelet/sysctl/namespace_test.go
@@ -22,10 +22,10 @@ import (
 
 func TestNamespacedBy(t *testing.T) {
 	tests := map[string]Namespace{
-		"kernel.shm_rmid_forced": IpcNamespace,
-		"net.a.b.c":              NetNamespace,
-		"fs.mqueue.a.b.c":        IpcNamespace,
-		"foo":                    UnknownNamespace,
+		"kernel.shm_rmid_forced": ipcNamespace,
+		"net.a.b.c":              netNamespace,
+		"fs.mqueue.a.b.c":        ipcNamespace,
+		"foo":                    unknownNamespace,
 	}
 
 	for sysctl, ns := range tests {

--- a/pkg/kubelet/sysctl/whitelist.go
+++ b/pkg/kubelet/sysctl/whitelist.go
@@ -58,13 +58,13 @@ func NewWhitelist(patterns []string) (*patternWhitelist, error) {
 		if strings.HasSuffix(s, "*") {
 			prefix := s[:len(s)-1]
 			ns := NamespacedBy(prefix)
-			if ns == UnknownNamespace {
+			if ns == unknownNamespace {
 				return nil, fmt.Errorf("the sysctls %q are not known to be namespaced", s)
 			}
 			w.prefixes[prefix] = ns
 		} else {
 			ns := NamespacedBy(s)
-			if ns == UnknownNamespace {
+			if ns == unknownNamespace {
 				return nil, fmt.Errorf("the sysctl %q are not known to be namespaced", s)
 			}
 			w.sysctls[s] = ns
@@ -83,20 +83,20 @@ func NewWhitelist(patterns []string) (*patternWhitelist, error) {
 func (w *patternWhitelist) validateSysctl(sysctl string, hostNet, hostIPC bool) error {
 	nsErrorFmt := "%q not allowed with host %s enabled"
 	if ns, found := w.sysctls[sysctl]; found {
-		if ns == IpcNamespace && hostIPC {
+		if ns == ipcNamespace && hostIPC {
 			return fmt.Errorf(nsErrorFmt, sysctl, ns)
 		}
-		if ns == NetNamespace && hostNet {
+		if ns == netNamespace && hostNet {
 			return fmt.Errorf(nsErrorFmt, sysctl, ns)
 		}
 		return nil
 	}
 	for p, ns := range w.prefixes {
 		if strings.HasPrefix(sysctl, p) {
-			if ns == IpcNamespace && hostIPC {
+			if ns == ipcNamespace && hostIPC {
 				return fmt.Errorf(nsErrorFmt, sysctl, ns)
 			}
-			if ns == NetNamespace && hostNet {
+			if ns == netNamespace && hostNet {
 				return fmt.Errorf(nsErrorFmt, sysctl, ns)
 			}
 			return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
add some comments for const variables
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
