### PR TITLE
fix golint of pkg/kubelet/stats:replace stats.StatsProvider with stats.Provider

### DIFF
--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -248,7 +248,7 @@ func newTestKubeletWithImageList(
 	volumeStatsAggPeriod := time.Second * 10
 	kubelet.resourceAnalyzer = serverstats.NewResourceAnalyzer(kubelet, volumeStatsAggPeriod)
 
-	kubelet.StatsProvider = stats.NewCadvisorStatsProvider(
+	kubelet.Provider = stats.NewCadvisorStatsProvider(
 		kubelet.cadvisor,
 		kubelet.resourceAnalyzer,
 		kubelet.podManager,
@@ -259,7 +259,7 @@ func newTestKubeletWithImageList(
 		HighThresholdPercent: 90,
 		LowThresholdPercent:  80,
 	}
-	imageGCManager, err := images.NewImageGCManager(fakeRuntime, kubelet.StatsProvider, fakeRecorder, fakeNodeRef, fakeImageGCPolicy, "")
+	imageGCManager, err := images.NewImageGCManager(fakeRuntime, kubelet.Provider, fakeRecorder, fakeNodeRef, fakeImageGCPolicy, "")
 	assert.NoError(t, err)
 	kubelet.imageManager = &fakeImageGCManager{
 		fakeImageService: fakeRuntime,

--- a/pkg/kubelet/stats/stats_provider.go
+++ b/pkg/kubelet/stats/stats_provider.go
@@ -43,7 +43,7 @@ func NewCRIStatsProvider(
 	imageService internalapi.ImageManagerService,
 	logMetricsService LogMetricsService,
 	osInterface kubecontainer.OSInterface,
-) *StatsProvider {
+) *Provider {
 	return newStatsProvider(cadvisor, podManager, runtimeCache, newCRIStatsProvider(cadvisor, resourceAnalyzer,
 		runtimeService, imageService, logMetricsService, osInterface))
 }
@@ -57,7 +57,7 @@ func NewCadvisorStatsProvider(
 	runtimeCache kubecontainer.RuntimeCache,
 	imageService kubecontainer.ImageService,
 	statusProvider status.PodStatusProvider,
-) *StatsProvider {
+) *Provider {
 	return newStatsProvider(cadvisor, podManager, runtimeCache, newCadvisorStatsProvider(cadvisor, resourceAnalyzer, imageService, statusProvider))
 }
 
@@ -68,8 +68,8 @@ func newStatsProvider(
 	podManager kubepod.Manager,
 	runtimeCache kubecontainer.RuntimeCache,
 	containerStatsProvider containerStatsProvider,
-) *StatsProvider {
-	return &StatsProvider{
+) *Provider {
+	return &Provider{
 		cadvisor:               cadvisor,
 		podManager:             podManager,
 		runtimeCache:           runtimeCache,
@@ -77,8 +77,8 @@ func newStatsProvider(
 	}
 }
 
-// StatsProvider provides the stats of the node and the pod-managed containers.
-type StatsProvider struct {
+// Provider provides the stats of the node and the pod-managed containers.
+type Provider struct {
 	cadvisor     cadvisor.Interface
 	podManager   kubepod.Manager
 	runtimeCache kubecontainer.RuntimeCache
@@ -101,13 +101,13 @@ type rlimitStatsProvider interface {
 }
 
 // RlimitStats returns base information about process count
-func (p *StatsProvider) RlimitStats() (*statsapi.RlimitStats, error) {
+func (p *Provider) RlimitStats() (*statsapi.RlimitStats, error) {
 	return pidlimit.Stats()
 }
 
 // GetCgroupStats returns the stats of the cgroup with the cgroupName. Note that
 // this function doesn't generate filesystem stats.
-func (p *StatsProvider) GetCgroupStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, *statsapi.NetworkStats, error) {
+func (p *Provider) GetCgroupStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, *statsapi.NetworkStats, error) {
 	info, err := getCgroupInfo(p.cadvisor, cgroupName, updateStats)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get cgroup stats for %q: %v", cgroupName, err)
@@ -120,7 +120,7 @@ func (p *StatsProvider) GetCgroupStats(cgroupName string, updateStats bool) (*st
 
 // GetCgroupCPUAndMemoryStats returns the CPU and memory stats of the cgroup with the cgroupName. Note that
 // this function doesn't generate filesystem stats.
-func (p *StatsProvider) GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, error) {
+func (p *Provider) GetCgroupCPUAndMemoryStats(cgroupName string, updateStats bool) (*statsapi.ContainerStats, error) {
 	info, err := getCgroupInfo(p.cadvisor, cgroupName, updateStats)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cgroup stats for %q: %v", cgroupName, err)
@@ -131,7 +131,7 @@ func (p *StatsProvider) GetCgroupCPUAndMemoryStats(cgroupName string, updateStat
 }
 
 // RootFsStats returns the stats of the node root filesystem.
-func (p *StatsProvider) RootFsStats() (*statsapi.FsStats, error) {
+func (p *Provider) RootFsStats() (*statsapi.FsStats, error) {
 	rootFsInfo, err := p.cadvisor.RootFsInfo()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rootFs info: %v", err)
@@ -162,7 +162,7 @@ func (p *StatsProvider) RootFsStats() (*statsapi.FsStats, error) {
 }
 
 // GetContainerInfo returns stats (from cAdvisor) for a container.
-func (p *StatsProvider) GetContainerInfo(podFullName string, podUID types.UID, containerName string, req *cadvisorapiv1.ContainerInfoRequest) (*cadvisorapiv1.ContainerInfo, error) {
+func (p *Provider) GetContainerInfo(podFullName string, podUID types.UID, containerName string, req *cadvisorapiv1.ContainerInfoRequest) (*cadvisorapiv1.ContainerInfo, error) {
 	// Resolve and type convert back again.
 	// We need the static pod UID but the kubecontainer API works with types.UID.
 	podUID = types.UID(p.podManager.TranslatePodUID(podUID))
@@ -186,7 +186,7 @@ func (p *StatsProvider) GetContainerInfo(podFullName string, podUID types.UID, c
 
 // GetRawContainerInfo returns the stats (from cadvisor) for a non-Kubernetes
 // container.
-func (p *StatsProvider) GetRawContainerInfo(containerName string, req *cadvisorapiv1.ContainerInfoRequest, subcontainers bool) (map[string]*cadvisorapiv1.ContainerInfo, error) {
+func (p *Provider) GetRawContainerInfo(containerName string, req *cadvisorapiv1.ContainerInfoRequest, subcontainers bool) (map[string]*cadvisorapiv1.ContainerInfo, error) {
 	if subcontainers {
 		return p.cadvisor.SubcontainerInfo(containerName, req)
 	}
@@ -200,7 +200,7 @@ func (p *StatsProvider) GetRawContainerInfo(containerName string, req *cadvisora
 }
 
 // HasDedicatedImageFs returns true if a dedicated image filesystem exists for storing images.
-func (p *StatsProvider) HasDedicatedImageFs() (bool, error) {
+func (p *Provider) HasDedicatedImageFs() (bool, error) {
 	device, err := p.containerStatsProvider.ImageFsDevice()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:
fix golint of pkg/kubelet/stats:replace stats.StatsProvider with stats.Provider
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
pkg/kubelet/stats/stats_provider.go:46:4: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:60:4: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:71:4: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:104:10: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:110:10: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:123:10: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:134:10: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:165:10: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:189:10: undefined: StatsProvider
pkg/kubelet/stats/stats_provider.go:203:10: undefined: StatsProvider
pkg/kubelet/kubelet.go:1212:2: undefined: "k8s.io/kubernetes/pkg/kubelet/stats".StatsProvider
pkg/kubelet/kubelet.go:710:7: klet.StatsProvider undefined (type *Kubelet has no field or method StatsProvider)
pkg/kubelet/kubelet.go:718:7: klet.StatsProvider undefined (type *Kubelet has no field or method StatsProvider)
pkg/kubelet/kubelet.go:745:75: klet.StatsProvider undefined (type *Kubelet has no field or method StatsProvider)
pkg/kubelet/kubelet.go:1324:39: kl.StatsProvider undefined (type *Kubelet has no field or method StatsProvider)
pkg/kubelet/kubelet.go:1370:4: kl.StatsProvider undefined (type *Kubelet has no field or method StatsProvider)
pkg/kubelet/kubelet.go:1383:29: kl.StatsProvider undefined (type *Kubelet has no field or method StatsProvider)
```
