### PR TITLE
Prevent error message from being displayed during plugin list when path includes empty string

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -113,10 +113,14 @@ func (o *PluginListOptions) Run() error {
 	pluginWarnings := 0
 
 	for _, dir := range uniquePathsList(o.PluginPaths) {
+		if len(strings.TrimSpace(dir)) == 0 {
+			continue
+		}
+
 		files, err := ioutil.ReadDir(dir)
 		if err != nil {
 			if _, ok := err.(*os.PathError); ok {
-				fmt.Fprintf(o.ErrOut, "Unable read directory %q from your PATH: %v. Skipping...", dir, err)
+				fmt.Fprintf(o.ErrOut, "Unable read directory %q from your PATH: %v. Skipping...\n", dir, err)
 				continue
 			}
 
@@ -133,7 +137,7 @@ func (o *PluginListOptions) Run() error {
 			}
 
 			if isFirstFile {
-				fmt.Fprintf(o.ErrOut, "The following compatible plugins are available:\n\n")
+				fmt.Fprintf(o.Out, "The following compatible plugins are available:\n\n")
 				pluginsFound = true
 				isFirstFile = false
 			}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -169,7 +169,6 @@ func (o *PluginListOptions) Run() error {
 		}
 	}
 	if len(pluginErrors) > 0 {
-		fmt.Fprintln(o.ErrOut)
 		errs := bytes.NewBuffer(nil)
 		for _, e := range pluginErrors {
 			fmt.Fprintln(errs, e)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -108,7 +108,6 @@ func TestPluginPathsAreValid(t *testing.T) {
 				return ioutil.TempFile(tempDir, "notkubectl-")
 			},
 			expectErr: "unable to find any kubectl plugins in your PATH",
-			expectErrOut: "\n",
 		},
 		{
 			name:        "ensure de-duplicated plugin-paths slice",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -101,31 +101,31 @@ func TestPluginPathsAreValid(t *testing.T) {
 		expectOut          string
 	}{
 		{
-			name:        "ensure no plugins found if no files begin with kubectl- prefix",
-			pluginPaths: []string{tempDir},
-			verifier:    newFakePluginPathVerifier(),
-			pluginFile: func() (*os.File, error) {
+			name:         "ensure no plugins found if no files begin with kubectl- prefix",
+			pluginPaths:  []string{tempDir},
+			verifier:     newFakePluginPathVerifier(),
+			pluginFile:   func() (*os.File, error) {
 				return ioutil.TempFile(tempDir, "notkubectl-")
 			},
-			expectErr: "unable to find any kubectl plugins in your PATH",
+			expectErr:    "error: unable to find any kubectl plugins in your PATH\n",
 		},
 		{
-			name:        "ensure de-duplicated plugin-paths slice",
-			pluginPaths: []string{tempDir, tempDir},
-			verifier:    newFakePluginPathVerifier(),
-			pluginFile: func() (*os.File, error) {
+			name:         "ensure de-duplicated plugin-paths slice",
+			pluginPaths:  []string{tempDir, tempDir},
+			verifier:     newFakePluginPathVerifier(),
+			pluginFile:   func() (*os.File, error) {
 				return ioutil.TempFile(tempDir, "kubectl-")
 			},
-			expectOut: "The following compatible plugins are available:",
+			expectOut:    "The following compatible plugins are available:",
 		},
 		{
-			name:        "ensure no errors when empty string or blank path are specified",
-			pluginPaths: []string{tempDir, "", " "},
-			verifier:    newFakePluginPathVerifier(),
-			pluginFile: func() (*os.File, error) {
+			name:         "ensure no errors when empty string or blank path are specified",
+			pluginPaths:  []string{tempDir, "", " "},
+			verifier:     newFakePluginPathVerifier(),
+			pluginFile:   func() (*os.File, error) {
 				return ioutil.TempFile(tempDir, "kubectl-")
 			},
-			expectOut: "The following compatible plugins are available:",
+			expectOut:    "The following compatible plugins are available:",
 		},
 	}
 
@@ -138,8 +138,6 @@ func TestPluginPathsAreValid(t *testing.T) {
 
 				PluginPaths: test.pluginPaths,
 			}
-			o.Out = out
-			o.ErrOut = errOut
 
 			// create files
 			if test.pluginFile != nil {
@@ -158,10 +156,11 @@ func TestPluginPathsAreValid(t *testing.T) {
 
 			err := o.Run()
 			if err == nil && len(test.expectErr) > 0 {
-				t.Fatalf("unexpected non-error: expecting %v", test.expectErr)
-			}
-			if err != nil && len(test.expectErr) == 0 {
-				t.Fatalf("unexpected error: %v - %v", err, errOut.String())
+				t.Fatalf("unexpected non-error: expected %v, but got nothing", test.expectErr)
+			} else if err != nil && len(test.expectErr) == 0 {
+				t.Fatalf("unexpected error: expected nothing, but got %v", err.Error())
+			} else if err != nil && err.Error() != test.expectErr {
+				t.Fatalf("unexpected error: expected %v, but got %v", test.expectErr, err.Error())
 			}
 
 			if len(test.expectErrOut) == 0 && errOut.Len() > 0 {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin_test.go
@@ -101,31 +101,31 @@ func TestPluginPathsAreValid(t *testing.T) {
 		expectOut          string
 	}{
 		{
-			name:         "ensure no plugins found if no files begin with kubectl- prefix",
-			pluginPaths:  []string{tempDir},
-			verifier:     newFakePluginPathVerifier(),
-			pluginFile:   func() (*os.File, error) {
+			name:        "ensure no plugins found if no files begin with kubectl- prefix",
+			pluginPaths: []string{tempDir},
+			verifier:    newFakePluginPathVerifier(),
+			pluginFile: func() (*os.File, error) {
 				return ioutil.TempFile(tempDir, "notkubectl-")
 			},
-			expectErr:    "error: unable to find any kubectl plugins in your PATH\n",
+			expectErr: "error: unable to find any kubectl plugins in your PATH\n",
 		},
 		{
-			name:         "ensure de-duplicated plugin-paths slice",
-			pluginPaths:  []string{tempDir, tempDir},
-			verifier:     newFakePluginPathVerifier(),
-			pluginFile:   func() (*os.File, error) {
+			name:        "ensure de-duplicated plugin-paths slice",
+			pluginPaths: []string{tempDir, tempDir},
+			verifier:    newFakePluginPathVerifier(),
+			pluginFile: func() (*os.File, error) {
 				return ioutil.TempFile(tempDir, "kubectl-")
 			},
-			expectOut:    "The following compatible plugins are available:",
+			expectOut: "The following compatible plugins are available:",
 		},
 		{
-			name:         "ensure no errors when empty string or blank path are specified",
-			pluginPaths:  []string{tempDir, "", " "},
-			verifier:     newFakePluginPathVerifier(),
-			pluginFile:   func() (*os.File, error) {
+			name:        "ensure no errors when empty string or blank path are specified",
+			pluginPaths: []string{tempDir, "", " "},
+			verifier:    newFakePluginPathVerifier(),
+			pluginFile: func() (*os.File, error) {
 				return ioutil.TempFile(tempDir, "kubectl-")
 			},
-			expectOut:    "The following compatible plugins are available:",
+			expectOut: "The following compatible plugins are available:",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
On a clean Windows installation, my PATH string ends with a ; (path separator on windows). This is normal and it's provided by Windows by default.

This PR changes plugin search so that it does not attempt to resolve empty strings or white-space-only strings that are in your path, so you won't get a warning message saying `Unable to read directory "" from your PATH: The system cannot find the file specified.. Skipping...`

I also fixed a problem where multiple (legitimate) directory not found warnings are not getting newlines and were running together.

I also fixed a bug in the same function where the normal message `The following compatible plugins are available:` was accidentally being written to stderr instead of stdout.

I added a unit test case and also manually verified the fix in kubectl on both linux and windows.

**Which issue(s) this PR fixes**:
fixes https://github.com/kubernetes/kubectl/issues/792

**Special notes for your reviewer**:
Example of old behavior...
```
$ kubectl plugin list
Unable read directory "" from your PATH: open : no such file or directory. Skipping...
error: unable to find any kubectl plugins in your PATH
```

New message after this fix...
```
$ kubectl plugin list
error: unable to find any kubectl plugins in your PATH
```


**Does this PR introduce a user-facing change?**:
```release-note
Prevent error message from being displayed when running kubectl plugin list and your path includes an empty string
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
n/a
