### PR TITLE
test images: Rebases nautilus and kitten images

### DIFF
--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -74,7 +74,7 @@ build() {
     TAG=$(<VERSION)
 
     if [[ -f BASEIMAGE ]]; then
-      BASEIMAGE=$(getBaseImage "${arch}")
+      BASEIMAGE=$(getBaseImage "${arch}" | ${SED} "s|REGISTRY|${REGISTRY}|g")
       ${SED} -i "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
       ${SED} -i "s|BASEARCH|${arch}|g" Dockerfile
     fi

--- a/test/images/kitten/BASEIMAGE
+++ b/test/images/kitten/BASEIMAGE
@@ -1,5 +1,5 @@
-amd64=REGISTRY/agnhost-amd64:2.7
-arm=REGISTRY/agnhost-arm:2.7
-arm64=REGISTRY/agnhost-arm64:2.7
-ppc64le=REGISTRY/agnhost-ppc64le:2.7
-s390x=REGISTRY/agnhost-s390x:2.7
+amd64=REGISTRY/agnhost-amd64:2.10
+arm=REGISTRY/agnhost-arm:2.10
+arm64=REGISTRY/agnhost-arm64:2.10
+ppc64le=REGISTRY/agnhost-ppc64le:2.10
+s390x=REGISTRY/agnhost-s390x:2.10

--- a/test/images/kitten/BASEIMAGE
+++ b/test/images/kitten/BASEIMAGE
@@ -1,5 +1,5 @@
-amd64=gcr.io/kubernetes-e2e-test-images/agnhost-amd64:2.7
-arm=gcr.io/kubernetes-e2e-test-images/agnhost-arm:2.7
-arm64=gcr.io/kubernetes-e2e-test-images/agnhost-arm64:2.7
-ppc64le=gcr.io/kubernetes-e2e-test-images/agnhost-ppc64le:2.7
-s390x=gcr.io/kubernetes-e2e-test-images/agnhost-s390x:2.7
+amd64=REGISTRY/agnhost-amd64:2.7
+arm=REGISTRY/agnhost-arm:2.7
+arm64=REGISTRY/agnhost-arm64:2.7
+ppc64le=REGISTRY/agnhost-ppc64le:2.7
+s390x=REGISTRY/agnhost-s390x:2.7

--- a/test/images/nautilus/BASEIMAGE
+++ b/test/images/nautilus/BASEIMAGE
@@ -1,5 +1,5 @@
-amd64=REGISTRY/agnhost-amd64:2.7
-arm=REGISTRY/agnhost-arm:2.7
-arm64=REGISTRY/agnhost-arm64:2.7
-ppc64le=REGISTRY/agnhost-ppc64le:2.7
-s390x=REGISTRY/agnhost-s390x:2.7
+amd64=REGISTRY/agnhost-amd64:2.10
+arm=REGISTRY/agnhost-arm:2.10
+arm64=REGISTRY/agnhost-arm64:2.10
+ppc64le=REGISTRY/agnhost-ppc64le:2.10
+s390x=REGISTRY/agnhost-s390x:2.10

--- a/test/images/nautilus/BASEIMAGE
+++ b/test/images/nautilus/BASEIMAGE
@@ -1,5 +1,5 @@
-amd64=gcr.io/kubernetes-e2e-test-images/agnhost-amd64:2.7
-arm=gcr.io/kubernetes-e2e-test-images/agnhost-arm:2.7
-arm64=gcr.io/kubernetes-e2e-test-images/agnhost-arm64:2.7
-ppc64le=gcr.io/kubernetes-e2e-test-images/agnhost-ppc64le:2.7
-s390x=gcr.io/kubernetes-e2e-test-images/agnhost-s390x:2.7
+amd64=REGISTRY/agnhost-amd64:2.7
+arm=REGISTRY/agnhost-arm:2.7
+arm64=REGISTRY/agnhost-arm64:2.7
+ppc64le=REGISTRY/agnhost-ppc64le:2.7
+s390x=REGISTRY/agnhost-s390x:2.7


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

/sig testing
/area conformance

**What this PR does / why we need it**:

Image Centralization part 4 merged, which centralized other images into ``agnhost``, including ``test-webserver``. The ``kitten`` and ``nautilus`` images were based on the ``test-webserver`` image, but right now, they're built on top of ``agnhost:2.7``, but due to a few other merges, the image version in which the Image Centralization part 4 merged was 2.9, but the ``nautilus`` and ``kitten`` images were not updated properly.

Bumps the ``agnhost`` version in the ``kitten`` and ``nautilus`` ``BASEIMAGE`` files.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: #76342

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
