### PR TITLE
Remove nodevolumelimits filter plugin dependency on predicates package

### DIFF
--- a/pkg/scheduler/framework/plugins/nodevolumelimits/BUILD
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/BUILD
@@ -39,7 +39,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/features:go_default_library",
-        "//pkg/scheduler/algorithm/predicates:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/listers/fake:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi_test.go
@@ -34,7 +34,6 @@ import (
 	csitrans "k8s.io/csi-translation-lib"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
 	"k8s.io/kubernetes/pkg/features"
-	"k8s.io/kubernetes/pkg/scheduler/algorithm/predicates"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	fakelisters "k8s.io/kubernetes/pkg/scheduler/listers/fake"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
@@ -239,16 +238,15 @@ func TestCSILimits(t *testing.T) {
 	}
 
 	tests := []struct {
-		newPod                *v1.Pod
-		existingPods          []*v1.Pod
-		filterName            string
-		maxVols               int
-		driverNames           []string
-		test                  string
-		migrationEnabled      bool
-		limitSource           string
-		expectedFailureReason *predicates.PredicateFailureError
-		wantStatus            *framework.Status
+		newPod           *v1.Pod
+		existingPods     []*v1.Pod
+		filterName       string
+		maxVols          int
+		driverNames      []string
+		test             string
+		migrationEnabled bool
+		limitSource      string
+		wantStatus       *framework.Status
 	}{
 		{
 			newPod:       csiEBSOneVolPod,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Scheduler predicates and their error types are deprecated. The Scheduler moved to the plugins framework. At the same time, the nodevolumelimit filter plugins does not require any of the logic in predicates.

**Which issue(s) this PR fixes**:
Refs #86711

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
