### PR TITLE
Use v1 subjectaccessreview API in controller-manager CSR approver

### DIFF
--- a/pkg/controller/certificates/approver/BUILD
+++ b/pkg/controller/certificates/approver/BUILD
@@ -12,7 +12,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/certificates/v1beta1:go_default_library",
-        "//staging/src/k8s.io/api/authorization/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/authorization/v1:go_default_library",
         "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
@@ -28,7 +28,7 @@ go_library(
     deps = [
         "//pkg/apis/certificates/v1beta1:go_default_library",
         "//pkg/controller/certificates:go_default_library",
-        "//staging/src/k8s.io/api/authorization/v1beta1:go_default_library",
+        "//staging/src/k8s.io/api/authorization/v1:go_default_library",
         "//staging/src/k8s.io/api/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/informers/certificates/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -23,7 +23,7 @@ import (
 	"reflect"
 	"strings"
 
-	authorization "k8s.io/api/authorization/v1beta1"
+	authorization "k8s.io/api/authorization/v1"
 	capi "k8s.io/api/certificates/v1beta1"
 	certificatesinformers "k8s.io/client-go/informers/certificates/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
@@ -129,7 +129,7 @@ func (a *sarApprover) authorize(csr *capi.CertificateSigningRequest, rattrs auth
 			ResourceAttributes: &rattrs,
 		},
 	}
-	sar, err := a.client.AuthorizationV1beta1().SubjectAccessReviews().Create(sar)
+	sar, err := a.client.AuthorizationV1().SubjectAccessReviews().Create(sar)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/controller/certificates/approver/sarapprove_test.go
+++ b/pkg/controller/certificates/approver/sarapprove_test.go
@@ -27,7 +27,7 @@ import (
 	"net"
 	"testing"
 
-	authorization "k8s.io/api/authorization/v1beta1"
+	authorization "k8s.io/api/authorization/v1"
 	capi "k8s.io/api/certificates/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Part of conformance without beta efforts, ensures v1 APIs are used wherever possible.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig auth
/cc @BenTheElder 