### PR TITLE
Reduce default CPU requirement for konnectivity server

### DIFF
--- a/cluster/gce/manifests/konnectivity-server.yaml
+++ b/cluster/gce/manifests/konnectivity-server.yaml
@@ -14,7 +14,7 @@ spec:
     image: gcr.io/google-containers/proxy-server:v0.0.3
     resources:
       requests:
-        cpu: 40m
+        cpu: 25m
     command: [ "/proxy-server"{{ konnectivity_args }} ]
     livenessProbe:
       httpGet:


### PR DESCRIPTION
**What type of PR is this?**
 
/kind bug

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**What this PR does / why we need it**:

Our network proxy [e2e job](https://k8s-testgrid.appspot.com/sig-api-machinery-network-proxy#ci-kubernetes-e2e-gci-gce-network-proxy) is failing because we are requesting more resources than available on the system. 

The test clusters are consuming exactly 970m CPU resources without the konnectivity-server pod. Requesting 40m exceeds the 1000m limit and causes all tests to fail.

Long term we'll need to do some testing to determine the actual resource requirements, but this quick fix should allow the test to pass again.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:


