### PR TITLE
Create test for finding service from listing all namespaces

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2634,6 +2634,21 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectNoError(err)
 		e2eservice.WaitForServiceUpdatedWithFinalizer(cs, svc.Namespace, svc.Name, true)
 	})
+
+	ginkgo.It("should find a service from listing all namespaces", func() {
+		ginkgo.By("fetching services")
+		svcs, _ := f.ClientSet.CoreV1().Services("").List(metav1.ListOptions{})
+
+		foundSvc := false
+		for _, svc := range svcs.Items {
+			if svc.ObjectMeta.Name == "kubernetes" && svc.ObjectMeta.Namespace == "default" {
+				foundSvc = true
+				break
+			}
+		}
+
+		framework.ExpectEqual(foundSvc, true, "could not find service 'kubernetes' in service list in all namespaces")
+	})
 })
 
 // TODO: Get rid of [DisabledForLargeClusters] tag when issue #56138 is fixed.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a test for the untested endpoint listCoreV1ServiceForAllNamespaces.

**Which issue(s) this PR fixes**:
Fixes #86089

**Special notes for your reviewer**:
Adds +1 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/area testing
/sig testing