### PR TITLE
Reduce use of extra map for deletionFinalizersForGarbageCollection

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store_test.go
@@ -991,7 +991,7 @@ func TestStoreDeleteWithOrphanDependents(t *testing.T) {
 			orphanOptions,
 			defaultDeleteStrategy,
 			false,
-			[]string{"foo.com/x", "bar.com/y", metav1.FinalizerOrphanDependents},
+			[]string{"bar.com/y", "foo.com/x", metav1.FinalizerOrphanDependents},
 		},
 		{
 			podWithNoFinalizer("pod3"),
@@ -1015,7 +1015,7 @@ func TestStoreDeleteWithOrphanDependents(t *testing.T) {
 			nonOrphanOptions,
 			orphanDeleteStrategy,
 			false,
-			[]string{"foo.com/x", "bar.com/y"},
+			[]string{"bar.com/y", "foo.com/x"},
 		},
 		{
 			podWithOtherFinalizers("pod6"),
@@ -1068,7 +1068,7 @@ func TestStoreDeleteWithOrphanDependents(t *testing.T) {
 			nilOrphanOptions,
 			orphanDeleteStrategy,
 			false,
-			[]string{"foo.com/x", "bar.com/y", metav1.FinalizerOrphanDependents},
+			[]string{"bar.com/y", "foo.com/x", metav1.FinalizerOrphanDependents},
 		},
 		{
 			podWithNoFinalizer("pod13"),
@@ -1128,7 +1128,7 @@ func TestStoreDeleteWithOrphanDependents(t *testing.T) {
 			nil,
 			orphanDeleteStrategy,
 			false,
-			[]string{"foo.com/x", "bar.com/y", metav1.FinalizerOrphanDependents},
+			[]string{"bar.com/y", "foo.com/x", metav1.FinalizerOrphanDependents},
 		},
 		{
 			podWithNoFinalizer("pod21"),


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In deletionFinalizersForGarbageCollection, we create two maps: one for new finalizers and one for old finalizers.

This PR removes the use of map for old finalizers.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
