### PR TITLE
fix static check in cluster/images/etcd-version-monitor

### DIFF
--- a/cluster/images/etcd-version-monitor/etcd-version-monitor.go
+++ b/cluster/images/etcd-version-monitor/etcd-version-monitor.go
@@ -251,7 +251,6 @@ func getVersionPeriodically(stopCh <-chan struct{}) {
 		}
 		select {
 		case <-stopCh:
-			break
 		case <-time.After(scrapeTimeout):
 		}
 	}

--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,4 +1,3 @@
-cluster/images/etcd-version-monitor
 cluster/images/etcd/migrate
 pkg/controller/daemon
 pkg/controller/deployment


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:
Fix static check failures in cluster/images/etcd-version-monitor

**Which issue(s) this PR fixes**:
Ref: #81657 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
