### PR TITLE
Fix some scheduler metrics(pending_pods and schedule_attempts_total) are not recorded.

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -56,10 +56,13 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result"})
 	// PodScheduleSuccesses counts how many pods were scheduled.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleSuccesses = scheduleAttempts.With(metrics.Labels{"result": "scheduled"})
 	// PodScheduleFailures counts how many pods could not be scheduled.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
 	// PodScheduleErrors counts how many pods could not be scheduled due to a scheduler error.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleErrors            = scheduleAttempts.With(metrics.Labels{"result": "error"})
 	DeprecatedSchedulingDuration = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
@@ -262,6 +265,9 @@ func Register() {
 			legacyregistry.MustRegister(metric)
 		}
 		volumeschedulingmetrics.RegisterVolumeSchedulingMetrics()
+		PodScheduleSuccesses = scheduleAttempts.With(metrics.Labels{"result": "scheduled"})
+		PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
+		PodScheduleErrors = scheduleAttempts.With(metrics.Labels{"result": "error"})
 	})
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -291,6 +291,8 @@ func New(client clientset.Interface,
 		nodeInfoSnapshot:               snapshot,
 	}
 
+	metrics.Register()
+
 	var sched *Scheduler
 	source := options.schedulerAlgorithmSource
 	switch {
@@ -322,7 +324,6 @@ func New(client clientset.Interface,
 	default:
 		return nil, fmt.Errorf("unsupported algorithm source: %v", source)
 	}
-	metrics.Register()
 	// Additional tweaks to the config produced by the configurator.
 	sched.Recorder = recorder
 	sched.DisablePreemption = options.disablePreemption


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/sig scheduling

**What this PR does / why we need it**:

fix two scheduler metrics (`pending_pods` and `schedule_attempts_total`) are not recorded.

**Which issue(s) this PR fixes**:

Fixes #87690 

**Special notes for your reviewer**:

[`scheduler/metrics.{PodScheduleSuccesses, PodScheduleFailures, PodScheduleErrors}`](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/metrics/metrics.go#L58-L63) and [`scheduler/metrics.PendingPodsRecorders(ActivePods, UnschedulablePods, BackoffPods)`](https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/internal/queue/scheduling_queue.go#L217-L224) seems to too early to be  initialized.

All the `k8s.io/component-base/metrics`'s metrics primitives are lazy metric.  So, calling `some_metric.With(labels)` before registration [returns `noop` metrics](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/component-base/metrics/gauge.go#L144-L146).

So I made mainly two modifications.

- move `scheduler/metrics.Registry()` before crerating scheduler queue
- delayed `PodScheduleSuccesses, PodScheduleFailures, PodScheduleErrors` metrics' initialization


**Does this PR introduce a user-facing change?**:

```release-note
fixed two scheduler metrics (pending_pods and schedule_attempts_total) not being recorded
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

none.