### PR TITLE
kubeadm: support for CA bundles

### DIFF
--- a/cmd/kubeadm/app/cmd/phases/init/certs.go
+++ b/cmd/kubeadm/app/cmd/phases/init/certs.go
@@ -263,9 +263,9 @@ func runCertPhase(cert *certsphase.KubeadmCert, caCert *certsphase.KubeadmCert) 
 			if err != nil {
 				return errors.Wrapf(err, "couldn't load CA certificate %s", caCert.Name)
 			}
-
-			if err := certData.CheckSignatureFrom(caCertData); err != nil {
-				return errors.Wrapf(err, "[certs] certificate %s not signed by CA certificate %s", cert.BaseName, caCert.BaseName)
+			_, err = pkiutil.CheckSignatureFromCAs(certData, caCertData)
+			if err != nil {
+				return errors.Wrapf(err, "[certs] certificate %s not signed by any CA certificate from %s file", cert.BaseName, caCert.BaseName)
 			}
 
 			fmt.Printf("[certs] Using existing %s certificate and key on disk\n", cert.BaseName)

--- a/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
+++ b/cmd/kubeadm/app/phases/kubeconfig/kubeconfig.go
@@ -374,7 +374,7 @@ func ValidateKubeconfigsForExternalCA(outDir string, cfg *kubeadmapi.InitConfigu
 		return err
 	}
 
-	validationConfig := kubeconfigutil.CreateBasic(controlPlaneEndpoint, "dummy", "dummy", pkiutil.EncodeCertPEM(caCert))
+	validationConfig := kubeconfigutil.CreateBasic(controlPlaneEndpoint, "dummy", "dummy", pkiutil.EncodeCertsPEM(caCert))
 
 	// validate user provided kubeconfig files
 	for _, kubeConfigFileName := range kubeConfigFileNames {

--- a/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
+++ b/cmd/kubeadm/app/phases/upgrade/staticpods_test.go
@@ -804,10 +804,11 @@ func TestRenewCertsByComponent(t *testing.T) {
 					t.Fatalf("couldn't create certificate %q: %v", kubeCert.Name, err)
 				}
 
-				cert, err := pkiutil.TryLoadCertFromDisk(tmpDir, kubeCert.BaseName)
+				certs, err := pkiutil.TryLoadCertFromDisk(tmpDir, kubeCert.BaseName)
 				if err != nil {
 					t.Fatalf("couldn't load certificate %q: %v", kubeCert.Name, err)
 				}
+				cert := certs[0]
 				certMaps[kubeCert.Name] = *cert.SerialNumber
 			}
 
@@ -844,11 +845,12 @@ func TestRenewCertsByComponent(t *testing.T) {
 
 			// See if the certificate serial numbers change
 			for _, kubeCert := range test.certsShouldExist {
-				newCert, err := pkiutil.TryLoadCertFromDisk(tmpDir, kubeCert.BaseName)
+				newCerts, err := pkiutil.TryLoadCertFromDisk(tmpDir, kubeCert.BaseName)
 				if err != nil {
 					t.Errorf("couldn't load new certificate %q: %v", kubeCert.Name, err)
 					continue
 				}
+				newCert := newCerts[0]
 				oldSerial := certMaps[kubeCert.Name]
 
 				shouldBeRenewed := true


### PR DESCRIPTION
/kind bug

/sig kubeadm

Motivation behind this PR is to make certificate authority live migration possible when using kubeadm.

Fixes https://github.com/kubernetes/kubeadm/issues/1723

Namely, now kubeadm supports multiple PEM-encoded CA certificates in /etc/kubernetes/pki/ca.crt or other certificate files. This allows both old and new CA to co-exist until new CA is in use by all parties, such as kubectl client configs.

Previously, CA replacement required a coordinated replacement of all kubeconfigs and the kube-apiserver TLS keypar.

**Does this PR introduce a user-facing change?**:
NONE

CC: @boluisa @neolit123

**Special notes for your reviewer**:

`make test KUBE_TIMEOUT="-timeout=300s"` is green on Linux.
