### PR TITLE
Remove test/e2e dependency on scheduler/predicates package

### DIFF
--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -76,8 +76,6 @@
 				"k8s.io/kubernetes/pkg/master/ports",
 				"k8s.io/kubernetes/pkg/registry/core/service/allocator",
 				"k8s.io/kubernetes/pkg/registry/core/service/portallocator",
-				"k8s.io/kubernetes/pkg/scheduler/algorithm",
-				"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates",
 				"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util",
 				"k8s.io/kubernetes/pkg/scheduler/api",
 				"k8s.io/kubernetes/pkg/scheduler/metrics",

--- a/test/e2e/framework/node/BUILD
+++ b/test/e2e/framework/node/BUILD
@@ -9,8 +9,8 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/framework/node",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/controller/nodelifecycle:go_default_library",
-        "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Scheduler predicates are deprecated, this PR cleans up test/e2e dependency on the predicates package.

**Which issue(s) this PR fixes**:
Ref #85822

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
