### PR TITLE
Fixed a failing test on a RBD mount scenario

### DIFF
--- a/pkg/volume/rbd/rbd_test.go
+++ b/pkg/volume/rbd/rbd_test.go
@@ -385,7 +385,6 @@ func TestPlugin(t *testing.T) {
 					RBDPool:      "pool1",
 					RBDImage:     "image1",
 					FSType:       "ext4",
-					ReadOnly:     true,
 				},
 			},
 		}),


### PR DESCRIPTION
This PR is an "easy fix" for #87408 

It ensures that in all RBD tests scenarios, we attempt to mount the volumes in read-write mode. It would be nice to cover the read-only case too though.

/kind failing-test

**Which issue(s) this PR fixes**:

> It blocks #85617 and would solve #87408

```release-note
NONE
```