### PR TITLE
[1.15] No-op whitespace fix to CHANGELOG-1.15 to trigger a new 1.15 build

### DIFF
--- a/CHANGELOG-1.15.md
+++ b/CHANGELOG-1.15.md
@@ -174,7 +174,6 @@
 
 ## Downloads for v1.15.8
 
-
 filename | sha512 hash
 -------- | -----------
 [kubernetes.tar.gz](https://dl.k8s.io/v1.15.8/kubernetes.tar.gz) | `b546b43b3920d5d62a1a326ebf26a57e927c88b583a517eb8774a3ab557808ff484dfd1023b98fde2f4b897b039a6038fe7b0fbeee64038386c33853d0138181`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a minimal lint fix to trigger a new build version of Kubernetes 1.15
so that we can cut another release to fix the out of order tagging issue
described in k/k#86182.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes**:
Related #86182 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @tpepper @neolit123 @liggitt 
cc: @kubernetes/release-engineering 