### PR TITLE
Improve error message when diff binary is not in PATH

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -130,7 +130,7 @@ type DiffProgram struct {
 	genericclioptions.IOStreams
 }
 
-func (d *DiffProgram) getCommand(args ...string) exec.Cmd {
+func (d *DiffProgram) getCommand(args ...string) (string, exec.Cmd) {
 	diff := ""
 	if envDiff := os.Getenv("KUBECTL_EXTERNAL_DIFF"); envDiff != "" {
 		diff = envDiff
@@ -143,12 +143,16 @@ func (d *DiffProgram) getCommand(args ...string) exec.Cmd {
 	cmd.SetStdout(d.Out)
 	cmd.SetStderr(d.ErrOut)
 
-	return cmd
+	return diff, cmd
 }
 
 // Run runs the detected diff program. `from` and `to` are the directory to diff.
 func (d *DiffProgram) Run(from, to string) error {
-	return d.getCommand(from, to).Run()
+	diff, cmd := d.getCommand(from, to)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to run %q: %v", diff, err)
+	}
+	return nil
 }
 
 // Printer is used to print an object.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes partially #87343

**Special notes for your reviewer**:
Examples,

**Before**
```
PATH= /usr/bin/kubectl diff -f manifest.yaml
error: executable file not found in $PATH

KUBECTL_EXTERNAL_DIFF=unknown-binary kubectl diff -f manifest.yaml
error: executable file not found in $PATH
```

**After**
```
PATH= /usr/bin/kubectl diff -f manifest.yaml
error: failed to run "diff": executable file not found in $PATH

KUBECTL_EXTERNAL_DIFF=unknown-binary kubectl diff -f manifest.yaml
error: failed to run "unknown-binary": executable file not found in $PATH
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
