### PR TITLE
remove duplicate default etcd server version from CHANGELOG-1.17.md

### DIFF
--- a/CHANGELOG-1.10.md
+++ b/CHANGELOG-1.10.md
@@ -1,4 +1,4 @@
-<!-- BEGIN MUNGE: GENERATED_TOC -->
+<!-- BEGIN MUNGE: GENERATED_TOC --> 
 - [v1.10.13](#v11013)
   - [Downloads for v1.10.13](#downloads-for-v11013)
     - [Client Binaries](#client-binaries)

--- a/CHANGELOG-1.10.md
+++ b/CHANGELOG-1.10.md
@@ -1,4 +1,4 @@
-<!-- BEGIN MUNGE: GENERATED_TOC --> 
+<!-- BEGIN MUNGE: GENERATED_TOC -->
 - [v1.10.13](#v11013)
   - [Downloads for v1.10.13](#downloads-for-v11013)
     - [Client Binaries](#client-binaries)

--- a/CHANGELOG-1.17.md
+++ b/CHANGELOG-1.17.md
@@ -744,8 +744,6 @@ Renamed FeatureGate RequestManagement to APIPriorityAndFairness.  This feature g
 - Update to use go1.12.12 ([#84064](https://github.com/kubernetes/kubernetes/pull/84064), [@cblecker](https://github.com/cblecker))
 - Update to go 1.12.10 ([#83139](https://github.com/kubernetes/kubernetes/pull/83139), [@cblecker](https://github.com/cblecker))
 - Update default etcd server version to 3.4.3 ([#84329](https://github.com/kubernetes/kubernetes/pull/84329), [@jingyih](https://github.com/jingyih))
-- Upgrade default etcd server version to 3.3.17 ([#83804](https://github.com/kubernetes/kubernetes/pull/83804), [@jpbetz](https://github.com/jpbetz))
-- Upgrade to etcd client 3.3.17 to fix bug where etcd client does not parse IPv6 addresses correctly when members are joining, and to fix bug where failover on multi-member etcd cluster fails certificate check on DNS mismatch ([#83801](https://github.com/kubernetes/kubernetes/pull/83801), [@jpbetz](https://github.com/jpbetz))
 
 ### Detailed go Dependency Changes
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

CHANGELOG-1.17.md lists both 3.3.17 and 3.4.3 as default etcd server version