### PR TITLE
[Step 2] Build mips64le v1.0.0 debian-base image

### DIFF
--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -22,7 +22,7 @@ TAG ?= v1.0.0
 
 TAR_FILE ?= rootfs.tar
 ARCH?=amd64
-ALL_ARCH = amd64 arm arm64 ppc64le s390x
+ALL_ARCH = amd64 arm arm64 ppc64le s390x mips64le
 
 TEMP_DIR:=$(shell mktemp -d)
 QEMUVERSION=v2.9.1
@@ -50,6 +50,10 @@ endif
 ifeq ($(ARCH),s390x)
 	BASEIMAGE?=s390x/debian:stretch
 	QEMUARCH=s390x
+endif
+ifeq ($(ARCH),mips64le)
+        BASEIMAGE?=inspurcloud/debian-debootstrap:mips64el-stretch
+        QEMUARCH=mips64el
 endif
 
 sub-build-%:

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -52,7 +52,7 @@ ifeq ($(ARCH),s390x)
 	QEMUARCH=s390x
 endif
 ifeq ($(ARCH),mips64le)
-        BASEIMAGE?=inspurcloud/debian-debootstrap:mips64el-stretch
+        BASEIMAGE?=multiarch/debian-debootstrap:mips64el-stretch
         QEMUARCH=mips64el
 endif
 

--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -24,7 +24,7 @@ ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 CACHEBUST?=1
 
-BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):0.4.1
+BASEIMAGE=k8s.gcr.io/debian-base-$(ARCH):v1.0.0
 CNI_VERSION=v0.7.5
 
 TEMP_DIR:=$(shell mktemp -d)


### PR DESCRIPTION
**What type of PR is this?**

 /kind bug
 /kind feature

**What this PR does / why we need it**:

Build mips64le v1.0.0 debian-base image in release-1.16.
Update the tag of debian-hyperkube-base image in release-1.16.

**Which issue(s) this PR fixes**:

Fixes #87056
Fixes #86808

```release-note
NONE
```
