### PR TITLE
Sample Filter extenstion point metrics; Add  node_fit_evaluation_seconds metric

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -187,7 +187,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 	}
 	trace.Step("Running prefilter plugins done")
 
-	startPredicateEvalTime := time.Now()
+	startNodeFitEvalTime := time.Now()
 	filteredNodes, filteredNodesStatuses, err := g.findNodesThatFitPod(ctx, state, pod)
 	if err != nil {
 		return result, err
@@ -208,8 +208,9 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 		}
 	}
 	trace.Step("Running postfilter plugins done")
-	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startPredicateEvalTime))
-	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startPredicateEvalTime))
+	metrics.NodeFitEvaluationSeconds.Observe(metrics.SinceInSeconds(startNodeFitEvalTime))
+	metrics.DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration.Observe(metrics.SinceInSeconds(startNodeFitEvalTime))
+	metrics.DeprecatedSchedulingDuration.WithLabelValues(metrics.PredicateEvaluation).Observe(metrics.SinceInSeconds(startNodeFitEvalTime))
 
 	startPriorityEvalTime := time.Now()
 	// When only one node after predicate, just use it.

--- a/pkg/scheduler/framework/v1alpha1/cycle_state.go
+++ b/pkg/scheduler/framework/v1alpha1/cycle_state.go
@@ -55,16 +55,18 @@ func NewCycleState() *CycleState {
 	}
 }
 
-// ShouldRecordPluginMetrics returns whether PluginExecutionDuration metrics should be recorded.
-func (c *CycleState) ShouldRecordPluginMetrics() bool {
+// ShouldRecordFrameworkMetrics returns whether certain metrics should be recorded for a scheduling cycle.
+// For performance reasons, we sample metrics for framework executions that are called multiple times per scheduling
+// cycle, such as running multiple plugins, or invoking filter extension point for many nodes.
+func (c *CycleState) ShouldRecordFrameworkMetrics() bool {
 	if c == nil {
 		return false
 	}
 	return c.recordPluginMetrics
 }
 
-// SetRecordPluginMetrics sets recordPluginMetrics to the given value.
-func (c *CycleState) SetRecordPluginMetrics(flag bool) {
+// SetRecordFrameworkMetrics sets recordPluginMetrics to the given value.
+func (c *CycleState) SetRecordFrameworkMetrics(flag bool) {
 	if c == nil {
 		return
 	}

--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -92,6 +92,15 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		},
 	)
+	NodeFitEvaluationSeconds = metrics.NewHistogram(
+		&metrics.HistogramOpts{
+			Subsystem:         SchedulerSubsystem,
+			Name:              "node_fit_evaluation_seconds",
+			Help:              "Duration to find nodes that fit for a pod in seconds",
+			Buckets:           metrics.ExponentialBuckets(0.001, 2, 15),
+			StabilityLevel:    metrics.ALPHA,
+		},
+	)
 	DeprecatedSchedulingAlgorithmPredicateEvaluationSecondsDuration = metrics.NewHistogram(
 		&metrics.HistogramOpts{
 			Subsystem:         SchedulerSubsystem,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -53,8 +53,8 @@ const (
 	BindTimeoutSeconds = 100
 	// SchedulerError is the reason recorded for events when an error occurs during scheduling a pod.
 	SchedulerError = "SchedulerError"
-	// Percentage of plugin metrics to be sampled.
-	pluginMetricsSamplePercent = 10
+	// Percentage of scheduling cycles whose framework metrics should be sampled.
+	frameworkMetricsSamplePercent = 10
 )
 
 // podConditionUpdater updates the condition of a pod based on the passed
@@ -598,7 +598,7 @@ func (sched *Scheduler) scheduleOne(ctx context.Context) {
 	// Synchronously attempt to find a fit for the pod.
 	start := time.Now()
 	state := framework.NewCycleState()
-	state.SetRecordPluginMetrics(rand.Intn(100) < pluginMetricsSamplePercent)
+	state.SetRecordFrameworkMetrics(rand.Intn(100) < frameworkMetricsSamplePercent)
 	schedulingCycleCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	scheduleResult, err := sched.Algorithm.Schedule(schedulingCycleCtx, state, pod)


### PR DESCRIPTION
…_seconds metric.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/kind feature


**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
This is an alternative to #87422. To be honest, I don't think this is an idea fix. I am OK with either this one or #87422.

In my opinion, we should change the `RunFilterPlugins` interface to accept a given list of nodes and return a list that fits the pod. This is consistent with other interfaces such as `RunScorePlugin`, that you only call it once in each scheduling cycle. The benefit of this is that we don't special case `RunFilterPlugins` to sample metrics, it also makes the code in `generic_scheduler` cleaner too. But this change may not be trivial or even possible.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add  node_fit_evaluation_seconds metric.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig scheduling
cc @ahg-g 