### PR TITLE
Add comments in several hack/verify-*.sh

### DIFF
--- a/hack/verify-all.sh
+++ b/hack/verify-all.sh
@@ -14,7 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This script is a vestigial redirection.  Please do not add "real" logic.
+# This script runs all the verify scripts respectively, so we should run
+# `hack/verify-all.sh` before submit a PR. It is equivalent to `make verify`.
+# Usage: `hack/verify-all.sh` or `make verify`.
+# Note: This script is a vestigial redirection. Please do not add "real" logic.
 
 set -o errexit
 set -o nounset

--- a/hack/verify-api-groups.sh
+++ b/hack/verify-api-groups.sh
@@ -14,8 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# locate all API groups by their packages and versions
-
+# This scripts locates all API groups by their packages and versions
+# Usage: `hack/verify-api-groups.sh`.
 
 set -o errexit
 set -o nounset

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script checks whether updating of the bazel compilation files is needed
+# or not. We should run `hack/update-bazel.sh` if actually updates them.
+# Usage: `hack/verify-bazel.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script checks boilerplate header for all files.
+# Usage: `hack/verify-boilerplate.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/verify-cli-conventions.sh
+++ b/hack/verify-cli-conventions.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script checks the description format of help message of kubectl command
+# is valid or not. And this checking is done for all kubectl sub-commands.
+# Usage: `hack/verify-cli-conventions.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script verifies whether code update is needed or not against the
+# specific sub-projects. The sub-projects are listed below this script(the
+# line that starts with `CODEGEN_PKG`).
+# Usage: `hack/verify-codegen.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/verify-conformance-requirements.sh
+++ b/hack/verify-conformance-requirements.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script checks conformance tests follow the requirements as
+# https://git.k8s.io/community/contributors/devel/sig-architecture/conformance-tests.md#conformance-test-requirements
+# Usage: `hack/verify-conformance-requirements.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/verify-description.sh
+++ b/hack/verify-description.sh
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script checks API-related files for missing descriptions and outputs a
+# list of structs and fields that are missing descriptions.
+# Usage: `hack/verify-description.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail

--- a/hack/verify-external-dependencies-version.sh
+++ b/hack/verify-external-dependencies-version.sh
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# This script verifies that dependencies are up-to-date across different files
+# Usage: `hack/verify-external-dependencies-version.sh`.
+
 set -o errexit
 set -o nounset
 set -o pipefail


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind documentation

**What this PR does / why we need it**:
Add or update the comments for the following scripts. (a-f of verify-XXX.sh)

hack/verify-all.sh
hack/verify-api-groups.sh
hack/verify-bazel.sh
hack/verify-boilerplate.sh
hack/verify-cli-conventions.sh
hack/verify-codegen.sh
hack/verify-conformance-requirements.sh
hack/verify-description.sh
hack/verify-external-dependencies-version.sh

**Which issue(s) this PR fixes**:
ref:#86597

**Special notes for your reviewer**:
/cc @fejta

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
