### PR TITLE
Re-enable apply for 50% of requests

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -35,7 +35,7 @@ const DefaultMaxUpdateManagers int = 10
 
 // DefaultTrackOnCreateProbability defines the default probability that the field management of an object
 // starts being tracked from the object's creation, instead of from the first time the object is applied to.
-const DefaultTrackOnCreateProbability float32 = 0.0
+const DefaultTrackOnCreateProbability float32 = 0.5
 
 // Managed groups a fieldpath.ManagedFields together with the timestamps associated with each operation.
 type Managed interface {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/priority important-soon
/wg apply

**What this PR does / why we need it**:
Now that https://github.com/kubernetes/kubernetes/issues/82042 is fixed, we can revert #87196

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

No release note because we won't release with this at 50%, only at 0 or 100

/cc @lavalamp