### PR TITLE
Openapi/delete return type

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -975,6 +975,11 @@ func (e *Store) Delete(ctx context.Context, name string, deleteValidation rest.V
 	return out, true, err
 }
 
+// DeleteReturnsDeletedObject implements the rest.MayReturnFullObjectDeleter interface
+func (e *Store) DeleteReturnsDeletedObject() bool {
+	return e.ReturnDeletedObject
+}
+
 // DeleteCollection removes all items returned by List with a given ListOptions from storage.
 //
 // DeleteCollection is currently NOT atomic. It can happen that only subset of objects

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/rest.go
@@ -161,6 +161,11 @@ type GracefulDeleter interface {
 	Delete(ctx context.Context, name string, deleteValidation ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error)
 }
 
+// MayReturnFullObjectDeleter may return deleted object (instead of a simple status) on deletion.
+type MayReturnFullObjectDeleter interface {
+	DeleteReturnsDeletedObject() bool
+}
+
 // CollectionDeleter is an object that can delete a collection
 // of RESTful resources.
 type CollectionDeleter interface {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
Update response type of some DELETE requests with correct object type instead of the generic `Status`. Specifically, I was trying to use a code generation tool and it crashes because of the mismatched response type.

**Which issue(s) this PR fixes**:
Fixes #59501

**Special notes for your reviewer**:
I have also included the new spec json in this PR.

This PR may be related to https://github.com/kubernetes/enhancements/pull/1263

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

