### PR TITLE
Added 'No resources found' message to describe <type> and top pod commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe.go
@@ -203,6 +203,15 @@ func (o *DescribeOptions) Run() error {
 		}
 	}
 
+	if len(infos) == 0 && len(allErrs) == 0 {
+		// if we wrote no output, and had no errors, be sure we output something.
+		if o.AllNamespaces {
+			fmt.Fprintln(o.ErrOut, "No resources found")
+		} else {
+			fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
+		}
+	}
+
 	return utilerrors.NewAggregate(allErrs)
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -245,6 +245,59 @@ func TestDescribeHelpMessage(t *testing.T) {
 	}
 }
 
+func TestDescribeNoResourcesFound(t *testing.T) {
+	testNS := "testns"
+	testCases := []struct {
+		name            string
+		flags           map[string]string
+		namespace       string
+		expectedOutput  string
+		expectedErr	    string
+	}{
+		{
+			name:           "all namespaces",
+			flags:           map[string]string{"all-namespaces": "true"},
+			expectedOutput: "",
+			expectedErr:    "No resources found\n",
+		},
+		{
+			name:           "all in namespace",
+			namespace:      testNS,
+			expectedOutput: "",
+			expectedErr:    "No resources found in " + testNS + " namespace.\n",
+		},
+	}
+	cmdtesting.InitTestErrorHandler(t)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			pods, _, _ := cmdtesting.EmptyTestData()
+			tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
+			defer tf.Cleanup()
+			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+
+			tf.UnstructuredClient = &fake.RESTClient{
+				NegotiatedSerializer: resource.UnstructuredPlusDefaultContentConfig().NegotiatedSerializer,
+				Resp:                 &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, pods)},
+			}
+
+			streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+
+			cmd := NewCmdDescribe("kubectl", tf, streams)
+			for name, value := range testCase.flags {
+				_ = cmd.Flags().Set(name, value)
+			}
+			cmd.Run(cmd, []string{"pods"})
+
+			if e, a := testCase.expectedOutput, buf.String(); e != a {
+				t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", e, a)
+			}
+			if e, a := testCase.expectedErr, errbuf.String(); e != a {
+				t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
+			}
+		})
+	}
+}
+
 type testDescriber struct {
 	Name, Namespace string
 	Settings        describe.DescriberSettings

--- a/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/describe/describe_test.go
@@ -248,15 +248,15 @@ func TestDescribeHelpMessage(t *testing.T) {
 func TestDescribeNoResourcesFound(t *testing.T) {
 	testNS := "testns"
 	testCases := []struct {
-		name            string
-		flags           map[string]string
-		namespace       string
-		expectedOutput  string
-		expectedErr	    string
+		name           string
+		flags          map[string]string
+		namespace      string
+		expectedOutput string
+		expectedErr    string
 	}{
 		{
 			name:           "all namespaces",
-			flags:           map[string]string{"all-namespaces": "true"},
+			flags:          map[string]string{"all-namespaces": "true"},
 			expectedOutput: "",
 			expectedErr:    "No resources found\n",
 		},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod.go
@@ -196,6 +196,13 @@ func (o TopPodOptions) RunTopPod() error {
 		if e != nil {
 			return e
 		}
+
+		// if we had no errors, be sure we output something.
+		if o.AllNamespaces {
+			fmt.Fprintln(o.ErrOut, "No resources found")
+		} else {
+			fmt.Fprintf(o.ErrOut, "No resources found in %s namespace.\n", o.Namespace)
+		}
 	}
 	if err != nil {
 		return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -452,12 +452,12 @@ func TestTopPodWithMetricsServer(t *testing.T) {
 func TestTopPodNoResourcesFound(t *testing.T) {
 	testNS := "testns"
 	testCases := []struct {
-		name            string
-		options         *TopPodOptions
-		namespace       string
-		expectedOutput  string
-		expectedErr	    string
-		expectedPath    string
+		name           string
+		options        *TopPodOptions
+		namespace      string
+		expectedOutput string
+		expectedErr    string
+		expectedPath   string
 	}{
 		{
 			name:           "all namespaces",
@@ -501,7 +501,7 @@ func TestTopPodNoResourcesFound(t *testing.T) {
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
 					case p == "/apis":
 						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
-					case p == "/api/v1/namespaces/" + testNS + "/pods":
+					case p == "/api/v1/namespaces/"+testNS+"/pods":
 						// Top Pod calls this endpoint to check if there are pods whenever it gets no metrics,
 						// so we need to return no pods for this test scenario
 						body, _ := marshallBody(metricsv1alpha1api.PodMetricsList{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/top/top_pod_test.go
@@ -449,6 +449,108 @@ func TestTopPodWithMetricsServer(t *testing.T) {
 	}
 }
 
+func TestTopPodNoResourcesFound(t *testing.T) {
+	testNS := "testns"
+	testCases := []struct {
+		name            string
+		options         *TopPodOptions
+		namespace       string
+		expectedOutput  string
+		expectedErr	    string
+		expectedPath    string
+	}{
+		{
+			name:           "all namespaces",
+			options:        &TopPodOptions{AllNamespaces: true},
+			expectedOutput: "",
+			expectedErr:    "No resources found\n",
+			expectedPath:   topMetricsAPIPathPrefix + "/pods",
+		},
+		{
+			name:           "all in namespace",
+			namespace:      testNS,
+			expectedOutput: "",
+			expectedErr:    "No resources found in " + testNS + " namespace.\n",
+			expectedPath:   topMetricsAPIPathPrefix + "/namespaces/" + testNS + "/pods",
+		},
+	}
+	cmdtesting.InitTestErrorHandler(t)
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			fakemetricsClientset := &metricsfake.Clientset{}
+			fakemetricsClientset.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+				res := &metricsv1beta1api.PodMetricsList{
+					ListMeta: metav1.ListMeta{
+						ResourceVersion: "2",
+					},
+					Items: nil, // No metrics found
+				}
+				return true, res, nil
+			})
+
+			tf := cmdtesting.NewTestFactory().WithNamespace(testNS)
+			defer tf.Cleanup()
+
+			ns := scheme.Codecs.WithoutConversion()
+
+			tf.Client = &fake.RESTClient{
+				NegotiatedSerializer: ns,
+				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					switch p := req.URL.Path; {
+					case p == "/api":
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte(apibody)))}, nil
+					case p == "/apis":
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: ioutil.NopCloser(bytes.NewReader([]byte(apisbodyWithMetrics)))}, nil
+					case p == "/api/v1/namespaces/" + testNS + "/pods":
+						// Top Pod calls this endpoint to check if there are pods whenever it gets no metrics,
+						// so we need to return no pods for this test scenario
+						body, _ := marshallBody(metricsv1alpha1api.PodMetricsList{
+							ListMeta: metav1.ListMeta{
+								ResourceVersion: "2",
+							},
+							Items: nil, // No pods found
+						})
+						return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: body}, nil
+					default:
+						t.Fatalf("%s: unexpected request: %#v\nGot URL: %#v",
+							testCase.name, req, req.URL)
+						return nil, nil
+					}
+				}),
+			}
+			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+			streams, _, buf, errbuf := genericclioptions.NewTestIOStreams()
+
+			cmd := NewCmdTopPod(tf, nil, streams)
+			var cmdOptions *TopPodOptions
+			if testCase.options != nil {
+				cmdOptions = testCase.options
+			} else {
+				cmdOptions = &TopPodOptions{}
+			}
+			cmdOptions.IOStreams = streams
+
+			if err := cmdOptions.Complete(tf, cmd, nil); err != nil {
+				t.Fatal(err)
+			}
+			cmdOptions.MetricsClient = fakemetricsClientset
+			if err := cmdOptions.Validate(); err != nil {
+				t.Fatal(err)
+			}
+			if err := cmdOptions.RunTopPod(); err != nil {
+				t.Fatal(err)
+			}
+
+			if e, a := testCase.expectedOutput, buf.String(); e != a {
+				t.Errorf("Unexpected output:\nExpected:\n%v\nActual:\n%v", e, a)
+			}
+			if e, a := testCase.expectedErr, errbuf.String(); e != a {
+				t.Errorf("Unexpected error:\nExpected:\n%v\nActual:\n%v", e, a)
+			}
+		})
+	}
+}
+
 type fakeDiscovery struct{}
 
 // ServerGroups returns the supported groups, with information like supported versions and the


### PR DESCRIPTION

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds messaging to the `kubectl describe <type>` and `kubectl top pod` commands so that if no resources are found, it displays a message saying "No resources found" or "No resources found in <namespace> namespace" just like `kubectl get <type>` does currently.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/796

**Special notes for your reviewer**:
I realize this is a minor fix, but this being my first Kubernetes PR, I wanted a simple one where I could become familiar with building and testing the code base.

I'm not sure if this actually requires a release note or not, but technically I guess this is a user facing change since it is a new message to the user in some cases.  If it does **not** require one, let me know and I will update my PR accordingly.

**Does this PR introduce a user-facing change?**:
Yes
```release-note
kubectl describe <type> and kubectl top pod will return a message saying "No resources found" or "No resources found in <namespace> namespace" if there are no results to display.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A