### PR TITLE
Allow a preloaded gke-exec-auth-plugin

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -292,6 +292,11 @@ function install-exec-auth-plugin {
   local -r plugin_url="${EXEC_AUTH_PLUGIN_URL}"
   local -r plugin_sha1="${EXEC_AUTH_PLUGIN_SHA1}"
 
+  if is-preloaded "gke-exec-auth-plugin" "${plugin_sha1}"; then
+    echo "gke-exec-auth-plugin is preloaded"
+    return
+  fi
+
   echo "Downloading gke-exec-auth-plugin binary"
   download-or-bust "${plugin_sha1}" "${plugin_url}"
   mv "${KUBE_HOME}/gke-exec-auth-plugin" "${KUBE_BIN}/gke-exec-auth-plugin"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`gke-exec-auth-plugin` can now be preloaded. Handle that to avoid re-downloading the binary. This change only affects GCP.

**Which issue(s) this PR fixes**:
n/a

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
