### PR TITLE
test/e2e/framework/rc/:refactor function ByNameContainer remove unused flag

### DIFF
--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -205,7 +205,7 @@ func RestartNodes(c clientset.Interface, nodes []v1.Node) error {
 func rcByNamePort(name string, replicas int32, image string, containerArgs []string, port int, protocol v1.Protocol,
 	labels map[string]string, gracePeriod *int64) *v1.ReplicationController {
 
-	return e2erc.ByNameContainer(name, replicas, image, labels, v1.Container{
+	return e2erc.ByNameContainer(name, replicas, labels, v1.Container{
 		Name:  name,
 		Image: image,
 		Args:  containerArgs,

--- a/test/e2e/framework/rc/rc_utils.go
+++ b/test/e2e/framework/rc/rc_utils.go
@@ -32,7 +32,7 @@ import (
 )
 
 // ByNameContainer returns a ReplicationController with specified name and container
-func ByNameContainer(name string, replicas int32, image string, labels map[string]string, c v1.Container,
+func ByNameContainer(name string, replicas int32, labels map[string]string, c v1.Container,
 	gracePeriod *int64) *v1.ReplicationController {
 
 	zeroGracePeriod := int64(0)

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -1966,7 +1966,7 @@ var _ = SIGDescribe("Services", func() {
 				PublishNotReadyAddresses: true,
 			},
 		}
-		rcSpec := e2erc.ByNameContainer(t.Name, 1, t.Image, t.Labels, v1.Container{
+		rcSpec := e2erc.ByNameContainer(t.Name, 1, t.Labels, v1.Container{
 			Args:  []string{"netexec", fmt.Sprintf("--http-port=%d", port)},
 			Name:  t.Name,
 			Image: t.Image,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 
/kind cleanup
/priority backlog
/release-note-none

**What this PR does / why we need it**:

the flag image of function ByNameContainer is unused , rcByNamePort and https://github.com/kubernetes/kubernetes/compare/master...tanjunchen:refactor-function-e2erc.ByNameContainer?expand=1#diff-3e87abdcaa68e4594b468bc5e5d99551L1972 are not need flag image.
the image flag belongs to  v1.Container,image passes it repeatly.so remove the flag.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
