### PR TITLE
Update GCE Windows smoke-test script to work with 1909 nodes.

### DIFF
--- a/cluster/gce/windows/README-GCE-Windows-kube-up.md
+++ b/cluster/gce/windows/README-GCE-Windows-kube-up.md
@@ -84,14 +84,15 @@ Now bring up a cluster using one of the following two methods:
 ```
 # Invoke kube-up.sh with these environment variables:
 #   PROJECT: text name of your GCP project.
-#   KUBERNETES_SKIP_CONFIRM: skips any kube-up prompts.
-PROJECT=${CLOUDSDK_CORE_PROJECT} KUBERNETES_SKIP_CONFIRM=y ./cluster/kube-up.sh
+#   KUBE_UP_AUTOMATIC_CLEANUP (optional): cleans up existing cluster without
+#     prompting.
+PROJECT=${CLOUDSDK_CORE_PROJECT} KUBE_UP_AUTOMATIC_CLEANUP=true ./cluster/kube-up.sh
 ```
 
 To teardown the cluster run:
 
 ```
-PROJECT=${CLOUDSDK_CORE_PROJECT} KUBERNETES_SKIP_CONFIRM=y ./cluster/kube-down.sh
+PROJECT=${CLOUDSDK_CORE_PROJECT} ./cluster/kube-down.sh
 ```
 
 #### 2b. Create a Kubernetes end-to-end (E2E) test cluster	

--- a/cluster/gce/windows/smoke-test.sh
+++ b/cluster/gce/windows/smoke-test.sh
@@ -245,17 +245,19 @@ function undeploy_linux_command_pod {
   ${kubectl} delete deployment $linux_command_deployment
 }
 
-windows_webserver_deployment=windows-nettest
-windows_webserver_pod_label=nettest
+windows_webserver_deployment=windows-agnhost
+windows_webserver_pod_label=agnhost
+# The default port for 'agnhost serve-hostname'. The documentation says that
+# this can be changed but the --port arg does not seem to work.
+windows_webserver_port=9376
 windows_webserver_replicas=1
 
 function deploy_windows_webserver_pod {
   echo "Writing example deployment to $windows_webserver_deployment.yaml"
   cat <<EOF > $windows_webserver_deployment.yaml
-# You can run a pod with the e2eteam/nettest:1.0 image (which should listen on
-# <podIP>:8080) and create another pod on a different node (linux would be
-# easier) to curl the http server:
-#   curl http://<pod_ip>:8080/read
+# A multi-arch Windows container that runs an HTTP server on port
+# $windows_webserver_port that serves the container's hostname.
+#   curl -s http://<pod_ip>:$windows_webserver_port
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -273,8 +275,10 @@ spec:
         app: $windows_webserver_pod_label
     spec:
       containers:
-      - name: nettest
-        image: e2eteam/nettest:1.0
+      - name: agnhost
+        image: e2eteam/agnhost:2.8
+        args:
+        - serve-hostname
       nodeSelector:
         beta.kubernetes.io/os: windows
       tolerations:
@@ -332,6 +336,7 @@ windows_command_deployment=windows-powershell
 windows_command_pod_label=powershell
 windows_command_replicas=1
 
+# Deploys a multi-arch Windows pod capable of running PowerShell.
 function deploy_windows_command_pod {
   echo "Writing example deployment to $windows_command_deployment.yaml"
   cat <<EOF > $windows_command_deployment.yaml
@@ -352,8 +357,8 @@ spec:
         app: $windows_command_pod_label
     spec:
       containers:
-      - name: nettest
-        image: e2eteam/nettest:1.0
+      - name: pause-win
+        image: gcr.io/gke-release/pause-win:1.1.0
       nodeSelector:
         beta.kubernetes.io/os: windows
       tolerations:
@@ -422,7 +427,7 @@ function test_linux_pod_to_linux_pod {
   local linux_webserver_pod_ip
   linux_webserver_pod_ip="$(get_linux_webserver_pod_ip)"
 
-  if ! $kubectl exec "$linux_command_pod" -- curl -m 20 \
+  if ! $kubectl exec "$linux_command_pod" -- curl -s -m 20 \
       "http://$linux_webserver_pod_ip" &> $output_file; then
     cleanup_deployments
     echo "Failing output: $(cat $output_file)"
@@ -444,8 +449,8 @@ function test_linux_pod_to_windows_pod {
   local windows_webserver_pod_ip
   windows_webserver_pod_ip="$(get_windows_webserver_pod_ip)"
 
-  if ! $kubectl exec "$linux_command_pod" -- curl -m 20 \
-      "http://$windows_webserver_pod_ip:8080/read" &> $output_file; then
+  if ! $kubectl exec "$linux_command_pod" -- curl -s -m 20 \
+      "http://$windows_webserver_pod_ip:$windows_webserver_port" &> $output_file; then
     cleanup_deployments
     echo "Failing output: $(cat $output_file)"
     echo "FAILED: ${FUNCNAME[0]}"
@@ -461,7 +466,7 @@ function test_linux_pod_to_internet {
   # A stable (hopefully) HTTP server provided by Cloudflare.
   local internet_ip="1.1.1.1"
 
-  if ! $kubectl exec "$linux_command_pod" -- curl -m 20 \
+  if ! $kubectl exec "$linux_command_pod" -- curl -s -m 20 \
       "http://$internet_ip" > $output_file; then
     cleanup_deployments
     echo "Failing output: $(cat $output_file)"
@@ -486,7 +491,7 @@ function test_linux_pod_to_k8s_service {
   # curl-ing the metrics-server service downloads 14 bytes of unprintable binary
   # data and sets a return code of success (0).
   if ! $kubectl exec "$linux_command_pod" -- \
-      curl -m 20 "http://$service_ip:$service_port" &> $output_file; then
+      curl -s -m 20 "http://$service_ip:$service_port" &> $output_file; then
     cleanup_deployments
     echo "Failing output: $(cat $output_file)"
     echo "FAILED: ${FUNCNAME[0]}"
@@ -534,7 +539,7 @@ function test_windows_pod_to_windows_pod {
   windows_webserver_pod_ip="$(get_windows_webserver_pod_ip)"
 
   if ! $kubectl exec "$windows_command_pod" -- powershell.exe \
-      "curl -UseBasicParsing http://$windows_webserver_pod_ip:8080/read" \
+      "curl -UseBasicParsing http://$windows_webserver_pod_ip:$windows_webserver_port" \
       > $output_file; then
     cleanup_deployments
     echo "Failing output: $(cat $output_file)"


### PR DESCRIPTION
This PR changes the smoke-test script for Windows clusters on GCE to use the [agnhost](https://github.com/kubernetes/kubernetes/tree/master/test/images/agnhost) [container](https://hub.docker.com/r/e2eteam/agnhost). The old nettest container does not seem to have been updated in a while and it is not built as a multi-arch container, so the smoke test would fail when run against Windows 1909 nodes. This agnhost container is used for many Windows e2e tests and so it will be maintained regularly. For running powershell commands, this PR also changes from the nettest container to the GKE pause image, which is built as multi-arch and supports powershell.

This PR lets the smoke test succeed against clusters running Windows 2019 or 1809 or 1909 nodes.

/kind cleanup

```release-note
NONE
```