### PR TITLE
staticcheck:test/integration/master/

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -59,7 +59,6 @@ test/integration/etcd
 test/integration/examples
 test/integration/framework
 test/integration/garbagecollector
-test/integration/master
 test/integration/scheduler_perf
 test/integration/ttlcontroller
 vendor/k8s.io/apimachinery/pkg/api/meta

--- a/test/integration/master/audit_dynamic_test.go
+++ b/test/integration/master/audit_dynamic_test.go
@@ -274,8 +274,7 @@ func asyncOps(
 				continue
 			}
 			e := expected.Load().([]utils.AuditEvent)
-			evList := []utils.AuditEvent{}
-			evList = append(e, exp...)
+			evList := append(e, exp...)
 			expected.Store(evList)
 		}
 	}

--- a/test/integration/master/crd_test.go
+++ b/test/integration/master/crd_test.go
@@ -30,7 +30,6 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
@@ -297,21 +296,4 @@ func reverse(s []string) {
 	for i, j := 0, len(s)-1; i < j; i, j = i+1, j-1 {
 		s[i], s[j] = s[j], s[i]
 	}
-}
-
-type Foo struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
-}
-
-func unstructuredFoo(foo *Foo) (*unstructured.Unstructured, error) {
-	bs, err := json.Marshal(foo)
-	if err != nil {
-		return nil, err
-	}
-	ret := &unstructured.Unstructured{}
-	if err = ret.UnmarshalJSON(bs); err != nil {
-		return nil, err
-	}
-	return ret, nil
 }

--- a/test/integration/master/kms_transformation_test.go
+++ b/test/integration/master/kms_transformation_test.go
@@ -177,6 +177,9 @@ resources:
 
 	// Secrets should be un-enveloped on direct reads from Kube API Server.
 	s, err := test.restClient.CoreV1().Secrets(testNamespace).Get(testSecret, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("failed to get Secret from %s, err: %v", testNamespace, err)
+	}
 	if secretVal != string(s.Data[secretKey]) {
 		t.Fatalf("expected %s from KubeAPI, but got %s", secretVal, string(s.Data[secretKey]))
 	}

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -297,6 +297,9 @@ func TestOpenAPIApiextensionsOverlapProtection(t *testing.T) {
 		t.Fatalf("unexpected error: apiextensions definition doesn't exist")
 	}
 	bytes, err := json.Marshal(apiextensionsDefinition)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if exist := strings.Contains(string(bytes), testApiextensionsOverlapProbeString); exist {
 		t.Fatalf("unexpected error: apiextensions definition gets overlapped")
 	}
@@ -428,6 +431,10 @@ func testReconcilersMasterLease(t *testing.T, leaseCount int, masterCount int) {
 	// 2. verify master count servers have registered
 	if err := wait.PollImmediate(3*time.Second, 2*time.Minute, func() (bool, error) {
 		client, err := kubernetes.NewForConfig(masterCountServers[0].ClientConfig)
+		if err != nil {
+			t.Logf("error creating client: %v", err)
+			return false, nil
+		}
 		endpoints, err := client.CoreV1().Endpoints("default").Get("kubernetes", metav1.GetOptions{})
 		if err != nil {
 			t.Logf("error fetching endpoints: %v", err)

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -425,20 +425,6 @@ func autoscalingPath(resource, namespace, name string) string {
 	return path.Join("/apis/autoscaling/v1", namespace, resource, name)
 }
 
-func batchPath(resource, namespace, name string) string {
-	if namespace != "" {
-		namespace = path.Join("namespaces", namespace)
-	}
-	return path.Join("/apis/batch/v1", namespace, resource, name)
-}
-
-func extensionsPath(resource, namespace, name string) string {
-	if namespace != "" {
-		namespace = path.Join("namespaces", namespace)
-	}
-	return path.Join("/apis/extensions/v1beta1", namespace, resource, name)
-}
-
 func appsPath(resource, namespace, name string) string {
 	if namespace != "" {
 		namespace = path.Join("namespaces", namespace)
@@ -471,11 +457,11 @@ func TestAutoscalingGroupBackwardCompatibility(t *testing.T) {
 		}
 		func() {
 			resp, err := transport.RoundTrip(req)
-			defer resp.Body.Close()
 			if err != nil {
 				t.Logf("case %v", r)
 				t.Fatalf("unexpected error: %v", err)
 			}
+			defer resp.Body.Close()
 			b, _ := ioutil.ReadAll(resp.Body)
 			body := string(b)
 			if _, ok := r.expectedStatusCodes[resp.StatusCode]; !ok {
@@ -519,11 +505,11 @@ func TestAppsGroupBackwardCompatibility(t *testing.T) {
 		}
 		func() {
 			resp, err := transport.RoundTrip(req)
-			defer resp.Body.Close()
 			if err != nil {
 				t.Logf("case %v", r)
 				t.Fatalf("unexpected error: %v", err)
 			}
+			defer resp.Body.Close()
 			b, _ := ioutil.ReadAll(resp.Body)
 			body := string(b)
 			if _, ok := r.expectedStatusCodes[resp.StatusCode]; !ok {

--- a/test/integration/master/transformation_testcase.go
+++ b/test/integration/master/transformation_testcase.go
@@ -134,6 +134,9 @@ func (e *transformTest) run(unSealSecretFunc unSealSecret, expectedEnvelopePrefi
 
 	// Secrets should be un-enveloped on direct reads from Kube API Server.
 	s, err := e.restClient.CoreV1().Secrets(testNamespace).Get(testSecret, metav1.GetOptions{})
+	if err != nil {
+		e.logger.Errorf("failed to get Secret from %s, err: %v", testNamespace, err)
+	}
 	if secretVal != string(s.Data[secretKey]) {
 		e.logger.Errorf("expected %s from KubeAPI, but got %s", secretVal, string(s.Data[secretKey]))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:https://github.com/kubernetes/kubernetes/issues/81657

**Special notes for your reviewer**:

```
test/integration/master/audit_dynamic_test.go:277:4: this value of evList is never used (SA4006)
test/integration/master/crd_test.go:302:6: type Foo is unused (U1000)
test/integration/master/crd_test.go:307:6: func unstructuredFoo is unused (U1000)
test/integration/master/kms_transformation_test.go:179:5: this value of err is never used (SA4006)
test/integration/master/kube_apiserver_test.go:299:9: this value of err is never used (SA4006)
test/integration/master/kube_apiserver_test.go:430:11: this value of err is never used (SA4006)
test/integration/master/synthetic_master_test.go:428:6: func batchPath is unused (U1000)
test/integration/master/synthetic_master_test.go:435:6: func extensionsPath is unused (U1000)
test/integration/master/synthetic_master_test.go:474:4: should check returned error before deferring resp.Body.Close() (SA5001)
test/integration/master/synthetic_master_test.go:522:4: should check returned error before deferring resp.Body.Close() (SA5001)
test/integration/master/transformation_testcase.go:136:5: this value of err is never used (SA4006)

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
