### PR TITLE
Add import-aliases check of e2e sub framework

### DIFF
--- a/hack/.import-aliases
+++ b/hack/.import-aliases
@@ -51,5 +51,10 @@
   "k8s.io/kubernetes/pkg/kubelet/apis/stats/v1alpha1": "kubeletstatsv1alpha1",
   "k8s.io/kubernetes/pkg/proxy/apis/config/v1alpha1": "proxyconfigv1alpha1",
   "k8s.io/kubernetes/pkg/scheduler/apis/config/v1alpha1": "schedulerconfigv1alpha1",
-  "k8s.io/kubernetes/test/e2e/framework/service": "e2eservice"
+  "k8s.io/kubernetes/test/e2e/framework/kubectl": "e2ekubectl",
+  "k8s.io/kubernetes/test/e2e/framework/node": "e2enode",
+  "k8s.io/kubernetes/test/e2e/framework/pod": "e2epod",
+  "k8s.io/kubernetes/test/e2e/framework/resource": "e2eresource",
+  "k8s.io/kubernetes/test/e2e/framework/service": "e2eservice",
+  "k8s.io/kubernetes/test/e2e/framework/ssh": "e2essh"
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This adds import-aliases check of e2e sub framework packages for consistent aliases.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

