### PR TITLE
Support test deprecated metrics 

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/registry.go
+++ b/staging/src/k8s.io/component-base/metrics/registry.go
@@ -279,6 +279,9 @@ func (kr *kubeRegistry) enableHiddenStableCollectors() {
 	kr.CustomMustRegister(cs...)
 }
 
+// BuildVersion is a helper function that can be easily mocked.
+var BuildVersion = version.Get
+
 func newKubeRegistry(v apimachineryversion.Info) *kubeRegistry {
 	r := &kubeRegistry{
 		PromRegistry:     prometheus.NewRegistry(),
@@ -296,7 +299,7 @@ func newKubeRegistry(v apimachineryversion.Info) *kubeRegistry {
 // NewKubeRegistry creates a new vanilla Registry without any Collectors
 // pre-registered.
 func NewKubeRegistry() KubeRegistry {
-	r := newKubeRegistry(version.Get())
+	r := newKubeRegistry(BuildVersion())
 
 	return r
 }

--- a/staging/src/k8s.io/component-base/metrics/testutil/BUILD
+++ b/staging/src/k8s.io/component-base/metrics/testutil/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/component-base/metrics/testutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/testutil:go_default_library",
         "//vendor/github.com/prometheus/common/expfmt:go_default_library",
@@ -29,4 +30,11 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["testutil_test.go"],
+    embed = [":go_default_library"],
+    deps = ["//staging/src/k8s.io/component-base/metrics:go_default_library"],
 )

--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil_test.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/component-base/metrics"
+)
+
+func TestNewFakeKubeRegistry(t *testing.T) {
+	registryVersion := "1.18.0"
+	counter := metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name: "test_counter_name",
+			Help: "counter help",
+		},
+	)
+	deprecatedCounter := metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:              "test_deprecated_counter",
+			Help:              "counter help",
+			DeprecatedVersion: "1.18.0",
+		},
+	)
+	hiddenCounter := metrics.NewCounter(
+		&metrics.CounterOpts{
+			Name:              "test_hidden_counter",
+			Help:              "counter help",
+			DeprecatedVersion: "1.17.0",
+		},
+	)
+
+	var tests = []struct {
+		name     string
+		metric   *metrics.Counter
+		expected string
+	}{
+		{
+			name:   "normal",
+			metric: counter,
+			expected: `
+				# HELP test_counter_name [ALPHA] counter help
+				# TYPE test_counter_name counter
+				test_counter_name 0
+				`,
+		},
+		{
+			name:   "deprecated",
+			metric: deprecatedCounter,
+			expected: `
+				# HELP test_deprecated_counter [ALPHA] (Deprecated since 1.18.0) counter help
+				# TYPE test_deprecated_counter counter
+				test_deprecated_counter 0
+				`,
+		},
+		{
+			name:     "hidden",
+			metric:   hiddenCounter,
+			expected: ``,
+		},
+	}
+
+	for _, test := range tests {
+		tc := test
+		t.Run(tc.name, func(t *testing.T) {
+			registry := NewFakeKubeRegistry(registryVersion)
+			registry.MustRegister(tc.metric)
+			if err := GatherAndCompare(registry, strings.NewReader(tc.expected), tc.metric.FQName()); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
We need a mechanism to support the deprecated metrics unit test, especially for the packages out of `component-base`.

Since we can't get build-in versions in unit tests, so we need a fake method to create a registry with an individual version. 

**Which issue(s) this PR fixes**:
Fixes #86292

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority backlog
/milestone v1.18
