### PR TITLE
Move yaml limit tests to benchmarks

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/yaml/yaml_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/serializer/yaml/yaml_test.go
@@ -75,6 +75,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "arrays of null aliases",
@@ -96,6 +97,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "arrays of zero int aliases",
@@ -117,6 +119,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "arrays of zero float aliases",
@@ -138,6 +141,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "arrays of big float aliases",
@@ -159,6 +163,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "arrays of bool aliases",
@@ -180,6 +185,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "map key aliases",
@@ -201,6 +207,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "map value aliases",
@@ -222,6 +229,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "nested map aliases",
@@ -243,6 +251,7 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
 			name:  "nested slice aliases",
@@ -264,10 +273,12 @@ metadata:
 name: yaml-bomb
 namespace: default
 `),
+			benchmark: true,
 		},
 		{
-			name: "3MB map without alias",
-			data: []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 3*1024*1024/4) + `]`),
+			name:      "3MB map without alias",
+			data:      []byte(`a: &a [{a}` + strings.Repeat(`,{a}`, 3*1024*1024/4) + `]`),
+			benchmark: true,
 		},
 		{
 			name:  "3MB map with alias",
@@ -275,6 +286,7 @@ namespace: default
 			data: []byte(`
 a: &a [{a}` + strings.Repeat(`,{a}`, 3*1024*1024/4) + `]
 b: &b [*a]`),
+			benchmark: true,
 		},
 		{
 			name:  "deeply nested slices",


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/kind cleanup

**What this PR does / why we need it**:
Moves most of the yaml limit tests to benchmarks, leaving a few present as unit tests. Most of the tests existed to measure memory use of different problematic yaml documents.

Before this change, running unit tests with `-race` took ~75-300 seconds on this package, depending on the machine it was running on. After this change it takes ~20-60 seconds (which is still long, but doesn't trigger the timeout errors I was seeing).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @cjcullen 