### PR TITLE
kubeadm: remove the deprecated GA CoreDNS feature-gate

### DIFF
--- a/cmd/kubeadm/app/cmd/BUILD
+++ b/cmd/kubeadm/app/cmd/BUILD
@@ -85,7 +85,6 @@ go_test(
         "//cmd/kubeadm/app/apis/output/v1alpha1:go_default_library",
         "//cmd/kubeadm/app/cmd/options:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/config:go_default_library",
         "//cmd/kubeadm/app/util/output:go_default_library",

--- a/cmd/kubeadm/app/cmd/init_test.go
+++ b/cmd/kubeadm/app/cmd/init_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package cmd
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -25,7 +24,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/kubernetes/cmd/kubeadm/app/cmd/options"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 )
 
 const (
@@ -83,13 +81,6 @@ func TestNewInitData(t *testing.T) {
 			name: "fail if unknown feature gates flag are passed",
 			flags: map[string]string{
 				options.FeatureGatesString: "unknown=true",
-			},
-			expectError: true,
-		},
-		{
-			name: "fail if deprecated feature gates are set",
-			flags: map[string]string{
-				options.FeatureGatesString: fmt.Sprintf("%s=true", features.CoreDNS),
 			},
 			expectError: true,
 		},

--- a/cmd/kubeadm/app/features/features.go
+++ b/cmd/kubeadm/app/features/features.go
@@ -28,19 +28,12 @@ import (
 )
 
 const (
-
-	// CoreDNS is GA in v1.11
-	CoreDNS = "CoreDNS"
 	// IPv6DualStack is expected to be alpha in v1.16
 	IPv6DualStack = "IPv6DualStack"
 )
 
-var coreDNSMessage = "featureGates:CoreDNS has been removed in v1.13\n" +
-	"\tUse kubeadm-config to select which DNS addon to install."
-
 // InitFeatureGates are the default feature gates for the init command
 var InitFeatureGates = FeatureList{
-	CoreDNS:       {FeatureSpec: featuregate.FeatureSpec{Default: true, PreRelease: featuregate.Deprecated}, HiddenInHelpText: true, DeprecationMessage: coreDNSMessage},
 	IPv6DualStack: {FeatureSpec: featuregate.FeatureSpec{Default: false, PreRelease: featuregate.Alpha}},
 }
 

--- a/cmd/kubeadm/test/cmd/init_test.go
+++ b/cmd/kubeadm/test/cmd/init_test.go
@@ -353,10 +353,6 @@ func TestCmdInitFeatureGates(t *testing.T) {
 			args: "",
 		},
 		{
-			name: "feature gate CoreDNS=true",
-			args: "--feature-gates=CoreDNS=true",
-		},
-		{
 			name: "feature gate IPv6DualStack=true",
 			args: "--feature-gates=IPv6DualStack=true",
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the deprecated GA CoreDNS feature-gate from kubeadm.

The CoreDNS GA feature-gate in kubeadm was deprecated since v1.13.
The k8s policy is to remove the gate 2 releases after it transitions
to GA:
https://kubernetes.io/docs/reference/using-api/deprecation-policy/#deprecation

It  was kept it around for longer to prevent existing setups from breaking
as it caused minimal maintenance overhead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
https://github.com/kubernetes/kubernetes/commit/6759334f6eda2bf7e9b16abc00b7466f26cc12d2#diff-a6e7ba50788e0e5791c8204fcd54b00dR47

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: remove the deprecated CoreDNS feature-gate. It was set to "true" since v1.11 when the feature went GA. In v1.13 it was marked as deprecated and hidden from the CLI.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/cc @rosti @chrisohaver @rajansandeep 
looking for an LGTM.

/priority important-longeterm
/kind cleanup
