### PR TITLE
Refactor Topology Manager policies to reduce code duplication 

### DIFF
--- a/pkg/kubelet/cm/topologymanager/policy.go
+++ b/pkg/kubelet/cm/topologymanager/policy.go
@@ -93,6 +93,53 @@ func filterProvidersHints(providersHints []map[string][]TopologyHint) [][]Topolo
 	return allProviderHints
 }
 
+func mergeFilteredHints(numaNodes []int, filteredHints [][]TopologyHint) TopologyHint {
+	// Set the default affinity as an any-numa affinity containing the list
+	// of NUMA Nodes available on this machine.
+	defaultAffinity, _ := bitmask.NewBitMask(numaNodes...)
+
+	// Set the bestHint to return from this function as {nil false}.
+	// This will only be returned if no better hint can be found when
+	// merging hints from each hint provider.
+	bestHint := TopologyHint{defaultAffinity, false}
+	iterateAllProviderTopologyHints(filteredHints, func(permutation []TopologyHint) {
+		// Get the NUMANodeAffinity from each hint in the permutation and see if any
+		// of them encode unpreferred allocations.
+		mergedHint := mergePermutation(numaNodes, permutation)
+		// Only consider mergedHints that result in a NUMANodeAffinity > 0 to
+		// replace the current bestHint.
+		if mergedHint.NUMANodeAffinity.Count() == 0 {
+			return
+		}
+
+		// If the current bestHint is non-preferred and the new mergedHint is
+		// preferred, always choose the preferred hint over the non-preferred one.
+		if mergedHint.Preferred && !bestHint.Preferred {
+			bestHint = mergedHint
+			return
+		}
+
+		// If the current bestHint is preferred and the new mergedHint is
+		// non-preferred, never update bestHint, regardless of mergedHint's
+		// narowness.
+		if !mergedHint.Preferred && bestHint.Preferred {
+			return
+		}
+
+		// If mergedHint and bestHint has the same preference, only consider
+		// mergedHints that have a narrower NUMANodeAffinity than the
+		// NUMANodeAffinity in the current bestHint.
+		if !mergedHint.NUMANodeAffinity.IsNarrowerThan(bestHint.NUMANodeAffinity) {
+			return
+		}
+
+		// In all other cases, update bestHint to the current mergedHint
+		bestHint = mergedHint
+	})
+
+	return bestHint
+}
+
 // Iterate over all permutations of hints in 'allProviderHints [][]TopologyHint'.
 //
 // This procedure is implemented as a recursive function over the set of hints

--- a/pkg/kubelet/cm/topologymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/topologymanager/policy_best_effort.go
@@ -17,7 +17,6 @@ limitations under the License.
 package topologymanager
 
 import (
-	"k8s.io/klog"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
 	"k8s.io/kubernetes/pkg/kubelet/lifecycle"
 )
@@ -48,46 +47,17 @@ func (p *bestEffortPolicy) canAdmitPodResult(hint *TopologyHint) lifecycle.PodAd
 }
 
 func (p *bestEffortPolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult) {
-	hint := p.mergeProvidersHints(providersHints)
+	filteredProvidersHints := filterProvidersHints(providersHints)
+	hint := p.mergeProvidersHints(filteredProvidersHints)
 	admit := p.canAdmitPodResult(&hint)
 	return hint, admit
 }
 
 // Merge the hints from all hint providers to find the best one.
-func (p *bestEffortPolicy) mergeProvidersHints(providersHints []map[string][]TopologyHint) TopologyHint {
+func (p *bestEffortPolicy) mergeProvidersHints(filteredHints [][]TopologyHint) TopologyHint {
 	// Set the default affinity as an any-numa affinity containing the list
 	// of NUMA Nodes available on this machine.
 	defaultAffinity, _ := bitmask.NewBitMask(p.numaNodes...)
-
-	// Loop through all hint providers and save an accumulated list of the
-	// hints returned by each hint provider. If no hints are provided, assume
-	// that provider has no preference for topology-aware allocation.
-	var allProviderHints [][]TopologyHint
-	for _, hints := range providersHints {
-		// If hints is nil, insert a single, preferred any-numa hint into allProviderHints.
-		if len(hints) == 0 {
-			klog.Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with any resource")
-			allProviderHints = append(allProviderHints, []TopologyHint{{nil, true}})
-			continue
-		}
-
-		// Otherwise, accumulate the hints for each resource type into allProviderHints.
-		for resource := range hints {
-			if hints[resource] == nil {
-				klog.Infof("[topologymanager] Hint Provider has no preference for NUMA affinity with resource '%s'", resource)
-				allProviderHints = append(allProviderHints, []TopologyHint{{nil, true}})
-				continue
-			}
-
-			if len(hints[resource]) == 0 {
-				klog.Infof("[topologymanager] Hint Provider has no possible NUMA affinities for resource '%s'", resource)
-				allProviderHints = append(allProviderHints, []TopologyHint{{nil, false}})
-				continue
-			}
-
-			allProviderHints = append(allProviderHints, hints[resource])
-		}
-	}
 
 	// Iterate over all permutations of hints in 'allProviderHints'. Merge the
 	// hints in each permutation by taking the bitwise-and of their affinity masks.
@@ -95,7 +65,7 @@ func (p *bestEffortPolicy) mergeProvidersHints(providersHints []map[string][]Top
 	// permutations that have at least one NUMA ID set. If no merged mask can be
 	// found that has at least one NUMA ID set, return the 'defaultAffinity'.
 	bestHint := TopologyHint{defaultAffinity, false}
-	iterateAllProviderTopologyHints(allProviderHints, func(permutation []TopologyHint) {
+	iterateAllProviderTopologyHints(filteredHints, func(permutation []TopologyHint) {
 		// Get the NUMANodeAffinity from each hint in the permutation and see if any
 		// of them encode unpreferred allocations.
 		mergedHint := mergePermutation(p.numaNodes, permutation)

--- a/pkg/kubelet/cm/topologymanager/policy_restricted.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted.go
@@ -53,7 +53,7 @@ func (p *restrictedPolicy) canAdmitPodResult(hint *TopologyHint) lifecycle.PodAd
 
 func (p *restrictedPolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult) {
 	filteredHints := filterProvidersHints(providersHints)
-	hint := p.mergeProvidersHints(filteredHints)
+	hint := mergeFilteredHints(p.numaNodes, filteredHints)
 	admit := p.canAdmitPodResult(&hint)
 	return hint, admit
 }

--- a/pkg/kubelet/cm/topologymanager/policy_restricted.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted.go
@@ -52,7 +52,8 @@ func (p *restrictedPolicy) canAdmitPodResult(hint *TopologyHint) lifecycle.PodAd
 }
 
 func (p *restrictedPolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult) {
-	hint := p.mergeProvidersHints(providersHints)
+	filteredHints := filterProvidersHints(providersHints)
+	hint := p.mergeProvidersHints(filteredHints)
 	admit := p.canAdmitPodResult(&hint)
 	return hint, admit
 }

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
@@ -55,7 +55,7 @@ func (p *singleNumaNodePolicy) canAdmitPodResult(hint *TopologyHint) lifecycle.P
 }
 
 // Return hints that have valid bitmasks with exactly one bit set.
-func (p *singleNumaNodePolicy) filterHints(allResourcesHints [][]TopologyHint) [][]TopologyHint {
+func filterSingleNumaHints(allResourcesHints [][]TopologyHint) [][]TopologyHint {
 	var filteredResourcesHints [][]TopologyHint
 	for _, oneResourceHints := range allResourcesHints {
 		var filtered []TopologyHint
@@ -108,7 +108,7 @@ func (p *singleNumaNodePolicy) mergeProvidersHints(providersHints []map[string][
 	}
 
 	// Filter to only include don't cares and hints with a single NUMA node.
-	allProviderHints = p.filterHints(allProviderHints)
+	allProviderHints = filterSingleNumaHints(allProviderHints)
 
 	// Set the bestHint to return from this function as {nil false}.
 	// This will only be returned if no better hint can be found when

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
@@ -76,9 +76,6 @@ func (p *singleNumaNodePolicy) mergeProvidersHints(filteredHints [][]TopologyHin
 	// of NUMA Nodes available on this machine.
 	defaultAffinity, _ := bitmask.NewBitMask(p.numaNodes...)
 
-	// Filter to only include don't cares and hints with a single NUMA node.
-	filteredHints = filterSingleNumaHints(filteredHints)
-
 	// Set the bestHint to return from this function as {nil false}.
 	// This will only be returned if no better hint can be found when
 	// merging hints from each hint provider.
@@ -128,7 +125,9 @@ func (p *singleNumaNodePolicy) mergeProvidersHints(filteredHints [][]TopologyHin
 
 func (p *singleNumaNodePolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult) {
 	filteredHints := filterProvidersHints(providersHints)
-	hint := p.mergeProvidersHints(filteredHints)
+	// Filter to only include don't cares and hints with a single NUMA node.
+	singleNumaHints := filterSingleNumaHints(filteredHints)
+	hint := p.mergeProvidersHints(singleNumaHints)
 	admit := p.canAdmitPodResult(&hint)
 	return hint, admit
 }

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
@@ -71,63 +71,17 @@ func filterSingleNumaHints(allResourcesHints [][]TopologyHint) [][]TopologyHint 
 	return filteredResourcesHints
 }
 
-func (p *singleNumaNodePolicy) mergeProvidersHints(filteredHints [][]TopologyHint) TopologyHint {
-	// Set the default affinity as an any-numa affinity containing the list
-	// of NUMA Nodes available on this machine.
-	defaultAffinity, _ := bitmask.NewBitMask(p.numaNodes...)
-
-	// Set the bestHint to return from this function as {nil false}.
-	// This will only be returned if no better hint can be found when
-	// merging hints from each hint provider.
-	bestHint := TopologyHint{defaultAffinity, false}
-	iterateAllProviderTopologyHints(filteredHints, func(permutation []TopologyHint) {
-		// Get the NUMANodeAffinity from each hint in the permutation and see if any
-		// of them encode unpreferred allocations.
-		mergedHint := mergePermutation(p.numaNodes, permutation)
-
-		// Only consider mergedHints that result in a NUMANodeAffinity > 0 to
-		// replace the current bestHint.
-		if mergedHint.NUMANodeAffinity.Count() == 0 {
-			return
-		}
-
-		// If the current bestHint is non-preferred and the new mergedHint is
-		// preferred, always choose the preferred hint over the non-preferred one.
-		if mergedHint.Preferred && !bestHint.Preferred {
-			bestHint = mergedHint
-			return
-		}
-
-		// If the current bestHint is preferred and the new mergedHint is
-		// non-preferred, never update bestHint, regardless of mergedHint's
-		// narowness.
-		if !mergedHint.Preferred && bestHint.Preferred {
-			return
-		}
-
-		// If mergedHint and bestHint has the same preference, only consider
-		// mergedHints that have a narrower NUMANodeAffinity than the
-		// NUMANodeAffinity in the current bestHint.
-		if !mergedHint.NUMANodeAffinity.IsNarrowerThan(bestHint.NUMANodeAffinity) {
-			return
-		}
-
-		// In all other cases, update bestHint to the current mergedHint
-		bestHint = mergedHint
-	})
-
-	if bestHint.NUMANodeAffinity.IsEqual(defaultAffinity) {
-		bestHint = TopologyHint{nil, bestHint.Preferred}
-	}
-
-	return bestHint
-}
-
 func (p *singleNumaNodePolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, lifecycle.PodAdmitResult) {
 	filteredHints := filterProvidersHints(providersHints)
 	// Filter to only include don't cares and hints with a single NUMA node.
 	singleNumaHints := filterSingleNumaHints(filteredHints)
-	hint := p.mergeProvidersHints(singleNumaHints)
-	admit := p.canAdmitPodResult(&hint)
-	return hint, admit
+	bestHint := mergeFilteredHints(p.numaNodes, singleNumaHints)
+
+	defaultAffinity, _ := bitmask.NewBitMask(p.numaNodes...)
+	if bestHint.NUMANodeAffinity.IsEqual(defaultAffinity) {
+		bestHint = TopologyHint{nil, bestHint.Preferred}
+	}
+
+	admit := p.canAdmitPodResult(&bestHint)
+	return bestHint, admit
 }

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
@@ -155,10 +155,8 @@ func TestPolicySingleNumaNodeFilterHints(t *testing.T) {
 		},
 	}
 
-	numaNodes := []int{0, 1, 2, 3}
 	for _, tc := range tcases {
-		policy := NewSingleNumaNodePolicy(numaNodes)
-		actual := policy.(*singleNumaNodePolicy).filterHints(tc.allResources)
+		actual := filterSingleNumaHints(tc.allResources)
 		if !reflect.DeepEqual(tc.expectedResources, actual) {
 			t.Errorf("Test Case: %s", tc.name)
 			t.Errorf("Expected result to be %v, got %v", tc.expectedResources, actual)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
<!--
> /kind api-change
> /kind bug
-->
/kind cleanup
<!--
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake
-->
**What this PR does / why we need it**:
#85798 introduced specific topology hint merge strategies to individual Topology Manager policies. As a result, a lot of this functionality has been duplicated across the different policies.
This PR is a clean up to refactor some existing functions which can be made generic across all policies.
<!--

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*

Fixes #

**Special notes for your reviewer**:
-->
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
