### PR TITLE
fix staticcheck errors in pkg/volume/hostpath.

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -48,7 +48,6 @@ pkg/volume/emptydir
 pkg/volume/fc
 pkg/volume/flexvolume
 pkg/volume/flocker
-pkg/volume/hostpath
 pkg/volume/iscsi
 pkg/volume/local
 pkg/volume/portworx

--- a/pkg/volume/hostpath/host_path.go
+++ b/pkg/volume/hostpath/host_path.go
@@ -357,9 +357,8 @@ type hostPathTypeChecker interface {
 }
 
 type fileTypeChecker struct {
-	path   string
-	exists bool
-	hu     hostutil.HostUtils
+	path string
+	hu   hostutil.HostUtils
 }
 
 func (ftc *fileTypeChecker) Exists() bool {

--- a/pkg/volume/hostpath/host_path_test.go
+++ b/pkg/volume/hostpath/host_path_test.go
@@ -327,10 +327,10 @@ func setUp() error {
 	}
 
 	f, err := os.OpenFile("/tmp/ExistingFolder/foo", os.O_CREATE, os.FileMode(0644))
-	defer f.Close()
 	if err != nil {
 		return err
 	}
+	defer f.Close()
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>
clean remaining static check errors in pkg/volume/hostpath.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug
> /kind cleanup


**What this PR does / why we need it**:
cleanup staticcheck errors, it says as below:
<!--
pkg/volume/hostpath/host_path.go:361:2: field exists is unused (U1000)
-->
**Which issue(s) this PR fixes**:
Ref:#81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
