### PR TITLE
Initialize map for singleton cache

### DIFF
--- a/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
+++ b/staging/src/k8s.io/apimachinery/third_party/forked/golang/json/fields.go
@@ -295,10 +295,10 @@ func dominantField(fields []field) (field, bool) {
 	return fields[0], true
 }
 
-var fieldCache struct {
+var fieldCache = &struct {
 	sync.RWMutex
 	m map[reflect.Type][]field
-}
+}{m: make(map[reflect.Type][]field)}
 
 // cachedTypeFields is like typeFields but uses a cache to avoid repeated work.
 func cachedTypeFields(t reflect.Type) []field {
@@ -317,9 +317,6 @@ func cachedTypeFields(t reflect.Type) []field {
 	}
 
 	fieldCache.Lock()
-	if fieldCache.m == nil {
-		fieldCache.m = map[reflect.Type][]field{}
-	}
 	fieldCache.m[t] = f
 	fieldCache.Unlock()
 	return f


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR lifts the map initialization where the cache variable is created.

**Which issue(s) this PR fixes**:
Fixes #86814

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
