### PR TITLE
kubelet stats interface segregate

### DIFF
--- a/pkg/kubelet/server/stats/fs_resource_analyzer.go
+++ b/pkg/kubelet/server/stats/fs_resource_analyzer.go
@@ -29,8 +29,8 @@ import (
 
 type statCache map[types.UID]*volumeStatCalculator
 
-// fsResourceAnalyzerInterface is for embedding fs functions into ResourceAnalyzer
-type fsResourceAnalyzerInterface interface {
+// FileSystemResourceAnalyzer is for embedding fs functions into ResourceAnalyzer
+type FileSystemResourceAnalyzer interface {
 	GetPodVolumeStats(uid types.UID) (PodVolumeStats, bool)
 }
 
@@ -42,7 +42,7 @@ type fsResourceAnalyzer struct {
 	startOnce             sync.Once
 }
 
-var _ fsResourceAnalyzerInterface = &fsResourceAnalyzer{}
+var _ FileSystemResourceAnalyzer = &fsResourceAnalyzer{}
 
 // newFsResourceAnalyzer returns a new fsResourceAnalyzer implementation
 func newFsResourceAnalyzer(statsMetadataProvider MetadataPovider, calcVolumePeriod time.Duration) *fsResourceAnalyzer {

--- a/pkg/kubelet/server/stats/fs_resource_analyzer.go
+++ b/pkg/kubelet/server/stats/fs_resource_analyzer.go
@@ -36,19 +36,19 @@ type fsResourceAnalyzerInterface interface {
 
 // fsResourceAnalyzer provides stats about fs resource usage
 type fsResourceAnalyzer struct {
-	statsProvider     Provider
-	calcPeriod        time.Duration
-	cachedVolumeStats atomic.Value
-	startOnce         sync.Once
+	statsMetadataProvider MetadataPovider
+	calcPeriod            time.Duration
+	cachedVolumeStats     atomic.Value
+	startOnce             sync.Once
 }
 
 var _ fsResourceAnalyzerInterface = &fsResourceAnalyzer{}
 
 // newFsResourceAnalyzer returns a new fsResourceAnalyzer implementation
-func newFsResourceAnalyzer(statsProvider Provider, calcVolumePeriod time.Duration) *fsResourceAnalyzer {
+func newFsResourceAnalyzer(statsMetadataProvider MetadataPovider, calcVolumePeriod time.Duration) *fsResourceAnalyzer {
 	r := &fsResourceAnalyzer{
-		statsProvider: statsProvider,
-		calcPeriod:    calcVolumePeriod,
+		statsMetadataProvider: statsMetadataProvider,
+		calcPeriod:            calcVolumePeriod,
 	}
 	r.cachedVolumeStats.Store(make(statCache))
 	return r
@@ -72,9 +72,9 @@ func (s *fsResourceAnalyzer) updateCachedPodVolumeStats() {
 	newCache := make(statCache)
 
 	// Copy existing entries to new map, creating/starting new entries for pods missing from the cache
-	for _, pod := range s.statsProvider.GetPods() {
+	for _, pod := range s.statsMetadataProvider.GetPods() {
 		if value, found := oldCache[pod.GetUID()]; !found {
-			newCache[pod.GetUID()] = newVolumeStatCalculator(s.statsProvider, s.calcPeriod, pod).StartOnce()
+			newCache[pod.GetUID()] = newVolumeStatCalculator(s.statsMetadataProvider, s.calcPeriod, pod).StartOnce()
 		} else {
 			newCache[pod.GetUID()] = value
 		}

--- a/pkg/kubelet/server/stats/resource_analyzer.go
+++ b/pkg/kubelet/server/stats/resource_analyzer.go
@@ -24,7 +24,7 @@ import (
 type ResourceAnalyzer interface {
 	Start()
 
-	fsResourceAnalyzerInterface
+	FileSystemResourceAnalyzer
 	SummaryProvider
 }
 

--- a/pkg/kubelet/stats/cadvisor_stats_provider.go
+++ b/pkg/kubelet/stats/cadvisor_stats_provider.go
@@ -45,7 +45,7 @@ type cadvisorStatsProvider struct {
 	// are managed by pods.
 	cadvisor cadvisor.Interface
 	// resourceAnalyzer is used to get the volume stats of the pods.
-	resourceAnalyzer stats.ResourceAnalyzer
+	resourceAnalyzer stats.FileSystemResourceAnalyzer
 	// imageService is used to get the stats of the image filesystem.
 	imageService kubecontainer.ImageService
 	// statusProvider is used to get pod metadata
@@ -56,7 +56,7 @@ type cadvisorStatsProvider struct {
 // container stats from cAdvisor.
 func newCadvisorStatsProvider(
 	cadvisor cadvisor.Interface,
-	resourceAnalyzer stats.ResourceAnalyzer,
+	resourceAnalyzer stats.FileSystemResourceAnalyzer,
 	imageService kubecontainer.ImageService,
 	statusProvider status.PodStatusProvider,
 ) containerStatsProvider {

--- a/pkg/kubelet/stats/cri_stats_provider.go
+++ b/pkg/kubelet/stats/cri_stats_provider.go
@@ -60,7 +60,7 @@ type criStatsProvider struct {
 	// filesystem stats.
 	cadvisor cadvisor.Interface
 	// resourceAnalyzer is used to get the volume stats of the pods.
-	resourceAnalyzer stats.ResourceAnalyzer
+	resourceAnalyzer stats.FileSystemResourceAnalyzer
 	// runtimeService is used to get the status and stats of the pods and its
 	// managed containers.
 	runtimeService internalapi.RuntimeService
@@ -80,7 +80,7 @@ type criStatsProvider struct {
 // provides container stats using CRI.
 func newCRIStatsProvider(
 	cadvisor cadvisor.Interface,
-	resourceAnalyzer stats.ResourceAnalyzer,
+	resourceAnalyzer stats.FileSystemResourceAnalyzer,
 	runtimeService internalapi.RuntimeService,
 	imageService internalapi.ImageManagerService,
 	logMetricsService LogMetricsService,


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:
The package `kubelet/server/stats` has some weird dependency relationship, which makes code hard to understand.
The `StatProvider` struct relies on `ResourceAnalyzer`, but `ResourceAnalyzer` in turn relies on `Provider` interface, which is partly implemented by `StatProvider`. 

we can make `ResourceAnalyzer` rely on a smaller and more specific one instead of the whole big `Provider` interface so that we can make the code be easier to understand.

This fix will make  `ResourceAnalyzer`(actually fsResourceAnalyzer) only have to know about the methods that are of interest to them and the code may be easier to understand. 


This fix follows the design principles of [Interface Segregation Principle](https://en.wikipedia.org/wiki/Interface_segregation_principle)


the `fsResourceAnalyzerInterface` also has the same issue, so I fixed in the second commit of this PR.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig node
/area kubelet