### PR TITLE
fix staticcheck errors in pkg/controller/daemon.

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -1,6 +1,5 @@
 cluster/images/etcd-version-monitor
 cluster/images/etcd/migrate
-pkg/controller/daemon
 pkg/controller/deployment
 pkg/controller/disruption
 pkg/controller/garbagecollector

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -305,16 +305,6 @@ func (dsc *DaemonSetsController) enqueue(ds *apps.DaemonSet) {
 	dsc.queue.Add(key)
 }
 
-func (dsc *DaemonSetsController) enqueueRateLimited(ds *apps.DaemonSet) {
-	key, err := controller.KeyFunc(ds)
-	if err != nil {
-		utilruntime.HandleError(fmt.Errorf("Couldn't get key for object %#v: %v", ds, err))
-		return
-	}
-
-	dsc.queue.AddRateLimited(key)
-}
-
 func (dsc *DaemonSetsController) enqueueDaemonSetAfter(obj interface{}, after time.Duration) {
 	key, err := controller.KeyFunc(obj)
 	if err != nil {

--- a/pkg/controller/daemon/daemon_controller_test.go
+++ b/pkg/controller/daemon/daemon_controller_test.go
@@ -223,7 +223,6 @@ type fakePodControl struct {
 	podStore     cache.Store
 	podIDMap     map[string]*v1.Pod
 	expectations controller.ControllerExpectationsInterface
-	dsc          *daemonSetsController
 }
 
 func newFakePodControl() *fakePodControl {


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
cleanup staticcheck errors, it says as below:

```
pkg/controller/daemon/daemon_controller.go:308:34: func (*DaemonSetsController).enqueueRateLimited is unused (U1000)
pkg/controller/daemon/daemon_controller_test.go:226:2: field dsc is unused (U1000)

```

**Which issue(s) this PR fixes**:
Ref:#81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--

-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
