### PR TITLE
Fix static check failures in test/integration/deployment

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -37,7 +37,6 @@ pkg/volume/util/subpath
 pkg/volume/vsphere_volume
 test/e2e/apps
 test/e2e/autoscaling
-test/integration/deployment
 test/integration/examples
 test/integration/framework
 test/integration/garbagecollector

--- a/test/integration/deployment/BUILD
+++ b/test/integration/deployment/BUILD
@@ -40,7 +40,6 @@ go_library(
         "//pkg/controller/replicaset:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
-        "//staging/src/k8s.io/api/extensions/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/test/integration/deployment/util.go
+++ b/test/integration/deployment/util.go
@@ -25,7 +25,6 @@ import (
 
 	apps "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -98,47 +97,6 @@ func newDeployment(name, ns string, replicas int32) *apps.Deployment {
 				},
 			},
 		},
-	}
-}
-
-func newReplicaSet(name, ns string, replicas int32) *apps.ReplicaSet {
-	return &apps.ReplicaSet{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "ReplicaSet",
-			APIVersion: "apps/v1",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns,
-			Name:      name,
-			Labels:    testLabels(),
-		},
-		Spec: apps.ReplicaSetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: testLabels(),
-			},
-			Replicas: &replicas,
-			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: testLabels(),
-				},
-				Spec: v1.PodSpec{
-					Containers: []v1.Container{
-						{
-							Name:  fakeContainerName,
-							Image: fakeImage,
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func newDeploymentRollback(name string, annotations map[string]string, revision int64) *extensions.DeploymentRollback {
-	return &extensions.DeploymentRollback{
-		Name:               name,
-		UpdatedAnnotations: annotations,
-		RollbackTo:         extensions.RollbackConfig{Revision: revision},
 	}
 }
 
@@ -251,7 +209,7 @@ func (d *deploymentTester) markUpdatedPodsReady(wg *sync.WaitGroup) {
 		return false, nil
 	})
 	if err != nil {
-		d.t.Fatalf("failed to mark updated Deployment pods to ready: %v", err)
+		d.t.Errorf("failed to mark updated Deployment pods to ready: %v", err)
 	}
 }
 
@@ -365,20 +323,6 @@ func (d *deploymentTester) expectNewReplicaSet() (*apps.ReplicaSet, error) {
 
 func (d *deploymentTester) updateReplicaSet(name string, applyUpdate testutil.UpdateReplicaSetFunc) (*apps.ReplicaSet, error) {
 	return testutil.UpdateReplicaSetWithRetries(d.c, d.deployment.Namespace, name, applyUpdate, d.t.Logf, pollInterval, pollTimeout)
-}
-
-func (d *deploymentTester) updateReplicaSetStatus(name string, applyStatusUpdate testutil.UpdateReplicaSetFunc) (*apps.ReplicaSet, error) {
-	return testutil.UpdateReplicaSetStatusWithRetries(d.c, d.deployment.Namespace, name, applyStatusUpdate, d.t.Logf, pollInterval, pollTimeout)
-}
-
-// waitForDeploymentRollbackCleared waits for deployment either started rolling back or doesn't need to rollback.
-func (d *deploymentTester) waitForDeploymentRollbackCleared() error {
-	return testutil.WaitForDeploymentRollbackCleared(d.c, d.deployment.Namespace, d.deployment.Name, pollInterval, pollTimeout)
-}
-
-// checkDeploymentRevisionAndImage checks if the input deployment's and its new replica set's revision and image are as expected.
-func (d *deploymentTester) checkDeploymentRevisionAndImage(revision, image string) error {
-	return testutil.CheckDeploymentRevisionAndImage(d.c, d.deployment.Namespace, d.deployment.Name, revision, image)
 }
 
 func (d *deploymentTester) waitForDeploymentUpdatedReplicasGTE(minUpdatedReplicas int32) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:

when removing `test/integration/deployment` from `hack/.staticcheck_failures` ,  the result is below:
```
$ ./hack/verify-staticcheck.sh
Errors from staticcheck:
test/integration/deployment/util.go:104:6: func newReplicaSet is unused (U1000)
test/integration/deployment/util.go:137:6: func newDeploymentRollback is unused (U1000)
test/integration/deployment/util.go:287:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
test/integration/deployment/util.go:307:2: the goroutine calls T.Fatalf, which must be called in the same goroutine as the test (SA2002)
test/integration/deployment/util.go:370:28: func (*deploymentTester).updateReplicaSetStatus is unused (U1000)
test/integration/deployment/util.go:375:28: func (*deploymentTester).waitForDeploymentRollbackCleared is unused (U1000)
test/integration/deployment/util.go:380:28: func (*deploymentTester).checkDeploymentRevisionAndImage is unused (U1000)
```

This PR fixes static check failures in `test/integration/deployment` .

**Which issue(s) this PR fixes**:
Ref: #81657



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
