### PR TITLE
Make CustomResourceDefinitionStatus fields +optional

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
@@ -238,6 +238,7 @@ message CustomResourceDefinitionStatus {
 
   // acceptedNames are the names that are actually being used to serve discovery.
   // They may be different than the names in spec.
+  // +optional
   optional CustomResourceDefinitionNames acceptedNames = 2;
 
   // storedVersions lists all versions of CustomResources that were ever persisted. Tracking these
@@ -246,6 +247,7 @@ message CustomResourceDefinitionStatus {
   // no old objects are left in storage), and then remove the rest of the
   // versions from this list.
   // Versions may not be removed from `spec.versions` while they exist in this list.
+  // +optional
   repeated string storedVersions = 3;
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types.go
@@ -322,6 +322,7 @@ type CustomResourceDefinitionStatus struct {
 
 	// acceptedNames are the names that are actually being used to serve discovery.
 	// They may be different than the names in spec.
+	// +optional
 	AcceptedNames CustomResourceDefinitionNames `json:"acceptedNames" protobuf:"bytes,2,opt,name=acceptedNames"`
 
 	// storedVersions lists all versions of CustomResources that were ever persisted. Tracking these
@@ -330,6 +331,7 @@ type CustomResourceDefinitionStatus struct {
 	// no old objects are left in storage), and then remove the rest of the
 	// versions from this list.
 	// Versions may not be removed from `spec.versions` while they exist in this list.
+	// +optional
 	StoredVersions []string `json:"storedVersions" protobuf:"bytes,3,rep,name=storedVersions"`
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -284,6 +284,7 @@ message CustomResourceDefinitionStatus {
 
   // acceptedNames are the names that are actually being used to serve discovery.
   // They may be different than the names in spec.
+  // +optional
   optional CustomResourceDefinitionNames acceptedNames = 2;
 
   // storedVersions lists all versions of CustomResources that were ever persisted. Tracking these
@@ -292,6 +293,7 @@ message CustomResourceDefinitionStatus {
   // no old objects are left in storage), and then remove the rest of the
   // versions from this list.
   // Versions may not be removed from `spec.versions` while they exist in this list.
+  // +optional
   repeated string storedVersions = 3;
 }
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types.go
@@ -354,6 +354,7 @@ type CustomResourceDefinitionStatus struct {
 
 	// acceptedNames are the names that are actually being used to serve discovery.
 	// They may be different than the names in spec.
+	// +optional
 	AcceptedNames CustomResourceDefinitionNames `json:"acceptedNames" protobuf:"bytes,2,opt,name=acceptedNames"`
 
 	// storedVersions lists all versions of CustomResources that were ever persisted. Tracking these
@@ -362,6 +363,7 @@ type CustomResourceDefinitionStatus struct {
 	// no old objects are left in storage), and then remove the rest of the
 	// versions from this list.
 	// Versions may not be removed from `spec.versions` while they exist in this list.
+	// +optional
 	StoredVersions []string `json:"storedVersions" protobuf:"bytes,3,rep,name=storedVersions"`
 }
 


### PR DESCRIPTION
Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This change allows for `Status` to be omitted when submitting CRD manifests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #87040

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CustomResourceDefinition status fields are no longer required for client validation when submitting manifests. 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```

/cc @liggitt @fedebongio @jpbetz 
/sig api-machinery
/area custom-resources
