### PR TITLE
set MemorySwap equal to Memory in dockershim.UpdateContainerResources

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -442,10 +442,12 @@ func (ds *dockerService) UpdateContainerResources(_ context.Context, r *runtimea
 	resources := r.Linux
 	updateConfig := dockercontainer.UpdateConfig{
 		Resources: dockercontainer.Resources{
-			CPUPeriod:  resources.CpuPeriod,
-			CPUQuota:   resources.CpuQuota,
-			CPUShares:  resources.CpuShares,
+			CPUPeriod: resources.CpuPeriod,
+			CPUQuota:  resources.CpuQuota,
+			CPUShares: resources.CpuShares,
+			// Memory and MemorySwap are set to the same value, this prevents containers from using any swap.
 			Memory:     resources.MemoryLimitInBytes,
+			MemorySwap: resources.MemoryLimitInBytes,
 			CpusetCpus: resources.CpusetCpus,
 			CpusetMems: resources.CpusetMems,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fix an issue when updating container memory limit via dockershim.

In my test environment, the kubelet container runtime is backed by docker, so a dockershim.DockerService is started to serve CRI requests. Currently, kubelet doesn't update container memory limit and everything is fine.

I encountered an issue when using crictl to update it. 
Firstly, I created a guaranteed pod. Then I issued below command to update its memory limit and I got an error
```
./crictl update --memory 9242880 e494227f5f18ba8a9555f8682b974c54af98a1b7479ee22b3dadf0ee8641c88c
FATA[0000] Updating container resources for "e494227f5f18ba8a9555f8682b974c54af98a1b7479ee22b3dadf0ee8641c88c" failed: rpc error: code = Unknown desc = failed to update container "e494227f5f18ba8a9555f8682b974c5
4af98a1b7479ee22b3dadf0ee8641c88c": Error response from daemon: Cannot update container e494227f5f18ba8a9555f8682b974c54af98a1b7479ee22b3dadf0ee8641c88c: Memory limit should be smaller than already set memoryswa
p limit, update the memoryswap at the same time
```
I've done a quick investigation on cri-tools, and I found that it's talking to container runtime via '/var/run/dockershim.sock' by default, so dockershim.DockerService was requested to update container resources. This issue occured because that the MemorySwap is not set when updating container resources in dockershim.DockerService.

This has no impact on kubelet, while it:

- fails crictl
- may cause problems when doing pod inplace update as described in this KEP:https://github.com/kubernetes/enhancements/blob/master/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
https://github.com/kubernetes/enhancements/blob/master/keps/sig-autoscaling/20181106-in-place-update-of-pod-resources.md
```
