### PR TITLE
fix static check errors in vendor/k8s.io/apimachinery/pkg/api/resource

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -48,7 +48,6 @@ test/integration/garbagecollector
 test/integration/scheduler_perf
 test/integration/ttlcontroller
 vendor/k8s.io/apimachinery/pkg/api/meta
-vendor/k8s.io/apimachinery/pkg/api/resource
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured/unstructuredscheme
 vendor/k8s.io/apimachinery/pkg/apis/meta/v1/validation

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/math.go
@@ -37,12 +37,8 @@ var (
 	big1024     = big.NewInt(1024)
 
 	// Commonly needed inf.Dec values-- treat as read only!
-	decZero      = inf.NewDec(0, 0)
-	decOne       = inf.NewDec(1, 0)
-	decMinusOne  = inf.NewDec(-1, 0)
-	decThousand  = inf.NewDec(1000, 0)
-	dec1024      = inf.NewDec(1024, 0)
-	decMinus1024 = inf.NewDec(-1024, 0)
+	decZero = inf.NewDec(0, 0)
+	decOne  = inf.NewDec(1, 0)
 
 	// Largest (in magnitude) number allowed.
 	maxAllowed = infDecAmount{inf.NewDec((1<<63)-1, 0)} // == max int64

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/quantity_test.go
@@ -28,11 +28,6 @@ import (
 	inf "gopkg.in/inf.v0"
 )
 
-func amount(i int64, exponent int) infDecAmount {
-	// See the below test-- scale is the negative of an exponent.
-	return infDecAmount{inf.NewDec(i, inf.Scale(-exponent))}
-}
-
 func dec(i int64, exponent int) infDecAmount {
 	// See the below test-- scale is the negative of an exponent.
 	return infDecAmount{inf.NewDec(i, inf.Scale(-exponent))}


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>



**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
cleanup staticcheck errors,for:
```
vendor/k8s.io/apimachinery/pkg/api/resource
```
it says as below:
```
vendor/k8s.io/apimachinery/pkg/api/resource/math.go:42:2: var decMinusOne is unused (U1000)
vendor/k8s.io/apimachinery/pkg/api/resource/math.go:43:2: var decThousand is unused (U1000)
vendor/k8s.io/apimachinery/pkg/api/resource/math.go:44:2: var dec1024 is unused (U1000)
vendor/k8s.io/apimachinery/pkg/api/resource/math.go:45:2: var decMinus1024 is unused (U1000)
vendor/k8s.io/apimachinery/pkg/api/resource/quantity_test.go:31:6: func amount is unused (U1000)
```

**Which issue(s) this PR fixes**:
Ref:#81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
