### PR TITLE
Fix shellcheck warnings/errors in /build/lib/release.sh

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -372,17 +372,10 @@ function kube::release::create_docker_images_for_server() {
         docker_build_opts='--pull'
     fi
 
-    for wrappable in "${binaries[@]}"; do
+    for wrappable in $binaries; do
 
-      local oldifs=$IFS
-      IFS=","
-      # Word splitting is most intentional here
-      # shellcheck disable=SC2086
-      set $wrappable
-      IFS=$oldifs
-
-      local binary_name="$1"
-      local base_image="$2"
+      local binary_name=${wrappable%%,*}
+      local base_image=${wrappable##*,}
       local binary_file_path="${binary_dir}/${binary_name}"
       local docker_build_path="${binary_file_path}.dockerbuild"
       local docker_file_path="${docker_build_path}/Dockerfile"

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -108,7 +108,7 @@ function kube::release::package_tarballs() {
 function kube::release::package_src_tarball() {
   local -r src_tarball="${RELEASE_TARS}/kubernetes-src.tar.gz"
   kube::log::status "Building tarball: src"
-  if [ "${KUBE_GIT_TREE_STATE-}" = 'clean' ]; then
+  if [[ "${KUBE_GIT_TREE_STATE-}" = 'clean' ]]; then
     git archive -o "${src_tarball}" HEAD
   else
     find "${KUBE_ROOT}" -mindepth 1 -maxdepth 1 \
@@ -140,7 +140,7 @@ function kube::release::package_client_tarballs() {
       mkdir -p "${release_stage}/client/bin"
 
       local client_bins=("${KUBE_CLIENT_BINARIES[@]}")
-      if [ "${platform%/*}" = 'windows' ]; then
+      if [[ "${platform%/*}" = 'windows' ]]; then
         client_bins=("${KUBE_CLIENT_BINARIES_WIN[@]}")
       fi
 
@@ -176,7 +176,7 @@ function kube::release::package_node_tarballs() {
     mkdir -p "${release_stage}/node/bin"
 
     local node_bins=("${KUBE_NODE_BINARIES[@]}")
-    if [ "${platform%/*}" = 'windows' ]; then
+    if [[ "${platform%/*}" = 'windows' ]]; then
       node_bins=("${KUBE_NODE_BINARIES_WIN[@]}")
     fi
     # This fancy expression will expand to prepend a path
@@ -190,7 +190,7 @@ function kube::release::package_node_tarballs() {
 
     # Include the client binaries here too as they are useful debugging tools.
     local client_bins=("${KUBE_CLIENT_BINARIES[@]}")
-    if [ "${platform%/*}" = 'windows' ]; then
+    if [[ "${platform%/*}" = 'windows' ]]; then
       client_bins=("${KUBE_CLIENT_BINARIES_WIN[@]}")
     fi
     # This fancy expression will expand to prepend a path
@@ -262,7 +262,7 @@ function kube::release::package_server_tarballs() {
     # Include the client binaries here too as they are useful debugging tools.
     local client_bins
     client_bins=("${KUBE_CLIENT_BINARIES[@]}")
-    if [ "${platform%/*}" = 'windows' ]; then
+    if [[ "${platform%/*}" = 'windows' ]]; then
       client_bins=("${KUBE_CLIENT_BINARIES_WIN[@]}")
     fi
     # This fancy expression will expand to prepend a path
@@ -310,7 +310,7 @@ function kube::release::build_hyperkube_image() {
 
   local hyperkube_tag
   hyperkube_tag="${registry}/hyperkube-${arch}:${version}"
-  if [ -n "${save_dir}" ]; then
+  if [[ -n "${save_dir}" ]]; then
     "${DOCKER[@]}" save "${hyperkube_tag}" > "${save_dir}/hyperkube-${arch}.tar"
   fi
   kube::log::status "Deleting hyperkube image ${hyperkube_tag}"
@@ -328,7 +328,7 @@ function kube::release::build_conformance_image() {
 
   local conformance_tag
   conformance_tag="${registry}/conformance-${arch}:${version}"
-  if [ -n "${save_dir}" ]; then
+  if [[ -n "${save_dir}" ]]; then
     "${DOCKER[@]}" save "${conformance_tag}" > "${save_dir}/conformance-${arch}.tar"
   fi
   kube::log::status "Deleting conformance image ${conformance_tag}"
@@ -358,7 +358,7 @@ function kube::release::create_docker_images_for_server() {
     local -r docker_registry="k8s.gcr.io"
     # Docker tags cannot contain '+'
     local docker_tag="${KUBE_GIT_VERSION/+/_}"
-    if [ -z "${docker_tag}" ]; then
+    if [[ -z "${docker_tag}" ]]; then
       kube::log::error "git version information missing; cannot create Docker tag"
       return 1
     fi
@@ -401,7 +401,7 @@ EOF
         # If we are building an official/alpha/beta release we want to keep
         # docker images and tag them appropriately.
         local -r release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
-        if [ "${release_docker_image_tag}" != "${docker_image_tag}" ]; then
+        if [[ "${release_docker_image_tag}" != "${docker_image_tag}" ]]; then
           kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
           "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
           "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
@@ -456,7 +456,7 @@ function kube::release::package_kube_manifests_tarball() {
   find "${src_dir}" -name 'internal-*' -exec cp {} "${dst_dir}" \;
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-helper.sh" "${dst_dir}/gci-configure-helper.sh"
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-kubeapiserver.sh" "${dst_dir}/configure-kubeapiserver.sh"
-  if [ -e "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" ]; then
+  if [[ -e "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" ]]; then
     cp "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" "${dst_dir}/"
   fi
   cp "${KUBE_ROOT}/cluster/gce/gci/health-monitor.sh" "${dst_dir}/health-monitor.sh"
@@ -495,7 +495,7 @@ function kube::release::package_test_platform_tarballs() {
       mkdir -p "${release_stage}/test/bin"
 
       local test_bins=("${KUBE_TEST_BINARIES[@]}")
-      if [ "${platform%/*}" = 'windows' ]; then
+      if [[ "${platform%/*}" = 'windows' ]]; then
         test_bins=("${KUBE_TEST_BINARIES_WIN[@]}")
       fi
       # This fancy expression will expand to prepend a path

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -472,7 +472,7 @@ function kube::release::package_kube_manifests_tarball() {
   # Merge GCE-specific addons with general purpose addons.
   local gce_objects
   gce_objects=$(cd "${KUBE_ROOT}/cluster/gce/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) \( -not -name \*demo\* \))
-  if [ -n "${gce_objects}" ]; then
+  if [[ -n ${gce_objects} ]]; then
     tar c -C "${KUBE_ROOT}/cluster/gce/addons" "${gce_objects}" | tar x -C "${dst_dir}"
   fi
 

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -108,7 +108,7 @@ function kube::release::package_tarballs() {
 function kube::release::package_src_tarball() {
   local -r src_tarball="${RELEASE_TARS}/kubernetes-src.tar.gz"
   kube::log::status "Building tarball: src"
-  if [[ "${KUBE_GIT_TREE_STATE-}" == "clean" ]]; then
+  if [ "${KUBE_GIT_TREE_STATE-}" = 'clean' ]; then
     git archive -o "${src_tarball}" HEAD
   else
     "${TAR}" czf "${src_tarball}" --transform 's|^\.|kubernetes|' -C "${KUBE_ROOT}" "$(cd "${KUBE_ROOT}" && find . -mindepth 1 -maxdepth 1 \
@@ -138,7 +138,7 @@ function kube::release::package_client_tarballs() {
       mkdir -p "${release_stage}/client/bin"
 
       local client_bins=("${KUBE_CLIENT_BINARIES[@]}")
-      if [[ "${platform%/*}" == "windows" ]]; then
+      if [ "${platform%/*}" = 'windows' ]; then
         client_bins=("${KUBE_CLIENT_BINARIES_WIN[@]}")
       fi
 
@@ -174,7 +174,7 @@ function kube::release::package_node_tarballs() {
     mkdir -p "${release_stage}/node/bin"
 
     local node_bins=("${KUBE_NODE_BINARIES[@]}")
-    if [[ "${platform%/*}" == "windows" ]]; then
+    if [ "${platform%/*}" = 'windows' ]; then
       node_bins=("${KUBE_NODE_BINARIES_WIN[@]}")
     fi
     # This fancy expression will expand to prepend a path
@@ -188,7 +188,7 @@ function kube::release::package_node_tarballs() {
 
     # Include the client binaries here too as they are useful debugging tools.
     local client_bins=("${KUBE_CLIENT_BINARIES[@]}")
-    if [[ "${platform%/*}" == "windows" ]]; then
+    if [ "${platform%/*}" = 'windows' ]; then
       client_bins=("${KUBE_CLIENT_BINARIES_WIN[@]}")
     fi
     # This fancy expression will expand to prepend a path
@@ -260,7 +260,7 @@ function kube::release::package_server_tarballs() {
     # Include the client binaries here too as they are useful debugging tools.
     local client_bins
     client_bins=("${KUBE_CLIENT_BINARIES[@]}")
-    if [[ "${platform%/*}" == "windows" ]]; then
+    if [ "${platform%/*}" = 'windows' ]; then
       client_bins=("${KUBE_CLIENT_BINARIES_WIN[@]}")
     fi
     # This fancy expression will expand to prepend a path
@@ -308,7 +308,7 @@ function kube::release::build_hyperkube_image() {
 
   local hyperkube_tag
   hyperkube_tag="${registry}/hyperkube-${arch}:${version}"
-  if [[ -n "${save_dir}" ]]; then
+  if [ -n "${save_dir}" ]; then
     "${DOCKER[@]}" save "${hyperkube_tag}" > "${save_dir}/hyperkube-${arch}.tar"
   fi
   kube::log::status "Deleting hyperkube image ${hyperkube_tag}"
@@ -326,7 +326,7 @@ function kube::release::build_conformance_image() {
 
   local conformance_tag
   conformance_tag="${registry}/conformance-${arch}:${version}"
-  if [[ -n "${save_dir}" ]]; then
+  if [ -n "${save_dir}" ]; then
     "${DOCKER[@]}" save "${conformance_tag}" > "${save_dir}/conformance-${arch}.tar"
   fi
   kube::log::status "Deleting conformance image ${conformance_tag}"
@@ -357,7 +357,7 @@ function kube::release::create_docker_images_for_server() {
     local -r docker_registry="k8s.gcr.io"
     # Docker tags cannot contain '+'
     local docker_tag="${KUBE_GIT_VERSION/+/_}"
-    if [[ -z "${docker_tag}" ]]; then
+    if [ -z "${docker_tag}" ]; then
       kube::log::error "git version information missing; cannot create Docker tag"
       return 1
     fi
@@ -401,11 +401,11 @@ EOF
           echo "COPY nsswitch.conf /etc/" >> "${docker_file_path}"
         fi
 
-        "${DOCKER[@]}" build "${docker_build_opts}" -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
+        "${DOCKER[@]}" build ${docker_build_opts:+"${docker_build_opts}"} -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
         # If we are building an official/alpha/beta release we want to keep
         # docker images and tag them appropriately.
         local -r release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
-        if [[ "${release_docker_image_tag}" != "${docker_image_tag}" ]]; then
+        if [ "${release_docker_image_tag}" != "${docker_image_tag}" ]; then
           kube::log::status "Tagging docker image ${docker_image_tag} as ${release_docker_image_tag}"
           "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
           "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
@@ -463,7 +463,7 @@ function kube::release::package_kube_manifests_tarball() {
   done
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-helper.sh" "${dst_dir}/gci-configure-helper.sh"
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-kubeapiserver.sh" "${dst_dir}/configure-kubeapiserver.sh"
-  if [[ -e "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" ]]; then
+  if [ -e "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" ]; then
     cp "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" "${dst_dir}/"
   fi
   cp "${KUBE_ROOT}/cluster/gce/gci/health-monitor.sh" "${dst_dir}/health-monitor.sh"
@@ -473,7 +473,7 @@ function kube::release::package_kube_manifests_tarball() {
   # Merge GCE-specific addons with general purpose addons.
   local gce_objects
   gce_objects=$(cd "${KUBE_ROOT}/cluster/gce/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) \( -not -name \*demo\* \))
-  if [[ -n "${gce_objects}" ]]; then
+  if [ -n "${gce_objects}" ]; then
     tar c -C "${KUBE_ROOT}/cluster/gce/addons" "${gce_objects}" | tar x -C "${dst_dir}"
   fi
 
@@ -507,7 +507,7 @@ function kube::release::package_test_platform_tarballs() {
       mkdir -p "${release_stage}/test/bin"
 
       local test_bins=("${KUBE_TEST_BINARIES[@]}")
-      if [[ "${platform%/*}" == "windows" ]]; then
+      if [ "${platform%/*}" = 'windows' ]; then
         test_bins=("${KUBE_TEST_BINARIES_WIN[@]}")
       fi
       # This fancy expression will expand to prepend a path

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -458,10 +458,7 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${src_dir}/kube-addon-manager.yaml" "${dst_dir}"
   cp "${src_dir}/glbc.manifest" "${dst_dir}"
   cp "${src_dir}/etcd-empty-dir-cleanup.yaml" "${dst_dir}/"
-  local internal_manifest
-  for internal_manifest in "${src_dir}/internal-"*; do
-    cp "${internal_manifest}" "${dst_dir}"
-  done
+  find "${src_dir}" -name 'internal-*' -exec cp {} "${dst_dir}" \;
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-helper.sh" "${dst_dir}/gci-configure-helper.sh"
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-kubeapiserver.sh" "${dst_dir}/configure-kubeapiserver.sh"
   if [ -e "${KUBE_ROOT}/cluster/gce/gci/gke-internal-configure-helper.sh" ]; then

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -56,12 +56,23 @@ function kube::release::parse_and_validate_ci_version() {
     kube::log::error "Invalid ci version: '${version}', must match regex ${version_regex}"
     return 1
   }
+
+  # The VERSION variables are used when this file is sourced, hence
+  # the shellcheck SC2034 'appears unused' warning is to be ignored.
+
+  # shellcheck disable=SC2034
   VERSION_MAJOR="${BASH_REMATCH[1]}"
+  # shellcheck disable=SC2034
   VERSION_MINOR="${BASH_REMATCH[2]}"
+  # shellcheck disable=SC2034
   VERSION_PATCH="${BASH_REMATCH[3]}"
+  # shellcheck disable=SC2034
   VERSION_PRERELEASE="${BASH_REMATCH[4]}"
+  # shellcheck disable=SC2034
   VERSION_PRERELEASE_REV="${BASH_REMATCH[5]}"
+  # shellcheck disable=SC2034
   VERSION_BUILD_INFO="${BASH_REMATCH[6]}"
+  # shellcheck disable=SC2034
   VERSION_COMMITS="${BASH_REMATCH[7]}"
 }
 
@@ -100,17 +111,14 @@ function kube::release::package_src_tarball() {
   if [[ "${KUBE_GIT_TREE_STATE-}" == "clean" ]]; then
     git archive -o "${src_tarball}" HEAD
   else
-    local source_files=(
-      $(cd "${KUBE_ROOT}" && find . -mindepth 1 -maxdepth 1 \
+    "${TAR}" czf "${src_tarball}" --transform 's|^\.|kubernetes|' -C "${KUBE_ROOT}" "$(cd "${KUBE_ROOT}" && find . -mindepth 1 -maxdepth 1 \
         -not \( \
           \( -path ./_\*        -o \
              -path ./.git\*     -o \
              -path ./.config\* -o \
              -path ./.gsutil\*    \
           \) -prune \
-        \))
-    )
-    "${TAR}" czf "${src_tarball}" --transform 's|^\.|kubernetes|' -C "${KUBE_ROOT}" "${source_files[@]}"
+        \))"
   fi
 }
 
@@ -118,10 +126,10 @@ function kube::release::package_src_tarball() {
 # a full SDK
 function kube::release::package_client_tarballs() {
    # Find all of the built client binaries
-  local platform platforms
-  platforms=($(cd "${LOCAL_OUTPUT_BINPATH}" ; echo */*))
-  for platform in "${platforms[@]}"; do
-    local platform_tag=${platform/\//-} # Replace a "/" for a "-"
+  for platform in "${LOCAL_OUTPUT_BINPATH}"/*/*; do
+    local platform_tag
+    platform_tag=${platform##${LOCAL_OUTPUT_BINPATH}/} # Strip LOCAL_OUTPUT_BINPATH
+    platform_tag=${platform_tag/\//-} # Replace a "/" for a "-"
     kube::log::status "Starting tarball: client $platform_tag"
 
     (
@@ -155,8 +163,10 @@ function kube::release::package_client_tarballs() {
 function kube::release::package_node_tarballs() {
   local platform
   for platform in "${KUBE_NODE_PLATFORMS[@]}"; do
-    local platform_tag=${platform/\//-} # Replace a "/" for a "-"
-    local arch=$(basename "${platform}")
+    local platform_tag
+    local arch
+    platform_tag=${platform/\//-} # Replace a "/" for a "-"
+    arch=$(basename "${platform}")
     kube::log::status "Building tarball: node $platform_tag"
 
     local release_stage="${RELEASE_STAGE}/node/${platform_tag}/kubernetes"
@@ -204,11 +214,14 @@ function kube::release::build_server_images() {
   rm -rf "${RELEASE_IMAGES}"
   local platform
   for platform in "${KUBE_SERVER_PLATFORMS[@]}"; do
-    local platform_tag=${platform/\//-} # Replace a "/" for a "-"
-    local arch=$(basename "${platform}")
+    local platform_tag
+    local arch
+    platform_tag=${platform/\//-} # Replace a "/" for a "-"
+    arch=$(basename "${platform}")
     kube::log::status "Building images: $platform_tag"
 
-    local release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
+    local release_stage
+    release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
     rm -rf "${release_stage}"
     mkdir -p "${release_stage}/server/bin"
 
@@ -227,12 +240,15 @@ function kube::release::package_server_tarballs() {
   kube::release::build_server_images
   local platform
   for platform in "${KUBE_SERVER_PLATFORMS[@]}"; do
-    local platform_tag=${platform/\//-} # Replace a "/" for a "-"
-    local arch=$(basename "${platform}")
+    local platform_tag
+    local arch
+    platform_tag=${platform/\//-} # Replace a "/" for a "-"
+    arch=$(basename "${platform}")
     kube::log::status "Building tarball: server $platform_tag"
 
     # NOTE: this directory was setup in kube::release::build_server_images
-    local release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
+    local release_stage
+    release_stage="${RELEASE_STAGE}/server/${platform_tag}/kubernetes"
     mkdir -p "${release_stage}/addons"
 
     # This fancy expression will expand to prepend a path
@@ -242,7 +258,8 @@ function kube::release::package_server_tarballs() {
       "${release_stage}/server/bin/"
 
     # Include the client binaries here too as they are useful debugging tools.
-    local client_bins=("${KUBE_CLIENT_BINARIES[@]}")
+    local client_bins
+    client_bins=("${KUBE_CLIENT_BINARIES[@]}")
     if [[ "${platform%/*}" == "windows" ]]; then
       client_bins=("${KUBE_CLIENT_BINARIES_WIN[@]}")
     fi
@@ -258,7 +275,8 @@ function kube::release::package_server_tarballs() {
 
     kube::release::clean_cruft
 
-    local package_name="${RELEASE_TARS}/kubernetes-server-${platform_tag}.tar.gz"
+    local package_name
+    package_name="${RELEASE_TARS}/kubernetes-server-${platform_tag}.tar.gz"
     kube::release::create_tarball "${package_name}" "${release_stage}/.."
   done
 }
@@ -288,7 +306,8 @@ function kube::release::build_hyperkube_image() {
   ARCH="${arch}" REGISTRY="${registry}" VERSION="${version}" \
     make -C cluster/images/hyperkube/ build >/dev/null
 
-  local hyperkube_tag="${registry}/hyperkube-${arch}:${version}"
+  local hyperkube_tag
+  hyperkube_tag="${registry}/hyperkube-${arch}:${version}"
   if [[ -n "${save_dir}" ]]; then
     "${DOCKER[@]}" save "${hyperkube_tag}" > "${save_dir}/hyperkube-${arch}.tar"
   fi
@@ -305,7 +324,8 @@ function kube::release::build_conformance_image() {
   ARCH="${arch}" REGISTRY="${registry}" VERSION="${version}" \
     make -C cluster/images/conformance/ build >/dev/null
 
-  local conformance_tag="${registry}/conformance-${arch}:${version}"
+  local conformance_tag
+  conformance_tag="${registry}/conformance-${arch}:${version}"
   if [[ -n "${save_dir}" ]]; then
     "${DOCKER[@]}" save "${conformance_tag}" > "${save_dir}/conformance-${arch}.tar"
   fi
@@ -320,11 +340,15 @@ function kube::release::build_conformance_image() {
 function kube::release::create_docker_images_for_server() {
   # Create a sub-shell so that we don't pollute the outer environment
   (
-    local binary_dir="$1"
-    local arch="$2"
-    local binary_name
-    local binaries=($(kube::build::get_docker_wrapped_binaries "${arch}"))
-    local images_dir="${RELEASE_IMAGES}/${arch}"
+    local binary_dir
+    local arch
+    local binaries
+    local images_dir
+    binary_dir="$1"
+    arch="$2"
+    binary_name
+    binaries=$(kube::build::get_docker_wrapped_binaries "${arch}")
+    images_dir="${RELEASE_IMAGES}/${arch}"
     mkdir -p "${images_dir}"
 
     # k8s.gcr.io is the constant tag in the docker archives, this is also the default for config scripts in GKE.
@@ -341,31 +365,31 @@ function kube::release::create_docker_images_for_server() {
     # provide `--pull` argument to `docker build` if `KUBE_BUILD_PULL_LATEST_IMAGES`
     # is set to y or Y; otherwise try to build the image without forcefully
     # pulling the latest base image.
-    local DOCKER_BUILD_OPTS=()
+    local docker_build_opts
+    docker_build_opts=
     if [[ "${KUBE_BUILD_PULL_LATEST_IMAGES}" =~ [yY] ]]; then
-        DOCKER_BUILD_OPTS+=("--pull")
+        docker_build_opts='--pull'
     fi
-    local -r docker_build_opts="${DOCKER_BUILD_OPTS[@]}"
 
     for wrappable in "${binaries[@]}"; do
 
       local oldifs=$IFS
       IFS=","
-      set $wrappable
+      set "$wrappable"
       IFS=$oldifs
 
       local binary_name="$1"
       local base_image="$2"
-      local docker_build_path="${binary_dir}/${binary_name}.dockerbuild"
-      local docker_file_path="${docker_build_path}/Dockerfile"
       local binary_file_path="${binary_dir}/${binary_name}"
+      local docker_build_path="${binary_file_path}.dockerbuild"
+      local docker_file_path="${docker_build_path}/Dockerfile"
       local docker_image_tag="${docker_registry}/${binary_name}-${arch}:${docker_tag}"
 
       kube::log::status "Starting docker build for image: ${binary_name}-${arch}"
       (
         rm -rf "${docker_build_path}"
         mkdir -p "${docker_build_path}"
-        ln "${binary_dir}/${binary_name}" "${docker_build_path}/${binary_name}"
+        ln "${binary_file_path}" "${docker_build_path}/${binary_name}"
         ln "${KUBE_ROOT}/build/nsswitch.conf" "${docker_build_path}/nsswitch.conf"
         chmod 0644 "${docker_build_path}/nsswitch.conf"
         cat <<EOF > "${docker_file_path}"
@@ -377,7 +401,7 @@ EOF
           echo "COPY nsswitch.conf /etc/" >> "${docker_file_path}"
         fi
 
-        "${DOCKER[@]}" build ${docker_build_opts} -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
+        "${DOCKER[@]}" build "${docker_build_opts}" -q -t "${docker_image_tag}" "${docker_build_path}" >/dev/null
         # If we are building an official/alpha/beta release we want to keep
         # docker images and tag them appropriately.
         local -r release_docker_image_tag="${KUBE_DOCKER_REGISTRY-$docker_registry}/${binary_name}-${arch}:${KUBE_DOCKER_IMAGE_TAG-$docker_tag}"
@@ -386,10 +410,10 @@ EOF
           "${DOCKER[@]}" rmi "${release_docker_image_tag}" 2>/dev/null || true
           "${DOCKER[@]}" tag "${docker_image_tag}" "${release_docker_image_tag}" 2>/dev/null
         fi
-        "${DOCKER[@]}" save -o "${binary_dir}/${binary_name}.tar" "${docker_image_tag}" ${release_docker_image_tag}
-        echo "${docker_tag}" > "${binary_dir}/${binary_name}.docker_tag"
+        "${DOCKER[@]}" save -o "${binary_file_path}.tar" "${docker_image_tag}" "${release_docker_image_tag}"
+        echo "${docker_tag}" > "${binary_file_path}.docker_tag"
         rm -rf "${docker_build_path}"
-        ln "${binary_dir}/${binary_name}.tar" "${images_dir}/"
+        ln "${binary_file_path}.tar" "${images_dir}/"
 
         kube::log::status "Deleting docker image ${docker_image_tag}"
         "${DOCKER[@]}" rmi "${docker_image_tag}" &>/dev/null || true
@@ -434,8 +458,8 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${src_dir}/glbc.manifest" "${dst_dir}"
   cp "${src_dir}/etcd-empty-dir-cleanup.yaml" "${dst_dir}/"
   local internal_manifest
-  for internal_manifest in $(ls "${src_dir}" | grep "^internal-*"); do
-    cp "${src_dir}/${internal_manifest}" "${dst_dir}"
+  for internal_manifest in "${src_dir}/internal-"*; do
+    cp "${internal_manifest}" "${dst_dir}"
   done
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-helper.sh" "${dst_dir}/gci-configure-helper.sh"
   cp "${KUBE_ROOT}/cluster/gce/gci/configure-kubeapiserver.sh" "${dst_dir}/configure-kubeapiserver.sh"
@@ -445,12 +469,12 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${KUBE_ROOT}/cluster/gce/gci/health-monitor.sh" "${dst_dir}/health-monitor.sh"
   local objects
   objects=$(cd "${KUBE_ROOT}/cluster/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) | grep -v demo)
-  tar c -C "${KUBE_ROOT}/cluster/addons" ${objects} | tar x -C "${dst_dir}"
+  tar c -C "${KUBE_ROOT}/cluster/addons" "${objects}" | tar x -C "${dst_dir}"
   # Merge GCE-specific addons with general purpose addons.
   local gce_objects
   gce_objects=$(cd "${KUBE_ROOT}/cluster/gce/addons" && find . \( -name \*.yaml -or -name \*.yaml.in -or -name \*.json \) \( -not -name \*demo\* \))
   if [[ -n "${gce_objects}" ]]; then
-    tar c -C "${KUBE_ROOT}/cluster/gce/addons" ${gce_objects} | tar x -C "${dst_dir}"
+    tar c -C "${KUBE_ROOT}/cluster/gce/addons" "${gce_objects}" | tar x -C "${dst_dir}"
   fi
 
   kube::release::clean_cruft

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -126,10 +126,11 @@ function kube::release::package_src_tarball() {
 # a full SDK
 function kube::release::package_client_tarballs() {
    # Find all of the built client binaries
-  for platform in "${LOCAL_OUTPUT_BINPATH}"/*/*; do
+  for platform_long in "${LOCAL_OUTPUT_BINPATH}"/*/*; do
+    local platform
     local platform_tag
-    platform_tag=${platform##${LOCAL_OUTPUT_BINPATH}/} # Strip LOCAL_OUTPUT_BINPATH
-    platform_tag=${platform_tag/\//-} # Replace a "/" for a "-"
+    platform=${platform_long##${LOCAL_OUTPUT_BINPATH}/} # Strip LOCAL_OUTPUT_BINPATH
+    platform_tag=${platform/\//-} # Replace a "/" for a "-"
     kube::log::status "Starting tarball: client $platform_tag"
 
     (

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -111,14 +111,15 @@ function kube::release::package_src_tarball() {
   if [ "${KUBE_GIT_TREE_STATE-}" = 'clean' ]; then
     git archive -o "${src_tarball}" HEAD
   else
-    "${TAR}" czf "${src_tarball}" --transform 's|^\.|kubernetes|' -C "${KUBE_ROOT}" "$(cd "${KUBE_ROOT}" && find . -mindepth 1 -maxdepth 1 \
-        -not \( \
-          \( -path ./_\*        -o \
-             -path ./.git\*     -o \
-             -path ./.config\* -o \
-             -path ./.gsutil\*    \
-          \) -prune \
-        \))"
+    find "${KUBE_ROOT}" -mindepth 1 -maxdepth 1 \
+      -not \( \
+        \( -path "${KUBE_ROOT}"/_\*       -o \
+           -path "${KUBE_ROOT}"/.git\*    -o \
+           -path "${KUBE_ROOT}"/.config\* -o \
+           -path "${KUBE_ROOT}"/.gsutil\*    \
+        \) -prune \
+      \) -print0 \
+    | "${TAR}" czf "${src_tarball}" --transform "s|${KUBE_ROOT#/*}|kubernetes|" --null -T -
   fi
 }
 

--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -376,7 +376,9 @@ function kube::release::create_docker_images_for_server() {
 
       local oldifs=$IFS
       IFS=","
-      set "$wrappable"
+      # Word splitting is most intentional here
+      # shellcheck disable=SC2086
+      set $wrappable
       IFS=$oldifs
 
       local binary_name="$1"

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -1,4 +1,3 @@
-./build/lib/release.sh
 ./cluster/gce/config-default.sh
 ./cluster/gce/config-test.sh
 ./cluster/gce/gci/configure-helper.sh


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes the shellcheck failures for /build/lib/release.sh

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
