### PR TITLE
dockershim/network: add sig-network-approvers to OWNERS

### DIFF
--- a/pkg/kubelet/dockershim/network/OWNERS
+++ b/pkg/kubelet/dockershim/network/OWNERS
@@ -1,10 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- thockin
 - dchen1107
-- freehan
-- dcbw
+- sig-network-approvers
 emeritus_approvers:
 - matchstick
 reviewers:


### PR DESCRIPTION
/kind cleanup
```release-note
NONE
```

@thockin @danwinship @kubernetes/sig-network-misc 