### PR TITLE
Fix mount error when the parent directory where the file is located does not exist, when using the hostpath in FileOrCreate mode

### DIFF
--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -19,6 +19,7 @@ package hostpath
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 
 	"k8s.io/utils/mount"
@@ -482,9 +483,16 @@ func makeDir(pathname string) error {
 	return nil
 }
 
-// makeFile creates an empty file.
+// makeFile creates an empty file, also creating parent directories if necessary.
 // If pathname already exists, whether a file or directory, no error is returned.
 func makeFile(pathname string) error {
+	path, _ := filepath.Split(pathname)
+	if _, statErr := os.Stat(path); os.IsNotExist(statErr) {
+		err := makeDir(path)
+		if err != nil {
+			return err
+		}
+	}
 	f, err := os.OpenFile(pathname, os.O_CREATE, os.FileMode(0644))
 	if f != nil {
 		f.Close()


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

Ensure that the file parent directory can be created when it does not exist, and when using the hostpath of the FileOrCreate mode, so as to ensure a successful mount

https://kubernetes.io/docs/concepts/storage/volumes/#hostpath

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #87112

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Ensure that the file parent directory can be created when it does not exist, and when using the hostpath of the`FileOrCreate` mode
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage