### PR TITLE
Update scheduler's RunFilterPlugins to return a plugin to status map

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -616,7 +616,8 @@ func (g *genericScheduler) podFitsOnNode(
 			break
 		}
 
-		status = g.framework.RunFilterPlugins(ctx, stateToUse, pod, nodeInfoToUse)
+		statusMap := g.framework.RunFilterPlugins(ctx, stateToUse, pod, nodeInfoToUse)
+		status = statusMap.Merge()
 		if !status.IsSuccess() && !status.IsUnschedulable() {
 			return false, status, status.AsError()
 		}

--- a/pkg/scheduler/framework/v1alpha1/interface_test.go
+++ b/pkg/scheduler/framework/v1alpha1/interface_test.go
@@ -90,3 +90,33 @@ func assertStatusCode(t *testing.T, code Code, value int) {
 		t.Errorf("Status code %q should have a value of %v but got %v", code.String(), value, int(code))
 	}
 }
+
+func TestPluginToStatusMerge(t *testing.T) {
+	tests := []struct {
+		statusMap PluginToStatus
+		wantCode  Code
+	}{
+		{
+			statusMap: PluginToStatus{"p1": NewStatus(Error), "p2": NewStatus(Unschedulable)},
+			wantCode:  Error,
+		},
+		{
+			statusMap: PluginToStatus{"p1": NewStatus(Success), "p2": NewStatus(Unschedulable)},
+			wantCode:  Unschedulable,
+		},
+		{
+			statusMap: PluginToStatus{"p1": NewStatus(Success), "p2": NewStatus(UnschedulableAndUnresolvable), "p3": NewStatus(Unschedulable)},
+			wantCode:  UnschedulableAndUnresolvable,
+		},
+		{
+			wantCode: Success,
+		},
+	}
+
+	for i, test := range tests {
+		gotStatus := test.statusMap.Merge()
+		if test.wantCode != gotStatus.Code() {
+			t.Errorf("test #%v, wantCode %v, gotCode %v", i, test.wantCode, gotStatus.Code())
+		}
+	}
+}

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -195,7 +195,7 @@ func (*fakeFramework) RunPreFilterPlugins(ctx context.Context, state *framework.
 	return nil
 }
 
-func (*fakeFramework) RunFilterPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) *framework.Status {
+func (*fakeFramework) RunFilterPlugins(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) framework.PluginToStatus {
 	return nil
 }
 


### PR DESCRIPTION

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Updates RunFilterPlugins to allow identifying which exact Plugin return which status. This is needed for CA to make informed decisions on how to scale the cluster.


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @alculquicondor 