### PR TITLE
Simplified and corrected logic around context cancelation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/interface.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/interface.go
@@ -60,7 +60,10 @@ type QueueSet interface {
 	// executing the request and, once the request finishes execution
 	// or is canceled, call afterExecution().  Otherwise the client
 	// should not execute the request and afterExecution is
-	// irrelevant.
+	// irrelevant.  Canceling the context while the request is waiting
+	// in its queue will cut short that wait and cause a return with
+	// tryAnother and execute both false; later cancellations are the
+	// caller's problem.
 	Wait(ctx context.Context, hashValue uint64, descr1, descr2 interface{}) (tryAnother, execute bool, afterExecution func())
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/lockingpromise/lockingpromise.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise/lockingpromise/lockingpromise.go
@@ -23,57 +23,108 @@ import (
 	"k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/promise"
 )
 
-// lockingPromise implements LockingMutable based on a condition
-// variable.  This implementation tracks active goroutines: the given
-// counter is decremented for a goroutine waiting for this varible to
-// be set and incremented when such a goroutine is unblocked.
-type lockingPromise struct {
+// promisoid is the data and reading behavior common to all the
+// promise-like abstractions implemented here.  This implementation is
+// based on a condition variable.  This implementation tracks active
+// goroutines: the given counter is decremented for a goroutine
+// waiting for this varible to be set and incremented when such a
+// goroutine is unblocked.
+type promisoid struct {
 	lock          sync.Locker
 	cond          sync.Cond
 	activeCounter counter.GoRoutineCounter // counter of active goroutines
-	waitingCount  int                      // number of goroutines idle due to this mutable being unset
+	waitingCount  int                      // number of goroutines idle due to this being unset
 	isSet         bool
 	value         interface{}
 }
 
-var _ promise.LockingMutable = &lockingPromise{}
+func (pr *promisoid) Get() interface{} {
+	pr.lock.Lock()
+	defer pr.lock.Unlock()
+	return pr.GetLocked()
+}
 
-// NewLockingPromise makes a new promise.LockingMutable
-func NewLockingPromise(lock sync.Locker, activeCounter counter.GoRoutineCounter) promise.LockingMutable {
-	return &lockingPromise{
+func (pr *promisoid) GetLocked() interface{} {
+	if !pr.isSet {
+		pr.waitingCount++
+		pr.activeCounter.Add(-1)
+		pr.cond.Wait()
+	}
+	return pr.value
+}
+
+func (pr *promisoid) IsSet() bool {
+	pr.lock.Lock()
+	defer pr.lock.Unlock()
+	return pr.IsSetLocked()
+}
+
+func (pr *promisoid) IsSetLocked() bool {
+	return pr.isSet
+}
+
+type writeOnce struct {
+	promisoid
+}
+
+var _ promise.LockingWriteOnce = &writeOnce{}
+
+// NewWriteOnce makes a new promise.LockingWriteOnce
+func NewWriteOnce(lock sync.Locker, activeCounter counter.GoRoutineCounter) promise.LockingWriteOnce {
+	return &writeOnce{promisoid{
 		lock:          lock,
 		cond:          *sync.NewCond(lock),
 		activeCounter: activeCounter,
+	}}
+}
+
+func (wr *writeOnce) Set(value interface{}) bool {
+	wr.lock.Lock()
+	defer wr.lock.Unlock()
+	return wr.SetLocked(value)
+}
+
+func (wr *writeOnce) SetLocked(value interface{}) bool {
+	if wr.isSet {
+		return false
 	}
-}
-
-func (lp *lockingPromise) Set(value interface{}) {
-	lp.lock.Lock()
-	defer lp.lock.Unlock()
-	lp.SetLocked(value)
-}
-
-func (lp *lockingPromise) Get() interface{} {
-	lp.lock.Lock()
-	defer lp.lock.Unlock()
-	return lp.GetLocked()
-}
-
-func (lp *lockingPromise) SetLocked(value interface{}) {
-	lp.isSet = true
-	lp.value = value
-	if lp.waitingCount > 0 {
-		lp.activeCounter.Add(lp.waitingCount)
-		lp.waitingCount = 0
-		lp.cond.Broadcast()
+	wr.isSet = true
+	wr.value = value
+	if wr.waitingCount > 0 {
+		wr.activeCounter.Add(wr.waitingCount)
+		wr.waitingCount = 0
+		wr.cond.Broadcast()
 	}
+	return true
 }
 
-func (lp *lockingPromise) GetLocked() interface{} {
-	if !lp.isSet {
-		lp.waitingCount++
-		lp.activeCounter.Add(-1)
-		lp.cond.Wait()
+type writeMultiple struct {
+	promisoid
+}
+
+var _ promise.LockingWriteMultiple = &writeMultiple{}
+
+// NewWriteMultiple makes a new promise.LockingWriteMultiple
+func NewWriteMultiple(lock sync.Locker, activeCounter counter.GoRoutineCounter) promise.LockingWriteMultiple {
+	return &writeMultiple{promisoid{
+		lock:          lock,
+		cond:          *sync.NewCond(lock),
+		activeCounter: activeCounter,
+	}}
+}
+
+func (wr *writeMultiple) Set(value interface{}) {
+	wr.lock.Lock()
+	defer wr.lock.Unlock()
+	wr.SetLocked(value)
+}
+
+func (wr *writeMultiple) SetLocked(value interface{}) {
+	wr.isSet = true
+	wr.value = value
+	if wr.waitingCount > 0 {
+		wr.activeCounter.Add(wr.waitingCount)
+		wr.waitingCount = 0
+		wr.cond.Broadcast()
 	}
-	return lp.value
 }

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -247,3 +247,48 @@ func TestTimeout(t *testing.T) {
 		{1001001001, 5, 100, time.Second, time.Second},
 	}, time.Second*10, true, false, clk, counter)
 }
+
+func TestContextCancel(t *testing.T) {
+	now := time.Now()
+	clk, counter := clock.NewFakeEventClock(now, 0, nil)
+	qsf := NewQueueSetFactory(clk, counter)
+	config := fq.QueueSetConfig{
+		Name:             "TestTimeout",
+		ConcurrencyLimit: 1,
+		DesiredNumQueues: 11,
+		QueueLengthLimit: 11,
+		HandSize:         1,
+		RequestWaitLimit: 15 * time.Second,
+	}
+	qs, err := qsf.NewQueueSet(config)
+	if err != nil {
+		t.Fatalf("QueueSet creation failed with %v", err)
+	}
+	counter.Add(1) // account for the goroutine running this test
+	ctx1 := context.Background()
+	another1, exec1, cleanup1 := qs.Wait(ctx1, 1, "test", "one")
+	if another1 || !exec1 {
+		t.Errorf("Unexpected: another1=%v, exec1=%v", another1, exec1)
+		return
+	}
+	defer cleanup1()
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	tBefore := time.Now()
+	go func() {
+		time.Sleep(time.Second)
+		cancel2()
+	}()
+	another2, exec2, cleanup2 := qs.Wait(ctx2, 2, "test", "two")
+	tAfter := time.Now()
+	if another2 || exec2 {
+		t.Errorf("Unexpected: another2=%v, exec2=%v", another2, exec2)
+		if exec2 {
+			defer cleanup2()
+		}
+	} else {
+		dt := tAfter.Sub(tBefore)
+		if dt < time.Second || dt > 2*time.Second {
+			t.Errorf("Unexpected: dt=%d", dt)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR tightens up the logic around cancelation of the context.Context.  Previously a request could get more than one decision (in series), with a decisionCancel overwriting a decisionReject or decisionExecute and causing confusion.  Now a request gets exactly one decision, and QueueSet allows context cancelation to only cut short the time spent waiting in the queue.  This PR also adds a QueueSet test for context cancelation.  This PR also fixes a metrics oversight.

There is no official issue for this PR, but the problem was reported in a conversation that ended at https://github.com/MikeSpreitzer/kubernetes/commit/1c31b2bdc65377f502c2306dbdf32a802eb1afb7#r36721437 .

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
