### PR TITLE
Add error handling of CloseWrite()

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -321,7 +321,9 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	fmt.Fprint(conn, "abc")
 
 	ginkgo.By("Closing the write half of the client's connection")
-	conn.CloseWrite()
+	if err = conn.CloseWrite(); err != nil {
+		framework.Failf("Couldn't close the write half of the client's connection: %v", err)
+	}
 
 	ginkgo.By("Reading data from the local port")
 	fromServer, err := ioutil.ReadAll(conn)


### PR DESCRIPTION

**What type of PR is this?**
/kind cleanup
/kind flake

**What this PR does / why we need it**:

The e2e test "Kubectl Port forwarding With a server listening .."
is failed sometimes due to the difference between expected data and
received data. To receive the data, the test does CloseWrite() but
it didn't have the corresponding error handling.
This adds it to investigate the issue more.

Ref: https://github.com/kubernetes/kubernetes/issues/86678

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

