### PR TITLE
Fix back off when scheduling cycle is delayed

### DIFF
--- a/pkg/scheduler/internal/queue/scheduling_queue.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue.go
@@ -214,7 +214,7 @@ func NewPriorityQueue(
 	pq := &PriorityQueue{
 		clock:            options.clock,
 		stop:             make(chan struct{}),
-		podBackoff:       NewPodBackoffMap(options.podInitialBackoffDuration, options.podMaxBackoffDuration),
+		podBackoff:       NewPodBackoffMap(options.podInitialBackoffDuration, options.podMaxBackoffDuration, options.clock),
 		activeQ:          heap.NewWithRecorder(podInfoKeyFunc, comp, metrics.NewActivePodsRecorder()),
 		unschedulableQ:   newUnschedulablePodsMap(metrics.NewUnschedulablePodsRecorder()),
 		nominatedPods:    newNominatedPodMap(),

--- a/pkg/scheduler/internal/queue/scheduling_queue_test.go
+++ b/pkg/scheduler/internal/queue/scheduling_queue_test.go
@@ -1515,3 +1515,85 @@ func createAndRunPriorityQueue(fwk framework.Framework, opts ...Option) *Priorit
 	q.Run()
 	return q
 }
+
+func TestBackOffFlow(t *testing.T) {
+	cl := clock.NewFakeClock(time.Now())
+	q := NewPriorityQueue(newDefaultFramework(), WithClock(cl))
+	steps := []struct {
+		wantBackoff time.Duration
+	}{
+		{wantBackoff: time.Second},
+		{wantBackoff: 2 * time.Second},
+		{wantBackoff: 4 * time.Second},
+		{wantBackoff: 8 * time.Second},
+		{wantBackoff: 10 * time.Second},
+		{wantBackoff: 10 * time.Second},
+		{wantBackoff: 10 * time.Second},
+	}
+	pod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-pod",
+			Namespace: "test-ns",
+			UID:       "test-uid",
+		},
+	}
+	podID := nsNameForPod(pod)
+	if err := q.Add(pod); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, step := range steps {
+		t.Run(fmt.Sprintf("step %d", i), func(t *testing.T) {
+			timestamp := cl.Now()
+			// Simulate schedule attempt.
+			podInfo, err := q.Pop()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if podInfo.Attempts != i+1 {
+				t.Errorf("got attempts %d, want %d", podInfo.Attempts, i+1)
+			}
+			if err := q.AddUnschedulableIfNotPresent(podInfo, int64(i)); err != nil {
+				t.Fatal(err)
+			}
+
+			// An event happens.
+			q.MoveAllToActiveOrBackoffQueue("deleted pod")
+
+			if _, ok, _ := q.podBackoffQ.Get(podInfo); !ok {
+				t.Errorf("pod %v is not in the backoff queue", podID)
+			}
+
+			// Check backoff duration.
+			deadline, ok := q.podBackoff.GetBackoffTime(podID)
+			if !ok {
+				t.Errorf("didn't get backoff for pod %s", podID)
+			}
+			backoff := deadline.Sub(timestamp)
+			if backoff != step.wantBackoff {
+				t.Errorf("got backoff %s, want %s", backoff, step.wantBackoff)
+			}
+
+			// Simulate routine that continuously flushes the backoff queue.
+			cl.Step(time.Millisecond)
+			q.flushBackoffQCompleted()
+			// Still in backoff queue after an early flush.
+			if _, ok, _ := q.podBackoffQ.Get(podInfo); !ok {
+				t.Errorf("pod %v is not in the backoff queue", podID)
+			}
+			// Moved out of the backoff queue after timeout.
+			cl.Step(backoff)
+			q.flushBackoffQCompleted()
+			if _, ok, _ := q.podBackoffQ.Get(podInfo); ok {
+				t.Errorf("pod %v is still in the backoff queue", podID)
+			}
+		})
+	}
+	// After some time, backoff information is cleared.
+	cl.Step(time.Hour)
+	q.podBackoff.CleanupPodsCompletesBackingoff()
+	_, ok := q.podBackoff.GetBackoffTime(podID)
+	if ok {
+		t.Errorf("backoff information for pod %s was not cleared", podID)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Every time a pod is unschedulable, we update the backoff information for it. But we also clear backoff information for pods that have a backoff older than `maxDuration` (10s by default). This means that, in a cluster with several unschedulable pods, we lose backoff information regularly. As a result, these pods can produce starvation of scheduling cycles for pods with lower priority.

The mitigation is to just wait twice the `maxDuration`. The rest of the PR is the unit test, which fails with the current implementation.

*Before PR*:

If a pod doesn't get an schedule attempt in `maxDuration` (by default 10s) it gets moved to `activeQ` and its entry in backoff map is cleared.

*After PR*:

If a pod doesn't get an schedule attempt in `maxDuration`, it gets moved to activeQ but its entry in backoff map is **not** cleared.

If a pod doesn't get an schedule attempt in another `maxDuration` (for a total of `2 * maxDuration` since last schedule attempt), the backoff map is cleared.

**Which issue(s) this PR fixes**:

Mitigates #86373

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/priority important-soon