### PR TITLE
Add: PodTemplate lifecycle test

### DIFF
--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -26,6 +26,7 @@ go_library(
         "networking.go",
         "node_lease.go",
         "pods.go",
+        "podtemplates.go",
         "privileged.go",
         "projected_combined.go",
         "projected_configmap.go",

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"encoding/json"
+	//"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/kubernetes/test/e2e/framework"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/onsi/ginkgo"
+)
+
+var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
+	f := framework.NewDefaultFramework("podtemplate")
+
+	ginkgo.It("should run the lifecycle of PodTemplates", func() {
+		testNamespaceName := f.Namespace.Name
+		podTemplateName := "nginx-pod-template-" + string(uuid.NewUUID())
+
+		// get a list of PodTemplates (in all namespaces to hit endpoint)
+		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates("").List(metav1.ListOptions{})
+		framework.ExpectNoError(err, "failed to list all PodTemplates")
+		framework.ExpectEqual(len(podTemplateList.Items) == 0, true, "unable to find templates")
+
+		// create a PodTemplate
+		_, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Create(&v1.PodTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: podTemplateName,
+				Labels: map[string]string{
+					"podtemplate-static": "true",
+				},
+			},
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{Name: "nginx", Image: "nginx"},
+					},
+				},
+			},
+		})
+		framework.ExpectNoError(err, "failed to create PodTemplate")
+
+		// get template
+		podTemplateRead, err := f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Get(podTemplateName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get created PodTemplate")
+		framework.ExpectEqual(podTemplateRead.ObjectMeta.Name, podTemplateName)
+
+		// patch template
+		podTemplatePatch, err := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{
+				"labels": map[string]string{
+					"podtemplate": "patched",
+				},
+			},
+		})
+		framework.ExpectNoError(err, "failed to marshal patch data")
+		_, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Patch(podTemplateName, types.StrategicMergePatchType, []byte(podTemplatePatch))
+		framework.ExpectNoError(err, "failed to patch PodTemplate")
+
+		// get template (ensure label is there)
+		podTemplateRead, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Get(podTemplateName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "failed to get PodTemplate")
+		framework.ExpectEqual(podTemplateRead.ObjectMeta.Labels["podtemplate"], "patched", "failed to patch template, new label not found")
+
+		// delete the PodTemplate
+		err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Delete(podTemplateName, &metav1.DeleteOptions{})
+		framework.ExpectNoError(err, "failed to delete PodTemplate")
+
+		// list the PodTemplates
+		podTemplateListWithLabel, err := f.ClientSet.CoreV1().PodTemplates("").List(metav1.ListOptions{
+			LabelSelector: "podtemplate-static=true",
+		})
+		framework.ExpectNoError(err, "failed to list PodTemplate")
+		framework.ExpectEqual(len(podTemplateListWithLabel.Items) == 0, true, "PodTemplate list returned items, failed to delete PodTemplate")
+	})
+})

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -36,7 +36,9 @@ var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 		podTemplateName := "nginx-pod-template-" + string(uuid.NewUUID())
 
 		// get a list of PodTemplates (in all namespaces to hit endpoint)
-		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates("").List(metav1.ListOptions{})
+		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates("").List(metav1.ListOptions{
+			LabelSelector: "podtemplate-static=true",
+		})
 		framework.ExpectNoError(err, "failed to list all PodTemplates")
 		framework.ExpectEqual(len(podTemplateList.Items), 0, "unable to find templates")
 
@@ -85,10 +87,10 @@ var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 		framework.ExpectNoError(err, "failed to delete PodTemplate")
 
 		// list the PodTemplates
-		podTemplateListWithLabel, err := f.ClientSet.CoreV1().PodTemplates("").List(metav1.ListOptions{
+		podTemplateList, err = f.ClientSet.CoreV1().PodTemplates("").List(metav1.ListOptions{
 			LabelSelector: "podtemplate-static=true",
 		})
 		framework.ExpectNoError(err, "failed to list PodTemplate")
-		framework.ExpectEqual(len(podTemplateListWithLabel.Items), 0, "PodTemplate list returned items, failed to delete PodTemplate")
+		framework.ExpectEqual(len(podTemplateList.Items), 0, "PodTemplate list returned items, failed to delete PodTemplate")
 	})
 })

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -18,13 +18,12 @@ package common
 
 import (
 	"encoding/json"
-	//"fmt"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/onsi/ginkgo"
 )
@@ -39,7 +38,7 @@ var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 		// get a list of PodTemplates (in all namespaces to hit endpoint)
 		podTemplateList, err := f.ClientSet.CoreV1().PodTemplates("").List(metav1.ListOptions{})
 		framework.ExpectNoError(err, "failed to list all PodTemplates")
-		framework.ExpectEqual(len(podTemplateList.Items) == 0, true, "unable to find templates")
+		framework.ExpectEqual(len(podTemplateList.Items), 0, "unable to find templates")
 
 		// create a PodTemplate
 		_, err = f.ClientSet.CoreV1().PodTemplates(testNamespaceName).Create(&v1.PodTemplate{
@@ -90,6 +89,6 @@ var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 			LabelSelector: "podtemplate-static=true",
 		})
 		framework.ExpectNoError(err, "failed to list PodTemplate")
-		framework.ExpectEqual(len(podTemplateListWithLabel.Items) == 0, true, "PodTemplate list returned items, failed to delete PodTemplate")
+		framework.ExpectEqual(len(podTemplateListWithLabel.Items), 0, "PodTemplate list returned items, failed to delete PodTemplate")
 	})
 })


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a test to test the following untested stable endpoints:
- deleteCoreV1NamespacedPodTemplate
- listCoreV1PodTemplateForAllNamespaces
- patchCoreV1NamespacedPodTemplate
- readCoreV1NamespacedPodTemplate

**Which issue(s) this PR fixes**:
Fixes #86141

**Special notes for your reviewer**:
Adds + 3 test endpoint coverage (good for conformance)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing