### PR TITLE
DualStack: endpoints for headless services

### DIFF
--- a/pkg/controller/endpoint/endpoints_controller_test.go
+++ b/pkg/controller/endpoint/endpoints_controller_test.go
@@ -1102,6 +1102,9 @@ func TestShouldPodBeInEndpoints(t *testing.T) {
 	}
 }
 func TestPodToEndpointAddressForService(t *testing.T) {
+	ip4family := v1.IPv4Protocol
+	ip6family := v1.IPv6Protocol
+
 	testCases := []struct {
 		name               string
 		expectedEndPointIP string
@@ -1182,6 +1185,51 @@ func TestPodToEndpointAddressForService(t *testing.T) {
 			service: v1.Service{
 				Spec: v1.ServiceSpec{
 					ClusterIP: "3000::1",
+				},
+			},
+		},
+		{
+			name:               "headless v4 service, in a dual stack cluster. dual stack enabled",
+			expectedEndPointIP: "1.2.3.4",
+
+			enableDualStack:    true,
+			expectError:        false,
+			enableDualStackPod: true,
+
+			service: v1.Service{
+				Spec: v1.ServiceSpec{
+					ClusterIP: "None",
+					IPFamily:  &ip4family,
+				},
+			},
+		},
+		{
+			name:               "headless v6 service, in a dual stack cluster. dual stack enabled",
+			expectedEndPointIP: "2000::0",
+
+			enableDualStack:    true,
+			expectError:        false,
+			enableDualStackPod: true,
+
+			service: v1.Service{
+				Spec: v1.ServiceSpec{
+					ClusterIP: "None",
+					IPFamily:  &ip6family,
+				},
+			},
+		},
+		{
+			name:               "headless nil ipFamily service, in a dual stack cluster. dual stack enabled",
+			expectedEndPointIP: "1.2.3.4",
+
+			enableDualStack:    true,
+			expectError:        false,
+			enableDualStackPod: true,
+
+			service: v1.Service{
+				Spec: v1.ServiceSpec{
+					ClusterIP: "None",
+					IPFamily:  nil,
 				},
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Headless services doesn't have a ClusterIP, it's set to "None",
hence we can not infer the IP family of the service from that field.

Current logic assumes that all headless services are IPv4, we can use
the IPFamily field, if there is no ClusterIP, to detect the family of the
service and return the correct endpoints in a dual-stack cluster.

If there is no IPFamily then headless services defaults to IPv4.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

Bug detected by Dan Winship https://github.com/kubernetes/kubernetes/pull/86895#issuecomment-577070772

How to repro https://gist.github.com/aojea/c61240d9dd77106058e9351d248b3629

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Headless services on dual-stack clusters return the endpoints based on the Spec.IPFamily field of the service, defaulting to IPv4 if the IPFamily is not set.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
