### PR TITLE
fix staticcheck:pkg/volume/flocker

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -33,7 +33,6 @@ pkg/volume/csi
 pkg/volume/emptydir
 pkg/volume/fc
 pkg/volume/flexvolume
-pkg/volume/flocker
 pkg/volume/hostpath
 pkg/volume/iscsi
 pkg/volume/local

--- a/pkg/volume/flocker/flocker.go
+++ b/pkg/volume/flocker/flocker.go
@@ -394,7 +394,6 @@ func (b *flockerVolumeMounter) updateDatasetPrimary(datasetUUID string, primaryU
 				datasetUUID, primaryUUID, err,
 			)
 		case <-tickChan.C:
-			break
 		}
 	}
 

--- a/pkg/volume/flocker/flocker_volume_test.go
+++ b/pkg/volume/flocker/flocker_volume_test.go
@@ -85,7 +85,7 @@ func TestProvision(t *testing.T) {
 
 	dir, provisioner = newTestableProvisioner(t, assert, options)
 	defer os.RemoveAll(dir)
-	persistentSpec, err = provisioner.Provision(nil, nil)
+	_, err = provisioner.Provision(nil, nil)
 	assert.Error(err, "Provision() did not fail with Parameters specified")
 
 	// selectors are not supported
@@ -97,6 +97,6 @@ func TestProvision(t *testing.T) {
 
 	dir, provisioner = newTestableProvisioner(t, assert, options)
 	defer os.RemoveAll(dir)
-	persistentSpec, err = provisioner.Provision(nil, nil)
+	_, err = provisioner.Provision(nil, nil)
 	assert.Error(err, "Provision() did not fail with Selector specified")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:#81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
pkg/volume/flocker/flocker.go:397:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
pkg/volume/flocker/flocker_volume_test.go:88:2: this value of persistentSpec is never used (SA4006)
pkg/volume/flocker/flocker_volume_test.go:100:2: this value of persistentSpec is never used (SA4006)

```
