### PR TITLE
Promote: Secret patching test

### DIFF
--- a/test/conformance/testdata/conformance.txt
+++ b/test/conformance/testdata/conformance.txt
@@ -206,6 +206,7 @@ test/e2e/common/runtime.go: "should report termination message  from file when p
 test/e2e/common/secrets.go: "should be consumable from pods in env vars"
 test/e2e/common/secrets.go: "should be consumable via the environment"
 test/e2e/common/secrets.go: "should fail to create secret due to empty secret key"
+test/e2e/common/secrets.go: "should patch a secret"
 test/e2e/common/secrets_volume.go: "should be consumable from pods in volume"
 test/e2e/common/secrets_volume.go: "should be consumable from pods in volume with defaultMode set"
 test/e2e/common/secrets_volume.go: "should be consumable from pods in volume as non-root with defaultMode and fsGroup set"

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -138,7 +138,16 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 		framework.ExpectError(err, "created secret %q with empty key in namespace %q", secret.Name, f.Namespace.Name)
 	})
 
-	ginkgo.It("should patch a secret", func() {
+	/*
+	   Release : v1.18
+	   Testname: Secret patching
+	   Description: A Secret is created.
+           Listing all Secrets MUST return an empty list.
+           Given the patching and fetching of the Secret, the fields MUST equal the new values.
+           The Secret is deleted by it's static Label.
+           Secrets are listed finally, the list MUST NOT include the originally created Secret.
+	*/
+	framework.ConformanceIt("should patch a secret", func() {
 		ginkgo.By("creating a secret")
 
 		secretTestName := "test-secret-" + string(uuid.NewUUID())

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -139,13 +139,13 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 	})
 
 	/*
-		   Release : v1.18
-		   Testname: Secret patching
-		   Description: A Secret is created.
-	           Listing all Secrets MUST return an empty list.
-	           Given the patching and fetching of the Secret, the fields MUST equal the new values.
-	           The Secret is deleted by it's static Label.
-	           Secrets are listed finally, the list MUST NOT include the originally created Secret.
+			   Release : v1.18
+			   Testname: Secret patching
+			   Description: A Secret is created.
+		           Listing all Secrets MUST return an empty list.
+		           Given the patching and fetching of the Secret, the fields MUST equal the new values.
+		           The Secret is deleted by it's static Label.
+		           Secrets are listed finally, the list MUST NOT include the originally created Secret.
 	*/
 	framework.ConformanceIt("should patch a secret", func() {
 		ginkgo.By("creating a secret")

--- a/test/e2e/common/secrets.go
+++ b/test/e2e/common/secrets.go
@@ -139,13 +139,13 @@ var _ = ginkgo.Describe("[sig-api-machinery] Secrets", func() {
 	})
 
 	/*
-	   Release : v1.18
-	   Testname: Secret patching
-	   Description: A Secret is created.
-           Listing all Secrets MUST return an empty list.
-           Given the patching and fetching of the Secret, the fields MUST equal the new values.
-           The Secret is deleted by it's static Label.
-           Secrets are listed finally, the list MUST NOT include the originally created Secret.
+		   Release : v1.18
+		   Testname: Secret patching
+		   Description: A Secret is created.
+	           Listing all Secrets MUST return an empty list.
+	           Given the patching and fetching of the Secret, the fields MUST equal the new values.
+	           The Secret is deleted by it's static Label.
+	           Secrets are listed finally, the list MUST NOT include the originally created Secret.
 	*/
 	framework.ConformanceIt("should patch a secret", func() {
 		ginkgo.By("creating a secret")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
`test/e2e/common/secrets.go: "should patch a secret"`

**Special notes for your reviewer**:
Adds +3 conformance endpoint coverage.
Fixes #86393

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/area conformance
/area test
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg