### PR TITLE
Staticcheck: vendor/k8s.io/kubectl/pkg/cmd/testing etc.

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -92,7 +92,5 @@ vendor/k8s.io/client-go/transport
 vendor/k8s.io/component-base/metrics
 vendor/k8s.io/kubectl/pkg/cmd/edit
 vendor/k8s.io/kubectl/pkg/cmd/get
-vendor/k8s.io/kubectl/pkg/cmd/scale
 vendor/k8s.io/kubectl/pkg/cmd/set
-vendor/k8s.io/kubectl/pkg/cmd/testing
 vendor/k8s.io/metrics/pkg/client/custom_metrics

--- a/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/proxy/proxy.go
@@ -199,6 +199,9 @@ func (o ProxyOptions) Validate() error {
 // RunProxy checks given arguments and executes command
 func (o ProxyOptions) RunProxy() error {
 	server, err := proxy.NewServer(o.staticDir, o.apiPrefix, o.staticPrefix, o.filter, o.clientConfig, o.keepalive)
+	if err != nil {
+		klog.Fatal(err)
+	}
 
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/scale/scale.go
@@ -196,7 +196,7 @@ func (o *ScaleOptions) RunScale() error {
 	}
 
 	infos := []*resource.Info{}
-	err = r.Visit(func(info *resource.Info, err error) error {
+	_ = r.Visit(func(info *resource.Info, err error) error {
 		if err == nil {
 			infos = append(infos, info)
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/testing/fake.go
@@ -18,7 +18,6 @@ package testing
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -270,8 +269,6 @@ func convertExternalNamespacedType2ToInternalNamespacedType(in *ExternalNamespac
 	out.Namespace = in.Namespace
 	return nil
 }
-
-var errInvalidVersion = errors.New("not a version")
 
 // ValidVersion of API
 var ValidVersion = "v1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Fix static check failures for:


~~vendor/k8s.io/kubectl/pkg/cmd/proxy~~
~~vendor/k8s.io/kubectl/pkg/cmd/rollingupdate~~
```
vendor/k8s.io/kubectl/pkg/cmd/scale
vendor/k8s.io/kubectl/pkg/cmd/testing
```

Ref: #81657

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
