### PR TITLE
fix static check errors in test/integration/etcd

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -45,7 +45,6 @@ test/e2e/apps
 test/e2e/autoscaling
 test/e2e/instrumentation/logging/stackdriver
 test/integration/deployment
-test/integration/etcd
 test/integration/examples
 test/integration/framework
 test/integration/garbagecollector

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -135,10 +135,10 @@ func StartRealMasterOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOp
 
 		prepared, err := kubeAPIServer.PrepareRun()
 		if err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 		if err := prepared.Run(stopCh); err != nil {
-			t.Fatal(err)
+			t.Error(err)
 		}
 	}()
 
@@ -174,7 +174,7 @@ func StartRealMasterOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOp
 	restMapper := restmapper.NewDeferredDiscoveryRESTMapper(discoveryClient)
 	restMapper.Reset()
 
-	serverResources, err := kubeClient.Discovery().ServerResources()
+	_, serverResources, err := kubeClient.Discovery().ServerGroupsAndResources()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>


**What type of PR is this?**
> /kind cleanup


**What this PR does / why we need it**:
cleanup staticcheck errors, it says as below:
```
test/integration/etcd/server.go:128:2: the goroutine calls T.Fatal, which must be called in the same goroutine as the test (SA2002)
test/integration/etcd/server.go:177:26: kubeClient.Discovery().ServerResources is deprecated: use ServerGroupsAndResources instead.  (SA1019)
```

**Which issue(s) this PR fixes**:
Ref:#81657
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
