### PR TITLE
aws: add ipv6 addresses for NodeAddresses

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -1490,11 +1490,17 @@ func (c *Cloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]v1.No
 
 		for _, macID := range macIDs {
 			ipPath := path.Join("network/interfaces/macs/", macID, "local-ipv4s")
-			internalIPs, err := c.metadata.GetMetadata(ipPath)
+			v4ips, err := c.metadata.GetMetadata(ipPath)
 			if err != nil {
 				return nil, fmt.Errorf("error querying AWS metadata for %q: %q", ipPath, err)
 			}
-
+			ipPath = path.Join("network/interfaces/macs/", macID, "ipv6s")
+			v6ips, err := c.metadata.GetMetadata(ipPath)
+			if err != nil {
+				klog.V(3).Infof("Error querying IPv6 IPs: %v", err)
+				v6ips = ""
+			}
+			internalIPs := v4ips + "\n" + v6ips
 			for _, internalIP := range strings.Split(internalIPs, "\n") {
 				if internalIP == "" {
 					continue

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -39,6 +39,7 @@ type FakeAWSServices struct {
 	selfInstance                *ec2.Instance
 	networkInterfacesMacs       []string
 	networkInterfacesPrivateIPs [][]string
+	networkInterfacesIPv6s      [][]string
 	networkInterfacesVpcIDs     []string
 
 	ec2      FakeEC2
@@ -371,6 +372,13 @@ func (m *FakeMetadata) GetMetadata(key string) (string, error) {
 			for i, macElem := range m.aws.networkInterfacesMacs {
 				if macParam == macElem {
 					return strings.Join(m.aws.networkInterfacesPrivateIPs[i], "/\n"), nil
+				}
+			}
+		}
+		if len(keySplit) == 5 && keySplit[4] == "ipv6s" {
+			for i, macElem := range m.aws.networkInterfacesMacs {
+				if macParam == macElem {
+					return strings.Join(m.aws.networkInterfacesIPv6s[i], "/\n"), nil
 				}
 			}
 		}

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_test.go
@@ -662,6 +662,7 @@ func TestNodeAddressesWithMetadata(t *testing.T) {
 
 	awsServices.networkInterfacesMacs = []string{"0a:77:89:f3:9c:f6", "0a:26:64:c4:6a:48"}
 	awsServices.networkInterfacesPrivateIPs = [][]string{{"192.168.0.1"}, {"192.168.0.2"}}
+	awsServices.networkInterfacesIPv6s = [][]string{{"2001:DB8::0001"}, {"2001:DB8::0002"}}
 	addrs, err := awsCloud.NodeAddresses(context.TODO(), "")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
@@ -670,15 +671,23 @@ func TestNodeAddressesWithMetadata(t *testing.T) {
 	testHasNodeAddress(t, addrs, v1.NodeInternalIP, "192.168.0.2")
 	testHasNodeAddress(t, addrs, v1.NodeExternalIP, "2.3.4.5")
 	var index1, index2 int
+	var indexIPv61, indexIPv62 int
 	for i, addr := range addrs {
 		if addr.Type == v1.NodeInternalIP && addr.Address == "192.168.0.1" {
 			index1 = i
 		} else if addr.Type == v1.NodeInternalIP && addr.Address == "192.168.0.2" {
 			index2 = i
+		} else if addr.Type == v1.NodeInternalIP && addr.Address == "2001:DB8::0001" {
+			indexIPv61 = i
+		} else if addr.Type == v1.NodeInternalIP && addr.Address == "2001:DB8::0002" {
+			indexIPv62 = i
 		}
 	}
 	if index1 > index2 {
-		t.Errorf("Addresses in incorrect order: %v", addrs)
+		t.Errorf("IPV4 Addresses in incorrect order: %v", addrs)
+	}
+	if indexIPv61 > indexIPv62 {
+		t.Errorf("IPV6 Addresses in incorrect order: %v", addrs)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For single stack IPv6 clusters the IPv6 addresses on AWS are not available within the NodeAddresses. This PR adds the ipv6 addresses to the list of available addressees.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
AWS cloud provider now includes IPv6 addresses in node status.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
