### PR TITLE
Break Filter plugins dependency on predicates package

### DIFF
--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -37,8 +37,6 @@ var (
 	ErrPodNotMatchHostName = NewPredicateFailureError("HostName", "node(s) didn't match the requested hostname")
 	// ErrPodNotFitsHostPorts is used for PodFitsHostPorts predicate error.
 	ErrPodNotFitsHostPorts = NewPredicateFailureError("PodFitsHostPorts", "node(s) didn't have free ports for the requested pod ports")
-	// ErrServiceAffinityViolated is used for CheckServiceAffinity predicate error.
-	ErrServiceAffinityViolated = NewPredicateFailureError("CheckServiceAffinity", "node(s) didn't match service affinity")
 	// ErrNodeUnderMemoryPressure is used for NodeUnderMemoryPressure predicate error.
 	ErrNodeUnderMemoryPressure = NewPredicateFailureError("NodeUnderMemoryPressure", "node(s) had memory pressure")
 	// ErrNodeUnderDiskPressure is used for NodeUnderDiskPressure predicate error.

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/BUILD
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/BUILD
@@ -39,7 +39,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/features:go_default_library",
-        "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/listers/fake:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -34,7 +34,6 @@ import (
 	csitrans "k8s.io/csi-translation-lib"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	fakelisters "k8s.io/kubernetes/pkg/scheduler/listers/fake"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -247,7 +246,6 @@ func TestCSILimits(t *testing.T) {
 		test                  string
 		migrationEnabled      bool
 		limitSource           string
-		expectedFailureReason *predicates.PredicateFailureError
 		wantStatus            *framework.Status
 	}{
 		{

--- a/pkg/scheduler/framework/plugins/serviceaffinity/BUILD
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/BUILD
@@ -6,8 +6,6 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/serviceaffinity",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/scheduler/algorithm/predicates:go_default_library",
-        "//pkg/scheduler/framework/plugins/migration:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/listers:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
@@ -25,8 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/klog"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/migration"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	schedulerlisters "k8s.io/kubernetes/pkg/scheduler/listers"
 	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -39,6 +37,9 @@ const (
 	// preFilterStateKey is the key in CycleState to InterPodAffinity pre-computed data.
 	// Using the name of the plugin will likely help us avoid collisions with other plugins.
 	preFilterStateKey = "PreFilter" + Name
+
+	// ErrReasonViolated is used for CheckServiceAffinity predicate error.
+	ErrReasonViolated = "node(s) didn't match service affinity"
 )
 
 // Args holds the args that are used to configure the plugin.
@@ -276,7 +277,7 @@ func (pl *ServiceAffinity) Filter(ctx context.Context, cycleState *framework.Cyc
 		return nil
 	}
 
-	return migration.PredicateResultToFrameworkStatus([]predicates.PredicateFailureReason{predicates.ErrServiceAffinityViolated}, nil)
+	return framework.NewStatus(framework.Unschedulable, ErrReasonViolated)
 }
 
 // Score invoked at the Score extension point.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Scheduler predicates and their error types are deprecated. The Scheduler moved to the plugins framework. At the same time, the nodevolumelimit and serviceaffinity filter plugins do not require any of the logic in predicates.

**Which issue(s) this PR fixes**:
Refs #86711

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
