### PR TITLE
Automated cherry pick of #82267: kubeadm: Form correct URL for IPv6 in HTTPProxy check

### DIFF
--- a/cmd/kubeadm/app/preflight/BUILD
+++ b/cmd/kubeadm/app/preflight/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ] + select({
         "@io_bazel_rules_go//go/platform:linux": [
             "//cmd/kubeadm/app/util:go_default_library",

--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -52,6 +52,7 @@ import (
 	ipvsutil "k8s.io/kubernetes/pkg/util/ipvs"
 	kubeadmversion "k8s.io/kubernetes/pkg/version"
 	utilsexec "k8s.io/utils/exec"
+	utilsnet "k8s.io/utils/net"
 )
 
 const (
@@ -437,9 +438,12 @@ func (hst HTTPProxyCheck) Name() string {
 // Check validates http connectivity type, direct or via proxy.
 func (hst HTTPProxyCheck) Check() (warnings, errorList []error) {
 	klog.V(1).Infoln("validating if the connectivity type is via proxy or direct")
-	u := (&url.URL{Scheme: hst.Proto, Host: hst.Host}).String()
+	u := &url.URL{Scheme: hst.Proto, Host: hst.Host}
+	if utilsnet.IsIPv6String(hst.Host) {
+		u.Host = net.JoinHostPort(hst.Host, "1234")
+	}
 
-	req, err := http.NewRequest("GET", u, nil)
+	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return nil, []error{err}
 	}

--- a/cmd/kubeadm/app/preflight/checks_test.go
+++ b/cmd/kubeadm/app/preflight/checks_test.go
@@ -590,6 +590,22 @@ func TestHTTPProxyCheck(t *testing.T) {
 			}, // Expected to go via proxy, range is not in 2001:db8::/48
 			expectWarnings: true,
 		},
+		{
+			name: "IPv6 direct access, no brackets",
+			check: HTTPProxyCheck{
+				Proto: "https",
+				Host:  "2001:db8::1:15",
+			}, // Expected to be accessed directly, part of 2001:db8::/48 in NO_PROXY
+			expectWarnings: false,
+		},
+		{
+			name: "IPv6 via proxy, no brackets",
+			check: HTTPProxyCheck{
+				Proto: "https",
+				Host:  "2001:db8:1::1:15",
+			}, // Expected to go via proxy, range is not in 2001:db8::/48
+			expectWarnings: true,
+		},
 	}
 
 	// Save current content of *_proxy and *_PROXY variables.


### PR DESCRIPTION
Cherry pick of #82267 on release-1.15.

#82267: kubeadm: Form correct URL for IPv6 in HTTPProxy check

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.