### PR TITLE
Extend sharedIndexInformer testing wrt resync periods

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/BUILD
+++ b/staging/src/k8s.io/client-go/tools/cache/BUILD
@@ -88,7 +88,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/tools/pager:go_default_library",
-        "//staging/src/k8s.io/client-go/util/retry:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/buffer:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -183,73 +183,141 @@ func TestListenerResyncPeriods(t *testing.T) {
 }
 
 func TestResyncCheckPeriod(t *testing.T) {
+	checkResyncCheckPeriod(t, true)
+	checkResyncCheckPeriod(t, false)
+}
+
+func checkResyncCheckPeriod(t *testing.T, doResyncs bool) {
 	// source simulates an apiserver object endpoint.
 	source := fcache.NewFakeControllerSource()
 
-	// create the shared informer and resync every 12 hours
-	informer := NewSharedInformer(source, &v1.Pod{}, 12*time.Hour).(*sharedIndexInformer)
+	// Give it something to report, so that we have a way to wait for
+	// the informer to finish starting up.
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}})
+
+	// create the shared informer with an appropriate initial resync period
+	informer := NewSharedInformer(source, &v1.Pod{}, zeroDuration(12*time.Hour, !doResyncs)).(*sharedIndexInformer)
 
 	clock := clock.NewFakeClock(time.Now())
 	informer.clock = clock
 	informer.processor.clock = clock
 
 	// listener 1, never resync
-	listener1 := newTestListener("listener1", 0)
+	listener1 := newTestListener("listener1", 0, "pod1")
 	informer.AddEventHandlerWithResyncPeriod(listener1, listener1.resyncPeriod)
-	if e, a := 12*time.Hour, informer.resyncCheckPeriod; e != a {
+	if e, a := zeroDuration(12*time.Hour, !doResyncs), informer.resyncCheckPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
+	if e, a := time.Duration(0), informer.processor.listeners[0].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
+	checkResyncPeriods(t, informer.processor, !doResyncs)
 
 	// listener 2, resync every minute
-	listener2 := newTestListener("listener2", 1*time.Minute)
+	listener2 := newTestListener("listener2", 1*time.Minute, "pod1")
 	informer.AddEventHandlerWithResyncPeriod(listener2, listener2.resyncPeriod)
-	if e, a := 1*time.Minute, informer.resyncCheckPeriod; e != a {
+	if e, a := zeroDuration(1*time.Minute, !doResyncs), informer.resyncCheckPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
+	if e, a := time.Duration(0), informer.processor.listeners[0].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := 1*time.Minute, informer.processor.listeners[1].resyncPeriod; e != a {
+	if e, a := 1*time.Minute, informer.processor.listeners[1].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
+	checkResyncPeriods(t, informer.processor, !doResyncs)
 
 	// listener 3, resync every 55 seconds
-	listener3 := newTestListener("listener3", 55*time.Second)
+	listener3 := newTestListener("listener3", 55*time.Second, "pod1")
 	informer.AddEventHandlerWithResyncPeriod(listener3, listener3.resyncPeriod)
-	if e, a := 55*time.Second, informer.resyncCheckPeriod; e != a {
+	if e, a := zeroDuration(55*time.Second, !doResyncs), informer.resyncCheckPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
+	if e, a := time.Duration(0), informer.processor.listeners[0].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := 1*time.Minute, informer.processor.listeners[1].resyncPeriod; e != a {
+	if e, a := 1*time.Minute, informer.processor.listeners[1].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := 55*time.Second, informer.processor.listeners[2].resyncPeriod; e != a {
+	if e, a := 55*time.Second, informer.processor.listeners[2].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
+	checkResyncPeriods(t, informer.processor, !doResyncs)
 
 	// listener 4, resync every 5 seconds
-	listener4 := newTestListener("listener4", 5*time.Second)
+	listener4 := newTestListener("listener4", 5*time.Second, "pod1")
 	informer.AddEventHandlerWithResyncPeriod(listener4, listener4.resyncPeriod)
-	if e, a := 5*time.Second, informer.resyncCheckPeriod; e != a {
+	if e, a := zeroDuration(5*time.Second, !doResyncs), informer.resyncCheckPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
+	if e, a := time.Duration(0), informer.processor.listeners[0].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := 1*time.Minute, informer.processor.listeners[1].resyncPeriod; e != a {
+	if e, a := 1*time.Minute, informer.processor.listeners[1].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := 55*time.Second, informer.processor.listeners[2].resyncPeriod; e != a {
+	if e, a := 55*time.Second, informer.processor.listeners[2].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
-	if e, a := 5*time.Second, informer.processor.listeners[3].resyncPeriod; e != a {
+	if e, a := 5*time.Second, informer.processor.listeners[3].requestedResyncPeriod; e != a {
 		t.Errorf("expected %d, got %d", e, a)
 	}
+	checkResyncPeriods(t, informer.processor, !doResyncs)
+
+	// Now start the informer so we can test that the resyncCheckPeriod shrinks no further
+	stop := make(chan struct{})
+	defer close(stop)
+	go informer.Run(stop)
+
+	// Now wait for the informer to finish starting up
+	if !listener1.ok() {
+		t.Errorf("%s: expected %v, got %v", listener1.name, listener1.expectedItemNames, listener1.receivedItemNames)
+	}
+
+	// listener 5, request resync every 3 seconds, get every 5
+	listener5 := newTestListener("listener5", 3*time.Second, "pod1")
+	informer.AddEventHandlerWithResyncPeriod(listener5, listener5.resyncPeriod)
+	if e, a := zeroDuration(5*time.Second, !doResyncs), informer.resyncCheckPeriod; e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+	if e, a := time.Duration(0), informer.processor.listeners[0].requestedResyncPeriod; e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+	if e, a := 1*time.Minute, informer.processor.listeners[1].requestedResyncPeriod; e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+	if e, a := 55*time.Second, informer.processor.listeners[2].requestedResyncPeriod; e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+	if e, a := 5*time.Second, informer.processor.listeners[3].requestedResyncPeriod; e != a {
+		t.Errorf("expected %d, got %d", e, a)
+	}
+	if e, a := ifElseDuration(doResyncs, 5*time.Second, 3*time.Second), informer.processor.listeners[4].requestedResyncPeriod; e != a {
+		t.Errorf("for doResyncs=%v: expected %d, got %d", doResyncs, e, a)
+	}
+	checkResyncPeriods(t, informer.processor, !doResyncs)
+
+}
+
+func checkResyncPeriods(t *testing.T, p *sharedProcessor, expectZero bool) {
+	for idx, listener := range p.listeners {
+		e := zeroDuration(listener.requestedResyncPeriod, expectZero)
+		a := listener.resyncPeriod
+		if e != a {
+			t.Errorf("for listener %d: expected %d, got %d", idx, e, a)
+		}
+	}
+}
+
+func zeroDuration(dur time.Duration, zeroIt bool) time.Duration {
+	return ifElseDuration(zeroIt, 0, dur)
+}
+
+func ifElseDuration(cond bool, durIf, durElse time.Duration) time.Duration {
+	if cond {
+		return durIf
+	}
+	return durElse
 }
 
 // verify that https://github.com/kubernetes/kubernetes/issues/59822 is fixed


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR does two things.  One is to extend the testing of resync period values and logic for sharedIndexInformer objects.  The old test did not examine what happens after the informer starts.  The old test did not look at the requestedResyncPeriod fields.  The old test did not look at what happens for an informer that does not do resyncs.  The new test does those things, and exposes the almost complete redundancy between the resyncPeriod and requestedResyncPeriod fields and the consequent irrelevance of the resyncCheckPeriodChanged function.

This PR also removes the unnecessary use of wait.ExponentialBackoff in processorListener::run.

This test shows what #86862 is about.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
