### PR TITLE
Do not require token secrets when using bound service account tokens

### DIFF
--- a/plugin/pkg/admission/serviceaccount/BUILD
+++ b/plugin/pkg/admission/serviceaccount/BUILD
@@ -46,6 +46,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission/testing:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**Which issue(s) this PR fixes**:
Fixes #87028

**Does this PR introduce a user-facing change?**:
```release-note
Fixes service account token admission error in clusters that do not run the service account token controller
```

/sig auth
/cc @mikedanese 