### PR TITLE
[Kubemark] Remove flags that prevents creation of some components

### DIFF
--- a/test/kubemark/gce/util.sh
+++ b/test/kubemark/gce/util.sh
@@ -50,11 +50,9 @@ function create-kubemark-master {
     export KUBE_GCE_ENABLE_IP_ALIASES=true
     export KUBE_GCE_NODE_IPAM_MODE=RangeAllocator
 
-    # Disable all addons. They are running outside of the kubemark cluster.
+    # Disable some addons. We do not replicate them in Kubemark cluster.
     export KUBE_ENABLE_CLUSTER_AUTOSCALER=false
     export KUBE_ENABLE_CLUSTER_DNS=false
-    export KUBE_ENABLE_NODE_LOGGING=false
-    export KUBE_ENABLE_METRICS_SERVER=false
     export KUBE_ENABLE_L7_LOADBALANCING="none"
 
     # Unset env variables set by kubetest for 'root cluster'. We need recompute them


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scalability

**What this PR does / why we need it**:

These flags are used to control creation of dummy components in Kubemark cluster. To match load on a real cluster, we can enable this dummy components to put additional work on measured components.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```