### PR TITLE
Invoke metrics.Register as early as possible in the scheduler initialization

### DIFF
--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -242,6 +242,7 @@ func New(client clientset.Interface,
 	recorder events.EventRecorder,
 	stopCh <-chan struct{},
 	opts ...Option) (*Scheduler, error) {
+	metrics.Register()
 
 	stopEverything := stopCh
 	if stopEverything == nil {
@@ -322,7 +323,6 @@ func New(client clientset.Interface,
 	default:
 		return nil, fmt.Errorf("unsupported algorithm source: %v", source)
 	}
-	metrics.Register()
 	// Additional tweaks to the config produced by the configurator.
 	sched.Recorder = recorder
 	sched.DisablePreemption = options.disablePreemption


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/commit/8da448dbe34ddcc64e943a06e4a8436e6ecc9204   switched the scheduler from Prometheus to k8s wrapper in 1.16, but didn't fix the registration. 

This caused the scheduler's ```pending_pods``` metric to break: this metric is reported by the scheduler queue. At the time of instantiating the queue, we obtain a reference to the ```pending_pods``` metric, but this happens before the metric is registered, which means the reference that the queue obtained is a noop metric. 

**Which issue(s) this PR fixes**:
Part of #87690

**Special notes for your reviewer**:
I am sending a separate PR to fix the registration order to make it easy to backport to 1.16

**Does this PR introduce a user-facing change?**:
```release-note
scheduler's pending_pods metric to be reported back.
```

/cc @liu-cong 