### PR TITLE
Assign CPUset for system reserved cgroup.

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -677,15 +677,17 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, featureGate f
 		}
 
 		if reservedSystemCPUs.Size() > 0 {
-			// at cmd option valication phase it is tested either --system-reserved-cgroup or --kube-reserved-cgroup is specified, so overwrite should be ok
+			// In case --kube-reserved-cgroup or --system-reserved-cgroup is specified, it depends on the --enforce-node-allocatable whether --reserved-cpus
+			// should enforce the cpuset of those cgroups. Here we set just the cpu shares.
 			klog.Infof("Option --reserved-cpus is specified, it will overwrite the cpu setting in KubeReserved=\"%v\", SystemReserved=\"%v\".", s.KubeReserved, s.SystemReserved)
-			if s.KubeReserved != nil {
-				delete(s.KubeReserved, "cpu")
-			}
 			if s.SystemReserved == nil {
 				s.SystemReserved = make(map[string]string)
 			}
+			if s.KubeReserved == nil {
+				s.KubeReserved = make(map[string]string)
+			}
 			s.SystemReserved["cpu"] = strconv.Itoa(reservedSystemCPUs.Size())
+			s.KubeReserved["cpu"] = strconv.Itoa(reservedSystemCPUs.Size())
 			klog.Infof("After cpu setting is overwritten, KubeReserved=\"%v\", SystemReserved=\"%v\"", s.KubeReserved, s.SystemReserved)
 		}
 		kubeReserved, err := parseResourceList(s.KubeReserved)

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -145,10 +145,6 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 			kc.HairpinMode, kubeletconfig.HairpinNone, kubeletconfig.HairpinVeth, kubeletconfig.PromiscuousBridge))
 	}
 	if kc.ReservedSystemCPUs != "" {
-		// --reserved-cpus does not support --system-reserved-cgroup or --kube-reserved-cgroup
-		if kc.KubeReservedCgroup != "" {
-			allErrors = append(allErrors, fmt.Errorf("can't use --reserved-cpus with --kube-reserved-cgroup"))
-		}
 		if _, err := cpuset.Parse(kc.ReservedSystemCPUs); err != nil {
 			allErrors = append(allErrors, fmt.Errorf("unable to parse --reserved-cpus, error: %v", err))
 		}

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -146,8 +146,8 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 	}
 	if kc.ReservedSystemCPUs != "" {
 		// --reserved-cpus does not support --system-reserved-cgroup or --kube-reserved-cgroup
-		if kc.SystemReservedCgroup != "" || kc.KubeReservedCgroup != "" {
-			allErrors = append(allErrors, fmt.Errorf("can't use --reserved-cpus with --system-reserved-cgroup or --kube-reserved-cgroup"))
+		if kc.KubeReservedCgroup != "" {
+			allErrors = append(allErrors, fmt.Errorf("can't use --reserved-cpus with --kube-reserved-cgroup"))
 		}
 		if _, err := cpuset.Parse(kc.ReservedSystemCPUs); err != nil {
 			allErrors = append(allErrors, fmt.Errorf("unable to parse --reserved-cpus, error: %v", err))

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -118,8 +118,11 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 0},
 	}
 	const numErrsErrorCase1 = 25
-	if allErrors := ValidateKubeletConfiguration(errorCase1); len(allErrors.(utilerrors.Aggregate).Errors()) != numErrsErrorCase1 {
-		t.Errorf("expect %d errors, got %v", numErrsErrorCase1, len(allErrors.(utilerrors.Aggregate).Errors()))
+	allErrors := ValidateKubeletConfiguration(errorCase1)
+	if allErrors == nil {
+		t.Errorf("expected an error but got success")
+	} else if len(allErrors.(utilerrors.Aggregate).Errors()) != numErrsErrorCase1 {
+		t.Errorf("expect %d errors, got %d", numErrsErrorCase1, len(allErrors.(utilerrors.Aggregate).Errors()))
 	}
 
 	errorCase2 := &kubeletconfig.KubeletConfiguration{
@@ -152,7 +155,10 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		ReservedSystemCPUs:          "0-3",
 	}
 	const numErrsErrorCase2 = 1
-	if allErrors := ValidateKubeletConfiguration(errorCase2); len(allErrors.(utilerrors.Aggregate).Errors()) != numErrsErrorCase2 {
-		t.Errorf("expect %d errors, got %v", numErrsErrorCase2, len(allErrors.(utilerrors.Aggregate).Errors()))
+	allErrors = ValidateKubeletConfiguration(errorCase2)
+	if allErrors == nil {
+		t.Errorf("expected an error but got success")
+	} else if len(allErrors.(utilerrors.Aggregate).Errors()) != numErrsErrorCase2 {
+		t.Errorf("expect %d errors, got %d", numErrsErrorCase2, len(allErrors.(utilerrors.Aggregate).Errors()))
 	}
 }

--- a/pkg/kubelet/apis/config/validation/validation_test.go
+++ b/pkg/kubelet/apis/config/validation/validation_test.go
@@ -125,7 +125,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		t.Errorf("expect %d errors, got %d", numErrsErrorCase1, len(allErrors.(utilerrors.Aggregate).Errors()))
 	}
 
-	errorCase2 := &kubeletconfig.KubeletConfiguration{
+	successCase3 := &kubeletconfig.KubeletConfiguration{
 		CgroupsPerQOS:               true,
 		EnforceNodeAllocatable:      []string{"pods", "system-reserved", "kube-reserved"},
 		SystemReservedCgroup:        "/system.slice",
@@ -154,11 +154,7 @@ func TestValidateKubeletConfiguration(t *testing.T) {
 		CPUCFSQuotaPeriod:           metav1.Duration{Duration: 100 * time.Millisecond},
 		ReservedSystemCPUs:          "0-3",
 	}
-	const numErrsErrorCase2 = 1
-	allErrors = ValidateKubeletConfiguration(errorCase2)
-	if allErrors == nil {
-		t.Errorf("expected an error but got success")
-	} else if len(allErrors.(utilerrors.Aggregate).Errors()) != numErrsErrorCase2 {
-		t.Errorf("expect %d errors, got %d", numErrsErrorCase2, len(allErrors.(utilerrors.Aggregate).Errors()))
+	if allErrors = ValidateKubeletConfiguration(successCase3); allErrors != nil {
+		t.Errorf("expect no errors, got %v", allErrors)
 	}
 }

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -329,7 +329,7 @@ func getSupportedSubsystems() map[subsystem]bool {
 		&cgroupfs.MemoryGroup{}: true,
 		&cgroupfs.CpuGroup{}:    true,
 		&cgroupfs.PidsGroup{}:   false,
-		&cgroupfs.CpusetGroup{}: false, // currently needed only for setting cpuset for system-reserved cgroup
+		&cgroupfs.CpusetGroup{}: false, // currently needed only for setting cpuset for system-reserved and kube-reserved cgroups
 	}
 	// not all hosts support hugetlb cgroup, and in the absent of hugetlb, we will fail silently by reporting no capacity.
 	supportedSubsystems[&cgroupfs.HugetlbGroup{}] = false

--- a/pkg/kubelet/cm/cgroup_manager_linux.go
+++ b/pkg/kubelet/cm/cgroup_manager_linux.go
@@ -329,6 +329,7 @@ func getSupportedSubsystems() map[subsystem]bool {
 		&cgroupfs.MemoryGroup{}: true,
 		&cgroupfs.CpuGroup{}:    true,
 		&cgroupfs.PidsGroup{}:   false,
+		&cgroupfs.CpusetGroup{}: false, // currently needed only for setting cpuset for system-reserved cgroup
 	}
 	// not all hosts support hugetlb cgroup, and in the absent of hugetlb, we will fail silently by reporting no capacity.
 	supportedSubsystems[&cgroupfs.HugetlbGroup{}] = false
@@ -439,6 +440,12 @@ func (m *cgroupManagerImpl) toResources(resourceConfig *ResourceConfig) *libcont
 			Pagesize: pageSize,
 			Limit:    uint64(0),
 		})
+	}
+
+	// Empty CPUSet means that it hasn't been declared for this cgroup.
+	// Only add the CPUSet to resources when it's declared.
+	if !resourceConfig.CpuSet.IsEmpty() {
+		resources.CpusetCpus = resourceConfig.CpuSet.String()
 	}
 	return resources
 }

--- a/pkg/kubelet/cm/node_container_manager_linux.go
+++ b/pkg/kubelet/cm/node_container_manager_linux.go
@@ -120,7 +120,7 @@ func (cm *containerManagerImpl) enforceNodeAllocatableCgroups() error {
 	}
 	if nc.EnforceNodeAllocatable.Has(kubetypes.KubeReservedEnforcementKey) {
 		klog.V(2).Infof("Enforcing kube reserved on cgroup %q with limits: %+v", nc.KubeReservedCgroupName, nc.KubeReserved)
-		if err := enforceExistingCgroup(cm.cgroupManager, cm.cgroupManager.CgroupName(nc.KubeReservedCgroupName), nc.KubeReserved, cpuset.NewCPUSet()); err != nil {
+		if err := enforceExistingCgroup(cm.cgroupManager, cm.cgroupManager.CgroupName(nc.KubeReservedCgroupName), nc.KubeReserved, cm.NodeConfig.ReservedSystemCPUs); err != nil {
 			message := fmt.Sprintf("Failed to enforce Kube Reserved Cgroup Limits on %q: %v", nc.KubeReservedCgroupName, err)
 			cm.recorder.Event(nodeRef, v1.EventTypeWarning, events.FailedNodeAllocatableEnforcement, message)
 			return fmt.Errorf(message)
@@ -137,7 +137,7 @@ func enforceExistingCgroup(cgroupManager CgroupManager, cName CgroupName, rl v1.
 		ResourceParameters: getCgroupConfig(rl),
 	}
 	if cgroupConfig.ResourceParameters == nil {
-		return fmt.Errorf("%q cgroup is not config properly", cgroupConfig.Name)
+		return fmt.Errorf("%q cgroup is not configured properly", cgroupConfig.Name)
 	}
 	cgroupConfig.ResourceParameters.CpuSet = cpus
 	klog.V(4).Infof("Enforcing limits on cgroup %q with %d cpu shares, %d bytes of memory, %d processes, and cpuset '%s'", cName, cgroupConfig.ResourceParameters.CpuShares, cgroupConfig.ResourceParameters.Memory, cgroupConfig.ResourceParameters.PidsLimit, cpus)

--- a/pkg/kubelet/cm/types.go
+++ b/pkg/kubelet/cm/types.go
@@ -19,6 +19,7 @@ package cm
 import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 )
 
 // ResourceConfig holds information about all the supported cgroup resource parameters.
@@ -35,6 +36,8 @@ type ResourceConfig struct {
 	HugePageLimit map[int64]int64
 	// Maximum number of pids
 	PidsLimit *int64
+	// CPUSet for the cgroup.
+	CpuSet cpuset.CPUSet
 }
 
 // CgroupName is the abstract name of a cgroup prior to any driver specific conversion.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

Previously system reserved cgroup could not be declared if `--reserved-cpus` option was used. Now it's allowed, and the cpuset defined with `--reserved-cpus` will be assigned to the system reserved cgroup if `--enforce-node-allocatable=system-reserved`.

So, in order to let system services (assigned to cpuset /foobar.slice on a systemd system) on CPUs 4 and 5, you could run kubelet with

    kubelet --reserved-cpus=4,5 \
            --enforce-node-allocatable=system-reserved \
            --system-reserved-cgroup=foobar

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85764

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Kubelet can use --system-reserved-cgroup with --reserved-cpus option.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

Documentation PR will need to be submitted when the command line interface change is confirmed.

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
