### PR TITLE
Fix static check failures in test/e2e/instrumentation/monitoring

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -48,7 +48,6 @@ pkg/volume/vsphere_volume
 test/e2e/apps
 test/e2e/autoscaling
 test/e2e/instrumentation/logging/stackdriver
-test/e2e/instrumentation/monitoring
 test/integration/deployment
 test/integration/etcd
 test/integration/examples

--- a/test/e2e/instrumentation/monitoring/BUILD
+++ b/test/e2e/instrumentation/monitoring/BUILD
@@ -48,6 +48,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/google.golang.org/api/monitoring/v3:go_default_library",
+        "//vendor/google.golang.org/api/option:go_default_library",
     ],
 )
 

--- a/test/e2e/instrumentation/monitoring/accelerator.go
+++ b/test/e2e/instrumentation/monitoring/accelerator.go
@@ -35,6 +35,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"golang.org/x/oauth2/google"
 	gcm "google.golang.org/api/monitoring/v3"
+	"google.golang.org/api/option"
 )
 
 // Stackdriver container accelerator metrics, as described here:
@@ -63,8 +64,9 @@ func testStackdriverAcceleratorMonitoring(f *framework.Framework) {
 
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
+	framework.ExpectNoError(err)
 
-	gcmService, err := gcm.New(client)
+	gcmService, err := gcm.NewService(ctx, option.WithHTTPClient(client))
 
 	framework.ExpectNoError(err)
 

--- a/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/onsi/ginkgo"
 	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
 )
 
 const (
@@ -99,8 +100,9 @@ func testCustomMetrics(f *framework.Framework, kubeClient clientset.Interface, c
 
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
+	framework.ExpectNoError(err)
 
-	gcmService, err := gcm.New(client)
+	gcmService, err := gcm.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		framework.Failf("Failed to create gcm service, %v", err)
 	}
@@ -145,8 +147,9 @@ func testExternalMetrics(f *framework.Framework, kubeClient clientset.Interface,
 
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
+	framework.ExpectNoError(err)
 
-	gcmService, err := gcm.New(client)
+	gcmService, err := gcm.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		framework.Failf("Failed to create gcm service, %v", err)
 	}

--- a/test/e2e/instrumentation/monitoring/stackdriver.go
+++ b/test/e2e/instrumentation/monitoring/stackdriver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/onsi/ginkgo"
 	"golang.org/x/oauth2/google"
 	gcm "google.golang.org/api/monitoring/v3"
+	"google.golang.org/api/option"
 )
 
 var (
@@ -76,6 +77,7 @@ func testStackdriverMonitoring(f *framework.Framework, pods, allPodsCPU int, per
 
 	ctx := context.Background()
 	client, err := google.DefaultClient(ctx, gcm.CloudPlatformScope)
+	framework.ExpectNoError(err)
 
 	// Hack for running tests locally
 	// If this is your use case, create application default credentials:
@@ -90,7 +92,7 @@ func testStackdriverMonitoring(f *framework.Framework, pods, allPodsCPU int, per
 		client := oauth2.NewClient(oauth2.NoContext, ts)
 	*/
 
-	gcmService, err := gcm.New(client)
+	gcmService, err := gcm.NewService(ctx, option.WithHTTPClient(client))
 
 	// set this env var if accessing Stackdriver test endpoint (default is prod):
 	// $ export STACKDRIVER_API_ENDPOINT_OVERRIDE=https://test-monitoring.sandbox.googleapis.com/


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
when removing test/e2e/instrumentation/monitoring from `hack/.staticcheck_failures` , the result is below:
```
$ ./hack/verify-staticcheck.sh
installing staticcheck from vendor
Errors from staticcheck:
test/e2e/instrumentation/monitoring/accelerator.go:65:10: this value of err is never used (SA4006)
test/e2e/instrumentation/monitoring/accelerator.go:67:21: gcm.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (SA1019)
test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go:101:10: this value of err is never used (SA4006)
test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go:103:21: gcm.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (SA1019)
test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go:147:10: this value of err is never used (SA4006)
test/e2e/instrumentation/monitoring/custom_metrics_stackdriver.go:149:21: gcm.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (SA1019)
test/e2e/instrumentation/monitoring/stackdriver.go:78:10: this value of err is never used (SA4006)
test/e2e/instrumentation/monitoring/stackdriver.go:93:21: gcm.New is deprecated: please use NewService instead. To provide a custom HTTP client, use option.WithHTTPClient. If you are using google.golang.org/api/googleapis/transport.APIKey, use option.WithAPIKey with NewService instead.  (SA1019)
```
This PR fixes static check failures in test/e2e/instrumentation/monitoring

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref: #81657

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
