### PR TITLE
Update QueueSet to enable checking before create/update

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/queueset/queueset_test.go
@@ -145,7 +145,7 @@ func TestNoRestraint(t *testing.T) {
 	config := fq.QueueSetConfig{}
 	nr, err := nrf.NewQueueSet(config)
 	if err != nil {
-		t.Fatalf("QueueSet creation failed with %v", err)
+		t.Error(err)
 	}
 	exerciseQueueSetUniformScenario(t, "NoRestraint", nr, []uniformClient{
 		{1001001001, 5, 10, time.Second, time.Second},
@@ -166,9 +166,12 @@ func TestUniformFlows(t *testing.T) {
 		HandSize:         3,
 		RequestWaitLimit: 10 * time.Minute,
 	}
+	if err := qsf.CheckConfig(config); err != nil {
+		t.Error(err)
+	}
 	qs, err := qsf.NewQueueSet(config)
 	if err != nil {
-		t.Fatalf("QueueSet creation failed with %v", err)
+		t.Error(err)
 	}
 
 	exerciseQueueSetUniformScenario(t, "UniformFlows", qs, []uniformClient{
@@ -190,9 +193,12 @@ func TestDifferentFlows(t *testing.T) {
 		HandSize:         3,
 		RequestWaitLimit: 10 * time.Minute,
 	}
+	if err := qsf.CheckConfig(config); err != nil {
+		t.Error(err)
+	}
 	qs, err := qsf.NewQueueSet(config)
 	if err != nil {
-		t.Fatalf("QueueSet creation failed with %v", err)
+		t.Error(err)
 	}
 
 	exerciseQueueSetUniformScenario(t, "DifferentFlows", qs, []uniformClient{
@@ -210,13 +216,13 @@ func TestDifferentFlowsWithoutQueuing(t *testing.T) {
 		Name:             "TestDifferentFlowsWithoutQueuing",
 		ConcurrencyLimit: 4,
 		DesiredNumQueues: 0,
-		QueueLengthLimit: 6,
-		HandSize:         3,
-		RequestWaitLimit: 10 * time.Minute,
+	}
+	if err := qsf.CheckConfig(config); err != nil {
+		t.Error(err)
 	}
 	qs, err := qsf.NewQueueSet(config)
 	if err != nil {
-		t.Fatalf("QueueSet creation failed with %v", err)
+		t.Error(err)
 	}
 
 	exerciseQueueSetUniformScenario(t, "DifferentFlowsWithoutQueuing", qs, []uniformClient{
@@ -238,9 +244,12 @@ func TestTimeout(t *testing.T) {
 		HandSize:         1,
 		RequestWaitLimit: 0,
 	}
+	if err := qsf.CheckConfig(config); err != nil {
+		t.Error(err)
+	}
 	qs, err := qsf.NewQueueSet(config)
 	if err != nil {
-		t.Fatalf("QueueSet creation failed with %v", err)
+		t.Error(err)
 	}
 
 	exerciseQueueSetUniformScenario(t, "Timeout", qs, []uniformClient{

--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/no-restraint.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/fairqueuing/testing/no-restraint.go
@@ -31,6 +31,10 @@ func NewNoRestraintFactory() fq.QueueSetFactory {
 
 type noRestraintFactory struct{}
 
+func (noRestraintFactory) CheckConfig(config fq.QueueSetConfig) error {
+	return nil
+}
+
 func (noRestraintFactory) NewQueueSet(config fq.QueueSetConfig) (fq.QueueSet, error) {
 	return noRestraint{}, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This PR updates the QueueSetFactory abstraction so that a client can get the QueueSetFactory to check shuffle-sharding config before using that config in a create or update operation.  This is needed so that the API Priority and Fairness configuration controller can decide which priority levels have good config before apportioning concurrency to them (which, in turn, is needed before the aforementioned create/update).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->


**Special notes for your reviewer**:
This is part of the ongoing work to introduce API Priority and Fairness.  This is part of what was developed in #85319 .

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190228-priority-and-fairness.md
```
