### PR TITLE
Improve SharedInformer testing wrt resync period

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/BUILD
+++ b/staging/src/k8s.io/client-go/tools/cache/BUILD
@@ -29,7 +29,6 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
@@ -40,6 +39,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache/testing:go_default_library",
         "//vendor/github.com/google/gofuzz:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/client-go/tools/cache/main_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/main_test.go
@@ -21,9 +21,12 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"k8s.io/klog"
 )
 
 func TestMain(m *testing.M) {
 	rand.Seed(time.Now().UnixNano())
+	klog.InitFlags(nil)
 	os.Exit(m.Run())
 }

--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -18,13 +18,13 @@ package cache
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -32,20 +32,45 @@ import (
 	fcache "k8s.io/client-go/tools/cache/testing"
 )
 
+const timeFmt = "15:04:05.999999999"
+
 type testListener struct {
-	lock              sync.RWMutex
-	resyncPeriod      time.Duration
-	expectedItemNames sets.String
-	receivedItemNames []string
-	name              string
+	t                *testing.T
+	name             string
+	clock            clock.PassiveClock
+	resyncPeriod     time.Duration
+	checkTiming      bool // whether handle() checks timing
+	expectedItemKeys sets.String
+	lock             sync.RWMutex
+	whenReceived     map[string]time.Time // maps key to when last received
 }
 
-func newTestListener(name string, resyncPeriod time.Duration, expected ...string) *testListener {
+func (l *testListener) receivedItemKeys() sets.String {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	return sets.StringKeySet(l.whenReceived)
+}
+
+func (l *testListener) reset() {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	l.whenReceived = make(map[string]time.Time)
+}
+
+func newTestListener(t *testing.T, name string, clock clock.PassiveClock, resyncPeriod time.Duration, expected ...string) *testListener {
+	return newTimableListener(t, name, clock, resyncPeriod, false, expected...)
+}
+
+func newTimableListener(t *testing.T, name string, clock clock.PassiveClock, resyncPeriod time.Duration, checkTiming bool, expected ...string) *testListener {
 	l := &testListener{
-		resyncPeriod:      resyncPeriod,
-		expectedItemNames: sets.NewString(expected...),
-		name:              name,
+		t:                t,
+		name:             name,
+		clock:            clock,
+		resyncPeriod:     resyncPeriod,
+		checkTiming:      checkTiming,
+		expectedItemKeys: sets.NewString(expected...),
 	}
+	l.reset()
 	return l
 }
 
@@ -62,16 +87,50 @@ func (l *testListener) OnDelete(obj interface{}) {
 
 func (l *testListener) handle(obj interface{}) {
 	key, _ := MetaNamespaceKeyFunc(obj)
-	fmt.Printf("%s: handle: %v\n", l.name, key)
+	now := l.clock.Now()
+	l.t.Logf("%s %s: handle: %v\n", now.Format(timeFmt), l.name, key)
 	l.lock.Lock()
 	defer l.lock.Unlock()
+	prev, wasThere := l.whenReceived[key]
+	l.whenReceived[key] = now
+	if l.checkTiming && wasThere && (l.resyncPeriod <= 0 || now.Sub(prev) < l.resyncPeriod) {
+		l.t.Errorf("%s %s: prev receipt of %v was at %s but requested period is %s", now.Format(timeFmt), l.name, key, prev.Format(timeFmt), l.resyncPeriod)
+	}
+}
 
-	objectMeta, _ := meta.Accessor(obj)
-	l.receivedItemNames = append(l.receivedItemNames, objectMeta.GetName())
+func (l *testListener) checkRecency(checkPeriod time.Duration) {
+	for key := range l.expectedItemKeys {
+		var prev, now time.Time
+		var good bool
+		// time since last receipt should not go above this quantity
+		expectedResyncPeriod := checkPeriod * time.Duration(math.Ceil(float64(l.resyncPeriod)/float64(checkPeriod)))
+		err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
+			l.lock.Lock()
+			defer l.lock.Unlock()
+			var got bool
+			prev, got = l.whenReceived[key]
+			if !got {
+				return false, nil
+			}
+			if l.resyncPeriod <= 0 {
+				good = true
+				return true, nil
+			}
+			now = l.clock.Now()
+			lat := now.Sub(prev)
+			good = lat <= expectedResyncPeriod
+			return good, nil
+		})
+		if err != nil {
+			l.t.Errorf("%s %s: for %s, failed: %s", now.Format(timeFmt), l.name, key, err.Error())
+		} else if !good {
+			l.t.Errorf("%s %s: prev receipt of %v was at %s but requested period is %s", now.Format(timeFmt), l.name, key, prev.Format(timeFmt), l.resyncPeriod)
+		}
+	}
 }
 
 func (l *testListener) ok() bool {
-	fmt.Println("polling")
+	l.t.Logf("%s %s: polling\n", l.clock.Now().Format(timeFmt), l.name)
 	err := wait.PollImmediate(100*time.Millisecond, 2*time.Second, func() (bool, error) {
 		if l.satisfiedExpectations() {
 			return true, nil
@@ -83,9 +142,9 @@ func (l *testListener) ok() bool {
 	}
 
 	// wait just a bit to allow any unexpected stragglers to come in
-	fmt.Println("sleeping")
+	l.t.Logf("%s %s: sleeping\n", l.clock.Now().Format(timeFmt), l.name)
 	time.Sleep(1 * time.Second)
-	fmt.Println("final check")
+	l.t.Logf("%s %s: final check\n", l.clock.Now().Format(timeFmt), l.name)
 	return l.satisfiedExpectations()
 }
 
@@ -93,163 +152,77 @@ func (l *testListener) satisfiedExpectations() bool {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
 
-	return sets.NewString(l.receivedItemNames...).Equal(l.expectedItemNames)
+	return sets.StringKeySet(l.whenReceived).Equal(l.expectedItemKeys)
 }
 
 func TestListenerResyncPeriods(t *testing.T) {
+	for _, defaultCheckPeriodMsec := range []int{1000, 1300, 1500, 5000} {
+		t.Run(fmt.Sprintf("defaultCheckPeriod=%dms", defaultCheckPeriodMsec), func(t *testing.T) { checkListenerResyncPeriods(t, defaultCheckPeriodMsec) })
+	}
+}
+
+func checkListenerResyncPeriods(t *testing.T, defaultCheckPeriodMsec int) {
+	sfx := fmt.Sprintf("-%dms", defaultCheckPeriodMsec)
+	defaultCheckPeriod := time.Duration(defaultCheckPeriodMsec) * time.Millisecond
+	name1 := "pod1" + sfx
+	name2 := "pod2" + sfx
 	// source simulates an apiserver object endpoint.
 	source := fcache.NewFakeControllerSource()
-	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1"}})
-	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2"}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name1}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: name2}})
 
 	// create the shared informer and resync every 1s
-	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
+	informer := NewSharedInformer(source, &v1.Pod{}, defaultCheckPeriod).(*sharedIndexInformer)
 
-	clock := clock.NewFakeClock(time.Now())
+	startTime := time.Now()
+	clock := clock.NewFakeClock(startTime)
 	informer.clock = clock
 	informer.processor.clock = clock
 
 	// listener 1, never resync
-	listener1 := newTestListener("listener1", 0, "pod1", "pod2")
+	listener1 := newTimableListener(t, "listener1"+sfx, clock, 0, true, name1, name2)
 	informer.AddEventHandlerWithResyncPeriod(listener1, listener1.resyncPeriod)
 
 	// listener 2, resync every 2s
-	listener2 := newTestListener("listener2", 2*time.Second, "pod1", "pod2")
+	listener2 := newTimableListener(t, "listener2"+sfx, clock, 2*time.Second, true, name1, name2)
 	informer.AddEventHandlerWithResyncPeriod(listener2, listener2.resyncPeriod)
 
 	// listener 3, resync every 3s
-	listener3 := newTestListener("listener3", 3*time.Second, "pod1", "pod2")
+	listener3 := newTimableListener(t, "listener3"+sfx, clock, 3*time.Second, true, name1, name2)
 	informer.AddEventHandlerWithResyncPeriod(listener3, listener3.resyncPeriod)
-	listeners := []*testListener{listener1, listener2, listener3}
+
+	expectedCheckPeriod := defaultCheckPeriod
+	if expectedCheckPeriod > 2*time.Second {
+		expectedCheckPeriod = 2 * time.Second
+	}
 
 	stop := make(chan struct{})
 	defer close(stop)
 
 	go informer.Run(stop)
+	// Ensure informer is started before adding the last listener
+	WaitForCacheSync(stop, informer.HasSynced)
+
+	// listener 4, resync every 600ms
+	listener4 := newTimableListener(t, "listener4"+sfx, clock, 600*time.Millisecond, true, name1, name2)
+	informer.AddEventHandlerWithResyncPeriod(listener4, listener4.resyncPeriod)
+	listeners := []*testListener{listener1, listener2, listener3, listener4}
 
 	// ensure all listeners got the initial List
 	for _, listener := range listeners {
 		if !listener.ok() {
-			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemNames, listener.receivedItemNames)
+			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemKeys, listener.receivedItemKeys())
 		}
 	}
 
-	// reset
-	for _, listener := range listeners {
-		listener.receivedItemNames = []string{}
-	}
-
-	// advance so listener2 gets a resync
-	clock.Step(2 * time.Second)
-
-	// make sure listener2 got the resync
-	if !listener2.ok() {
-		t.Errorf("%s: expected %v, got %v", listener2.name, listener2.expectedItemNames, listener2.receivedItemNames)
-	}
-
-	// wait a bit to give errant items a chance to go to 1 and 3
-	time.Sleep(1 * time.Second)
-
-	// make sure listeners 1 and 3 got nothing
-	if len(listener1.receivedItemNames) != 0 {
-		t.Errorf("listener1: should not have resynced (got %d)", len(listener1.receivedItemNames))
-	}
-	if len(listener3.receivedItemNames) != 0 {
-		t.Errorf("listener3: should not have resynced (got %d)", len(listener3.receivedItemNames))
-	}
-
-	// reset
-	for _, listener := range listeners {
-		listener.receivedItemNames = []string{}
-	}
-
-	// advance so listener3 gets a resync
-	clock.Step(1 * time.Second)
-
-	// make sure listener3 got the resync
-	if !listener3.ok() {
-		t.Errorf("%s: expected %v, got %v", listener3.name, listener3.expectedItemNames, listener3.receivedItemNames)
-	}
-
-	// wait a bit to give errant items a chance to go to 1 and 2
-	time.Sleep(1 * time.Second)
-
-	// make sure listeners 1 and 2 got nothing
-	if len(listener1.receivedItemNames) != 0 {
-		t.Errorf("listener1: should not have resynced (got %d)", len(listener1.receivedItemNames))
-	}
-	if len(listener2.receivedItemNames) != 0 {
-		t.Errorf("listener2: should not have resynced (got %d)", len(listener2.receivedItemNames))
-	}
-}
-
-func TestResyncCheckPeriod(t *testing.T) {
-	// source simulates an apiserver object endpoint.
-	source := fcache.NewFakeControllerSource()
-
-	// create the shared informer and resync every 12 hours
-	informer := NewSharedInformer(source, &v1.Pod{}, 12*time.Hour).(*sharedIndexInformer)
-
-	clock := clock.NewFakeClock(time.Now())
-	informer.clock = clock
-	informer.processor.clock = clock
-
-	// listener 1, never resync
-	listener1 := newTestListener("listener1", 0)
-	informer.AddEventHandlerWithResyncPeriod(listener1, listener1.resyncPeriod)
-	if e, a := 12*time.Hour, informer.resyncCheckPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-
-	// listener 2, resync every minute
-	listener2 := newTestListener("listener2", 1*time.Minute)
-	informer.AddEventHandlerWithResyncPeriod(listener2, listener2.resyncPeriod)
-	if e, a := 1*time.Minute, informer.resyncCheckPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := 1*time.Minute, informer.processor.listeners[1].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-
-	// listener 3, resync every 55 seconds
-	listener3 := newTestListener("listener3", 55*time.Second)
-	informer.AddEventHandlerWithResyncPeriod(listener3, listener3.resyncPeriod)
-	if e, a := 55*time.Second, informer.resyncCheckPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := 1*time.Minute, informer.processor.listeners[1].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := 55*time.Second, informer.processor.listeners[2].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-
-	// listener 4, resync every 5 seconds
-	listener4 := newTestListener("listener4", 5*time.Second)
-	informer.AddEventHandlerWithResyncPeriod(listener4, listener4.resyncPeriod)
-	if e, a := 5*time.Second, informer.resyncCheckPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := time.Duration(0), informer.processor.listeners[0].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := 1*time.Minute, informer.processor.listeners[1].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := 55*time.Second, informer.processor.listeners[2].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
-	}
-	if e, a := 5*time.Second, informer.processor.listeners[3].resyncPeriod; e != a {
-		t.Errorf("expected %d, got %d", e, a)
+	// Run the test through two of the longest cycles
+	testDuration := expectedCheckPeriod * time.Duration(math.Ceil(float64(3*time.Second)/float64(expectedCheckPeriod))) * 2
+	for dt := expectedCheckPeriod; dt <= testDuration; dt += expectedCheckPeriod {
+		clock.SetTime(startTime.Add(dt))
+		time.Sleep(1 * time.Second) // give unexpected stuff a chance to happen
+		for _, listener := range listeners {
+			listener.checkRecency(expectedCheckPeriod)
+		}
 	}
 }
 
@@ -257,7 +230,7 @@ func TestResyncCheckPeriod(t *testing.T) {
 func TestSharedInformerInitializationRace(t *testing.T) {
 	source := fcache.NewFakeControllerSource()
 	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
-	listener := newTestListener("raceListener", 0)
+	listener := newTestListener(t, "raceListener", clock.RealClock{}, 0)
 
 	stop := make(chan struct{})
 	go informer.AddEventHandlerWithResyncPeriod(listener, listener.resyncPeriod)
@@ -283,10 +256,10 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 	informer.processor.clock = clock
 
 	// listener, never resync
-	listenerNoResync := newTestListener("listenerNoResync", 0, "pod1", "pod2")
+	listenerNoResync := newTestListener(t, "listenerNoResync", clock, 0, "pod1", "pod2")
 	informer.AddEventHandlerWithResyncPeriod(listenerNoResync, listenerNoResync.resyncPeriod)
 
-	listenerResync := newTestListener("listenerResync", 1*time.Second, "pod1", "pod2")
+	listenerResync := newTestListener(t, "listenerResync", clock, 1*time.Second, "pod1", "pod2")
 	informer.AddEventHandlerWithResyncPeriod(listenerResync, listenerResync.resyncPeriod)
 	listeners := []*testListener{listenerNoResync, listenerResync}
 
@@ -297,7 +270,7 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 
 	for _, listener := range listeners {
 		if !listener.ok() {
-			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemNames, listener.receivedItemNames)
+			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemKeys, listener.receivedItemKeys())
 		}
 	}
 
@@ -308,16 +281,16 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 	// Ensure that nobody saw any changes
 	for _, listener := range listeners {
 		if !listener.ok() {
-			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemNames, listener.receivedItemNames)
+			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemKeys, listener.receivedItemKeys())
 		}
 	}
 
 	for _, listener := range listeners {
-		listener.receivedItemNames = []string{}
+		listener.reset()
 	}
 
-	listenerNoResync.expectedItemNames = sets.NewString("pod2", "pod3")
-	listenerResync.expectedItemNames = sets.NewString("pod1", "pod2", "pod3")
+	listenerNoResync.expectedItemKeys = sets.NewString("pod2", "pod3")
+	listenerResync.expectedItemKeys = sets.NewString("pod1", "pod2", "pod3")
 
 	// This calls shouldSync, which deletes noResync from the list of syncingListeners
 	clock.Step(1 * time.Second)
@@ -327,7 +300,7 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 
 	for _, listener := range listeners {
 		if !listener.ok() {
-			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemNames, listener.receivedItemNames)
+			t.Errorf("%s: expected %v, got %v", listener.name, listener.expectedItemKeys, listener.receivedItemKeys())
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR changes TestListenerResyncPeriods to be a more thorough test of resync
behavior, covering a variety of relationships among the default
checking period and the requested resync periods.

This PR also deletes the test that examined the data structure that implements
resync timing, because that is examining implementation details rather
than behavior --- in particular, implementation details that should be
simplified (see #86862).

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
This PR is in contrast to #87392 , which extends the examination of the implementation data struccture.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
