### PR TITLE
Fix a bug that ipvs proxier doesn't discover secondary IP on an interface

### DIFF
--- a/pkg/proxy/ipvs/BUILD
+++ b/pkg/proxy/ipvs/BUILD
@@ -11,6 +11,7 @@ go_test(
     srcs = [
         "graceful_termination_test.go",
         "ipset_test.go",
+        "netlink_test.go",
         "proxier_test.go",
     ],
     embed = [":go_default_library"],

--- a/pkg/proxy/ipvs/netlink_test.go
+++ b/pkg/proxy/ipvs/netlink_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ipvs
+
+import (
+	"net"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+// getNodeIPs returns a set of all node IP addresses.
+func getNodeIPs(isIPv6 bool) (sets.String, error) {
+	res := sets.NewString()
+
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
+		ip, _, _ := net.ParseCIDR(addr.String())
+		if isIPv6 {
+			if ip.To4() == nil {
+				res.Insert(ip.String())
+			}
+		} else {
+			if ip.To4() != nil {
+				res.Insert(ip.String())
+			}
+		}
+	}
+
+	return res, nil
+}
+
+func TestGetLocalAddresses(t *testing.T) {
+	isIPv6 := false
+	h := NewNetLinkHandle(isIPv6)
+	nodeIPSet, err := getNodeIPs(isIPv6)
+	if err != nil {
+		t.Errorf("GetLocalAddresses() error get node ip: %v", err)
+	}
+
+	tests := []struct {
+		testName  string
+		dev       string
+		filterDev string
+		want      sets.String
+		wantErr   bool
+	}{
+		{
+			testName: "invalid dev",
+			dev:      "foobar",
+			wantErr:  true,
+		},
+		{
+			testName: "invalid filterDev",
+			dev:      "foobar",
+			wantErr:  true,
+		},
+		{
+			testName: "lo as dev",
+			dev:      "lo",
+			want:     sets.NewString("127.0.0.1"),
+		},
+		{
+			testName:  "all network interfaces",
+			dev:       "",
+			filterDev: "",
+			want:      nodeIPSet,
+		},
+		{
+			testName:  "all network interfaces except lo",
+			dev:       "",
+			filterDev: "lo",
+			want:      nodeIPSet.Difference(sets.NewString("127.0.0.1")),
+		},
+		{
+			testName:  "dev and filterDev are the same",
+			dev:       "lo",
+			filterDev: "lo",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			got, err := h.GetLocalAddresses(test.dev, test.filterDev)
+			if (err != nil) != test.wantErr {
+				t.Errorf("GetLocalAddresses() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !got.Equal(test.want) {
+				t.Errorf("GetLocalAddresses() got = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/proxy/ipvs/netlink_unsupported.go
+++ b/pkg/proxy/ipvs/netlink_unsupported.go
@@ -61,3 +61,5 @@ func (h *emptyHandle) ListBindAddress(devName string) ([]string, error) {
 func (h *emptyHandle) GetLocalAddresses(dev, filterDev string) (sets.String, error) {
 	return nil, fmt.Errorf("netlink is not supported in this platform")
 }
+
+var _ NetLinkHandle = &emptyHandle{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:

When a interface has two IP addresses with the same mask size, kube-proxy will fail to extract the secondary IP from local route since they have the same `src`.
`route.Dst` is used to get local IP addresses for IPv6 while `route.Src` is used for IPv4. So this PR also unifies IPv4 and IPv6 via `route.Dst`.

An example is shown below.

```bash
# chen @ x1 in ~ [23:59:50] 
$ ip addr show eth0
2: enp3s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UP group default qlen 1000
    link/ether 00:30:48:f8:97:0e brd ff:ff:ff:ff:ff:ff
    inet 192.168.1.46/24 brd 192.168.1.255 scope global noprefixroute enp3s0
       valid_lft forever preferred_lft forever
    inet 192.168.1.47/24 scope global secondary enp3s0
       valid_lft forever preferred_lft forever
    inet6 2001:da8:d800:1472:d209:5c3:bc09:4182/64 scope global dynamic noprefixroute 
       valid_lft 86375sec preferred_lft 14375sec
    inet6 fe80::cacc:775a:56c1:723d/64 scope link noprefixroute 
       valid_lft forever preferred_lft forever

# chen @ x1 in ~ [23:59:54] 
$ ip route show table local type local proto kernel
local 10.0.0.1 dev kube-ipvs0 scope host src 10.0.0.1 
local 10.0.0.10 dev kube-ipvs0 scope host src 10.0.0.10 
local 10.0.0.119 dev kube-ipvs0 scope host src 10.0.0.119 
local 10.1.0.1 dev cbr0 scope host src 10.1.0.1 
local 127.0.0.0/8 dev lo scope host src 127.0.0.1 
local 127.0.0.1 dev lo scope host src 127.0.0.1 
local 172.17.0.1 dev docker0 scope host src 172.17.0.1 
local 192.168.1.46 dev enp3s0 scope host src 192.168.1.46 
local 192.168.1.47 dev enp3s0 scope host src 192.168.1.46 # this causes problems!!! 192.168.1.47 is missed
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #75443

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix a bug that ipvs proxier doesn't discover secondary IP on an interface
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
