### PR TITLE
Break interpodaffinity Filter plugins dependency on predicates package

### DIFF
--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -33,14 +33,6 @@ var (
 
 	// ErrNodeSelectorNotMatch is used for MatchNodeSelector predicate error.
 	ErrNodeSelectorNotMatch = NewPredicateFailureError("MatchNodeSelector", "node(s) didn't match node selector")
-	// ErrPodAffinityNotMatch is used for MatchInterPodAffinity predicate error.
-	ErrPodAffinityNotMatch = NewPredicateFailureError("MatchInterPodAffinity", "node(s) didn't match pod affinity/anti-affinity")
-	// ErrPodAffinityRulesNotMatch is used for PodAffinityRulesNotMatch predicate error.
-	ErrPodAffinityRulesNotMatch = NewPredicateFailureError("PodAffinityRulesNotMatch", "node(s) didn't match pod affinity rules")
-	// ErrPodAntiAffinityRulesNotMatch is used for PodAntiAffinityRulesNotMatch predicate error.
-	ErrPodAntiAffinityRulesNotMatch = NewPredicateFailureError("PodAntiAffinityRulesNotMatch", "node(s) didn't match pod anti-affinity rules")
-	// ErrExistingPodsAntiAffinityRulesNotMatch is used for ExistingPodsAntiAffinityRulesNotMatch predicate error.
-	ErrExistingPodsAntiAffinityRulesNotMatch = NewPredicateFailureError("ExistingPodsAntiAffinityRulesNotMatch", "node(s) didn't satisfy existing pods anti-affinity rules")
 	// ErrTaintsTolerationsNotMatch is used for PodToleratesNodeTaints predicate error.
 	ErrTaintsTolerationsNotMatch = NewPredicateFailureError("PodToleratesNodeTaints", "node(s) had taints that the pod didn't tolerate")
 	// ErrPodNotMatchHostName is used for HostName predicate error.
@@ -72,7 +64,6 @@ var (
 
 var unresolvablePredicateFailureErrors = map[PredicateFailureReason]struct{}{
 	ErrNodeSelectorNotMatch:      {},
-	ErrPodAffinityRulesNotMatch:  {},
 	ErrPodNotMatchHostName:       {},
 	ErrTaintsTolerationsNotMatch: {},
 	// Node conditions won't change when scheduler simulates removal of preemption victims.

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1879,9 +1879,9 @@ func TestNodesWherePreemptionMightHelp(t *testing.T) {
 			expected: map[string]bool{},
 		},
 		{
-			name: "ErrPodAffinityNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod affinity or anti-affinity",
+			name: "ErrReasonAffinityNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod affinity or anti-affinity",
 			nodesStatuses: framework.NodeToStatusMap{
-				"machine1": framework.NewStatus(framework.Unschedulable, algorithmpredicates.ErrPodAffinityNotMatch.GetReason()),
+				"machine1": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAffinityNotMatch),
 				"machine2": framework.NewStatus(framework.UnschedulableAndUnresolvable, algorithmpredicates.ErrPodNotMatchHostName.GetReason()),
 				"machine3": framework.NewStatus(framework.UnschedulableAndUnresolvable, algorithmpredicates.ErrNodeUnschedulable.GetReason()),
 			},
@@ -1890,16 +1890,16 @@ func TestNodesWherePreemptionMightHelp(t *testing.T) {
 		{
 			name: "pod with both pod affinity and anti-affinity should be tried",
 			nodesStatuses: framework.NodeToStatusMap{
-				"machine1": framework.NewStatus(framework.Unschedulable, algorithmpredicates.ErrPodAffinityNotMatch.GetReason()),
+				"machine1": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAffinityNotMatch),
 				"machine2": framework.NewStatus(framework.UnschedulableAndUnresolvable, algorithmpredicates.ErrPodNotMatchHostName.GetReason()),
 			},
 			expected: map[string]bool{"machine1": true, "machine3": true, "machine4": true},
 		},
 		{
-			name: "ErrPodAffinityRulesNotMatch should not be tried as it indicates that the pod is unschedulable due to inter-pod affinity, but ErrPodAffinityNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod affinity or anti-affinity",
+			name: "ErrReasonAffinityRulesNotMatch should not be tried as it indicates that the pod is unschedulable due to inter-pod affinity, but ErrReasonAffinityNotMatch should be tried as it indicates that the pod is unschedulable due to inter-pod affinity or anti-affinity",
 			nodesStatuses: framework.NodeToStatusMap{
-				"machine1": framework.NewStatus(framework.UnschedulableAndUnresolvable, algorithmpredicates.ErrPodAffinityRulesNotMatch.GetReason()),
-				"machine2": framework.NewStatus(framework.Unschedulable, algorithmpredicates.ErrPodAffinityNotMatch.GetReason()),
+				"machine1": framework.NewStatus(framework.UnschedulableAndUnresolvable, interpodaffinity.ErrReasonAffinityRulesNotMatch),
+				"machine2": framework.NewStatus(framework.Unschedulable, interpodaffinity.ErrReasonAffinityNotMatch),
 			},
 			expected: map[string]bool{"machine2": true, "machine3": true, "machine4": true},
 		},

--- a/pkg/scheduler/framework/plugins/interpodaffinity/BUILD
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/BUILD
@@ -10,9 +10,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/algorithm/priorities/util:go_default_library",
-        "//pkg/scheduler/framework/plugins/migration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
@@ -35,7 +33,6 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/nodeinfo/snapshot:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering_test.go
@@ -23,7 +23,6 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	nodeinfosnapshot "k8s.io/kubernetes/pkg/scheduler/nodeinfo/snapshot"
 )
@@ -134,8 +133,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "Does not satisfy the PodAffinity with labelSelector because of diff Namespace",
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrPodAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -158,8 +157,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "Doesn't satisfy the PodAffinity because of unmatching labelSelector with the existing pod",
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrPodAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -237,8 +236,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "The labelSelector requirements(items of matchExpressions) are ANDed, the pod cannot schedule onto the node because one of the matchExpression item don't match.",
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrPodAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -360,8 +359,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "satisfies the PodAffinity but doesn't satisfy the PodAntiAffinity with the existing pod",
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -415,8 +414,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "satisfies the PodAffinity and PodAntiAffinity but doesn't satisfy PodAntiAffinity symmetry with the existing pod",
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -440,8 +439,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "pod matches its own Label in PodAffinity and that matches the existing pod Labels",
 			wantStatus: framework.NewStatus(
 				framework.UnschedulableAndUnresolvable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrPodAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -471,8 +470,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "verify that PodAntiAffinity from existing pod is respected when pod has no AntiAffinity constraints. doesn't satisfy PodAntiAffinity symmetry with the existing pod",
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -547,8 +546,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			name: "satisfies the PodAntiAffinity with existing pod but doesn't satisfy PodAntiAffinity symmetry with incoming pod",
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonAntiAffinityRulesNotMatch,
 			),
 		},
 		{
@@ -596,8 +595,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonAntiAffinityRulesNotMatch,
 			),
 			name: "PodAntiAffinity symmetry check a1: incoming pod and existing pod partially match each other on AffinityTerms",
 		},
@@ -646,8 +645,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 			name: "PodAntiAffinity symmetry check a2: incoming pod and existing pod partially match each other on AffinityTerms",
 		},
@@ -707,8 +706,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 			name: "PodAntiAffinity symmetry check b1: incoming pod and existing pod partially match each other on AffinityTerms",
 		},
@@ -768,8 +767,8 @@ func TestRequiredAffinitySingleNode(t *testing.T) {
 			node: &node1,
 			wantStatus: framework.NewStatus(
 				framework.Unschedulable,
-				predicates.ErrPodAffinityNotMatch.GetReason(),
-				predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+				ErrReasonAffinityNotMatch,
+				ErrReasonExistingAntiAffinityRulesNotMatch,
 			),
 			name: "PodAntiAffinity symmetry check b2: incoming pod and existing pod partially match each other on AffinityTerms",
 		},
@@ -845,8 +844,8 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 				nil,
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAffinityRulesNotMatch,
 				),
 			},
 			name: "A pod can be scheduled onto all the nodes that have the same topology key & label value with one of them has an existing pod that matches the affinity rules",
@@ -914,13 +913,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
 			name: "NodeA and nodeB have same topologyKey and label value. NodeA has an existing pod that matches the inter pod affinity rule. The pod can not be scheduled onto nodeA and nodeB.",
@@ -963,13 +962,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
 			name: "This test ensures that anti-affinity matches a pod when any term of the anti-affinity rule matches a pod.",
@@ -1001,13 +1000,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
 			},
@@ -1061,13 +1060,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
 			},
@@ -1171,13 +1170,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 			},
 			name: "Test existing pod's anti-affinity: incoming pod wouldn't considered as a fit as it violates each existingPod's terms on all nodes",
@@ -1229,13 +1228,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
 			name: "Test incoming pod's anti-affinity: incoming pod wouldn't considered as a fit as it at least violates one anti-affinity rule of existingPod",
@@ -1278,8 +1277,8 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				nil,
 			},
@@ -1326,8 +1325,8 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				nil,
 			},
@@ -1371,13 +1370,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 			},
 			name: "Test existing pod's anti-affinity: only when labelSelector and topologyKey both match, it's counted as a single term match - case when all terms have valid topologyKey",
@@ -1423,13 +1422,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAntiAffinityRulesNotMatch,
 				),
 			},
 			name: "Test incoming pod's anti-affinity: only when labelSelector and topologyKey both match, it's counted as a single term match - case when all terms have valid topologyKey",
@@ -1498,13 +1497,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.Unschedulable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrExistingPodsAntiAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonExistingAntiAffinityRulesNotMatch,
 				),
 				nil,
 			},
@@ -1598,13 +1597,13 @@ func TestRequiredAffinityMultipleNodes(t *testing.T) {
 			wantStatuses: []*framework.Status{
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAffinityRulesNotMatch,
 				),
 				framework.NewStatus(
 					framework.UnschedulableAndUnresolvable,
-					predicates.ErrPodAffinityNotMatch.GetReason(),
-					predicates.ErrPodAffinityRulesNotMatch.GetReason(),
+					ErrReasonAffinityNotMatch,
+					ErrReasonAffinityRulesNotMatch,
 				),
 			},
 			name: "Test incoming pod's affinity: firstly check if all affinityTerms match, and then check if all topologyKeys match, and the match logic should be satisfied on the same pod",

--- a/pkg/scheduler/framework/plugins/migration/utils_test.go
+++ b/pkg/scheduler/framework/plugins/migration/utils_test.go
@@ -43,18 +43,18 @@ func TestPredicateResultToFrameworkStatus(t *testing.T) {
 		{
 			name:       "Error with reason",
 			err:        errors.New("Failed with error"),
-			reasons:    []predicates.PredicateFailureReason{predicates.ErrTaintsTolerationsNotMatch},
+			reasons:    []predicates.PredicateFailureReason{predicates.ErrPodNotFitsHostPorts},
 			wantStatus: framework.NewStatus(framework.Error, "Failed with error"),
 		},
 		{
 			name:       "Unschedulable",
-			reasons:    []predicates.PredicateFailureReason{predicates.ErrExistingPodsAntiAffinityRulesNotMatch},
-			wantStatus: framework.NewStatus(framework.Unschedulable, "node(s) didn't satisfy existing pods anti-affinity rules"),
+			reasons:    []predicates.PredicateFailureReason{predicates.ErrPodNotFitsHostPorts},
+			wantStatus: framework.NewStatus(framework.Unschedulable, "node(s) didn't have free ports for the requested pod ports"),
 		},
 		{
 			name:       "Unschedulable and Unresolvable",
-			reasons:    []predicates.PredicateFailureReason{predicates.ErrTaintsTolerationsNotMatch, predicates.ErrNodeSelectorNotMatch},
-			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) had taints that the pod didn't tolerate", "node(s) didn't match node selector"),
+			reasons:    []predicates.PredicateFailureReason{predicates.ErrPodNotFitsHostPorts, predicates.ErrNodeSelectorNotMatch},
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, "node(s) didn't have free ports for the requested pod ports", "node(s) didn't match node selector"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Scheduler predicates and their error types are deprecated. The Scheduler moved to the plugins framework. At the same time, the interpodaffinity filter plugins does not require any of the logic in predicates.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs #86711

**Special notes for your reviewer**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
