### PR TITLE
Automated cherry pick of #83362: Bind metrics-server containers to linux nodes to avoid

### DIFF
--- a/cluster/addons/metrics-server/metrics-server-deployment.yaml
+++ b/cluster/addons/metrics-server/metrics-server-deployment.yaml
@@ -46,6 +46,8 @@ spec:
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: metrics-server
+      nodeSelector:
+        kubernetes.io/os: linux
       containers:
       - name: metrics-server
         image: k8s.gcr.io/metrics-server-amd64:v0.3.6


### PR DESCRIPTION
Cherry pick of #83362 on release-1.17.

#83362: Bind metrics-server containers to linux nodes to avoid

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
Bind metrics-server containers to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes
```