### PR TITLE
Adds unit test on Bind extension for the scheduler

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -1064,6 +1064,46 @@ func TestRunBindPlugins(t *testing.T) {
 			injects:    []Code{Skip, Success, Error},
 			wantStatus: Success,
 		},
+		{
+			name:       "no bind plugin, returns default binder",
+			injects:    []Code{},
+			wantStatus: Success,
+		},
+		{
+			name:       "invalid status",
+			injects:    []Code{Unschedulable},
+			wantStatus: Error,
+		},
+		{
+			name:       "simple error",
+			injects:    []Code{Error},
+			wantStatus: Error,
+		},
+		{
+			name:       "success on second, returns success",
+			injects:    []Code{Skip, Success},
+			wantStatus: Success,
+		},
+		{
+			name:       "invalid status, returns error",
+			injects:    []Code{Skip, UnschedulableAndUnresolvable},
+			wantStatus: Error,
+		},
+		{
+			name:       "error after success status, returns success",
+			injects:    []Code{Success, Error},
+			wantStatus: Success,
+		},
+		{
+			name:       "success before invalid status, returns success",
+			injects:    []Code{Success, Error},
+			wantStatus: Success,
+		},
+		{
+			name:       "success after error status, returns error",
+			injects:    []Code{Error, Success},
+			wantStatus: Error,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:
It adds more unit test for the scheduler

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of unit tests for #80272 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
