### PR TITLE
Log when client rate limiter latency is very high at a lower log level

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -30,6 +30,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"golang.org/x/net/http2"
@@ -51,6 +52,9 @@ var (
 	// throttled (via the provided rateLimiter) for more than longThrottleLatency will
 	// be logged.
 	longThrottleLatency = 50 * time.Millisecond
+
+	// extraLongThrottleLatency defines the threshold for logging requests at log level 2.
+	extraLongThrottleLatency = 1 * time.Second
 )
 
 // HTTPClient is an interface for testing a request object.
@@ -557,11 +561,42 @@ func (r *Request) tryThrottle(ctx context.Context) error {
 
 	err := r.rateLimiter.Wait(ctx)
 
-	if latency := time.Since(now); latency > longThrottleLatency {
+	latency := time.Since(now)
+	if latency > longThrottleLatency {
 		klog.V(3).Infof("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String())
+	}
+	if latency > extraLongThrottleLatency {
+		globalThrottledLogger.Log(2, fmt.Sprintf("Throttling request took %v, request: %s:%s", latency, r.verb, r.URL().String()))
 	}
 
 	return err
+}
+
+type throttledLogger struct {
+	logTimeLock    sync.RWMutex
+	lastLogTime    time.Time
+	minLogInterval time.Duration
+}
+
+var globalThrottledLogger = &throttledLogger{
+	minLogInterval: 1 * time.Second,
+}
+
+func (b *throttledLogger) Log(level klog.Level, message string) {
+	if bool(klog.V(level)) {
+		if func() bool {
+			b.logTimeLock.RLock()
+			defer b.logTimeLock.RUnlock()
+			return time.Since(b.lastLogTime) > b.minLogInterval
+		}() {
+			b.logTimeLock.Lock()
+			defer b.logTimeLock.Unlock()
+			if time.Since(b.lastLogTime) > b.minLogInterval {
+				klog.V(level).Info(message)
+				b.lastLogTime = time.Now()
+			}
+		}
+	}
 }
 
 // Watch attempts to begin watching the requested location.


### PR DESCRIPTION
**What type of PR is this?**:
/kind feature
/priority important-soon
/sig api-machinery
/cc @lavalamp

**What this PR does / why we need it**:
Currently, high client side rate limiter latency logging only happens when at log level 3, it would be useful to also log this information at lower log levels, but we need to avoid spamming the logs. This PR logs a maximum of once per second whenever the rate limiter latency exceeds 1s.

**Does this PR introduce a user-facing change?**:
```release-note
API request throttling (due to a high rate of requests) is now reported in client-go logs at log level 2.  The messages are of the form

Throttling request took 1.50705208s, request: GET:<URL>

The presence of these messages, may indicate to the administrator the need to tune the cluster accordingly.
```