### PR TITLE
Allow update of onXPN field in fake GCE clients.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_fake.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_fake.go
@@ -35,6 +35,7 @@ type TestClusterValues struct {
 	SecondaryZoneName string
 	ClusterID         string
 	ClusterName       string
+	OnXPN             bool
 }
 
 // DefaultTestClusterValues Creates a reasonable set of default cluster values
@@ -74,8 +75,14 @@ func NewFakeGCECloud(vals TestClusterValues) *Cloud {
 		projectID:        vals.ProjectID,
 		networkProjectID: vals.ProjectID,
 		ClusterID:        fakeClusterID(vals.ClusterID),
+		onXPN:            vals.OnXPN,
 	}
 	c := cloud.NewMockGCE(&gceProjectRouter{gce})
 	gce.c = c
 	return gce
+}
+
+// UpdateFakeGCECloud updates the fake GCE cloud with the specified values. Currently only the onXPN value is updated.
+func UpdateFakeGCECloud(g *Cloud, vals TestClusterValues) {
+	g.onXPN = vals.OnXPN
 }


### PR DESCRIPTION

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Allows setting and updating onXPN field in fake GCE clients. This will help in tests written outside the gce pkg.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
