### PR TITLE
Correct comment around which integrations require cadvisor_stats

### DIFF
--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -70,7 +70,7 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 // CRI integrations should get container metrics via CRI. Docker
 // uses the built-in cadvisor to gather such metrics on Linux for
 // historical reasons.
-// cri-o relies on cadvisor as a temporary workaround. The code should
+// TODO: cri-o relies on cadvisor as a temporary workaround. The code should
 // be removed. Related issue:
 // https://github.com/kubernetes/kubernetes/issues/51798
 func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -38,8 +38,10 @@ import (
 )
 
 // cadvisorStatsProvider implements the containerStatsProvider interface by
-// getting the container stats from cAdvisor. This is needed by docker and rkt
-// integrations since they do not provide stats from CRI.
+// getting the container stats from cAdvisor. This is needed by
+// integrations which do not provide stats from CRI. See
+// `pkg/kubelet/cadvisor/util.go#UsingLegacyCadvisorStats` for the logic for
+// determining which integrations do not provide stats from CRI.
 type cadvisorStatsProvider struct {
 	// cadvisor is used to get the stats of the cgroup for the containers that
 	// are managed by pods.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This commit is part of a larger effort to clean up references to `rkt`
in the kubelet.

Previously, this comment hard-coded which integrations required
the cadvisor stats provider. The comment has grown stale
(i.e. referenced rkt and did not reference cri-o).

Update the comment to instead point to the code which determines which
integrations need the cadvisor stats provider.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
