### PR TITLE
Remove Brad Childs from OWNERS files

### DIFF
--- a/pkg/controller/volume/OWNERS
+++ b/pkg/controller/volume/OWNERS
@@ -1,12 +1,10 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- childsb
 - jsafrane
 - saad-ali
 - msau42
 reviewers:
-- childsb
 - saad-ali
 - jsafrane
 - jingxu97

--- a/pkg/volume/OWNERS
+++ b/pkg/volume/OWNERS
@@ -6,7 +6,6 @@ approvers:
 - jsafrane
 - rootfs
 - gnufied
-- childsb
 - msau42
 reviewers:
 - saad-ali


### PR DESCRIPTION
This PR remove Brad Childs' github ID from the OWNERS files where it appears.

Associated with kubernetes/community#4418