### PR TITLE
[1.17] No-op whitespace fix to CHANGELOG-1.17 to trigger a new 1.17 build

### DIFF
--- a/CHANGELOG-1.17.md
+++ b/CHANGELOG-1.17.md
@@ -117,7 +117,6 @@
 
 ## Downloads for v1.17.1
 
-
 filename | sha512 hash
 -------- | -----------
 [kubernetes.tar.gz](https://dl.k8s.io/v1.17.1/kubernetes.tar.gz) | `b75a513ac1edc366a0ab829866687c4937485a00a0621a729860ae95fa278ecdadf37d63e608b2259e1c683dd01faf26eb828636710d9864e6f092b1a3cfd1cf`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a minimal lint fix to trigger a new build version of Kubernetes 1.17
so that we can cut another release to fix the out of order tagging issue
described in k/k#86182.

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

**Which issue(s) this PR fixes**:
Related #86182 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/assign @tpepper @neolit123 @liggitt 
cc: @kubernetes/release-engineering 
/sig release
/area release-eng
/priority critical-urgent