### PR TITLE
Provide variant which skips sorting Requirement slice

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller.go
+++ b/pkg/controller/endpoint/endpoints_controller.go
@@ -383,7 +383,7 @@ func (e *EndpointController) syncService(key string) error {
 	}
 
 	klog.V(5).Infof("About to update endpoints for service %q", key)
-	pods, err := e.podLister.Pods(service.Namespace).List(labels.Set(service.Spec.Selector).AsSelectorPreValidated())
+	pods, err := e.podLister.Pods(service.Namespace).List(labels.Set(service.Spec.Selector).AsUnsortedSelectorPreValidated())
 	if err != nil {
 		// Since we're getting stuff from a local cache, it is
 		// basically impossible to get this error.

--- a/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/labels.go
@@ -71,6 +71,15 @@ func (ls Set) AsSelectorPreValidated() Selector {
 	return SelectorFromValidatedSet(ls)
 }
 
+// AsSelectorPreValidated converts labels into a selector, but
+// assumes that labels are already validated and thus don't
+// preform any validation.
+// According to our measurements this is significantly faster
+// in codepaths that matter at high scale.
+func (ls Set) AsUnsortedSelectorPreValidated() Selector {
+	return SelectorWithoutSortingFromValidatedSet(ls)
+}
+
 // FormatLabels convert label map into plain string
 func FormatLabels(labelMap map[string]string) string {
 	l := Set(labelMap).String()

--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -904,6 +904,20 @@ func SelectorFromValidatedSet(ls Set) Selector {
 	return internalSelector(requirements)
 }
 
+// SelectorFromValidatedSet returns a Selector which will match exactly the given Set.
+// A nil and empty Sets are considered equivalent to Everything().
+// It assumes that Set is already validated and doesn't do any validation.
+func SelectorWithoutSortingFromValidatedSet(ls Set) Selector {
+	if ls == nil || len(ls) == 0 {
+		return internalSelector{}
+	}
+	requirements := make([]Requirement, 0, len(ls))
+	for label, value := range ls {
+		requirements = append(requirements, Requirement{key: label, operator: selection.Equals, strValues: []string{value}})
+	}
+	return internalSelector(requirements)
+}
+
 // ParseToRequirements takes a string representing a selector and returns a list of
 // requirements. This function is suitable for those callers that perform additional
 // processing on selector requirements.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Looking at the references to SelectorFromValidatedSet(), the return value is used for calling api-server where sorted key is not required.

With sorting:
```
BenchmarkSelectorFromValidatedSet-12             5000000               257 ns/op             208 B/op          5 allocs/op
```
Without sorting:
```
BenchmarkSelectorFromValidatedSet-12            10000000               202 ns/op             176 B/op          4 allocs/op
```
The memory savings is about 15%.
Speedup is 22%

See #84280 for some related information:
```
make a service selector cache to avoid high cpu consume caused by AsSelectorPreValidated frequently called
```
AsSelectorPreValidated calls SelectorFromValidatedSet
```
func (ls Set) AsSelectorPreValidated() Selector {
	return SelectorFromValidatedSet(ls)
```
This PR introduces unsorted selector for k8s internal use.

**Which issue(s) this PR fixes**:
Fixes #86851

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
