### PR TITLE
[WIP] Using GCP default credentials if set to download release artifacts 

### DIFF
--- a/cluster/get-kube-binaries.sh
+++ b/cluster/get-kube-binaries.sh
@@ -146,8 +146,15 @@ function sha1sum_file() {
 # Get default service account credentials of the VM.
 GCE_METADATA_INTERNAL="http://metadata.google.internal/computeMetadata/v1/instance"
 function get-credentials {
-  curl "${GCE_METADATA_INTERNAL}/service-accounts/default/token" -H "Metadata-Flavor: Google" -s | python -c \
-    'import sys; import json; print(json.loads(sys.stdin.read())["access_token"])'
+  local token=''
+  # If a default credential is set, we should use it instead of relying
+  # on VM credentials (Workload Identity)
+  token="$(gcloud auth application-default print-access-token || echo '')"
+  if [[ -z "${token}" ]] && [[ $(valid-storage-scope) ]]; then
+    token="$(curl "${GCE_METADATA_INTERNAL}/service-accounts/default/token" -H "Metadata-Flavor: Google" -s | python -c \
+      'import sys; import json; print(json.loads(sys.stdin.read())["access_token"])' || echo '')"
+  fi
+  echo "${token}"
 }
 
 function valid-storage-scope {
@@ -168,7 +175,7 @@ function download_tarball() {
     # if the url belongs to GCS API we should use oauth2_token in the headers
     curl_headers=""
     if { [[ "${KUBERNETES_PROVIDER:-gce}" == "gce" ]] || [[ "${KUBERNETES_PROVIDER}" == "gke" ]] ; } &&
-       [[ "$url" =~ ^https://storage.googleapis.com.* ]] && valid-storage-scope ; then
+       [[ "$url" =~ ^https://storage.googleapis.com.* ]]; then
       curl_headers="Authorization: Bearer $(get-credentials)"
     fi
     curl ${curl_headers:+-H "${curl_headers}"} -fL --retry 3 --keepalive-time 2 "${url}" -o "${download_path}/${file}"


### PR DESCRIPTION
In GCE, GKE, We should not be relying on VM credentials if a default
service account is set. This is mostly true when using Workload Identity
in GKE.

Follow up of #82801
/kind bug
/sig gcp
/assign @fejta 