### PR TITLE
Reduce public methods for DryRunVerifier

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/dry_run_verifier_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/dry_run_verifier_test.go
@@ -66,7 +66,7 @@ func TestSupportsDryRun(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		supports, err := SupportsDryRun(doc, test.gvk)
+		supports, err := supportsDryRun(doc, test.gvk)
 		if supports != test.supports || ((err == nil) != test.success) {
 			errStr := "nil"
 			if test.success == false {
@@ -85,7 +85,7 @@ var fakeSchema = openapitesting.Fake{Path: filepath.Join("..", "..", "artifacts"
 
 func TestDryRunVerifier(t *testing.T) {
 	dryRunVerifier := DryRunVerifier{
-		Finder: NewCRDFinder(func() ([]schema.GroupKind, error) {
+		finder: NewCRDFinder(func() ([]schema.GroupKind, error) {
 			return []schema.GroupKind{
 				{
 					Group: "crd.com",
@@ -97,7 +97,7 @@ func TestDryRunVerifier(t *testing.T) {
 				},
 			}, nil
 		}),
-		OpenAPIGetter: &fakeSchema,
+		openAPIGetter: &fakeSchema,
 	}
 
 	err := dryRunVerifier.HasSupport(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "NodeProxyOptions"})
@@ -129,7 +129,7 @@ func (EmptyOpenAPI) OpenAPISchema() (*openapi_v2.Document, error) {
 
 func TestDryRunVerifierNoOpenAPI(t *testing.T) {
 	dryRunVerifier := DryRunVerifier{
-		Finder: NewCRDFinder(func() ([]schema.GroupKind, error) {
+		finder: NewCRDFinder(func() ([]schema.GroupKind, error) {
 			return []schema.GroupKind{
 				{
 					Group: "crd.com",
@@ -141,7 +141,7 @@ func TestDryRunVerifierNoOpenAPI(t *testing.T) {
 				},
 			}, nil
 		}),
-		OpenAPIGetter: EmptyOpenAPI{},
+		openAPIGetter: EmptyOpenAPI{},
 	}
 
 	err := dryRunVerifier.HasSupport(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This is a follow up to this PR comment https://github.com/kubernetes/kubernetes/pull/86408#pullrequestreview-345841527 from @soltysh: we want to expose `NewDryRunVerifier` and `VerifyDryRun` in cli-runtime only, and make the internal methods and struct members private:

> I'd hide here every bit of implementation except for the methods being used. Namely NewDryRunVerifier and VerifyDryRun. Remember, this is a library and whatever we expose our users will start consuming, thus making it impossible for us to change. Everything about DryRunVerifier struct can be made private and hidden from consumers.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow up cleanup for #85652.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/cc @apelisse 
/assign @soltysh 
/sig cli
/priority important-soon