### PR TITLE
Add '-n <namespace' to kubectl attach command output after session detach

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -293,7 +293,7 @@ func (o *AttachOptions) Run() error {
 	}
 
 	if o.Stdin && t.Raw && o.Pod.Spec.RestartPolicy == corev1.RestartPolicyAlways {
-		fmt.Fprintf(o.Out, "Session ended, resume using '%s %s -c %s -i -t' command when the pod is running\n", o.CommandName, o.Pod.Name, containerToAttach.Name)
+		fmt.Fprintf(o.Out, "Session ended, resume using '%s -n %s %s -c %s -i -t' command when the pod is running\n", o.CommandName, o.Pod.Namespace, o.Pod.Name, containerToAttach.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

- Currently, when you use `kubectl run -i --tty <pod> --sh` to create a Pod
  on a K8s cluster and attach your terminal to it and then detach/exit your
  session, the output message printed that includes a `kubectl attach` command
  to reattach is not complete and omits the proper Namespace flag.
  - Example message: `Session ended, resume using 'kubectl attach busybox -c busybox -i -t' command when the pod is running`
- This commit changes the detachment message to include the proper
  Namespace flag like so:
  - New Example message: `Session ended, resume using 'kubectl attach -n mynamespace busybox -c busybox -i -t' command when the pod is running`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #86976

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Include proper namespace flag in kubectl attach command outputted on kubectl run session detachment
```