### PR TITLE
Make API Priority and Fairness suggested config avoid the mandatory catch-all

### DIFF
--- a/pkg/apis/flowcontrol/validation/validation_test.go
+++ b/pkg/apis/flowcontrol/validation/validation_test.go
@@ -1013,14 +1013,10 @@ func TestPriorityLevelConfigurationValidation(t *testing.T) {
 				Spec: flowcontrol.PriorityLevelConfigurationSpec{
 					Type: flowcontrol.PriorityLevelEnablementLimited,
 					Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-						AssuredConcurrencyShares: 100,
+						AssuredConcurrencyShares: 1,
 						LimitResponse: flowcontrol.LimitResponse{
-							Type: flowcontrol.LimitResponseTypeQueue,
-							Queuing: &flowcontrol.QueuingConfiguration{
-								Queues:           128,
-								HandSize:         6,
-								QueueLengthLimit: 100,
-							}}}},
+							Type: flowcontrol.LimitResponseTypeReject,
+						}}},
 			},
 			expectedErrors: field.ErrorList{},
 		},

--- a/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/flowcontrol/bootstrap/default.go
@@ -59,6 +59,8 @@ var (
 		// "workload-low" is used by those workloads with lower priority which availability only has a
 		// minor impact on the cluster.
 		SuggestedPriorityLevelConfigurationWorkloadLow,
+		// "global-default" serves the rest traffic not handled by the other suggested flow-schemas above.
+		SuggestedPriorityLevelConfigurationGlobalDefault,
 	}
 	SuggestedFlowSchemas = []*flowcontrol.FlowSchema{
 		SuggestedFlowSchemaSystemNodes,               // references "system" priority-level
@@ -68,6 +70,7 @@ var (
 		SuggestedFlowSchemaKubeScheduler,             // references "workload-high" priority-level
 		SuggestedFlowSchemaKubeSystemServiceAccounts, // references "workload-high" priority-level
 		SuggestedFlowSchemaServiceAccounts,           // references "workload-low" priority-level
+		SuggestedFlowSchemaGlobalDefault,             // references "global-default" priority-level
 	}
 )
 
@@ -84,14 +87,9 @@ var (
 		flowcontrol.PriorityLevelConfigurationSpec{
 			Type: flowcontrol.PriorityLevelEnablementLimited,
 			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
-				AssuredConcurrencyShares: 100,
+				AssuredConcurrencyShares: 1,
 				LimitResponse: flowcontrol.LimitResponse{
-					Type: flowcontrol.LimitResponseTypeQueue,
-					Queuing: &flowcontrol.QueuingConfiguration{
-						Queues:           128,
-						HandSize:         6,
-						QueueLengthLimit: 100,
-					},
+					Type: flowcontrol.LimitResponseTypeReject,
 				},
 			},
 		})
@@ -99,7 +97,8 @@ var (
 
 // Mandatory FlowSchema objects
 var (
-	// exempt priority-level
+	// "exempt" priority-level is used for preventing priority inversion and ensuring that sysadmin
+	// requests are always possible.
 	MandatoryFlowSchemaExempt = newFlowSchema(
 		"exempt",
 		flowcontrol.PriorityLevelConfigurationNameExempt,
@@ -124,7 +123,8 @@ var (
 			},
 		},
 	)
-	// catch-all priority-level
+	// "catch-all" priority-level only gets a minimal positive share of concurrency and won't be reaching
+	// ideally unless you intentionally deleted the suggested "global-default".
 	MandatoryFlowSchemaCatchAll = newFlowSchema(
 		"catch-all",
 		"catch-all",
@@ -165,7 +165,7 @@ var (
 					Queuing: &flowcontrol.QueuingConfiguration{
 						Queues:           64,
 						HandSize:         6,
-						QueueLengthLimit: 1000,
+						QueueLengthLimit: 50,
 					},
 				},
 			},
@@ -182,7 +182,7 @@ var (
 					Queuing: &flowcontrol.QueuingConfiguration{
 						Queues:           16,
 						HandSize:         4,
-						QueueLengthLimit: 100,
+						QueueLengthLimit: 50,
 					},
 				},
 			},
@@ -199,7 +199,7 @@ var (
 					Queuing: &flowcontrol.QueuingConfiguration{
 						Queues:           128,
 						HandSize:         6,
-						QueueLengthLimit: 100,
+						QueueLengthLimit: 50,
 					},
 				},
 			},
@@ -216,7 +216,24 @@ var (
 					Queuing: &flowcontrol.QueuingConfiguration{
 						Queues:           128,
 						HandSize:         6,
-						QueueLengthLimit: 100,
+						QueueLengthLimit: 50,
+					},
+				},
+			},
+		})
+	// global-default priority-level
+	SuggestedPriorityLevelConfigurationGlobalDefault = newPriorityLevelConfiguration(
+		"global-default",
+		flowcontrol.PriorityLevelConfigurationSpec{
+			Type: flowcontrol.PriorityLevelEnablementLimited,
+			Limited: &flowcontrol.LimitedPriorityLevelConfiguration{
+				AssuredConcurrencyShares: 100,
+				LimitResponse: flowcontrol.LimitResponse{
+					Type: flowcontrol.LimitResponseTypeQueue,
+					Queuing: &flowcontrol.QueuingConfiguration{
+						Queues:           128,
+						HandSize:         6,
+						QueueLengthLimit: 50,
 					},
 				},
 			},
@@ -343,6 +360,24 @@ var (
 	)
 	SuggestedFlowSchemaServiceAccounts = newFlowSchema(
 		"service-accounts", "workload-low", 9000,
+		flowcontrol.FlowDistinguisherMethodByUserType,
+		flowcontrol.PolicyRulesWithSubjects{
+			Subjects: groups(serviceaccount.AllServiceAccountsGroup),
+			ResourceRules: []flowcontrol.ResourcePolicyRule{resourceRule(
+				[]string{flowcontrol.VerbAll},
+				[]string{flowcontrol.APIGroupAll},
+				[]string{flowcontrol.ResourceAll},
+				[]string{flowcontrol.NamespaceEvery},
+				true)},
+			NonResourceRules: []flowcontrol.NonResourcePolicyRule{
+				nonResourceRule(
+					[]string{flowcontrol.VerbAll},
+					[]string{flowcontrol.NonResourceAll}),
+			},
+		},
+	)
+	SuggestedFlowSchemaGlobalDefault = newFlowSchema(
+		"global-default", "global-default", 9900,
 		flowcontrol.FlowDistinguisherMethodByUserType,
 		flowcontrol.PolicyRulesWithSubjects{
 			Subjects: groups(serviceaccount.AllServiceAccountsGroup),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:
This is an updated version of #87130 .
This PR revises the suggested configuration so that it does not send traffic to the mandatory catch-all priority level but instead introduces another priority level of its own.  This is because we decided that the mandatory catch-all priority level should get a tiny concurrency allocation and be avoided in non-broken configs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190228-priority-and-fairness.md
```
