### PR TITLE
Add --version-json flag to kubelet to get complete information

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -55,6 +55,7 @@ const defaultRootDir = "/var/lib/kubelet"
 type KubeletFlags struct {
 	KubeConfig          string
 	BootstrapKubeconfig string
+	VersionJSON         bool
 
 	// Insert a probability of random errors during calls to the master.
 	ChaosChance float64
@@ -351,6 +352,7 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 
 	fs.StringVar(&f.KubeletConfigFile, "config", f.KubeletConfigFile, "The Kubelet will load its initial configuration from this file. The path may be absolute or relative; relative paths start at the Kubelet's current working directory. Omit this flag to use the built-in default configuration values. Command-line flags override configuration from this file.")
 	fs.StringVar(&f.KubeConfig, "kubeconfig", f.KubeConfig, "Path to a kubeconfig file, specifying how to connect to the API server. Providing --kubeconfig enables API server mode, omitting --kubeconfig enables standalone mode.")
+	fs.BoolVar(&f.VersionJSON, "version-json", f.VersionJSON, "Prints complete version information and quit. ")
 
 	fs.StringVar(&f.BootstrapKubeconfig, "bootstrap-kubeconfig", f.BootstrapKubeconfig, "Path to a kubeconfig file that will be used to get client certificate for kubelet. "+
 		"If the file specified by --kubeconfig does not exist, the bootstrap kubeconfig is used to request a client certificate from the API server. "+

--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -20,6 +20,7 @@ package app
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net"
@@ -173,6 +174,15 @@ HTTP server: The kubelet can also listen for HTTP and respond to a simple API
 				return
 			}
 
+			if kubeletFlags.VersionJSON {
+				clientVersion := version.Get()
+				y, err := json.MarshalIndent(&clientVersion, "", "  ")
+				if err != nil {
+					klog.Fatal(err)
+				}
+				fmt.Println(string(y))
+				os.Exit(0)
+			}
 			// short-circuit on verflag
 			verflag.PrintAndExitIfRequested()
 			utilflag.PrintFlags(cleanFlagSet)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:
Add --version-json flag to kubelet to get complete information

**Which issue(s) this PR fixes**:
Fixes #86779

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adds a new flag --version-json to kubelet binary.

For example:
kubelet --version-json
{
  "major": "1",
  "minor": "18+",
  "gitVersion": "v1.18.0-alpha.1.852+05b6c32886cf52-dirty",
  "gitCommit": "05b6c32886cf522550928de30287806d53e1b293",
  "gitTreeState": "dirty",
  "buildDate": "2020-01-17T12:33:36Z",
  "goVersion": "go1.13.5",
  "compiler": "gc",
  "platform": "linux/amd64"
}
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
