### PR TITLE
Add: ConfigMap lifecycle test

### DIFF
--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -22,10 +22,10 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/onsi/ginkgo"
 )

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"encoding/json"
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
 	imageutils "k8s.io/kubernetes/test/utils/image"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/onsi/ginkgo"
 )
@@ -152,6 +154,67 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 		framework.ExpectNoError(err, "failed to get ConfigMap")
 		ginkgo.By(fmt.Sprintf("Verifying update of ConfigMap %v/%v", f.Namespace.Name, configMap.Name))
 		framework.ExpectEqual(configMapFromUpdate.Data, configMap.Data)
+	})
+
+	ginkgo.It("should run through a ConfigMap lifecycle", func() {
+		testNamespaceName := f.Namespace.Name
+		testConfigMapName := "test-configmap" + string(uuid.NewUUID())
+
+		_, err := f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Create(&v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testConfigMapName,
+				Labels: map[string]string{
+					"test-configmap-static": "true",
+				},
+			},
+			Data: map[string]string{
+				"valueName": "value",
+			},
+		})
+		framework.ExpectNoError(err, "failed to create ConfigMap")
+
+		configMapPatchPayload, err := json.Marshal(v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"test-configmap": "patched",
+				},
+			},
+			Data: map[string]string{
+				"valueName": "value1",
+			},
+		})
+		framework.ExpectNoError(err, "failed to marshal patch data")
+
+		_, err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Patch(testConfigMapName, types.StrategicMergePatchType, []byte(configMapPatchPayload))
+		framework.ExpectNoError(err, "failed to patch ConfigMap")
+
+		configMap, err := f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).Get(testConfigMapName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get ConfigMap")
+		framework.ExpectEqual(configMap.Data["valueName"], "value1", "failed to patch ConfigMap")
+		framework.ExpectEqual(configMap.Labels["test-configmap"], "patched", "failed to patch ConfigMap")
+
+		// listing in all namespaces to hit the endpoint
+		configMapList, err := f.ClientSet.CoreV1().ConfigMaps("").List(metav1.ListOptions{
+			LabelSelector: "test-configmap-static=true",
+		})
+		framework.ExpectNoError(err, "failed to list ConfigMaps with LabelSelector")
+		framework.ExpectNotEqual(len(configMapList.Items), 0, "no ConfigMaps found in ConfigMap list")
+		testConfigMapFound := false
+		for _, cm := range configMapList.Items {
+			if cm.ObjectMeta.Name == testConfigMapName &&
+				cm.ObjectMeta.Namespace == testNamespaceName &&
+				cm.ObjectMeta.Labels["test-configmap-static"] == "true" &&
+				cm.Data["valueName"] == "value1" {
+				testConfigMapFound = true
+				break
+			}
+		}
+		framework.ExpectEqual(testConfigMapFound, true, "failed to find ConfigMap in list")
+
+		err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{
+			LabelSelector: "test-configmap-static=true",
+		})
+		framework.ExpectNoError(err, "failed to delete ConfigMap collection with LabelSelector")
 	})
 })
 


### PR DESCRIPTION
- [x] [mock test ticket](https://github.com/kubernetes/kubernetes/issues/87120)
- [x] [PR](#)
- [ ] [promotion](https://github.com/kubernetes/kubernetes/pull/88034)
  - [ ] [update to improve](https://github.com/kubernetes/kubernetes/pull/89707)

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a test to test the following untested stable endpoints:
- listCoreV1ConfigMapForAllNamespaces
- deleteCoreV1CollectionNamespacedEndpoints

**Which issue(s) this PR fixes**:
Fixes #87120

**Special notes for your reviewer**:
Adds +2 test endpoint coverage (good for conformance)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing