### PR TITLE
Fix dynamic client integration test flake

### DIFF
--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -69,6 +69,9 @@ func TestDynamicClient(t *testing.T) {
 		t.Fatalf("unexpected error when creating pod: %v", err)
 	}
 
+	// TODO: remove this when #82042 is resolved
+	actual.ObjectMeta.ManagedFields = nil
+
 	// check dynamic list
 	unstructuredList, err := dynamicClient.Resource(resource).Namespace("default").List(metav1.ListOptions{})
 	if err != nil {
@@ -211,6 +214,9 @@ func unstructuredToPod(obj *unstructured.Unstructured) (*v1.Pod, error) {
 	err = runtime.DecodeInto(clientscheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), json, pod)
 	pod.Kind = ""
 	pod.APIVersion = ""
+
+	// TODO: remove this when #82042 is resolved
+	pod.ObjectMeta.ManagedFields = nil
 	return pod, err
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind flake
/sig api-machinery
/wg apply
/cc @liggitt @apelisse @lavalamp 
/priority critical-urgent

**What this PR does / why we need it**:
Fix client integration test flake by temporarily not comparing the contents of managedFields, since #82042 makes that unsafe when roundtripping through unstructured, like the dynamic client does.

**Which issue(s) this PR fixes**:
Fixes #87131

**Special notes for your reviewer**:
Alternative to #87196

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```