### PR TITLE
fix staticcheck errors in pkg/volume/emptydir.

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -44,7 +44,6 @@ pkg/volume/azure_dd
 pkg/volume/azure_file
 pkg/volume/cinder
 pkg/volume/csi
-pkg/volume/emptydir
 pkg/volume/fc
 pkg/volume/flexvolume
 pkg/volume/flocker

--- a/pkg/volume/emptydir/empty_dir.go
+++ b/pkg/volume/emptydir/empty_dir.go
@@ -172,7 +172,6 @@ type emptyDir struct {
 	mounter       mount.Interface
 	mountDetector mountDetector
 	plugin        *emptyDirPlugin
-	desiredSize   int64
 	volume.MetricsProvider
 }
 


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

> /kind bug
> /kind cleanup


**What this PR does / why we need it**:
cleanup staticcheck errors, it says as below:
```
pkg/volume/emptydir/empty_dir.go:175:2: field desiredSize is unused (U1000)
```
**Which issue(s) this PR fixes**:
Ref:#81657

**Special notes for your reviewer**:
<!--
None
-->
**Does this PR introduce a user-facing change?**:
<!--
None
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
None
-->
```docs

```
