### PR TITLE
Fix rbac.yaml links in storage-csi README

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/external-attacher/README.md
+++ b/test/e2e/testing-manifests/storage-csi/external-attacher/README.md
@@ -1,1 +1,1 @@
-The original file is https://github.com/kubernetes-csi/external-attacher/blob/<version>/deploy/kubernetes/rbac.yaml
+The original file is https://github.com/kubernetes-csi/external-attacher/blob/master/deploy/kubernetes/rbac.yaml

--- a/test/e2e/testing-manifests/storage-csi/external-provisioner/README.md
+++ b/test/e2e/testing-manifests/storage-csi/external-provisioner/README.md
@@ -1,1 +1,1 @@
-The original file is https://github.com/kubernetes-csi/external-provisioner/blob/<version>/deploy/kubernetes/rbac.yaml
+The original file is https://github.com/kubernetes-csi/external-provisioner/blob/master/deploy/kubernetes/rbac.yaml

--- a/test/e2e/testing-manifests/storage-csi/external-resizer/README.md
+++ b/test/e2e/testing-manifests/storage-csi/external-resizer/README.md
@@ -1,1 +1,1 @@
-The original file is https://github.com/kubernetes-csi/external-resizer/blob/<version>/deploy/kubernetes/rbac.yaml
+The original file is https://github.com/kubernetes-csi/external-resizer/blob/master/deploy/kubernetes/rbac.yaml

--- a/test/e2e/testing-manifests/storage-csi/external-snapshotter/README.md
+++ b/test/e2e/testing-manifests/storage-csi/external-snapshotter/README.md
@@ -1,1 +1,1 @@
-The original file is https://github.com/kubernetes-csi/external-snapshotter/blob/<version>/deploy/kubernetes/rbac.yaml
+The original file is https://github.com/kubernetes-csi/external-snapshotter/blob/master/deploy/kubernetes/csi-snapshotter/rbac-external-provisioner.yaml


### PR DESCRIPTION
Signed-off-by: Bharath Thiruveedula <bharath_ves@hotmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>

> /kind documentation

**What this PR does / why we need it**:
Fixes the rbac.yaml reference links in storage-csi README files
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #86651

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
