### PR TITLE
Fix how we check for node info list consistency

### DIFF
--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -261,12 +261,12 @@ func (cache *schedulerCache) UpdateNodeInfoSnapshot(nodeSnapshot *nodeinfosnapsh
 		cache.updateNodeInfoSnapshotList(nodeSnapshot, updateAllLists)
 	}
 
-	if len(nodeSnapshot.NodeInfoList) != len(nodeSnapshot.NodeInfoMap) {
-		errMsg := fmt.Sprintf("snapshot state is not consistent, length of NodeInfoList=%v not equal to length of NodeInfoMap=%v "+
-			"length of nodes in cache=%v, length of nodes in tree=%v"+
+	if len(nodeSnapshot.NodeInfoList) != cache.nodeTree.numNodes {
+		errMsg := fmt.Sprintf("snapshot state is not consistent, length of NodeInfoList=%v not equal to length of nodes in tree=%v "+
+			", length of NodeInfoMap=%v, length of nodes in cache=%v"+
 			", trying to recover",
-			len(nodeSnapshot.NodeInfoList), len(nodeSnapshot.NodeInfoMap),
-			len(cache.nodes), cache.nodeTree.numNodes)
+			len(nodeSnapshot.NodeInfoList), cache.nodeTree.numNodes,
+			len(nodeSnapshot.NodeInfoMap), len(cache.nodes))
 		klog.Error(errMsg)
 		// We will try to recover by re-creating the lists for the next scheduling cycle, but still return an
 		// error to surface the problem, the error will likely cause a failure to the current scheduling cycle.


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

We added a recent check to ```UpdateNodeInfoSnapshot``` to verify that NodeInfoMap and NodeInfoList length are equal, on failure we returned an error. It turns out that the map and the list could go out of sync not because of an issue in the snapshot logic, but because we sometimes on a delete node event, we don't remove a node from the scheduler cache (the source of truth for the NodeInfoMap) but we remove it from the node tree (the source of truth for the NodeInfoList).

The case where this happens is when the scheduler receives a node remove event before all pods on that node were removed. See comment here: https://github.com/kubernetes/kubernetes/blob/11a31590e432ba9c723b951e1691d5a97c09dba7/pkg/scheduler/internal/cache/cache.go#L631, 

We should revisit this logic in a followup issue, but for now this PR updates the check to verify that the nodeInfoList and the node tree are equal, rather than checking for equal length of the nodeinfolist and the nodeinfomap.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @mm4tt @mborsz @liu-cong @alculquicondor 