### PR TITLE
[manual cherry-pick] blank out value for unbounded client label

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/BUILD
@@ -20,7 +20,6 @@ go_library(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/validation:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/metrics/metrics.go
@@ -27,11 +27,10 @@ import (
 	"sync"
 	"time"
 
-	restful "github.com/emicklei/go-restful"
+	"github.com/emicklei/go-restful"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/types"
-	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilsets "k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/features"
@@ -301,7 +300,8 @@ func RecordLongRunning(req *http.Request, requestInfo *request.RequestInfo, comp
 func MonitorRequest(req *http.Request, verb, group, version, resource, subresource, scope, component, contentType string, httpCode, respSize int, elapsed time.Duration) {
 	reportedVerb := cleanVerb(verb, req)
 	dryRun := cleanDryRun(req.URL)
-	client := cleanUserAgent(utilnet.GetHTTPClient(req))
+	// blank out client string here, in order to avoid cardinality issues
+	client := ""
 	elapsedMicroseconds := float64(elapsed / time.Microsecond)
 	elapsedSeconds := elapsed.Seconds()
 	requestCounter.WithLabelValues(reportedVerb, dryRun, group, version, resource, subresource, scope, component, client, contentType, codeToString(httpCode)).Inc()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR backports a backwards compatible fix for the unbounded client label on `apiserver_request_count` and `apiserver_request_total` metrics. 

**Special notes for your reviewer**:

We are fixing this at head by removing the client dimension, but in order to remain API compatible, we are cherrypicking a fix for this which blanks out the client dimension (without changing the API of the metric itself).

Existing issue: https://github.com/kubernetes/kubernetes/issues/76302

**Does this PR introduce a user-facing change?**:
```release-note
The client label for apiserver_request_count and apiserver_request_total now no-opts and merely records an empty string.
```