### PR TITLE
Fix a taint nodes example in the help text

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -83,7 +83,7 @@ var (
 		kubectl taint node -l myLabel=X  dedicated=foo:PreferNoSchedule
 
 		# Add to node 'foo' a taint with key 'bar' and no value
-		kubectl taint nodes foo bar:NoSchedule`))
+		kubectl taint nodes foo bar=:NoSchedule`))
 )
 
 func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

`kubectl taint nodes foo bar:NoSchedule` in the help text does not work correctly.

```bash
$ kubectl taint nodes foo bar:NoSchedule
error: at least one taint update is required
```

It should be `bar=:NoSchedule`.

```
$ kubectl taint nodes foo bar=:NoSchedule
node/foo tainted
```

**Does this PR introduce a user-facing change?:**

```release-note
Fix a taint nodes example in the help text.
```
