### PR TITLE
Create test to patch a secret

### DIFF
--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -189,6 +189,14 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		_, err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Patch(secretCreatedName, types.StrategicMergePatchType, []byte(secretPatch))
 		framework.ExpectNoError(err, "failed to patch secret")
 
+		secret, err := f.ClientSet.CoreV1().Secrets(f.Namespace.Name).Get(secretCreatedName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get secret")
+
+		secretDecodedstring, err := base64.StdEncoding.DecodeString(string(secret.Data["key"]))
+		framework.ExpectNoError(err, "failed to decode secret from Base64")
+
+		framework.ExpectEqual(string(secretDecodedstring), "value1", "found secret, but the data wasn't updated from the patch")
+
 		ginkgo.By("deleting the secret using a LabelSelector")
 		err = f.ClientSet.CoreV1().Secrets(f.Namespace.Name).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: "testsecret=true",

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -27,7 +27,6 @@ import (
 
 	"encoding/base64"
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -159,7 +158,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		// list all secrets in namespace default
 		secretsList, err := f.ClientSet.CoreV1().Secrets("").List(metav1.ListOptions{})
 		framework.ExpectNoError(err, "failed to list secrets")
-		gomega.Expect(len(secretsList.Items)).ToNot(gomega.Equal(0), "no secrets found")
+		framework.ExpectNotEqual(len(secretsList.Items), 0, "no secrets found")
 
 		foundCreatedSecret := false
 		var secretCreatedName string
@@ -169,7 +168,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 				secretCreatedName = val.ObjectMeta.Name
 			}
 		}
-		gomega.Expect(foundCreatedSecret).To(gomega.BeTrue(), "unable to find secret by its value")
+		framework.ExpectEqual(foundCreatedSecret, true, "unable to find secret by its value")
 
 		ginkgo.By("patching the secret")
 		// patch the secret
@@ -195,7 +194,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 				foundCreatedSecret = true
 			}
 		}
-		gomega.Expect(foundCreatedSecret).To(gomega.BeFalse(), "secret was not deleted successfully")
+		framework.ExpectEqual(foundCreatedSecret, false, "secret was not deleted successfully")
 	})
 })
 

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 
+	"encoding/base64"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
-	"encoding/base64"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -143,7 +143,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 
 		secretTestName := "test-secret-" + string(uuid.NewUUID())
 
-		 // create a secret in namespace default
+		// create a secret in namespace default
 		_, err := f.ClientSet.CoreV1().Secrets("default").Create(&v1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: secretTestName,
@@ -193,10 +193,9 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		for _, val := range secretsList.Items {
 			if val.ObjectMeta.Name == secretTestName && string(val.Data["key"]) == "value" {
 				foundCreatedSecret = true
-				secretCreatedName = val.ObjectMeta.Name
 			}
 		}
-		gomega.Expect(foundCreatedSecret).To(gomega.BeFalse(), "secret was not deleted sucessfully")
+		gomega.Expect(foundCreatedSecret).To(gomega.BeFalse(), "secret was not deleted successfully")
 	})
 })
 

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -159,7 +159,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		framework.ExpectNoError(err, "failed to create secret")
 
 		ginkgo.By("listing secrets in all namespaces to ensure that there are more than zero")
-		// list all secrets in all namespaces
+		// list all secrets in all namespaces to ensure endpoint coverage
 		secretsList, err := f.ClientSet.CoreV1().Secrets("").List(metav1.ListOptions{
 			LabelSelector: "testsecret-constant=true",
 		})
@@ -169,9 +169,10 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		foundCreatedSecret := false
 		var secretCreatedName string
 		for _, val := range secretsList.Items {
-			if val.ObjectMeta.Name == secretTestName && string(val.Data["key"]) == "value" {
+			if val.ObjectMeta.Name == secretTestName && val.ObjectMeta.Namespace == f.Namespace.Name {
 				foundCreatedSecret = true
 				secretCreatedName = val.ObjectMeta.Name
+				break
 			}
 		}
 		framework.ExpectEqual(foundCreatedSecret, true, "unable to find secret by its value")
@@ -214,6 +215,7 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		for _, val := range secretsList.Items {
 			if val.ObjectMeta.Name == secretTestName && val.ObjectMeta.Namespace == f.Namespace.Name {
 				foundCreatedSecret = true
+				break
 			}
 		}
 		framework.ExpectEqual(foundCreatedSecret, false, "secret was not deleted successfully")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a test to test untested endpoints:
- patchCoreV1NamespacedSecret
- listCoreV1SecretForAllNamespaces
- deleteCoreV1CollectionNamespacedSecret

**Which issue(s) this PR fixes**:
Fixes #86393

**Special notes for your reviewer**:
Adds +3 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing