### PR TITLE
Treat empty cloud provider as external 

### DIFF
--- a/cmd/kube-controller-manager/app/cloudproviders.go
+++ b/cmd/kube-controller-manager/app/cloudproviders.go
@@ -32,7 +32,7 @@ func createCloudProvider(cloudProvider string, externalCloudVolumePlugin string,
 	var cloud cloudprovider.Interface
 	var loopMode ControllerLoopMode
 	var err error
-	if cloudprovider.IsExternal(cloudProvider) {
+	if cloudprovider.IsExternal(cloudProvider) || len(cloudProvider) == 0 {
 		loopMode = ExternalLoops
 		if externalCloudVolumePlugin == "" {
 			// externalCloudVolumePlugin is temporary until we split all cloud providers out.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The flag `--cloud-provider` of `kube-controller-manager` will be deprecated in the long term.
For now, `--cloud-provider` cloud be empty or a redundant value `external` if people run CCM. 

So, this PR just check if provider is empty and if so, treat it as the case of external.

**Which issue(s) this PR fixes**:
Fixes #87224

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

/priority backlog