### PR TITLE
pkg/controller/: cleanup staticcheck

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,11 +1,8 @@
 cluster/images/etcd/migrate
 pkg/controller/daemon
 pkg/controller/deployment
-pkg/controller/garbagecollector
 pkg/controller/nodeipam
 pkg/controller/podautoscaler
-pkg/controller/replicaset
-pkg/controller/resourcequota
 pkg/controller/statefulset
 pkg/probe/http
 pkg/registry/autoscaling/horizontalpodautoscaler/storage

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -910,7 +910,7 @@ func expectSyncNotBlocked(fakeDiscoveryClient *fakeServerResources, workerLock *
 	workerLockAcquired := make(chan struct{})
 	go func() {
 		workerLock.Lock()
-		workerLock.Unlock()
+		defer workerLock.Unlock()
 		close(workerLockAcquired)
 	}()
 	select {

--- a/pkg/controller/replicaset/replica_set_test.go
+++ b/pkg/controller/replicaset/replica_set_test.go
@@ -503,13 +503,6 @@ func TestPodControllerLookup(t *testing.T) {
 	}
 }
 
-// byName sorts pods by their names.
-type byName []*v1.Pod
-
-func (pods byName) Len() int           { return len(pods) }
-func (pods byName) Swap(i, j int)      { pods[i], pods[j] = pods[j], pods[i] }
-func (pods byName) Less(i, j int) bool { return pods[i].Name < pods[j].Name }
-
 func TestRelatedPodsLookup(t *testing.T) {
 	someRS := newReplicaSet(1, map[string]string{"foo": "bar"})
 	someRS.Name = "foo1"
@@ -1123,7 +1116,7 @@ func TestDeleteControllerAndExpectations(t *testing.T) {
 	manager.deleteRS(rs)
 	manager.syncReplicaSet(GetKey(rs, t))
 
-	if _, exists, err = manager.expectations.GetExpectations(rsKey); exists {
+	if _, exists, _ = manager.expectations.GetExpectations(rsKey); exists {
 		t.Errorf("Found expectations, expected none since the ReplicaSet has been deleted.")
 	}
 
@@ -1215,7 +1208,7 @@ func TestExpectationsOnRecreate(t *testing.T) {
 		t.Fatalf("Deleting RS didn't result in new item in the queue: %v", err)
 	}
 
-	rsExp, exists, err = manager.expectations.GetExpectations(oldRSKey)
+	_, exists, err = manager.expectations.GetExpectations(oldRSKey)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/resourcequota/resource_quota_controller_test.go
+++ b/pkg/controller/resourcequota/resource_quota_controller_test.go
@@ -1138,7 +1138,7 @@ func expectSyncNotBlocked(fakeDiscoveryClient *fakeServerResources, workerLock *
 	workerLockAcquired := make(chan struct{})
 	go func() {
 		workerLock.Lock()
-		workerLock.Unlock()
+		defer workerLock.Unlock()
 		close(workerLockAcquired)
 	}()
 	select {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**


/kind cleanup

**What this PR does / why we need it**:

pkg/controller/: cleanup staticcheck

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:https://github.com/kubernetes/kubernetes/issues/81657

**Special notes for your reviewer**:

```
pkg/controller/garbagecollector/garbagecollector_test.go:913:3: empty critical section (SA2001)
pkg/controller/podgc/gc_controller_test.go:39:6: type FakeController is unused (U1000)
pkg/controller/replicaset/replica_set_test.go:507:6: type byName is unused (U1000)
pkg/controller/replicaset/replica_set_test.go:1126:16: this value of err is never used (SA4006)
pkg/controller/replicaset/replica_set_test.go:1218:2: this value of rsExp is never used (SA4006)
pkg/controller/resourcequota/resource_quota_controller_test.go:1141:3: empty critical section (SA2001)
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
