### PR TITLE
Cleanup unused parameter of NewGenericScheduler

### DIFF
--- a/pkg/scheduler/core/BUILD
+++ b/pkg/scheduler/core/BUILD
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/scheduler/algorithm:go_default_library",
-        "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/algorithm/priorities:go_default_library",
         "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/apis/extender/v1:go_default_library",

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -584,7 +584,6 @@ func TestGenericSchedulerWithExtenders(t *testing.T) {
 			scheduler := NewGenericScheduler(
 				cache,
 				queue,
-				nil,
 				priorities.EmptyMetadataProducer,
 				emptySnapshot,
 				fwk,

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities"
 	extenderv1 "k8s.io/kubernetes/pkg/scheduler/apis/extender/v1"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
@@ -112,9 +111,6 @@ type ScheduleAlgorithm interface {
 	// It returns the node where preemption happened, a list of preempted pods, a
 	// list of pods whose nominated node name should be removed, and error if any.
 	Preempt(context.Context, *framework.CycleState, *v1.Pod, error) (selectedNode *v1.Node, preemptedPods []*v1.Pod, cleanupNominatedPods []*v1.Pod, err error)
-	// Predicates() returns a pointer to a map of predicate functions. This is
-	// exposed for testing.
-	Predicates() map[string]predicates.FitPredicate
 	// Prioritizers returns a slice of priority config. This is exposed for
 	// testing.
 	Extenders() []algorithm.SchedulerExtender
@@ -141,7 +137,6 @@ type ScheduleResult struct {
 type genericScheduler struct {
 	cache                    internalcache.Cache
 	schedulingQueue          internalqueue.SchedulingQueue
-	predicates               map[string]predicates.FitPredicate
 	priorityMetaProducer     priorities.MetadataProducer
 	prioritizers             []priorities.PriorityConfig
 	framework                framework.Framework
@@ -260,12 +255,6 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 // functions and their config. It is exposed for testing only.
 func (g *genericScheduler) Prioritizers() []priorities.PriorityConfig {
 	return g.prioritizers
-}
-
-// Predicates returns a map containing all the scheduler's predicate
-// functions. It is exposed for testing only.
-func (g *genericScheduler) Predicates() map[string]predicates.FitPredicate {
-	return g.predicates
 }
 
 func (g *genericScheduler) Extenders() []algorithm.SchedulerExtender {
@@ -1111,11 +1100,9 @@ func podPassesBasicChecks(pod *v1.Pod, pvcLister corelisters.PersistentVolumeCla
 }
 
 // NewGenericScheduler creates a genericScheduler object.
-// TODO(Huang-Wei): remove 'predicates'.
 func NewGenericScheduler(
 	cache internalcache.Cache,
 	podQueue internalqueue.SchedulingQueue,
-	predicates map[string]predicates.FitPredicate,
 	priorityMetaProducer priorities.MetadataProducer,
 	nodeInfoSnapshot *nodeinfosnapshot.Snapshot,
 	framework framework.Framework,
@@ -1129,7 +1116,6 @@ func NewGenericScheduler(
 	return &genericScheduler{
 		cache:                    cache,
 		schedulingQueue:          podQueue,
-		predicates:               predicates,
 		priorityMetaProducer:     priorityMetaProducer,
 		framework:                framework,
 		extenders:                extenders,

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -782,7 +782,6 @@ func TestGenericScheduler(t *testing.T) {
 			scheduler := NewGenericScheduler(
 				cache,
 				internalqueue.NewSchedulingQueue(nil),
-				nil,
 				priorities.EmptyMetadataProducer,
 				snapshot,
 				fwk,
@@ -827,7 +826,6 @@ func makeScheduler(nodes []*v1.Node, fns ...st.RegisterPluginFunc) *genericSched
 	s := NewGenericScheduler(
 		cache,
 		internalqueue.NewSchedulingQueue(nil),
-		nil,
 		priorities.EmptyMetadataProducer,
 		emptySnapshot,
 		fwk,
@@ -955,7 +953,6 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 		scheduler := NewGenericScheduler(
 			cache,
 			queue,
-			nil,
 			priorities.EmptyMetadataProducer,
 			emptySnapshot,
 			fwk,
@@ -1148,7 +1145,6 @@ func TestZeroRequest(t *testing.T) {
 			}
 
 			scheduler := NewGenericScheduler(
-				nil,
 				nil,
 				nil,
 				metadataProducer,
@@ -1596,7 +1592,6 @@ func TestSelectNodesForPreemption(t *testing.T) {
 			scheduler := NewGenericScheduler(
 				nil,
 				internalqueue.NewSchedulingQueue(nil),
-				nil,
 				priorities.EmptyMetadataProducer,
 				snapshot,
 				fwk,
@@ -2323,7 +2318,6 @@ func TestPreempt(t *testing.T) {
 			scheduler := NewGenericScheduler(
 				cache,
 				internalqueue.NewSchedulingQueue(nil),
-				nil,
 				priorities.EmptyMetadataProducer,
 				snapshot,
 				fwk,

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -145,7 +145,6 @@ func (c *Configurator) create(extenders []algorithm.SchedulerExtender) (*Schedul
 	algo := core.NewGenericScheduler(
 		c.schedulerCache,
 		podQueue,
-		nil,
 		priorities.NewMetadataFactory(
 			c.informerFactory.Core().V1().Services().Lister(),
 			c.informerFactory.Core().V1().ReplicationControllers().Lister(),

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -674,7 +674,6 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 	algo := core.NewGenericScheduler(
 		scache,
 		internalqueue.NewSchedulingQueue(nil),
-		nil,
 		priorities.EmptyMetadataProducer,
 		nodeinfosnapshot.NewEmptySnapshot(),
 		fwk,
@@ -730,7 +729,6 @@ func setupTestSchedulerLongBindingWithRetry(queuedPodStore *clientcache.FIFO, sc
 	algo := core.NewGenericScheduler(
 		scache,
 		queue,
-		nil,
 		priorities.EmptyMetadataProducer,
 		nodeinfosnapshot.NewEmptySnapshot(),
 		fwk,


### PR DESCRIPTION
/kind cleanup
/sig scheduling

Part of #85822 

```release-note
NONE
```

/cc @ahg-g
