### PR TITLE
feat(scheduling): address disabled plugins in scheduling framework

### DIFF
--- a/pkg/scheduler/apis/config/BUILD
+++ b/pkg/scheduler/apis/config/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -15,6 +15,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/component-base/config:go_default_library",
     ],
 )
@@ -38,4 +39,11 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["types_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//vendor/github.com/google/go-cmp/cmp:go_default_library"],
 )

--- a/pkg/scheduler/apis/config/types_test.go
+++ b/pkg/scheduler/apis/config/types_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPluginsApply(t *testing.T) {
+	tests := []struct {
+		name            string
+		customPlugins   *Plugins
+		defaultPlugins  *Plugins
+		expectedPlugins *Plugins
+	}{
+		{
+			name: "AppendCustomPlugin",
+			customPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "CustomPlugin"},
+					},
+				},
+			},
+			defaultPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin1"},
+						{Name: "DefaultPlugin2"},
+					},
+				},
+			},
+			expectedPlugins: &Plugins{
+				QueueSort: &PluginSet{Enabled: []Plugin{}},
+				PreFilter: &PluginSet{Enabled: []Plugin{}},
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin1"},
+						{Name: "DefaultPlugin2"},
+						{Name: "CustomPlugin"},
+					},
+				},
+				PostFilter: &PluginSet{Enabled: []Plugin{}},
+				Score:      &PluginSet{Enabled: []Plugin{}},
+				Reserve:    &PluginSet{Enabled: []Plugin{}},
+				Permit:     &PluginSet{Enabled: []Plugin{}},
+				PreBind:    &PluginSet{Enabled: []Plugin{}},
+				Bind:       &PluginSet{Enabled: []Plugin{}},
+				PostBind:   &PluginSet{Enabled: []Plugin{}},
+				Unreserve:  &PluginSet{Enabled: []Plugin{}},
+			},
+		},
+		{
+			name: "InsertAfterDefaultPlugins2",
+			customPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "CustomPlugin"},
+						{Name: "DefaultPlugin2"},
+					},
+					Disabled: []Plugin{
+						{Name: "DefaultPlugin2"},
+					},
+				},
+			},
+			defaultPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin1"},
+						{Name: "DefaultPlugin2"},
+					},
+				},
+			},
+			expectedPlugins: &Plugins{
+				QueueSort: &PluginSet{Enabled: []Plugin{}},
+				PreFilter: &PluginSet{Enabled: []Plugin{}},
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin1"},
+						{Name: "CustomPlugin"},
+						{Name: "DefaultPlugin2"},
+					},
+				},
+				PostFilter: &PluginSet{Enabled: []Plugin{}},
+				Score:      &PluginSet{Enabled: []Plugin{}},
+				Reserve:    &PluginSet{Enabled: []Plugin{}},
+				Permit:     &PluginSet{Enabled: []Plugin{}},
+				PreBind:    &PluginSet{Enabled: []Plugin{}},
+				Bind:       &PluginSet{Enabled: []Plugin{}},
+				PostBind:   &PluginSet{Enabled: []Plugin{}},
+				Unreserve:  &PluginSet{Enabled: []Plugin{}},
+			},
+		},
+		{
+			name: "InsertBeforeAllPlugins",
+			customPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "CustomPlugin"},
+						{Name: "DefaultPlugin1"},
+						{Name: "DefaultPlugin2"},
+					},
+					Disabled: []Plugin{
+						{Name: "*"},
+					},
+				},
+			},
+			defaultPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin1"},
+						{Name: "DefaultPlugin2"},
+					},
+				},
+			},
+			expectedPlugins: &Plugins{
+				QueueSort: &PluginSet{Enabled: []Plugin{}},
+				PreFilter: &PluginSet{Enabled: []Plugin{}},
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "CustomPlugin"},
+						{Name: "DefaultPlugin1"},
+						{Name: "DefaultPlugin2"},
+					},
+				},
+				PostFilter: &PluginSet{Enabled: []Plugin{}},
+				Score:      &PluginSet{Enabled: []Plugin{}},
+				Reserve:    &PluginSet{Enabled: []Plugin{}},
+				Permit:     &PluginSet{Enabled: []Plugin{}},
+				PreBind:    &PluginSet{Enabled: []Plugin{}},
+				Bind:       &PluginSet{Enabled: []Plugin{}},
+				PostBind:   &PluginSet{Enabled: []Plugin{}},
+				Unreserve:  &PluginSet{Enabled: []Plugin{}},
+			},
+		},
+		{
+			name: "ReorderDefaultPlugins",
+			customPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin2"},
+						{Name: "DefaultPlugin1"},
+					},
+					Disabled: []Plugin{
+						{Name: "*"},
+					},
+				},
+			},
+			defaultPlugins: &Plugins{
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin1"},
+						{Name: "DefaultPlugin2"},
+					},
+				},
+			},
+			expectedPlugins: &Plugins{
+				QueueSort: &PluginSet{Enabled: []Plugin{}},
+				PreFilter: &PluginSet{Enabled: []Plugin{}},
+				Filter: &PluginSet{
+					Enabled: []Plugin{
+						{Name: "DefaultPlugin2"},
+						{Name: "DefaultPlugin1"},
+					},
+				},
+				PostFilter: &PluginSet{Enabled: []Plugin{}},
+				Score:      &PluginSet{Enabled: []Plugin{}},
+				Reserve:    &PluginSet{Enabled: []Plugin{}},
+				Permit:     &PluginSet{Enabled: []Plugin{}},
+				PreBind:    &PluginSet{Enabled: []Plugin{}},
+				Bind:       &PluginSet{Enabled: []Plugin{}},
+				PostBind:   &PluginSet{Enabled: []Plugin{}},
+				Unreserve:  &PluginSet{Enabled: []Plugin{}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.defaultPlugins.Apply(test.customPlugins)
+			if d := cmp.Diff(test.expectedPlugins, test.defaultPlugins); d != "" {
+				t.Fatalf("plugins mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -185,11 +185,11 @@ func (c *Configurator) createFromProvider(providerName string) (*Scheduler, erro
 	}
 
 	// Combine the provided plugins with the ones from component config.
-	// TODO(#86789): address disabled plugins.
-	var plugins schedulerapi.Plugins
-	plugins.Append(provider.FrameworkPlugins)
-	plugins.Append(c.plugins)
-	c.plugins = &plugins
+	var defaultPlugins schedulerapi.Plugins
+	defaultPlugins.Append(provider.FrameworkPlugins)
+	defaultPlugins.Apply(c.plugins)
+	c.plugins = &defaultPlugins
+
 	var pluginConfig []schedulerapi.PluginConfig
 	pluginConfig = append(pluginConfig, provider.FrameworkPluginConfig...)
 	pluginConfig = append(pluginConfig, c.pluginConfig...)
@@ -296,11 +296,11 @@ func (c *Configurator) createFromConfig(policy schedulerapi.Policy) (*Scheduler,
 	}
 	// Combine all framework configurations. If this results in any duplication, framework
 	// instantiation should fail.
-	var plugins schedulerapi.Plugins
-	plugins.Append(pluginsForPredicates)
-	plugins.Append(pluginsForPriorities)
-	plugins.Append(c.plugins)
-	c.plugins = &plugins
+	var defaultPlugins schedulerapi.Plugins
+	defaultPlugins.Append(pluginsForPredicates)
+	defaultPlugins.Append(pluginsForPriorities)
+	defaultPlugins.Apply(c.plugins)
+	c.plugins = &defaultPlugins
 
 	var pluginConfig []schedulerapi.PluginConfig
 	pluginConfig = append(pluginConfig, pluginConfigForPredicates...)


### PR DESCRIPTION
/sig scheduling
/priority important-soon
/kind feature

+ Custom plugins run after the default plugins.
+ Disable default plugins and re-enable them in the configuration could update
  the execution order.
+ Use `*` to disable all the default plugins of specific extension points.

Fixes #86789

```release-note
NONE
```