### PR TITLE
Fix kubectl drain ignore daemonsets and others

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/drain/drain_test.go
@@ -867,7 +867,7 @@ func TestDrain(t *testing.T) {
 				switch {
 				case recovered != nil && !sawFatal:
 					t.Fatalf("got panic: %v", recovered)
-				case test.expectDelete && test.expectFatal && !sawFatal:
+				case test.expectFatal && !sawFatal:
 					t.Fatalf("%s: unexpected non-error when using %s", test.description, currMethod)
 				case !test.expectFatal && sawFatal:
 					t.Fatalf("%s: unexpected error when using %s: %s", test.description, currMethod, fatalMsg)
@@ -903,7 +903,7 @@ func TestDrain(t *testing.T) {
 					t.Fatalf("%s: same pod deleted %d times and evicted %d times", test.description, deletions, evictions)
 				}
 
-				if test.expectDelete && len(test.expectWarning) > 0 {
+				if len(test.expectWarning) > 0 {
 					if len(errBuf.String()) == 0 {
 						t.Fatalf("%s: expected warning, but found no stderr output", test.description)
 					}

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -180,12 +180,13 @@ func (d *Helper) GetPodsForDeletion(nodeName string) (*podDeleteList, []error) {
 				break
 			}
 		}
-		if status.delete {
-			pods = append(pods, podDelete{
-				pod:    pod,
-				status: status,
-			})
-		}
+		// Add the pod to podDeleteList no matter what podDeleteStatus is,
+		// those pods whose podDeleteStatus is false like DaemonSet will
+		// be catched by list.errors()
+		pods = append(pods, podDelete{
+			pod:    pod,
+			status: status,
+		})
 	}
 
 	list := &podDeleteList{items: pods}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
This is actually a change back of the PR which is submitted 3 months ago.
https://github.com/kubernetes/kubernetes/pull/84562

The origin PR wants stop those pods whose `status.delete` is `false` add to `podDeleteList`. The thought is good but actually after this logic there is a 
```
	if errs := list.errors(); len(errs) > 0 {
		return list, errs
	}
```
The function `list.errors` will check those pods who has `i.status.reason == podDeleteStatusTypeError`.  So those `daemonsets`, pods with volumes and others, whose `status.delete` is actually `false` will never be found in conditions after this PR. Causing error like https://github.com/kubernetes/kubectl/issues/803.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # https://github.com/kubernetes/kubectl/issues/803


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl drain ignore daemonsets and others.
```

