### PR TITLE
JSONPath support to filter on non-existent fields

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -458,6 +458,11 @@ func (j *JSONPath) evalFilter(input []reflect.Value, node *FilterNode) ([]reflec
 					results = append(results, value.Index(i))
 				}
 				continue
+			} else if node.Operator == "notexists" {
+				if len(lefts) == 0 {
+					results = append(results, value.Index(i))
+				}
+				continue
 			}
 
 			if err != nil {

--- a/staging/src/k8s.io/client-go/util/jsonpath/parser_test.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/parser_test.go
@@ -83,6 +83,9 @@ var parserTests = []parserTest{
 		newArray([3]ParamsEntry{{-1, true, false}, {0, true, true}, {0, false, false}})}, false},
 	{"negative index slice, equals a[1] to a[len-1]", `{[1:-1]}`, []Node{newList(),
 		newArray([3]ParamsEntry{{1, true, false}, {-1, true, false}, {0, false, false}})}, false},
+	{"filter", `{[?(!@.price)]}`,
+		[]Node{newList(), newFilter(newList(), newList(), "notexists"),
+			newList(), newField("price"), newList()}, false},
 }
 
 func collectNode(nodes []Node, cur Node) []Node {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements a new feature in jsonpath: with this feature it is possible to filter on non-existent fields.
Example:  get the list of nodes that do not have taints: 
`kubectl get node -o jsonpath={.items[?(!@.spec.taints]}`

**Which issue(s) this PR fixes**:
No issue
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Yes, it adds a new way how filters can be defined in the jsonpath expressions.
```release-note
Users can define filters that return array items that does not have the field defined in the filter expression in their json representation. 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
