### PR TITLE
Add charset check for go files

### DIFF
--- a/hack/verify-gofile-charset.sh
+++ b/hack/verify-gofile-charset.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GoFmt apparently is changing @ head...
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
+source "${KUBE_ROOT}/hack/lib/init.sh"
+
+cd "${KUBE_ROOT}"
+
+find_files() {
+  # TODO: Need to check other go files also
+  find test/e2e/storage/ -name '*.go'
+}
+
+invalid_files=()
+for gofile in `find_files`
+do
+	if [ -n "$(file -i ${gofile} | grep utf-8)" ]
+	then
+		invalid_files+=( "${gofile}" )
+	fi
+done
+
+if [ ${#invalid_files[@]} -ne 0 ]; then
+  {
+    echo "Errors:"
+    for err in "${invalid_files[@]}"; do
+      echo "$err"
+    done
+    echo
+    echo 'The above files contains non-ascii string, need to remove it'
+    echo
+  } >&2
+  exit 1
+fi

--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -193,7 +193,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 
 	// Slow by design [~150 Seconds].
 	// This test uses deprecated GitRepo VolumeSource so it MUST not be promoted to Conformance.
-	// To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod’s container.
+	// To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
 	// This projected volume maps approach can also be tested with secrets and downwardapi VolumeSource but are less prone to the race problem.
 	ginkgo.It("should not cause race condition when used for git_repo [Serial] [Slow]", func() {
 		gitURL, gitRepo, cleanup := createGitServer(f)

--- a/test/e2e/storage/testsuites/base_test.go
+++ b/test/e2e/storage/testsuites/base_test.go
@@ -26,7 +26,7 @@ import (
 // intersection of the intervals (if it exists) and return the minimum of the intersection
 // to be used as the claim size for the test.
 // if value not set, that means there's no minimum or maximum size limitation and we set default size for it.
-// Considerate all corner case as followed：
+// Considerate all corner case as followed:
 // first: A,B is regular value and ? means unspecified
 // second: C,D is regular value and ? means unspecified
 // ----------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Accedentally non-ascii charactors can be included and it is hard to
detect them during human review process.
This adds charset check as one of verify jobs.

**Special notes for your reviewer**:

Current check just covers `test/e2e/storage/` only because there is a lot of non-ascii chars.
At this time, I'd like to see we can get a consensus of this before taking much time.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

