### PR TITLE
Feature bandwidth burst

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni.go
+++ b/pkg/kubelet/dockershim/network/cni/cni.go
@@ -95,12 +95,10 @@ type cniBandwidthEntry struct {
 	// IngressRate is the bandwidth rate in bits per second for traffic through container. 0 for no limit. If ingressRate is set, ingressBurst must also be set
 	IngressRate int `json:"ingressRate,omitempty"`
 	// IngressBurst is the bandwidth burst in bits for traffic through container. 0 for no limit. If ingressBurst is set, ingressRate must also be set
-	// NOTE: it's not used for now and default to 0.
 	IngressBurst int `json:"ingressBurst,omitempty"`
 	// EgressRate is the bandwidth is the bandwidth rate in bits per second for traffic through container. 0 for no limit. If egressRate is set, egressBurst must also be set
 	EgressRate int `json:"egressRate,omitempty"`
 	// EgressBurst is the bandwidth burst in bits for traffic through container. 0 for no limit. If egressBurst is set, egressRate must also be set
-	// NOTE: it's not used for now and default to 0.
 	EgressBurst int `json:"egressBurst,omitempty"`
 }
 
@@ -435,12 +433,20 @@ func (plugin *cniNetworkPlugin) buildCNIRuntimeConf(podName string, podNs string
 			// see: https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md and
 			// https://github.com/containernetworking/plugins/blob/master/plugins/meta/bandwidth/README.md
 			// Rates are in bits per second, burst values are in bits.
-			bandwidthParam.IngressRate = int(ingress.Value())
-			bandwidthParam.IngressBurst = math.MaxInt32 // no limit
+			bandwidthParam.IngressRate = int(ingress.Rate.Value())
+			if ingress.Burst != nil {
+				bandwidthParam.IngressBurst = int(ingress.Burst.Value())
+			} else {
+				bandwidthParam.IngressBurst = math.MaxInt32
+			}
 		}
 		if egress != nil {
-			bandwidthParam.EgressRate = int(egress.Value())
-			bandwidthParam.EgressBurst = math.MaxInt32 // no limit
+			bandwidthParam.EgressRate = int(egress.Rate.Value())
+			if egress.Burst != nil {
+				bandwidthParam.EgressBurst = int(egress.Burst.Value())
+			} else {
+				bandwidthParam.EgressBurst = math.MaxInt32
+			}
 		}
 		rt.CapabilityArgs[bandwidthCapability] = bandwidthParam
 	}

--- a/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
+++ b/pkg/kubelet/dockershim/network/kubenet/kubenet_linux.go
@@ -429,7 +429,7 @@ func (plugin *kubenetNetworkPlugin) addTrafficShaping(id kubecontainer.Container
 				return fmt.Errorf("failed to setup traffic shaping for pod ip%s", ip)
 			}
 
-			if err := shaper.ReconcileCIDR(fmt.Sprintf("%v/%v", ip, mask), egress, ingress); err != nil {
+			if err := shaper.ReconcileCIDR(fmt.Sprintf("%v/%v", ip, mask), egress.Rate, ingress.Rate); err != nil {
 				return fmt.Errorf("failed to add pod to shaper: %v", err)
 			}
 		}

--- a/pkg/util/bandwidth/utils.go
+++ b/pkg/util/bandwidth/utils.go
@@ -17,50 +17,109 @@ limitations under the License.
 package bandwidth
 
 import (
+	"errors"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
-var minRsrc = resource.MustParse("1k")
-var maxRsrc = resource.MustParse("1P")
+const (
+	directionIngress = "ingress"
+	directionEgress  = "egress"
+)
+
+var (
+	minBandwidth = resource.MustParse("1k")
+	maxBandwidth = resource.MustParse("1P")
+
+	minBurst = resource.MustParse("1k")
+	maxBurst = resource.MustParse("4G") // comply with bandwidth plugin limit
+)
 
 func validateBandwidthIsReasonable(rsrc *resource.Quantity) error {
-	if rsrc.Value() < minRsrc.Value() {
-		return fmt.Errorf("resource is unreasonably small (< 1kbit)")
+	if rsrc.Value() < minBandwidth.Value() {
+		return fmt.Errorf("bandwidth is unreasonably small (< 1kbit)")
 	}
-	if rsrc.Value() > maxRsrc.Value() {
-		return fmt.Errorf("resoruce is unreasonably large (> 1Pbit)")
+	if rsrc.Value() > maxBandwidth.Value() {
+		return fmt.Errorf("bandwidth is unreasonably large (> 1Pbit)")
 	}
 	return nil
 }
 
+func validateBurstIsReasonable(rsrc *resource.Quantity) error {
+	if rsrc.Value() < minBurst.Value() {
+		return fmt.Errorf("burst is unreasonably small (< 1kbit)")
+	}
+	if rsrc.Value() > maxBurst.Value() {
+		return fmt.Errorf("burst is unreasonably large (> 4GB)")
+	}
+	return nil
+
+}
+
+// Limit provides a mapping to cniBandwidthEntry.
+// Rate: The speed knob.
+// Burst: Also known as buffer or maxburst. Size of the bucket.
+// See tc(8) for details.
+type Limit struct {
+	Rate, Burst *resource.Quantity
+}
+
+func extractPodBandwidthResources(direction string, podAnnotations map[string]string) (limit *Limit, err error) {
+	if podAnnotations == nil {
+		return
+	}
+
+	limit = new(Limit)
+	prefix := fmt.Sprintf("kubernetes.io/%s-", direction)
+
+	str, rateFound := podAnnotations[prefix+"bandwidth"]
+	if rateFound {
+		rateValue, err := resource.ParseQuantity(str)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateBandwidthIsReasonable(&rateValue); err != nil {
+			return nil, err
+		}
+		limit.Rate = &rateValue
+	}
+
+	str, burstFound := podAnnotations[prefix+"burst"]
+	if burstFound {
+		if !rateFound {
+			return nil, errors.New("rate must be set if burst is set")
+		}
+		burstValue, err := resource.ParseQuantity(str)
+		if err != nil {
+			return nil, err
+		}
+		if err := validateBurstIsReasonable(&burstValue); err != nil {
+			return nil, err
+		}
+		limit.Burst = &burstValue
+	}
+
+	if !rateFound {
+		limit = nil
+	}
+
+	return
+}
+
 // ExtractPodBandwidthResources extracts the ingress and egress from the given pod annotations
-func ExtractPodBandwidthResources(podAnnotations map[string]string) (ingress, egress *resource.Quantity, err error) {
+func ExtractPodBandwidthResources(podAnnotations map[string]string) (ingress, egress *Limit, err error) {
 	if podAnnotations == nil {
 		return nil, nil, nil
 	}
-	str, found := podAnnotations["kubernetes.io/ingress-bandwidth"]
-	if found {
-		ingressValue, err := resource.ParseQuantity(str)
-		if err != nil {
-			return nil, nil, err
-		}
-		ingress = &ingressValue
-		if err := validateBandwidthIsReasonable(ingress); err != nil {
-			return nil, nil, err
-		}
+	ingress, err = extractPodBandwidthResources(directionIngress, podAnnotations)
+	if err != nil {
+		return nil, nil, err
 	}
-	str, found = podAnnotations["kubernetes.io/egress-bandwidth"]
-	if found {
-		egressValue, err := resource.ParseQuantity(str)
-		if err != nil {
-			return nil, nil, err
-		}
-		egress = &egressValue
-		if err := validateBandwidthIsReasonable(egress); err != nil {
-			return nil, nil, err
-		}
+	egress, err = extractPodBandwidthResources(directionEgress, podAnnotations)
+	if err != nil {
+		return nil, nil, err
 	}
+
 	return ingress, egress, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature


**What this PR does / why we need it**:
Previously CNI cniBandwidthEntry.{In,E}gressBurst is not used and
defaults to the MaxInt32, this renders bandwidth control nearly
useless for cost control since the peak bandwidth is basically
unpredictable. See https://stackoverflow.com/questions/59729354/set-burst-for-bandwidth-limit-for-a-pod.

This patch introduces two new annotations
kubernetes.io/ingress-busrt and kubernetes.io/egress-burst to setup
cniBandwidthEntry.IngressBurst and cniBandwidthEntry.EgressBurst.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Introduces two new annotations
kubernetes.io/ingress-busrt and kubernetes.io/egress-burst to setup
cniBandwidthEntry.IngressBurst and cniBandwidthEntry.EgressBurst
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
