### PR TITLE
kubetestgen: improve errors handling

### DIFF
--- a/test/conformance/kubetestgen/kubetestgen.go
+++ b/test/conformance/kubetestgen/kubetestgen.go
@@ -131,6 +131,7 @@ func printYAML(fileName string, areaO Area) {
 	f, err := os.Create(fileName + ".yaml")
 	if err != nil {
 		fmt.Printf("ERROR: %s\n", err.Error())
+		os.Exit(1)
 	}
 	defer f.Close()
 	y, err := yaml.Marshal(areaO)
@@ -139,7 +140,11 @@ func printYAML(fileName string, areaO Area) {
 		os.Exit(1)
 	}
 
-	f.WriteString(string(y))
+	_, err = f.WriteString(string(y))
+	if err != nil {
+		fmt.Printf("ERROR: %s\n", err.Error())
+		os.Exit(1)
+	}
 }
 
 func countFields(suites []Suite) {


### PR DESCRIPTION
This PR adds the following improvements:
- don't proceed when a file creation has been failed
- handle a possible error from `WriteString()`

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This improvement adds a fail-fast behavior so when an error occurs it will fail at the place where it happened and not in the code that is executed later. Better error message simplify debugging.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```