### PR TITLE
WIP: kubeadm: ensure that flex volume path is write-able

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/diff.go
+++ b/cmd/kubeadm/app/cmd/upgrade/diff.go
@@ -121,7 +121,10 @@ func runDiff(flags *diffFlags, args []string) error {
 
 	cfg.ClusterConfiguration.KubernetesVersion = flags.newK8sVersionStr
 
-	specs := controlplane.GetStaticPodSpecs(&cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint)
+	specs, err := controlplane.GetStaticPodSpecs(&cfg.ClusterConfiguration, &cfg.LocalAPIEndpoint)
+	if err != nil {
+		return err
+	}
 	for spec, pod := range specs {
 		var path string
 		switch spec {

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -51,7 +51,10 @@ func TestGetStaticPodSpecs(t *testing.T) {
 	}
 
 	// Executes GetStaticPodSpecs
-	specs := GetStaticPodSpecs(cfg, &kubeadmapi.APIEndpoint{})
+	specs, err := GetStaticPodSpecs(cfg, &kubeadmapi.APIEndpoint{})
+	if err != nil {
+		t.Errorf("unable to get static pod specs")
+	}
 
 	var tests = []struct {
 		name          string

--- a/cmd/kubeadm/app/phases/controlplane/volumes_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/volumes_test.go
@@ -518,7 +518,10 @@ func TestGetHostPathVolumesForTheControlPlane(t *testing.T) {
 
 	for _, rt := range tests {
 		t.Run(rt.name, func(t *testing.T) {
-			mounts := getHostPathVolumesForTheControlPlane(rt.cfg)
+			mounts, err := getHostPathVolumesForTheControlPlane(rt.cfg)
+			if err != nil {
+				t.Fatalf("Couldn't get host path volumes for the control plane")
+			}
 
 			// Avoid unit test errors when the flexvolume is mounted
 			delete(mounts.volumes[kubeadmconstants.KubeControllerManager], flexvolumeDirVolumeName)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

In #84468 we added a host path mount for a flex volume which is needed
by the controller manager. We should pre-check if the path is write-able
at all because the default path might be read-only. To do this, we now
do an `os.MkdirAll` and propagate the error up to to the caller.

**Which issue(s) this PR fixes**:
None but refers to https://github.com/kubernetes/kubernetes/pull/84468

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
- Added kubeadm check if the provided `--flex-volume-plugin-dir` (per default `/usr/libexec/kubernetes/kubelet-plugins/volume/exec`) is write-able by the node
```

/assign @ereslibre @yastij
/priority backlog
/sig cluster-lifecycle