### PR TITLE
Staticcheck: vendor/k8s.io/kubectl/pkg/cmd/set and .../edit

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -91,9 +91,7 @@ vendor/k8s.io/client-go/restmapper
 vendor/k8s.io/client-go/tools/leaderelection
 vendor/k8s.io/client-go/transport
 vendor/k8s.io/component-base/metrics
-vendor/k8s.io/kubectl/pkg/cmd/edit
 vendor/k8s.io/kubectl/pkg/cmd/get
 vendor/k8s.io/kubectl/pkg/cmd/scale
-vendor/k8s.io/kubectl/pkg/cmd/set
 vendor/k8s.io/kubectl/pkg/cmd/testing
 vendor/k8s.io/metrics/pkg/client/custom_metrics

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -17,8 +17,6 @@ limitations under the License.
 package edit
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -77,7 +75,7 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Edit a resource on the server"),
 		Long:                  editLong,
-		Example:               fmt.Sprintf(editExample),
+		Example:               editExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := o.Complete(f, args, cmd); err != nil {
 				cmdutil.CheckErr(err)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/helper.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/helper.go
@@ -54,6 +54,7 @@ func selectString(s, spec string) bool {
 	pos := 0
 	match := true
 	parts := strings.Split(spec, "*")
+Loop:
 	for i, part := range parts {
 		if len(part) == 0 {
 			continue
@@ -69,7 +70,7 @@ func selectString(s, spec string) bool {
 		// last part does not exactly match remaining part of string
 		case i == (len(parts)-1) && len(s) != (len(part)+next):
 			match = false
-			break
+			break Loop
 		default:
 			pos = next
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -151,7 +151,7 @@ func NewCmdEnv(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 		DisableFlagsInUseLine: true,
 		Short:                 "Update environment variables on a pod template",
 		Long:                  envLong,
-		Example:               fmt.Sprintf(envExample),
+		Example:               envExample,
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(f, cmd, args))
 			cmdutil.CheckErr(o.Validate())

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
@@ -175,6 +175,9 @@ func (o *SetSelectorOptions) RunSelector() error {
 	r := o.ResourceFinder.Do()
 
 	return r.Visit(func(info *resource.Info, err error) error {
+		if err != nil {
+			return err
+		}
 		patch := &Patch{Info: info}
 
 		if len(o.resourceVersion) != 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject_test.go
@@ -411,7 +411,7 @@ func TestAddSubject(t *testing.T) {
 	}
 	for _, tt := range tests {
 		changed := false
-		got := []rbacv1.Subject{}
+		var got []rbacv1.Subject
 		if changed, got = addSubjects(tt.existing, tt.subjects); (changed != false) != tt.wantChange {
 			t.Errorf("%q. addSubjects() changed = %v, wantChange = %v", tt.Name, changed, tt.wantChange)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Fix static check failures for:

```
vendor/k8s.io/kubectl/pkg/cmd/set
vendor/k8s.io/kubectl/pkg/cmd/edit
```

Ref #81657

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
