### PR TITLE
[Step 1] Build mips64le kube-cross and v2.0.0 debian-base images

### DIFF
--- a/build/build-image/cross/Dockerfile
+++ b/build/build-image/cross/Dockerfile
@@ -22,13 +22,15 @@ ENV KUBE_DYNAMIC_CROSSPLATFORMS \
   armhf \
   arm64 \
   s390x \
-  ppc64el
+  ppc64el \
+  mips64el
 
 ENV KUBE_CROSSPLATFORMS \
   linux/386 \
   linux/arm linux/arm64 \
   linux/ppc64le \
   linux/s390x \
+  linux/mips64le \
   darwin/amd64 darwin/386 \
   windows/amd64 windows/386
 

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -22,7 +22,7 @@ TAG ?= v2.0.0
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH = amd64 arm arm64 ppc64le s390x mips64le
 
 TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=v2.9.1
@@ -50,6 +50,10 @@ endif
 ifeq ($(ARCH),s390x)
 	BASEIMAGE?=s390x/debian:buster-slim
 	QEMUARCH=s390x
+endif
+ifeq ($(ARCH),mips64le)
+	BASEIMAGE?=multiarch/debian-debootstrap:mips64el-buster-slim
+	QEMUARCH=mips64el
 endif
 
 sub-build-%:


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does**:

Build mips64le kube-cross and v2.0.0 debian-base images.

**Which issue(s) this PR fixes**:

Fixes #87056

```release-note
Build mips64le kube-cross and v2.0.0 debian-base images.
```