### PR TITLE
Set cache to nil data when Azure node provisioning state is deleting

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
@@ -34,8 +34,12 @@ const (
 )
 
 func newTestScaleSet(scaleSetName, zone string, faultDomain int32, vmList []string) (*scaleSet, error) {
+	return newTestScaleSetWithState(scaleSetName, zone, faultDomain, vmList, "Running")
+}
+
+func newTestScaleSetWithState(scaleSetName, zone string, faultDomain int32, vmList []string, state string) (*scaleSet, error) {
 	cloud := getTestCloud()
-	setTestVirtualMachineCloud(cloud, scaleSetName, zone, faultDomain, vmList)
+	setTestVirtualMachineCloud(cloud, scaleSetName, zone, faultDomain, vmList, state)
 	ss, err := newScaleSet(cloud)
 	if err != nil {
 		return nil, err
@@ -44,7 +48,7 @@ func newTestScaleSet(scaleSetName, zone string, faultDomain int32, vmList []stri
 	return ss.(*scaleSet), nil
 }
 
-func setTestVirtualMachineCloud(ss *Cloud, scaleSetName, zone string, faultDomain int32, vmList []string) {
+func setTestVirtualMachineCloud(ss *Cloud, scaleSetName, zone string, faultDomain int32, vmList []string, state string) {
 	virtualMachineScaleSetsClient := newFakeVirtualMachineScaleSetsClient()
 	virtualMachineScaleSetVMsClient := newFakeVirtualMachineScaleSetVMsClient()
 	publicIPAddressesClient := newFakeAzurePIPClient("rg")
@@ -99,6 +103,7 @@ func setTestVirtualMachineCloud(ss *Cloud, scaleSetName, zone string, faultDomai
 		}
 		vmssVM := compute.VirtualMachineScaleSetVM{
 			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+				ProvisioningState: to.StringPtr(state),
 				OsProfile: &compute.OSProfile{
 					ComputerName: &nodeName,
 				},

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_wrap.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
+	"github.com/Azure/go-autorest/autorest/to"
 
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
@@ -190,6 +191,12 @@ func (az *Cloud) newVMCache() (*timedCache, error) {
 
 		if !exists {
 			klog.V(2).Infof("Virtual machine %q not found", key)
+			return nil, nil
+		}
+
+		if vm.VirtualMachineProperties != nil &&
+			strings.EqualFold(to.String(vm.VirtualMachineProperties.ProvisioningState), string(compute.ProvisioningStateDeleting)) {
+			klog.V(2).Infof("Virtual machine %q is under deleting", key)
 			return nil, nil
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/sig cloud-provider
/area provider/azure
/priority critical-urgent

**What this PR does / why we need it**:

Part of https://github.com/kubernetes-sigs/cloud-provider-azure/issues/247: Set cache to nil data when Azure node provisioning state is deleting. This would help node lifecycle controller to delete the Node object faster, so that fewer requests would be invoked in the following sync loops.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

The PR would be cherry-picked to v1.15-v1.17 branches after merged.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
To reduce chances of throttling, VM cache is set to nil when Azure node provisioning state is deleting
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
```
