### PR TITLE
Add logs of port-forward-tester pod

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -330,6 +330,12 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 	}
 
 	if e, a := strings.Repeat("x", 100), string(fromServer); e != a {
+		podlogs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
+		if err != nil {
+			framework.Logf("Failed to get logs of portforwardtester pod: %v", err)
+		} else {
+			framework.Logf("Logs of portforwardtester pod: %v", podlogs)
+		}
 		framework.Failf("Expected %q from server, got %q", e, a)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/kind flake

**What this PR does / why we need it**:

The e2e test "Kubectl Port forwarding With a server listening .." is failed sometimes due to
the difference between expected data and received data.
The testing pod is port-forward-tester and the pod can finish before sending full data if an error happens as https://github.com/kubernetes/kubernetes/blob/36abc02533fadecdcbe380aa6b5c2a7d4b32d0f4/test/images/agnhost/port-forward-tester/portforwardtester.go#L135-L138

This adds logs of port-forward-tester pod for knowing what happens on the pod side.

Ref: https://github.com/kubernetes/kubernetes/issues/86678

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
