### PR TITLE
Create ComponentStatus test

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -11,6 +11,7 @@ go_library(
         "aggregator.go",
         "certs.go",
         "chunking.go",
+        "component_statuses.go",
         "crd_conversion_webhook.go",
         "crd_publish_openapi.go",
         "crd_watch.go",

--- a/test/e2e/apimachinery/component_statuses.go
+++ b/test/e2e/apimachinery/component_statuses.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 
 	"github.com/onsi/ginkgo"
-	"github.com/onsi/gomega"
 )
 
 var _ = SIGDescribe("ComponentStatuses", func() {
@@ -41,22 +40,25 @@ var _ = SIGDescribe("ComponentStatuses", func() {
 			}
 		}
 
-		gomega.Expect(healthyCount).To(gomega.Equal(len(csList.Items)), "Components are not all healthy")
+		framework.ExpectEqual(healthyCount, len(csList.Items), "Components are not all healthy")
 	})
 
 	ginkgo.It("should ensure select Components exist", func() {
-		requiredComponentsFound := map[string]string{
-			"scheduler": "false",
-			"controller-manager": "false",
+		requiredComponents := map[string]bool{
+			"scheduler": true,
+			"controller-manager": true,
 		}
+		requiredComponentFoundCount := 0
 
 		ginkgo.By("listing all ComponentStatuses")
 		csList, _ := f.ClientSet.CoreV1().ComponentStatuses().List(metav1.ListOptions{})
 		for _, csItem := range csList.Items {
-			if requiredComponentsFound[csItem.ObjectMeta.Name] == "false" {
-				requiredComponentsFound[csItem.ObjectMeta.Name] = "true"
+			if requiredComponents[csItem.ObjectMeta.Name] == true {
+				requiredComponentFoundCount ++
 			}
 		}
+
+		framework.ExpectEqual(requiredComponentFoundCount, len(requiredComponents), "Components are not all healthy")
 	})
 })
 

--- a/test/e2e/apimachinery/component_statuses.go
+++ b/test/e2e/apimachinery/component_statuses.go
@@ -27,7 +27,7 @@ import (
 var _ = SIGDescribe("ComponentStatuses", func() {
 	f := framework.NewDefaultFramework("componentstatuses")
 
-	ginkgo.It("should read and list ComponentStatuses", func() {
+	ginkgo.It("should read and list ComponentStatuses to ensure health", func() {
 		ginkgo.By("listing all ComponentStatuses")
 		csList, _ := f.ClientSet.CoreV1().ComponentStatuses().List(metav1.ListOptions{})
 		healthyCount := 0
@@ -42,6 +42,21 @@ var _ = SIGDescribe("ComponentStatuses", func() {
 		}
 
 		gomega.Expect(healthyCount).To(gomega.Equal(len(csList.Items)), "Components are not all healthy")
+	})
+
+	ginkgo.It("should ensure select Components exist", func() {
+		requiredComponentsFound := map[string]string{
+			"scheduler": "false",
+			"controller-manager": "false",
+		}
+
+		ginkgo.By("listing all ComponentStatuses")
+		csList, _ := f.ClientSet.CoreV1().ComponentStatuses().List(metav1.ListOptions{})
+		for _, csItem := range csList.Items {
+			if requiredComponentsFound[csItem.ObjectMeta.Name] == "false" {
+				requiredComponentsFound[csItem.ObjectMeta.Name] = "true"
+			}
+		}
 	})
 })
 

--- a/test/e2e/apimachinery/component_statuses.go
+++ b/test/e2e/apimachinery/component_statuses.go
@@ -35,7 +35,7 @@ var _ = SIGDescribe("ComponentStatuses", func() {
 
 			for _, condition := range cs.Conditions {
 				if condition.Type == "Healthy" && condition.Status == "True" {
-					healthyCount ++
+					healthyCount++
 				}
 			}
 		}
@@ -45,7 +45,7 @@ var _ = SIGDescribe("ComponentStatuses", func() {
 
 	ginkgo.It("should ensure select Components exist", func() {
 		requiredComponents := map[string]bool{
-			"scheduler": true,
+			"scheduler":          true,
 			"controller-manager": true,
 		}
 		requiredComponentFoundCount := 0
@@ -54,11 +54,10 @@ var _ = SIGDescribe("ComponentStatuses", func() {
 		csList, _ := f.ClientSet.CoreV1().ComponentStatuses().List(metav1.ListOptions{})
 		for _, csItem := range csList.Items {
 			if requiredComponents[csItem.ObjectMeta.Name] == true {
-				requiredComponentFoundCount ++
+				requiredComponentFoundCount++
 			}
 		}
 
 		framework.ExpectEqual(requiredComponentFoundCount, len(requiredComponents), "Components are not all healthy")
 	})
 })
-

--- a/test/e2e/apimachinery/component_statuses.go
+++ b/test/e2e/apimachinery/component_statuses.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apimachinery
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubernetes/test/e2e/framework"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+var _ = SIGDescribe("ComponentStatuses", func() {
+	f := framework.NewDefaultFramework("componentstatuses")
+
+	ginkgo.It("should read and list ComponentStatuses", func() {
+		ginkgo.By("listing all ComponentStatuses")
+		csList, _ := f.ClientSet.CoreV1().ComponentStatuses().List(metav1.ListOptions{})
+		healthyCount := 0
+		for _, csItem := range csList.Items {
+			cs, _ := f.ClientSet.CoreV1().ComponentStatuses().Get(csItem.ObjectMeta.Name, metav1.GetOptions{})
+
+			for _, condition := range cs.Conditions {
+				if condition.Type == "Healthy" && condition.Status == "True" {
+					healthyCount ++
+				}
+			}
+		}
+
+		gomega.Expect(healthyCount).To(gomega.Equal(len(csList.Items)), "Components are not all healthy")
+	})
+})
+


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a test for the following untested endpoints:
- listCoreV1ComponentStatus
- readCoreV1ComponentStatus

**Which issue(s) this PR fixes**:
Fixes #86087

**Special notes for your reviewer**:
Adds +2 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing