### PR TITLE
Stop tracking managedField on create/update

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -35,7 +35,7 @@ const DefaultMaxUpdateManagers int = 10
 
 // DefaultTrackOnCreateProbability defines the default probability that the field management of an object
 // starts being tracked from the object's creation, instead of from the first time the object is applied to.
-const DefaultTrackOnCreateProbability float32 = 0.5
+const DefaultTrackOnCreateProbability float32 = 0.0
 
 // Managed groups a fieldpath.ManagedFields together with the timestamps associated with each operation.
 type Managed interface {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Stops tracking managedField on create/update to clean up CI signal (current pass rate is ~30%).

**Which issue(s) this PR fixes**:
Fixes #87131

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @jennybuckley 
/priority critical-urgent
/sig api-machinery
