### PR TITLE
Automated cherry pick of #84654: Drop version from static openapi json file

### DIFF
--- a/hack/update-openapi-spec.sh
+++ b/hack/update-openapi-spec.sh
@@ -86,7 +86,7 @@ fi
 
 kube::log::status "Updating " "${OPENAPI_ROOT_DIR}"
 
-curl -w "\n" -fs "${API_HOST}:${API_PORT}/openapi/v2" | jq -S . > "${OPENAPI_ROOT_DIR}/swagger.json"
+curl -w "\n" -fs "${API_HOST}:${API_PORT}/openapi/v2" | jq -S '.info.version="unversioned"' > "${OPENAPI_ROOT_DIR}/swagger.json"
 
 kube::log::status "SUCCESS"
 


### PR DESCRIPTION
Cherry pick of #84654 on release-1.17.

#84654: Drop version from static openapi json file

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```