### PR TITLE
[1.16] No-op whitespace fix to CHANGELOG-1.16 to trigger a new 1.16 build

### DIFF
--- a/CHANGELOG-1.16.md
+++ b/CHANGELOG-1.16.md
@@ -144,7 +144,6 @@
 
 ## Downloads for v1.16.5
 
-
 filename | sha512 hash
 -------- | -----------
 [kubernetes.tar.gz](https://dl.k8s.io/v1.16.5/kubernetes.tar.gz) | `574c4abd42d3640eb98bf4144afc64bbe25b752235d3398e3717a64fa505b5848e3e0b7a31cbea13d936201844c4f6385006556cf8c191f7bdac638a388345b9`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a minimal lint fix to trigger a new build version of Kubernetes 1.16
so that we can cut another release to fix the out of order tagging issue
described in k/k#86182.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes**:
Related #86182 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @tpepper @neolit123 @liggitt 
cc: @kubernetes/release-engineering 