### PR TITLE
Remove `scheduler/algorithm/priorities` in import-restrictions

### DIFF
--- a/pkg/controller/.import-restrictions
+++ b/pkg/controller/.import-restrictions
@@ -239,8 +239,6 @@
         "k8s.io/kubernetes/pkg/kubelet/util/format",
         "k8s.io/kubernetes/pkg/quota",
         "k8s.io/kubernetes/pkg/registry/core/secret",
-        "k8s.io/kubernetes/pkg/scheduler/algorithm",
-        "k8s.io/kubernetes/pkg/scheduler/algorithm/predicates",
         "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper",
         "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1",
         "k8s.io/kubernetes/pkg/scheduler/nodeinfo",

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -76,7 +76,6 @@
 				"k8s.io/kubernetes/pkg/master/ports",
 				"k8s.io/kubernetes/pkg/registry/core/service/allocator",
 				"k8s.io/kubernetes/pkg/registry/core/service/portallocator",
-				"k8s.io/kubernetes/pkg/scheduler/algorithm/priorities/util",
 				"k8s.io/kubernetes/pkg/scheduler/api",
 				"k8s.io/kubernetes/pkg/scheduler/metrics",
 				"k8s.io/kubernetes/pkg/scheduler/nodeinfo",


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

`scheduler/algorithm/priorities/util` package has been removed in https://github.com/kubernetes/kubernetes/pull/87051/ , but there is a nit that forgot to remove it in `test/e2e/framework/.import-restrictions`.

**Which issue(s) this PR fixes**:

Refs #86993

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
