### PR TITLE
fix a bug in scheduler's node resource limits score

### DIFF
--- a/pkg/scheduler/algorithmprovider/registry.go
+++ b/pkg/scheduler/algorithmprovider/registry.go
@@ -169,7 +169,9 @@ func applyFeatureGates(config *Config) {
 	// Prioritizes nodes that satisfy pod's resource limits
 	if utilfeature.DefaultFeatureGate.Enabled(features.ResourceLimitsPriorityFunction) {
 		klog.Infof("Registering resourcelimits priority function")
-		s := schedulerapi.Plugin{Name: noderesources.ResourceLimitsName, Weight: 1}
+		s := schedulerapi.Plugin{Name: noderesources.ResourceLimitsName}
+		config.FrameworkPlugins.PostFilter.Enabled = append(config.FrameworkPlugins.PostFilter.Enabled, s)
+		s = schedulerapi.Plugin{Name: noderesources.ResourceLimitsName, Weight: 1}
 		config.FrameworkPlugins.Score.Enabled = append(config.FrameworkPlugins.Score.Enabled, s)
 	}
 }

--- a/pkg/scheduler/algorithmprovider/registry_test.go
+++ b/pkg/scheduler/algorithmprovider/registry_test.go
@@ -208,6 +208,7 @@ func TestApplyFeatureGates(t *testing.T) {
 							{Name: interpodaffinity.Name},
 							{Name: tainttoleration.Name},
 							{Name: podtopologyspread.Name},
+							{Name: noderesources.ResourceLimitsName},
 						},
 					},
 					Score: &schedulerapi.PluginSet{

--- a/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
@@ -22,9 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
-	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
@@ -84,11 +82,10 @@ func (rl *ResourceLimits) PostFilter(
 	return nil
 }
 
-func getPodResource(cycleState *framework.CycleState) (*nodeinfo.Resource, error) {
+func getPodResource(cycleState *framework.CycleState) (*schedulernodeinfo.Resource, error) {
 	c, err := cycleState.Read(postFilterStateKey)
 	if err != nil {
-		klog.V(5).Infof("Error reading %q from cycleState: %v", postFilterStateKey, err)
-		return nil, nil
+		return nil, fmt.Errorf("Error reading %q from cycleState: %v", postFilterStateKey, err)
 	}
 
 	s, ok := c.(*postFilterState)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

Scheduler hit a panic because we were de-referencing a nil pointer in NodeResourceLimits alpha plugin. The pointer we were de-referencing is that of a state we lookup from CycleState.

There were two problems: 
1) postFilter wasn't added to the default list of plugins, and so the state didn't exist
2) the code didn't return an error when reading nil

I opened https://github.com/kubernetes/kubernetes/issues/86926 to add integration test for this alpha feature, which would have caught this problem.

**Which issue(s) this PR fixes**:
Fixes #86908

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @zouyee @draveness 