### PR TITLE
Added a protobuf tag for `Quantity.Format`.

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity.go
@@ -95,7 +95,7 @@ type Quantity struct {
 
 	// Change Format at will. See the comment for Canonicalize for
 	// more details.
-	Format
+	Format `protobuf:"bytes,1,opt,name=string"`
 }
 
 // CanonicalValue allows a quantity amount to be converted to a string.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

It is currently impossible to specify resource quantities in starlark through `skycfg` to generate pod specs, because `skycfg` uses protobuf tags to convert a starlark expression (e.g., `resource.Quantity(string = "1000m")`) to its corresponding go struct, but the protobuf tag for `string` is missing.

**Which issue(s) this PR fixes**:

Adding a protobuf tag to `Quantity` so we can specify resource quantities in starlark through `skycfg` (in conjunction with https://github.com/stripe/skycfg/pull/69).

**Special notes for your reviewer**:

It would be nice if this change can be backported to 1.14+.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```