### PR TITLE
kubelet: ensure static pod UIDs are unique

### DIFF
--- a/pkg/kubelet/config/common.go
+++ b/pkg/kubelet/config/common.go
@@ -58,13 +58,15 @@ func generatePodName(name string, nodeName types.NodeName) string {
 func applyDefaults(pod *api.Pod, source string, isFile bool, nodeName types.NodeName) error {
 	if len(pod.UID) == 0 {
 		hasher := md5.New()
+		hash.DeepHashObject(hasher, pod)
+		// DeepHashObject resets the hash, so we should write the pod source
+		// information AFTER it.
 		if isFile {
 			fmt.Fprintf(hasher, "host:%s", nodeName)
 			fmt.Fprintf(hasher, "file:%s", source)
 		} else {
 			fmt.Fprintf(hasher, "url:%s", source)
 		}
-		hash.DeepHashObject(hasher, pod)
 		pod.UID = types.UID(hex.EncodeToString(hasher.Sum(nil)[0:]))
 		klog.V(5).Infof("Generated UID %q pod %q from %s", pod.UID, pod.Name, source)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix the issue where pods like kube-proxy, created from the same static manifest across a cluster, all have the same UID. This breaks the concept of a unique ID and [confuses some tools](https://github.com/weaveworks/scope/issues/2931).

The underlying issue is a simple clash of behaviours: kubelet uses a md5 hasher which was changed to reset the hash in `DeepHashObject`.  The fix is to re-order the calls so that one goes first.
This does have the side-effect that all pod UIDs will change.

**Special notes for your reviewer**:
This is a re-opening of #43420. It and the similar #57135 were held up and ultimately abandoned over concerns that all pods would get restarted during upgrade.

Since then, several Kubernetes upgrades have restarted all pods, and there is a statement at #84443 that this is expected behaviour, so this should not be a reason to delay the fix.

```release-note
The calculation of pod UIDs for static pods has changed to ensure each static pod gets a unique value - this will cause all static pod containers to be recreated/restarted if an in-place kubelet upgrade from 1.20 to 1.21 is performed. Note that draining pods before upgrading the kubelet across minor versions is the supported upgrade path.
```

/kind bug
/sig node