### PR TITLE
Move RequestedToCapacityRatio argument processing to its plugin

### DIFF
--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -32,7 +32,6 @@ go_library(
         "//pkg/scheduler/framework/plugins/volumezone:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/volumebinder:go_default_library",
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
@@ -82,9 +81,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/scheduler/apis/config:go_default_library",
-        "//pkg/scheduler/framework/plugins/noderesources:go_default_library",
-        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
-        "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/pkg/scheduler/framework/plugins/legacy_registry_test.go
+++ b/pkg/scheduler/framework/plugins/legacy_registry_test.go
@@ -22,60 +22,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/stretchr/testify/assert"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
-	schedulerapi "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 )
-
-func TestBuildScoringFunctionShapeFromRequestedToCapacityRatioArguments(t *testing.T) {
-	arguments := schedulerapi.RequestedToCapacityRatioArguments{
-		Shape: []schedulerapi.UtilizationShapePoint{
-			{Utilization: 10, Score: 1},
-			{Utilization: 30, Score: 5},
-			{Utilization: 70, Score: 2},
-		},
-		Resources: []schedulerapi.ResourceSpec{
-			{Name: string(v1.ResourceCPU)},
-			{Name: string(v1.ResourceMemory)},
-		},
-	}
-	builtShape, resources := buildScoringFunctionShapeFromRequestedToCapacityRatioArguments(&arguments)
-	expectedShape, _ := noderesources.NewFunctionShape([]noderesources.FunctionShapePoint{
-		{Utilization: 10, Score: 10},
-		{Utilization: 30, Score: 50},
-		{Utilization: 70, Score: 20},
-	})
-	expectedResources := noderesources.ResourceToWeightMap{
-		v1.ResourceCPU:    1,
-		v1.ResourceMemory: 1,
-	}
-	assert.Equal(t, expectedShape, builtShape)
-	assert.Equal(t, expectedResources, resources)
-}
-
-func TestBuildScoringFunctionShapeFromRequestedToCapacityRatioArgumentsNilResourceToWeightMap(t *testing.T) {
-	arguments := schedulerapi.RequestedToCapacityRatioArguments{
-		Shape: []schedulerapi.UtilizationShapePoint{
-			{Utilization: 10, Score: 1},
-			{Utilization: 30, Score: 5},
-			{Utilization: 70, Score: 2},
-		},
-	}
-	builtShape, resources := buildScoringFunctionShapeFromRequestedToCapacityRatioArguments(&arguments)
-	expectedShape, _ := noderesources.NewFunctionShape([]noderesources.FunctionShapePoint{
-		{Utilization: 10, Score: 10},
-		{Utilization: 30, Score: 50},
-		{Utilization: 70, Score: 20},
-	})
-	expectedResources := noderesources.ResourceToWeightMap{
-		v1.ResourceCPU:    1,
-		v1.ResourceMemory: 1,
-	}
-	assert.Equal(t, expectedShape, builtShape)
-	assert.Equal(t, expectedResources, resources)
-}
 
 func produceConfig(keys []string, producersMap map[string]ConfigProducer, args ConfigProducerArgs) (*config.Plugins, []config.PluginConfig, error) {
 	var plugins config.Plugins

--- a/pkg/scheduler/framework/plugins/noderesources/BUILD
+++ b/pkg/scheduler/framework/plugins/noderesources/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//pkg/features:go_default_library",
         "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/algorithm/priorities/util:go_default_library",
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/plugins/migration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -74,7 +74,7 @@ func NewBalancedAllocation(_ *runtime.Unknown, h framework.FrameworkHandle) (fra
 		resourceAllocationScorer: resourceAllocationScorer{
 			BalancedAllocationName,
 			balancedResourceScorer,
-			DefaultRequestedRatioResources,
+			defaultRequestedRatioResources,
 		},
 	}, nil
 }

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -69,14 +69,14 @@ func NewLeastAllocated(_ *runtime.Unknown, h framework.FrameworkHandle) (framewo
 		resourceAllocationScorer: resourceAllocationScorer{
 			LeastAllocatedName,
 			leastResourceScorer,
-			DefaultRequestedRatioResources,
+			defaultRequestedRatioResources,
 		},
 	}, nil
 }
 
 func leastResourceScorer(requested, allocable resourceToValueMap, includeVolumes bool, requestedVolumes int, allocatableVolumes int) int64 {
 	var nodeScore, weightSum int64
-	for resource, weight := range DefaultRequestedRatioResources {
+	for resource, weight := range defaultRequestedRatioResources {
 		resourceScore := leastRequestedScore(requested[resource], allocable[resource])
 		nodeScore += resourceScore * weight
 		weightSum += weight

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -67,14 +67,14 @@ func NewMostAllocated(_ *runtime.Unknown, h framework.FrameworkHandle) (framewor
 		resourceAllocationScorer: resourceAllocationScorer{
 			MostAllocatedName,
 			mostResourceScorer,
-			DefaultRequestedRatioResources,
+			defaultRequestedRatioResources,
 		},
 	}, nil
 }
 
 func mostResourceScorer(requested, allocable resourceToValueMap, includeVolumes bool, requestedVolumes int, allocatableVolumes int) int64 {
 	var nodeScore, weightSum int64
-	for resource, weight := range DefaultRequestedRatioResources {
+	for resource, weight := range defaultRequestedRatioResources {
 		resourceScore := mostRequestedScore(requested[resource], allocable[resource])
 		nodeScore += resourceScore * weight
 		weightSum += weight

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -67,8 +67,11 @@ func TestRequestedToCapacityRatio(t *testing.T) {
 			state := framework.NewCycleState()
 			snapshot := nodeinfosnapshot.NewSnapshot(nodeinfosnapshot.CreateNodeInfoMap(test.scheduledPods, test.nodes))
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
-			args := &runtime.Unknown{Raw: []byte(`{"FunctionShape" : [{"Utilization" : 0, "Score" : 100}, {"Utilization" : 100, "Score" : 0}], "ResourceToWeightMap" : {"memory" : 1, "cpu" : 1}}`)}
-			p, _ := NewRequestedToCapacityRatio(args, fh)
+			args := &runtime.Unknown{Raw: []byte(`{"shape" : [{"utilization" : 0, "score" : 10}, {"utilization" : 100, "score" : 0}], "resources" : [{"name" : "memory", "weight" : 1}, {"name" : "cpu", "weight" : 1}]}`)}
+			p, err := NewRequestedToCapacityRatio(args, fh)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			var gotPriorities framework.NodeScoreList
 			for _, n := range test.nodes {
@@ -106,43 +109,43 @@ func makePod(node string, milliCPU, memory int64) *v1.Pod {
 
 func TestCreatingFunctionShapeErrorsIfEmptyPoints(t *testing.T) {
 	var err error
-	_, err = NewFunctionShape([]FunctionShapePoint{})
+	err = validateFunctionShape([]functionShapePoint{})
 	assert.Equal(t, "at least one point must be specified", err.Error())
 }
 
 func TestCreatingResourceNegativeWeight(t *testing.T) {
-	err := validateResourceWeightMap(ResourceToWeightMap{v1.ResourceCPU: -1})
+	err := validateResourceWeightMap(resourceToWeightMap{v1.ResourceCPU: -1})
 	assert.Equal(t, "resource cpu weight -1 must not be less than 1", err.Error())
 }
 
 func TestCreatingResourceDefaultWeight(t *testing.T) {
-	err := validateResourceWeightMap(ResourceToWeightMap{})
+	err := validateResourceWeightMap(resourceToWeightMap{})
 	assert.Equal(t, "resourceToWeightMap cannot be nil", err.Error())
 
 }
 
 func TestCreatingFunctionShapeErrorsIfXIsNotSorted(t *testing.T) {
 	var err error
-	_, err = NewFunctionShape([]FunctionShapePoint{{10, 1}, {15, 2}, {20, 3}, {19, 4}, {25, 5}})
+	err = validateFunctionShape([]functionShapePoint{{10, 1}, {15, 2}, {20, 3}, {19, 4}, {25, 5}})
 	assert.Equal(t, "utilization values must be sorted. Utilization[2]==20 >= Utilization[3]==19", err.Error())
 
-	_, err = NewFunctionShape([]FunctionShapePoint{{10, 1}, {20, 2}, {20, 3}, {22, 4}, {25, 5}})
+	err = validateFunctionShape([]functionShapePoint{{10, 1}, {20, 2}, {20, 3}, {22, 4}, {25, 5}})
 	assert.Equal(t, "utilization values must be sorted. Utilization[1]==20 >= Utilization[2]==20", err.Error())
 }
 
 func TestCreatingFunctionPointNotInAllowedRange(t *testing.T) {
 	var err error
-	_, err = NewFunctionShape([]FunctionShapePoint{{-1, 0}, {100, 100}})
+	err = validateFunctionShape([]functionShapePoint{{-1, 0}, {100, 100}})
 	assert.Equal(t, "utilization values must not be less than 0. Utilization[0]==-1", err.Error())
 
-	_, err = NewFunctionShape([]FunctionShapePoint{{0, 0}, {101, 100}})
+	err = validateFunctionShape([]functionShapePoint{{0, 0}, {101, 100}})
 	assert.Equal(t, "utilization values must not be greater than 100. Utilization[1]==101", err.Error())
 
-	_, err = NewFunctionShape([]FunctionShapePoint{{0, -1}, {100, 100}})
+	err = validateFunctionShape([]functionShapePoint{{0, -1}, {100, 100}})
 	assert.Equal(t, "score values must not be less than 0. Score[0]==-1", err.Error())
 
-	_, err = NewFunctionShape([]FunctionShapePoint{{0, 0}, {100, 101}})
-	assert.Equal(t, "score valuses not be greater than 100. Score[1]==101", err.Error())
+	err = validateFunctionShape([]functionShapePoint{{0, 0}, {100, 101}})
+	assert.Equal(t, "score values not be greater than 100. Score[1]==101", err.Error())
 }
 
 func TestBrokenLinearFunction(t *testing.T) {
@@ -151,13 +154,13 @@ func TestBrokenLinearFunction(t *testing.T) {
 		expected int64
 	}
 	type Test struct {
-		points     []FunctionShapePoint
+		points     []functionShapePoint
 		assertions []Assertion
 	}
 
 	tests := []Test{
 		{
-			points: []FunctionShapePoint{{10, 1}, {90, 9}},
+			points: []functionShapePoint{{10, 1}, {90, 9}},
 			assertions: []Assertion{
 				{p: -10, expected: 1},
 				{p: 0, expected: 1},
@@ -174,7 +177,7 @@ func TestBrokenLinearFunction(t *testing.T) {
 			},
 		},
 		{
-			points: []FunctionShapePoint{{0, 2}, {40, 10}, {100, 0}},
+			points: []functionShapePoint{{0, 2}, {40, 10}, {100, 0}},
 			assertions: []Assertion{
 				{p: -10, expected: 2},
 				{p: 0, expected: 2},
@@ -187,7 +190,7 @@ func TestBrokenLinearFunction(t *testing.T) {
 			},
 		},
 		{
-			points: []FunctionShapePoint{{0, 2}, {40, 2}, {100, 2}},
+			points: []functionShapePoint{{0, 2}, {40, 2}, {100, 2}},
 			assertions: []Assertion{
 				{p: -10, expected: 2},
 				{p: 0, expected: 2},
@@ -202,9 +205,7 @@ func TestBrokenLinearFunction(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		functionShape, err := NewFunctionShape(test.points)
-		assert.Nil(t, err)
-		function := buildBrokenLinearFunction(functionShape)
+		function := buildBrokenLinearFunction(test.points)
 		for _, assertion := range test.assertions {
 			assert.InDelta(t, assertion.expected, function(assertion.p), 0.1, "points=%v, p=%f", test.points, assertion.p)
 		}
@@ -350,8 +351,11 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 			state := framework.NewCycleState()
 			snapshot := nodeinfosnapshot.NewSnapshot(nodeinfosnapshot.CreateNodeInfoMap(test.pods, test.nodes))
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
-			args := &runtime.Unknown{Raw: []byte(`{"FunctionShape" : [{"Utilization" : 0, "Score" : 0}, {"Utilization" : 100, "Score" : 10}], "ResourceToWeightMap" : {"intel.com/foo" : 1}}`)}
-			p, _ := NewRequestedToCapacityRatio(args, fh)
+			args := &runtime.Unknown{Raw: []byte(`{"shape" : [{"utilization" : 0, "score" : 0}, {"utilization" : 100, "score" : 1}], "resources" : [{"name" : "intel.com/foo", "weight" : 1}]}`)}
+			p, err := NewRequestedToCapacityRatio(args, fh)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			var gotList framework.NodeScoreList
 			for _, n := range test.nodes {
@@ -582,8 +586,11 @@ func TestResourceBinPackingMultipleExtended(t *testing.T) {
 			state := framework.NewCycleState()
 			snapshot := nodeinfosnapshot.NewSnapshot(nodeinfosnapshot.CreateNodeInfoMap(test.pods, test.nodes))
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
-			args := &runtime.Unknown{Raw: []byte(`{"FunctionShape" : [{"Utilization" : 0, "Score" : 0}, {"Utilization" : 100, "Score" : 10}], "ResourceToWeightMap" : {"intel.com/foo" : 3, "intel.com/bar" : 5}}`)}
-			p, _ := NewRequestedToCapacityRatio(args, fh)
+			args := &runtime.Unknown{Raw: []byte(`{"shape" : [{"utilization" : 0, "score" : 0}, {"utilization" : 100, "score" : 1}], "resources" : [{"name" : "intel.com/foo", "weight" : 3}, {"name" : "intel.com/bar", "weight": 5}]}`)}
+			p, err := NewRequestedToCapacityRatio(args, fh)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
 
 			var gotList framework.NodeScoreList
 			for _, n := range test.nodes {

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -27,17 +27,17 @@ import (
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
-// ResourceToWeightMap contains resource name and weight.
-type ResourceToWeightMap map[v1.ResourceName]int64
+// resourceToWeightMap contains resource name and weight.
+type resourceToWeightMap map[v1.ResourceName]int64
 
-// DefaultRequestedRatioResources is used to set default requestToWeight map for CPU and memory
-var DefaultRequestedRatioResources = ResourceToWeightMap{v1.ResourceMemory: 1, v1.ResourceCPU: 1}
+// defaultRequestedRatioResources is used to set default requestToWeight map for CPU and memory
+var defaultRequestedRatioResources = resourceToWeightMap{v1.ResourceMemory: 1, v1.ResourceCPU: 1}
 
 // resourceAllocationScorer contains information to calculate resource allocation score.
 type resourceAllocationScorer struct {
 	Name                string
 	scorer              func(requested, allocable resourceToValueMap, includeVolumes bool, requestedVolumes int, allocatableVolumes int) int64
-	resourceToWeightMap ResourceToWeightMap
+	resourceToWeightMap resourceToWeightMap
 }
 
 // resourceToValueMap contains resource name and score.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

Move RequestedToCapacityRatio argument processing to its plugin. This also allows us to avoid exporting internal types and variables related to node resources plugins (specifically ResourceToWeightMap type and defaultRequestedRatioResources var).

**Which issue(s) this PR fixes**:
Part of #85822

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @Huang-Wei 