### PR TITLE
Remove nodes from cache immediately on delete events

### DIFF
--- a/pkg/scheduler/nodeinfo/node_info.go
+++ b/pkg/scheduler/nodeinfo/node_info.go
@@ -632,23 +632,6 @@ func (n *NodeInfo) SetNode(node *v1.Node) error {
 	return nil
 }
 
-// RemoveNode removes the overall information about the node.
-func (n *NodeInfo) RemoveNode(node *v1.Node) error {
-	// We don't remove NodeInfo for because there can still be some pods on this node -
-	// this is because notifications about pods are delivered in a different watch,
-	// and thus can potentially be observed later, even though they happened before
-	// node removal. This is handled correctly in cache.go file.
-	n.node = nil
-	n.allocatableResource = &Resource{}
-	n.taints, n.taintsErr = nil, nil
-	n.memoryPressureCondition = v1.ConditionUnknown
-	n.diskPressureCondition = v1.ConditionUnknown
-	n.pidPressureCondition = v1.ConditionUnknown
-	n.imageStates = make(map[string]*ImageStateSummary)
-	n.generation = nextGeneration()
-	return nil
-}
-
 // FilterOutPods receives a list of pods and filters out those whose node names
 // are equal to the node of this NodeInfo, but are not found in the pods of this NodeInfo.
 //


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Remove nodes from cache's structs when getting a Remove event. Previously, we keep them in some caches until all remove pod events arrive.
This is unnecessary and it causes structs to be become out-of-sync.

We still keep pods in other intermediate caches until their delete events arrive. This is to avoid the complexity of having to handle removed elements when we receive the delete, forget or expires events (the last 2 are internal events to the scheduler, not from k8s). This is fine for the purposes of scheduling, as plugins and the generic scheduler implementation is only expected to use the node and pod listers, which use the list of nodes as source of truth.

/sig scheduling

**Which issue(s) this PR fixes**:

Fixes #86920

**Special notes for your reviewer**:

This builds on top of #86930, only review from 2nd commit.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
