### PR TITLE
fix command variable exited with status 1

### DIFF
--- a/hack/lib/util.sh
+++ b/hack/lib/util.sh
@@ -700,8 +700,7 @@ function kube::util::ensure_dockerized {
 function kube::util::ensure-gnu-sed {
   # NOTE: the echo below is a workaround to ensure sed is executed before the grep.
   # see: https://github.com/kubernetes/kubernetes/issues/87251
-  sed_help="$(LANG=C sed --help 2>&1)"
-  if echo "${sed_help}" | grep -q "GNU\|BusyBox"; then
+  if LANG=C sed --help 2>&1 | grep -q "GNU\|BusyBox"; then
     SED="sed"
   elif command -v gsed &>/dev/null; then
     SED="gsed"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind bug

**What this PR does / why we need it**:
If you're using ``gsed`` , exited with status 1 since the ``sed_help`` variable
```
!!! [0130 00:24:17] Call tree:
!!! [0130 00:24:17]  1: hack/local-up-cluster.sh:146 kube::util::ensure-gnu-sed(...)
!!! Error in /golang/src/k8s.io/kubernetes/hack/lib/util.sh:703
  Error in /golang/src/k8s.io/kubernetes/hack/lib/util.sh:703. 'sed_help="$(LANG=C sed --help 2>&1)"' exited with status 1
Call stack:
  1: golang/src/k8s.io/kubernetes/hack/lib/util.sh:703 kube::util::ensure-gnu-sed(...)
  2: hack/local-up-cluster.sh:146 main(...)
Exiting with status 1
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
