### PR TITLE
Address TODO around merging loops in image_gc_manager.go

### DIFF
--- a/pkg/kubelet/images/BUILD
+++ b/pkg/kubelet/images/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//pkg/kubelet/util/sliceutils:go_default_library",
         "//pkg/util/parsers:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The TODO suggested it'd be beneficial to merge the two loops.

I think this newer version, which uses two separate tickers and kicks
off goroutines as necessary, is slightly more readable.

I also think the usage of the `apimachinery/util/clock` sets us up to
better mock out time dependent operations, and write slightly more
"realistic" unit tests. Should this diff be merged, I'll explore this
option more in a later diff.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @Random-Liu 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
