### PR TITLE
PodTolerationRestriction: Mention Whitelist Scope in Error

### DIFF
--- a/plugin/pkg/admission/podtolerationrestriction/admission.go
+++ b/plugin/pkg/admission/podtolerationrestriction/admission.go
@@ -127,6 +127,7 @@ func (p *Plugin) Validate(ctx context.Context, a admission.Attributes, o admissi
 	pod := a.GetObject().(*api.Pod)
 	if len(pod.Spec.Tolerations) > 0 {
 		whitelist, err := p.getNamespaceTolerationsWhitelist(a.GetNamespace())
+		whitelistScope := "namespace"
 		if err != nil {
 			return err
 		}
@@ -135,12 +136,13 @@ func (p *Plugin) Validate(ctx context.Context, a admission.Attributes, o admissi
 		// fall back to cluster's whitelist of tolerations.
 		if whitelist == nil {
 			whitelist = p.pluginConfig.Whitelist
+			whitelistScope = "cluster"
 		}
 
 		if len(whitelist) > 0 {
 			// check if the merged pod tolerations satisfy its namespace whitelist
 			if !tolerations.VerifyAgainstWhitelist(pod.Spec.Tolerations, whitelist) {
-				return fmt.Errorf("pod tolerations (possibly merged with namespace default tolerations) conflict with its namespace whitelist")
+				return fmt.Errorf("pod tolerations (possibly merged with namespace default tolerations) conflict with its %s whitelist", whitelistScope)
 			}
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently it's not clear if the issue came from the namespace whitelist
of if the namespace whitelist was not applied at all (i.e. via a misspelled
annotation). This makes the error more explicit if the pod tolerations
caused a conflict with cluster-level or namespace-level whitelist.
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
Not sure if an error message is considered user-facing.
```release-note
PodTolerationRestriction: Mention Whitelist Scope in Error
```