### PR TITLE
Promote: Namespace patch test

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -25,6 +25,7 @@ test/e2e/apimachinery/garbage_collector.go: "should not delete dependents that h
 test/e2e/apimachinery/garbage_collector.go: "should not be blocked by dependency circle"
 test/e2e/apimachinery/namespace.go: "should ensure that all pods are removed when a namespace is deleted"
 test/e2e/apimachinery/namespace.go: "should ensure that all services are removed when a namespace is deleted"
+test/e2e/apimachinery/namespace.go: "should patch a Namespace"
 test/e2e/apimachinery/resource_quota.go: "should create a ResourceQuota and ensure its status is promptly calculated."
 test/e2e/apimachinery/resource_quota.go: "should create a ResourceQuota and capture the life of a service."
 test/e2e/apimachinery/resource_quota.go: "should create a ResourceQuota and capture the life of a secret."

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -250,12 +250,12 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 		func() { extinguish(f, 100, 0, 150) })
 
 	/*
-          Release : v1.18
-          Testname: Namespace patching
-          Description: A Namespace is created.
-          The Namespace is patched.
-          The Namespace and MUST now include the new Label.
-        */
+	   Release : v1.18
+	   Testname: Namespace patching
+	   Description: A Namespace is created.
+	   The Namespace is patched.
+	   The Namespace and MUST now include the new Label.
+	*/
 	framework.ConformanceIt("should patch a Namespace", func() {
 		ginkgo.By("creating a Namespace")
 		namespaceName := "nspatchtest-" + string(uuid.NewUUID())

--- a/test/e2e/apimachinery/namespace.go
+++ b/test/e2e/apimachinery/namespace.go
@@ -249,7 +249,14 @@ var _ = SIGDescribe("Namespaces [Serial]", func() {
 	ginkgo.It("should always delete fast (ALL of 100 namespaces in 150 seconds) [Feature:ComprehensiveNamespaceDraining]",
 		func() { extinguish(f, 100, 0, 150) })
 
-	ginkgo.It("should patch a Namespace", func() {
+	/*
+          Release : v1.18
+          Testname: Namespace patching
+          Description: A Namespace is created.
+          The Namespace is patched.
+          The Namespace and MUST now include the new Label.
+        */
+	framework.ConformanceIt("should patch a Namespace", func() {
 		ginkgo.By("creating a Namespace")
 		namespaceName := "nspatchtest-" + string(uuid.NewUUID())
 		ns, err := f.CreateNamespace(namespaceName, nil)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
`test/e2e/apimachinery/namespace.go: "should patch a Namespace"`

**Special notes for your reviewer**:
Adds +1 conformance endpoint coverage.
Original test ticket #86854.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/area conformance
/area test
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg