### PR TITLE
Don't save managedFields if object is too large

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -103,6 +103,8 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/util/wsstream:go_default_library",
         "//vendor/github.com/evanphx/json-patch:go_default_library",
         "//vendor/golang.org/x/net/websocket:go_default_library",
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/trace:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",

--- a/test/integration/apiserver/apply/BUILD
+++ b/test/integration/apiserver/apply/BUILD
@@ -25,6 +25,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/dynamic:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig api-machinery
/wg apply
/priority important-soon

**What this PR does / why we need it**:
Valid objects close to the etcd object size limit could become invalid when server-side apply is enabled. To prevent that, this PR makes any modifying request which would go over the size limit due to the size of managedFields fall back to the old behavior, and remove everything from managedFields.

Apply requests that would increase the object size past the limit will still fail, since removing managedFields wouldn't make sense in this case.

/cc @apelisse @kwiesmueller @lavalamp 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```