### PR TITLE
add dynamic reloading for CSR signing controllers

### DIFF
--- a/pkg/controller/.import-restrictions
+++ b/pkg/controller/.import-restrictions
@@ -74,6 +74,7 @@
         "k8s.io/apimachinery/pkg/version",
         "k8s.io/api/imagepolicy/v1alpha1",
         "k8s.io/apiserver/pkg/admission",
+        "k8s.io/apiserver/pkg/server/dynamiccertificates",
         "k8s.io/apiserver/pkg/storage",
         "k8s.io/api/batch/v2alpha1",
         "k8s.io/apiserver/pkg/registry/rest",

--- a/pkg/controller/certificates/authority/authority.go
+++ b/pkg/controller/certificates/authority/authority.go
@@ -30,6 +30,11 @@ var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 // CertificateAuthority implements a certificate authority that supports policy
 // based signing. It's used by the signing controller.
 type CertificateAuthority struct {
+	// RawCert is an optional field to determine if signing cert/key pairs have changed
+	RawCert []byte
+	// RawKey is an optional field to determine if signing cert/key pairs have changed
+	RawKey []byte
+
 	Certificate *x509.Certificate
 	PrivateKey  crypto.Signer
 	Backdate    time.Duration

--- a/pkg/controller/certificates/signer/BUILD
+++ b/pkg/controller/certificates/signer/BUILD
@@ -26,13 +26,17 @@ go_test(
 
 go_library(
     name = "go_default_library",
-    srcs = ["signer.go"],
+    srcs = [
+        "ca_provider.go",
+        "signer.go",
+    ],
     importpath = "k8s.io/kubernetes/pkg/controller/certificates/signer",
     deps = [
         "//pkg/apis/certificates/v1beta1:go_default_library",
         "//pkg/controller/certificates:go_default_library",
         "//pkg/controller/certificates/authority:go_default_library",
         "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates:go_default_library",
         "//staging/src/k8s.io/client-go/informers/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",

--- a/pkg/controller/certificates/signer/ca_provider.go
+++ b/pkg/controller/certificates/signer/ca_provider.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signer
+
+import (
+	"bytes"
+	"crypto"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/apiserver/pkg/server/dynamiccertificates"
+	"k8s.io/client-go/util/cert"
+	"k8s.io/client-go/util/keyutil"
+	"k8s.io/kubernetes/pkg/controller/certificates/authority"
+)
+
+func newCAProvider(caFile, caKeyFile string) (*caProvider, error) {
+	caLoader, err := dynamiccertificates.NewDynamicServingContentFromFiles("csr-controller", caFile, caKeyFile)
+	if err != nil {
+		return nil, fmt.Errorf("error reading CA cert file %q: %v", caFile, err)
+	}
+
+	ret := &caProvider{
+		caLoader: caLoader,
+	}
+	if err := ret.setCA(); err != nil {
+		return nil, err
+	}
+
+	return ret, nil
+}
+
+type caProvider struct {
+	caValue  atomic.Value
+	caLoader *dynamiccertificates.DynamicFileServingContent
+}
+
+// setCA unconditionally stores the current cert/key content
+func (p *caProvider) setCA() error {
+	certPEM, keyPEM := p.caLoader.CurrentCertKeyContent()
+
+	certs, err := cert.ParseCertsPEM(certPEM)
+	if err != nil {
+		return fmt.Errorf("error reading CA cert file %q: %v", p.caLoader.Name(), err)
+	}
+	if len(certs) != 1 {
+		return fmt.Errorf("error reading CA cert file %q: expected 1 certificate, found %d", p.caLoader.Name(), len(certs))
+	}
+
+	key, err := keyutil.ParsePrivateKeyPEM(keyPEM)
+	if err != nil {
+		return fmt.Errorf("error reading CA key file %q: %v", p.caLoader.Name(), err)
+	}
+	priv, ok := key.(crypto.Signer)
+	if !ok {
+		return fmt.Errorf("error reading CA key file %q: key did not implement crypto.Signer", p.caLoader.Name())
+	}
+
+	ca := &authority.CertificateAuthority{
+		RawCert: certPEM,
+		RawKey:  keyPEM,
+
+		Certificate: certs[0],
+		PrivateKey:  priv,
+		Backdate:    5 * time.Minute,
+	}
+	p.caValue.Store(ca)
+
+	return nil
+}
+
+// currentCA provides the curent value of the CA.
+// It always check for a stale value.  This is cheap because it's all an in memory cache of small slices.
+func (p *caProvider) currentCA() (*authority.CertificateAuthority, error) {
+	certPEM, keyPEM := p.caLoader.CurrentCertKeyContent()
+	currCA := p.caValue.Load().(*authority.CertificateAuthority)
+	if bytes.Equal(currCA.RawCert, certPEM) && bytes.Equal(currCA.RawKey, keyPEM) {
+		return currCA, nil
+	}
+
+	// the bytes weren't equal, so we have to set and then load
+	if err := p.setCA(); err != nil {
+		return currCA, err
+	}
+	return p.caValue.Load().(*authority.CertificateAuthority), nil
+}

--- a/pkg/controller/certificates/signer/ca_provider.go
+++ b/pkg/controller/certificates/signer/ca_provider.go
@@ -47,7 +47,7 @@ func newCAProvider(caFile, caKeyFile string) (*caProvider, error) {
 
 type caProvider struct {
 	caValue  atomic.Value
-	caLoader *dynamiccertificates.DynamicFileServingContent
+	caLoader *dynamiccertificates.DynamicCertKeyPairContent
 }
 
 // setCA unconditionally stores the current cert/key content

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -38,8 +38,13 @@ func TestSigner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create signer: %v", err)
 	}
-	s.ca.Now = clock.Now
-	s.ca.Backdate = 0
+	currCA, err := s.caProvider.currentCA()
+	if err != nil {
+		t.Fatal(err)
+	}
+	currCA.Now = clock.Now
+	currCA.Backdate = 0
+	s.caProvider.caValue.Store(currCA)
 
 	csrb, err := ioutil.ReadFile("./testdata/kubelet.csr")
 	if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_sni_content.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/dynamic_sni_content.go
@@ -18,7 +18,7 @@ package dynamiccertificates
 
 // DynamicFileSNIContent provides a SNICertKeyContentProvider that can dynamically react to new file content
 type DynamicFileSNIContent struct {
-	*DynamicFileServingContent
+	*DynamicCertKeyPairContent
 	sniNames []string
 }
 
@@ -34,10 +34,10 @@ func NewDynamicSNIContentFromFiles(purpose, certFile, keyFile string, sniNames .
 	}
 
 	ret := &DynamicFileSNIContent{
-		DynamicFileServingContent: servingContent,
+		DynamicCertKeyPairContent: servingContent,
 		sniNames:                  sniNames,
 	}
-	if err := ret.loadServingCert(); err != nil {
+	if err := ret.loadCertKeyPair(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This updates the CSR controllers to match the kube-apiserver for cert/key pair reloading behavior.  It reuses our existing reloading code.

/kind cleanup
/priority important-soon

```release-note
the CSR signing cert/key pairs will be reloaded from disk like the kube-apiserver cert/key pairs
```