### PR TITLE
Delete TODO to use docker client

### DIFF
--- a/test/e2e_node/image_list.go
+++ b/test/e2e_node/image_list.go
@@ -95,7 +95,6 @@ func (dp *dockerPuller) Name() string {
 }
 
 func (dp *dockerPuller) Pull(image string) ([]byte, error) {
-	// TODO(random-liu): Use docker client to get rid of docker binary dependency.
 	return exec.Command("docker", "pull", image).CombinedOutput()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Re conversation in https://github.com/kubernetes/kubernetes/pull/87373,
we should keep the current behavior (i.e. using the docker binary
instead of the docker client). Delete the TODO instructing us to change
the behavior.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @dims @Random-Liu 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
