### PR TITLE
Promote: find Kubernetes Service in default Namespace

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -259,6 +259,7 @@ test/e2e/network/service.go: "should be able to change the type from ExternalNam
 test/e2e/network/service.go: "should be able to change the type from ExternalName to NodePort"
 test/e2e/network/service.go: "should be able to change the type from ClusterIP to ExternalName"
 test/e2e/network/service.go: "should be able to change the type from NodePort to ExternalName"
+test/e2e/network/service.go: "should find a service from listing all namespaces"
 test/e2e/network/service_latency.go: "should not be very high"
 test/e2e/node/events.go: "should be sent by kubelets and the scheduler about pods scheduling and running"
 test/e2e/node/pods.go: "should be set on Pods with matching resource requests and limits for memory and cpu"

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2637,9 +2637,9 @@ var _ = SIGDescribe("Services", func() {
 	})
 
 	/*
-          Release : v1.18
-          Testname: Find Kubernetes Service in default Namespace
-          Description: List all Services in all Namespaces, response MUST include a Service named Kubernetes with the Namespace of default.
+	   Release : v1.18
+	   Testname: Find Kubernetes Service in default Namespace
+	   Description: List all Services in all Namespaces, response MUST include a Service named Kubernetes with the Namespace of default.
 	*/
 	framework.ConformanceIt("should find a service from listing all namespaces", func() {
 		ginkgo.By("fetching services")

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2636,7 +2636,12 @@ var _ = SIGDescribe("Services", func() {
 		e2eservice.WaitForServiceUpdatedWithFinalizer(cs, svc.Namespace, svc.Name, true)
 	})
 
-	ginkgo.It("should find a service from listing all namespaces", func() {
+	/*
+          Release : v1.18
+          Testname: Find Kubernetes Service in default Namespace
+          Description: List all Services in all Namespaces, response MUST include a Service named Kubernetes with the Namespace of default.
+	*/
+	framework.ConformanceIt("should find a service from listing all namespaces", func() {
 		ginkgo.By("fetching services")
 		svcs, _ := f.ClientSet.CoreV1().Services("").List(metav1.ListOptions{})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E test to Conformance:
`test/e2e/network/service.go: "should find a service from listing all namespaces"`

**Special notes for your reviewer**:
Adds +1 conformance endpoint coverage.
Fixes #86089.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/area conformance
/area test
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg