### PR TITLE
add comment in hack/update-*.sh

### DIFF
--- a/hack/pin-dependency.sh
+++ b/hack/pin-dependency.sh
@@ -14,18 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Usage:
+#   hack/pin-dependency.sh $MODULE $SHA-OR-TAG
+#
+# Example:
+#   hack/pin-dependency.sh github.com/docker/docker 501cb131a7b7
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/init.sh"
-
-# Usage:
-#   hack/pin-dependency.sh $MODULE $SHA-OR-TAG
-#
-# Example:
-#   hack/pin-dependency.sh github.com/docker/docker 501cb131a7b7
 
 # Explicitly opt into go modules, even though we're inside a GOPATH directory
 export GO111MODULE=on

--- a/hack/update-all.sh
+++ b/hack/update-all.sh
@@ -16,6 +16,9 @@
 
 # This script is a vestigial redirection.  Please do not add "real" logic.
 # The "true" target of this makerule is `hack/make-rules/update.sh`.
+# We should run `hack/update-all.sh` if anything fails after 
+# running `hack/verify-all.sh`. It is equivalent to `make update`. 
+# Usage: `hack/update-all.sh` or `make update`.
 
 set -o errexit
 set -o nounset

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Please do not add any logic to this shell script. Add logic to the go code
+# that generates the set-gen program.
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -33,10 +36,6 @@ make -C "${KUBE_ROOT}" WHAT="${BUILD_TARGETS[*]}"
 clientgen=$(kube::util::find-binary "client-gen")
 listergen=$(kube::util::find-binary "lister-gen")
 informergen=$(kube::util::find-binary "informer-gen")
-
-# Please do not add any logic to this shell script. Add logic to the go code
-# that generates the set-gen program.
-#
 
 IFS=" " read -r -a GROUP_VERSIONS <<< "${KUBE_AVAILABLE_GROUP_VERSIONS}"
 GV_DIRS=()

--- a/hack/update-generated-device-plugin-dockerized.sh
+++ b/hack/update-generated-device-plugin-dockerized.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script generates `*/api.pb.go` from the protobuf file `*/api.proto`.
+# Example:
+#   kube::protoc::generate_proto "${DEVICE_PLUGIN_ALPHA}"
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-generated-kubelet-plugin-registration-dockerized.sh
+++ b/hack/update-generated-kubelet-plugin-registration-dockerized.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script generates `*/api.pb.go` from the protobuf file `*/api.proto`.
+# Example:
+#   kube::protoc::generate_proto "${KUBELET_PLUGIN_REGISTRATION_V1ALPHA}"
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-generated-pod-resources-dockerized.sh
+++ b/hack/update-generated-pod-resources-dockerized.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script generates `*/api.pb.go` from the protobuf file `*/api.proto`.
+# Example:
+#   kube::protoc::generate_proto "${POD_RESOURCES_ALPHA}"
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-import-aliases.sh
+++ b/hack/update-import-aliases.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script fixes imports programmatically according to 
+# all the imports that we have our preferred alias(es).
+# Usage: `hack/update-import-aliases.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/update-translations.sh
+++ b/hack/update-translations.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script updates `translations/kubectl/template.pot` for 
+# `pkg/kubectl/cmd/*.go pkg/kubectl/cmd/*/*.go`. 
+# Usage: `update-translations.sh`.
+
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 source "${KUBE_ROOT}/hack/lib/util.sh"
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

kubernetes/hack/update-all.sh
kubernetes/hack/update-bazel.sh
kubernetes/hack/update-codegen.sh
kubernetes/hack/update-generated-api-compatibility-data.sh
kubernetes/hack/update-generated-device-plugin-dockerized.sh
kubernetes/hack/update-generated-device-plugin.sh
kubernetes/hack/update-generated-docs.sh
kubernetes/hack/update-generated-kms-dockerized.sh
kubernetes/hack/update-generated-kms.sh
kubernetes/hack/update-generated-kubelet-plugin-registration-dockerized.sh
kubernetes/hack/update-generated-kubelet-plugin-registration.sh
kubernetes/hack/update-generated-pod-resources-dockerized.sh
kubernetes/hack/update-generated-pod-resources.sh
kubernetes/hack/update-generated-protobuf-dockerized.sh
kubernetes/hack/update-generated-protobuf.sh
kubernetes/hack/update-generated-runtime-dockerized.sh
kubernetes/hack/update-generated-runtime.sh
kubernetes/hack/update-generated-swagger-docs.sh
kubernetes/hack/update-gofmt.sh
kubernetes/hack/update-import-aliases.sh
kubernetes/hack/update-openapi-spec.sh
kubernetes/hack/update-translations.sh
kubernetes/hack/update-vendor-licenses.sh
kubernetes/hack/update-vendor.sh
kubernetes/hack/update-workspace-mirror.sh

update the comment for them

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:https://github.com/kubernetes/kubernetes/issues/86597

**Special notes for your reviewer**:
/cc @fejta 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
