### PR TITLE
fix static check errors in test/integration/etcd

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -47,7 +47,6 @@ test/e2e/apps
 test/e2e/autoscaling
 test/e2e/instrumentation/logging/stackdriver
 test/integration/deployment
-test/integration/etcd
 test/integration/examples
 test/integration/framework
 test/integration/garbagecollector

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -125,22 +125,20 @@ func StartRealMasterOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOp
 
 	kubeClient := clientset.NewForConfigOrDie(kubeClientConfig)
 
-	go func() {
-		// Catch panics that occur in this go routine so we get a comprehensible failure
-		defer func() {
-			if err := recover(); err != nil {
-				t.Errorf("Unexpected panic trying to start API master: %#v", err)
-			}
-		}()
-
-		prepared, err := kubeAPIServer.PrepareRun()
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err := prepared.Run(stopCh); err != nil {
-			t.Fatal(err)
+	// Catch panics that occur in this go routine so we get a comprehensible failure
+	defer func() {
+		if err := recover(); err != nil {
+			t.Errorf("Unexpected panic trying to start API master: %#v", err)
 		}
 	}()
+
+	prepared, err := kubeAPIServer.PrepareRun()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := prepared.Run(stopCh); err != nil {
+		t.Fatal(err)
+	}
 
 	lastHealth := ""
 	attempt := 0
@@ -174,7 +172,7 @@ func StartRealMasterOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOp
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
 	restMapper.Reset()
 
-	serverResources, err := kubeClient.Discovery().ServerResources()
+	_, serverResources, err := kubeClient.Discovery().ServerGroupsAndResources()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -125,20 +125,22 @@ func StartRealMasterOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOp
 
 	kubeClient := clientset.NewForConfigOrDie(kubeClientConfig)
 
-	// Catch panics that occur in this go routine so we get a comprehensible failure
-	defer func() {
-		if err := recover(); err != nil {
-			t.Errorf("Unexpected panic trying to start API master: %#v", err)
+	go func() {
+		// Catch panics that occur in this go routine so we get a comprehensible failure
+		defer func() {
+			if err := recover(); err != nil {
+				t.Errorf("Unexpected panic trying to start API master: %#v", err)
+			}
+		}()
+
+		prepared, err := kubeAPIServer.PrepareRun()
+		if err != nil {
+			t.Error(err)
+		}
+		if err := prepared.Run(stopCh); err != nil {
+			t.Error(err)
 		}
 	}()
-
-	prepared, err := kubeAPIServer.PrepareRun()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := prepared.Run(stopCh); err != nil {
-		t.Fatal(err)
-	}
 
 	lastHealth := ""
 	attempt := 0


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
-->

**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
cleanup staticcheck errors, it says as below:
```
test/integration/etcd/server.go:128:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
test/integration/etcd/server.go:177:26: kubeClient.Discovery().ServerResources is deprecated: use ServerGroupsAndResources instead.  (SA1019)
```

**Which issue(s) this PR fixes**:
Ref:#81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
