### PR TITLE
kube-proxy: fix the bug that kube-proxy could not restart automatically after changing kube-proxy configmap

### DIFF
--- a/cmd/kube-proxy/app/server.go
+++ b/cmd/kube-proxy/app/server.go
@@ -19,11 +19,13 @@ limitations under the License.
 package app
 
 import (
+	"crypto/md5"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
+	"path/filepath"
 	goruntime "runtime"
 	"strings"
 	"time"
@@ -115,6 +117,8 @@ type Options struct {
 	WindowsService bool
 	// config is the proxy server's configuration object.
 	config *kubeproxyconfig.KubeProxyConfiguration
+	// configFileMd5sum is the md5sum of the proxy server configuration file's content.
+	configFileMd5sum string
 	// watcher is used to watch on the update change of ConfigFile
 	watcher filesystem.FSWatcher
 	// proxyServer is the interface to run the proxy server
@@ -251,9 +255,37 @@ func (o *Options) initWatcher() error {
 	if err != nil {
 		return err
 	}
+
+	// watch the parent dir of the config file to observe atomic renames
+	parentDir := filepath.Dir(o.ConfigFile)
+	err = fswatcher.AddWatch(parentDir)
+	if err != nil {
+		return err
+	}
+
+	// watch the config file itself to observe writes
 	err = fswatcher.AddWatch(o.ConfigFile)
 	if err != nil {
 		return err
+	}
+
+	// resolve symlinks to observe the underlying file as well (best-effort)
+	if linkedPath, err := filepath.EvalSymlinks(o.ConfigFile); err == nil && linkedPath != o.ConfigFile {
+
+		// watch the linked file to observe writes
+		err = fswatcher.AddWatch(linkedPath)
+		if err != nil {
+			klog.Warningf("failed to add watch for %s: %v", linkedPath, err)
+		}
+
+		// watch the parent dir of the linked file to observe replaces
+		linkedParentDir := filepath.Dir(linkedPath)
+		if linkedParentDir != parentDir {
+			err = fswatcher.AddWatch(linkedParentDir)
+			if err != nil {
+				klog.Warningf("failed to add watch for %s: %v", linkedParentDir, err)
+			}
+		}
 	}
 	o.watcher = fswatcher
 	return nil
@@ -263,12 +295,34 @@ func (o *Options) eventHandler(ent fsnotify.Event) {
 	eventOpIs := func(Op fsnotify.Op) bool {
 		return ent.Op&Op == Op
 	}
-	if eventOpIs(fsnotify.Write) || eventOpIs(fsnotify.Rename) {
+
+	if eventOpIs(fsnotify.Create) || eventOpIs(fsnotify.Write) || eventOpIs(fsnotify.Rename) {
+		if _, err := os.Stat(o.ConfigFile); os.IsNotExist(err) {
+			return
+		}
+		data, err := ioutil.ReadFile(o.ConfigFile)
+		if err != nil {
+			klog.Warningf("fs watcher failed to read content from %s: %v", o.ConfigFile, err)
+			return
+		}
+		// ignore the event if config file has not changed
+		if fmt.Sprintf("%x", md5.Sum(data)) == o.configFileMd5sum {
+			return
+		}
+
+		cfg, err := NewOptions().loadConfig(data)
+		if err != nil {
+			klog.Warningf("a change of %s was detected, but failed to reload it: %v", o.ConfigFile, err)
+			return
+		}
+		if errs := validation.Validate(cfg); len(errs) != 0 {
+			klog.Warningf("a change of %s was detected, but found invalid configuration: %v", o.ConfigFile, errs.ToAggregate())
+			return
+		}
+
 		// error out when ConfigFile is updated
 		o.errCh <- fmt.Errorf("content of the proxy server's configuration file was updated")
-		return
 	}
-	o.errCh <- nil
 }
 
 func (o *Options) errorHandler(err error) {
@@ -405,6 +459,7 @@ func (o *Options) loadConfigFromFile(file string) (*kubeproxyconfig.KubeProxyCon
 		return nil, err
 	}
 
+	o.configFileMd5sum = fmt.Sprintf("%x", md5.Sum(data))
 	return o.loadConfig(data)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
kube-proxy: fix the bug that kube-proxy could not restart automatically after changing kube-proxy configmap.

I found that if I modified the `kube-proxy` configmap, it would not trigger a kube-proxy restart.
The reason for the problem is that the file change events triggered by modifying configmap are `CHMOD` and `REMOVE`,  we're not dealing properly with either of these events.

Here are some of the events captured after I edited the `kube-proxy` configmap:
```
W0106 11:49:18.016395       1 server_others.go:335] Unknown proxy mode "", assuming iptables proxy
I0106 11:49:18.025677       1 node.go:135] Successfully retrieved node IP: 192.168.137.71
I0106 11:49:18.025710       1 server_others.go:150] Using iptables Proxier.
W0106 11:49:18.025787       1 proxier.go:288] clusterCIDR not specified, unable to distinguish between internal and external traffic
I0106 11:49:18.025985       1 server.go:583] Version: v1.18.0-alpha.0.2231+13b5effeada5f4-dirty
I0106 11:49:18.026304       1 conntrack.go:52] Setting nf_conntrack_max to 131072
I0106 11:49:18.026523       1 config.go:315] Starting service config controller
I0106 11:49:18.026534       1 shared_informer.go:197] Waiting for caches to sync for service config
I0106 11:49:18.026554       1 config.go:133] Starting endpoints config controller
I0106 11:49:18.026564       1 shared_informer.go:197] Waiting for caches to sync for endpoints config
I0106 11:49:18.126638       1 shared_informer.go:204] Caches are synced for endpoints config 
I0106 11:49:18.126717       1 shared_informer.go:204] Caches are synced for service config 
W0106 11:50:45.684562       1 server.go:267] configuration change event: "/var/lib/kube-proxy/config.conf": CHMOD 
W0106 11:50:45.684628       1 server.go:267] configuration change event: "/var/lib/kube-proxy/config.conf": REMOVE 
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-proxy: fix the bug that kube-proxy could not restart automatically after changing kube-proxy configmap
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
