### PR TITLE
add to api repo documentation

### DIFF
--- a/staging/src/k8s.io/api/README.md
+++ b/staging/src/k8s.io/api/README.md
@@ -6,6 +6,30 @@ Schema of the external API types that are served by the Kubernetes API server.
 
 This library is the canonical location of the Kubernetes API definition. Most likely interaction with this repository is as a dependency of client-go.
 
+It is published separately to avoid diamond dependency problems for users who
+depend on more than one of `k8s.io/client-go`, `k8s.io/apimachinery`,
+`k8s.io/apiserver`...
+
+## Recommended Use
+
+We recommend using the go types in this repo. You may serialize them directly to
+JSON.
+
+If you want to store or interact with proto-formatted Kubernetes API objects, we
+recommend using the "official" serialization stack in `k8s.io/apimachinery`.
+Directly serializing these types to proto will not result in data that matches
+the wire format or is compatible with other kubernetes ecosystem tools. The
+reason is that the wire format includes a magic prefix and an envelope proto.
+Please see:
+https://kubernetes.io/docs/reference/using-api/api-concepts/#protobuf-encoding
+
+For the same reason, we do not recommend embedding these proto objects within
+your own proto definitions. It is better to store Kubernetes objects as byte
+arrays, in the wire format, which is self-describing. This permits you to use
+either JSON or binary (proto) wire formats without code changes. It will be
+difficult for you to operate on both Custom Resources and built-in types
+otherwise.
+
 ## Compatibility
 
 Branches track Kubernetes branches and are compatible with that repo.


### PR DESCRIPTION
It's come to my attention that folks are doing... interesting things with the proto files in this published repo.


/kind documentation

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
