### PR TITLE
remove TODO in test/e2e/framework/providers/gce/ingress.go

### DIFF
--- a/test/e2e/framework/providers/gce/ingress.go
+++ b/test/e2e/framework/providers/gce/ingress.go
@@ -571,19 +571,8 @@ func (cont *IngressController) GetFirewallRuleName() string {
 }
 
 // GetFirewallRule returns the firewall used by the IngressController.
-// Causes a fatal error incase of an error.
-// TODO: Rename this to GetFirewallRuleOrDie and similarly rename all other
-// methods here to be consistent with rest of the code in this repo.
-func (cont *IngressController) GetFirewallRule() *compute.Firewall {
-	fw, err := cont.GetFirewallRuleOrError()
-	framework.ExpectNoError(err)
-	return fw
-}
-
-// GetFirewallRuleOrError returns the firewall used by the IngressController.
 // Returns an error if that fails.
-// TODO: Rename this to GetFirewallRule when the above method with that name is renamed.
-func (cont *IngressController) GetFirewallRuleOrError() (*compute.Firewall, error) {
+func (cont *IngressController) GetFirewallRule() (*compute.Firewall, error) {
 	gceCloud := cont.Cloud.Provider.(*Provider).gceCloud
 	fwName := cont.GetFirewallRuleName()
 	return gceCloud.GetFirewall(fwName)

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -227,7 +227,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				framework.Failf("unexpected backend service, expected none, got: %v", gceController.ListGlobalBackendServices())
 			}
 			// Controller does not have a list command for firewall rule. We use get instead.
-			if fw, err := gceController.GetFirewallRuleOrError(); err == nil {
+			if fw, err := gceController.GetFirewallRule(); err == nil {
 				framework.Failf("unexpected nil error in getting firewall rule, expected firewall NotFound, got firewall: %v", fw)
 			}
 


### PR DESCRIPTION
Signed-off-by: yuxiaobo <yuxiaobogo@163.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:#86763

**Special notes for your reviewer**:

The TODO in the function GetFirewallRuleOrError is related to the function GetFirewallRule. But the function GetFirewallRule is not used, so remove this function and modify the function GetFirewallRuleOrError to GetFirewallRule.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
