### PR TITLE
Migrate health monitor from read only port to healthz port

### DIFF
--- a/cluster/gce/gci/health-monitor.sh
+++ b/cluster/gce/gci/health-monitor.sh
@@ -72,7 +72,7 @@ function kubelet_monitoring {
   local -r max_seconds=10
   local output=""
   while [ 1 ]; do
-    if ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10255/healthz 2>&1); then
+    if ! output=$(curl -m "${max_seconds}" -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
       # Print the response and/or errors.
       echo $output
       echo "Kubelet is unhealthy!"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Moves health-monitor script off the kubelet read only port to the healthz port.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
