### PR TITLE
Automated cherry pick of #87090: changelog: clarify 1.17 upgrade requirements

### DIFF
--- a/CHANGELOG-1.17.md
+++ b/CHANGELOG-1.17.md
@@ -324,7 +324,7 @@ Prior to 1.17 and for existing nodes created by `kubeadm init` where kubelet cli
 - Kubeadm: when adding extra apiserver authorization-modes, the defaults `Node,RBAC` are no longer prepended in the resulting static Pod manifests and a full override is allowed. ([#82616](https://github.com/kubernetes/kubernetes/pull/82616), [@ghouscht](https://github.com/ghouscht))
 
 #### Storage
-- All nodes need to be drained before upgrading Kubernetes cluster, because paths used for block volumes are changed in this release, so on-line upgrade of nodes aren't allowed. ([#74026](https://github.com/kubernetes/kubernetes/pull/74026), [@mkimuram](https://github.com/mkimuram))
+- A node that uses a CSI raw block volume needs to be drained before kubelet can be upgraded to 1.17. ([#74026](https://github.com/kubernetes/kubernetes/pull/74026), [@mkimuram](https://github.com/mkimuram))
 
 #### Windows
 - The Windows containers RunAsUsername feature is now beta.


### PR DESCRIPTION
Cherry pick of #87090 on release-1.17.

#87090: changelog: clarify 1.17 upgrade requirements

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.