### PR TITLE
Revert "Cleanup/Enhance scheduler metrics"

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/cycle_state.go
+++ b/pkg/scheduler/framework/v1alpha1/cycle_state.go
@@ -44,8 +44,8 @@ type StateKey string
 type CycleState struct {
 	mx      sync.RWMutex
 	storage map[StateKey]StateData
-	// if recordPluginMetrics is true, PluginExecutionDuration will be recorded for this cycle.
-	recordPluginMetrics bool
+	// if recordFrameworkMetrics is true, framework metrics will be recorded for this cycle.
+	recordFrameworkMetrics bool
 }
 
 // NewCycleState initializes a new CycleState and returns its pointer.
@@ -55,20 +55,20 @@ func NewCycleState() *CycleState {
 	}
 }
 
-// ShouldRecordPluginMetrics returns whether PluginExecutionDuration metrics should be recorded.
-func (c *CycleState) ShouldRecordPluginMetrics() bool {
+// ShouldRecordFrameworkMetrics returns whether framework metrics should be recorded.
+func (c *CycleState) ShouldRecordFrameworkMetrics() bool {
 	if c == nil {
 		return false
 	}
-	return c.recordPluginMetrics
+	return c.recordFrameworkMetrics
 }
 
-// SetRecordPluginMetrics sets recordPluginMetrics to the given value.
-func (c *CycleState) SetRecordPluginMetrics(flag bool) {
+// SetRecordFrameworkMetrics sets recordFrameworkMetrics to the given value.
+func (c *CycleState) SetRecordFrameworkMetrics(flag bool) {
 	if c == nil {
 		return
 	}
-	c.recordPluginMetrics = flag
+	c.recordFrameworkMetrics = flag
 }
 
 // Clone creates a copy of CycleState and returns its pointer. Clone returns

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -626,6 +626,7 @@ func TestPreFilterPlugins(t *testing.T) {
 			t.Errorf("AddPod called %v, expected: 1", preFilter2.RemoveCalled)
 		}
 	})
+
 }
 
 func TestFilterPlugins(t *testing.T) {
@@ -849,9 +850,7 @@ func TestFilterPlugins(t *testing.T) {
 }
 
 func TestRecordingMetrics(t *testing.T) {
-	state := &CycleState{
-		recordPluginMetrics: true,
-	}
+	state := &CycleState{recordFrameworkMetrics: true}
 	tests := []struct {
 		name               string
 		action             func(f Framework)

--- a/pkg/scheduler/framework/v1alpha1/metrics_recorder.go
+++ b/pkg/scheduler/framework/v1alpha1/metrics_recorder.go
@@ -60,7 +60,21 @@ func newMetricsRecorder(bufferSize int, interval time.Duration) *metricsRecorder
 	return recorder
 }
 
-// observePluginDurationAsync observes the plugin_execution_duration_seconds metric.
+// observeExtensionPointDurationAsync observes the framework_extension_point_duration_seconds metric.
+// The metric will be flushed to Prometheus asynchronously.
+func (r *metricsRecorder) observeExtensionPointDurationAsync(extensionPoint string, status *Status, value float64) {
+	newMetric := &frameworkMetric{
+		metric:      metrics.FrameworkExtensionPointDuration,
+		labelValues: []string{extensionPoint, status.Code().String()},
+		value:       value,
+	}
+	select {
+	case r.bufferCh <- newMetric:
+	default:
+	}
+}
+
+// observeExtensionPointDurationAsync observes the plugin_execution_duration_seconds metric.
 // The metric will be flushed to Prometheus asynchronously.
 func (r *metricsRecorder) observePluginDurationAsync(extensionPoint, pluginName string, status *Status, value float64) {
 	newMetric := &frameworkMetric{

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -53,8 +53,8 @@ const (
 	BindTimeoutSeconds = 100
 	// SchedulerError is the reason recorded for events when an error occurs during scheduling a pod.
 	SchedulerError = "SchedulerError"
-	// Percentage of plugin metrics to be sampled.
-	pluginMetricsSamplePercent = 10
+	// Percentage of framework metrics to be sampled.
+	frameworkMetricsSamplePercent = 10
 )
 
 // podConditionUpdater updates the condition of a pod based on the passed
@@ -598,7 +598,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 	// Synchronously attempt to find a fit for the pod.
 	start := time.Now()
 	state := framework.NewCycleState()
-	state.SetRecordPluginMetrics(rand.Intn(100) < pluginMetricsSamplePercent)
+	state.SetRecordFrameworkMetrics(rand.Intn(100) < frameworkMetricsSamplePercent)
 	schedulingCycleCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	scheduleResult, err := sched.Algorithm.Schedule(schedulingCycleCtx, state, pod)


### PR DESCRIPTION
Reverts kubernetes/kubernetes#86545

This may have caused a bump in predicate evaluation overhead on the 99th percentile, I am not 100% certain, but profiling the scheduler before and after this PR does indicate that this has a non-negligible overhead: 

http://perf-dash.k8s.io/#/?jobname=gce-5000Nodes&metriccategoryname=Scheduler&metricname=SchedulingLatency&Operation=predicate_evaluation

/cc @liu-cong 