### PR TITLE
Remove `ErrNodeUnknownCondition` in predicates error.

### DIFF
--- a/pkg/scheduler/algorithm/predicates/error.go
+++ b/pkg/scheduler/algorithm/predicates/error.go
@@ -37,17 +37,11 @@ var (
 	ErrPodNotMatchHostName = NewPredicateFailureError("HostName", "node(s) didn't match the requested hostname")
 	// ErrPodNotFitsHostPorts is used for PodFitsHostPorts predicate error.
 	ErrPodNotFitsHostPorts = NewPredicateFailureError("PodFitsHostPorts", "node(s) didn't have free ports for the requested pod ports")
-	// ErrNodeUnknownCondition is used for NodeUnknownCondition predicate error.
-	ErrNodeUnknownCondition = NewPredicateFailureError("NodeUnknownCondition", "node(s) had unknown conditions")
 )
 
 var unresolvablePredicateFailureErrors = map[PredicateFailureReason]struct{}{
 	ErrNodeSelectorNotMatch: {},
 	ErrPodNotMatchHostName:  {},
-	// Node conditions won't change when scheduler simulates removal of preemption victims.
-	// So, it is pointless to try nodes that have not been able to host the pod due to node
-	// conditions.
-	ErrNodeUnknownCondition: {},
 }
 
 // UnresolvablePredicateExists checks if there is at least one unresolvable predicate failure reason.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Scheduler predicates and their error types are deprecated. The Scheduler moved to the plugins framework. Since `ErrNodeUnknownCondition` is not used anymore, we could remove it safely now.

**Which issue(s) this PR fixes**:
Refs #86711

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
