### PR TITLE
Respect `--image-pull-progress-deadline` flag when using containerd

### DIFF
--- a/pkg/kubelet/config/flags.go
+++ b/pkg/kubelet/config/flags.go
@@ -86,6 +86,7 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ContainerRuntime, "container-runtime", s.ContainerRuntime, "The container runtime to use. Possible values: 'docker', 'remote'.")
 	fs.StringVar(&s.RuntimeCgroups, "runtime-cgroups", s.RuntimeCgroups, "Optional absolute name of cgroups to create and run the runtime in.")
 	fs.BoolVar(&s.RedirectContainerStreaming, "redirect-container-streaming", s.RedirectContainerStreaming, "Enables container streaming redirect. If false, kubelet will proxy container streaming data between apiserver and container runtime; if true, kubelet will return an http redirect to apiserver, and apiserver will access container runtime directly. The proxy approach is more secure, but introduces some overhead. The redirect approach is more performant, but less secure because the connection between apiserver and container runtime may not be authenticated.")
+	fs.DurationVar(&s.ImagePullProgressDeadline.Duration, "image-pull-progress-deadline", s.ImagePullProgressDeadline.Duration, "If no pulling progress is made before this deadline, the image pulling will be cancelled.")
 
 	// Docker-specific settings.
 	fs.BoolVar(&s.ExperimentalDockershim, "experimental-dockershim", s.ExperimentalDockershim, "Enable dockershim only mode. In this mode, kubelet will only start dockershim without any other functionalities. This flag only serves test purpose, please do not use it unless you are conscious of what you are doing. [default=false]")
@@ -94,7 +95,6 @@ func (s *ContainerRuntimeOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkHidden("experimental-dockershim-root-directory")
 	fs.StringVar(&s.PodSandboxImage, "pod-infra-container-image", s.PodSandboxImage, fmt.Sprintf("The image whose network/ipc namespaces containers in each pod will use. %s", dockerOnlyWarning))
 	fs.StringVar(&s.DockerEndpoint, "docker-endpoint", s.DockerEndpoint, fmt.Sprintf("Use this for the docker endpoint to communicate with. %s", dockerOnlyWarning))
-	fs.DurationVar(&s.ImagePullProgressDeadline.Duration, "image-pull-progress-deadline", s.ImagePullProgressDeadline.Duration, fmt.Sprintf("If no pulling progress is made before this deadline, the image pulling will be cancelled. %s", dockerOnlyWarning))
 
 	// Network plugin settings for Docker.
 	fs.StringVar(&s.NetworkPluginName, "network-plugin", s.NetworkPluginName, fmt.Sprintf("<Warning: Alpha feature> The name of the network plugin to be invoked for various events in kubelet/pod lifecycle. %s", dockerOnlyWarning))

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -392,7 +392,7 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	if kubeDeps.RemoteRuntimeService, err = remote.NewRemoteRuntimeService(remoteRuntimeEndpoint, kubeCfg.RuntimeRequestTimeout.Duration); err != nil {
 		return err
 	}
-	if kubeDeps.RemoteImageService, err = remote.NewRemoteImageService(remoteImageEndpoint, kubeCfg.RuntimeRequestTimeout.Duration); err != nil {
+	if kubeDeps.RemoteImageService, err = remote.NewRemoteImageService(remoteImageEndpoint, kubeCfg.RuntimeRequestTimeout.Duration, crOptions.ImagePullProgressDeadline.Duration); err != nil {
 		return err
 	}
 

--- a/pkg/kubelet/remote/remote_runtime.go
+++ b/pkg/kubelet/remote/remote_runtime.go
@@ -92,8 +92,8 @@ func (r *RemoteRuntimeService) Version(apiVersion string) (*runtimeapi.VersionRe
 // RunPodSandbox creates and starts a pod-level sandbox. Runtimes should ensure
 // the sandbox is in ready state.
 func (r *RemoteRuntimeService) RunPodSandbox(config *runtimeapi.PodSandboxConfig, runtimeHandler string) (string, error) {
-	// Use 2 times longer timeout for sandbox operation (4 mins by default)
-	// TODO: Make the pod sandbox timeout configurable.
+	// Use 2 times longer connectionTimeout for sandbox operation (4 mins by default)
+	// TODO: Make the pod sandbox connectionTimeout configurable.
 	ctx, cancel := getContextWithTimeout(r.timeout * 2)
 	defer cancel()
 
@@ -226,9 +226,9 @@ func (r *RemoteRuntimeService) StartContainer(containerID string) error {
 	return nil
 }
 
-// StopContainer stops a running container with a grace period (i.e., timeout).
+// StopContainer stops a running container with a grace period (i.e., connectionTimeout).
 func (r *RemoteRuntimeService) StopContainer(containerID string, timeout int64) error {
-	// Use timeout + default timeout (2 minutes) as timeout to leave extra time
+	// Use connectionTimeout + default connectionTimeout (2 minutes) as connectionTimeout to leave extra time
 	// for SIGKILL container and request latency.
 	t := r.timeout + time.Duration(timeout)*time.Second
 	ctx, cancel := getContextWithTimeout(t)
@@ -328,11 +328,11 @@ func (r *RemoteRuntimeService) UpdateContainerResources(containerID string, reso
 // ExecSync executes a command in the container, and returns the stdout output.
 // If command exits with a non-zero exit code, an error is returned.
 func (r *RemoteRuntimeService) ExecSync(containerID string, cmd []string, timeout time.Duration) (stdout []byte, stderr []byte, err error) {
-	// Do not set timeout when timeout is 0.
+	// Do not set connectionTimeout when connectionTimeout is 0.
 	var ctx context.Context
 	var cancel context.CancelFunc
 	if timeout != 0 {
-		// Use timeout + default timeout (2 minutes) as timeout to leave some time for
+		// Use connectionTimeout + default connectionTimeout (2 minutes) as connectionTimeout to leave some time for
 		// the runtime to do cleanup.
 		ctx, cancel = getContextWithTimeout(r.timeout + timeout)
 	} else {
@@ -483,8 +483,8 @@ func (r *RemoteRuntimeService) ContainerStats(containerID string) (*runtimeapi.C
 }
 
 func (r *RemoteRuntimeService) ListContainerStats(filter *runtimeapi.ContainerStatsFilter) ([]*runtimeapi.ContainerStats, error) {
-	// Do not set timeout, because writable layer stats collection takes time.
-	// TODO(random-liu): Should we assume runtime should cache the result, and set timeout here?
+	// Do not set connectionTimeout, because writable layer stats collection takes time.
+	// TODO(random-liu): Should we assume runtime should cache the result, and set connectionTimeout here?
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 

--- a/pkg/kubelet/remote/utils.go
+++ b/pkg/kubelet/remote/utils.go
@@ -28,7 +28,7 @@ import (
 // grpc library default is 4MB
 const maxMsgSize = 1024 * 1024 * 16
 
-// getContextWithTimeout returns a context with timeout.
+// getContextWithTimeout returns a context with connectionTimeout.
 func getContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), timeout)
 }

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -417,6 +417,8 @@ func runCommand(cmd ...string) (string, error) {
 func getCRIClient() (internalapi.RuntimeService, internalapi.ImageManagerService, error) {
 	// connection timeout for CRI service connection
 	const connectionTimeout = 2 * time.Minute
+	// image pull timeout for CRI service
+	const imagePullProgressDeadline = 1 * time.Minute
 	runtimeEndpoint := framework.TestContext.ContainerRuntimeEndpoint
 	r, err := remote.NewRemoteRuntimeService(runtimeEndpoint, connectionTimeout)
 	if err != nil {
@@ -428,7 +430,7 @@ func getCRIClient() (internalapi.RuntimeService, internalapi.ImageManagerService
 		//explicitly specified
 		imageManagerEndpoint = framework.TestContext.ImageServiceEndpoint
 	}
-	i, err := remote.NewRemoteImageService(imageManagerEndpoint, connectionTimeout)
+	i, err := remote.NewRemoteImageService(imageManagerEndpoint, connectionTimeout, imagePullProgressDeadline)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

After https://github.com/kubernetes/kubernetes/pull/41274 , kubernetes ignore pull image timeout when using cri.

**Which issue(s) this PR fixes**:

NONE

**Special notes for your reviewer**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
