### PR TITLE
Refactor context handling in rest.Request

### DIFF
--- a/cmd/cloud-controller-manager/app/testing/testserver.go
+++ b/cmd/cloud-controller-manager/app/testing/testserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -133,7 +134,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		default:
 		}
 
-		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
+		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 		status := 0
 		result.StatusCode(&status)
 		if status == 200 {

--- a/cmd/controller-manager/app/helper.go
+++ b/cmd/controller-manager/app/helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -33,7 +34,7 @@ func WaitForAPIServer(client clientset.Interface, timeout time.Duration) error {
 
 	err := wait.PollImmediate(time.Second, timeout, func() (bool, error) {
 		healthStatus := 0
-		result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		result := client.Discovery().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&healthStatus)
 		if result.Error() != nil {
 			lastErr = fmt.Errorf("failed to get apiserver /healthz status: %v", result.Error())
 			return false, nil

--- a/cmd/kube-apiserver/app/testing/testserver.go
+++ b/cmd/kube-apiserver/app/testing/testserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -210,7 +211,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		default:
 		}
 
-		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
+		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 		status := 0
 		result.StatusCode(&status)
 		if status == 200 {

--- a/cmd/kube-controller-manager/app/testing/testserver.go
+++ b/cmd/kube-controller-manager/app/testing/testserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -133,7 +134,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		default:
 		}
 
-		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
+		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 		status := 0
 		result.StatusCode(&status)
 		if status == 200 {

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package options
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -640,7 +641,7 @@ pluginConfig:
 
 			// test the client talks to the endpoint we expect with the credentials we expect
 			username = ""
-			_, err = config.Client.Discovery().RESTClient().Get().AbsPath("/").DoRaw()
+			_, err = config.Client.Discovery().RESTClient().Get().AbsPath("/").DoRaw(context.TODO())
 			if err != nil {
 				t.Error(err)
 				return

--- a/cmd/kube-scheduler/app/testing/testserver.go
+++ b/cmd/kube-scheduler/app/testing/testserver.go
@@ -135,7 +135,7 @@ func StartTestServer(t Logger, customFlags []string) (result TestServer, err err
 		default:
 		}
 
-		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
+		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 		status := 0
 		result.StatusCode(&status)
 		if status == 200 {

--- a/cmd/kubeadm/app/util/apiclient/wait.go
+++ b/cmd/kubeadm/app/util/apiclient/wait.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiclient
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -77,7 +78,7 @@ func (w *KubeWaiter) WaitForAPI() error {
 	start := time.Now()
 	return wait.PollImmediate(kubeadmconstants.APICallRetryInterval, w.timeout, func() (bool, error) {
 		healthStatus := 0
-		w.client.Discovery().RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		w.client.Discovery().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&healthStatus)
 		if healthStatus != http.StatusOK {
 			return false, nil
 		}

--- a/pkg/controller/client_builder.go
+++ b/pkg/controller/client_builder.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	v1authenticationapi "k8s.io/api/authentication/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
@@ -207,7 +207,7 @@ func (b SAControllerClientBuilder) getAuthenticatedConfig(sa *v1.ServiceAccount,
 	if err != nil {
 		return nil, false, err
 	}
-	err = client.Get().AbsPath("/apis").Do().Error()
+	err = client.Get().AbsPath("/apis").Do(context.TODO()).Error()
 	if apierrors.IsUnauthorized(err) {
 		klog.Warningf("Token for %s/%s did not authenticate correctly: %v", sa.Namespace, sa.Name, err)
 		return nil, false, nil

--- a/pkg/controller/podautoscaler/legacy_horizontal_test.go
+++ b/pkg/controller/podautoscaler/legacy_horizontal_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podautoscaler
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -55,11 +56,11 @@ import (
 	_ "k8s.io/kubernetes/pkg/apis/core/install"
 )
 
-func (w fakeResponseWrapper) DoRaw() ([]byte, error) {
+func (w fakeResponseWrapper) DoRaw(context.Context) ([]byte, error) {
 	return w.raw, nil
 }
 
-func (w fakeResponseWrapper) Stream() (io.ReadCloser, error) {
+func (w fakeResponseWrapper) Stream(context.Context) (io.ReadCloser, error) {
 	return nil, nil
 }
 

--- a/pkg/controller/podautoscaler/metrics/legacy_metrics_client.go
+++ b/pkg/controller/podautoscaler/metrics/legacy_metrics_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -27,7 +28,7 @@ import (
 	metricsapi "k8s.io/metrics/pkg/apis/metrics/v1alpha1"
 
 	autoscaling "k8s.io/api/autoscaling/v2beta2"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	clientset "k8s.io/client-go/kubernetes"
@@ -68,7 +69,7 @@ func (h *HeapsterMetricsClient) GetResourceMetric(resource v1.ResourceName, name
 
 	resultRaw, err := h.services.
 		ProxyGet(h.heapsterScheme, h.heapsterService, h.heapsterPort, metricPath, params).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("failed to get pod resource metrics: %v", err)
 	}
@@ -139,7 +140,7 @@ func (h *HeapsterMetricsClient) GetRawMetric(metricName string, namespace string
 
 	resultRaw, err := h.services.
 		ProxyGet(h.heapsterScheme, h.heapsterService, h.heapsterPort, metricPath, map[string]string{"start": startTime.Format(time.RFC3339)}).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		return nil, time.Time{}, fmt.Errorf("failed to get pod metrics: %v", err)
 	}

--- a/pkg/controller/podautoscaler/metrics/legacy_metrics_client_test.go
+++ b/pkg/controller/podautoscaler/metrics/legacy_metrics_client_test.go
@@ -17,13 +17,14 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -40,11 +41,11 @@ import (
 
 var fixedTimestamp = time.Date(2015, time.November, 10, 12, 30, 0, 0, time.UTC)
 
-func (w fakeResponseWrapper) DoRaw() ([]byte, error) {
+func (w fakeResponseWrapper) DoRaw(context.Context) ([]byte, error) {
 	return w.raw, nil
 }
 
-func (w fakeResponseWrapper) Stream() (io.ReadCloser, error) {
+func (w fakeResponseWrapper) Stream(context.Context) (io.ReadCloser, error) {
 	return nil, nil
 }
 

--- a/pkg/kubelet/certificate/bootstrap/bootstrap.go
+++ b/pkg/kubelet/certificate/bootstrap/bootstrap.go
@@ -291,7 +291,7 @@ func waitForServer(cfg restclient.Config, deadline time.Duration) error {
 
 	var connected bool
 	wait.JitterUntil(func() {
-		if _, err := cli.Get().AbsPath("/healthz").Do().Raw(); err != nil {
+		if _, err := cli.Get().AbsPath("/healthz").Do(context.TODO()).Raw(); err != nil {
 			klog.Infof("Failed to connect to apiserver: %v", err)
 			return
 		}

--- a/pkg/kubelet/certificate/transport_test.go
+++ b/pkg/kubelet/certificate/transport_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certificate
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -198,7 +199,7 @@ func TestRotateShutsDownConnections(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := client.Get().Do().Error(); err != nil {
+	if err := client.Get().Do(context.TODO()).Error(); err != nil {
 		t.Fatal(err)
 	}
 	firstCertSerial := lastSerialNumber()
@@ -209,7 +210,7 @@ func TestRotateShutsDownConnections(t *testing.T) {
 
 	for i := 0; i < 5; i++ {
 		time.Sleep(time.Millisecond * 10)
-		client.Get().Do()
+		client.Get().Do(context.TODO())
 		if firstCertSerial.Cmp(lastSerialNumber()) != 0 {
 			// The certificate changed!
 			return

--- a/pkg/master/controller.go
+++ b/pkg/master/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package master
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"net/http"
@@ -210,7 +211,7 @@ func (c *Controller) RunKubernetesService(ch chan struct{}) {
 	// wait until process is ready
 	wait.PollImmediateUntil(100*time.Millisecond, func() (bool, error) {
 		var code int
-		c.healthClient.Get().AbsPath("/healthz").Do().StatusCode(&code)
+		c.healthClient.Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&code)
 		return code == http.StatusOK, nil
 	}, ch)
 

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -174,7 +174,7 @@ func (a *Plugin) admitPod(ctx context.Context, pod *api.Pod, attributes admissio
 		review.Status = entry.(v1alpha1.ImageReviewStatus)
 	} else {
 		result := a.webhook.WithExponentialBackoff(ctx, func() rest.Result {
-			return a.webhook.RestClient.Post().Context(ctx).Body(review).Do()
+			return a.webhook.RestClient.Post().Context(ctx).Body(review).Do(context.TODO())
 		})
 
 		if err := result.Error(); err != nil {

--- a/plugin/pkg/admission/imagepolicy/admission.go
+++ b/plugin/pkg/admission/imagepolicy/admission.go
@@ -174,7 +174,7 @@ func (a *Plugin) admitPod(ctx context.Context, pod *api.Pod, attributes admissio
 		review.Status = entry.(v1alpha1.ImageReviewStatus)
 	} else {
 		result := a.webhook.WithExponentialBackoff(ctx, func() rest.Result {
-			return a.webhook.RestClient.Post().Context(ctx).Body(review).Do(context.TODO())
+			return a.webhook.RestClient.Post().Body(review).Do(ctx)
 		})
 
 		if err := result.Error(); err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/example.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apiextensions-apiserver/examples/client-go/pkg/apis/cr/v1"
@@ -70,7 +71,7 @@ func (c *examples) Get(name string, options metav1.GetOptions) (result *v1.Examp
 		Resource("examples").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *examples) List(opts metav1.ListOptions) (result *v1.ExampleList, err er
 		Resource("examples").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *examples) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("examples").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a example and creates it.  Returns the server's representation of the example, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *examples) Create(example *v1.Example) (result *v1.Example, err error) {
 		Namespace(c.ns).
 		Resource("examples").
 		Body(example).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *examples) Update(example *v1.Example) (result *v1.Example, err error) {
 		Resource("examples").
 		Name(example.Name).
 		Body(example).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *examples) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("examples").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *examples) DeleteCollection(options *metav1.DeleteOptions, listOptions m
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *examples) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter.go
@@ -271,7 +271,7 @@ func (c *webhookConverter) Convert(in runtime.Object, toGV schema.GroupVersion) 
 
 	// TODO: Figure out if adding one second timeout make sense here.
 	ctx := context.TODO()
-	r := c.restClient.Post().Context(ctx).Body(request).Do()
+	r := c.restClient.Post().Context(ctx).Body(request).Do(context.TODO())
 	if err := r.Into(response); err != nil {
 		// TODO: Return a webhook specific error to be able to convert it to meta.Status
 		return nil, fmt.Errorf("conversion webhook for %v failed: %v", in.GetObjectKind().GroupVersionKind(), err)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/conversion/webhook_converter.go
@@ -271,7 +271,7 @@ func (c *webhookConverter) Convert(in runtime.Object, toGV schema.GroupVersion) 
 
 	// TODO: Figure out if adding one second timeout make sense here.
 	ctx := context.TODO()
-	r := c.restClient.Post().Context(ctx).Body(request).Do(context.TODO())
+	r := c.restClient.Post().Body(request).Do(ctx)
 	if err := r.Into(response); err != nil {
 		// TODO: Return a webhook specific error to be able to convert it to meta.Status
 		return nil, fmt.Errorf("conversion webhook for %v failed: %v", in.GetObjectKind().GroupVersionKind(), err)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/customresourcedefinition.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -68,7 +69,7 @@ func (c *customResourceDefinitions) Get(name string, options metav1.GetOptions) 
 		Resource("customresourcedefinitions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *customResourceDefinitions) List(opts metav1.ListOptions) (result *v1.Cu
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *customResourceDefinitions) Watch(opts metav1.ListOptions) (watch.Interf
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *customResourceDefinitions) Create(customResourceDefinition *v1.CustomRe
 	err = c.client.Post().
 		Resource("customresourcedefinitions").
 		Body(customResourceDefinition).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *customResourceDefinitions) Update(customResourceDefinition *v1.CustomRe
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		Body(customResourceDefinition).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *v1.Cu
 		Name(customResourceDefinition.Name).
 		SubResource("status").
 		Body(customResourceDefinition).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *customResourceDefinitions) Delete(name string, options *metav1.DeleteOp
 		Resource("customresourcedefinitions").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *customResourceDefinitions) DeleteCollection(options *metav1.DeleteOptio
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *customResourceDefinitions) Patch(name string, pt types.PatchType, data 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/customresourcedefinition.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -68,7 +69,7 @@ func (c *customResourceDefinitions) Get(name string, options v1.GetOptions) (res
 		Resource("customresourcedefinitions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *customResourceDefinitions) List(opts v1.ListOptions) (result *v1beta1.C
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *customResourceDefinitions) Watch(opts v1.ListOptions) (watch.Interface,
 		Resource("customresourcedefinitions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a customResourceDefinition and creates it.  Returns the server's representation of the customResourceDefinition, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *customResourceDefinitions) Create(customResourceDefinition *v1beta1.Cus
 	err = c.client.Post().
 		Resource("customresourcedefinitions").
 		Body(customResourceDefinition).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *customResourceDefinitions) Update(customResourceDefinition *v1beta1.Cus
 		Resource("customresourcedefinitions").
 		Name(customResourceDefinition.Name).
 		Body(customResourceDefinition).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *customResourceDefinitions) UpdateStatus(customResourceDefinition *v1bet
 		Name(customResourceDefinition.Name).
 		SubResource("status").
 		Body(customResourceDefinition).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *customResourceDefinitions) Delete(name string, options *v1.DeleteOption
 		Resource("customresourcedefinitions").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *customResourceDefinitions) DeleteCollection(options *v1.DeleteOptions, 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *customResourceDefinitions) Patch(name string, pt types.PatchType, data 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testserver.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testing
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -170,7 +171,7 @@ func StartTestServer(t Logger, instanceOptions *TestServerInstanceOptions, custo
 		default:
 		}
 
-		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
+		result := client.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 		status := 0
 		result.StatusCode(&status)
 		if status == 200 {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apply_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -73,7 +74,7 @@ values:
 		Name("mytest").
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatal(err, string(result))
 	}
@@ -82,7 +83,7 @@ values:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name("mytest").
 		Body([]byte(`{"values":{"numVal": 5}}`)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatal(err, string(result))
 	}
@@ -93,7 +94,7 @@ values:
 		Name("mytest").
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when applying object, got no error: %s", result)
 	}
@@ -112,7 +113,7 @@ values:
 		Param("force", "true").
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatal(err, string(result))
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sort"
@@ -1010,7 +1011,7 @@ func TestStatusGetAndPatch(t *testing.T) {
 		Resource("customresourcedefinitions").
 		Name(noxuDefinition.Name).
 		SubResource("status").
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	if err != nil {
 		t.Fatal(err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/limit_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -71,7 +72,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsRequestEntityTooLargeError(err) {
 			t.Errorf("expected too large error, got %v", err)
 		}
@@ -91,7 +92,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
 		}
@@ -111,7 +112,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
 		}
@@ -132,7 +133,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			SetHeader("Content-Type", "application/json").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(jsonBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsRequestEntityTooLargeError(err) {
 			t.Errorf("expected too large error, got %v", err)
 		}
@@ -153,7 +154,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			SetHeader("Content-Type", "application/json").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(jsonBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
 		}
@@ -174,7 +175,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 			SetHeader("Content-Type", "application/json").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(jsonBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
 		}
@@ -183,7 +184,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 	// Create instance to allow patching
 	{
 		jsonBody := []byte(fmt.Sprintf(`{"apiVersion": %q, "kind": %q, "metadata": {"name": "test"}}`, apiVersion, kind))
-		_, err := rest.Post().AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).Body(jsonBody).DoRaw()
+		_, err := rest.Post().AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).Body(jsonBody).DoRaw(context.TODO())
 		if err != nil {
 			t.Fatalf("error creating object: %v", err)
 		}
@@ -192,7 +193,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 	t.Run("JSONPatchType nested patch under limit", func(t *testing.T) {
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}]`)
 		err = rest.Patch(types.JSONPatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
 		}
@@ -200,7 +201,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 	t.Run("MergePatchType nested patch under limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.MergePatchType).AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
 		}
@@ -208,7 +209,7 @@ values: `+strings.Repeat("[", 3*1024*1024), apiVersion, kind))
 	t.Run("ApplyPatchType nested patch under limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "test").
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request err, got %#v", err)
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -164,7 +165,7 @@ func TestTableGet(t *testing.T) {
 				Resource(crd.Spec.Names.Plural).
 				SetHeader("Accept", fmt.Sprintf("application/json;as=Table;v=%s;g=%s, application/json", metav1beta1.SchemeGroupVersion.Version, metav1beta1.GroupName)).
 				VersionedParams(&metav1beta1.TableOptions{}, parameterCodec).
-				Do().
+				Do(context.TODO()).
 				Get()
 			if err != nil {
 				t.Fatalf("failed to list %v resources: %v", gvk, err)
@@ -262,7 +263,7 @@ func TestTableGet(t *testing.T) {
 				Resource(crd.Spec.Names.Plural).
 				SetHeader("Accept", fmt.Sprintf("application/json;as=Table;v=%s;g=%s, application/json", metav1.SchemeGroupVersion.Version, metav1.GroupName)).
 				VersionedParams(&metav1.TableOptions{}, parameterCodec).
-				Do().
+				Do(context.TODO()).
 				Get()
 			if err != nil {
 				t.Fatalf("failed to list %v resources: %v", gvk, err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/yaml_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -67,7 +68,7 @@ func TestYAML(t *testing.T) {
 		result, err := rest.Get().
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version).
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err, string(result))
 		}
@@ -88,7 +89,7 @@ func TestYAML(t *testing.T) {
 		result, err := rest.Get().
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "missingname").
-			DoRaw()
+			DoRaw(context.TODO())
 		if !errors.IsNotFound(err) {
 			t.Fatalf("expected not found, got %v", err)
 		}
@@ -124,7 +125,7 @@ values:
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err, string(result))
 		}
@@ -159,7 +160,7 @@ values:
 		result, err := rest.Get().
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "mytest").
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -192,7 +193,7 @@ values:
 		result, err := rest.Get().
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err, string(result))
 		}
@@ -237,7 +238,7 @@ values:
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Param("watch", "true").
-			DoRaw()
+			DoRaw(context.TODO())
 		if !errors.IsNotAcceptable(err) {
 			t.Fatalf("expected not acceptable error, got %v (%s)", err, string(result))
 		}
@@ -274,7 +275,7 @@ values:
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "mytest").
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err, string(result))
 		}
@@ -315,7 +316,7 @@ values:
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "mytest").
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !errors.IsUnsupportedMediaType(err) {
 			t.Fatalf("Expected bad request, got %v\n%s", err, string(result))
 		}
@@ -336,7 +337,7 @@ values:
 		result, err := rest.Delete().
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "mytest").
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err, string(result))
 		}
@@ -398,7 +399,7 @@ spec:
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err, string(result))
 		}
@@ -427,7 +428,7 @@ spec:
 		result, err := rest.Get().
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "mytest", "status").
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -467,7 +468,7 @@ status:
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "mytest", "status").
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err, string(result))
 		}
@@ -500,7 +501,7 @@ status:
 		result, err := rest.Get().
 			SetHeader("Accept", "application/yaml").
 			AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural, "mytest", "scale").
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	jsonpatch "github.com/evanphx/json-patch"
+
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/klog"
 
@@ -250,7 +251,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 		}
 	}
 
-	if err := r.Do().Into(response); err != nil {
+	if err := r.Do(context.TODO()).Into(response); err != nil {
 		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	trace.Step("Request completed")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/mutating/dispatcher.go
@@ -236,7 +236,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 		defer cancel()
 	}
 
-	r := client.Post().Context(ctx).Body(request)
+	r := client.Post().Body(request)
 
 	// if the context has a deadline, set it as a parameter to inform the backend
 	if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
@@ -251,7 +251,7 @@ func (a *mutatingDispatcher) callAttrMutatingHook(ctx context.Context, h *admiss
 		}
 	}
 
-	if err := r.Do(context.TODO()).Into(response); err != nil {
+	if err := r.Do(ctx).Into(response); err != nil {
 		return false, &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	trace.Step("Request completed")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -196,7 +196,7 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 		defer cancel()
 	}
 
-	r := client.Post().Context(ctx).Body(request)
+	r := client.Post().Body(request)
 
 	// if the context has a deadline, set it as a parameter to inform the backend
 	if deadline, hasDeadline := ctx.Deadline(); hasDeadline {
@@ -211,7 +211,7 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 		}
 	}
 
-	if err := r.Do(context.TODO()).Into(response); err != nil {
+	if err := r.Do(ctx).Into(response); err != nil {
 		return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	trace.Step("Request completed")

--- a/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/validating/dispatcher.go
@@ -22,7 +22,7 @@ import (
 	"sync"
 	"time"
 
-	"k8s.io/api/admissionregistration/v1"
+	v1 "k8s.io/api/admissionregistration/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -211,7 +211,7 @@ func (d *validatingDispatcher) callHook(ctx context.Context, h *v1.ValidatingWeb
 		}
 	}
 
-	if err := r.Do().Into(response); err != nil {
+	if err := r.Do(context.TODO()).Into(response); err != nil {
 		return &webhookutil.ErrCallingWebhook{WebhookName: h.Name, Reason: err}
 	}
 	trace.Step("Request completed")

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/webhook_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd/api/v1"
+	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
 )
 
 const (
@@ -397,7 +397,7 @@ func TestTLSConfig(t *testing.T) {
 			wh, err := NewGenericWebhook(runtime.NewScheme(), scheme.Codecs, configFile, groupVersions, retryBackoff)
 
 			if err == nil {
-				err = wh.RestClient.Get().Do().Error()
+				err = wh.RestClient.Get().Do(context.TODO()).Error()
 			}
 
 			if err == nil {
@@ -466,7 +466,7 @@ func TestRequestTimeout(t *testing.T) {
 
 	resultCh := make(chan rest.Result)
 
-	go func() { resultCh <- wh.RestClient.Get().Do() }()
+	go func() { resultCh <- wh.RestClient.Get().Do(context.TODO()) }()
 	select {
 	case <-time.After(time.Second * 5):
 		t.Errorf("expected request to timeout after %s", requestTimeout)
@@ -552,7 +552,7 @@ func TestWithExponentialBackoff(t *testing.T) {
 	}
 
 	result := wh.WithExponentialBackoff(context.Background(), func() rest.Result {
-		return wh.RestClient.Get().Do()
+		return wh.RestClient.Get().Do(context.TODO())
 	})
 
 	var statusCode int
@@ -564,7 +564,7 @@ func TestWithExponentialBackoff(t *testing.T) {
 	}
 
 	result = wh.WithExponentialBackoff(context.Background(), func() rest.Result {
-		return wh.RestClient.Get().Do()
+		return wh.RestClient.Get().Do(context.TODO())
 	})
 
 	result.StatusCode(&statusCode)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/audit/webhook/webhook.go
@@ -124,7 +124,7 @@ func (b *backend) processEvents(ev ...*auditinternal.Event) error {
 		// allow enough time for the serialization/deserialization of audit events, which
 		// contain nested request and response objects plus additional event fields.
 		defer trace.LogIfLong(time.Duration(50+25*len(list.Items)) * time.Millisecond)
-		return b.w.RestClient.Post().Body(&list).Do()
+		return b.w.RestClient.Post().Body(&list).Do(context.TODO())
 	}).Error()
 }
 

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
@@ -198,7 +198,7 @@ type tokenReviewV1Client struct {
 
 func (t *tokenReviewV1Client) CreateContext(ctx context.Context, review *authenticationv1.TokenReview) (*authenticationv1.TokenReview, error) {
 	result := &authenticationv1.TokenReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(review).Do(context.TODO()).Into(result)
+	err := t.w.RestClient.Post().Body(review).Do(ctx).Into(result)
 	return result, err
 }
 
@@ -209,7 +209,7 @@ type tokenReviewV1beta1Client struct {
 func (t *tokenReviewV1beta1Client) CreateContext(ctx context.Context, review *authenticationv1.TokenReview) (*authenticationv1.TokenReview, error) {
 	v1beta1Review := &authenticationv1beta1.TokenReview{Spec: v1SpecToV1beta1Spec(&review.Spec)}
 	v1beta1Result := &authenticationv1beta1.TokenReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(v1beta1Review).Do(context.TODO()).Into(v1beta1Result)
+	err := t.w.RestClient.Post().Body(v1beta1Review).Do(ctx).Into(v1beta1Result)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook.go
@@ -198,7 +198,7 @@ type tokenReviewV1Client struct {
 
 func (t *tokenReviewV1Client) CreateContext(ctx context.Context, review *authenticationv1.TokenReview) (*authenticationv1.TokenReview, error) {
 	result := &authenticationv1.TokenReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(review).Do().Into(result)
+	err := t.w.RestClient.Post().Context(ctx).Body(review).Do(context.TODO()).Into(result)
 	return result, err
 }
 
@@ -209,7 +209,7 @@ type tokenReviewV1beta1Client struct {
 func (t *tokenReviewV1beta1Client) CreateContext(ctx context.Context, review *authenticationv1.TokenReview) (*authenticationv1.TokenReview, error) {
 	v1beta1Review := &authenticationv1beta1.TokenReview{Spec: v1SpecToV1beta1Spec(&review.Spec)}
 	v1beta1Result := &authenticationv1beta1.TokenReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(v1beta1Review).Do().Into(v1beta1Result)
+	err := t.w.RestClient.Post().Context(ctx).Body(v1beta1Review).Do(context.TODO()).Into(v1beta1Result)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -289,7 +289,7 @@ type subjectAccessReviewV1Client struct {
 
 func (t *subjectAccessReviewV1Client) CreateContext(ctx context.Context, subjectAccessReview *authorizationv1.SubjectAccessReview) (*authorizationv1.SubjectAccessReview, error) {
 	result := &authorizationv1.SubjectAccessReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(subjectAccessReview).Do(context.TODO()).Into(result)
+	err := t.w.RestClient.Post().Body(subjectAccessReview).Do(ctx).Into(result)
 	return result, err
 }
 
@@ -300,7 +300,7 @@ type subjectAccessReviewV1beta1Client struct {
 func (t *subjectAccessReviewV1beta1Client) CreateContext(ctx context.Context, subjectAccessReview *authorizationv1.SubjectAccessReview) (*authorizationv1.SubjectAccessReview, error) {
 	v1beta1Review := &authorizationv1beta1.SubjectAccessReview{Spec: v1SpecToV1beta1Spec(&subjectAccessReview.Spec)}
 	v1beta1Result := &authorizationv1beta1.SubjectAccessReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(v1beta1Review).Do(context.TODO()).Into(v1beta1Result)
+	err := t.w.RestClient.Post().Body(v1beta1Review).Do(ctx).Into(v1beta1Result)
 	if err == nil {
 		subjectAccessReview.Status = v1beta1StatusToV1Status(&v1beta1Result.Status)
 	}

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authorizer/webhook/webhook.go
@@ -289,7 +289,7 @@ type subjectAccessReviewV1Client struct {
 
 func (t *subjectAccessReviewV1Client) CreateContext(ctx context.Context, subjectAccessReview *authorizationv1.SubjectAccessReview) (*authorizationv1.SubjectAccessReview, error) {
 	result := &authorizationv1.SubjectAccessReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(subjectAccessReview).Do().Into(result)
+	err := t.w.RestClient.Post().Context(ctx).Body(subjectAccessReview).Do(context.TODO()).Into(result)
 	return result, err
 }
 
@@ -300,7 +300,7 @@ type subjectAccessReviewV1beta1Client struct {
 func (t *subjectAccessReviewV1beta1Client) CreateContext(ctx context.Context, subjectAccessReview *authorizationv1.SubjectAccessReview) (*authorizationv1.SubjectAccessReview, error) {
 	v1beta1Review := &authorizationv1beta1.SubjectAccessReview{Spec: v1SpecToV1beta1Spec(&subjectAccessReview.Spec)}
 	v1beta1Result := &authorizationv1beta1.SubjectAccessReview{}
-	err := t.w.RestClient.Post().Context(ctx).Body(v1beta1Review).Do().Into(v1beta1Result)
+	err := t.w.RestClient.Post().Context(ctx).Body(v1beta1Review).Do(context.TODO()).Into(v1beta1Result)
 	if err == nil {
 		subjectAccessReview.Status = v1beta1StatusToV1Status(&v1beta1Result.Status)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"context"
 	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -72,7 +73,7 @@ func (m *Helper) Get(namespace, name string, export bool) (runtime.Object, error
 		// TODO: I should be part of GetOptions
 		req.Param("export", strconv.FormatBool(export))
 	}
-	return req.Do().Get()
+	return req.Do(context.TODO()).Get()
 }
 
 func (m *Helper) List(namespace, apiVersion string, export bool, options *metav1.ListOptions) (runtime.Object, error) {
@@ -84,7 +85,7 @@ func (m *Helper) List(namespace, apiVersion string, export bool, options *metav1
 		// TODO: I should be part of ListOptions
 		req.Param("export", strconv.FormatBool(export))
 	}
-	return req.Do().Get()
+	return req.Do(context.TODO()).Get()
 }
 
 func (m *Helper) Watch(namespace, apiVersion string, options *metav1.ListOptions) (watch.Interface, error) {
@@ -93,7 +94,7 @@ func (m *Helper) Watch(namespace, apiVersion string, options *metav1.ListOptions
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		VersionedParams(options, metav1.ParameterCodec).
-		Watch()
+		Watch(context.TODO())
 }
 
 func (m *Helper) WatchSingle(namespace, name, resourceVersion string) (watch.Interface, error) {
@@ -105,7 +106,7 @@ func (m *Helper) WatchSingle(namespace, name, resourceVersion string) (watch.Int
 			Watch:           true,
 			FieldSelector:   fields.OneTermEqualSelector("metadata.name", name).String(),
 		}, metav1.ParameterCodec).
-		Watch()
+		Watch(context.TODO())
 }
 
 func (m *Helper) Delete(namespace, name string) (runtime.Object, error) {
@@ -125,7 +126,7 @@ func (m *Helper) DeleteWithOptions(namespace, name string, options *metav1.Delet
 		Resource(m.Resource).
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Get()
 }
 
@@ -163,7 +164,7 @@ func (m *Helper) createResource(c RESTClient, resource, namespace string, obj ru
 		Resource(resource).
 		VersionedParams(options, metav1.ParameterCodec).
 		Body(obj).
-		Do().
+		Do(context.TODO()).
 		Get()
 }
 func (m *Helper) Patch(namespace, name string, pt types.PatchType, data []byte, options *metav1.PatchOptions) (runtime.Object, error) {
@@ -179,7 +180,7 @@ func (m *Helper) Patch(namespace, name string, pt types.PatchType, data []byte, 
 		Name(name).
 		VersionedParams(options, metav1.ParameterCodec).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Get()
 }
 
@@ -198,7 +199,7 @@ func (m *Helper) Replace(namespace, name string, overwrite bool, obj runtime.Obj
 	}
 	if version == "" && overwrite {
 		// Retrieve the current version of the object to overwrite the server object
-		serverObj, err := c.Get().NamespaceIfScoped(namespace, m.NamespaceScoped).Resource(m.Resource).Name(name).Do().Get()
+		serverObj, err := c.Get().NamespaceIfScoped(namespace, m.NamespaceScoped).Resource(m.Resource).Name(name).Do(context.TODO()).Get()
 		if err != nil {
 			// The object does not exist, but we want it to be created
 			return m.replaceResource(c, m.Resource, namespace, name, obj, options)
@@ -222,6 +223,6 @@ func (m *Helper) replaceResource(c RESTClient, resource, namespace, name string,
 		Name(name).
 		VersionedParams(options, metav1.ParameterCodec).
 		Body(obj).
-		Do().
+		Do(context.TODO()).
 		Get()
 }

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -18,6 +18,7 @@ package resource
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -30,6 +31,8 @@ import (
 	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 
+	"sigs.k8s.io/kustomize/pkg/fs"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/cli-runtime/pkg/kustomize"
-	"sigs.k8s.io/kustomize/pkg/fs"
 )
 
 const (
@@ -100,7 +102,7 @@ func (i *Info) Get() (err error) {
 	obj, err := NewHelper(i.Client, i.Mapping).Get(i.Namespace, i.Name, i.Export)
 	if err != nil {
 		if errors.IsNotFound(err) && len(i.Namespace) > 0 && i.Namespace != metav1.NamespaceDefault && i.Namespace != metav1.NamespaceAll {
-			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do().Error()
+			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do(context.TODO()).Error()
 			if err2 != nil && errors.IsNotFound(err2) {
 				return err2
 			}

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dynamic
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -111,7 +112,7 @@ func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts meta
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(outBytes).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -146,7 +147,7 @@ func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts meta
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(outBytes).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -182,7 +183,7 @@ func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opt
 		AbsPath(append(c.makeURLSegments(name), "status")...).
 		Body(outBytes).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -214,7 +215,7 @@ func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, 
 		Delete().
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(deleteOptionsByte).
-		Do()
+		Do(context.TODO())
 	return result.Error()
 }
 
@@ -232,7 +233,7 @@ func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, lis
 		AbsPath(c.makeURLSegments("")...).
 		Body(deleteOptionsByte).
 		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	return result.Error()
 }
 
@@ -240,7 +241,7 @@ func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subreso
 	if len(name) == 0 {
 		return nil, fmt.Errorf("name is required")
 	}
-	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -256,7 +257,7 @@ func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subreso
 }
 
 func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do()
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -283,7 +284,7 @@ func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface,
 	opts.Watch = true
 	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Watch()
+		Watch(context.TODO())
 }
 
 func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
@@ -295,7 +296,7 @@ func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []by
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(data).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/mutatingwebhookconfiguration.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/admissionregistration/v1"
@@ -67,7 +68,7 @@ func (c *mutatingWebhookConfigurations) Get(name string, options metav1.GetOptio
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *mutatingWebhookConfigurations) List(opts metav1.ListOptions) (result *v
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *mutatingWebhookConfigurations) Watch(opts metav1.ListOptions) (watch.In
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a mutatingWebhookConfiguration and creates it.  Returns the server's representation of the mutatingWebhookConfiguration, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *mutatingWebhookConfigurations) Create(mutatingWebhookConfiguration *v1.
 	err = c.client.Post().
 		Resource("mutatingwebhookconfigurations").
 		Body(mutatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *mutatingWebhookConfigurations) Update(mutatingWebhookConfiguration *v1.
 		Resource("mutatingwebhookconfigurations").
 		Name(mutatingWebhookConfiguration.Name).
 		Body(mutatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *mutatingWebhookConfigurations) Delete(name string, options *metav1.Dele
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *mutatingWebhookConfigurations) DeleteCollection(options *metav1.DeleteO
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *mutatingWebhookConfigurations) Patch(name string, pt types.PatchType, d
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/validatingwebhookconfiguration.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/admissionregistration/v1"
@@ -67,7 +68,7 @@ func (c *validatingWebhookConfigurations) Get(name string, options metav1.GetOpt
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *validatingWebhookConfigurations) List(opts metav1.ListOptions) (result 
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *validatingWebhookConfigurations) Watch(opts metav1.ListOptions) (watch.
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a validatingWebhookConfiguration and creates it.  Returns the server's representation of the validatingWebhookConfiguration, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *validatingWebhookConfigurations) Create(validatingWebhookConfiguration 
 	err = c.client.Post().
 		Resource("validatingwebhookconfigurations").
 		Body(validatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *validatingWebhookConfigurations) Update(validatingWebhookConfiguration 
 		Resource("validatingwebhookconfigurations").
 		Name(validatingWebhookConfiguration.Name).
 		Body(validatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *validatingWebhookConfigurations) Delete(name string, options *metav1.De
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *validatingWebhookConfigurations) DeleteCollection(options *metav1.Delet
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *validatingWebhookConfigurations) Patch(name string, pt types.PatchType,
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/mutatingwebhookconfiguration.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -67,7 +68,7 @@ func (c *mutatingWebhookConfigurations) Get(name string, options v1.GetOptions) 
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *mutatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1bet
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *mutatingWebhookConfigurations) Watch(opts v1.ListOptions) (watch.Interf
 		Resource("mutatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a mutatingWebhookConfiguration and creates it.  Returns the server's representation of the mutatingWebhookConfiguration, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *mutatingWebhookConfigurations) Create(mutatingWebhookConfiguration *v1b
 	err = c.client.Post().
 		Resource("mutatingwebhookconfigurations").
 		Body(mutatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *mutatingWebhookConfigurations) Update(mutatingWebhookConfiguration *v1b
 		Resource("mutatingwebhookconfigurations").
 		Name(mutatingWebhookConfiguration.Name).
 		Body(mutatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *mutatingWebhookConfigurations) Delete(name string, options *v1.DeleteOp
 		Resource("mutatingwebhookconfigurations").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *mutatingWebhookConfigurations) DeleteCollection(options *v1.DeleteOptio
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *mutatingWebhookConfigurations) Patch(name string, pt types.PatchType, d
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/validatingwebhookconfiguration.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -67,7 +68,7 @@ func (c *validatingWebhookConfigurations) Get(name string, options v1.GetOptions
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *validatingWebhookConfigurations) List(opts v1.ListOptions) (result *v1b
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *validatingWebhookConfigurations) Watch(opts v1.ListOptions) (watch.Inte
 		Resource("validatingwebhookconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a validatingWebhookConfiguration and creates it.  Returns the server's representation of the validatingWebhookConfiguration, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *validatingWebhookConfigurations) Create(validatingWebhookConfiguration 
 	err = c.client.Post().
 		Resource("validatingwebhookconfigurations").
 		Body(validatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *validatingWebhookConfigurations) Update(validatingWebhookConfiguration 
 		Resource("validatingwebhookconfigurations").
 		Name(validatingWebhookConfiguration.Name).
 		Body(validatingWebhookConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *validatingWebhookConfigurations) Delete(name string, options *v1.Delete
 		Resource("validatingwebhookconfigurations").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *validatingWebhookConfigurations) DeleteCollection(options *v1.DeleteOpt
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *validatingWebhookConfigurations) Patch(name string, pt types.PatchType,
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/controllerrevision.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
@@ -70,7 +71,7 @@ func (c *controllerRevisions) Get(name string, options metav1.GetOptions) (resul
 		Resource("controllerrevisions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *controllerRevisions) List(opts metav1.ListOptions) (result *v1.Controll
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *controllerRevisions) Watch(opts metav1.ListOptions) (watch.Interface, e
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *controllerRevisions) Create(controllerRevision *v1.ControllerRevision) 
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Body(controllerRevision).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *controllerRevisions) Update(controllerRevision *v1.ControllerRevision) 
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).
 		Body(controllerRevision).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *controllerRevisions) Delete(name string, options *metav1.DeleteOptions)
 		Resource("controllerrevisions").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *controllerRevisions) DeleteCollection(options *metav1.DeleteOptions, li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *controllerRevisions) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/daemonset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
@@ -71,7 +72,7 @@ func (c *daemonSets) Get(name string, options metav1.GetOptions) (result *v1.Dae
 		Resource("daemonsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *daemonSets) List(opts metav1.ListOptions) (result *v1.DaemonSetList, er
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *daemonSets) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *daemonSets) Create(daemonSet *v1.DaemonSet) (result *v1.DaemonSet, err 
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *daemonSets) Update(daemonSet *v1.DaemonSet) (result *v1.DaemonSet, err 
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *daemonSets) UpdateStatus(daemonSet *v1.DaemonSet) (result *v1.DaemonSet
 		Name(daemonSet.Name).
 		SubResource("status").
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *daemonSets) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("daemonsets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *daemonSets) DeleteCollection(options *metav1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *daemonSets) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/deployment.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
@@ -75,7 +76,7 @@ func (c *deployments) Get(name string, options metav1.GetOptions) (result *v1.De
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -92,7 +93,7 @@ func (c *deployments) List(opts metav1.ListOptions) (result *v1.DeploymentList, 
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -109,7 +110,7 @@ func (c *deployments) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
@@ -119,7 +120,7 @@ func (c *deployments) Create(deployment *v1.Deployment) (result *v1.Deployment, 
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -132,7 +133,7 @@ func (c *deployments) Update(deployment *v1.Deployment) (result *v1.Deployment, 
 		Resource("deployments").
 		Name(deployment.Name).
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -148,7 +149,7 @@ func (c *deployments) UpdateStatus(deployment *v1.Deployment) (result *v1.Deploy
 		Name(deployment.Name).
 		SubResource("status").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -160,7 +161,7 @@ func (c *deployments) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("deployments").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -176,7 +177,7 @@ func (c *deployments) DeleteCollection(options *metav1.DeleteOptions, listOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -189,7 +190,7 @@ func (c *deployments) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -203,7 +204,7 @@ func (c *deployments) GetScale(deploymentName string, options metav1.GetOptions)
 		Name(deploymentName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -217,7 +218,7 @@ func (c *deployments) UpdateScale(deploymentName string, scale *autoscalingv1.Sc
 		Name(deploymentName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/replicaset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
@@ -75,7 +76,7 @@ func (c *replicaSets) Get(name string, options metav1.GetOptions) (result *v1.Re
 		Resource("replicasets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -92,7 +93,7 @@ func (c *replicaSets) List(opts metav1.ListOptions) (result *v1.ReplicaSetList, 
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -109,7 +110,7 @@ func (c *replicaSets) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
@@ -119,7 +120,7 @@ func (c *replicaSets) Create(replicaSet *v1.ReplicaSet) (result *v1.ReplicaSet, 
 		Namespace(c.ns).
 		Resource("replicasets").
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -132,7 +133,7 @@ func (c *replicaSets) Update(replicaSet *v1.ReplicaSet) (result *v1.ReplicaSet, 
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -148,7 +149,7 @@ func (c *replicaSets) UpdateStatus(replicaSet *v1.ReplicaSet) (result *v1.Replic
 		Name(replicaSet.Name).
 		SubResource("status").
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -160,7 +161,7 @@ func (c *replicaSets) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("replicasets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -176,7 +177,7 @@ func (c *replicaSets) DeleteCollection(options *metav1.DeleteOptions, listOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -189,7 +190,7 @@ func (c *replicaSets) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -203,7 +204,7 @@ func (c *replicaSets) GetScale(replicaSetName string, options metav1.GetOptions)
 		Name(replicaSetName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -217,7 +218,7 @@ func (c *replicaSets) UpdateScale(replicaSetName string, scale *autoscalingv1.Sc
 		Name(replicaSetName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/statefulset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/apps/v1"
@@ -75,7 +76,7 @@ func (c *statefulSets) Get(name string, options metav1.GetOptions) (result *v1.S
 		Resource("statefulsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -92,7 +93,7 @@ func (c *statefulSets) List(opts metav1.ListOptions) (result *v1.StatefulSetList
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -109,7 +110,7 @@ func (c *statefulSets) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
@@ -119,7 +120,7 @@ func (c *statefulSets) Create(statefulSet *v1.StatefulSet) (result *v1.StatefulS
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -132,7 +133,7 @@ func (c *statefulSets) Update(statefulSet *v1.StatefulSet) (result *v1.StatefulS
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -148,7 +149,7 @@ func (c *statefulSets) UpdateStatus(statefulSet *v1.StatefulSet) (result *v1.Sta
 		Name(statefulSet.Name).
 		SubResource("status").
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -160,7 +161,7 @@ func (c *statefulSets) Delete(name string, options *metav1.DeleteOptions) error 
 		Resource("statefulsets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -176,7 +177,7 @@ func (c *statefulSets) DeleteCollection(options *metav1.DeleteOptions, listOptio
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -189,7 +190,7 @@ func (c *statefulSets) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -203,7 +204,7 @@ func (c *statefulSets) GetScale(statefulSetName string, options metav1.GetOption
 		Name(statefulSetName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -217,7 +218,7 @@ func (c *statefulSets) UpdateScale(statefulSetName string, scale *autoscalingv1.
 		Name(statefulSetName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/controllerrevision.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/apps/v1beta1"
@@ -70,7 +71,7 @@ func (c *controllerRevisions) Get(name string, options v1.GetOptions) (result *v
 		Resource("controllerrevisions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta1.Control
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *controllerRevisions) Create(controllerRevision *v1beta1.ControllerRevis
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Body(controllerRevision).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *controllerRevisions) Update(controllerRevision *v1beta1.ControllerRevis
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).
 		Body(controllerRevision).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *controllerRevisions) Delete(name string, options *v1.DeleteOptions) err
 		Resource("controllerrevisions").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *controllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *controllerRevisions) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/deployment.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/apps/v1beta1"
@@ -71,7 +72,7 @@ func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.D
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.De
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 		Resource("deployments").
 		Name(deployment.Name).
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1be
 		Name(deployment.Name).
 		SubResource("status").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *deployments) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("deployments").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *deployments) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/statefulset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/apps/v1beta1"
@@ -71,7 +72,7 @@ func (c *statefulSets) Get(name string, options v1.GetOptions) (result *v1beta1.
 		Resource("statefulsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta1.StatefulSetLis
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *statefulSets) Create(statefulSet *v1beta1.StatefulSet) (result *v1beta1
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *statefulSets) Update(statefulSet *v1beta1.StatefulSet) (result *v1beta1
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *statefulSets) UpdateStatus(statefulSet *v1beta1.StatefulSet) (result *v
 		Name(statefulSet.Name).
 		SubResource("status").
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *statefulSets) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("statefulsets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *statefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *statefulSets) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/controllerrevision.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "k8s.io/api/apps/v1beta2"
@@ -70,7 +71,7 @@ func (c *controllerRevisions) Get(name string, options v1.GetOptions) (result *v
 		Resource("controllerrevisions").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *controllerRevisions) List(opts v1.ListOptions) (result *v1beta2.Control
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *controllerRevisions) Watch(opts v1.ListOptions) (watch.Interface, error
 		Resource("controllerrevisions").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a controllerRevision and creates it.  Returns the server's representation of the controllerRevision, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *controllerRevisions) Create(controllerRevision *v1beta2.ControllerRevis
 		Namespace(c.ns).
 		Resource("controllerrevisions").
 		Body(controllerRevision).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *controllerRevisions) Update(controllerRevision *v1beta2.ControllerRevis
 		Resource("controllerrevisions").
 		Name(controllerRevision.Name).
 		Body(controllerRevision).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *controllerRevisions) Delete(name string, options *v1.DeleteOptions) err
 		Resource("controllerrevisions").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *controllerRevisions) DeleteCollection(options *v1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *controllerRevisions) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/daemonset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "k8s.io/api/apps/v1beta2"
@@ -71,7 +72,7 @@ func (c *daemonSets) Get(name string, options v1.GetOptions) (result *v1beta2.Da
 		Resource("daemonsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta2.DaemonSetList, e
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *daemonSets) Create(daemonSet *v1beta2.DaemonSet) (result *v1beta2.Daemo
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *daemonSets) Update(daemonSet *v1beta2.DaemonSet) (result *v1beta2.Daemo
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *daemonSets) UpdateStatus(daemonSet *v1beta2.DaemonSet) (result *v1beta2
 		Name(daemonSet.Name).
 		SubResource("status").
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *daemonSets) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("daemonsets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *daemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *daemonSets) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/deployment.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "k8s.io/api/apps/v1beta2"
@@ -71,7 +72,7 @@ func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta2.D
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta2.DeploymentList,
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *deployments) Create(deployment *v1beta2.Deployment) (result *v1beta2.De
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *deployments) Update(deployment *v1beta2.Deployment) (result *v1beta2.De
 		Resource("deployments").
 		Name(deployment.Name).
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *deployments) UpdateStatus(deployment *v1beta2.Deployment) (result *v1be
 		Name(deployment.Name).
 		SubResource("status").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *deployments) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("deployments").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *deployments) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/replicaset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "k8s.io/api/apps/v1beta2"
@@ -71,7 +72,7 @@ func (c *replicaSets) Get(name string, options v1.GetOptions) (result *v1beta2.R
 		Resource("replicasets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta2.ReplicaSetList,
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *replicaSets) Create(replicaSet *v1beta2.ReplicaSet) (result *v1beta2.Re
 		Namespace(c.ns).
 		Resource("replicasets").
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *replicaSets) Update(replicaSet *v1beta2.ReplicaSet) (result *v1beta2.Re
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *replicaSets) UpdateStatus(replicaSet *v1beta2.ReplicaSet) (result *v1be
 		Name(replicaSet.Name).
 		SubResource("status").
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *replicaSets) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("replicasets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *replicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *replicaSets) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/statefulset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta2
 
 import (
+	"context"
 	"time"
 
 	v1beta2 "k8s.io/api/apps/v1beta2"
@@ -74,7 +75,7 @@ func (c *statefulSets) Get(name string, options v1.GetOptions) (result *v1beta2.
 		Resource("statefulsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -91,7 +92,7 @@ func (c *statefulSets) List(opts v1.ListOptions) (result *v1beta2.StatefulSetLis
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -108,7 +109,7 @@ func (c *statefulSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("statefulsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a statefulSet and creates it.  Returns the server's representation of the statefulSet, and an error, if there is any.
@@ -118,7 +119,7 @@ func (c *statefulSets) Create(statefulSet *v1beta2.StatefulSet) (result *v1beta2
 		Namespace(c.ns).
 		Resource("statefulsets").
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *statefulSets) Update(statefulSet *v1beta2.StatefulSet) (result *v1beta2
 		Resource("statefulsets").
 		Name(statefulSet.Name).
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *statefulSets) UpdateStatus(statefulSet *v1beta2.StatefulSet) (result *v
 		Name(statefulSet.Name).
 		SubResource("status").
 		Body(statefulSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -159,7 +160,7 @@ func (c *statefulSets) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("statefulsets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -175,7 +176,7 @@ func (c *statefulSets) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -188,7 +189,7 @@ func (c *statefulSets) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -202,7 +203,7 @@ func (c *statefulSets) GetScale(statefulSetName string, options v1.GetOptions) (
 		Name(statefulSetName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -216,7 +217,7 @@ func (c *statefulSets) UpdateScale(statefulSetName string, scale *v1beta2.Scale)
 		Name(statefulSetName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/auditsink.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/auditregistration/v1alpha1"
@@ -67,7 +68,7 @@ func (c *auditSinks) Get(name string, options v1.GetOptions) (result *v1alpha1.A
 		Resource("auditsinks").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *auditSinks) List(opts v1.ListOptions) (result *v1alpha1.AuditSinkList, 
 		Resource("auditsinks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *auditSinks) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("auditsinks").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a auditSink and creates it.  Returns the server's representation of the auditSink, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *auditSinks) Create(auditSink *v1alpha1.AuditSink) (result *v1alpha1.Aud
 	err = c.client.Post().
 		Resource("auditsinks").
 		Body(auditSink).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *auditSinks) Update(auditSink *v1alpha1.AuditSink) (result *v1alpha1.Aud
 		Resource("auditsinks").
 		Name(auditSink.Name).
 		Body(auditSink).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *auditSinks) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("auditsinks").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *auditSinks) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *auditSinks) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview_expansion.go
@@ -37,7 +37,7 @@ func (c *tokenReviews) CreateContext(ctx context.Context, tokenReview *authentic
 		Context(ctx).
 		Resource("tokenreviews").
 		Body(tokenReview).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1/tokenreview_expansion.go
@@ -34,10 +34,9 @@ func (c *tokenReviews) Create(tokenReview *authenticationapi.TokenReview) (resul
 func (c *tokenReviews) CreateContext(ctx context.Context, tokenReview *authenticationapi.TokenReview) (result *authenticationapi.TokenReview, err error) {
 	result = &authenticationapi.TokenReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("tokenreviews").
 		Body(tokenReview).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview_expansion.go
@@ -37,7 +37,7 @@ func (c *tokenReviews) CreateContext(ctx context.Context, tokenReview *authentic
 		Context(ctx).
 		Resource("tokenreviews").
 		Body(tokenReview).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authentication/v1beta1/tokenreview_expansion.go
@@ -34,10 +34,9 @@ func (c *tokenReviews) Create(tokenReview *authenticationapi.TokenReview) (resul
 func (c *tokenReviews) CreateContext(ctx context.Context, tokenReview *authenticationapi.TokenReview) (result *authenticationapi.TokenReview, err error) {
 	result = &authenticationapi.TokenReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("tokenreviews").
 		Body(tokenReview).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview_expansion.go
@@ -34,11 +34,10 @@ func (c *localSubjectAccessReviews) Create(sar *authorizationapi.LocalSubjectAcc
 func (c *localSubjectAccessReviews) CreateContext(ctx context.Context, sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.LocalSubjectAccessReview, err error) {
 	result = &authorizationapi.LocalSubjectAccessReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Namespace(c.ns).
 		Resource("localsubjectaccessreviews").
 		Body(sar).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/localsubjectaccessreview_expansion.go
@@ -38,7 +38,7 @@ func (c *localSubjectAccessReviews) CreateContext(ctx context.Context, sar *auth
 		Namespace(c.ns).
 		Resource("localsubjectaccessreviews").
 		Body(sar).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview_expansion.go
@@ -37,7 +37,7 @@ func (c *selfSubjectAccessReviews) CreateContext(ctx context.Context, sar *autho
 		Context(ctx).
 		Resource("selfsubjectaccessreviews").
 		Body(sar).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectaccessreview_expansion.go
@@ -34,10 +34,9 @@ func (c *selfSubjectAccessReviews) Create(sar *authorizationapi.SelfSubjectAcces
 func (c *selfSubjectAccessReviews) CreateContext(ctx context.Context, sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
 	result = &authorizationapi.SelfSubjectAccessReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("selfsubjectaccessreviews").
 		Body(sar).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview_expansion.go
@@ -37,7 +37,7 @@ func (c *selfSubjectRulesReviews) CreateContext(ctx context.Context, srr *author
 		Context(ctx).
 		Resource("selfsubjectrulesreviews").
 		Body(srr).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/selfsubjectrulesreview_expansion.go
@@ -34,10 +34,9 @@ func (c *selfSubjectRulesReviews) Create(srr *authorizationapi.SelfSubjectRulesR
 func (c *selfSubjectRulesReviews) CreateContext(ctx context.Context, srr *authorizationapi.SelfSubjectRulesReview) (result *authorizationapi.SelfSubjectRulesReview, err error) {
 	result = &authorizationapi.SelfSubjectRulesReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("selfsubjectrulesreviews").
 		Body(srr).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview_expansion.go
@@ -38,7 +38,7 @@ func (c *subjectAccessReviews) CreateContext(ctx context.Context, sar *authoriza
 		Context(ctx).
 		Resource("subjectaccessreviews").
 		Body(sar).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1/subjectaccessreview_expansion.go
@@ -35,10 +35,9 @@ func (c *subjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview)
 func (c *subjectAccessReviews) CreateContext(ctx context.Context, sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error) {
 	result = &authorizationapi.SubjectAccessReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("subjectaccessreviews").
 		Body(sar).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview_expansion.go
@@ -34,11 +34,10 @@ func (c *localSubjectAccessReviews) Create(sar *authorizationapi.LocalSubjectAcc
 func (c *localSubjectAccessReviews) CreateContext(ctx context.Context, sar *authorizationapi.LocalSubjectAccessReview) (result *authorizationapi.LocalSubjectAccessReview, err error) {
 	result = &authorizationapi.LocalSubjectAccessReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Namespace(c.ns).
 		Resource("localsubjectaccessreviews").
 		Body(sar).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/localsubjectaccessreview_expansion.go
@@ -38,7 +38,7 @@ func (c *localSubjectAccessReviews) CreateContext(ctx context.Context, sar *auth
 		Namespace(c.ns).
 		Resource("localsubjectaccessreviews").
 		Body(sar).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview_expansion.go
@@ -37,7 +37,7 @@ func (c *selfSubjectAccessReviews) CreateContext(ctx context.Context, sar *autho
 		Context(ctx).
 		Resource("selfsubjectaccessreviews").
 		Body(sar).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectaccessreview_expansion.go
@@ -34,10 +34,9 @@ func (c *selfSubjectAccessReviews) Create(sar *authorizationapi.SelfSubjectAcces
 func (c *selfSubjectAccessReviews) CreateContext(ctx context.Context, sar *authorizationapi.SelfSubjectAccessReview) (result *authorizationapi.SelfSubjectAccessReview, err error) {
 	result = &authorizationapi.SelfSubjectAccessReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("selfsubjectaccessreviews").
 		Body(sar).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview_expansion.go
@@ -37,7 +37,7 @@ func (c *selfSubjectRulesReviews) CreateContext(ctx context.Context, srr *author
 		Context(ctx).
 		Resource("selfsubjectrulesreviews").
 		Body(srr).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/selfsubjectrulesreview_expansion.go
@@ -34,10 +34,9 @@ func (c *selfSubjectRulesReviews) Create(srr *authorizationapi.SelfSubjectRulesR
 func (c *selfSubjectRulesReviews) CreateContext(ctx context.Context, srr *authorizationapi.SelfSubjectRulesReview) (result *authorizationapi.SelfSubjectRulesReview, err error) {
 	result = &authorizationapi.SelfSubjectRulesReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("selfsubjectrulesreviews").
 		Body(srr).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview_expansion.go
@@ -38,7 +38,7 @@ func (c *subjectAccessReviews) CreateContext(ctx context.Context, sar *authoriza
 		Context(ctx).
 		Resource("subjectaccessreviews").
 		Body(sar).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/authorization/v1beta1/subjectaccessreview_expansion.go
@@ -35,10 +35,9 @@ func (c *subjectAccessReviews) Create(sar *authorizationapi.SubjectAccessReview)
 func (c *subjectAccessReviews) CreateContext(ctx context.Context, sar *authorizationapi.SubjectAccessReview) (result *authorizationapi.SubjectAccessReview, err error) {
 	result = &authorizationapi.SubjectAccessReview{}
 	err = c.client.Post().
-		Context(ctx).
 		Resource("subjectaccessreviews").
 		Body(sar).
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/horizontalpodautoscaler.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/autoscaling/v1"
@@ -71,7 +72,7 @@ func (c *horizontalPodAutoscalers) Get(name string, options metav1.GetOptions) (
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *horizontalPodAutoscalers) List(opts metav1.ListOptions) (result *v1.Hor
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *horizontalPodAutoscalers) Watch(opts metav1.ListOptions) (watch.Interfa
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v1.Horizontal
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v1.Horizontal
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v1.Hori
 		Name(horizontalPodAutoscaler.Name).
 		SubResource("status").
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *horizontalPodAutoscalers) Delete(name string, options *metav1.DeleteOpt
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *metav1.DeleteOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *horizontalPodAutoscalers) Patch(name string, pt types.PatchType, data [
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/horizontalpodautoscaler.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v2beta1
 
 import (
+	"context"
 	"time"
 
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -71,7 +72,7 @@ func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (resu
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta1.Ho
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, 
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2beta1.Horiz
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2beta1.Horiz
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v2beta1
 		Name(horizontalPodAutoscaler.Name).
 		SubResource("status").
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *horizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, l
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *horizontalPodAutoscalers) Patch(name string, pt types.PatchType, data [
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/horizontalpodautoscaler.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v2beta2
 
 import (
+	"context"
 	"time"
 
 	v2beta2 "k8s.io/api/autoscaling/v2beta2"
@@ -71,7 +72,7 @@ func (c *horizontalPodAutoscalers) Get(name string, options v1.GetOptions) (resu
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *horizontalPodAutoscalers) List(opts v1.ListOptions) (result *v2beta2.Ho
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *horizontalPodAutoscalers) Watch(opts v1.ListOptions) (watch.Interface, 
 		Resource("horizontalpodautoscalers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a horizontalPodAutoscaler and creates it.  Returns the server's representation of the horizontalPodAutoscaler, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *horizontalPodAutoscalers) Create(horizontalPodAutoscaler *v2beta2.Horiz
 		Namespace(c.ns).
 		Resource("horizontalpodautoscalers").
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *horizontalPodAutoscalers) Update(horizontalPodAutoscaler *v2beta2.Horiz
 		Resource("horizontalpodautoscalers").
 		Name(horizontalPodAutoscaler.Name).
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *horizontalPodAutoscalers) UpdateStatus(horizontalPodAutoscaler *v2beta2
 		Name(horizontalPodAutoscaler.Name).
 		SubResource("status").
 		Body(horizontalPodAutoscaler).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *horizontalPodAutoscalers) Delete(name string, options *v1.DeleteOptions
 		Resource("horizontalpodautoscalers").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *horizontalPodAutoscalers) DeleteCollection(options *v1.DeleteOptions, l
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *horizontalPodAutoscalers) Patch(name string, pt types.PatchType, data [
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/job.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/batch/v1"
@@ -71,7 +72,7 @@ func (c *jobs) Get(name string, options metav1.GetOptions) (result *v1.Job, err 
 		Resource("jobs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *jobs) List(opts metav1.ListOptions) (result *v1.JobList, err error) {
 		Resource("jobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *jobs) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("jobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a job and creates it.  Returns the server's representation of the job, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *jobs) Create(job *v1.Job) (result *v1.Job, err error) {
 		Namespace(c.ns).
 		Resource("jobs").
 		Body(job).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *jobs) Update(job *v1.Job) (result *v1.Job, err error) {
 		Resource("jobs").
 		Name(job.Name).
 		Body(job).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *jobs) UpdateStatus(job *v1.Job) (result *v1.Job, err error) {
 		Name(job.Name).
 		SubResource("status").
 		Body(job).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *jobs) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("jobs").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *jobs) DeleteCollection(options *metav1.DeleteOptions, listOptions metav
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *jobs) Patch(name string, pt types.PatchType, data []byte, subresources 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/cronjob.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/batch/v1beta1"
@@ -71,7 +72,7 @@ func (c *cronJobs) Get(name string, options v1.GetOptions) (result *v1beta1.Cron
 		Resource("cronjobs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v1beta1.CronJobList, err e
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *cronJobs) Create(cronJob *v1beta1.CronJob) (result *v1beta1.CronJob, er
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Body(cronJob).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *cronJobs) Update(cronJob *v1beta1.CronJob) (result *v1beta1.CronJob, er
 		Resource("cronjobs").
 		Name(cronJob.Name).
 		Body(cronJob).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *cronJobs) UpdateStatus(cronJob *v1beta1.CronJob) (result *v1beta1.CronJ
 		Name(cronJob.Name).
 		SubResource("status").
 		Body(cronJob).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *cronJobs) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("cronjobs").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *cronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *cronJobs) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/cronjob.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v2alpha1
 
 import (
+	"context"
 	"time"
 
 	v2alpha1 "k8s.io/api/batch/v2alpha1"
@@ -71,7 +72,7 @@ func (c *cronJobs) Get(name string, options v1.GetOptions) (result *v2alpha1.Cro
 		Resource("cronjobs").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *cronJobs) List(opts v1.ListOptions) (result *v2alpha1.CronJobList, err 
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *cronJobs) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("cronjobs").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a cronJob and creates it.  Returns the server's representation of the cronJob, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *cronJobs) Create(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, 
 		Namespace(c.ns).
 		Resource("cronjobs").
 		Body(cronJob).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *cronJobs) Update(cronJob *v2alpha1.CronJob) (result *v2alpha1.CronJob, 
 		Resource("cronjobs").
 		Name(cronJob.Name).
 		Body(cronJob).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *cronJobs) UpdateStatus(cronJob *v2alpha1.CronJob) (result *v2alpha1.Cro
 		Name(cronJob.Name).
 		SubResource("status").
 		Body(cronJob).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *cronJobs) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("cronjobs").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *cronJobs) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *cronJobs) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/certificates/v1beta1"
@@ -68,7 +69,7 @@ func (c *certificateSigningRequests) Get(name string, options v1.GetOptions) (re
 		Resource("certificatesigningrequests").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *certificateSigningRequests) List(opts v1.ListOptions) (result *v1beta1.
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *certificateSigningRequests) Watch(opts v1.ListOptions) (watch.Interface
 		Resource("certificatesigningrequests").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a certificateSigningRequest and creates it.  Returns the server's representation of the certificateSigningRequest, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *certificateSigningRequests) Create(certificateSigningRequest *v1beta1.C
 	err = c.client.Post().
 		Resource("certificatesigningrequests").
 		Body(certificateSigningRequest).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *certificateSigningRequests) Update(certificateSigningRequest *v1beta1.C
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
 		Body(certificateSigningRequest).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *certificateSigningRequests) UpdateStatus(certificateSigningRequest *v1b
 		Name(certificateSigningRequest.Name).
 		SubResource("status").
 		Body(certificateSigningRequest).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *certificateSigningRequests) Delete(name string, options *v1.DeleteOptio
 		Resource("certificatesigningrequests").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *certificateSigningRequests) DeleteCollection(options *v1.DeleteOptions,
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *certificateSigningRequests) Patch(name string, pt types.PatchType, data
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest_expansion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+
 	certificates "k8s.io/api/certificates/v1beta1"
 )
 
@@ -31,7 +33,7 @@ func (c *certificateSigningRequests) UpdateApproval(certificateSigningRequest *c
 		Name(certificateSigningRequest.Name).
 		Body(certificateSigningRequest).
 		SubResource("approval").
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/lease.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/coordination/v1"
@@ -70,7 +71,7 @@ func (c *leases) Get(name string, options metav1.GetOptions) (result *v1.Lease, 
 		Resource("leases").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *leases) List(opts metav1.ListOptions) (result *v1.LeaseList, err error)
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *leases) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a lease and creates it.  Returns the server's representation of the lease, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *leases) Create(lease *v1.Lease) (result *v1.Lease, err error) {
 		Namespace(c.ns).
 		Resource("leases").
 		Body(lease).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *leases) Update(lease *v1.Lease) (result *v1.Lease, err error) {
 		Resource("leases").
 		Name(lease.Name).
 		Body(lease).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *leases) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("leases").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *leases) DeleteCollection(options *metav1.DeleteOptions, listOptions met
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *leases) Patch(name string, pt types.PatchType, data []byte, subresource
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/lease.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/coordination/v1beta1"
@@ -70,7 +71,7 @@ func (c *leases) Get(name string, options v1.GetOptions) (result *v1beta1.Lease,
 		Resource("leases").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *leases) List(opts v1.ListOptions) (result *v1beta1.LeaseList, err error
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *leases) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("leases").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a lease and creates it.  Returns the server's representation of the lease, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *leases) Create(lease *v1beta1.Lease) (result *v1beta1.Lease, err error)
 		Namespace(c.ns).
 		Resource("leases").
 		Body(lease).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *leases) Update(lease *v1beta1.Lease) (result *v1beta1.Lease, err error)
 		Resource("leases").
 		Name(lease.Name).
 		Body(lease).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *leases) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("leases").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *leases) DeleteCollection(options *v1.DeleteOptions, listOptions v1.List
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *leases) Patch(name string, pt types.PatchType, data []byte, subresource
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/componentstatus.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -67,7 +68,7 @@ func (c *componentStatuses) Get(name string, options metav1.GetOptions) (result 
 		Resource("componentstatuses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *componentStatuses) List(opts metav1.ListOptions) (result *v1.ComponentS
 		Resource("componentstatuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *componentStatuses) Watch(opts metav1.ListOptions) (watch.Interface, err
 		Resource("componentstatuses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a componentStatus and creates it.  Returns the server's representation of the componentStatus, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *componentStatuses) Create(componentStatus *v1.ComponentStatus) (result 
 	err = c.client.Post().
 		Resource("componentstatuses").
 		Body(componentStatus).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *componentStatuses) Update(componentStatus *v1.ComponentStatus) (result 
 		Resource("componentstatuses").
 		Name(componentStatus.Name).
 		Body(componentStatus).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *componentStatuses) Delete(name string, options *metav1.DeleteOptions) e
 		Resource("componentstatuses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *componentStatuses) DeleteCollection(options *metav1.DeleteOptions, list
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *componentStatuses) Patch(name string, pt types.PatchType, data []byte, 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/configmap.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *configMaps) Get(name string, options metav1.GetOptions) (result *v1.Con
 		Resource("configmaps").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *configMaps) List(opts metav1.ListOptions) (result *v1.ConfigMapList, er
 		Resource("configmaps").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *configMaps) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("configmaps").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a configMap and creates it.  Returns the server's representation of the configMap, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *configMaps) Create(configMap *v1.ConfigMap) (result *v1.ConfigMap, err 
 		Namespace(c.ns).
 		Resource("configmaps").
 		Body(configMap).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *configMaps) Update(configMap *v1.ConfigMap) (result *v1.ConfigMap, err 
 		Resource("configmaps").
 		Name(configMap.Name).
 		Body(configMap).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *configMaps) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("configmaps").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *configMaps) DeleteCollection(options *metav1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *configMaps) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/endpoints.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *endpoints) Get(name string, options metav1.GetOptions) (result *v1.Endp
 		Resource("endpoints").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *endpoints) List(opts metav1.ListOptions) (result *v1.EndpointsList, err
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *endpoints) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("endpoints").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a endpoints and creates it.  Returns the server's representation of the endpoints, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *endpoints) Create(endpoints *v1.Endpoints) (result *v1.Endpoints, err e
 		Namespace(c.ns).
 		Resource("endpoints").
 		Body(endpoints).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *endpoints) Update(endpoints *v1.Endpoints) (result *v1.Endpoints, err e
 		Resource("endpoints").
 		Name(endpoints.Name).
 		Body(endpoints).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *endpoints) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("endpoints").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *endpoints) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *endpoints) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *events) Get(name string, options metav1.GetOptions) (result *v1.Event, 
 		Resource("events").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *events) List(opts metav1.ListOptions) (result *v1.EventList, err error)
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *events) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *events) Create(event *v1.Event) (result *v1.Event, err error) {
 		Namespace(c.ns).
 		Resource("events").
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *events) Update(event *v1.Event) (result *v1.Event, err error) {
 		Resource("events").
 		Name(event.Name).
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *events) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("events").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *events) DeleteCollection(options *metav1.DeleteOptions, listOptions met
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *events) Patch(name string, pt types.PatchType, data []byte, subresource
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/event_expansion.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -54,7 +55,7 @@ func (e *events) CreateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
 		Resource("events").
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }
@@ -71,7 +72,7 @@ func (e *events) UpdateWithEventNamespace(event *v1.Event) (*v1.Event, error) {
 		Resource("events").
 		Name(event.Name).
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }
@@ -91,7 +92,7 @@ func (e *events) PatchWithEventNamespace(incompleteEvent *v1.Event, data []byte)
 		Resource("events").
 		Name(incompleteEvent.Name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/limitrange.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *limitRanges) Get(name string, options metav1.GetOptions) (result *v1.Li
 		Resource("limitranges").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *limitRanges) List(opts metav1.ListOptions) (result *v1.LimitRangeList, 
 		Resource("limitranges").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *limitRanges) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("limitranges").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a limitRange and creates it.  Returns the server's representation of the limitRange, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *limitRanges) Create(limitRange *v1.LimitRange) (result *v1.LimitRange, 
 		Namespace(c.ns).
 		Resource("limitranges").
 		Body(limitRange).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *limitRanges) Update(limitRange *v1.LimitRange) (result *v1.LimitRange, 
 		Resource("limitranges").
 		Name(limitRange.Name).
 		Body(limitRange).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *limitRanges) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("limitranges").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *limitRanges) DeleteCollection(options *metav1.DeleteOptions, listOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *limitRanges) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -67,7 +68,7 @@ func (c *namespaces) Get(name string, options metav1.GetOptions) (result *v1.Nam
 		Resource("namespaces").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *namespaces) List(opts metav1.ListOptions) (result *v1.NamespaceList, er
 		Resource("namespaces").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *namespaces) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("namespaces").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a namespace and creates it.  Returns the server's representation of the namespace, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *namespaces) Create(namespace *v1.Namespace) (result *v1.Namespace, err 
 	err = c.client.Post().
 		Resource("namespaces").
 		Body(namespace).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *namespaces) Update(namespace *v1.Namespace) (result *v1.Namespace, err 
 		Resource("namespaces").
 		Name(namespace.Name).
 		Body(namespace).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -135,7 +136,7 @@ func (c *namespaces) UpdateStatus(namespace *v1.Namespace) (result *v1.Namespace
 		Name(namespace.Name).
 		SubResource("status").
 		Body(namespace).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -146,7 +147,7 @@ func (c *namespaces) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("namespaces").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *namespaces) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace_expansion.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package v1
 
-import "k8s.io/api/core/v1"
+import (
+	"context"
+
+	v1 "k8s.io/api/core/v1"
+)
 
 // The NamespaceExpansion interface allows manually adding extra methods to the NamespaceInterface.
 type NamespaceExpansion interface {
@@ -26,6 +30,6 @@ type NamespaceExpansion interface {
 // Finalize takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
 func (c *namespaces) Finalize(namespace *v1.Namespace) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
-	err = c.client.Put().Resource("namespaces").Name(namespace.Name).SubResource("finalize").Body(namespace).Do().Into(result)
+	err = c.client.Put().Resource("namespaces").Name(namespace.Name).SubResource("finalize").Body(namespace).Do(context.TODO()).Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -68,7 +69,7 @@ func (c *nodes) Get(name string, options metav1.GetOptions) (result *v1.Node, er
 		Resource("nodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *nodes) List(opts metav1.ListOptions) (result *v1.NodeList, err error) {
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *nodes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a node and creates it.  Returns the server's representation of the node, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *nodes) Create(node *v1.Node) (result *v1.Node, err error) {
 	err = c.client.Post().
 		Resource("nodes").
 		Body(node).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *nodes) Update(node *v1.Node) (result *v1.Node, err error) {
 		Resource("nodes").
 		Name(node.Name).
 		Body(node).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *nodes) UpdateStatus(node *v1.Node) (result *v1.Node, err error) {
 		Name(node.Name).
 		SubResource("status").
 		Body(node).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *nodes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("nodes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *nodes) DeleteCollection(options *metav1.DeleteOptions, listOptions meta
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *nodes) Patch(name string, pt types.PatchType, data []byte, subresources
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/node_expansion.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	"context"
+
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -37,7 +39,7 @@ func (c *nodes) PatchStatus(nodeName string, data []byte) (*v1.Node, error) {
 		Name(nodeName).
 		SubResource("status").
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolume.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -68,7 +69,7 @@ func (c *persistentVolumes) Get(name string, options metav1.GetOptions) (result 
 		Resource("persistentvolumes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *persistentVolumes) List(opts metav1.ListOptions) (result *v1.Persistent
 		Resource("persistentvolumes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *persistentVolumes) Watch(opts metav1.ListOptions) (watch.Interface, err
 		Resource("persistentvolumes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a persistentVolume and creates it.  Returns the server's representation of the persistentVolume, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *persistentVolumes) Create(persistentVolume *v1.PersistentVolume) (resul
 	err = c.client.Post().
 		Resource("persistentvolumes").
 		Body(persistentVolume).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *persistentVolumes) Update(persistentVolume *v1.PersistentVolume) (resul
 		Resource("persistentvolumes").
 		Name(persistentVolume.Name).
 		Body(persistentVolume).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *persistentVolumes) UpdateStatus(persistentVolume *v1.PersistentVolume) 
 		Name(persistentVolume.Name).
 		SubResource("status").
 		Body(persistentVolume).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *persistentVolumes) Delete(name string, options *metav1.DeleteOptions) e
 		Resource("persistentvolumes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *persistentVolumes) DeleteCollection(options *metav1.DeleteOptions, list
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *persistentVolumes) Patch(name string, pt types.PatchType, data []byte, 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/persistentvolumeclaim.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -71,7 +72,7 @@ func (c *persistentVolumeClaims) Get(name string, options metav1.GetOptions) (re
 		Resource("persistentvolumeclaims").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *persistentVolumeClaims) List(opts metav1.ListOptions) (result *v1.Persi
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *persistentVolumeClaims) Watch(opts metav1.ListOptions) (watch.Interface
 		Resource("persistentvolumeclaims").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a persistentVolumeClaim and creates it.  Returns the server's representation of the persistentVolumeClaim, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *persistentVolumeClaims) Create(persistentVolumeClaim *v1.PersistentVolu
 		Namespace(c.ns).
 		Resource("persistentvolumeclaims").
 		Body(persistentVolumeClaim).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *persistentVolumeClaims) Update(persistentVolumeClaim *v1.PersistentVolu
 		Resource("persistentvolumeclaims").
 		Name(persistentVolumeClaim.Name).
 		Body(persistentVolumeClaim).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *persistentVolumeClaims) UpdateStatus(persistentVolumeClaim *v1.Persiste
 		Name(persistentVolumeClaim.Name).
 		SubResource("status").
 		Body(persistentVolumeClaim).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *persistentVolumeClaims) Delete(name string, options *metav1.DeleteOptio
 		Resource("persistentvolumeclaims").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *persistentVolumeClaims) DeleteCollection(options *metav1.DeleteOptions,
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *persistentVolumeClaims) Patch(name string, pt types.PatchType, data []b
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -74,7 +75,7 @@ func (c *pods) Get(name string, options metav1.GetOptions) (result *v1.Pod, err 
 		Resource("pods").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -91,7 +92,7 @@ func (c *pods) List(opts metav1.ListOptions) (result *v1.PodList, err error) {
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -108,7 +109,7 @@ func (c *pods) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a pod and creates it.  Returns the server's representation of the pod, and an error, if there is any.
@@ -118,7 +119,7 @@ func (c *pods) Create(pod *v1.Pod) (result *v1.Pod, err error) {
 		Namespace(c.ns).
 		Resource("pods").
 		Body(pod).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *pods) Update(pod *v1.Pod) (result *v1.Pod, err error) {
 		Resource("pods").
 		Name(pod.Name).
 		Body(pod).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *pods) UpdateStatus(pod *v1.Pod) (result *v1.Pod, err error) {
 		Name(pod.Name).
 		SubResource("status").
 		Body(pod).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -159,7 +160,7 @@ func (c *pods) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("pods").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -175,7 +176,7 @@ func (c *pods) DeleteCollection(options *metav1.DeleteOptions, listOptions metav
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -188,7 +189,7 @@ func (c *pods) Patch(name string, pt types.PatchType, data []byte, subresources 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -202,7 +203,7 @@ func (c *pods) GetEphemeralContainers(podName string, options metav1.GetOptions)
 		Name(podName).
 		SubResource("ephemeralcontainers").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -216,7 +217,7 @@ func (c *pods) UpdateEphemeralContainers(podName string, ephemeralContainers *v1
 		Name(podName).
 		SubResource("ephemeralcontainers").
 		Body(ephemeralContainers).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1
 
 import (
-	"k8s.io/api/core/v1"
+	"context"
+
+	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
@@ -32,11 +34,11 @@ type PodExpansion interface {
 
 // Bind applies the provided binding to the named pod in the current namespace (binding.Namespace is ignored).
 func (c *pods) Bind(binding *v1.Binding) error {
-	return c.client.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do().Error()
+	return c.client.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do(context.TODO()).Error()
 }
 
 func (c *pods) Evict(eviction *policy.Eviction) error {
-	return c.client.Post().Namespace(c.ns).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do().Error()
+	return c.client.Post().Namespace(c.ns).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(context.TODO()).Error()
 }
 
 // Get constructs a request for getting the logs for a pod

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/podtemplate.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *podTemplates) Get(name string, options metav1.GetOptions) (result *v1.P
 		Resource("podtemplates").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *podTemplates) List(opts metav1.ListOptions) (result *v1.PodTemplateList
 		Resource("podtemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *podTemplates) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("podtemplates").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a podTemplate and creates it.  Returns the server's representation of the podTemplate, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *podTemplates) Create(podTemplate *v1.PodTemplate) (result *v1.PodTempla
 		Namespace(c.ns).
 		Resource("podtemplates").
 		Body(podTemplate).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *podTemplates) Update(podTemplate *v1.PodTemplate) (result *v1.PodTempla
 		Resource("podtemplates").
 		Name(podTemplate.Name).
 		Body(podTemplate).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *podTemplates) Delete(name string, options *metav1.DeleteOptions) error 
 		Resource("podtemplates").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *podTemplates) DeleteCollection(options *metav1.DeleteOptions, listOptio
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *podTemplates) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/replicationcontroller.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -75,7 +76,7 @@ func (c *replicationControllers) Get(name string, options metav1.GetOptions) (re
 		Resource("replicationcontrollers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -92,7 +93,7 @@ func (c *replicationControllers) List(opts metav1.ListOptions) (result *v1.Repli
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -109,7 +110,7 @@ func (c *replicationControllers) Watch(opts metav1.ListOptions) (watch.Interface
 		Resource("replicationcontrollers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a replicationController and creates it.  Returns the server's representation of the replicationController, and an error, if there is any.
@@ -119,7 +120,7 @@ func (c *replicationControllers) Create(replicationController *v1.ReplicationCon
 		Namespace(c.ns).
 		Resource("replicationcontrollers").
 		Body(replicationController).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -132,7 +133,7 @@ func (c *replicationControllers) Update(replicationController *v1.ReplicationCon
 		Resource("replicationcontrollers").
 		Name(replicationController.Name).
 		Body(replicationController).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -148,7 +149,7 @@ func (c *replicationControllers) UpdateStatus(replicationController *v1.Replicat
 		Name(replicationController.Name).
 		SubResource("status").
 		Body(replicationController).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -160,7 +161,7 @@ func (c *replicationControllers) Delete(name string, options *metav1.DeleteOptio
 		Resource("replicationcontrollers").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -176,7 +177,7 @@ func (c *replicationControllers) DeleteCollection(options *metav1.DeleteOptions,
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -189,7 +190,7 @@ func (c *replicationControllers) Patch(name string, pt types.PatchType, data []b
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -203,7 +204,7 @@ func (c *replicationControllers) GetScale(replicationControllerName string, opti
 		Name(replicationControllerName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -217,7 +218,7 @@ func (c *replicationControllers) UpdateScale(replicationControllerName string, s
 		Name(replicationControllerName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/resourcequota.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -71,7 +72,7 @@ func (c *resourceQuotas) Get(name string, options metav1.GetOptions) (result *v1
 		Resource("resourcequotas").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *resourceQuotas) List(opts metav1.ListOptions) (result *v1.ResourceQuota
 		Resource("resourcequotas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *resourceQuotas) Watch(opts metav1.ListOptions) (watch.Interface, error)
 		Resource("resourcequotas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a resourceQuota and creates it.  Returns the server's representation of the resourceQuota, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *resourceQuotas) Create(resourceQuota *v1.ResourceQuota) (result *v1.Res
 		Namespace(c.ns).
 		Resource("resourcequotas").
 		Body(resourceQuota).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *resourceQuotas) Update(resourceQuota *v1.ResourceQuota) (result *v1.Res
 		Resource("resourcequotas").
 		Name(resourceQuota.Name).
 		Body(resourceQuota).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *resourceQuotas) UpdateStatus(resourceQuota *v1.ResourceQuota) (result *
 		Name(resourceQuota.Name).
 		SubResource("status").
 		Body(resourceQuota).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *resourceQuotas) Delete(name string, options *metav1.DeleteOptions) erro
 		Resource("resourcequotas").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *resourceQuotas) DeleteCollection(options *metav1.DeleteOptions, listOpt
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *resourceQuotas) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/secret.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *secrets) Get(name string, options metav1.GetOptions) (result *v1.Secret
 		Resource("secrets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *secrets) List(opts metav1.ListOptions) (result *v1.SecretList, err erro
 		Resource("secrets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *secrets) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("secrets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a secret and creates it.  Returns the server's representation of the secret, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *secrets) Create(secret *v1.Secret) (result *v1.Secret, err error) {
 		Namespace(c.ns).
 		Resource("secrets").
 		Body(secret).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *secrets) Update(secret *v1.Secret) (result *v1.Secret, err error) {
 		Resource("secrets").
 		Name(secret.Name).
 		Body(secret).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *secrets) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("secrets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *secrets) DeleteCollection(options *metav1.DeleteOptions, listOptions me
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *secrets) Patch(name string, pt types.PatchType, data []byte, subresourc
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/service.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *services) Get(name string, options metav1.GetOptions) (result *v1.Servi
 		Resource("services").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *services) List(opts metav1.ListOptions) (result *v1.ServiceList, err er
 		Resource("services").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *services) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("services").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a service and creates it.  Returns the server's representation of the service, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *services) Create(service *v1.Service) (result *v1.Service, err error) {
 		Namespace(c.ns).
 		Resource("services").
 		Body(service).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *services) Update(service *v1.Service) (result *v1.Service, err error) {
 		Resource("services").
 		Name(service.Name).
 		Body(service).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -143,7 +144,7 @@ func (c *services) UpdateStatus(service *v1.Service) (result *v1.Service, err er
 		Name(service.Name).
 		SubResource("status").
 		Body(service).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -155,7 +156,7 @@ func (c *services) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("services").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *services) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
@@ -70,7 +71,7 @@ func (c *serviceAccounts) Get(name string, options metav1.GetOptions) (result *v
 		Resource("serviceaccounts").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *serviceAccounts) List(opts metav1.ListOptions) (result *v1.ServiceAccou
 		Resource("serviceaccounts").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *serviceAccounts) Watch(opts metav1.ListOptions) (watch.Interface, error
 		Resource("serviceaccounts").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a serviceAccount and creates it.  Returns the server's representation of the serviceAccount, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *serviceAccounts) Create(serviceAccount *v1.ServiceAccount) (result *v1.
 		Namespace(c.ns).
 		Resource("serviceaccounts").
 		Body(serviceAccount).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *serviceAccounts) Update(serviceAccount *v1.ServiceAccount) (result *v1.
 		Resource("serviceaccounts").
 		Name(serviceAccount.Name).
 		Body(serviceAccount).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *serviceAccounts) Delete(name string, options *metav1.DeleteOptions) err
 		Resource("serviceaccounts").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *serviceAccounts) DeleteCollection(options *metav1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *serviceAccounts) Patch(name string, pt types.PatchType, data []byte, su
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/serviceaccount_expansion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1
 
 import (
+	"context"
+
 	authenticationv1 "k8s.io/api/authentication/v1"
 )
 
@@ -35,7 +37,7 @@ func (c *serviceAccounts) CreateToken(name string, tr *authenticationv1.TokenReq
 		SubResource("token").
 		Name(name).
 		Body(tr).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/endpointslice.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/discovery/v1alpha1"
@@ -70,7 +71,7 @@ func (c *endpointSlices) Get(name string, options v1.GetOptions) (result *v1alph
 		Resource("endpointslices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *endpointSlices) List(opts v1.ListOptions) (result *v1alpha1.EndpointSli
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *endpointSlices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a endpointSlice and creates it.  Returns the server's representation of the endpointSlice, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *endpointSlices) Create(endpointSlice *v1alpha1.EndpointSlice) (result *
 		Namespace(c.ns).
 		Resource("endpointslices").
 		Body(endpointSlice).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *endpointSlices) Update(endpointSlice *v1alpha1.EndpointSlice) (result *
 		Resource("endpointslices").
 		Name(endpointSlice.Name).
 		Body(endpointSlice).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *endpointSlices) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("endpointslices").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *endpointSlices) DeleteCollection(options *v1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *endpointSlices) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/endpointslice.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/discovery/v1beta1"
@@ -70,7 +71,7 @@ func (c *endpointSlices) Get(name string, options v1.GetOptions) (result *v1beta
 		Resource("endpointslices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *endpointSlices) List(opts v1.ListOptions) (result *v1beta1.EndpointSlic
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *endpointSlices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("endpointslices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a endpointSlice and creates it.  Returns the server's representation of the endpointSlice, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *endpointSlices) Create(endpointSlice *v1beta1.EndpointSlice) (result *v
 		Namespace(c.ns).
 		Resource("endpointslices").
 		Body(endpointSlice).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *endpointSlices) Update(endpointSlice *v1beta1.EndpointSlice) (result *v
 		Resource("endpointslices").
 		Name(endpointSlice.Name).
 		Body(endpointSlice).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *endpointSlices) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("endpointslices").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *endpointSlices) DeleteCollection(options *v1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *endpointSlices) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/events/v1beta1"
@@ -70,7 +71,7 @@ func (c *events) Get(name string, options v1.GetOptions) (result *v1beta1.Event,
 		Resource("events").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *events) List(opts v1.ListOptions) (result *v1beta1.EventList, err error
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *events) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("events").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a event and creates it.  Returns the server's representation of the event, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *events) Create(event *v1beta1.Event) (result *v1beta1.Event, err error)
 		Namespace(c.ns).
 		Resource("events").
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *events) Update(event *v1beta1.Event) (result *v1beta1.Event, err error)
 		Resource("events").
 		Name(event.Name).
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *events) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("events").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *events) DeleteCollection(options *v1.DeleteOptions, listOptions v1.List
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *events) Patch(name string, pt types.PatchType, data []byte, subresource
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/event_expansion.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 
 	"k8s.io/api/events/v1beta1"
@@ -51,7 +52,7 @@ func (e *events) CreateWithEventNamespace(event *v1beta1.Event) (*v1beta1.Event,
 		NamespaceIfScoped(event.Namespace, len(event.Namespace) > 0).
 		Resource("events").
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }
@@ -72,7 +73,7 @@ func (e *events) UpdateWithEventNamespace(event *v1beta1.Event) (*v1beta1.Event,
 		Resource("events").
 		Name(event.Name).
 		Body(event).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }
@@ -92,7 +93,7 @@ func (e *events) PatchWithEventNamespace(event *v1beta1.Event, data []byte) (*v1
 		Resource("events").
 		Name(event.Name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return result, err
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/daemonset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/extensions/v1beta1"
@@ -71,7 +72,7 @@ func (c *daemonSets) Get(name string, options v1.GetOptions) (result *v1beta1.Da
 		Resource("daemonsets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *daemonSets) List(opts v1.ListOptions) (result *v1beta1.DaemonSetList, e
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *daemonSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("daemonsets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a daemonSet and creates it.  Returns the server's representation of the daemonSet, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *daemonSets) Create(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 		Namespace(c.ns).
 		Resource("daemonsets").
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *daemonSets) Update(daemonSet *v1beta1.DaemonSet) (result *v1beta1.Daemo
 		Resource("daemonsets").
 		Name(daemonSet.Name).
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *daemonSets) UpdateStatus(daemonSet *v1beta1.DaemonSet) (result *v1beta1
 		Name(daemonSet.Name).
 		SubResource("status").
 		Body(daemonSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *daemonSets) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("daemonsets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *daemonSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *daemonSets) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/extensions/v1beta1"
@@ -74,7 +75,7 @@ func (c *deployments) Get(name string, options v1.GetOptions) (result *v1beta1.D
 		Resource("deployments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -91,7 +92,7 @@ func (c *deployments) List(opts v1.ListOptions) (result *v1beta1.DeploymentList,
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -108,7 +109,7 @@ func (c *deployments) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("deployments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a deployment and creates it.  Returns the server's representation of the deployment, and an error, if there is any.
@@ -118,7 +119,7 @@ func (c *deployments) Create(deployment *v1beta1.Deployment) (result *v1beta1.De
 		Namespace(c.ns).
 		Resource("deployments").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *deployments) Update(deployment *v1beta1.Deployment) (result *v1beta1.De
 		Resource("deployments").
 		Name(deployment.Name).
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *deployments) UpdateStatus(deployment *v1beta1.Deployment) (result *v1be
 		Name(deployment.Name).
 		SubResource("status").
 		Body(deployment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -159,7 +160,7 @@ func (c *deployments) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("deployments").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -175,7 +176,7 @@ func (c *deployments) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -188,7 +189,7 @@ func (c *deployments) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -202,7 +203,7 @@ func (c *deployments) GetScale(deploymentName string, options v1.GetOptions) (re
 		Name(deploymentName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -216,7 +217,7 @@ func (c *deployments) UpdateScale(deploymentName string, scale *v1beta1.Scale) (
 		Name(deploymentName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment_expansion.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package v1beta1
 
-import "k8s.io/api/extensions/v1beta1"
+import (
+	"context"
+
+	"k8s.io/api/extensions/v1beta1"
+)
 
 // The DeploymentExpansion interface allows manually adding extra methods to the DeploymentInterface.
 type DeploymentExpansion interface {
@@ -25,5 +29,5 @@ type DeploymentExpansion interface {
 
 // Rollback applied the provided DeploymentRollback to the named deployment in the current namespace.
 func (c *deployments) Rollback(deploymentRollback *v1beta1.DeploymentRollback) error {
-	return c.client.Post().Namespace(c.ns).Resource("deployments").Name(deploymentRollback.Name).SubResource("rollback").Body(deploymentRollback).Do().Error()
+	return c.client.Post().Namespace(c.ns).Resource("deployments").Name(deploymentRollback.Name).SubResource("rollback").Body(deploymentRollback).Do(context.TODO()).Error()
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/ingress.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/extensions/v1beta1"
@@ -71,7 +72,7 @@ func (c *ingresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ing
 		Resource("ingresses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 		Namespace(c.ns).
 		Resource("ingresses").
 		Body(ingress).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 		Resource("ingresses").
 		Name(ingress.Name).
 		Body(ingress).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingr
 		Name(ingress.Name).
 		SubResource("status").
 		Body(ingress).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *ingresses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("ingresses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *ingresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *ingresses) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/networkpolicy.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/extensions/v1beta1"
@@ -70,7 +71,7 @@ func (c *networkPolicies) Get(name string, options v1.GetOptions) (result *v1bet
 		Resource("networkpolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *networkPolicies) List(opts v1.ListOptions) (result *v1beta1.NetworkPoli
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *networkPolicies) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *networkPolicies) Create(networkPolicy *v1beta1.NetworkPolicy) (result *
 		Namespace(c.ns).
 		Resource("networkpolicies").
 		Body(networkPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *networkPolicies) Update(networkPolicy *v1beta1.NetworkPolicy) (result *
 		Resource("networkpolicies").
 		Name(networkPolicy.Name).
 		Body(networkPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *networkPolicies) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("networkpolicies").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *networkPolicies) DeleteCollection(options *v1.DeleteOptions, listOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *networkPolicies) Patch(name string, pt types.PatchType, data []byte, su
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/podsecuritypolicy.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/extensions/v1beta1"
@@ -67,7 +68,7 @@ func (c *podSecurityPolicies) Get(name string, options v1.GetOptions) (result *v
 		Resource("podsecuritypolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *podSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolic
 	err = c.client.Post().
 		Resource("podsecuritypolicies").
 		Body(podSecurityPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *podSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityPolic
 		Resource("podsecuritypolicies").
 		Name(podSecurityPolicy.Name).
 		Body(podSecurityPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *podSecurityPolicies) Delete(name string, options *v1.DeleteOptions) err
 		Resource("podsecuritypolicies").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *podSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *podSecurityPolicies) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/replicaset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/extensions/v1beta1"
@@ -74,7 +75,7 @@ func (c *replicaSets) Get(name string, options v1.GetOptions) (result *v1beta1.R
 		Resource("replicasets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -91,7 +92,7 @@ func (c *replicaSets) List(opts v1.ListOptions) (result *v1beta1.ReplicaSetList,
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -108,7 +109,7 @@ func (c *replicaSets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("replicasets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a replicaSet and creates it.  Returns the server's representation of the replicaSet, and an error, if there is any.
@@ -118,7 +119,7 @@ func (c *replicaSets) Create(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 		Namespace(c.ns).
 		Resource("replicasets").
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *replicaSets) Update(replicaSet *v1beta1.ReplicaSet) (result *v1beta1.Re
 		Resource("replicasets").
 		Name(replicaSet.Name).
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *replicaSets) UpdateStatus(replicaSet *v1beta1.ReplicaSet) (result *v1be
 		Name(replicaSet.Name).
 		SubResource("status").
 		Body(replicaSet).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -159,7 +160,7 @@ func (c *replicaSets) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("replicasets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -175,7 +176,7 @@ func (c *replicaSets) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -188,7 +189,7 @@ func (c *replicaSets) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -202,7 +203,7 @@ func (c *replicaSets) GetScale(replicaSetName string, options v1.GetOptions) (re
 		Name(replicaSetName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -216,7 +217,7 @@ func (c *replicaSets) UpdateScale(replicaSetName string, scale *v1beta1.Scale) (
 		Name(replicaSetName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/flowschema.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
@@ -68,7 +69,7 @@ func (c *flowSchemas) Get(name string, options v1.GetOptions) (result *v1alpha1.
 		Resource("flowschemas").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *flowSchemas) List(opts v1.ListOptions) (result *v1alpha1.FlowSchemaList
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *flowSchemas) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("flowschemas").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a flowSchema and creates it.  Returns the server's representation of the flowSchema, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *flowSchemas) Create(flowSchema *v1alpha1.FlowSchema) (result *v1alpha1.
 	err = c.client.Post().
 		Resource("flowschemas").
 		Body(flowSchema).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *flowSchemas) Update(flowSchema *v1alpha1.FlowSchema) (result *v1alpha1.
 		Resource("flowschemas").
 		Name(flowSchema.Name).
 		Body(flowSchema).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *flowSchemas) UpdateStatus(flowSchema *v1alpha1.FlowSchema) (result *v1a
 		Name(flowSchema.Name).
 		SubResource("status").
 		Body(flowSchema).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *flowSchemas) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("flowschemas").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *flowSchemas) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *flowSchemas) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/prioritylevelconfiguration.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/flowcontrol/v1alpha1"
@@ -68,7 +69,7 @@ func (c *priorityLevelConfigurations) Get(name string, options v1.GetOptions) (r
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *priorityLevelConfigurations) List(opts v1.ListOptions) (result *v1alpha
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *priorityLevelConfigurations) Watch(opts v1.ListOptions) (watch.Interfac
 		Resource("prioritylevelconfigurations").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a priorityLevelConfiguration and creates it.  Returns the server's representation of the priorityLevelConfiguration, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *priorityLevelConfigurations) Create(priorityLevelConfiguration *v1alpha
 	err = c.client.Post().
 		Resource("prioritylevelconfigurations").
 		Body(priorityLevelConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *priorityLevelConfigurations) Update(priorityLevelConfiguration *v1alpha
 		Resource("prioritylevelconfigurations").
 		Name(priorityLevelConfiguration.Name).
 		Body(priorityLevelConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *priorityLevelConfigurations) UpdateStatus(priorityLevelConfiguration *v
 		Name(priorityLevelConfiguration.Name).
 		SubResource("status").
 		Body(priorityLevelConfiguration).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *priorityLevelConfigurations) Delete(name string, options *v1.DeleteOpti
 		Resource("prioritylevelconfigurations").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *priorityLevelConfigurations) DeleteCollection(options *v1.DeleteOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *priorityLevelConfigurations) Patch(name string, pt types.PatchType, dat
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/networkpolicy.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/networking/v1"
@@ -70,7 +71,7 @@ func (c *networkPolicies) Get(name string, options metav1.GetOptions) (result *v
 		Resource("networkpolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *networkPolicies) List(opts metav1.ListOptions) (result *v1.NetworkPolic
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *networkPolicies) Watch(opts metav1.ListOptions) (watch.Interface, error
 		Resource("networkpolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a networkPolicy and creates it.  Returns the server's representation of the networkPolicy, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *networkPolicies) Create(networkPolicy *v1.NetworkPolicy) (result *v1.Ne
 		Namespace(c.ns).
 		Resource("networkpolicies").
 		Body(networkPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *networkPolicies) Update(networkPolicy *v1.NetworkPolicy) (result *v1.Ne
 		Resource("networkpolicies").
 		Name(networkPolicy.Name).
 		Body(networkPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *networkPolicies) Delete(name string, options *metav1.DeleteOptions) err
 		Resource("networkpolicies").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *networkPolicies) DeleteCollection(options *metav1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *networkPolicies) Patch(name string, pt types.PatchType, data []byte, su
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/ingress.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/networking/v1beta1"
@@ -71,7 +72,7 @@ func (c *ingresses) Get(name string, options v1.GetOptions) (result *v1beta1.Ing
 		Resource("ingresses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *ingresses) List(opts v1.ListOptions) (result *v1beta1.IngressList, err 
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *ingresses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("ingresses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a ingress and creates it.  Returns the server's representation of the ingress, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *ingresses) Create(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 		Namespace(c.ns).
 		Resource("ingresses").
 		Body(ingress).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *ingresses) Update(ingress *v1beta1.Ingress) (result *v1beta1.Ingress, e
 		Resource("ingresses").
 		Name(ingress.Name).
 		Body(ingress).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *ingresses) UpdateStatus(ingress *v1beta1.Ingress) (result *v1beta1.Ingr
 		Name(ingress.Name).
 		SubResource("status").
 		Body(ingress).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *ingresses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("ingresses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *ingresses) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *ingresses) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/runtimeclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/node/v1alpha1"
@@ -67,7 +68,7 @@ func (c *runtimeClasses) Get(name string, options v1.GetOptions) (result *v1alph
 		Resource("runtimeclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *runtimeClasses) Create(runtimeClass *v1alpha1.RuntimeClass) (result *v1
 	err = c.client.Post().
 		Resource("runtimeclasses").
 		Body(runtimeClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *runtimeClasses) Update(runtimeClass *v1alpha1.RuntimeClass) (result *v1
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).
 		Body(runtimeClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *runtimeClasses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("runtimeclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *runtimeClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *runtimeClasses) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/runtimeclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/node/v1beta1"
@@ -67,7 +68,7 @@ func (c *runtimeClasses) Get(name string, options v1.GetOptions) (result *v1beta
 		Resource("runtimeclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1beta1.RuntimeClass
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *runtimeClasses) Create(runtimeClass *v1beta1.RuntimeClass) (result *v1b
 	err = c.client.Post().
 		Resource("runtimeclasses").
 		Body(runtimeClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *runtimeClasses) Update(runtimeClass *v1beta1.RuntimeClass) (result *v1b
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).
 		Body(runtimeClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *runtimeClasses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("runtimeclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *runtimeClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *runtimeClasses) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction_expansion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
+
 	policy "k8s.io/api/policy/v1beta1"
 )
 
@@ -33,6 +35,6 @@ func (c *evictions) Evict(eviction *policy.Eviction) error {
 		Name(eviction.Name).
 		SubResource("eviction").
 		Body(eviction).
-		Do().
+		Do(context.TODO()).
 		Error()
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/poddisruptionbudget.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/policy/v1beta1"
@@ -71,7 +72,7 @@ func (c *podDisruptionBudgets) Get(name string, options v1.GetOptions) (result *
 		Resource("poddisruptionbudgets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *podDisruptionBudgets) List(opts v1.ListOptions) (result *v1beta1.PodDis
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *podDisruptionBudgets) Watch(opts v1.ListOptions) (watch.Interface, erro
 		Resource("poddisruptionbudgets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a podDisruptionBudget and creates it.  Returns the server's representation of the podDisruptionBudget, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *podDisruptionBudgets) Create(podDisruptionBudget *v1beta1.PodDisruption
 		Namespace(c.ns).
 		Resource("poddisruptionbudgets").
 		Body(podDisruptionBudget).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *podDisruptionBudgets) Update(podDisruptionBudget *v1beta1.PodDisruption
 		Resource("poddisruptionbudgets").
 		Name(podDisruptionBudget.Name).
 		Body(podDisruptionBudget).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *podDisruptionBudgets) UpdateStatus(podDisruptionBudget *v1beta1.PodDisr
 		Name(podDisruptionBudget.Name).
 		SubResource("status").
 		Body(podDisruptionBudget).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *podDisruptionBudgets) Delete(name string, options *v1.DeleteOptions) er
 		Resource("poddisruptionbudgets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *podDisruptionBudgets) DeleteCollection(options *v1.DeleteOptions, listO
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *podDisruptionBudgets) Patch(name string, pt types.PatchType, data []byt
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/podsecuritypolicy.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/policy/v1beta1"
@@ -67,7 +68,7 @@ func (c *podSecurityPolicies) Get(name string, options v1.GetOptions) (result *v
 		Resource("podsecuritypolicies").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *podSecurityPolicies) List(opts v1.ListOptions) (result *v1beta1.PodSecu
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *podSecurityPolicies) Watch(opts v1.ListOptions) (watch.Interface, error
 		Resource("podsecuritypolicies").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a podSecurityPolicy and creates it.  Returns the server's representation of the podSecurityPolicy, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *podSecurityPolicies) Create(podSecurityPolicy *v1beta1.PodSecurityPolic
 	err = c.client.Post().
 		Resource("podsecuritypolicies").
 		Body(podSecurityPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *podSecurityPolicies) Update(podSecurityPolicy *v1beta1.PodSecurityPolic
 		Resource("podsecuritypolicies").
 		Name(podSecurityPolicy.Name).
 		Body(podSecurityPolicy).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *podSecurityPolicies) Delete(name string, options *v1.DeleteOptions) err
 		Resource("podsecuritypolicies").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *podSecurityPolicies) DeleteCollection(options *v1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *podSecurityPolicies) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrole.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/rbac/v1"
@@ -67,7 +68,7 @@ func (c *clusterRoles) Get(name string, options metav1.GetOptions) (result *v1.C
 		Resource("clusterroles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *clusterRoles) List(opts metav1.ListOptions) (result *v1.ClusterRoleList
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *clusterRoles) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *clusterRoles) Create(clusterRole *v1.ClusterRole) (result *v1.ClusterRo
 	err = c.client.Post().
 		Resource("clusterroles").
 		Body(clusterRole).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *clusterRoles) Update(clusterRole *v1.ClusterRole) (result *v1.ClusterRo
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		Body(clusterRole).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *clusterRoles) Delete(name string, options *metav1.DeleteOptions) error 
 		Resource("clusterroles").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *clusterRoles) DeleteCollection(options *metav1.DeleteOptions, listOptio
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *clusterRoles) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/clusterrolebinding.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/rbac/v1"
@@ -67,7 +68,7 @@ func (c *clusterRoleBindings) Get(name string, options metav1.GetOptions) (resul
 		Resource("clusterrolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *clusterRoleBindings) List(opts metav1.ListOptions) (result *v1.ClusterR
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *clusterRoleBindings) Watch(opts metav1.ListOptions) (watch.Interface, e
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *clusterRoleBindings) Create(clusterRoleBinding *v1.ClusterRoleBinding) 
 	err = c.client.Post().
 		Resource("clusterrolebindings").
 		Body(clusterRoleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *clusterRoleBindings) Update(clusterRoleBinding *v1.ClusterRoleBinding) 
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		Body(clusterRoleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *clusterRoleBindings) Delete(name string, options *metav1.DeleteOptions)
 		Resource("clusterrolebindings").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *clusterRoleBindings) DeleteCollection(options *metav1.DeleteOptions, li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *clusterRoleBindings) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/role.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/rbac/v1"
@@ -70,7 +71,7 @@ func (c *roles) Get(name string, options metav1.GetOptions) (result *v1.Role, er
 		Resource("roles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *roles) List(opts metav1.ListOptions) (result *v1.RoleList, err error) {
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *roles) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *roles) Create(role *v1.Role) (result *v1.Role, err error) {
 		Namespace(c.ns).
 		Resource("roles").
 		Body(role).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *roles) Update(role *v1.Role) (result *v1.Role, err error) {
 		Resource("roles").
 		Name(role.Name).
 		Body(role).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *roles) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("roles").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *roles) DeleteCollection(options *metav1.DeleteOptions, listOptions meta
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *roles) Patch(name string, pt types.PatchType, data []byte, subresources
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/rolebinding.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/rbac/v1"
@@ -70,7 +71,7 @@ func (c *roleBindings) Get(name string, options metav1.GetOptions) (result *v1.R
 		Resource("rolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *roleBindings) List(opts metav1.ListOptions) (result *v1.RoleBindingList
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *roleBindings) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *roleBindings) Create(roleBinding *v1.RoleBinding) (result *v1.RoleBindi
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Body(roleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *roleBindings) Update(roleBinding *v1.RoleBinding) (result *v1.RoleBindi
 		Resource("rolebindings").
 		Name(roleBinding.Name).
 		Body(roleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *roleBindings) Delete(name string, options *metav1.DeleteOptions) error 
 		Resource("rolebindings").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *roleBindings) DeleteCollection(options *metav1.DeleteOptions, listOptio
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *roleBindings) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrole.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
@@ -67,7 +68,7 @@ func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *v1alpha1
 		Resource("clusterroles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1alpha1.ClusterRoleLi
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *clusterRoles) Create(clusterRole *v1alpha1.ClusterRole) (result *v1alph
 	err = c.client.Post().
 		Resource("clusterroles").
 		Body(clusterRole).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *clusterRoles) Update(clusterRole *v1alpha1.ClusterRole) (result *v1alph
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		Body(clusterRole).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *clusterRoles) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("clusterroles").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *clusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *clusterRoles) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/clusterrolebinding.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
@@ -67,7 +68,7 @@ func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *v
 		Resource("clusterrolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1alpha1.Cluste
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *clusterRoleBindings) Create(clusterRoleBinding *v1alpha1.ClusterRoleBin
 	err = c.client.Post().
 		Resource("clusterrolebindings").
 		Body(clusterRoleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *clusterRoleBindings) Update(clusterRoleBinding *v1alpha1.ClusterRoleBin
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		Body(clusterRoleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *clusterRoleBindings) Delete(name string, options *v1.DeleteOptions) err
 		Resource("clusterrolebindings").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *clusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *clusterRoleBindings) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/role.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
@@ -70,7 +71,7 @@ func (c *roles) Get(name string, options v1.GetOptions) (result *v1alpha1.Role, 
 		Resource("roles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *roles) List(opts v1.ListOptions) (result *v1alpha1.RoleList, err error)
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *roles) Create(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 		Namespace(c.ns).
 		Resource("roles").
 		Body(role).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *roles) Update(role *v1alpha1.Role) (result *v1alpha1.Role, err error) {
 		Resource("roles").
 		Name(role.Name).
 		Body(role).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *roles) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("roles").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *roles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *roles) Patch(name string, pt types.PatchType, data []byte, subresources
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/rolebinding.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/rbac/v1alpha1"
@@ -70,7 +71,7 @@ func (c *roleBindings) Get(name string, options v1.GetOptions) (result *v1alpha1
 		Resource("rolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1alpha1.RoleBindingLi
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *roleBindings) Create(roleBinding *v1alpha1.RoleBinding) (result *v1alph
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Body(roleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *roleBindings) Update(roleBinding *v1alpha1.RoleBinding) (result *v1alph
 		Resource("rolebindings").
 		Name(roleBinding.Name).
 		Body(roleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *roleBindings) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("rolebindings").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *roleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *roleBindings) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrole.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/rbac/v1beta1"
@@ -67,7 +68,7 @@ func (c *clusterRoles) Get(name string, options v1.GetOptions) (result *v1beta1.
 		Resource("clusterroles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *clusterRoles) List(opts v1.ListOptions) (result *v1beta1.ClusterRoleLis
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *clusterRoles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("clusterroles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterRole and creates it.  Returns the server's representation of the clusterRole, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *clusterRoles) Create(clusterRole *v1beta1.ClusterRole) (result *v1beta1
 	err = c.client.Post().
 		Resource("clusterroles").
 		Body(clusterRole).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *clusterRoles) Update(clusterRole *v1beta1.ClusterRole) (result *v1beta1
 		Resource("clusterroles").
 		Name(clusterRole.Name).
 		Body(clusterRole).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *clusterRoles) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("clusterroles").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *clusterRoles) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *clusterRoles) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/clusterrolebinding.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/rbac/v1beta1"
@@ -67,7 +68,7 @@ func (c *clusterRoleBindings) Get(name string, options v1.GetOptions) (result *v
 		Resource("clusterrolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *clusterRoleBindings) List(opts v1.ListOptions) (result *v1beta1.Cluster
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *clusterRoleBindings) Watch(opts v1.ListOptions) (watch.Interface, error
 		Resource("clusterrolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterRoleBinding and creates it.  Returns the server's representation of the clusterRoleBinding, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *clusterRoleBindings) Create(clusterRoleBinding *v1beta1.ClusterRoleBind
 	err = c.client.Post().
 		Resource("clusterrolebindings").
 		Body(clusterRoleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *clusterRoleBindings) Update(clusterRoleBinding *v1beta1.ClusterRoleBind
 		Resource("clusterrolebindings").
 		Name(clusterRoleBinding.Name).
 		Body(clusterRoleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *clusterRoleBindings) Delete(name string, options *v1.DeleteOptions) err
 		Resource("clusterrolebindings").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *clusterRoleBindings) DeleteCollection(options *v1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *clusterRoleBindings) Patch(name string, pt types.PatchType, data []byte
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/role.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/rbac/v1beta1"
@@ -70,7 +71,7 @@ func (c *roles) Get(name string, options v1.GetOptions) (result *v1beta1.Role, e
 		Resource("roles").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *roles) List(opts v1.ListOptions) (result *v1beta1.RoleList, err error) 
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *roles) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("roles").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a role and creates it.  Returns the server's representation of the role, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *roles) Create(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 		Namespace(c.ns).
 		Resource("roles").
 		Body(role).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *roles) Update(role *v1beta1.Role) (result *v1beta1.Role, err error) {
 		Resource("roles").
 		Name(role.Name).
 		Body(role).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *roles) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("roles").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *roles) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListO
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *roles) Patch(name string, pt types.PatchType, data []byte, subresources
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/rolebinding.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/rbac/v1beta1"
@@ -70,7 +71,7 @@ func (c *roleBindings) Get(name string, options v1.GetOptions) (result *v1beta1.
 		Resource("rolebindings").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *roleBindings) List(opts v1.ListOptions) (result *v1beta1.RoleBindingLis
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *roleBindings) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("rolebindings").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a roleBinding and creates it.  Returns the server's representation of the roleBinding, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *roleBindings) Create(roleBinding *v1beta1.RoleBinding) (result *v1beta1
 		Namespace(c.ns).
 		Resource("rolebindings").
 		Body(roleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *roleBindings) Update(roleBinding *v1beta1.RoleBinding) (result *v1beta1
 		Resource("rolebindings").
 		Name(roleBinding.Name).
 		Body(roleBinding).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *roleBindings) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("rolebindings").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *roleBindings) DeleteCollection(options *v1.DeleteOptions, listOptions v
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *roleBindings) Patch(name string, pt types.PatchType, data []byte, subre
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/priorityclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/scheduling/v1"
@@ -67,7 +68,7 @@ func (c *priorityClasses) Get(name string, options metav1.GetOptions) (result *v
 		Resource("priorityclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *priorityClasses) List(opts metav1.ListOptions) (result *v1.PriorityClas
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *priorityClasses) Watch(opts metav1.ListOptions) (watch.Interface, error
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *priorityClasses) Create(priorityClass *v1.PriorityClass) (result *v1.Pr
 	err = c.client.Post().
 		Resource("priorityclasses").
 		Body(priorityClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *priorityClasses) Update(priorityClass *v1.PriorityClass) (result *v1.Pr
 		Resource("priorityclasses").
 		Name(priorityClass.Name).
 		Body(priorityClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *priorityClasses) Delete(name string, options *metav1.DeleteOptions) err
 		Resource("priorityclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *priorityClasses) DeleteCollection(options *metav1.DeleteOptions, listOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *priorityClasses) Patch(name string, pt types.PatchType, data []byte, su
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/priorityclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/scheduling/v1alpha1"
@@ -67,7 +68,7 @@ func (c *priorityClasses) Get(name string, options v1.GetOptions) (result *v1alp
 		Resource("priorityclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1alpha1.PriorityCl
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *priorityClasses) Create(priorityClass *v1alpha1.PriorityClass) (result 
 	err = c.client.Post().
 		Resource("priorityclasses").
 		Body(priorityClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *priorityClasses) Update(priorityClass *v1alpha1.PriorityClass) (result 
 		Resource("priorityclasses").
 		Name(priorityClass.Name).
 		Body(priorityClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *priorityClasses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("priorityclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *priorityClasses) DeleteCollection(options *v1.DeleteOptions, listOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *priorityClasses) Patch(name string, pt types.PatchType, data []byte, su
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/priorityclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/scheduling/v1beta1"
@@ -67,7 +68,7 @@ func (c *priorityClasses) Get(name string, options v1.GetOptions) (result *v1bet
 		Resource("priorityclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *priorityClasses) List(opts v1.ListOptions) (result *v1beta1.PriorityCla
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *priorityClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("priorityclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a priorityClass and creates it.  Returns the server's representation of the priorityClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *priorityClasses) Create(priorityClass *v1beta1.PriorityClass) (result *
 	err = c.client.Post().
 		Resource("priorityclasses").
 		Body(priorityClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *priorityClasses) Update(priorityClass *v1beta1.PriorityClass) (result *
 		Resource("priorityclasses").
 		Name(priorityClass.Name).
 		Body(priorityClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *priorityClasses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("priorityclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *priorityClasses) DeleteCollection(options *v1.DeleteOptions, listOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *priorityClasses) Patch(name string, pt types.PatchType, data []byte, su
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/podpreset.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/settings/v1alpha1"
@@ -70,7 +71,7 @@ func (c *podPresets) Get(name string, options v1.GetOptions) (result *v1alpha1.P
 		Resource("podpresets").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -87,7 +88,7 @@ func (c *podPresets) List(opts v1.ListOptions) (result *v1alpha1.PodPresetList, 
 		Resource("podpresets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *podPresets) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("podpresets").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a podPreset and creates it.  Returns the server's representation of the podPreset, and an error, if there is any.
@@ -114,7 +115,7 @@ func (c *podPresets) Create(podPreset *v1alpha1.PodPreset) (result *v1alpha1.Pod
 		Namespace(c.ns).
 		Resource("podpresets").
 		Body(podPreset).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -127,7 +128,7 @@ func (c *podPresets) Update(podPreset *v1alpha1.PodPreset) (result *v1alpha1.Pod
 		Resource("podpresets").
 		Name(podPreset.Name).
 		Body(podPreset).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -139,7 +140,7 @@ func (c *podPresets) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("podpresets").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -155,7 +156,7 @@ func (c *podPresets) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -168,7 +169,7 @@ func (c *podPresets) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/csinode.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/storage/v1"
@@ -67,7 +68,7 @@ func (c *cSINodes) Get(name string, options metav1.GetOptions) (result *v1.CSINo
 		Resource("csinodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *cSINodes) List(opts metav1.ListOptions) (result *v1.CSINodeList, err er
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *cSINodes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a cSINode and creates it.  Returns the server's representation of the cSINode, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *cSINodes) Create(cSINode *v1.CSINode) (result *v1.CSINode, err error) {
 	err = c.client.Post().
 		Resource("csinodes").
 		Body(cSINode).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *cSINodes) Update(cSINode *v1.CSINode) (result *v1.CSINode, err error) {
 		Resource("csinodes").
 		Name(cSINode.Name).
 		Body(cSINode).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *cSINodes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("csinodes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *cSINodes) DeleteCollection(options *metav1.DeleteOptions, listOptions m
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *cSINodes) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/storageclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/storage/v1"
@@ -67,7 +68,7 @@ func (c *storageClasses) Get(name string, options metav1.GetOptions) (result *v1
 		Resource("storageclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *storageClasses) List(opts metav1.ListOptions) (result *v1.StorageClassL
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *storageClasses) Watch(opts metav1.ListOptions) (watch.Interface, error)
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *storageClasses) Create(storageClass *v1.StorageClass) (result *v1.Stora
 	err = c.client.Post().
 		Resource("storageclasses").
 		Body(storageClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *storageClasses) Update(storageClass *v1.StorageClass) (result *v1.Stora
 		Resource("storageclasses").
 		Name(storageClass.Name).
 		Body(storageClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *storageClasses) Delete(name string, options *metav1.DeleteOptions) erro
 		Resource("storageclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *storageClasses) DeleteCollection(options *metav1.DeleteOptions, listOpt
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *storageClasses) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/volumeattachment.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/api/storage/v1"
@@ -68,7 +69,7 @@ func (c *volumeAttachments) Get(name string, options metav1.GetOptions) (result 
 		Resource("volumeattachments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *volumeAttachments) List(opts metav1.ListOptions) (result *v1.VolumeAtta
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *volumeAttachments) Watch(opts metav1.ListOptions) (watch.Interface, err
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *volumeAttachments) Create(volumeAttachment *v1.VolumeAttachment) (resul
 	err = c.client.Post().
 		Resource("volumeattachments").
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *volumeAttachments) Update(volumeAttachment *v1.VolumeAttachment) (resul
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *volumeAttachments) UpdateStatus(volumeAttachment *v1.VolumeAttachment) 
 		Name(volumeAttachment.Name).
 		SubResource("status").
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *volumeAttachments) Delete(name string, options *metav1.DeleteOptions) e
 		Resource("volumeattachments").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *volumeAttachments) DeleteCollection(options *metav1.DeleteOptions, list
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *volumeAttachments) Patch(name string, pt types.PatchType, data []byte, 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/volumeattachment.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1alpha1 "k8s.io/api/storage/v1alpha1"
@@ -68,7 +69,7 @@ func (c *volumeAttachments) Get(name string, options v1.GetOptions) (result *v1a
 		Resource("volumeattachments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1alpha1.VolumeAt
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *volumeAttachments) Watch(opts v1.ListOptions) (watch.Interface, error) 
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *volumeAttachments) Create(volumeAttachment *v1alpha1.VolumeAttachment) 
 	err = c.client.Post().
 		Resource("volumeattachments").
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *volumeAttachments) Update(volumeAttachment *v1alpha1.VolumeAttachment) 
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *volumeAttachments) UpdateStatus(volumeAttachment *v1alpha1.VolumeAttach
 		Name(volumeAttachment.Name).
 		SubResource("status").
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *volumeAttachments) Delete(name string, options *v1.DeleteOptions) error
 		Resource("volumeattachments").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *volumeAttachments) DeleteCollection(options *v1.DeleteOptions, listOpti
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *volumeAttachments) Patch(name string, pt types.PatchType, data []byte, 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csidriver.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/storage/v1beta1"
@@ -67,7 +68,7 @@ func (c *cSIDrivers) Get(name string, options v1.GetOptions) (result *v1beta1.CS
 		Resource("csidrivers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *cSIDrivers) List(opts v1.ListOptions) (result *v1beta1.CSIDriverList, e
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *cSIDrivers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("csidrivers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a cSIDriver and creates it.  Returns the server's representation of the cSIDriver, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *cSIDrivers) Create(cSIDriver *v1beta1.CSIDriver) (result *v1beta1.CSIDr
 	err = c.client.Post().
 		Resource("csidrivers").
 		Body(cSIDriver).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *cSIDrivers) Update(cSIDriver *v1beta1.CSIDriver) (result *v1beta1.CSIDr
 		Resource("csidrivers").
 		Name(cSIDriver.Name).
 		Body(cSIDriver).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *cSIDrivers) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("csidrivers").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *cSIDrivers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *cSIDrivers) Patch(name string, pt types.PatchType, data []byte, subreso
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/csinode.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/storage/v1beta1"
@@ -67,7 +68,7 @@ func (c *cSINodes) Get(name string, options v1.GetOptions) (result *v1beta1.CSIN
 		Resource("csinodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *cSINodes) List(opts v1.ListOptions) (result *v1beta1.CSINodeList, err e
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *cSINodes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("csinodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a cSINode and creates it.  Returns the server's representation of the cSINode, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *cSINodes) Create(cSINode *v1beta1.CSINode) (result *v1beta1.CSINode, er
 	err = c.client.Post().
 		Resource("csinodes").
 		Body(cSINode).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *cSINodes) Update(cSINode *v1beta1.CSINode) (result *v1beta1.CSINode, er
 		Resource("csinodes").
 		Name(cSINode.Name).
 		Body(cSINode).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *cSINodes) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("csinodes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *cSINodes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *cSINodes) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/storageclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/storage/v1beta1"
@@ -67,7 +68,7 @@ func (c *storageClasses) Get(name string, options v1.GetOptions) (result *v1beta
 		Resource("storageclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *storageClasses) List(opts v1.ListOptions) (result *v1beta1.StorageClass
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *storageClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("storageclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a storageClass and creates it.  Returns the server's representation of the storageClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *storageClasses) Create(storageClass *v1beta1.StorageClass) (result *v1b
 	err = c.client.Post().
 		Resource("storageclasses").
 		Body(storageClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *storageClasses) Update(storageClass *v1beta1.StorageClass) (result *v1b
 		Resource("storageclasses").
 		Name(storageClass.Name).
 		Body(storageClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *storageClasses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("storageclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *storageClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *storageClasses) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/volumeattachment.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1beta1 "k8s.io/api/storage/v1beta1"
@@ -68,7 +69,7 @@ func (c *volumeAttachments) Get(name string, options v1.GetOptions) (result *v1b
 		Resource("volumeattachments").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *volumeAttachments) List(opts v1.ListOptions) (result *v1beta1.VolumeAtt
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *volumeAttachments) Watch(opts v1.ListOptions) (watch.Interface, error) 
 		Resource("volumeattachments").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a volumeAttachment and creates it.  Returns the server's representation of the volumeAttachment, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *volumeAttachments) Create(volumeAttachment *v1beta1.VolumeAttachment) (
 	err = c.client.Post().
 		Resource("volumeattachments").
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *volumeAttachments) Update(volumeAttachment *v1beta1.VolumeAttachment) (
 		Resource("volumeattachments").
 		Name(volumeAttachment.Name).
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *volumeAttachments) UpdateStatus(volumeAttachment *v1beta1.VolumeAttachm
 		Name(volumeAttachment.Name).
 		SubResource("status").
 		Body(volumeAttachment).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *volumeAttachments) Delete(name string, options *v1.DeleteOptions) error
 		Resource("volumeattachments").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *volumeAttachments) DeleteCollection(options *v1.DeleteOptions, listOpti
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *volumeAttachments) Patch(name string, pt types.PatchType, data []byte, 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/metadata/metadata.go
+++ b/staging/src/k8s.io/client-go/metadata/metadata.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metadata
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -135,7 +136,7 @@ func (c *client) Delete(name string, opts *metav1.DeleteOptions, subresources ..
 		Delete().
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(deleteOptionsByte).
-		Do()
+		Do(context.TODO())
 	return result.Error()
 }
 
@@ -154,7 +155,7 @@ func (c *client) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1
 		AbsPath(c.makeURLSegments("")...).
 		Body(deleteOptionsByte).
 		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	return result.Error()
 }
 
@@ -166,7 +167,7 @@ func (c *client) Get(name string, opts metav1.GetOptions, subresources ...string
 	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -202,7 +203,7 @@ func (c *client) List(opts metav1.ListOptions) (*metav1.PartialObjectMetadataLis
 	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).
 		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadataList;g=meta.k8s.io;v=v1,application/json").
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -242,7 +243,7 @@ func (c *client) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Patch modifies the named resource in the specified scope (namespace or cluster).
@@ -256,7 +257,7 @@ func (c *client) Patch(name string, pt types.PatchType, data []byte, opts metav1
 		Body(data).
 		SetHeader("Accept", "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/json").
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/rest/client_test.go
+++ b/staging/src/k8s.io/client-go/rest/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package rest
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -79,7 +80,7 @@ func TestDoRequestSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	body, err := c.Get().Prefix("test").Do().Raw()
+	body, err := c.Get().Prefix("test").Do(context.Background()).Raw()
 
 	testParam := TestParam{actualError: err, expectingError: false, expCreated: true,
 		expStatus: status, testBody: true, testBodyErrorIsNotNil: false}
@@ -107,7 +108,7 @@ func TestDoRequestFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	err = c.Get().Do().Error()
+	err = c.Get().Do(context.Background()).Error()
 	if err == nil {
 		t.Errorf("unexpected non-error")
 	}
@@ -146,7 +147,7 @@ func TestDoRawRequestFailed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	body, err := c.Get().Do().Raw()
+	body, err := c.Get().Do(context.Background()).Raw()
 
 	if err == nil || body == nil {
 		t.Errorf("unexpected non-error: %#v", body)
@@ -170,7 +171,7 @@ func TestDoRequestCreated(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	created := false
-	body, err := c.Get().Prefix("test").Do().WasCreated(&created).Raw()
+	body, err := c.Get().Prefix("test").Do(context.Background()).WasCreated(&created).Raw()
 
 	testParam := TestParam{actualError: err, expectingError: false, expCreated: true,
 		expStatus: status, testBody: false}
@@ -185,7 +186,7 @@ func TestDoRequestNotCreated(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	created := false
-	body, err := c.Get().Prefix("test").Do().WasCreated(&created).Raw()
+	body, err := c.Get().Prefix("test").Do(context.Background()).WasCreated(&created).Raw()
 	testParam := TestParam{actualError: err, expectingError: false, expCreated: false,
 		expStatus: expectedStatus, testBody: false}
 	validate(testParam, t, body, fakeHandler)
@@ -200,7 +201,7 @@ func TestDoRequestAcceptedNoContentReturned(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	created := false
-	body, err := c.Get().Prefix("test").Do().WasCreated(&created).Raw()
+	body, err := c.Get().Prefix("test").Do(context.Background()).WasCreated(&created).Raw()
 	testParam := TestParam{actualError: err, expectingError: false, expCreated: false,
 		testBody: false}
 	validate(testParam, t, body, fakeHandler)
@@ -214,7 +215,7 @@ func TestBadRequest(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	created := false
-	body, err := c.Get().Prefix("test").Do().WasCreated(&created).Raw()
+	body, err := c.Get().Prefix("test").Do(context.Background()).WasCreated(&created).Raw()
 	testParam := TestParam{actualError: err, expectingError: true, expCreated: false,
 		testBody: true}
 	validate(testParam, t, body, fakeHandler)

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -786,6 +786,7 @@ func (r *Request) request(ctx context.Context, fn func(*http.Request, *http.Resp
 	maxRetries := 10
 	retries := 0
 	for {
+
 		url := r.URL().String()
 		req, err := http.NewRequest(r.verb, url, r.body)
 		if err != nil {

--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -94,9 +94,9 @@ func TestRequestSetsHeaders(t *testing.T) {
 	r.c.Client = server
 
 	// Check if all "issue" methods are setting headers.
-	_ = r.Do()
-	_, _ = r.Watch()
-	_, _ = r.Stream()
+	_ = r.Do(context.Background())
+	_, _ = r.Watch(context.Background())
+	_, _ = r.Stream(context.Background())
 }
 
 func TestRequestWithErrorWontChange(t *testing.T) {
@@ -1059,7 +1059,7 @@ func TestRequestWatch(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Run("", func(t *testing.T) {
 			testCase.Request.backoff = &NoBackoff{}
-			watch, err := testCase.Request.Watch()
+			watch, err := testCase.Request.Watch(context.Background())
 			hasErr := err != nil
 			if hasErr != testCase.Err {
 				t.Fatalf("expected %t, got %t: %v", testCase.Err, hasErr, err)
@@ -1162,7 +1162,7 @@ func TestRequestStream(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		testCase.Request.backoff = &NoBackoff{}
-		body, err := testCase.Request.Stream()
+		body, err := testCase.Request.Stream(context.Background())
 		hasErr := err != nil
 		if hasErr != testCase.Err {
 			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
@@ -1240,7 +1240,7 @@ func TestRequestDo(t *testing.T) {
 	}
 	for i, testCase := range testCases {
 		testCase.Request.backoff = &NoBackoff{}
-		body, err := testCase.Request.Do().Raw()
+		body, err := testCase.Request.Do(context.Background()).Raw()
 		hasErr := err != nil
 		if hasErr != testCase.Err {
 			t.Errorf("%d: expected %t, got %t: %v", i, testCase.Err, hasErr, err)
@@ -1272,7 +1272,7 @@ func TestDoRequestNewWay(t *testing.T) {
 		Suffix("baz").
 		Timeout(time.Second).
 		Body([]byte(reqBody)).
-		Do().Get()
+		Do(context.Background()).Get()
 	if err != nil {
 		t.Errorf("Unexpected error: %v %#v", err, err)
 		return
@@ -1323,7 +1323,7 @@ func TestBackoffLifecycle(t *testing.T) {
 			t.Errorf("Backoff is %v instead of %v", thisBackoff, sec)
 		}
 		now := clock.Now()
-		request.DoRaw()
+		request.DoRaw(context.Background())
 		elapsed := clock.Since(now)
 		if clock.Since(now) != thisBackoff {
 			t.Errorf("CalculatedBackoff not honored by clock: Expected time of %v, but got %v ", thisBackoff, elapsed)
@@ -1372,7 +1372,7 @@ func TestCheckRetryClosesBody(t *testing.T) {
 		Suffix("baz").
 		Timeout(time.Second).
 		Body([]byte(strings.Repeat("abcd", 1000))).
-		DoRaw()
+		DoRaw(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v %#v", err, err)
 	}
@@ -1405,7 +1405,7 @@ func TestConnectionResetByPeerIsRetried(t *testing.T) {
 		backoff: backoff,
 	}
 	// We expect two retries of "connection reset by peer" and the success.
-	_, err := req.Do().Raw()
+	_, err := req.Do(context.Background()).Raw()
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
@@ -1445,7 +1445,7 @@ func TestCheckRetryHandles429And5xx(t *testing.T) {
 		Suffix("baz").
 		Timeout(time.Second).
 		Body([]byte(strings.Repeat("abcd", 1000))).
-		DoRaw()
+		DoRaw(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v %#v", err, err)
 	}
@@ -1481,7 +1481,7 @@ func BenchmarkCheckRetryClosesBody(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if _, err := requests[i].DoRaw(); err != nil {
+		if _, err := requests[i].DoRaw(context.Background()); err != nil {
 			b.Fatalf("Unexpected error (%d/%d): %v", i, b.N, err)
 		}
 	}
@@ -1510,7 +1510,7 @@ func TestDoRequestNewWayReader(t *testing.T) {
 		Prefix("foo").
 		Timeout(time.Second).
 		Body(bytes.NewBuffer(reqBodyExpected)).
-		Do().Get()
+		Do(context.Background()).Get()
 	if err != nil {
 		t.Errorf("Unexpected error: %v %#v", err, err)
 		return
@@ -1549,7 +1549,7 @@ func TestDoRequestNewWayObj(t *testing.T) {
 		Resource("foo").
 		Timeout(time.Second).
 		Body(reqObj).
-		Do().Get()
+		Do(context.Background()).Get()
 	if err != nil {
 		t.Errorf("Unexpected error: %v %#v", err, err)
 		return
@@ -1603,7 +1603,7 @@ func TestDoRequestNewWayFile(t *testing.T) {
 		Prefix("foo/bar", "baz").
 		Timeout(time.Second).
 		Body(file.Name()).
-		Do().WasCreated(&wasCreated).Get()
+		Do(context.Background()).WasCreated(&wasCreated).Get()
 	if err != nil {
 		t.Errorf("Unexpected error: %v %#v", err, err)
 		return
@@ -1648,7 +1648,7 @@ func TestWasCreated(t *testing.T) {
 		Prefix("foo/bar", "baz").
 		Timeout(time.Second).
 		Body(reqBodyExpected).
-		Do().WasCreated(&wasCreated).Get()
+		Do(context.Background()).WasCreated(&wasCreated).Get()
 	if err != nil {
 		t.Errorf("Unexpected error: %v %#v", err, err)
 		return
@@ -1831,7 +1831,7 @@ func TestWatch(t *testing.T) {
 	defer testServer.Close()
 
 	s := testRESTClient(t, testServer)
-	watching, err := s.Get().Prefix("path/to/watch/thing").Watch()
+	watching, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -1891,7 +1891,7 @@ func TestWatchNonDefaultContentType(t *testing.T) {
 	contentConfig := defaultContentConfig()
 	contentConfig.ContentType = "application/vnd.kubernetes.protobuf"
 	s := testRESTClientWithConfig(t, testServer, contentConfig)
-	watching, err := s.Get().Prefix("path/to/watch/thing").Watch()
+	watching, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
 	if err != nil {
 		t.Fatalf("Unexpected error")
 	}
@@ -1948,7 +1948,7 @@ func TestWatchUnknownContentType(t *testing.T) {
 	defer testServer.Close()
 
 	s := testRESTClient(t, testServer)
-	_, err := s.Get().Prefix("path/to/watch/thing").Watch()
+	_, err := s.Get().Prefix("path/to/watch/thing").Watch(context.Background())
 	if err == nil {
 		t.Fatalf("Expected to fail due to lack of known stream serialization for content type")
 	}
@@ -1970,7 +1970,7 @@ func TestStream(t *testing.T) {
 	defer testServer.Close()
 
 	s := testRESTClient(t, testServer)
-	readCloser, err := s.Get().Prefix("path/to/stream/thing").Stream()
+	readCloser, err := s.Get().Prefix("path/to/stream/thing").Stream(context.Background())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -2028,9 +2028,8 @@ func TestDoContext(t *testing.T) {
 
 	c := testRESTClient(t, testServer)
 	_, err := c.Verb("GET").
-		Context(ctx).
 		Prefix("foo").
-		DoRaw()
+		DoRaw(ctx)
 	if err == nil {
 		t.Fatal("Expected context cancellation error")
 	}

--- a/staging/src/k8s.io/client-go/scale/client.go
+++ b/staging/src/k8s.io/client-go/scale/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scale
 
 import (
+	"context"
 	"fmt"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
@@ -154,7 +155,7 @@ func (c *namespacedScaleClient) Get(resource schema.GroupResource, name string) 
 		Resource(gvr.Resource).
 		Name(name).
 		SubResource("scale").
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -196,7 +197,7 @@ func (c *namespacedScaleClient) Update(resource schema.GroupResource, scale *aut
 		Name(scale.Name).
 		SubResource("scale").
 		Body(scaleUpdateBytes).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		// propagate "raw" error from the API
 		// this allows callers to interpret underlying Reason field
@@ -216,7 +217,7 @@ func (c *namespacedScaleClient) Patch(gvr schema.GroupVersionResource, name stri
 		Name(name).
 		SubResource("scale").
 		Body(data).
-		Do()
+		Do(context.TODO())
 	if err := result.Error(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/tools/cache/listwatch.go
+++ b/staging/src/k8s.io/client-go/tools/cache/listwatch.go
@@ -17,6 +17,8 @@ limitations under the License.
 package cache
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -82,7 +84,7 @@ func NewFilteredListWatchFromClient(c Getter, resource string, namespace string,
 			Namespace(namespace).
 			Resource(resource).
 			VersionedParams(&options, metav1.ParameterCodec).
-			Do().
+			Do(context.TODO()).
 			Get()
 	}
 	watchFunc := func(options metav1.ListOptions) (watch.Interface, error) {
@@ -92,7 +94,7 @@ func NewFilteredListWatchFromClient(c Getter, resource string, namespace string,
 			Namespace(namespace).
 			Resource(resource).
 			VersionedParams(&options, metav1.ParameterCodec).
-			Watch()
+			Watch(context.TODO())
 	}
 	return &ListWatch{ListFunc: listFunc, WatchFunc: watchFunc}
 }

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +73,7 @@ func (c *clusterTestTypes) Get(name string, options metav1.GetOptions) (result *
 		Resource("clustertesttypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *clusterTestTypes) Watch(opts metav1.ListOptions) (watch.Interface, erro
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterTestType and creates it.  Returns the server's representation of the clusterTestType, and an error, if there is any.
@@ -113,7 +114,7 @@ func (c *clusterTestTypes) Create(clusterTestType *v1.ClusterTestType) (result *
 	err = c.client.Post().
 		Resource("clustertesttypes").
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -125,7 +126,7 @@ func (c *clusterTestTypes) Update(clusterTestType *v1.ClusterTestType) (result *
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -140,7 +141,7 @@ func (c *clusterTestTypes) UpdateStatus(clusterTestType *v1.ClusterTestType) (re
 		Name(clusterTestType.Name).
 		SubResource("status").
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -151,7 +152,7 @@ func (c *clusterTestTypes) Delete(name string, options *metav1.DeleteOptions) er
 		Resource("clustertesttypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -166,7 +167,7 @@ func (c *clusterTestTypes) DeleteCollection(options *metav1.DeleteOptions, listO
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -178,7 +179,7 @@ func (c *clusterTestTypes) Patch(name string, pt types.PatchType, data []byte, s
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -191,7 +192,7 @@ func (c *clusterTestTypes) GetScale(clusterTestTypeName string, options metav1.G
 		Name(clusterTestTypeName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -204,7 +205,7 @@ func (c *clusterTestTypes) UpdateScale(clusterTestTypeName string, scale *autosc
 		Name(clusterTestTypeName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options metav1.GetOptions) (result *v1.Test
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, er
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +73,7 @@ func (c *clusterTestTypes) Get(name string, options metav1.GetOptions) (result *
 		Resource("clustertesttypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *clusterTestTypes) Watch(opts metav1.ListOptions) (watch.Interface, erro
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterTestType and creates it.  Returns the server's representation of the clusterTestType, and an error, if there is any.
@@ -113,7 +114,7 @@ func (c *clusterTestTypes) Create(clusterTestType *v1.ClusterTestType) (result *
 	err = c.client.Post().
 		Resource("clustertesttypes").
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -125,7 +126,7 @@ func (c *clusterTestTypes) Update(clusterTestType *v1.ClusterTestType) (result *
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -140,7 +141,7 @@ func (c *clusterTestTypes) UpdateStatus(clusterTestType *v1.ClusterTestType) (re
 		Name(clusterTestType.Name).
 		SubResource("status").
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -151,7 +152,7 @@ func (c *clusterTestTypes) Delete(name string, options *metav1.DeleteOptions) er
 		Resource("clustertesttypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -166,7 +167,7 @@ func (c *clusterTestTypes) DeleteCollection(options *metav1.DeleteOptions, listO
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -178,7 +179,7 @@ func (c *clusterTestTypes) Patch(name string, pt types.PatchType, data []byte, s
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -191,7 +192,7 @@ func (c *clusterTestTypes) GetScale(clusterTestTypeName string, options metav1.G
 		Name(clusterTestTypeName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -204,7 +205,7 @@ func (c *clusterTestTypes) UpdateScale(clusterTestTypeName string, scale *autosc
 		Name(clusterTestTypeName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options metav1.GetOptions) (result *v1.Test
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, er
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options v1.GetOptions) (result *example.Tes
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example.TestTypeList, err
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *example.TestType) (result *example.TestType
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *example.TestType) (result *example.TestType
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *example.TestType) (result *example.Te
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +69,7 @@ func (c *testTypes) Get(name string, options v1.GetOptions) (result *example2.Te
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example2.TestTypeList, er
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *testTypes) Create(testType *example2.TestType) (result *example2.TestTy
 	err = c.client.Post().
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *testTypes) Update(testType *example2.TestType) (result *example2.TestTy
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *testTypes) UpdateStatus(testType *example2.TestType) (result *example2.
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *testTypes) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *testTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package internalversion
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options v1.GetOptions) (result *example3io.
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts v1.ListOptions) (result *example3io.TestTypeList, 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *example3io.TestType) (result *example3io.Te
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *example3io.TestType) (result *example3io.Te
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *example3io.TestType) (result *example
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *v1.DeleteOptions, listOptions v1.L
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options metav1.GetOptions) (result *v1.Test
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, er
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options metav1.GetOptions) (result *v1.Test
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, er
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options metav1.GetOptions) (result *v1.Test
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, er
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +73,7 @@ func (c *clusterTestTypes) Get(name string, options metav1.GetOptions) (result *
 		Resource("clustertesttypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *clusterTestTypes) List(opts metav1.ListOptions) (result *v1.ClusterTest
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -104,7 +105,7 @@ func (c *clusterTestTypes) Watch(opts metav1.ListOptions) (watch.Interface, erro
 		Resource("clustertesttypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a clusterTestType and creates it.  Returns the server's representation of the clusterTestType, and an error, if there is any.
@@ -113,7 +114,7 @@ func (c *clusterTestTypes) Create(clusterTestType *v1.ClusterTestType) (result *
 	err = c.client.Post().
 		Resource("clustertesttypes").
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -125,7 +126,7 @@ func (c *clusterTestTypes) Update(clusterTestType *v1.ClusterTestType) (result *
 		Resource("clustertesttypes").
 		Name(clusterTestType.Name).
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -140,7 +141,7 @@ func (c *clusterTestTypes) UpdateStatus(clusterTestType *v1.ClusterTestType) (re
 		Name(clusterTestType.Name).
 		SubResource("status").
 		Body(clusterTestType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -151,7 +152,7 @@ func (c *clusterTestTypes) Delete(name string, options *metav1.DeleteOptions) er
 		Resource("clustertesttypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -166,7 +167,7 @@ func (c *clusterTestTypes) DeleteCollection(options *metav1.DeleteOptions, listO
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -178,7 +179,7 @@ func (c *clusterTestTypes) Patch(name string, pt types.PatchType, data []byte, s
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -191,7 +192,7 @@ func (c *clusterTestTypes) GetScale(clusterTestTypeName string, options metav1.G
 		Name(clusterTestTypeName).
 		SubResource("scale").
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -204,7 +205,7 @@ func (c *clusterTestTypes) UpdateScale(clusterTestTypeName string, scale *autosc
 		Name(clusterTestTypeName).
 		SubResource("scale").
 		Body(scale).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options metav1.GetOptions) (result *v1.Test
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, er
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/testtype.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *testTypes) Get(name string, options metav1.GetOptions) (result *v1.Test
 		Resource("testtypes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *testTypes) List(opts metav1.ListOptions) (result *v1.TestTypeList, err 
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *testTypes) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("testtypes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a testType and creates it.  Returns the server's representation of the testType, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *testTypes) Create(testType *v1.TestType) (result *v1.TestType, err erro
 		Namespace(c.ns).
 		Resource("testtypes").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *testTypes) Update(testType *v1.TestType) (result *v1.TestType, err erro
 		Resource("testtypes").
 		Name(testType.Name).
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *testTypes) UpdateStatus(testType *v1.TestType) (result *v1.TestType, er
 		Name(testType.Name).
 		SubResource("status").
 		Body(testType).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *testTypes) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("testtypes").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *testTypes) DeleteCollection(options *metav1.DeleteOptions, listOptions 
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *testTypes) Patch(name string, pt types.PatchType, data []byte, subresou
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/generator_for_type.go
@@ -397,7 +397,7 @@ func (c *$.type|privatePlural$) List(opts $.ListOptions|raw$) (result *$.resultT
 		Resource("$.type|resource$").
 		VersionedParams(&opts, $.schemeParameterCodec|raw$).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -418,7 +418,7 @@ func (c *$.type|privatePlural$) List($.type|private$Name string, opts $.ListOpti
 		SubResource("$.subresourcePath$").
 		VersionedParams(&opts, $.schemeParameterCodec|raw$).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -433,7 +433,7 @@ func (c *$.type|privatePlural$) Get(name string, options $.GetOptions|raw$) (res
 		Resource("$.type|resource$").
 		Name(name).
 		VersionedParams(&options, $.schemeParameterCodec|raw$).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -449,7 +449,7 @@ func (c *$.type|privatePlural$) Get($.type|private$Name string, options $.GetOpt
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
 		VersionedParams(&options, $.schemeParameterCodec|raw$).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -463,7 +463,7 @@ func (c *$.type|privatePlural$) Delete(name string, options *$.DeleteOptions|raw
 		Resource("$.type|resource$").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 `
@@ -481,7 +481,7 @@ func (c *$.type|privatePlural$) DeleteCollection(options *$.DeleteOptions|raw$, 
 		VersionedParams(&listOptions, $.schemeParameterCodec|raw$).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 `
@@ -496,7 +496,7 @@ func (c *$.type|privatePlural$) Create($.type|private$Name string, $.inputType|p
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
 		Body($.inputType|private$).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -510,7 +510,7 @@ func (c *$.type|privatePlural$) Create($.inputType|private$ *$.inputType|raw$) (
 		$if .namespaced$Namespace(c.ns).$end$
 		Resource("$.type|resource$").
 		Body($.inputType|private$).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -526,7 +526,7 @@ func (c *$.type|privatePlural$) Update($.type|private$Name string, $.inputType|p
 		Name($.type|private$Name).
 		SubResource("$.subresourcePath$").
 		Body($.inputType|private$).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -541,7 +541,7 @@ func (c *$.type|privatePlural$) Update($.inputType|private$ *$.inputType|raw$) (
 		Resource("$.type|resource$").
 		Name($.inputType|private$.Name).
 		Body($.inputType|private$).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -559,7 +559,7 @@ func (c *$.type|privatePlural$) UpdateStatus($.type|private$ *$.type|raw$) (resu
 		Name($.type|private$.Name).
 		SubResource("status").
 		Body($.type|private$).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -578,7 +578,7 @@ func (c *$.type|privatePlural$) Watch(opts $.ListOptions|raw$) ($.watchInterface
 		Resource("$.type|resource$").
 		VersionedParams(&opts, $.schemeParameterCodec|raw$).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 `
 
@@ -592,7 +592,7 @@ func (c *$.type|privatePlural$) Patch(name string, pt $.PatchType|raw$, data []b
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/apiservice.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1
 
 import (
+	"context"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +69,7 @@ func (c *aPIServices) Get(name string, options metav1.GetOptions) (result *v1.AP
 		Resource("apiservices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *aPIServices) List(opts metav1.ListOptions) (result *v1.APIServiceList, 
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *aPIServices) Watch(opts metav1.ListOptions) (watch.Interface, error) {
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *aPIServices) Create(aPIService *v1.APIService) (result *v1.APIService, 
 	err = c.client.Post().
 		Resource("apiservices").
 		Body(aPIService).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *aPIServices) Update(aPIService *v1.APIService) (result *v1.APIService, 
 		Resource("apiservices").
 		Name(aPIService.Name).
 		Body(aPIService).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *aPIServices) UpdateStatus(aPIService *v1.APIService) (result *v1.APISer
 		Name(aPIService.Name).
 		SubResource("status").
 		Body(aPIService).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *aPIServices) Delete(name string, options *metav1.DeleteOptions) error {
 		Resource("apiservices").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *aPIServices) DeleteCollection(options *metav1.DeleteOptions, listOption
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *aPIServices) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/apiservice.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,7 +69,7 @@ func (c *aPIServices) Get(name string, options v1.GetOptions) (result *v1beta1.A
 		Resource("apiservices").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -84,7 +85,7 @@ func (c *aPIServices) List(opts v1.ListOptions) (result *v1beta1.APIServiceList,
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -100,7 +101,7 @@ func (c *aPIServices) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("apiservices").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a aPIService and creates it.  Returns the server's representation of the aPIService, and an error, if there is any.
@@ -109,7 +110,7 @@ func (c *aPIServices) Create(aPIService *v1beta1.APIService) (result *v1beta1.AP
 	err = c.client.Post().
 		Resource("apiservices").
 		Body(aPIService).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -121,7 +122,7 @@ func (c *aPIServices) Update(aPIService *v1beta1.APIService) (result *v1beta1.AP
 		Resource("apiservices").
 		Name(aPIService.Name).
 		Body(aPIService).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -136,7 +137,7 @@ func (c *aPIServices) UpdateStatus(aPIService *v1beta1.APIService) (result *v1be
 		Name(aPIService.Name).
 		SubResource("status").
 		Body(aPIService).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -147,7 +148,7 @@ func (c *aPIServices) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("apiservices").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -162,7 +163,7 @@ func (c *aPIServices) DeleteCollection(options *v1.DeleteOptions, listOptions v1
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -174,7 +175,7 @@ func (c *aPIServices) Patch(name string, pt types.PatchType, data []byte, subres
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -17,6 +17,7 @@ limitations under the License.
 package clusterinfo
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -263,7 +264,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 			}
 
 			for _, request := range requests {
-				data, err := request.DoRaw()
+				data, err := request.DoRaw(context.TODO())
 				if err != nil {
 					// Print error and return.
 					writer.Write([]byte(fmt.Sprintf("Request log error: %s\n", err.Error())))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -18,6 +18,7 @@ package logs
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -404,7 +405,7 @@ func (o LogsOptions) addPrefixIfNeeded(ref corev1.ObjectReference, writer io.Wri
 // Because the function is defined to read from request until io.EOF, it does
 // not treat an io.EOF as an error to be reported.
 func DefaultConsumeRequest(request rest.ResponseWrapper, out io.Writer) error {
-	readCloser, err := request.Stream()
+	readCloser, err := request.Stream(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -18,6 +18,7 @@ package logs
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -667,12 +668,12 @@ type responseWrapperMock struct {
 	err  error
 }
 
-func (r *responseWrapperMock) DoRaw() ([]byte, error) {
+func (r *responseWrapperMock) DoRaw(context.Context) ([]byte, error) {
 	data, _ := ioutil.ReadAll(r.data)
 	return data, r.err
 }
 
-func (r *responseWrapperMock) Stream() (io.ReadCloser, error) {
+func (r *responseWrapperMock) Stream(context.Context) (io.ReadCloser, error) {
 	return ioutil.NopCloser(r.data), r.err
 }
 
@@ -687,7 +688,7 @@ type logTestMock struct {
 }
 
 func (l *logTestMock) mockConsumeRequest(request restclient.ResponseWrapper, out io.Writer) error {
-	readCloser, err := request.Stream()
+	readCloser, err := request.Stream(context.Background())
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_client.go
+++ b/staging/src/k8s.io/kubectl/pkg/metricsutil/metrics_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metricsutil
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -166,5 +167,5 @@ func (cli *HeapsterMetricsClient) GetPodMetrics(namespace string, podName string
 func GetHeapsterMetrics(cli *HeapsterMetricsClient, path string, params map[string]string) ([]byte, error) {
 	return cli.SVCClient.Services(cli.HeapsterNamespace).
 		ProxyGet(cli.HeapsterScheme, cli.HeapsterService, cli.HeapsterPort, path, params).
-		DoRaw()
+		DoRaw(context.TODO())
 }

--- a/staging/src/k8s.io/kubectl/pkg/rawhttp/raw.go
+++ b/staging/src/k8s.io/kubectl/pkg/rawhttp/raw.go
@@ -18,6 +18,7 @@ package rawhttp
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -80,7 +81,7 @@ func raw(restClient *rest.RESTClient, streams genericclioptions.IOStreams, url, 
 		return fmt.Errorf("unknown requestType: %q", requestType)
 	}
 
-	stream, err := request.Stream()
+	stream, err := request.Stream(context.TODO())
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/nodemetrics.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +62,7 @@ func (c *nodeMetricses) Get(name string, options v1.GetOptions) (result *v1alpha
 		Resource("nodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -77,7 +78,7 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1alpha1.NodeMetricsL
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -93,5 +94,5 @@ func (c *nodeMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/podmetrics.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ func (c *podMetricses) Get(name string, options v1.GetOptions) (result *v1alpha1
 		Resource("pods").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -81,7 +82,7 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1alpha1.PodMetricsLis
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -98,5 +99,5 @@ func (c *podMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/nodemetrics.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,7 +62,7 @@ func (c *nodeMetricses) Get(name string, options v1.GetOptions) (result *v1beta1
 		Resource("nodes").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -77,7 +78,7 @@ func (c *nodeMetricses) List(opts v1.ListOptions) (result *v1beta1.NodeMetricsLi
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -93,5 +94,5 @@ func (c *nodeMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("nodes").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/podmetrics.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,7 @@ func (c *podMetricses) Get(name string, options v1.GetOptions) (result *v1beta1.
 		Resource("pods").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -81,7 +82,7 @@ func (c *podMetricses) List(opts v1.ListOptions) (result *v1beta1.PodMetricsList
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -98,5 +99,5 @@ func (c *podMetricses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("pods").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }

--- a/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/custom_metrics/versioned_client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package custom_metrics
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -116,7 +117,7 @@ func (m *rootScopedMetrics) getForNamespace(namespace string, metricName string,
 		Namespace(namespace).
 		Name(metricName).
 		VersionedParams(params, scheme.ParameterCodec).
-		Do()
+		Do(context.TODO())
 
 	metricObj, err := versionConverter.ConvertResultToVersion(result, v1beta2.SchemeGroupVersion)
 	if err != nil {
@@ -158,7 +159,7 @@ func (m *rootScopedMetrics) GetForObject(groupKind schema.GroupKind, name string
 		Name(name).
 		SubResource(metricName).
 		VersionedParams(params, scheme.ParameterCodec).
-		Do()
+		Do(context.TODO())
 
 	metricObj, err := versionConverter.ConvertResultToVersion(result, v1beta2.SchemeGroupVersion)
 	if err != nil {
@@ -201,7 +202,7 @@ func (m *rootScopedMetrics) GetForObjects(groupKind schema.GroupKind, selector l
 		Name(v1beta1.AllObjects).
 		SubResource(metricName).
 		VersionedParams(params, scheme.ParameterCodec).
-		Do()
+		Do(context.TODO())
 
 	metricObj, err := versionConverter.ConvertResultToVersion(result, v1beta2.SchemeGroupVersion)
 	if err != nil {
@@ -240,7 +241,7 @@ func (m *namespacedMetrics) GetForObject(groupKind schema.GroupKind, name string
 		Name(name).
 		SubResource(metricName).
 		VersionedParams(params, scheme.ParameterCodec).
-		Do()
+		Do(context.TODO())
 
 	metricObj, err := versionConverter.ConvertResultToVersion(result, v1beta2.SchemeGroupVersion)
 	if err != nil {
@@ -279,7 +280,7 @@ func (m *namespacedMetrics) GetForObjects(groupKind schema.GroupKind, selector l
 		Name(v1beta1.AllObjects).
 		SubResource(metricName).
 		VersionedParams(params, scheme.ParameterCodec).
-		Do()
+		Do(context.TODO())
 
 	metricObj, err := versionConverter.ConvertResultToVersion(result, v1beta2.SchemeGroupVersion)
 	if err != nil {

--- a/staging/src/k8s.io/metrics/pkg/client/external_metrics/client.go
+++ b/staging/src/k8s.io/metrics/pkg/client/external_metrics/client.go
@@ -17,6 +17,7 @@ limitations under the License.
 package external_metrics
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,7 +89,7 @@ func (m *namespacedMetrics) List(metricName string, metricSelector labels.Select
 		VersionedParams(&metav1.ListOptions{
 			LabelSelector: metricSelector.String(),
 		}, metav1.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(res)
 
 	if err != nil {

--- a/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
+++ b/staging/src/k8s.io/node-api/pkg/client/clientset/versioned/typed/node/v1alpha1/runtimeclass.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,7 +68,7 @@ func (c *runtimeClasses) Get(name string, options v1.GetOptions) (result *v1alph
 		Resource("runtimeclasses").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *runtimeClasses) List(opts v1.ListOptions) (result *v1alpha1.RuntimeClas
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *runtimeClasses) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("runtimeclasses").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a runtimeClass and creates it.  Returns the server's representation of the runtimeClass, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *runtimeClasses) Create(runtimeClass *v1alpha1.RuntimeClass) (result *v1
 	err = c.client.Post().
 		Resource("runtimeclasses").
 		Body(runtimeClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *runtimeClasses) Update(runtimeClass *v1alpha1.RuntimeClass) (result *v1
 		Resource("runtimeclasses").
 		Name(runtimeClass.Name).
 		Body(runtimeClass).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *runtimeClasses) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("runtimeclasses").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *runtimeClasses) DeleteCollection(options *v1.DeleteOptions, listOptions
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *runtimeClasses) Patch(name string, pt types.PatchType, data []byte, sub
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fischer.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -67,7 +68,7 @@ func (c *fischers) Get(name string, options v1.GetOptions) (result *v1alpha1.Fis
 		Resource("fischers").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -83,7 +84,7 @@ func (c *fischers) List(opts v1.ListOptions) (result *v1alpha1.FischerList, err 
 		Resource("fischers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -99,7 +100,7 @@ func (c *fischers) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("fischers").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a fischer and creates it.  Returns the server's representation of the fischer, and an error, if there is any.
@@ -108,7 +109,7 @@ func (c *fischers) Create(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, 
 	err = c.client.Post().
 		Resource("fischers").
 		Body(fischer).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -120,7 +121,7 @@ func (c *fischers) Update(fischer *v1alpha1.Fischer) (result *v1alpha1.Fischer, 
 		Resource("fischers").
 		Name(fischer.Name).
 		Body(fischer).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -131,7 +132,7 @@ func (c *fischers) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("fischers").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -146,7 +147,7 @@ func (c *fischers) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -158,7 +159,7 @@ func (c *fischers) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/flunder.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *flunders) Get(name string, options v1.GetOptions) (result *v1alpha1.Flu
 		Resource("flunders").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1alpha1.FlunderList, err 
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *flunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *flunders) Create(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, 
 		Namespace(c.ns).
 		Resource("flunders").
 		Body(flunder).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *flunders) Update(flunder *v1alpha1.Flunder) (result *v1alpha1.Flunder, 
 		Resource("flunders").
 		Name(flunder.Name).
 		Body(flunder).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *flunders) UpdateStatus(flunder *v1alpha1.Flunder) (result *v1alpha1.Flu
 		Name(flunder.Name).
 		SubResource("status").
 		Body(flunder).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *flunders) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("flunders").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *flunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *flunders) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/flunder.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *flunders) Get(name string, options v1.GetOptions) (result *v1beta1.Flun
 		Resource("flunders").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *flunders) List(opts v1.ListOptions) (result *v1beta1.FlunderList, err e
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *flunders) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("flunders").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a flunder and creates it.  Returns the server's representation of the flunder, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *flunders) Create(flunder *v1beta1.Flunder) (result *v1beta1.Flunder, er
 		Namespace(c.ns).
 		Resource("flunders").
 		Body(flunder).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *flunders) Update(flunder *v1beta1.Flunder) (result *v1beta1.Flunder, er
 		Resource("flunders").
 		Name(flunder.Name).
 		Body(flunder).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *flunders) UpdateStatus(flunder *v1beta1.Flunder) (result *v1beta1.Flund
 		Name(flunder.Name).
 		SubResource("status").
 		Body(flunder).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *flunders) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("flunders").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *flunders) DeleteCollection(options *v1.DeleteOptions, listOptions v1.Li
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *flunders) Patch(name string, pt types.PatchType, data []byte, subresour
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/foo.go
@@ -19,6 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"context"
 	"time"
 
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -71,7 +72,7 @@ func (c *foos) Get(name string, options v1.GetOptions) (result *v1alpha1.Foo, er
 		Resource("foos").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -88,7 +89,7 @@ func (c *foos) List(opts v1.ListOptions) (result *v1alpha1.FooList, err error) {
 		Resource("foos").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -105,7 +106,7 @@ func (c *foos) Watch(opts v1.ListOptions) (watch.Interface, error) {
 		Resource("foos").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
-		Watch()
+		Watch(context.TODO())
 }
 
 // Create takes the representation of a foo and creates it.  Returns the server's representation of the foo, and an error, if there is any.
@@ -115,7 +116,7 @@ func (c *foos) Create(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error) {
 		Namespace(c.ns).
 		Resource("foos").
 		Body(foo).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -128,7 +129,7 @@ func (c *foos) Update(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error) {
 		Resource("foos").
 		Name(foo.Name).
 		Body(foo).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -144,7 +145,7 @@ func (c *foos) UpdateStatus(foo *v1alpha1.Foo) (result *v1alpha1.Foo, err error)
 		Name(foo.Name).
 		SubResource("status").
 		Body(foo).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }
@@ -156,7 +157,7 @@ func (c *foos) Delete(name string, options *v1.DeleteOptions) error {
 		Resource("foos").
 		Name(name).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -172,7 +173,7 @@ func (c *foos) DeleteCollection(options *v1.DeleteOptions, listOptions v1.ListOp
 		VersionedParams(&listOptions, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(options).
-		Do().
+		Do(context.TODO()).
 		Error()
 }
 
@@ -185,7 +186,7 @@ func (c *foos) Patch(name string, pt types.PatchType, data []byte, subresources 
 		SubResource(subresources...).
 		Name(name).
 		Body(data).
-		Do().
+		Do(context.TODO()).
 		Into(result)
 	return
 }

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apimachinery
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -365,7 +366,7 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 
 		request := restClient.Get().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders")
 		request.SetHeader("Accept", "application/json")
-		_, err := request.DoRaw()
+		_, err := request.DoRaw(context.TODO())
 		if err != nil {
 			status, ok := err.(*apierrors.StatusError)
 			if !ok {
@@ -405,7 +406,7 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 	// curl -k -v -XPOST https://localhost/apis/wardle.example.com/v1alpha1/namespaces/default/flunders
 	// Request Body: {"apiVersion":"wardle.example.com/v1alpha1","kind":"Flunder","metadata":{"labels":{"sample-label":"true"},"name":"test-flunder","namespace":"default"}}
 	flunder := `{"apiVersion":"wardle.example.com/v1alpha1","kind":"Flunder","metadata":{"labels":{"sample-label":"true"},"name":"` + flunderName + `","namespace":"default"}}`
-	result := restClient.Post().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders").Body([]byte(flunder)).SetHeader("Accept", "application/json").Do()
+	result := restClient.Post().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders").Body([]byte(flunder)).SetHeader("Accept", "application/json").Do(context.TODO())
 	framework.ExpectNoError(result.Error(), "creating a new flunders resource")
 	var statusCode int
 	result.StatusCode(&statusCode)
@@ -425,7 +426,7 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 
 	// kubectl get flunders -v 9
 	// curl -k -v -XGET https://localhost/apis/wardle.example.com/v1alpha1/namespaces/default/flunders
-	contents, err := restClient.Get().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders").SetHeader("Accept", "application/json").DoRaw()
+	contents, err := restClient.Get().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders").SetHeader("Accept", "application/json").DoRaw(context.TODO())
 	framework.ExpectNoError(err, "attempting to get a newly created flunders resource")
 	var flundersList samplev1alpha1.FlunderList
 	err = json.Unmarshal(contents, &flundersList)
@@ -436,12 +437,12 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 
 	// kubectl delete flunder test-flunder -v 9
 	// curl -k -v -XDELETE  https://35.193.112.40/apis/wardle.example.com/v1alpha1/namespaces/default/flunders/test-flunder
-	_, err = restClient.Delete().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders/" + flunderName).DoRaw()
+	_, err = restClient.Delete().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders/" + flunderName).DoRaw(context.TODO())
 	validateErrorWithDebugInfo(f, err, pods, "attempting to delete a newly created flunders(%v) resource", flundersList.Items)
 
 	// kubectl get flunders -v 9
 	// curl -k -v -XGET https://localhost/apis/wardle.example.com/v1alpha1/namespaces/default/flunders
-	contents, err = restClient.Get().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders").SetHeader("Accept", "application/json").DoRaw()
+	contents, err = restClient.Get().AbsPath("/apis/wardle.example.com/v1alpha1/namespaces/default/flunders").SetHeader("Accept", "application/json").DoRaw(context.TODO())
 	framework.ExpectNoError(err, "confirming delete of a newly created flunders resource")
 	err = json.Unmarshal(contents, &flundersList)
 	validateErrorWithDebugInfo(f, err, pods, "Error in unmarshalling %T response from server %s", contents, "/apis/wardle.example.com/v1alpha1")

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apimachinery
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -197,7 +198,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		{
 			ginkgo.By("fetching the /apis discovery document")
 			apiGroupList := &metav1.APIGroupList{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis").Do().Into(apiGroupList)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis").Do(context.TODO()).Into(apiGroupList)
 			framework.ExpectNoError(err, "fetching /apis")
 
 			ginkgo.By("finding the apiextensions.k8s.io API group in the /apis discovery document")
@@ -224,7 +225,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		{
 			ginkgo.By("fetching the /apis/apiextensions.k8s.io discovery document")
 			group := &metav1.APIGroup{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/apiextensions.k8s.io").Do().Into(group)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/apiextensions.k8s.io").Do(context.TODO()).Into(group)
 			framework.ExpectNoError(err, "fetching /apis/apiextensions.k8s.io")
 			framework.ExpectEqual(group.Name, v1.GroupName, "verifying API group name in /apis/apiextensions.k8s.io discovery document")
 
@@ -242,7 +243,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		{
 			ginkgo.By("fetching the /apis/apiextensions.k8s.io/v1 discovery document")
 			apiResourceList := &metav1.APIResourceList{}
-			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/apiextensions.k8s.io/v1").Do().Into(apiResourceList)
+			err := f.ClientSet.Discovery().RESTClient().Get().AbsPath("/apis/apiextensions.k8s.io/v1").Do(context.TODO()).Into(apiResourceList)
 			framework.ExpectNoError(err, "fetching /apis/apiextensions.k8s.io/v1")
 			framework.ExpectEqual(apiResourceList.GroupVersion, v1.SchemeGroupVersion.String(), "verifying API group/version in /apis/apiextensions.k8s.io/v1 discovery document")
 

--- a/test/e2e/apimachinery/table_conversion.go
+++ b/test/e2e/apimachinery/table_conversion.go
@@ -26,7 +26,7 @@ import (
 	"github.com/onsi/gomega"
 
 	authorizationv1 "k8s.io/api/authorization/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
@@ -59,7 +59,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		framework.ExpectNoError(err, "failed to create pod %s in namespace: %s", podName, ns)
 
 		table := &metav1beta1.Table{}
-		err = c.CoreV1().RESTClient().Get().Resource("pods").Namespace(ns).Name(podName).SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do().Into(table)
+		err = c.CoreV1().RESTClient().Get().Resource("pods").Namespace(ns).Name(podName).SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do(context.TODO()).Into(table)
 		framework.ExpectNoError(err, "failed to get pod %s in Table form in namespace: %s", podName, ns)
 		framework.Logf("Table: %#v", table)
 
@@ -107,7 +107,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		err := c.CoreV1().RESTClient().Get().Namespace(ns).Resource("podtemplates").
 			VersionedParams(&metav1.ListOptions{Limit: 2}, metav1.ParameterCodec).
 			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").
-			Do().Into(pagedTable)
+			Do(context.TODO()).Into(pagedTable)
 		framework.ExpectNoError(err, "failed to get pod templates in Table form in namespace: %s", ns)
 		framework.ExpectEqual(len(pagedTable.Rows), 2)
 		framework.ExpectNotEqual(pagedTable.ResourceVersion, "")
@@ -119,7 +119,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		err = c.CoreV1().RESTClient().Get().Namespace(ns).Resource("podtemplates").
 			VersionedParams(&metav1.ListOptions{Continue: pagedTable.Continue}, metav1.ParameterCodec).
 			SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").
-			Do().Into(pagedTable)
+			Do(context.TODO()).Into(pagedTable)
 		framework.ExpectNoError(err, "failed to get pod templates in Table form in namespace: %s", ns)
 		gomega.Expect(len(pagedTable.Rows)).To(gomega.BeNumerically(">", 0))
 		framework.ExpectEqual(pagedTable.Rows[0].Cells[0], "template-0002")
@@ -129,7 +129,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 		c := f.ClientSet
 
 		table := &metav1beta1.Table{}
-		err := c.CoreV1().RESTClient().Get().Resource("nodes").SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do().Into(table)
+		err := c.CoreV1().RESTClient().Get().Resource("nodes").SetHeader("Accept", "application/json;as=Table;v=v1beta1;g=meta.k8s.io").Do(context.TODO()).Into(table)
 		framework.ExpectNoError(err, "failed to get nodes in Table form across all namespaces")
 		framework.Logf("Table: %#v", table)
 
@@ -163,7 +163,7 @@ var _ = SIGDescribe("Servers with support for Table transformation", func() {
 				},
 			},
 		}
-		err := c.AuthorizationV1().RESTClient().Post().Resource("selfsubjectaccessreviews").SetHeader("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io").Body(sar).Do().Into(table)
+		err := c.AuthorizationV1().RESTClient().Post().Resource("selfsubjectaccessreviews").SetHeader("Accept", "application/json;as=Table;v=v1;g=meta.k8s.io").Body(sar).Do(context.TODO()).Into(table)
 		framework.ExpectError(err, "failed to return error when posting self subject access review: %+v, to a backend that does not implement metadata", sar)
 		framework.ExpectEqual(err.(apierrors.APIStatus).Status().Code, int32(406))
 	})

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apimachinery
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -114,7 +115,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		{
 			ginkgo.By("fetching the /apis discovery document")
 			apiGroupList := &metav1.APIGroupList{}
-			err := client.Discovery().RESTClient().Get().AbsPath("/apis").Do().Into(apiGroupList)
+			err := client.Discovery().RESTClient().Get().AbsPath("/apis").Do(context.TODO()).Into(apiGroupList)
 			framework.ExpectNoError(err, "fetching /apis")
 
 			ginkgo.By("finding the admissionregistration.k8s.io API group in the /apis discovery document")
@@ -141,7 +142,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		{
 			ginkgo.By("fetching the /apis/admissionregistration.k8s.io discovery document")
 			group := &metav1.APIGroup{}
-			err := client.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io").Do().Into(group)
+			err := client.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io").Do(context.TODO()).Into(group)
 			framework.ExpectNoError(err, "fetching /apis/admissionregistration.k8s.io")
 			framework.ExpectEqual(group.Name, admissionregistrationv1.GroupName, "verifying API group name in /apis/admissionregistration.k8s.io discovery document")
 
@@ -159,7 +160,7 @@ var _ = SIGDescribe("AdmissionWebhook [Privileged:ClusterAdmin]", func() {
 		{
 			ginkgo.By("fetching the /apis/admissionregistration.k8s.io/v1 discovery document")
 			apiResourceList := &metav1.APIResourceList{}
-			err := client.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io/v1").Do().Into(apiResourceList)
+			err := client.Discovery().RESTClient().Get().AbsPath("/apis/admissionregistration.k8s.io/v1").Do(context.TODO()).Into(apiResourceList)
 			framework.ExpectNoError(err, "fetching /apis/admissionregistration.k8s.io/v1")
 			framework.ExpectEqual(apiResourceList.GroupVersion, admissionregistrationv1.SchemeGroupVersion.String(), "verifying API group/version in /apis/admissionregistration.k8s.io/v1 discovery document")
 

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -733,7 +734,7 @@ func expectEvents(f *framework.Framework, expectedEvents []utils.AuditEvent) {
 	pollingTimeout := 5 * time.Minute
 	err := wait.Poll(pollingInterval, pollingTimeout, func() (bool, error) {
 		// Fetch the log stream.
-		stream, err := f.ClientSet.CoreV1().RESTClient().Get().AbsPath("/logs/kube-apiserver-audit.log").Stream()
+		stream, err := f.ClientSet.CoreV1().RESTClient().Get().AbsPath("/logs/kube-apiserver-audit.log").Stream(context.TODO())
 		if err != nil {
 			return false, err
 		}

--- a/test/e2e/common/kubelet.go
+++ b/test/e2e/common/kubelet.go
@@ -18,11 +18,12 @@ package common
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -64,7 +65,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			})
 			gomega.Eventually(func() string {
 				sinceTime := metav1.NewTime(time.Now().Add(time.Duration(-1 * time.Hour)))
-				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{SinceTime: &sinceTime}).Stream()
+				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{SinceTime: &sinceTime}).Stream(context.TODO())
 				if err != nil {
 					return ""
 				}
@@ -167,7 +168,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 			})
 
 			gomega.Eventually(func() error {
-				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream()
+				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(context.TODO())
 				if err != nil {
 					return err
 				}
@@ -215,7 +216,7 @@ var _ = framework.KubeDescribe("Kubelet", func() {
 				},
 			})
 			gomega.Eventually(func() string {
-				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream()
+				rc, err := podClient.GetLogs(podName, &v1.PodLogOptions{}).Stream(context.TODO())
 				if err != nil {
 					return ""
 				}

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -247,14 +247,13 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
-			Context(ctx).
 			Name(rc.controllerName).
 			Suffix("ConsumeCPU").
 			Param("millicores", strconv.Itoa(millicores)).
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMillicores", strconv.Itoa(rc.requestSizeInMillicores))
 		framework.Logf("ConsumeCPU URL: %v", *req.URL())
-		_, err = req.DoRaw(context.TODO())
+		_, err = req.DoRaw(ctx)
 		if err != nil {
 			framework.Logf("ConsumeCPU failure: %v", err)
 			return false, nil
@@ -274,14 +273,13 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
-			Context(ctx).
 			Name(rc.controllerName).
 			Suffix("ConsumeMem").
 			Param("megabytes", strconv.Itoa(megabytes)).
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMegabytes", strconv.Itoa(rc.requestSizeInMegabytes))
 		framework.Logf("ConsumeMem URL: %v", *req.URL())
-		_, err = req.DoRaw(context.TODO())
+		_, err = req.DoRaw(ctx)
 		if err != nil {
 			framework.Logf("ConsumeMem failure: %v", err)
 			return false, nil
@@ -301,7 +299,6 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
 		proxyRequest, err := e2eservice.GetServicesProxyRequest(rc.clientSet, rc.clientSet.CoreV1().RESTClient().Post())
 		framework.ExpectNoError(err)
 		req := proxyRequest.Namespace(rc.nsName).
-			Context(ctx).
 			Name(rc.controllerName).
 			Suffix("BumpMetric").
 			Param("metric", customMetricName).
@@ -309,7 +306,7 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMetrics", strconv.Itoa(rc.requestSizeCustomMetric))
 		framework.Logf("ConsumeCustomMetric URL: %v", *req.URL())
-		_, err = req.DoRaw(context.TODO())
+		_, err = req.DoRaw(ctx)
 		if err != nil {
 			framework.Logf("ConsumeCustomMetric failure: %v", err)
 			return false, nil

--- a/test/e2e/framework/autoscaling/autoscaling_utils.go
+++ b/test/e2e/framework/autoscaling/autoscaling_utils.go
@@ -38,6 +38,7 @@ import (
 	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/onsi/ginkgo"
+
 	scaleclient "k8s.io/client-go/scale"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -253,7 +254,7 @@ func (rc *ResourceConsumer) sendConsumeCPURequest(millicores int) {
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMillicores", strconv.Itoa(rc.requestSizeInMillicores))
 		framework.Logf("ConsumeCPU URL: %v", *req.URL())
-		_, err = req.DoRaw()
+		_, err = req.DoRaw(context.TODO())
 		if err != nil {
 			framework.Logf("ConsumeCPU failure: %v", err)
 			return false, nil
@@ -280,7 +281,7 @@ func (rc *ResourceConsumer) sendConsumeMemRequest(megabytes int) {
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMegabytes", strconv.Itoa(rc.requestSizeInMegabytes))
 		framework.Logf("ConsumeMem URL: %v", *req.URL())
-		_, err = req.DoRaw()
+		_, err = req.DoRaw(context.TODO())
 		if err != nil {
 			framework.Logf("ConsumeMem failure: %v", err)
 			return false, nil
@@ -308,7 +309,7 @@ func (rc *ResourceConsumer) sendConsumeCustomMetric(delta int) {
 			Param("durationSec", strconv.Itoa(rc.consumptionTimeInSeconds)).
 			Param("requestSizeMetrics", strconv.Itoa(rc.requestSizeCustomMetric))
 		framework.Logf("ConsumeCustomMetric URL: %v", *req.URL())
-		_, err = req.DoRaw()
+		_, err = req.DoRaw(context.TODO())
 		if err != nil {
 			framework.Logf("ConsumeCustomMetric failure: %v", err)
 			return false, nil

--- a/test/e2e/framework/kubelet/stats.go
+++ b/test/e2e/framework/kubelet/stats.go
@@ -98,7 +98,7 @@ func ProxyRequest(c clientset.Interface, node, endpoint string, port int) (restc
 			SubResource("proxy").
 			Name(fmt.Sprintf("%v:%v", node, port)).
 			Suffix(endpoint).
-			Do()
+			Do(context.TODO())
 
 		finished <- struct{}{}
 	}()
@@ -225,7 +225,7 @@ func GetStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alp
 		SubResource("proxy").
 		Name(fmt.Sprintf("%v:%v", nodeName, ports.KubeletPort)).
 		Suffix("stats/summary").
-		Do().Raw()
+		Do(context.TODO()).Raw()
 
 	if err != nil {
 		return nil, err
@@ -246,7 +246,7 @@ func getNodeStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv
 		Name(fmt.Sprintf("%v:%v", nodeName, ports.KubeletPort)).
 		Suffix("stats/summary").
 		SetHeader("Content-Type", "application/json").
-		Do().Raw()
+		Do(context.TODO()).Raw()
 
 	if err != nil {
 		return nil, err

--- a/test/e2e/framework/kubelet/stats.go
+++ b/test/e2e/framework/kubelet/stats.go
@@ -220,12 +220,11 @@ func GetStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alp
 	defer cancel()
 
 	data, err := c.CoreV1().RESTClient().Get().
-		Context(ctx).
 		Resource("nodes").
 		SubResource("proxy").
 		Name(fmt.Sprintf("%v:%v", nodeName, ports.KubeletPort)).
 		Suffix("stats/summary").
-		Do(context.TODO()).Raw()
+		Do(ctx).Raw()
 
 	if err != nil {
 		return nil, err

--- a/test/e2e/framework/metrics/api_server_metrics.go
+++ b/test/e2e/framework/metrics/api_server_metrics.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package metrics
 
-import "k8s.io/component-base/metrics/testutil"
+import (
+	"context"
+
+	"k8s.io/component-base/metrics/testutil"
+)
 
 // APIServerMetrics is metrics for API server
 type APIServerMetrics testutil.Metrics
@@ -40,7 +44,7 @@ func parseAPIServerMetrics(data string) (APIServerMetrics, error) {
 }
 
 func (g *Grabber) getMetricsFromAPIServer() (string, error) {
-	rawOutput, err := g.client.CoreV1().RESTClient().Get().RequestURI("/metrics").Do().Raw()
+	rawOutput, err := g.client.CoreV1().RESTClient().Get().RequestURI("/metrics").Do(context.TODO()).Raw()
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/framework/metrics/kubelet_metrics.go
+++ b/test/e2e/framework/metrics/kubelet_metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -85,7 +86,7 @@ func (g *Grabber) getMetricsFromNode(nodeName string, kubeletPort int) (string, 
 			SubResource("proxy").
 			Name(fmt.Sprintf("%v:%v", nodeName, kubeletPort)).
 			Suffix("metrics").
-			Do().Raw()
+			Do(context.TODO()).Raw()
 		finished <- struct{}{}
 	}()
 	select {

--- a/test/e2e/framework/metrics/metrics_grabber.go
+++ b/test/e2e/framework/metrics/metrics_grabber.go
@@ -17,6 +17,7 @@ limitations under the License.
 package metrics
 
 import (
+	"context"
 	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -241,7 +242,7 @@ func (g *Grabber) getMetricsFromPod(client clientset.Interface, podName string, 
 		SubResource("proxy").
 		Name(fmt.Sprintf("%v:%v", podName, port)).
 		Suffix("metrics").
-		Do().Raw()
+		Do(context.TODO()).Raw()
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -103,7 +103,7 @@ func (r ProxyResponseChecker) CheckAllResponses() (done bool, err error) {
 			Resource("pods").
 			SubResource("proxy").
 			Name(string(pod.Name)).
-			Do().
+			Do(context.TODO()).
 			Raw()
 
 		if err != nil {
@@ -516,7 +516,7 @@ func getPodLogsInternal(c clientset.Interface, namespace, podName, containerName
 		Name(podName).SubResource("log").
 		Param("container", containerName).
 		Param("previous", strconv.FormatBool(previous)).
-		Do().
+		Do(context.TODO()).
 		Raw()
 	if err != nil {
 		return "", err

--- a/test/e2e/framework/pod/resource.go
+++ b/test/e2e/framework/pod/resource.go
@@ -98,12 +98,11 @@ func (r ProxyResponseChecker) CheckAllResponses() (done bool, err error) {
 		defer cancel()
 
 		body, err := r.c.CoreV1().RESTClient().Get().
-			Context(ctx).
 			Namespace(r.ns).
 			Resource("pods").
 			SubResource("proxy").
 			Name(string(pod.Name)).
-			Do(context.TODO()).
+			Do(ctx).
 			Raw()
 
 		if err != nil {

--- a/test/e2e/framework/podlogs/podlogs.go
+++ b/test/e2e/framework/podlogs/podlogs.go
@@ -47,8 +47,7 @@ import (
 //    rpc error: code = Unknown desc = Error: No such container: 41a...
 // when the pod gets deleted while streaming.
 func LogsForPod(ctx context.Context, cs clientset.Interface, ns, pod string, opts *v1.PodLogOptions) (io.ReadCloser, error) {
-	req := cs.CoreV1().Pods(ns).GetLogs(pod, opts)
-	return req.Context(ctx).Stream(context.TODO())
+	return cs.CoreV1().Pods(ns).GetLogs(pod, opts).Stream(ctx)
 }
 
 // LogOutput determines where output from CopyAllLogs goes.

--- a/test/e2e/framework/podlogs/podlogs.go
+++ b/test/e2e/framework/podlogs/podlogs.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
 )
@@ -48,7 +48,7 @@ import (
 // when the pod gets deleted while streaming.
 func LogsForPod(ctx context.Context, cs clientset.Interface, ns, pod string, opts *v1.PodLogOptions) (io.ReadCloser, error) {
 	req := cs.CoreV1().Pods(ns).GetLogs(pod, opts)
-	return req.Context(ctx).Stream()
+	return req.Context(ctx).Stream(context.TODO())
 }
 
 // LogOutput determines where output from CopyAllLogs goes.

--- a/test/e2e/framework/resource_usage_gatherer.go
+++ b/test/e2e/framework/resource_usage_gatherer.go
@@ -299,7 +299,7 @@ func getStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alp
 		SubResource("proxy").
 		Name(fmt.Sprintf("%v:%v", nodeName, ports.KubeletPort)).
 		Suffix("stats/summary").
-		Do().Raw()
+		Do(context.TODO()).Raw()
 
 	if err != nil {
 		return nil, err

--- a/test/e2e/framework/resource_usage_gatherer.go
+++ b/test/e2e/framework/resource_usage_gatherer.go
@@ -294,12 +294,11 @@ func getStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alp
 	defer cancel()
 
 	data, err := c.CoreV1().RESTClient().Get().
-		Context(ctx).
 		Resource("nodes").
 		SubResource("proxy").
 		Name(fmt.Sprintf("%v:%v", nodeName, ports.KubeletPort)).
 		Suffix("stats/summary").
-		Do(context.TODO()).Raw()
+		Do(ctx).Raw()
 
 	if err != nil {
 		return nil, err

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -38,6 +38,7 @@ import (
 	"time"
 
 	"golang.org/x/net/websocket"
+
 	"k8s.io/klog"
 
 	"github.com/onsi/ginkgo"
@@ -1017,7 +1018,7 @@ func getKubeletPods(c clientset.Interface, node string) (*v1.PodList, error) {
 			SubResource("proxy").
 			Name(fmt.Sprintf("%v:%v", node, ports.KubeletPort)).
 			Suffix("pods").
-			Do()
+			Do(context.TODO())
 
 		finished <- struct{}{}
 	}()

--- a/test/e2e/instrumentation/logging/elasticsearch/kibana.go
+++ b/test/e2e/instrumentation/logging/elasticsearch/kibana.go
@@ -94,9 +94,8 @@ func ClusterLevelLoggingWithKibana(f *framework.Framework) {
 		defer cancel()
 
 		_, err = req.Namespace(metav1.NamespaceSystem).
-			Context(ctx).
 			Name("kibana-logging").
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 		if err != nil {
 			framework.Logf("Proxy call to kibana-logging failed: %v", err)
 			return false, nil

--- a/test/e2e/instrumentation/logging/elasticsearch/kibana.go
+++ b/test/e2e/instrumentation/logging/elasticsearch/kibana.go
@@ -96,7 +96,7 @@ func ClusterLevelLoggingWithKibana(f *framework.Framework) {
 		_, err = req.Namespace(metav1.NamespaceSystem).
 			Context(ctx).
 			Name("kibana-logging").
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			framework.Logf("Proxy call to kibana-logging failed: %v", err)
 			return false, nil

--- a/test/e2e/instrumentation/logging/elasticsearch/utils.go
+++ b/test/e2e/instrumentation/logging/elasticsearch/utils.go
@@ -17,6 +17,7 @@ limitations under the License.
 package elasticsearch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -100,7 +101,7 @@ func (p *esLogProvider) Init() error {
 		// Query against the root URL for Elasticsearch.
 		response := proxyRequest.Namespace(api.NamespaceSystem).
 			Name("elasticsearch-logging").
-			Do()
+			Do(context.TODO())
 		err = response.Error()
 		response.StatusCode(&statusCode)
 
@@ -135,7 +136,7 @@ func (p *esLogProvider) Init() error {
 			Name("elasticsearch-logging").
 			Suffix("_cluster/health").
 			Param("level", "indices").
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			continue
 		}
@@ -189,9 +190,8 @@ func (p *esLogProvider) ReadEntries(name string) []utils.LogEntry {
 		Name("elasticsearch-logging").
 		Suffix("_search").
 		Param("q", query).
-		// Ask for more in case we included some unrelated records in our query
 		Param("size", strconv.Itoa(searchPageSize)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		framework.Logf("Failed to make proxy call to elasticsearch-logging: %v", err)
 		return nil

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2368,13 +2368,12 @@ func makeRequestToGuestbook(c clientset.Interface, cmd, value string, ns string)
 	defer cancel()
 
 	result, err := proxyRequest.Namespace(ns).
-		Context(ctx).
 		Name("frontend").
 		Suffix("/guestbook").
 		Param("cmd", cmd).
 		Param("key", "messages").
 		Param("value", value).
-		Do(context.TODO()).
+		Do(ctx).
 		Raw()
 	return string(result), err
 }

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -42,6 +42,8 @@ import (
 	"github.com/elazarl/goproxy"
 	openapi_v2 "github.com/googleapis/gnostic/OpenAPIv2"
 
+	"sigs.k8s.io/yaml"
+
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -83,7 +85,6 @@ import (
 	imageutils "k8s.io/kubernetes/test/utils/image"
 	uexec "k8s.io/utils/exec"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/yaml"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -2373,7 +2374,7 @@ func makeRequestToGuestbook(c clientset.Interface, cmd, value string, ns string)
 		Param("cmd", cmd).
 		Param("key", "messages").
 		Param("value", value).
-		Do().
+		Do(context.TODO()).
 		Raw()
 	return string(result), err
 }
@@ -2458,7 +2459,7 @@ func getUDData(jpgExpected string, ns string) func(clientset.Interface, string) 
 			SubResource("proxy").
 			Name(podID).
 			Suffix("data.json").
-			Do().
+			Do(context.TODO()).
 			Raw()
 
 		if err != nil {

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -528,13 +528,12 @@ func assertFilesContain(fileNames []string, fileDir string, pod *v1.Pod, client 
 
 		for _, fileName := range fileNames {
 			contents, err := client.CoreV1().RESTClient().Get().
-				Context(ctx).
 				Namespace(pod.Namespace).
 				Resource("pods").
 				SubResource("proxy").
 				Name(pod.Name).
 				Suffix(fileDir, fileName).
-				Do(context.TODO()).Raw()
+				Do(ctx).Raw()
 
 			if err != nil {
 				if ctx.Err() != nil {

--- a/test/e2e/network/dns_common.go
+++ b/test/e2e/network/dns_common.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	dnsutil "github.com/miekg/dns"
+
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -533,7 +534,7 @@ func assertFilesContain(fileNames []string, fileDir string, pod *v1.Pod, client 
 				SubResource("proxy").
 				Name(pod.Name).
 				Suffix(fileDir, fileName).
-				Do().Raw()
+				Do(context.TODO()).Raw()
 
 			if err != nil {
 				if ctx.Err() != nil {

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -194,7 +195,7 @@ func waitForServiceResponding(c clientset.Interface, ns, name string) error {
 		body, err := proxyRequest.Namespace(ns).
 			Context(ctx).
 			Name(name).
-			Do().
+			Do(context.TODO()).
 			Raw()
 		if err != nil {
 			if ctx.Err() != nil {

--- a/test/e2e/network/example_cluster_dns.go
+++ b/test/e2e/network/example_cluster_dns.go
@@ -193,9 +193,8 @@ func waitForServiceResponding(c clientset.Interface, ns, name string) error {
 		defer cancel()
 
 		body, err := proxyRequest.Namespace(ns).
-			Context(ctx).
 			Name(name).
-			Do(context.TODO()).
+			Do(ctx).
 			Raw()
 		if err != nil {
 			if ctx.Err() != nil {

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -17,6 +17,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -138,7 +139,7 @@ var _ = SIGDescribe("Networking", func() {
 			ginkgo.By(fmt.Sprintf("testing: %s", test.path))
 			data, err := f.ClientSet.CoreV1().RESTClient().Get().
 				AbsPath(test.path).
-				DoRaw()
+				DoRaw(context.TODO())
 			if err != nil {
 				framework.Failf("ginkgo.Failed: %v\nBody: %s", err, string(data))
 			}

--- a/test/e2e/network/proxy.go
+++ b/test/e2e/network/proxy.go
@@ -19,6 +19,7 @@ limitations under the License.
 package network
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"net/http"
@@ -249,7 +250,7 @@ var _ = SIGDescribe("Proxy", func() {
 			}
 
 			if len(errs) != 0 {
-				body, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).GetLogs(pods[0].Name, &v1.PodLogOptions{}).Do().Raw()
+				body, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).GetLogs(pods[0].Name, &v1.PodLogOptions{}).Do(context.TODO()).Raw()
 				if err != nil {
 					framework.Logf("Error getting logs for pod %s: %v", pods[0].Name, err)
 				} else {
@@ -270,7 +271,7 @@ func doProxy(f *framework.Framework, path string, i int) (body []byte, statusCod
 	//   chance of the things we are talking to being confused for an error
 	//   that apiserver would have emitted.
 	start := time.Now()
-	body, err = f.ClientSet.CoreV1().RESTClient().Get().AbsPath(path).Do().StatusCode(&statusCode).Raw()
+	body, err = f.ClientSet.CoreV1().RESTClient().Get().AbsPath(path).Do(context.TODO()).StatusCode(&statusCode).Raw()
 	d = time.Since(start)
 	if len(body) > 0 {
 		framework.Logf("(%v) %v: %s (%v; %v)", i, path, truncate(body, maxDisplayBodyLen), statusCode, d)

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -18,6 +18,7 @@ package network
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"math/rand"
@@ -674,7 +675,7 @@ func restartKubeProxy(host string) error {
 // waitForApiserverUp waits for the kube-apiserver to be up.
 func waitForApiserverUp(c clientset.Interface) error {
 	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(5 * time.Second) {
-		body, err := c.CoreV1().RESTClient().Get().AbsPath("/healthz").Do().Raw()
+		body, err := c.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).Raw()
 		if err == nil && string(body) == "ok" {
 			return nil
 		}

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -17,6 +17,7 @@ limitations under the License.
 package node
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"strconv"
@@ -103,7 +104,7 @@ var _ = SIGDescribe("Pods Extended", func() {
 			ginkgo.By("deleting the pod gracefully")
 			var lastPod v1.Pod
 			var statusCode int
-			err = f.ClientSet.CoreV1().RESTClient().Delete().AbsPath("/api/v1/namespaces", pod.Namespace, "pods", pod.Name).Param("gracePeriodSeconds", "30").Do().StatusCode(&statusCode).Into(&lastPod)
+			err = f.ClientSet.CoreV1().RESTClient().Delete().AbsPath("/api/v1/namespaces", pod.Namespace, "pods", pod.Name).Param("gracePeriodSeconds", "30").Do(context.TODO()).StatusCode(&statusCode).Into(&lastPod)
 			framework.ExpectNoError(err, "failed to use http client to send delete")
 			framework.ExpectEqual(statusCode, http.StatusOK, "failed to delete gracefully by client request")
 

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -141,7 +141,7 @@ func testPreStop(c clientset.Interface, ns string) {
 			SubResource("proxy").
 			Name(podDescr.Name).
 			Suffix("read").
-			DoRaw()
+			DoRaw(context.TODO())
 
 		if err != nil {
 			if ctx.Err() != nil {

--- a/test/e2e/node/pre_stop.go
+++ b/test/e2e/node/pre_stop.go
@@ -135,13 +135,12 @@ func testPreStop(c clientset.Interface, ns string) {
 
 		var body []byte
 		body, err = c.CoreV1().RESTClient().Get().
-			Context(ctx).
 			Namespace(ns).
 			Resource("pods").
 			SubResource("proxy").
 			Name(podDescr.Name).
 			Suffix("read").
-			DoRaw(context.TODO())
+			DoRaw(ctx)
 
 		if err != nil {
 			if ctx.Err() != nil {

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -17,6 +17,7 @@ limitations under the License.
 package testsuites
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -608,7 +609,7 @@ func StopPod(c clientset.Interface, pod *v1.Pod) {
 	if pod == nil {
 		return
 	}
-	body, err := c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{}).Do().Raw()
+	body, err := c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &v1.PodLogOptions{}).Do(context.TODO()).Raw()
 	if err != nil {
 		framework.Logf("Error getting logs for pod %s: %v", pod.Name, err)
 	} else {

--- a/test/e2e/ui/dashboard.go
+++ b/test/e2e/ui/dashboard.go
@@ -75,7 +75,7 @@ var _ = SIGDescribe("Kubernetes Dashboard [Feature:Dashboard]", func() {
 				Context(ctx).
 				Name(utilnet.JoinSchemeNamePort("https", uiServiceName, "")).
 				Timeout(framework.SingleCallTimeout).
-				Do().
+				Do(context.TODO()).
 				StatusCode(&status).
 				Error()
 			if err != nil {

--- a/test/e2e/ui/dashboard.go
+++ b/test/e2e/ui/dashboard.go
@@ -72,10 +72,9 @@ var _ = SIGDescribe("Kubernetes Dashboard [Feature:Dashboard]", func() {
 
 			// Query against the proxy URL for the kubernetes-dashboard service.
 			err := proxyRequest.Namespace(uiNamespace).
-				Context(ctx).
 				Name(utilnet.JoinSchemeNamePort("https", uiServiceName, "")).
 				Timeout(framework.SingleCallTimeout).
-				Do(context.TODO()).
+				Do(ctx).
 				StatusCode(&status).
 				Error()
 			if err != nil {

--- a/test/e2e_node/node_problem_detector_linux.go
+++ b/test/e2e_node/node_problem_detector_linux.go
@@ -19,12 +19,13 @@ limitations under the License.
 package e2enode
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -383,7 +384,7 @@ var _ = framework.KubeDescribe("NodeProblemDetector [NodeFeature:NodeProblemDete
 			gomega.Expect(c.CoreV1().Events(eventNamespace).DeleteCollection(metav1.NewDeleteOptions(0), eventListOptions)).To(gomega.Succeed())
 			ginkgo.By("Clean up the node condition")
 			patch := []byte(fmt.Sprintf(`{"status":{"conditions":[{"$patch":"delete","type":"%s"}]}}`, condition))
-			c.CoreV1().RESTClient().Patch(types.StrategicMergePatchType).Resource("nodes").Name(framework.TestContext.NodeName).SubResource("status").Body(patch).Do()
+			c.CoreV1().RESTClient().Patch(types.StrategicMergePatchType).Resource("nodes").Name(framework.TestContext.NodeName).SubResource("status").Body(patch).Do(context.TODO())
 		})
 	})
 })

--- a/test/images/agnhost/inclusterclient/main.go
+++ b/test/images/agnhost/inclusterclient/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package inclusterclient
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/base64"
 	"flag"
@@ -77,7 +78,7 @@ func main(cmd *cobra.Command, args []string) {
 	for {
 		<-t
 		klog.Infof("calling /healthz")
-		b, err := c.Get().AbsPath("/healthz").Do().Raw()
+		b, err := c.Get().AbsPath("/healthz").Do(context.TODO()).Raw()
 		if err != nil {
 			klog.Errorf("status=failed")
 			klog.Errorf("error checking /healthz: %v\n%s\n", err, string(b))

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package admissionwebhook
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -1016,11 +1017,11 @@ func testPodConnectSubresource(c *testContext) {
 		var err error
 		switch c.gvr {
 		case gvr("", "v1", "pods/exec"):
-			err = c.clientset.CoreV1().RESTClient().Verb(httpMethod).Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("exec").Do().Error()
+			err = c.clientset.CoreV1().RESTClient().Verb(httpMethod).Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("exec").Do(context.TODO()).Error()
 		case gvr("", "v1", "pods/attach"):
-			err = c.clientset.CoreV1().RESTClient().Verb(httpMethod).Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("attach").Do().Error()
+			err = c.clientset.CoreV1().RESTClient().Verb(httpMethod).Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("attach").Do(context.TODO()).Error()
 		case gvr("", "v1", "pods/portforward"):
-			err = c.clientset.CoreV1().RESTClient().Verb(httpMethod).Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("portforward").Do().Error()
+			err = c.clientset.CoreV1().RESTClient().Verb(httpMethod).Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("portforward").Do(context.TODO()).Error()
 		default:
 			c.t.Errorf("unknown subresource %#v", c.gvr)
 			return
@@ -1061,19 +1062,19 @@ func testPodBindingEviction(c *testContext) {
 		err = c.clientset.CoreV1().RESTClient().Post().Namespace(pod.GetNamespace()).Resource("bindings").Body(&corev1.Binding{
 			ObjectMeta: metav1.ObjectMeta{Name: pod.GetName()},
 			Target:     corev1.ObjectReference{Name: "foo", Kind: "Node", APIVersion: "v1"},
-		}).Do().Error()
+		}).Do(context.TODO()).Error()
 
 	case gvr("", "v1", "pods/binding"):
 		err = c.clientset.CoreV1().RESTClient().Post().Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("binding").Body(&corev1.Binding{
 			ObjectMeta: metav1.ObjectMeta{Name: pod.GetName()},
 			Target:     corev1.ObjectReference{Name: "foo", Kind: "Node", APIVersion: "v1"},
-		}).Do().Error()
+		}).Do(context.TODO()).Error()
 
 	case gvr("", "v1", "pods/eviction"):
 		err = c.clientset.CoreV1().RESTClient().Post().Namespace(pod.GetNamespace()).Resource("pods").Name(pod.GetName()).SubResource("eviction").Body(&policyv1beta1.Eviction{
 			ObjectMeta:    metav1.ObjectMeta{Name: pod.GetName()},
 			DeleteOptions: forceDelete,
-		}).Do().Error()
+		}).Do(context.TODO()).Error()
 
 	default:
 		c.t.Errorf("unhandled resource %#v", c.gvr)
@@ -1124,7 +1125,7 @@ func testSubresourceProxy(c *testContext) {
 		// set expectations
 		c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), schema.GroupVersionKind{}, v1beta1.Connect, obj.GetName(), obj.GetNamespace(), true, false, false)
 		// run the request. we don't actually care if the request is successful, just that admission gets called as expected
-		err = request.Resource(gvrWithoutSubresources.Resource).Name(obj.GetName()).SubResource(subresources...).Do().Error()
+		err = request.Resource(gvrWithoutSubresources.Resource).Name(obj.GetName()).SubResource(subresources...).Do(context.TODO()).Error()
 		if err != nil {
 			c.t.Logf("debug: result of subresource proxy (error expected): %v", err)
 		}

--- a/test/integration/apiserver/admissionwebhook/timeout_test.go
+++ b/test/integration/apiserver/admissionwebhook/timeout_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package admissionwebhook
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -291,7 +292,7 @@ func testWebhookTimeout(t *testing.T, watchCache bool) {
 			}
 
 			// set the timeout parameter manually so we don't actually cut off the request client-side, and wait for the server response
-			err = client.CoreV1().RESTClient().Post().Resource("pods").Namespace(ns).Body(body).Param("timeout", fmt.Sprintf("%ds", tt.timeoutSeconds)).Do().Error()
+			err = client.CoreV1().RESTClient().Post().Resource("pods").Namespace(ns).Body(body).Param("timeout", fmt.Sprintf("%ds", tt.timeoutSeconds)).Do(context.TODO()).Error()
 			// _, err = testClient.CoreV1().Pods(ns).Create(pod)
 
 			if tt.expectError {

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -188,7 +188,7 @@ func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 		AbsPath("/apis/apps/v1").
 		Namespace("default").
 		Resource("deployments").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to create object: %v: %v", err, resp)
 	}
@@ -197,7 +197,7 @@ func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 		Namespace("default").
 		Resource("deployments").
 		Name("deployment").
-		Body([]byte(`{"metadata":{"annotations":{"foo":["bar"]}}}`)).Do()
+		Body([]byte(`{"metadata":{"annotations":{"foo":["bar"]}}}`)).Do(context.TODO())
 	var statusCode int
 	result.StatusCode(&statusCode)
 	if statusCode != 422 {
@@ -208,7 +208,7 @@ func Test4xxStatusCodeInvalidPatch(t *testing.T) {
 		Namespace("default").
 		Resource("deployments").
 		Name("deployment").
-		Body([]byte(`{"metadata":{"annotations":{"foo":["bar"]}}}`)).Do()
+		Body([]byte(`{"metadata":{"annotations":{"foo":["bar"]}}}`)).Do(context.TODO())
 	result.StatusCode(&statusCode)
 	if statusCode != 422 {
 		t.Fatalf("Expected status code to be 422, got %v (%#v)", statusCode, result)
@@ -998,7 +998,7 @@ func TestAPICRDProtobuf(t *testing.T) {
 			w, err := client.Get().
 				Resource(resource).NamespaceIfScoped(obj.GetNamespace(), len(obj.GetNamespace()) > 0).Name(obj.GetName()).SubResource(tc.subresource).
 				SetHeader("Accept", tc.accept).
-				Stream()
+				Stream(context.TODO())
 			if (tc.wantErr != nil) != (err != nil) {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -1611,7 +1611,7 @@ func TestTransform(t *testing.T) {
 					FieldSelector:   fields.OneTermEqualSelector("metadata.name", obj.GetName()).String(),
 				}, metav1.ParameterCodec).
 				Param("includeObject", string(tc.includeObject)).
-				Stream()
+				Stream(context.TODO())
 			if (tc.wantErr != nil) != (err != nil) {
 				t.Fatalf("unexpected error: %v", err)
 			}

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -81,7 +82,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 	}
@@ -92,7 +93,7 @@ spec:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name(name).
 		Body([]byte(`{"spec":{"replicas": 5}}`)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to update number of replicas with merge patch: %v:\n%v", err, string(result))
 	}
@@ -104,7 +105,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when applying object after updating replicas, got no error: %s", result)
 	}
@@ -123,7 +124,7 @@ spec:
 		Param("force", "true").
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to apply object with force after updating replicas: %v:\n%v", err, string(result))
 	}
@@ -241,7 +242,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 	}
@@ -255,7 +256,7 @@ spec:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name(name).
 		Body([]byte(`{"metadata":{"finalizers":["test-finalizer","another-one"]}}`)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to add finalizer with merge patch: %v:\n%v", err, string(result))
 	}
@@ -270,7 +271,7 @@ spec:
 		Param("fieldManager", "apply_test").
 		SetHeader("Accept", "application/json").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to apply same config after adding a finalizer: %v:\n%v", err, string(result))
 	}
@@ -283,7 +284,7 @@ spec:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name(name).
 		Body([]byte(`{"spec":{"replicas": 5}}`)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to update number of replicas with merge patch: %v:\n%v", err, string(result))
 	}
@@ -295,7 +296,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when applying object after updating replicas, got no error: %s", result)
 	}
@@ -314,7 +315,7 @@ spec:
 		Param("force", "true").
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to apply object with force after updating replicas: %v:\n%v", err, string(result))
 	}
@@ -335,7 +336,7 @@ spec:
   - name: "y"
     containerPort: 80
     protocol: TCP`, apiVersion, kind, name))).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when a different applier updates existing list item, got no error: %s", result)
 	}
@@ -363,7 +364,7 @@ spec:
     containerPort: 8080
     protocol: TCP`, apiVersion, kind, name))).
 		SetHeader("Accept", "application/json").
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to add a new list item to the object as a different applier: %v:\n%v", err, string(result))
 	}
@@ -447,7 +448,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 	}
@@ -460,7 +461,7 @@ spec:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name(name).
 		Body([]byte(`{"metadata":{"finalizers":["test-finalizer","another-one"]}}`)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to add finalizer with merge patch: %v:\n%v", err, string(result))
 	}
@@ -475,7 +476,7 @@ spec:
 		Param("fieldManager", "apply_test").
 		SetHeader("Accept", "application/json").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to apply same config after adding a finalizer: %v:\n%v", err, string(result))
 	}
@@ -488,7 +489,7 @@ spec:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name(name).
 		Body([]byte(`{"spec":{"replicas": 5}}`)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to update number of replicas with merge patch: %v:\n%v", err, string(result))
 	}
@@ -500,7 +501,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when applying object after updating replicas, got no error: %s", result)
 	}
@@ -519,7 +520,7 @@ spec:
 		Param("force", "true").
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to apply object with force after updating replicas: %v:\n%v", err, string(result))
 	}
@@ -671,7 +672,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to create custom resource with apply: %v:\n%v", err, string(result))
 	}
@@ -682,7 +683,7 @@ spec:
 		AbsPath("/apis", noxuDefinition.Spec.Group, noxuDefinition.Spec.Version, noxuDefinition.Spec.Names.Plural).
 		Name(name).
 		Body([]byte(`{"spec":{"replicas": 5}}`)).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to update number of replicas with merge patch: %v:\n%v", err, string(result))
 	}
@@ -694,7 +695,7 @@ spec:
 		Name(name).
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when applying object after updating replicas, got no error: %s", result)
 	}
@@ -713,7 +714,7 @@ spec:
 		Param("force", "true").
 		Param("fieldManager", "apply_test").
 		Body(yamlBody).
-		DoRaw()
+		DoRaw(context.TODO())
 	if err != nil {
 		t.Fatalf("failed to apply object with force after updating replicas: %v:\n%v", err, string(result))
 	}

--- a/test/integration/apiserver/apply/apply_test.go
+++ b/test/integration/apiserver/apply/apply_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -26,6 +27,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"sigs.k8s.io/yaml"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -41,7 +44,6 @@ import (
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/master"
 	"k8s.io/kubernetes/test/integration/framework"
-	"sigs.k8s.io/yaml"
 )
 
 func setup(t testing.TB, groupVersions ...schema.GroupVersion) (*httptest.Server, clientset.Interface, framework.CloseFunc) {
@@ -119,13 +121,13 @@ func TestApplyAlsoCreates(t *testing.T) {
 			Name(tc.name).
 			Param("fieldManager", "apply_test").
 			Body([]byte(tc.body)).
-			Do().
+			Do(context.TODO()).
 			Get()
 		if err != nil {
 			t.Fatalf("Failed to create object using Apply patch: %v", err)
 		}
 
-		_, err = client.CoreV1().RESTClient().Get().Namespace("default").Resource(tc.resource).Name(tc.name).Do().Get()
+		_, err = client.CoreV1().RESTClient().Get().Namespace("default").Resource(tc.resource).Name(tc.name).Do(context.TODO()).Get()
 		if err != nil {
 			t.Fatalf("Failed to retrieve object: %v", err)
 		}
@@ -137,7 +139,7 @@ func TestApplyAlsoCreates(t *testing.T) {
 			Name(tc.name).
 			Param("fieldManager", "apply_test_2").
 			Body([]byte(tc.body)).
-			Do().
+			Do(context.TODO()).
 			Get()
 		if err != nil {
 			t.Fatalf("Failed to re-apply object using Apply patch: %v", err)
@@ -186,7 +188,7 @@ func TestNoOpUpdateSameResourceVersion(t *testing.T) {
 		Resource(podResource).
 		Name(podName).
 		Body(podBytes).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object: %v", err)
@@ -195,7 +197,7 @@ func TestNoOpUpdateSameResourceVersion(t *testing.T) {
 	// Sleep for one second to make sure that the times of each update operation is different.
 	time.Sleep(1 * time.Second)
 
-	createdObject, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource(podResource).Name(podName).Do().Get()
+	createdObject, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource(podResource).Name(podName).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve created object: %v", err)
 	}
@@ -216,13 +218,13 @@ func TestNoOpUpdateSameResourceVersion(t *testing.T) {
 		Resource(podResource).
 		Name(podName).
 		Body(createdBytes).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to apply no-op update: %v", err)
 	}
 
-	updatedObject, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource(podResource).Name(podName).Do().Get()
+	updatedObject, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource(podResource).Name(podName).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve updated object: %v", err)
 	}
@@ -274,7 +276,7 @@ func TestCreateOnApplyFailsWithUID(t *testing.T) {
 				}]
 			}
 		}`)).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if !apierrors.IsConflict(err) {
 		t.Fatalf("Expected conflict error but got: %v", err)
@@ -323,7 +325,7 @@ func TestApplyUpdateApplyConflictForced(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("fieldManager", "apply_test").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
 	}
@@ -333,7 +335,7 @@ func TestApplyUpdateApplyConflictForced(t *testing.T) {
 		Namespace("default").
 		Resource("deployments").
 		Name("deployment").
-		Body([]byte(`{"spec":{"replicas": 5}}`)).Do().Get()
+		Body([]byte(`{"spec":{"replicas": 5}}`)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
@@ -344,7 +346,7 @@ func TestApplyUpdateApplyConflictForced(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("fieldManager", "apply_test").
-		Body([]byte(obj)).Do().Get()
+		Body([]byte(obj)).Do(context.TODO()).Get()
 	if err == nil {
 		t.Fatalf("Expecting to get conflicts when applying object")
 	}
@@ -363,7 +365,7 @@ func TestApplyUpdateApplyConflictForced(t *testing.T) {
 		Name("deployment").
 		Param("force", "true").
 		Param("fieldManager", "apply_test").
-		Body([]byte(obj)).Do().Get()
+		Body([]byte(obj)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to apply object with force: %v", err)
 	}
@@ -391,7 +393,7 @@ func TestApplyGroupsManySeparateUpdates(t *testing.T) {
 		Resource("validatingwebhookconfigurations").
 		Name("webhook").
 		Param("fieldManager", "apply_test").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
 	}
@@ -407,7 +409,7 @@ func TestApplyGroupsManySeparateUpdates(t *testing.T) {
 			Resource("validatingwebhookconfigurations").
 			Name("webhook").
 			Param("fieldManager", unique).
-			Body([]byte(`{"metadata":{"labels":{"` + unique + `":"new"}}}`)).Do().Get()
+			Body([]byte(`{"metadata":{"labels":{"` + unique + `":"new"}}}`)).Do(context.TODO()).Get()
 		if err != nil {
 			t.Fatalf("Failed to patch object: %v", err)
 		}
@@ -464,7 +466,7 @@ func TestApplyManagedFields(t *testing.T) {
 				"key": "value"
 			}
 		}`)).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
@@ -475,7 +477,7 @@ func TestApplyManagedFields(t *testing.T) {
 		Resource("configmaps").
 		Name("test-cm").
 		Param("fieldManager", "updater").
-		Body([]byte(`{"data":{"new-key": "value"}}`)).Do().Get()
+		Body([]byte(`{"data":{"new-key": "value"}}`)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
@@ -490,12 +492,12 @@ func TestApplyManagedFields(t *testing.T) {
 		Resource("configmaps").
 		Name("test-cm").
 		Param("fieldManager", "updater").
-		Body([]byte(`{"data":{"key": "new value"}}`)).Do().Get()
+		Body([]byte(`{"data":{"key": "new value"}}`)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
 
-	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do().Get()
+	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
 	}
@@ -588,7 +590,7 @@ func TestApplyRemovesEmptyManagedFields(t *testing.T) {
 		Name("test-cm").
 		Param("fieldManager", "apply_test").
 		Body(obj).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
@@ -599,12 +601,12 @@ func TestApplyRemovesEmptyManagedFields(t *testing.T) {
 		Resource("configmaps").
 		Name("test-cm").
 		Param("fieldManager", "apply_test").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
 
-	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do().Get()
+	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
 	}
@@ -639,7 +641,7 @@ func TestApplyRequiresFieldManager(t *testing.T) {
 		Resource("configmaps").
 		Name("test-cm").
 		Body(obj).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err == nil {
 		t.Fatalf("Apply should fail to create without fieldManager")
@@ -651,7 +653,7 @@ func TestApplyRequiresFieldManager(t *testing.T) {
 		Name("test-cm").
 		Param("fieldManager", "apply_test").
 		Body(obj).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Apply failed to create with fieldManager: %v", err)
@@ -705,7 +707,7 @@ func TestApplyRemoveContainerPort(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("fieldManager", "apply_test").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
 	}
@@ -746,7 +748,7 @@ func TestApplyRemoveContainerPort(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("fieldManager", "apply_test").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to remove container port using Apply patch: %v", err)
 	}
@@ -805,7 +807,7 @@ func TestApplyFailsWithVersionMismatch(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("fieldManager", "apply_test").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
 	}
@@ -845,7 +847,7 @@ func TestApplyFailsWithVersionMismatch(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("fieldManager", "apply_test").
-		Body([]byte(obj)).Do().Get()
+		Body([]byte(obj)).Do(context.TODO()).Get()
 	if err == nil {
 		t.Fatalf("Expecting to get version mismatch when applying object")
 	}
@@ -925,7 +927,7 @@ func TestApplyConvertsManagedFieldsVersion(t *testing.T) {
 		AbsPath("/apis/apps/v1").
 		Namespace("default").
 		Resource("deployments").
-		Body(obj).Do().Get()
+		Body(obj).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to create object: %v", err)
 	}
@@ -954,7 +956,7 @@ func TestApplyConvertsManagedFieldsVersion(t *testing.T) {
 		Resource("deployments").
 		Name("deployment").
 		Param("fieldManager", "sidecar_controller").
-		Body([]byte(obj)).Do().Get()
+		Body([]byte(obj)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to apply object: %v", err)
 	}
@@ -1028,7 +1030,7 @@ func TestClearManagedFieldsWithMergePatch(t *testing.T) {
 				"key": "value"
 			}
 		}`)).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
@@ -1038,12 +1040,12 @@ func TestClearManagedFieldsWithMergePatch(t *testing.T) {
 		Namespace("default").
 		Resource("configmaps").
 		Name("test-cm").
-		Body([]byte(`{"metadata":{"managedFields": [{}]}}`)).Do().Get()
+		Body([]byte(`{"metadata":{"managedFields": [{}]}}`)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
 
-	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do().Get()
+	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
 	}
@@ -1084,7 +1086,7 @@ func TestClearManagedFieldsWithStrategicMergePatch(t *testing.T) {
 				"key": "value"
 			}
 		}`)).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
@@ -1094,12 +1096,12 @@ func TestClearManagedFieldsWithStrategicMergePatch(t *testing.T) {
 		Namespace("default").
 		Resource("configmaps").
 		Name("test-cm").
-		Body([]byte(`{"metadata":{"managedFields": [{}]}}`)).Do().Get()
+		Body([]byte(`{"metadata":{"managedFields": [{}]}}`)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
 
-	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do().Get()
+	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
 	}
@@ -1144,7 +1146,7 @@ func TestClearManagedFieldsWithJSONPatch(t *testing.T) {
 				"key": "value"
 			}
 		}`)).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
@@ -1154,12 +1156,12 @@ func TestClearManagedFieldsWithJSONPatch(t *testing.T) {
 		Namespace("default").
 		Resource("configmaps").
 		Name("test-cm").
-		Body([]byte(`[{"op": "replace", "path": "/metadata/managedFields", "value": [{}]}]`)).Do().Get()
+		Body([]byte(`[{"op": "replace", "path": "/metadata/managedFields", "value": [{}]}]`)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
 
-	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do().Get()
+	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
 	}
@@ -1200,7 +1202,7 @@ func TestClearManagedFieldsWithUpdate(t *testing.T) {
 				"key": "value"
 			}
 		}`)).
-		Do().
+		Do(context.TODO()).
 		Get()
 	if err != nil {
 		t.Fatalf("Failed to create object using Apply patch: %v", err)
@@ -1224,12 +1226,12 @@ func TestClearManagedFieldsWithUpdate(t *testing.T) {
 			"data": {
 				"key": "value"
 			}
-		}`)).Do().Get()
+		}`)).Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to patch object: %v", err)
 	}
 
-	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do().Get()
+	object, err := client.CoreV1().RESTClient().Get().Namespace("default").Resource("configmaps").Name("test-cm").Do(context.TODO()).Get()
 	if err != nil {
 		t.Fatalf("Failed to retrieve object: %v", err)
 	}
@@ -1416,7 +1418,7 @@ func getPodBytesWhenEnabled(b *testing.B, pod v1.Pod, format string) []byte {
 		Param("fieldManager", "apply_test").
 		Resource("pods").
 		SetHeader("Accept", format).
-		Body(encodePod(pod)).DoRaw()
+		Body(encodePod(pod)).DoRaw(context.TODO())
 	if err != nil {
 		b.Fatalf("Failed to create object: %#v", err)
 	}
@@ -1439,7 +1441,7 @@ func BenchmarkNoServerSideApplyButSameSize(b *testing.B) {
 		Resource("pods").
 		SetHeader("Content-Type", "application/yaml").
 		SetHeader("Accept", "application/vnd.kubernetes.protobuf").
-		Body(encodePod(pod)).DoRaw()
+		Body(encodePod(pod)).DoRaw(context.TODO())
 	if err != nil {
 		b.Fatalf("Failed to create object: %v", err)
 	}
@@ -1485,7 +1487,7 @@ func benchAll(b *testing.B, client kubernetes.Interface, pod v1.Pod) {
 		Namespace("default").
 		Resource("pods").
 		SetHeader("Content-Type", "application/yaml").
-		Body(encodePod(pod)).Do().Get()
+		Body(encodePod(pod)).Do(context.TODO()).Get()
 	if err != nil {
 		b.Fatalf("Failed to create object: %v", err)
 	}
@@ -1516,7 +1518,7 @@ func benchPostPod(client kubernetes.Interface, pod v1.Pod, parallel int) func(*t
 						Namespace("default").
 						Resource("pods").
 						SetHeader("Content-Type", "application/yaml").
-						Body(encodePod(pod)).Do().Get()
+						Body(encodePod(pod)).Do(context.TODO()).Get()
 					c <- err
 				}(pod)
 			}
@@ -1540,7 +1542,7 @@ func createNamespace(client kubernetes.Interface, name string) error {
 	_, err = client.CoreV1().RESTClient().Get().
 		Resource("namespaces").
 		SetHeader("Content-Type", "application/yaml").
-		Body(namespaceBytes).Do().Get()
+		Body(namespaceBytes).Do(context.TODO()).Get()
 	if err != nil {
 		return fmt.Errorf("Failed to create namespace: %v", err)
 	}
@@ -1561,7 +1563,7 @@ func benchListPod(client kubernetes.Interface, pod v1.Pod, num int) func(*testin
 				Namespace(namespace).
 				Resource("pods").
 				SetHeader("Content-Type", "application/yaml").
-				Body(encodePod(pod)).Do().Get()
+				Body(encodePod(pod)).Do(context.TODO()).Get()
 			if err != nil {
 				b.Fatalf("Failed to create object: %v", err)
 			}
@@ -1574,7 +1576,7 @@ func benchListPod(client kubernetes.Interface, pod v1.Pod, num int) func(*testin
 				Namespace(namespace).
 				Resource("pods").
 				SetHeader("Accept", "application/vnd.kubernetes.protobuf").
-				Do().Get()
+				Do(context.TODO()).Get()
 			if err != nil {
 				b.Fatalf("Failed to patch object: %v", err)
 			}
@@ -1591,7 +1593,7 @@ func benchRepeatedUpdate(client kubernetes.Interface, podName string) func(*test
 				Namespace("default").
 				Resource("pods").
 				Name(podName).
-				Body([]byte(fmt.Sprintf(`[{"op": "replace", "path": "/spec/containers/0/image", "value": "image%d"}]`, i))).Do().Get()
+				Body([]byte(fmt.Sprintf(`[{"op": "replace", "path": "/spec/containers/0/image", "value": "image%d"}]`, i))).Do(context.TODO()).Get()
 			if err != nil {
 				b.Fatalf("Failed to patch object: %v", err)
 			}

--- a/test/integration/apiserver/max_json_patch_operations_test.go
+++ b/test/integration/apiserver/max_json_patch_operations_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,7 +57,7 @@ func TestMaxJSONPatchOperations(t *testing.T) {
 	}
 
 	err = c.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-		Body(hugePatch).Do().Error()
+		Body(hugePatch).Do(context.TODO()).Error()
 	if err == nil {
 		t.Fatalf("unexpected no error")
 	}

--- a/test/integration/apiserver/max_request_body_bytes_test.go
+++ b/test/integration/apiserver/max_request_body_bytes_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -41,7 +42,7 @@ func TestMaxResourceSize(t *testing.T) {
 	c := clientSet.CoreV1().RESTClient()
 	t.Run("Create should limit the request body size", func(t *testing.T) {
 		err := c.Post().AbsPath(fmt.Sprintf("/api/v1/namespaces/default/pods")).
-			Body(hugeData).Do().Error()
+			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")
 		}
@@ -64,7 +65,7 @@ func TestMaxResourceSize(t *testing.T) {
 
 	t.Run("Update should limit the request body size", func(t *testing.T) {
 		err = c.Put().AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(hugeData).Do().Error()
+			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")
 		}
@@ -75,7 +76,7 @@ func TestMaxResourceSize(t *testing.T) {
 	})
 	t.Run("Patch should limit the request body size", func(t *testing.T) {
 		err = c.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(hugeData).Do().Error()
+			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")
 		}
@@ -87,7 +88,7 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("JSONPatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}]`)
 		err = rest.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
 		}
@@ -95,7 +96,7 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("JSONPatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`[{"op":"add","path":"/foo","value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}]`)
 		err = rest.Patch(types.JSONPatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -103,7 +104,7 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("MergePatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.MergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
 		}
@@ -111,7 +112,7 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("MergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
 		err = rest.Patch(types.MergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -119,7 +120,7 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("StrategicMergePatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.StrategicMergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %v", err)
 		}
@@ -127,7 +128,7 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("StrategicMergePatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":0` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
 		err = rest.Patch(types.StrategicMergePatchType).AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -135,7 +136,7 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("ApplyPatchType should handle a patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"value":` + strings.Repeat("[", 3*1024*1024/2-100) + strings.Repeat("]", 3*1024*1024/2-100) + `}`)
 		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected success or bad request err, got %#v", err)
 		}
@@ -143,14 +144,14 @@ func TestMaxResourceSize(t *testing.T) {
 	t.Run("ApplyPatchType should handle a valid patch just under the max limit", func(t *testing.T) {
 		patchBody := []byte(`{"apiVersion":"v1","kind":"Secret"` + strings.Repeat(" ", 3*1024*1024-100) + `}`)
 		err = rest.Patch(types.ApplyPatchType).Param("fieldManager", "test").AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(patchBody).Do().Error()
+			Body(patchBody).Do(context.TODO()).Error()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 	})
 	t.Run("Delete should limit the request body size", func(t *testing.T) {
 		err = c.Delete().AbsPath(fmt.Sprintf("/api/v1/namespaces/default/secrets/test")).
-			Body(hugeData).Do().Error()
+			Body(hugeData).Do(context.TODO()).Error()
 		if err == nil {
 			t.Fatalf("unexpected no error")
 		}
@@ -174,7 +175,7 @@ values: ` + strings.Repeat("[", 3*1024*1024))
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/api/v1/namespaces/default/configmaps").
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsRequestEntityTooLargeError(err) {
 			t.Errorf("expected too large error, got %v", err)
 		}
@@ -194,7 +195,7 @@ values: ` + strings.Repeat("[", 3*1024*1024/2-500) + strings.Repeat("]", 3*1024*
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/api/v1/namespaces/default/configmaps").
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
 		}
@@ -214,7 +215,7 @@ values: ` + strings.Repeat("[", 3*1024*1024-1000))
 			SetHeader("Content-Type", "application/yaml").
 			AbsPath("/api/v1/namespaces/default/configmaps").
 			Body(yamlBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
 		}
@@ -235,7 +236,7 @@ values: ` + strings.Repeat("[", 3*1024*1024-1000))
 			SetHeader("Content-Type", "application/json").
 			AbsPath("/api/v1/namespaces/default/configmaps").
 			Body(jsonBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsRequestEntityTooLargeError(err) {
 			t.Errorf("expected too large error, got %v", err)
 		}
@@ -256,7 +257,7 @@ values: ` + strings.Repeat("[", 3*1024*1024-1000))
 			SetHeader("Content-Type", "application/json").
 			AbsPath("/api/v1/namespaces/default/configmaps").
 			Body(jsonBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		// TODO(liggitt): expect bad request on deep nesting, rather than success on dropped unknown field data
 		if err != nil && !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
@@ -278,7 +279,7 @@ values: ` + strings.Repeat("[", 3*1024*1024-1000))
 			SetHeader("Content-Type", "application/json").
 			AbsPath("/api/v1/namespaces/default/configmaps").
 			Body(jsonBody).
-			DoRaw()
+			DoRaw(context.TODO())
 		if !apierrors.IsBadRequest(err) {
 			t.Errorf("expected bad request, got %v", err)
 		}

--- a/test/integration/apiserver/patch_test.go
+++ b/test/integration/apiserver/patch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -24,7 +25,7 @@ import (
 
 	"github.com/google/uuid"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -83,7 +84,7 @@ func TestPatchConflicts(t *testing.T) {
 				Resource("secrets").
 				Name("test").
 				Body([]byte(fmt.Sprintf(`{"metadata":{"labels":{"%s":"%s"}, "ownerReferences":[{"$patch":"delete","uid":"%s"}]}}`, labelName, value, UIDs[i]))).
-				Do().
+				Do(context.TODO()).
 				Get()
 
 			if apierrors.IsConflict(err) {

--- a/test/integration/apiserver/podlogs/podlogs_test.go
+++ b/test/integration/apiserver/podlogs/podlogs_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package podlogs
 
 import (
+	"context"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -137,7 +138,7 @@ func TestInsecurePodLogs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	insecureResult := clientSet.CoreV1().Pods("ns").GetLogs(pod.Name, &corev1.PodLogOptions{InsecureSkipTLSVerifyBackend: true}).Do()
+	insecureResult := clientSet.CoreV1().Pods("ns").GetLogs(pod.Name, &corev1.PodLogOptions{InsecureSkipTLSVerifyBackend: true}).Do(context.TODO())
 	if err := insecureResult.Error(); err != nil {
 		t.Fatal(err)
 	}
@@ -147,7 +148,7 @@ func TestInsecurePodLogs(t *testing.T) {
 		t.Fatal(insecureStatusCode)
 	}
 
-	secureResult := clientSet.CoreV1().Pods("ns").GetLogs(pod.Name, &corev1.PodLogOptions{}).Do()
+	secureResult := clientSet.CoreV1().Pods("ns").GetLogs(pod.Name, &corev1.PodLogOptions{}).Do(context.TODO())
 	if err := secureResult.Error(); err == nil || !strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
 		t.Fatal(err)
 	}

--- a/test/integration/apiserver/print_test.go
+++ b/test/integration/apiserver/print_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -238,7 +239,7 @@ func TestServerSidePrint(t *testing.T) {
 		if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
 			req = req.Namespace(ns.Name)
 		}
-		body, err := req.Resource(mapping.Resource.Resource).SetHeader("Accept", tableParam).Do().Raw()
+		body, err := req.Resource(mapping.Resource.Resource).SetHeader("Accept", tableParam).Do(context.TODO()).Raw()
 		if err != nil {
 			t.Errorf("unexpected error getting %s: %v", gvk, err)
 			continue

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package auth
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -84,7 +85,7 @@ func TestNodeAuthorizer(t *testing.T) {
 
 	// Wait for a healthy server
 	for {
-		result := superuserClient.CoreV1().RESTClient().Get().AbsPath("/healthz").Do()
+		result := superuserClient.CoreV1().RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 		_, err := result.Raw()
 		if err == nil {
 			break

--- a/test/integration/auth/rbac_test.go
+++ b/test/integration/auth/rbac_test.go
@@ -684,7 +684,7 @@ func TestBootstrapping(t *testing.T) {
 
 	t.Errorf("missing cluster-admin: %v", clusterRoles)
 
-	healthBytes, err := clientset.Discovery().RESTClient().Get().AbsPath("/healthz/poststarthook/rbac/bootstrap-roles").DoRaw()
+	healthBytes, err := clientset.Discovery().RESTClient().Get().AbsPath("/healthz/poststarthook/rbac/bootstrap-roles").DoRaw(context.TODO())
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/client/client_test.go
+++ b/test/integration/client/client_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"reflect"
@@ -263,7 +264,7 @@ func TestPatch(t *testing.T) {
 			Namespace("default").
 			Name(name).
 			Body(body).
-			Do()
+			Do(context.TODO())
 		if result.Error() != nil {
 			return result.Error()
 		}
@@ -341,7 +342,7 @@ func TestPatchWithCreateOnUpdate(t *testing.T) {
 	}
 
 	patchEndpoint := func(json []byte) (runtime.Object, error) {
-		return c.CoreV1().RESTClient().Patch(types.MergePatchType).Resource("endpoints").Namespace("default").Name("patchendpoint").Body(json).Do().Get()
+		return c.CoreV1().RESTClient().Patch(types.MergePatchType).Resource("endpoints").Namespace("default").Name("patchendpoint").Body(json).Do(context.TODO()).Get()
 	}
 
 	// Make sure patch doesn't get to CreateOnUpdate
@@ -496,7 +497,7 @@ func TestSingleWatch(t *testing.T) {
 			Watch:           true,
 			FieldSelector:   fields.OneTermEqualSelector("metadata.name", "event-9").String(),
 		}, metav1.ParameterCodec).
-		Watch()
+		Watch(context.TODO())
 
 	if err != nil {
 		t.Fatalf("Failed watch: %v", err)
@@ -757,7 +758,7 @@ func runSelfLinkTestOnNamespace(t *testing.T, c clientset.Interface, namespace s
 	if err != nil {
 		t.Fatalf("Failed creating selflinktest pod: %v", err)
 	}
-	if err = c.CoreV1().RESTClient().Get().RequestURI(pod.SelfLink).Do().Into(pod); err != nil {
+	if err = c.CoreV1().RESTClient().Get().RequestURI(pod.SelfLink).Do(context.TODO()).Into(pod); err != nil {
 		t.Errorf("Failed listing pod with supplied self link '%v': %v", pod.SelfLink, err)
 	}
 
@@ -766,7 +767,7 @@ func runSelfLinkTestOnNamespace(t *testing.T, c clientset.Interface, namespace s
 		t.Errorf("Failed listing pods: %v", err)
 	}
 
-	if err = c.CoreV1().RESTClient().Get().RequestURI(podList.SelfLink).Do().Into(podList); err != nil {
+	if err = c.CoreV1().RESTClient().Get().RequestURI(podList.SelfLink).Do(context.TODO()).Into(podList); err != nil {
 		t.Errorf("Failed listing pods with supplied self link '%v': %v", podList.SelfLink, err)
 	}
 
@@ -777,7 +778,7 @@ func runSelfLinkTestOnNamespace(t *testing.T, c clientset.Interface, namespace s
 			continue
 		}
 		found = true
-		err = c.CoreV1().RESTClient().Get().RequestURI(item.SelfLink).Do().Into(pod)
+		err = c.CoreV1().RESTClient().Get().RequestURI(item.SelfLink).Do(context.TODO()).Into(pod)
 		if err != nil {
 			t.Errorf("Failed listing pod with supplied self link '%v': %v", item.SelfLink, err)
 		}

--- a/test/integration/etcd/server.go
+++ b/test/integration/etcd/server.go
@@ -146,7 +146,7 @@ func StartRealMasterOrDie(t *testing.T, configFuncs ...func(*options.ServerRunOp
 	attempt := 0
 	if err := wait.PollImmediate(time.Second, time.Minute, func() (done bool, err error) {
 		// wait for the server to be healthy
-		result := kubeClient.RESTClient().Get().AbsPath("/healthz").Do()
+		result := kubeClient.RESTClient().Get().AbsPath("/healthz").Do(context.TODO())
 		content, _ := result.Raw()
 		lastHealth = string(content)
 		if errResult := result.Error(); errResult != nil {

--- a/test/integration/examples/apiserver_test.go
+++ b/test/integration/examples/apiserver_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiserver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -228,7 +229,7 @@ func waitForWardleRunning(t *testing.T, wardleToKASKubeConfig *rest.Config, ward
 			return false, nil
 		}
 		healthStatus := 0
-		result := wardleClient.Discovery().RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		result := wardleClient.Discovery().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&healthStatus)
 		lastHealthContent, lastHealthErr = result.Raw()
 		if healthStatus != http.StatusOK {
 			return false, nil
@@ -345,7 +346,7 @@ func createKubeConfig(clientCfg *rest.Config) *clientcmdapi.Config {
 }
 
 func readResponse(client rest.Interface, location string) ([]byte, error) {
-	return client.Get().AbsPath(location).DoRaw()
+	return client.Get().AbsPath(location).DoRaw(context.TODO())
 }
 
 func testAPIGroupList(t *testing.T, client rest.Interface) {

--- a/test/integration/framework/master_utils.go
+++ b/test/integration/framework/master_utils.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/google/uuid"
+
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
 	authauthenticator "k8s.io/apiserver/pkg/authentication/authenticator"
@@ -216,7 +217,7 @@ func startMasterOrDie(masterConfig *master.Config, incomingServer *httptest.Serv
 	}
 	var lastHealthContent []byte
 	err = wait.PollImmediate(100*time.Millisecond, 30*time.Second, func() (bool, error) {
-		result := privilegedClient.Get().AbsPath("/healthz").Do()
+		result := privilegedClient.Get().AbsPath("/healthz").Do(context.TODO())
 		status := 0
 		result.StatusCode(&status)
 		if status == 200 {

--- a/test/integration/framework/test_server.go
+++ b/test/integration/framework/test_server.go
@@ -17,6 +17,7 @@ limitations under the License.
 package framework
 
 import (
+	"context"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -150,7 +151,7 @@ func StartTestServer(t *testing.T, stopCh <-chan struct{}, setup TestServerSetup
 		}
 
 		healthStatus := 0
-		kubeClient.Discovery().RESTClient().Get().AbsPath("/healthz").Do().StatusCode(&healthStatus)
+		kubeClient.Discovery().RESTClient().Get().AbsPath("/healthz").Do(context.TODO()).StatusCode(&healthStatus)
 		if healthStatus != http.StatusOK {
 			return false, nil
 		}

--- a/test/integration/master/crd_test.go
+++ b/test/integration/master/crd_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package master
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -211,7 +212,7 @@ func TestCRDOpenAPI(t *testing.T) {
 	etcd.CreateTestCRDs(t, apiextensionsclient, false, structuralCRD)
 
 	getPublishedSchema := func(defName string) (*spec.Schema, error) {
-		bs, err := kubeclient.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+		bs, err := kubeclient.RESTClient().Get().AbsPath("openapi", "v2").DoRaw(context.TODO())
 		if err != nil {
 			return nil, err
 		}

--- a/test/integration/master/kms_transformation_test.go
+++ b/test/integration/master/kms_transformation_test.go
@@ -293,7 +293,7 @@ func getHealthz(checkName string, clientConfig *rest.Config) (int, error) {
 		return 0, fmt.Errorf("failed to create a client: %v", err)
 	}
 
-	result := client.CoreV1().RESTClient().Get().AbsPath(fmt.Sprintf("/healthz/%v", checkName)).Do()
+	result := client.CoreV1().RESTClient().Get().AbsPath(fmt.Sprintf("/healthz/%v", checkName)).Do(context.TODO())
 	status := 0
 	result.StatusCode(&status)
 	return status, nil

--- a/test/integration/master/kube_apiserver_test.go
+++ b/test/integration/master/kube_apiserver_test.go
@@ -18,6 +18,7 @@ package master
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -27,6 +28,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/spec"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -97,7 +99,7 @@ func TestRun(t *testing.T) {
 }
 
 func endpointReturnsStatusOK(client *kubernetes.Clientset, path string) bool {
-	res := client.CoreV1().RESTClient().Get().AbsPath(path).Do()
+	res := client.CoreV1().RESTClient().Get().AbsPath(path).Do(context.TODO())
 	var status int
 	res.StatusCode(&status)
 	return status == http.StatusOK
@@ -132,7 +134,7 @@ func TestOpenAPIDelegationChainPlumbing(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	result := kubeclient.RESTClient().Get().AbsPath("/openapi/v2").Do()
+	result := kubeclient.RESTClient().Get().AbsPath("/openapi/v2").Do(context.TODO())
 	status := 0
 	result.StatusCode(&status)
 	if status != http.StatusOK {
@@ -343,7 +345,7 @@ func triggerSpecUpdateWithProbeCRD(t *testing.T, apiextensionsclient *apiextensi
 }
 
 func specHasProbe(clientset *apiextensionsclientset.Clientset, probe string) (bool, error) {
-	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw(context.TODO())
 	if err != nil {
 		return false, err
 	}
@@ -351,7 +353,7 @@ func specHasProbe(clientset *apiextensionsclientset.Clientset, probe string) (bo
 }
 
 func getOpenAPIPath(clientset *apiextensionsclientset.Clientset, path string) (spec.PathItem, bool, error) {
-	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw(context.TODO())
 	if err != nil {
 		return spec.PathItem{}, false, err
 	}
@@ -367,7 +369,7 @@ func getOpenAPIPath(clientset *apiextensionsclientset.Clientset, path string) (s
 }
 
 func getOpenAPIDefinition(clientset *apiextensionsclientset.Clientset, definition string) (spec.Schema, bool, error) {
-	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw()
+	bs, err := clientset.RESTClient().Get().AbsPath("openapi", "v2").DoRaw(context.TODO())
 	if err != nil {
 		return spec.Schema{}, false, err
 	}

--- a/test/integration/scale/scale_test.go
+++ b/test/integration/scale/scale_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scale
 
 import (
+	"context"
 	"encoding/json"
 	"path"
 	"strings"
@@ -145,7 +146,7 @@ func TestScaleSubresources(t *testing.T) {
 		urlPath := path.Join(prefix, gvr.Group, gvr.Version, "namespaces", "default", resourceParts[0], "test", resourceParts[1])
 		obj := &unstructured.Unstructured{}
 
-		getData, err := clientSet.CoreV1().RESTClient().Get().AbsPath(urlPath).DoRaw()
+		getData, err := clientSet.CoreV1().RESTClient().Get().AbsPath(urlPath).DoRaw(context.TODO())
 		if err != nil {
 			t.Errorf("error fetching %s: %v", urlPath, err)
 			continue
@@ -162,7 +163,7 @@ func TestScaleSubresources(t *testing.T) {
 			continue
 		}
 
-		updateData, err := clientSet.CoreV1().RESTClient().Put().AbsPath(urlPath).Body(getData).DoRaw()
+		updateData, err := clientSet.CoreV1().RESTClient().Put().AbsPath(urlPath).Body(getData).DoRaw(context.TODO())
 		if err != nil {
 			t.Errorf("error putting to %s: %v", urlPath, err)
 			t.Log(string(getData))

--- a/test/soak/serve_hostnames/serve_hostnames.go
+++ b/test/soak/serve_hostnames/serve_hostnames.go
@@ -23,6 +23,7 @@ a serivce
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -273,7 +274,7 @@ func main() {
 		hostname, err := proxyRequest.
 			Namespace(ns).
 			Name("serve-hostnames").
-			DoRaw()
+			DoRaw(context.TODO())
 		if err != nil {
 			klog.Infof("After %v while making a proxy call got error %v", time.Since(start), err)
 			continue
@@ -303,7 +304,7 @@ func main() {
 				hostname, err := proxyRequest.
 					Namespace(ns).
 					Name("serve-hostnames").
-					DoRaw()
+					DoRaw(context.TODO())
 				klog.V(4).Infof("Proxy call in namespace %s took %v", ns, time.Since(t))
 				if err != nil {
 					klog.Warningf("Call failed during iteration %d query %d : %v", i, query, err)


### PR DESCRIPTION
Explicitly pass context.Context to Do(), DoRaw(), Stream(), Watch() and remove (*Request).Context() method and saved ctx field. This was discussed as an improved API in https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md.

Opening to test in CI and get feedback on the API change.

Commits:

1. The rest.Request API change.
1. Update client-gen to generate clients that pass context.TODO() to Do() and Watch()
1. automated client regeneration.
1. automated refactoring for the new API.
1. semi-automated refactoring for the new API.

/kind cleanup
/sig api-machinery

Part of #46503

```release-note
`(*"k8s.io/client-go/rest".Request).{Do,DoRaw,Stream,Watch}` now require callers to pass a `context.Context` as an argument. The context is used for timeout and cancellation signaling and to pass supplementary information to round trippers in the wrapped transport chain. If you don't need any of this functionality, it is sufficient to pass a context created with `context.Background()` to these functions. The `(*"k8s.io/client-go/rest".Request).Context` method is removed now that all methods that execute a request accept a context directly.
```