### PR TITLE
Add extra fields in node expansion CSI call

### DIFF
--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -107,9 +107,9 @@ func (m *csiBlockMapper) GetGlobalMapPath(spec *volume.Spec) (string, error) {
 	return dir, nil
 }
 
-// getStagingPath returns a staging path for a directory (on the node) that should be used on NodeStageVolume/NodeUnstageVolume
+// GetStagingPath returns a staging path for a directory (on the node) that should be used on NodeStageVolume/NodeUnstageVolume
 // Example: plugins/kubernetes.io/csi/volumeDevices/staging/{specName}
-func (m *csiBlockMapper) getStagingPath() string {
+func (m *csiBlockMapper) GetStagingPath() string {
 	return filepath.Join(m.plugin.host.GetVolumeDevicePluginDir(CSIPluginName), "staging", m.specName)
 }
 
@@ -143,7 +143,7 @@ func (m *csiBlockMapper) stageVolumeForBlock(
 ) (string, error) {
 	klog.V(4).Infof(log("blockMapper.stageVolumeForBlock called"))
 
-	stagingPath := m.getStagingPath()
+	stagingPath := m.GetStagingPath()
 	klog.V(4).Infof(log("blockMapper.stageVolumeForBlock stagingPath set [%s]", stagingPath))
 
 	// Check whether "STAGE_UNSTAGE_VOLUME" is set
@@ -237,7 +237,7 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 		ctx,
 		m.volumeID,
 		m.readOnly,
-		m.getStagingPath(),
+		m.GetStagingPath(),
 		publishPath,
 		accessMode,
 		publishVolumeInfo,
@@ -435,7 +435,7 @@ func (m *csiBlockMapper) TearDownDevice(globalMapPath, devicePath string) error 
 	}
 
 	// Call NodeUnstageVolume
-	stagingPath := m.getStagingPath()
+	stagingPath := m.GetStagingPath()
 	if _, err := os.Stat(stagingPath); err != nil {
 		if os.IsNotExist(err) {
 			klog.V(4).Infof(log("blockMapper.TearDownDevice stagingPath(%s) has already been deleted, skip calling NodeUnstageVolume", stagingPath))
@@ -471,7 +471,7 @@ func (m *csiBlockMapper) cleanupOrphanDeviceFiles() error {
 
 	// Remove artifacts of NodeStage.
 	// stagingPath: xxx/plugins/kubernetes.io/csi/volumeDevices/staging/<volume name>
-	stagingPath := m.getStagingPath()
+	stagingPath := m.GetStagingPath()
 	if err := os.Remove(stagingPath); err != nil && !os.IsNotExist(err) {
 		return errors.New(log("failed to delete volume staging path [%s]: %v", stagingPath, err))
 	}

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -255,26 +255,26 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 }
 
 // SetUpDevice ensures the device is attached returns path where the device is located.
-func (m *csiBlockMapper) SetUpDevice() error {
+func (m *csiBlockMapper) SetUpDevice() (string, error) {
 	if !m.plugin.blockEnabled {
-		return errors.New("CSIBlockVolume feature not enabled")
+		return "", errors.New("CSIBlockVolume feature not enabled")
 	}
 	klog.V(4).Infof(log("blockMapper.SetUpDevice called"))
 
 	// Get csiSource from spec
 	if m.spec == nil {
-		return errors.New(log("blockMapper.SetUpDevice spec is nil"))
+		return "", errors.New(log("blockMapper.SetUpDevice spec is nil"))
 	}
 
 	csiSource, err := getCSISourceFromSpec(m.spec)
 	if err != nil {
-		return errors.New(log("blockMapper.SetUpDevice failed to get CSI persistent source: %v", err))
+		return "", errors.New(log("blockMapper.SetUpDevice failed to get CSI persistent source: %v", err))
 	}
 
 	driverName := csiSource.Driver
 	skip, err := m.plugin.skipAttach(driverName)
 	if err != nil {
-		return errors.New(log("blockMapper.SetupDevice failed to check CSIDriver for %s: %v", driverName, err))
+		return "", errors.New(log("blockMapper.SetupDevice failed to check CSIDriver for %s: %v", driverName, err))
 	}
 
 	var attachment *storage.VolumeAttachment
@@ -284,7 +284,7 @@ func (m *csiBlockMapper) SetUpDevice() error {
 		attachID := getAttachmentName(csiSource.VolumeHandle, csiSource.Driver, nodeName)
 		attachment, err = m.k8s.StorageV1().VolumeAttachments().Get(context.TODO(), attachID, meta.GetOptions{})
 		if err != nil {
-			return errors.New(log("blockMapper.SetupDevice failed to get volume attachment [id=%v]: %v", attachID, err))
+			return "", errors.New(log("blockMapper.SetupDevice failed to get volume attachment [id=%v]: %v", attachID, err))
 		}
 	}
 
@@ -299,11 +299,11 @@ func (m *csiBlockMapper) SetUpDevice() error {
 
 	csiClient, err := m.csiClientGetter.Get()
 	if err != nil {
-		return errors.New(log("blockMapper.SetUpDevice failed to get CSI client: %v", err))
+		return "", errors.New(log("blockMapper.SetUpDevice failed to get CSI client: %v", err))
 	}
 
 	// Call NodeStageVolume
-	_, err = m.stageVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment)
+	stagingPath, err := m.stageVolumeForBlock(ctx, csiClient, accessMode, csiSource, attachment)
 	if err != nil {
 		if volumetypes.IsOperationFinishedError(err) {
 			cleanupErr := m.cleanupOrphanDeviceFiles()
@@ -312,10 +312,10 @@ func (m *csiBlockMapper) SetUpDevice() error {
 				klog.V(4).Infof("Failed to clean up block volume directory %s", cleanupErr)
 			}
 		}
-		return err
+		return "", err
 	}
 
-	return nil
+	return stagingPath, nil
 }
 
 func (m *csiBlockMapper) MapPodDevice() (string, error) {

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -234,13 +234,12 @@ func TestBlockMapperSetupDevice(t *testing.T) {
 	}
 	t.Log("created attachement ", attachID)
 
-	err = csiMapper.SetUpDevice()
+	stagingPath, err := csiMapper.SetUpDevice()
 	if err != nil {
 		t.Fatalf("mapper failed to SetupDevice: %v", err)
 	}
 
 	// Check if NodeStageVolume staged to the right path
-	stagingPath := csiMapper.getStagingPath()
 	svols := csiMapper.csiClient.(*fakeCsiDriverClient).nodeClient.GetNodeStagedVolumes()
 	svol, ok := svols[csiMapper.volumeID]
 	if !ok {

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -123,7 +123,7 @@ func TestBlockMapperGetStagingPath(t *testing.T) {
 			t.Fatalf("Failed to make a new Mapper: %v", err)
 		}
 
-		path := csiMapper.getStagingPath()
+		path := csiMapper.GetStagingPath()
 
 		if tc.path != path {
 			t.Errorf("expecting path %s, got %s", tc.path, path)

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -277,7 +277,7 @@ func TestBlockMapperSetupDeviceError(t *testing.T) {
 	}
 	t.Log("created attachement ", attachID)
 
-	err = csiMapper.SetUpDevice()
+	stagingPath, err := csiMapper.SetUpDevice()
 	if err == nil {
 		t.Fatal("mapper unexpectedly succeeded")
 	}
@@ -292,7 +292,7 @@ func TestBlockMapperSetupDeviceError(t *testing.T) {
 	if _, err := os.Stat(devDir); err == nil {
 		t.Errorf("volume publish device directory %s was not deleted", devDir)
 	}
-	stagingPath := csiMapper.getStagingPath()
+
 	if _, err := os.Stat(stagingPath); err == nil {
 		t.Errorf("volume staging path %s was not deleted", stagingPath)
 	}
@@ -474,12 +474,11 @@ func TestVolumeSetupTeardown(t *testing.T) {
 	}
 	t.Log("created attachement ", attachID)
 
-	err = csiMapper.SetUpDevice()
+	stagingPath, err := csiMapper.SetUpDevice()
 	if err != nil {
 		t.Fatalf("mapper failed to SetupDevice: %v", err)
 	}
 	// Check if NodeStageVolume staged to the right path
-	stagingPath := csiMapper.getStagingPath()
 	svols := csiMapper.csiClient.(*fakeCsiDriverClient).nodeClient.GetNodeStagedVolumes()
 	svol, ok := svols[csiMapper.volumeID]
 	if !ok {

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -282,16 +282,22 @@ func (c *csiDriverClient) NodeExpandVolume(ctx context.Context, opts csiResizeOp
 	defer closer.Close()
 
 	req := &csipbv1.NodeExpandVolumeRequest{
-		VolumeId:          opts.volumeID,
-		VolumePath:        opts.volumePath,
-		StagingTargetPath: opts.stagingTargetPath,
-		CapacityRange:     &csipbv1.CapacityRange{RequiredBytes: opts.newSize.Value()},
+		VolumeId:      opts.volumeID,
+		VolumePath:    opts.volumePath,
+		CapacityRange: &csipbv1.CapacityRange{RequiredBytes: opts.newSize.Value()},
 		VolumeCapability: &csipbv1.VolumeCapability{
 			AccessMode: &csipbv1.VolumeCapability_AccessMode{
 				Mode: asCSIAccessModeV1(opts.accessMode),
 			},
 		},
 	}
+
+	// not all CSI drivers support NodeStageUnstage and hence the StagingTargetPath
+	// should only be set when available
+	if opts.stagingTargetPath != "" {
+		req.StagingTargetPath = opts.stagingTargetPath
+	}
+
 	if opts.fsType == fsTypeBlockName {
 		req.VolumeCapability.AccessType = &csipbv1.VolumeCapability_Block{
 			Block: &csipbv1.VolumeCapability_BlockVolume{},

--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -54,7 +54,7 @@ type csiClient interface {
 		fsType string,
 		mountOptions []string,
 	) error
-	NodeExpandVolume(ctx context.Context, volumeid, volumePath string, newSize resource.Quantity) (resource.Quantity, error)
+	NodeExpandVolume(ctx context.Context, rsOpts csiResizeOptions) (resource.Quantity, error)
 	NodeUnpublishVolume(
 		ctx context.Context,
 		volID string,
@@ -93,6 +93,16 @@ type csiDriverClient struct {
 	driverName          csiDriverName
 	addr                csiAddr
 	nodeV1ClientCreator nodeV1ClientCreator
+}
+
+type csiResizeOptions struct {
+	volumeid          string
+	volumePath        string
+	stagingTargetPath string
+	fsType            string
+	accessMode        api.PersistentVolumeAccessMode
+	newSize           resource.Quantity
+	mountOptions      []string
 }
 
 var _ csiClient = &csiDriverClient{}
@@ -245,36 +255,55 @@ func (c *csiDriverClient) NodePublishVolume(
 	return err
 }
 
-func (c *csiDriverClient) NodeExpandVolume(ctx context.Context, volumeID, volumePath string, newSize resource.Quantity) (resource.Quantity, error) {
+func (c *csiDriverClient) NodeExpandVolume(ctx context.Context, opts csiResizeOptions) (resource.Quantity, error) {
 	if c.nodeV1ClientCreator == nil {
-		return newSize, fmt.Errorf("version of CSI driver does not support volume expansion")
+		return opts.newSize, fmt.Errorf("version of CSI driver does not support volume expansion")
 	}
 
-	if volumeID == "" {
-		return newSize, errors.New("missing volume id")
+	if opts.volumeid == "" {
+		return opts.newSize, errors.New("missing volume id")
 	}
-	if volumePath == "" {
-		return newSize, errors.New("missing volume path")
+	if opts.volumeid == "" {
+		return opts.newSize, errors.New("missing volume path")
 	}
 
-	if newSize.Value() < 0 {
-		return newSize, errors.New("size can not be less than 0")
+	if opts.newSize.Value() < 0 {
+		return opts.newSize, errors.New("size can not be less than 0")
 	}
 
 	nodeClient, closer, err := c.nodeV1ClientCreator(c.addr)
 	if err != nil {
-		return newSize, err
+		return opts.newSize, err
 	}
 	defer closer.Close()
 
 	req := &csipbv1.NodeExpandVolumeRequest{
-		VolumeId:      volumeID,
-		VolumePath:    volumePath,
-		CapacityRange: &csipbv1.CapacityRange{RequiredBytes: newSize.Value()},
+		VolumeId:          opts.volumeid,
+		VolumePath:        opts.volumePath,
+		StagingTargetPath: opts.stagingTargetPath,
+		CapacityRange:     &csipbv1.CapacityRange{RequiredBytes: opts.newSize.Value()},
+		VolumeCapability: &csipbv1.VolumeCapability{
+			AccessMode: &csipbv1.VolumeCapability_AccessMode{
+				Mode: asCSIAccessModeV1(opts.accessMode),
+			},
+		},
 	}
+	if opts.fsType == fsTypeBlockName {
+		req.VolumeCapability.AccessType = &csipbv1.VolumeCapability_Block{
+			Block: &csipbv1.VolumeCapability_BlockVolume{},
+		}
+	} else {
+		req.VolumeCapability.AccessType = &csipbv1.VolumeCapability_Mount{
+			Mount: &csipbv1.VolumeCapability_MountVolume{
+				FsType:     opts.fsType,
+				MountFlags: opts.mountOptions,
+			},
+		}
+	}
+
 	resp, err := nodeClient.NodeExpandVolume(ctx, req)
 	if err != nil {
-		return newSize, err
+		return opts.newSize, err
 	}
 	updatedQuantity := resource.NewQuantity(resp.CapacityBytes, resource.BinarySI)
 	return *updatedQuantity, nil

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -287,7 +287,7 @@ func (c *fakeCsiDriverClient) NodeSupportsStageUnstage(ctx context.Context) (boo
 func (c *fakeCsiDriverClient) NodeExpandVolume(ctx context.Context, opts csiResizeOptions) (resource.Quantity, error) {
 	c.t.Log("calling fake.NodeExpandVolume")
 	req := &csipbv1.NodeExpandVolumeRequest{
-		VolumeId:          opts.volumeid,
+		VolumeId:          opts.volumeID,
 		VolumePath:        opts.volumePath,
 		StagingTargetPath: opts.stagingTargetPath,
 		CapacityRange:     &csipbv1.CapacityRange{RequiredBytes: opts.newSize.Value()},
@@ -653,7 +653,7 @@ func TestNodeExpandVolume(t *testing.T) {
 				return nodeClient, fakeCloser, nil
 			},
 		}
-		opts := csiResizeOptions{volumeid: tc.volID, volumePath: tc.volumePath, newSize: tc.newSize}
+		opts := csiResizeOptions{volumeID: tc.volID, volumePath: tc.volumePath, newSize: tc.newSize}
 		_, err := client.NodeExpandVolume(context.Background(), opts)
 		checkErr(t, tc.mustFail, err)
 		if !tc.mustFail {

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -284,16 +284,34 @@ func (c *fakeCsiDriverClient) NodeSupportsStageUnstage(ctx context.Context) (boo
 	return stageUnstageSet, nil
 }
 
-func (c *fakeCsiDriverClient) NodeExpandVolume(ctx context.Context, volumeid, volumePath string, newSize resource.Quantity) (resource.Quantity, error) {
+func (c *fakeCsiDriverClient) NodeExpandVolume(ctx context.Context, opts csiResizeOptions) (resource.Quantity, error) {
 	c.t.Log("calling fake.NodeExpandVolume")
 	req := &csipbv1.NodeExpandVolumeRequest{
-		VolumeId:      volumeid,
-		VolumePath:    volumePath,
-		CapacityRange: &csipbv1.CapacityRange{RequiredBytes: newSize.Value()},
+		VolumeId:          opts.volumeid,
+		VolumePath:        opts.volumePath,
+		StagingTargetPath: opts.stagingTargetPath,
+		CapacityRange:     &csipbv1.CapacityRange{RequiredBytes: opts.newSize.Value()},
+		VolumeCapability: &csipbv1.VolumeCapability{
+			AccessMode: &csipbv1.VolumeCapability_AccessMode{
+				Mode: asCSIAccessModeV1(opts.accessMode),
+			},
+		},
+	}
+	if opts.fsType == fsTypeBlockName {
+		req.VolumeCapability.AccessType = &csipbv1.VolumeCapability_Block{
+			Block: &csipbv1.VolumeCapability_BlockVolume{},
+		}
+	} else {
+		req.VolumeCapability.AccessType = &csipbv1.VolumeCapability_Mount{
+			Mount: &csipbv1.VolumeCapability_MountVolume{
+				FsType:     opts.fsType,
+				MountFlags: opts.mountOptions,
+			},
+		}
 	}
 	resp, err := c.nodeClient.NodeExpandVolume(ctx, req)
 	if err != nil {
-		return newSize, err
+		return opts.newSize, err
 	}
 	updatedQuantity := resource.NewQuantity(resp.CapacityBytes, resource.BinarySI)
 	return *updatedQuantity, nil
@@ -635,7 +653,8 @@ func TestNodeExpandVolume(t *testing.T) {
 				return nodeClient, fakeCloser, nil
 			},
 		}
-		_, err := client.NodeExpandVolume(context.Background(), tc.volID, tc.volumePath, tc.newSize)
+		opts := csiResizeOptions{volumeid: tc.volID, volumePath: tc.volumePath, newSize: tc.newSize}
+		_, err := client.NodeExpandVolume(context.Background(), opts)
 		checkErr(t, tc.mustFail, err)
 		if !tc.mustFail {
 			fakeCloser.Check()

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -102,7 +102,7 @@ func (c *csiPlugin) nodeExpandWithClient(
 	opts := csiResizeOptions{
 		volumePath:        resizeOptions.DeviceMountPath,
 		stagingTargetPath: resizeOptions.DeviceStagePath,
-		volumeid:          csiSource.VolumeHandle,
+		volumeID:          csiSource.VolumeHandle,
 		newSize:           resizeOptions.NewSize,
 		fsType:            csiSource.FSType,
 		accessMode:        api.ReadWriteOnce,

--- a/pkg/volume/csi/expander.go
+++ b/pkg/volume/csi/expander.go
@@ -108,7 +108,11 @@ func (c *csiPlugin) nodeExpandWithClient(
 		accessMode:        api.ReadWriteOnce,
 		mountOptions:      pv.Spec.MountOptions,
 	}
+
 	if !fsVolume {
+		// for block volumes the volumePath in CSI NodeExpandvolumeRequest is
+		// basically same as DevicePath because block devices are not mounted and hence
+		// DeviceMountPath does not get populated in resizeOptions.DeviceMountPath
 		opts.volumePath = resizeOptions.DevicePath
 		opts.fsType = fsTypeBlockName
 	}

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -79,14 +79,15 @@ type CSIVolume struct {
 
 // NodeClient returns CSI node client
 type NodeClient struct {
-	nodePublishedVolumes map[string]CSIVolume
-	nodeStagedVolumes    map[string]CSIVolume
-	stageUnstageSet      bool
-	expansionSet         bool
-	volumeStatsSet       bool
-	nodeGetInfoResp      *csipb.NodeGetInfoResponse
-	nodeVolumeStatsResp  *csipb.NodeGetVolumeStatsResponse
-	nextErr              error
+	nodePublishedVolumes     map[string]CSIVolume
+	nodeStagedVolumes        map[string]CSIVolume
+	stageUnstageSet          bool
+	expansionSet             bool
+	volumeStatsSet           bool
+	nodeGetInfoResp          *csipb.NodeGetInfoResponse
+	nodeVolumeStatsResp      *csipb.NodeGetVolumeStatsResponse
+	FakeNodeExpansionRequest *csipb.NodeExpandVolumeRequest
+	nextErr                  error
 }
 
 // NewNodeClient returns fake node client
@@ -295,6 +296,8 @@ func (f *NodeClient) NodeExpandVolume(ctx context.Context, req *csipb.NodeExpand
 	if req.GetCapacityRange().RequiredBytes <= 0 {
 		return nil, errors.New("required bytes should be greater than 0")
 	}
+
+	f.FakeNodeExpansionRequest = req
 
 	resp := &csipb.NodeExpandVolumeResponse{
 		CapacityBytes: req.GetCapacityRange().RequiredBytes,

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -610,8 +610,8 @@ var _ volume.BlockVolumeMapper = &localVolumeMapper{}
 var _ volume.CustomBlockVolumeMapper = &localVolumeMapper{}
 
 // SetUpDevice prepares the volume to the node by the plugin specific way.
-func (m *localVolumeMapper) SetUpDevice() error {
-	return nil
+func (m *localVolumeMapper) SetUpDevice() (string, error) {
+	return "", nil
 }
 
 // MapPodDevice provides physical device path for the local PV.

--- a/pkg/volume/local/local.go
+++ b/pkg/volume/local/local.go
@@ -621,6 +621,11 @@ func (m *localVolumeMapper) MapPodDevice() (string, error) {
 	return globalPath, nil
 }
 
+// GetStagingPath returns
+func (m *localVolumeMapper) GetStagingPath() string {
+	return ""
+}
+
 // localVolumeUnmapper implements the BlockVolumeUnmapper interface for local volumes.
 type localVolumeUnmapper struct {
 	*localVolume

--- a/pkg/volume/local/local_test.go
+++ b/pkg/volume/local/local_test.go
@@ -375,7 +375,7 @@ func TestMapUnmap(t *testing.T) {
 	var devPath string
 
 	if customMapper, ok := mapper.(volume.CustomBlockVolumeMapper); ok {
-		err = customMapper.SetUpDevice()
+		_, err = customMapper.SetUpDevice()
 		if err != nil {
 			t.Errorf("Failed to SetUpDevice, err: %v", err)
 		}

--- a/pkg/volume/plugins.go
+++ b/pkg/volume/plugins.go
@@ -115,6 +115,9 @@ type NodeResizeOptions struct {
 	// it would be location where volume was mounted for the pod
 	DeviceMountPath string
 
+	// DeviceStagingPath stores location where the volume is staged
+	DeviceStagePath string
+
 	NewSize resource.Quantity
 	OldSize resource.Quantity
 

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -998,6 +998,10 @@ func (fv *FakeVolume) SetUpDevice() (string, error) {
 	return "", nil
 }
 
+func (fv *FakeVolume) GetStagingPath() string {
+	return filepath.Join(fv.Plugin.Host.GetVolumeDevicePluginDir(utilstrings.EscapeQualifiedName(fv.Plugin.PluginName)), "staging", fv.VolName)
+}
+
 // Block volume support
 func (fv *FakeVolume) GetSetUpDeviceCallCount() int {
 	fv.RLock()

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -956,46 +956,46 @@ func (fv *FakeVolume) TearDownAt(dir string) error {
 }
 
 // Block volume support
-func (fv *FakeVolume) SetUpDevice() error {
+func (fv *FakeVolume) SetUpDevice() (string, error) {
 	fv.Lock()
 	defer fv.Unlock()
 	if fv.VolName == TimeoutOnMountDeviceVolumeName {
 		fv.DeviceMountState[fv.VolName] = deviceMountUncertain
-		return volumetypes.NewUncertainProgressError("mount failed")
+		return "", volumetypes.NewUncertainProgressError("mount failed")
 	}
 	if fv.VolName == FailMountDeviceVolumeName {
 		fv.DeviceMountState[fv.VolName] = deviceNotMounted
-		return fmt.Errorf("error mapping disk: %s", fv.VolName)
+		return "", fmt.Errorf("error mapping disk: %s", fv.VolName)
 	}
 
 	if fv.VolName == TimeoutAndFailOnMountDeviceVolumeName {
 		_, ok := fv.DeviceMountState[fv.VolName]
 		if !ok {
 			fv.DeviceMountState[fv.VolName] = deviceMountUncertain
-			return volumetypes.NewUncertainProgressError("timed out mounting error")
+			return "", volumetypes.NewUncertainProgressError("timed out mounting error")
 		}
 		fv.DeviceMountState[fv.VolName] = deviceNotMounted
-		return fmt.Errorf("error mapping disk: %s", fv.VolName)
+		return "", fmt.Errorf("error mapping disk: %s", fv.VolName)
 	}
 
 	if fv.VolName == SuccessAndTimeoutDeviceName {
 		_, ok := fv.DeviceMountState[fv.VolName]
 		if ok {
 			fv.DeviceMountState[fv.VolName] = deviceMountUncertain
-			return volumetypes.NewUncertainProgressError("error mounting state")
+			return "", volumetypes.NewUncertainProgressError("error mounting state")
 		}
 	}
 	if fv.VolName == SuccessAndFailOnMountDeviceName {
 		_, ok := fv.DeviceMountState[fv.VolName]
 		if ok {
-			return fmt.Errorf("error mapping disk: %s", fv.VolName)
+			return "", fmt.Errorf("error mapping disk: %s", fv.VolName)
 		}
 	}
 
 	fv.DeviceMountState[fv.VolName] = deviceMounted
 	fv.SetUpDeviceCallCount++
 
-	return nil
+	return "", nil
 }
 
 // Block volume support

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -604,6 +604,7 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 			}
 
 			resizeOptions.DeviceMountPath = deviceMountPath
+			resizeOptions.DeviceStagePath = deviceMountPath
 			resizeOptions.CSIVolumePhase = volume.CSIVolumeStaged
 
 			// NodeExpandVolume will resize the file system if user has requested a resize of
@@ -1505,6 +1506,7 @@ func (og *operationGenerator) GenerateExpandInUseVolumeFunc(
 					return volumeToMount.GenerateError("NodeExpandVolume.GetDeviceMountPath failed", err)
 				}
 				resizeOptions.DeviceMountPath = dmp
+				resizeOptions.DeviceStagePath = dmp
 				resizeDone, simpleErr, detailedErr = og.doOnlineExpansion(volumeToMount, actualStateOfWorld, resizeOptions)
 				if simpleErr != nil || detailedErr != nil {
 					return simpleErr, detailedErr

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -603,6 +603,10 @@ func (og *operationGenerator) GenerateMountVolumeFunc(
 				return volumeToMount.GenerateError("MountVolume.MarkDeviceAsMounted failed", markDeviceMountedErr)
 			}
 
+			// If volume expansion is performed after MountDevice but before SetUp then
+			// deviceMountPath and deviceStagePath is going to be the same.
+			// Deprecation: Calling NodeExpandVolume after NodeStage/MountDevice will be deprecated
+			// in a future version of k8s.
 			resizeOptions.DeviceMountPath = deviceMountPath
 			resizeOptions.DeviceStagePath = deviceMountPath
 			resizeOptions.CSIVolumePhase = volume.CSIVolumeStaged

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -174,14 +174,15 @@ type CustomBlockVolumeMapper interface {
 	// For most in-tree plugins, attacher.Attach() and attacher.WaitForAttach()
 	// will do necessary works.
 	// This may be called more than once, so implementations must be idempotent.
-	SetUpDevice() (string, error)
+	// SetUpDevice returns stagingPath if device setup was successful
+	SetUpDevice() (stagingPath string, err error)
 
 	// MapPodDevice maps the block device to a path and return the path.
 	// Unique device path across kubelet node reboot is required to avoid
 	// unexpected block volume destruction.
 	// If empty string is returned, the path retuned by attacher.Attach() and
 	// attacher.WaitForAttach() will be used.
-	MapPodDevice() (string, error)
+	MapPodDevice() (publishPath string, err error)
 }
 
 // BlockVolumeUnmapper interface is an unmapper interface for block volume.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -183,6 +183,10 @@ type CustomBlockVolumeMapper interface {
 	// If empty string is returned, the path retuned by attacher.Attach() and
 	// attacher.WaitForAttach() will be used.
 	MapPodDevice() (publishPath string, err error)
+
+	// GetStagingPath returns path that was used for staging the volume
+	// it is mainly used by CSI plugins
+	GetStagingPath() string
 }
 
 // BlockVolumeUnmapper interface is an unmapper interface for block volume.

--- a/pkg/volume/volume.go
+++ b/pkg/volume/volume.go
@@ -174,7 +174,7 @@ type CustomBlockVolumeMapper interface {
 	// For most in-tree plugins, attacher.Attach() and attacher.WaitForAttach()
 	// will do necessary works.
 	// This may be called more than once, so implementations must be idempotent.
-	SetUpDevice() error
+	SetUpDevice() (string, error)
 
 	// MapPodDevice maps the block device to a path and return the path.
 	// Unique device path across kubelet node reboot is required to avoid


### PR DESCRIPTION
Supply missing fields into CSI node expansion volume requests

/sig storage

xref https://github.com/kubernetes/kubernetes/issues/86923

Also added test and verified manually:

Before:

```
I0701 15:40:55.257687       1 server.go:117] GRPC call: /csi.v1.Node/NodeExpandVolume
I0701 15:40:55.257700       1 server.go:118] GRPC request: {"capacity_range":{"required_bytes":4294967296},"volume_id":"07c6c2bc-bbb1-11ea-954d-0242ac110003","volume_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-d2e05ee7-007a-40db-b1d5-9ba9785cce9f/c26cd
7e3-c700-432b-8543-a48cb04dc045"}
```

After

```
0701 16:11:29.322344       1 server.go:117] GRPC call: /csi.v1.Node/NodeExpandVolume
I0701 16:11:29.322360       1 server.go:118] GRPC request: {"capacity_range":{"required_bytes":4294967296},"staging_target_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/staging/pvc-e429965b-a125-4032-92be-42938363b82c","volume_capability":{"AccessType":{"Block":{}},
"access_mode":{"mode":1}},"volume_id":"49682ea9-bbb5-11ea-9490-0242ac110003","volume_path":"/var/lib/kubelet/plugins/kubernetes.io/csi/volumeDevices/publish/pvc-e429965b-a125-4032-92be-42938363b82c/8dfb3718-fdae-45bc-8e74-c9a2e2303ed9"}
I0701 16:11:29.324695       1 server.go:123] GRPC response: {}
```


/kind bug

```release-note
Ensure that volume capability and staging target fields are present in nodeExpansion CSI calls
Behaviour of NodeExpandVolume being called between NodeStage and NodePublish is deprecated for CSI volumes. CSI drivers should support calling NodeExpandVolume after NodePublish if they have node EXPAND_VOLUME capability
```
