### PR TITLE
Automated cherry pick of #85703: Fixing Potential Race Condition in EndpointSlice Controller. #85368: Deep copying EndpointSlices in reconciler before modifying

### DIFF
--- a/pkg/controller/endpointslice/BUILD
+++ b/pkg/controller/endpointslice/BUILD
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "endpointset.go",
         "endpointslice_controller.go",
+        "endpointslice_tracker.go",
         "reconciler.go",
         "utils.go",
     ],
@@ -49,6 +50,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "endpointslice_controller_test.go",
+        "endpointslice_tracker_test.go",
         "reconciler_test.go",
         "utils_test.go",
     ],

--- a/pkg/controller/endpointslice/endpointslice_tracker.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointslice
+
+import (
+	"sync"
+
+	discovery "k8s.io/api/discovery/v1beta1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// endpointSliceResourceVersions tracks expected EndpointSlice resource versions
+// by EndpointSlice name.
+type endpointSliceResourceVersions map[string]string
+
+// endpointSliceTracker tracks EndpointSlices and their associated resource
+// versions to help determine if a change to an EndpointSlice has been processed
+// by the EndpointSlice controller.
+type endpointSliceTracker struct {
+	// lock protects resourceVersionsByService.
+	lock sync.Mutex
+	// resourceVersionsByService tracks the list of EndpointSlices and
+	// associated resource versions expected for a given Service.
+	resourceVersionsByService map[types.NamespacedName]endpointSliceResourceVersions
+}
+
+// newEndpointSliceTracker creates and initializes a new endpointSliceTracker.
+func newEndpointSliceTracker() *endpointSliceTracker {
+	return &endpointSliceTracker{
+		resourceVersionsByService: map[types.NamespacedName]endpointSliceResourceVersions{},
+	}
+}
+
+// Has returns true if the endpointSliceTracker has a resource version for the
+// provided EndpointSlice.
+func (est *endpointSliceTracker) Has(endpointSlice *discovery.EndpointSlice) bool {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	rrv := est.relatedResourceVersions(endpointSlice)
+	_, ok := rrv[endpointSlice.Name]
+	return ok
+}
+
+// Stale returns true if this endpointSliceTracker does not have a resource
+// version for the provided EndpointSlice or it does not match the resource
+// version of the provided EndpointSlice.
+func (est *endpointSliceTracker) Stale(endpointSlice *discovery.EndpointSlice) bool {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	rrv := est.relatedResourceVersions(endpointSlice)
+	return rrv[endpointSlice.Name] != endpointSlice.ResourceVersion
+}
+
+// Update adds or updates the resource version in this endpointSliceTracker for
+// the provided EndpointSlice.
+func (est *endpointSliceTracker) Update(endpointSlice *discovery.EndpointSlice) {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	rrv := est.relatedResourceVersions(endpointSlice)
+	rrv[endpointSlice.Name] = endpointSlice.ResourceVersion
+}
+
+// Delete removes the resource version in this endpointSliceTracker for the
+// provided EndpointSlice.
+func (est *endpointSliceTracker) Delete(endpointSlice *discovery.EndpointSlice) {
+	est.lock.Lock()
+	defer est.lock.Unlock()
+
+	rrv := est.relatedResourceVersions(endpointSlice)
+	delete(rrv, endpointSlice.Name)
+}
+
+// relatedResourceVersions returns the set of resource versions tracked for the
+// Service corresponding to the provided EndpointSlice. If no resource versions
+// are currently tracked for this service, an empty set is initialized.
+func (est *endpointSliceTracker) relatedResourceVersions(endpointSlice *discovery.EndpointSlice) endpointSliceResourceVersions {
+	serviceNN := getServiceNN(endpointSlice)
+	vers, ok := est.resourceVersionsByService[serviceNN]
+
+	if !ok {
+		vers = endpointSliceResourceVersions{}
+		est.resourceVersionsByService[serviceNN] = vers
+	}
+
+	return vers
+}
+
+// getServiceNN returns a namespaced name for the Service corresponding to the
+// provided EndpointSlice.
+func getServiceNN(endpointSlice *discovery.EndpointSlice) types.NamespacedName {
+	serviceName, _ := endpointSlice.Labels[discovery.LabelServiceName]
+	return types.NamespacedName{Name: serviceName, Namespace: endpointSlice.Namespace}
+}
+
+// managedByChanged returns true if one of the provided EndpointSlices is
+// managed by the EndpointSlice controller while the other is not.
+func managedByChanged(endpointSlice1, endpointSlice2 *discovery.EndpointSlice) bool {
+	return managedByController(endpointSlice1) != managedByController(endpointSlice2)
+}
+
+// managedByController returns true if the controller of the provided
+// EndpointSlices is the EndpointSlice controller.
+func managedByController(endpointSlice *discovery.EndpointSlice) bool {
+	managedBy, _ := endpointSlice.Labels[discovery.LabelManagedBy]
+	return managedBy == controllerName
+}

--- a/pkg/controller/endpointslice/endpointslice_tracker_test.go
+++ b/pkg/controller/endpointslice/endpointslice_tracker_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package endpointslice
+
+import (
+	"testing"
+
+	discovery "k8s.io/api/discovery/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestEndpointSliceTrackerUpdate(t *testing.T) {
+	epSlice1 := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "example-1",
+			Namespace:       "ns1",
+			ResourceVersion: "rv1",
+			Labels:          map[string]string{discovery.LabelServiceName: "svc1"},
+		},
+	}
+
+	epSlice1DifferentNS := epSlice1.DeepCopy()
+	epSlice1DifferentNS.Namespace = "ns2"
+
+	epSlice1DifferentService := epSlice1.DeepCopy()
+	epSlice1DifferentService.Labels[discovery.LabelServiceName] = "svc2"
+
+	epSlice1DifferentRV := epSlice1.DeepCopy()
+	epSlice1DifferentRV.ResourceVersion = "rv2"
+
+	testCases := map[string]struct {
+		updateParam *discovery.EndpointSlice
+		checksParam *discovery.EndpointSlice
+		expectHas   bool
+		expectStale bool
+	}{
+		"same slice": {
+			updateParam: epSlice1,
+			checksParam: epSlice1,
+			expectHas:   true,
+			expectStale: false,
+		},
+		"different namespace": {
+			updateParam: epSlice1,
+			checksParam: epSlice1DifferentNS,
+			expectHas:   false,
+			expectStale: true,
+		},
+		"different service": {
+			updateParam: epSlice1,
+			checksParam: epSlice1DifferentService,
+			expectHas:   false,
+			expectStale: true,
+		},
+		"different resource version": {
+			updateParam: epSlice1,
+			checksParam: epSlice1DifferentRV,
+			expectHas:   true,
+			expectStale: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			esTracker := newEndpointSliceTracker()
+			esTracker.Update(tc.updateParam)
+			if esTracker.Has(tc.checksParam) != tc.expectHas {
+				t.Errorf("tc.tracker.Has(%+v) == %t, expected %t", tc.checksParam, esTracker.Has(tc.checksParam), tc.expectHas)
+			}
+			if esTracker.Stale(tc.checksParam) != tc.expectStale {
+				t.Errorf("tc.tracker.Stale(%+v) == %t, expected %t", tc.checksParam, esTracker.Stale(tc.checksParam), tc.expectStale)
+			}
+		})
+	}
+}
+
+func TestEndpointSliceTrackerDelete(t *testing.T) {
+	epSlice1 := &discovery.EndpointSlice{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "example-1",
+			Namespace:       "ns1",
+			ResourceVersion: "rv1",
+			Labels:          map[string]string{discovery.LabelServiceName: "svc1"},
+		},
+	}
+
+	epSlice1DifferentNS := epSlice1.DeepCopy()
+	epSlice1DifferentNS.Namespace = "ns2"
+
+	epSlice1DifferentService := epSlice1.DeepCopy()
+	epSlice1DifferentService.Labels[discovery.LabelServiceName] = "svc2"
+
+	epSlice1DifferentRV := epSlice1.DeepCopy()
+	epSlice1DifferentRV.ResourceVersion = "rv2"
+
+	testCases := map[string]struct {
+		deleteParam *discovery.EndpointSlice
+		checksParam *discovery.EndpointSlice
+		expectHas   bool
+		expectStale bool
+	}{
+		"same slice": {
+			deleteParam: epSlice1,
+			checksParam: epSlice1,
+			expectHas:   false,
+			expectStale: true,
+		},
+		"different namespace": {
+			deleteParam: epSlice1DifferentNS,
+			checksParam: epSlice1DifferentNS,
+			expectHas:   false,
+			expectStale: true,
+		},
+		"different namespace, check original ep slice": {
+			deleteParam: epSlice1DifferentNS,
+			checksParam: epSlice1,
+			expectHas:   true,
+			expectStale: false,
+		},
+		"different service": {
+			deleteParam: epSlice1DifferentService,
+			checksParam: epSlice1DifferentService,
+			expectHas:   false,
+			expectStale: true,
+		},
+		"different service, check original ep slice": {
+			deleteParam: epSlice1DifferentService,
+			checksParam: epSlice1,
+			expectHas:   true,
+			expectStale: false,
+		},
+		"different resource version": {
+			deleteParam: epSlice1DifferentRV,
+			checksParam: epSlice1DifferentRV,
+			expectHas:   false,
+			expectStale: true,
+		},
+		"different resource version, check original ep slice": {
+			deleteParam: epSlice1DifferentRV,
+			checksParam: epSlice1,
+			expectHas:   false,
+			expectStale: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			esTracker := newEndpointSliceTracker()
+			esTracker.Update(epSlice1)
+
+			esTracker.Delete(tc.deleteParam)
+			if esTracker.Has(tc.checksParam) != tc.expectHas {
+				t.Errorf("esTracker.Has(%+v) == %t, expected %t", tc.checksParam, esTracker.Has(tc.checksParam), tc.expectHas)
+			}
+			if esTracker.Stale(tc.checksParam) != tc.expectStale {
+				t.Errorf("esTracker.Stale(%+v) == %t, expected %t", tc.checksParam, esTracker.Stale(tc.checksParam), tc.expectStale)
+			}
+		})
+	}
+}

--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -40,6 +40,7 @@ type reconciler struct {
 	client               clientset.Interface
 	nodeLister           corelisters.NodeLister
 	maxEndpointsPerSlice int32
+	endpointSliceTracker *endpointSliceTracker
 	metricsCache         *metrics.Cache
 }
 
@@ -212,6 +213,7 @@ func (r *reconciler) finalize(
 			}
 			errs = append(errs, fmt.Errorf("Error creating EndpointSlice for Service %s/%s: %v", service.Namespace, service.Name, err))
 		} else {
+			r.endpointSliceTracker.Update(endpointSlice)
 			metrics.EndpointSliceChanges.WithLabelValues("create").Inc()
 		}
 	}
@@ -222,6 +224,7 @@ func (r *reconciler) finalize(
 		if err != nil {
 			errs = append(errs, fmt.Errorf("Error updating %s EndpointSlice for Service %s/%s: %v", endpointSlice.Name, service.Namespace, service.Name, err))
 		} else {
+			r.endpointSliceTracker.Update(endpointSlice)
 			metrics.EndpointSliceChanges.WithLabelValues("update").Inc()
 		}
 	}
@@ -231,6 +234,7 @@ func (r *reconciler) finalize(
 		if err != nil {
 			errs = append(errs, fmt.Errorf("Error deleting %s EndpointSlice for Service %s/%s: %v", endpointSlice.Name, service.Namespace, service.Name, err))
 		} else {
+			r.endpointSliceTracker.Delete(endpointSlice)
 			metrics.EndpointSliceChanges.WithLabelValues("delete").Inc()
 		}
 	}

--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -752,6 +752,7 @@ func newReconciler(client *fake.Clientset, nodes []*corev1.Node, maxEndpointsPer
 		client:               client,
 		nodeLister:           corelisters.NewNodeLister(indexer),
 		maxEndpointsPerSlice: maxEndpointsPerSlice,
+		endpointSliceTracker: newEndpointSliceTracker(),
 		metricsCache:         metrics.NewCache(maxEndpointsPerSlice),
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This is a cherry pick of #85703 #85368 on release-1.17.

#85703: Fixing Potential Race Condition in EndpointSlice Controller.
#85368: Deep copying EndpointSlices in reconciler before modifying

These changes only affect the EndpointSlice controller, but provide significant bug fixes for a beta feature in 1.17. A large portion of the code added here is additional tests to ensure these problems don't surface again.

**Does this PR introduce a user-facing change?**:
```release-note
Bug fixes for EndpointSlice controller that prevent race condition and modifying shared objects.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
Enhancement Issue: kubernetes/enhancements#752

/sig network
/priority critical-urgent