### PR TITLE
Make schema error log message more useful

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
@@ -99,13 +99,13 @@ func (f *structuredMergeManager) Update(liveObj, newObj runtime.Object, managed 
 	newObjTyped, err := f.typeConverter.ObjectToTyped(newObjVersioned)
 	if err != nil {
 		// Return newObj and just by-pass fields update. This really shouldn't happen.
-		klog.Errorf("[SHOULD NOT HAPPEN] failed to create typed new object: %v", err)
+		klog.Errorf("[SHOULD NOT HAPPEN] failed to create typed new object of type %v: %v", newObjVersioned.GetObjectKind().GroupVersionKind(), err)
 		return newObj, managed, nil
 	}
 	liveObjTyped, err := f.typeConverter.ObjectToTyped(liveObjVersioned)
 	if err != nil {
 		// Return newObj and just by-pass fields update. This really shouldn't happen.
-		klog.Errorf("[SHOULD NOT HAPPEN] failed to create typed live object: %v", err)
+		klog.Errorf("[SHOULD NOT HAPPEN] failed to create typed live object of type %v: %v", liveObjVersioned.GetObjectKind().GroupVersionKind(), err)
 		return newObj, managed, nil
 	}
 	apiVersion := fieldpath.APIVersion(f.groupVersion.String())


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig api-machinery
/wg apply
/area apiserver
/priority important-longterm
/cc @MikeSpreitzer @apelisse 

**What this PR does / why we need it**:
Changes un-useful log error message from:
```
[SHOULD NOT HAPPEN] failed to create typed new object: .spec.rules: element 0: associative list without keys has an element that's a map type
```
to be more useful in identifying the problematic schema:
```
[SHOULD NOT HAPPEN] failed to create typed new object of type flowcontrol.apiserver.k8s.io/v1alpha1, Kind=FlowSchema: .spec.rules: element 0: associative list without keys has an element that's a map type
```

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes/kubernetes/issues/87594#issuecomment-579134807

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```