### PR TITLE
Refactor docker specific oom const out of qos pkg

### DIFF
--- a/pkg/kubelet/dockershim/BUILD
+++ b/pkg/kubelet/dockershim/BUILD
@@ -51,7 +51,6 @@ go_library(
         "//pkg/kubelet/dockershim/network/kubenet:go_default_library",
         "//pkg/kubelet/kuberuntime:go_default_library",
         "//pkg/kubelet/leaky:go_default_library",
-        "//pkg/kubelet/qos:go_default_library",
         "//pkg/kubelet/server/streaming:go_default_library",
         "//pkg/kubelet/types:go_default_library",
         "//pkg/kubelet/util/cache:go_default_library",

--- a/pkg/kubelet/dockershim/cm/BUILD
+++ b/pkg/kubelet/dockershim/cm/BUILD
@@ -18,7 +18,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/kubelet/cm:go_default_library",
             "//pkg/kubelet/dockershim/libdocker:go_default_library",
-            "//pkg/kubelet/qos:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",
@@ -40,7 +39,6 @@ go_library(
         "@io_bazel_rules_go//go/platform:linux": [
             "//pkg/kubelet/cm:go_default_library",
             "//pkg/kubelet/dockershim/libdocker:go_default_library",
-            "//pkg/kubelet/qos:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/version:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
             "//vendor/github.com/opencontainers/runc/libcontainer/cgroups/fs:go_default_library",

--- a/pkg/kubelet/dockershim/cm/container_manager_linux.go
+++ b/pkg/kubelet/dockershim/cm/container_manager_linux.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/klog"
 	kubecm "k8s.io/kubernetes/pkg/kubelet/cm"
-	"k8s.io/kubernetes/pkg/kubelet/qos"
 
 	"k8s.io/kubernetes/pkg/kubelet/dockershim/libdocker"
 )
@@ -45,8 +44,10 @@ const (
 	// The minimum memory limit allocated to docker container: 150Mi
 	minDockerMemoryLimit = 150 * 1024 * 1024
 
-	// The Docker OOM score adjustment.
-	dockerOOMScoreAdj = qos.DockerOOMScoreAdj
+	// The OOM score adjustment for the docker process (i.e. the docker
+	// daemon). Essentially, makes docker very unlikely to experience an oom
+	// kill.
+	dockerOOMScoreAdj = -999
 )
 
 var (

--- a/pkg/kubelet/qos/policy.go
+++ b/pkg/kubelet/qos/policy.go
@@ -23,15 +23,8 @@ import (
 )
 
 const (
-	// PodInfraOOMAdj is very docker specific. For arbitrary runtime, it may not make
-	// sense to set sandbox level oom score, e.g. a sandbox could only be a namespace
-	// without a process.
-	// TODO: Handle infra container oom score adj in a runtime agnostic way.
-	PodInfraOOMAdj int = -998
 	// KubeletOOMScoreAdj is the OOM score adjustment for Kubelet
 	KubeletOOMScoreAdj int = -999
-	// DockerOOMScoreAdj is the OOM score adjustment for Docker
-	DockerOOMScoreAdj int = -999
 	// KubeProxyOOMScoreAdj is the OOM score adjustment for kube-proxy
 	KubeProxyOOMScoreAdj  int = -999
 	guaranteedOOMScoreAdj int = -998


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Previously, `pkg/kubelet/qos` contained two different docker-specific
OOM constants. One set the oom adj for sandbox docker containers and the
other set the oom adj for the docker daemon. Move both to be closer to
their actual usages in `dockershim`.

This change addresses a TODO and leads us towards the overall goal of
making `pkg/kubelet` runtime agnostic except for `dockershim`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @Random-Liu (original author of the TODO)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
