### PR TITLE
Debugging 87473, printing out the last state of the dependent

### DIFF
--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -24,7 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionstestserver "k8s.io/apiextensions-apiserver/test/integration/fixtures"
@@ -950,12 +950,15 @@ var _ = SIGDescribe("Garbage collector", func() {
 		}
 
 		// Ensure the dependent is deleted.
+		var lastDependent *unstructured.Unstructured
+		var err2 error
 		if err := wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
-			_, err := resourceClient.Get(dependentName, metav1.GetOptions{})
-			return apierrors.IsNotFound(err), nil
+			lastDependent, err2 = resourceClient.Get(dependentName, metav1.GetOptions{})
+			return apierrors.IsNotFound(err2), nil
 		}); err != nil {
 			framework.Logf("owner: %#v", persistedOwner)
 			framework.Logf("dependent: %#v", persistedDependent)
+			framework.Logf("dependent last state: %#v", lastDependent)
 			framework.Failf("failed waiting for dependent resource %q to be deleted", dependentName)
 		}
 


### PR DESCRIPTION
/kind failing-test
/sig api-machinery

Printing out the last state of the dependent object to debug 87473. See https://github.com/kubernetes/kubernetes/issues/87473#issuecomment-577450205 for details.

/assign @lavalamp