### PR TITLE
Clean up rkt specific code in `pkg/kubelet/pleg`

### DIFF
--- a/pkg/kubelet/pleg/generic.go
+++ b/pkg/kubelet/pleg/generic.go
@@ -365,17 +365,6 @@ func (g *GenericPLEG) getPodIPs(pid types.UID, status *kubecontainer.PodStatus) 
 		}
 	}
 
-	if len(status.SandboxStatuses) == 0 {
-		// Without sandboxes (which built-in runtimes like rkt don't report)
-		// look at all the container statuses, and if any containers are
-		// running then use the new pod IP
-		for _, containerStatus := range status.ContainerStatuses {
-			if containerStatus.State == kubecontainer.ContainerStateCreated || containerStatus.State == kubecontainer.ContainerStateRunning {
-				return status.IPs
-			}
-		}
-	}
-
 	// For pods with no ready containers or sandboxes (like exited pods)
 	// use the old status' pod IP
 	return oldStatus.IPs


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Clean up code in PLEG which was only necessary for the `rkt` runtime.

Rkt is no longer a built-in runtime and docker(shim) uses the CRI, so
its safe to remove this code entirely.

This diff removes the last mentions of `rkt` in the kubelet.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
xref #87116 
cc @yujuhong @dashpole 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
