### PR TITLE
Separate skip as framework subpackage

### DIFF
--- a/test/e2e/apimachinery/BUILD
+++ b/test/e2e/apimachinery/BUILD
@@ -88,6 +88,7 @@ go_library(
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/rc:go_default_library",
+        "//test/e2e/framework/skipper:go_default_library",
         "//test/e2e/framework/ssh:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/crd:go_default_library",

--- a/test/e2e/apimachinery/discovery.go
+++ b/test/e2e/apimachinery/discovery.go
@@ -20,6 +20,7 @@ import (
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/apiserver/pkg/endpoints/discovery"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	"k8s.io/kubernetes/test/utils/crd"
 
 	"github.com/onsi/ginkgo"
@@ -34,7 +35,7 @@ var _ = SIGDescribe("Discovery", func() {
 	ginkgo.BeforeEach(func() {
 		namespaceName = f.Namespace.Name
 
-		framework.SkipUnlessServerVersionGTE(storageVersionServerVersion, f.ClientSet.Discovery())
+		e2eskipper.SkipUnlessServerVersionGTE(storageVersionServerVersion, f.ClientSet.Discovery())
 
 		ginkgo.By("Setting up server cert")
 		setupServerCert(namespaceName, serviceName)

--- a/test/e2e/apimachinery/etcd_failure.go
+++ b/test/e2e/apimachinery/etcd_failure.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/apps"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 	testutils "k8s.io/kubernetes/test/utils"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -43,8 +44,8 @@ var _ = SIGDescribe("Etcd failure [Disruptive]", func() {
 		// - master access
 		// ... so the provider check should be identical to the intersection of
 		// providers that provide those capabilities.
-		framework.SkipUnlessProviderIs("gce")
-		framework.SkipUnlessSSHKeyPresent()
+		e2eskipper.SkipUnlessProviderIs("gce")
+		e2eskipper.SkipUnlessSSHKeyPresent()
 
 		err := e2erc.RunRC(testutils.RCConfig{
 			Client:    f.ClientSet,

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	"github.com/onsi/ginkgo"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -1075,7 +1076,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 	})
 
 	ginkgo.It("should delete jobs and pods created by cronjob", func() {
-		framework.SkipIfMissingResource(f.DynamicClient, CronJobGroupVersionResource, f.Namespace.Name)
+		e2eskipper.SkipIfMissingResource(f.DynamicClient, CronJobGroupVersionResource, f.Namespace.Name)
 
 		ginkgo.By("Create the cronjob")
 		cronJob := newCronJob("simple", "*/1 * * * ?")

--- a/test/e2e/apimachinery/generated_clientset.go
+++ b/test/e2e/apimachinery/generated_clientset.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 
 	"github.com/onsi/ginkgo"
 	imageutils "k8s.io/kubernetes/test/utils/image"
@@ -213,7 +214,7 @@ var _ = SIGDescribe("Generated clientset", func() {
 	f := framework.NewDefaultFramework("clientset")
 
 	ginkgo.BeforeEach(func() {
-		framework.SkipIfMissingResource(f.DynamicClient, CronJobGroupVersionResource, f.Namespace.Name)
+		e2eskipper.SkipIfMissingResource(f.DynamicClient, CronJobGroupVersionResource, f.Namespace.Name)
 	})
 
 	ginkgo.It("should create v1beta1 cronJobs, delete cronJobs, watch cronJobs", func() {

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -35,6 +35,7 @@ import (
 	utilversion "k8s.io/apimachinery/pkg/util/version"
 	"k8s.io/cli-runtime/pkg/printers"
 	"k8s.io/kubernetes/test/e2e/framework"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -44,7 +45,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 	f := framework.NewDefaultFramework("tables")
 
 	ginkgo.BeforeEach(func() {
-		framework.SkipUnlessServerVersionGTE(serverPrintVersion, f.ClientSet.Discovery())
+		e2eskipper.SkipUnlessServerVersionGTE(serverPrintVersion, f.ClientSet.Discovery())
 	})
 
 	ginkgo.It("should return pod details", func() {

--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -145,6 +145,7 @@ filegroup(
         "//test/e2e/framework/resource:all-srcs",
         "//test/e2e/framework/security:all-srcs",
         "//test/e2e/framework/service:all-srcs",
+        "//test/e2e/framework/skipper:all-srcs",
         "//test/e2e/framework/ssh:all-srcs",
         "//test/e2e/framework/statefulset:all-srcs",
         "//test/e2e/framework/testfiles:all-srcs",

--- a/test/e2e/framework/skip.go
+++ b/test/e2e/framework/skip.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// This file will be removed after switching to use subpackage skipper.
+
 package framework
 
 import (

--- a/test/e2e/framework/skipper/BUILD
+++ b/test/e2e/framework/skipper/BUILD
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["skipper.go"],
+    importpath = "k8s.io/kubernetes/test/e2e/framework/skipper",
+    visibility = ["//visibility:public"],
+    deps = ["//test/e2e/framework:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package skipper
+
+import (
+	// TODO: Move function logic from framework after all callers switch to use this package
+	"k8s.io/kubernetes/test/e2e/framework"
+)
+
+// Skipf skips with information about why the test is being skipped.
+var Skipf = framework.Skipf
+
+// SkipUnlessAtLeast skips if the value is less than the minValue.
+var SkipUnlessAtLeast = framework.SkipUnlessAtLeast
+
+// SkipUnlessLocalEphemeralStorageEnabled skips if the LocalStorageCapacityIsolation is not enabled.
+var SkipUnlessLocalEphemeralStorageEnabled = framework.SkipUnlessLocalEphemeralStorageEnabled
+
+// SkipIfMissingResource skips if the gvr resource is missing.
+var SkipIfMissingResource = framework.SkipIfMissingResource
+
+// SkipUnlessNodeCountIsAtLeast skips if the number of nodes is less than the minNodeCount.
+var SkipUnlessNodeCountIsAtLeast = framework.SkipUnlessNodeCountIsAtLeast
+
+// SkipUnlessNodeCountIsAtMost skips if the number of nodes is greater than the maxNodeCount.
+var SkipUnlessNodeCountIsAtMost = framework.SkipUnlessNodeCountIsAtMost
+
+// SkipIfProviderIs skips if the provider is included in the unsupportedProviders.
+var SkipIfProviderIs = framework.SkipIfProviderIs
+
+// SkipUnlessProviderIs skips if the provider is not included in the supportedProviders.
+var SkipUnlessProviderIs = framework.SkipUnlessProviderIs
+
+// SkipUnlessMultizone skips if the cluster does not have multizone.
+var SkipUnlessMultizone = framework.SkipUnlessMultizone
+
+// SkipIfMultizone skips if the cluster has multizone.
+var SkipIfMultizone = framework.SkipIfMultizone
+
+// SkipUnlessMasterOSDistroIs skips if the master OS distro is not included in the supportedMasterOsDistros.
+var SkipUnlessMasterOSDistroIs = framework.SkipUnlessMasterOSDistroIs
+
+// SkipUnlessNodeOSDistroIs skips if the node OS distro is not included in the supportedNodeOsDistros.
+var SkipUnlessNodeOSDistroIs = framework.SkipUnlessNodeOSDistroIs
+
+// SkipIfNodeOSDistroIs skips if the node OS distro is included in the unsupportedNodeOsDistros.
+var SkipIfNodeOSDistroIs = framework.SkipIfNodeOSDistroIs
+
+// SkipUnlessServerVersionGTE skips if the server version is less than v.
+var SkipUnlessServerVersionGTE = framework.SkipUnlessServerVersionGTE
+
+// SkipUnlessSSHKeyPresent skips if no SSH key is found.
+var SkipUnlessSSHKeyPresent = framework.SkipUnlessSSHKeyPresent
+
+// AppArmorDistros are distros with AppArmor support
+var AppArmorDistros = framework.AppArmorDistros
+
+// SkipIfAppArmorNotSupported skips if the AppArmor is not supported by the node OS distro.
+var SkipIfAppArmorNotSupported = framework.SkipIfAppArmorNotSupported


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

skip.go of core e2e framework depends on subpackage, and that is invalid dependency as https://github.com/kubernetes/kubernetes/blob/b9c0aa0b2aca87baaa5a8ab99578e39c162501d3/test/e2e/framework/skip.go#L32-L34
In addition, skip.go can be a subpackage as a separated function.
So this makes skip subpackage from e2e core framework.

There is a lot of tests which use skip.go, this makes ` test/e2e/apimachinery` tests use the new subpackage.
Then we will move them to use the skip subpackage later to avoid a single huge PR.

Ref: https://github.com/kubernetes/kubernetes/issues/81245

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
