### PR TITLE
fix staticcheck:test/integration/ttlcontroller/

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -58,7 +58,6 @@ test/integration/examples
 test/integration/framework
 test/integration/garbagecollector
 test/integration/scheduler_perf
-test/integration/ttlcontroller
 vendor/k8s.io/apimachinery/pkg/api/meta
 vendor/k8s.io/apimachinery/pkg/api/resource
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured

--- a/test/integration/ttlcontroller/ttlcontroller_test.go
+++ b/test/integration/ttlcontroller/ttlcontroller_test.go
@@ -60,7 +60,8 @@ func createNodes(t *testing.T, client *clientset.Clientset, startIndex, endIndex
 				},
 			}
 			if _, err := client.CoreV1().Nodes().Create(node); err != nil {
-				t.Fatalf("Failed to create node: %v", err)
+				t.Errorf("Failed to create node: %v", err)
+				return
 			}
 		}(i)
 	}
@@ -75,7 +76,8 @@ func deleteNodes(t *testing.T, client *clientset.Clientset, startIndex, endIndex
 			defer wg.Done()
 			name := fmt.Sprintf("node-%d", idx)
 			if err := client.CoreV1().Nodes().Delete(name, &metav1.DeleteOptions{}); err != nil {
-				t.Fatalf("Failed to delete node: %v", err)
+				t.Errorf("Failed to delete node: %v", err)
+				return
 			}
 		}(i)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind cleanup


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:https://github.com/kubernetes/kubernetes/issues/81657

**Special notes for your reviewer**:
I referred to this link(https://github.com/minio/minio/pull/6682)
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
test/integration/ttlcontroller/ttlcontroller_test.go:55:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
test/integration/ttlcontroller/ttlcontroller_test.go:74:3: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
```
