### PR TITLE
Update OWNERS

### DIFF
--- a/test/e2e/windows/OWNERS
+++ b/test/e2e/windows/OWNERS
@@ -3,10 +3,11 @@
 approvers:
 - michmike
 - patricklang
+- benmoss
+- ddebroy
 reviewers:
 - adelina-t
 - bclau
-- benmoss
 - dineshgovindasamy
 - feiskyer
 - madhanrm


### PR DESCRIPTION
updating owners/approvers for sig windows to include the two tech leads Deep and Ben

```release-note
NONE
```