### PR TITLE
Automated cherry pick of #87706: Use standard default storage media type in

### DIFF
--- a/hack/local-up-cluster.sh
+++ b/hack/local-up-cluster.sh
@@ -78,7 +78,7 @@ CLOUD_PROVIDER=${CLOUD_PROVIDER:-""}
 CLOUD_CONFIG=${CLOUD_CONFIG:-""}
 FEATURE_GATES=${FEATURE_GATES:-"AllAlpha=false"}
 STORAGE_BACKEND=${STORAGE_BACKEND:-"etcd3"}
-STORAGE_MEDIA_TYPE=${STORAGE_MEDIA_TYPE:-""}
+STORAGE_MEDIA_TYPE=${STORAGE_MEDIA_TYPE:-"application/vnd.kubernetes.protobuf"}
 # preserve etcd data. you also need to set ETCD_DIR.
 PRESERVE_ETCD="${PRESERVE_ETCD:-false}"
 

--- a/pkg/apis/apps/v1/defaults.go
+++ b/pkg/apis/apps/v1/defaults.go
@@ -118,6 +118,17 @@ func SetDefaults_StatefulSet(obj *appsv1.StatefulSet) {
 		obj.Spec.RevisionHistoryLimit = new(int32)
 		*obj.Spec.RevisionHistoryLimit = 10
 	}
+	// Ensure apiVersion/kind are populated on volume template objects.
+	// This matches the population that was performed < 1.17.x by conversion.
+	// See http://issue.k8s.io/87583
+	for i := range obj.Spec.VolumeClaimTemplates {
+		if len(obj.Spec.VolumeClaimTemplates[i].APIVersion) == 0 {
+			obj.Spec.VolumeClaimTemplates[i].APIVersion = "v1"
+		}
+		if len(obj.Spec.VolumeClaimTemplates[i].Kind) == 0 {
+			obj.Spec.VolumeClaimTemplates[i].Kind = "PersistentVolumeClaim"
+		}
+	}
 }
 func SetDefaults_ReplicaSet(obj *appsv1.ReplicaSet) {
 	if obj.Spec.Replicas == nil {

--- a/pkg/apis/apps/v1/defaults_test.go
+++ b/pkg/apis/apps/v1/defaults_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -174,6 +174,8 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 	var defaultPartition int32 = 0
 	var defaultReplicas int32 = 1
 
+	filesystem := v1.PersistentVolumeFilesystem
+
 	period := int64(v1.DefaultTerminationGracePeriodSeconds)
 	defaultTemplate := v1.PodTemplateSpec{
 		Spec: v1.PodSpec{
@@ -254,6 +256,50 @@ func TestSetDefaultStatefulSet(t *testing.T) {
 				Spec: appsv1.StatefulSetSpec{
 					Replicas:            &defaultReplicas,
 					Template:            defaultTemplate,
+					PodManagementPolicy: appsv1.ParallelPodManagement,
+					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+						Type: appsv1.RollingUpdateStatefulSetStrategyType,
+						RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+							Partition: &defaultPartition,
+						},
+					},
+					RevisionHistoryLimit: utilpointer.Int32Ptr(10),
+				},
+			},
+		},
+		{ // Volume template defaults.
+			original: &appsv1.StatefulSet{
+				Spec: appsv1.StatefulSetSpec{
+					Template: defaultTemplate,
+					VolumeClaimTemplates: []v1.PersistentVolumeClaim{{
+						ObjectMeta: metav1.ObjectMeta{Name: "www"},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							StorageClassName: utilpointer.StringPtr("my-storage-class"),
+							Resources:        v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")}},
+						},
+					}},
+					PodManagementPolicy: appsv1.ParallelPodManagement,
+				},
+			},
+			expected: &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: defaultLabels,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: &defaultReplicas,
+					Template: defaultTemplate,
+					VolumeClaimTemplates: []v1.PersistentVolumeClaim{{
+						TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+						ObjectMeta: metav1.ObjectMeta{Name: "www"},
+						Spec: v1.PersistentVolumeClaimSpec{
+							AccessModes:      []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
+							StorageClassName: utilpointer.StringPtr("my-storage-class"),
+							Resources:        v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")}},
+							VolumeMode:       &filesystem,
+						},
+						Status: v1.PersistentVolumeClaimStatus{Phase: v1.ClaimPending},
+					}},
 					PodManagementPolicy: appsv1.ParallelPodManagement,
 					UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
 						Type: appsv1.RollingUpdateStatefulSetStrategyType,

--- a/pkg/apis/apps/v1beta1/defaults.go
+++ b/pkg/apis/apps/v1beta1/defaults.go
@@ -61,6 +61,17 @@ func SetDefaults_StatefulSet(obj *appsv1beta1.StatefulSet) {
 		*obj.Spec.UpdateStrategy.RollingUpdate.Partition = 0
 	}
 
+	// Ensure apiVersion/kind are populated on volume template objects.
+	// This matches the population that was performed < 1.17.x by conversion.
+	// See http://issue.k8s.io/87583
+	for i := range obj.Spec.VolumeClaimTemplates {
+		if len(obj.Spec.VolumeClaimTemplates[i].APIVersion) == 0 {
+			obj.Spec.VolumeClaimTemplates[i].APIVersion = "v1"
+		}
+		if len(obj.Spec.VolumeClaimTemplates[i].Kind) == 0 {
+			obj.Spec.VolumeClaimTemplates[i].Kind = "PersistentVolumeClaim"
+		}
+	}
 }
 
 // SetDefaults_Deployment sets additional defaults compared to its counterpart

--- a/pkg/apis/apps/v1beta2/defaults.go
+++ b/pkg/apis/apps/v1beta2/defaults.go
@@ -75,6 +75,18 @@ func SetDefaults_StatefulSet(obj *appsv1beta2.StatefulSet) {
 		obj.Spec.RevisionHistoryLimit = new(int32)
 		*obj.Spec.RevisionHistoryLimit = 10
 	}
+
+	// Ensure apiVersion/kind are populated on volume template objects.
+	// This matches the population that was performed < 1.17.x by conversion.
+	// See http://issue.k8s.io/87583
+	for i := range obj.Spec.VolumeClaimTemplates {
+		if len(obj.Spec.VolumeClaimTemplates[i].APIVersion) == 0 {
+			obj.Spec.VolumeClaimTemplates[i].APIVersion = "v1"
+		}
+		if len(obj.Spec.VolumeClaimTemplates[i].Kind) == 0 {
+			obj.Spec.VolumeClaimTemplates[i].Kind = "PersistentVolumeClaim"
+		}
+	}
 }
 
 // SetDefaults_Deployment sets additional defaults compared to its counterpart


### PR DESCRIPTION
Cherry pick of #87706 on release-1.17.

#87706: Use standard default storage media type in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.