### PR TITLE
Clean up rkt mentions in `pkg/kubelet/pleg`

### DIFF
--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -366,7 +366,7 @@ func (g *GenericPLEG) getPodIPs(pid types.UID, status *kubecontainer.PodStatus) 
 	}
 
 	if len(status.SandboxStatuses) == 0 {
-		// Without sandboxes (which built-in runtimes like rkt don't report)
+		// If sandboxes are not present, then
 		// look at all the container statuses, and if any containers are
 		// running then use the new pod IP
 		for _, containerStatus := range status.ContainerStatuses {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove the final direct mention of `rkt` in the kubelet codebase.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
