### PR TITLE
Remove Brad Childs from OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -130,7 +130,6 @@ aliases:
 
   sig-storage-reviewers:
     - saad-ali
-    - childsb
 
   sig-scheduling-maintainers:
     - alculquicondor
@@ -455,7 +454,6 @@ aliases:
     - bsalamat        # Scheduling
     - calebamiles     # Release
     - caseydavenport  # Network
-    - childsb         # Storage
     - countspongebob  # Scalability
     - csbell          # Multicluster
     - dcbw            # Network


### PR DESCRIPTION
This PR removes Brad Childs' github ID from the OWNERS files where it appears.

Associated with kubernetes/community#4418

/assign @pmorie 
/release-note-none
