### PR TITLE
Automated cherry pick of #87692: Fix pending_pods, schedule_attempts_total was not recorded

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -58,10 +58,13 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result"})
 	// PodScheduleSuccesses counts how many pods were scheduled.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleSuccesses = scheduleAttempts.With(metrics.Labels{"result": "scheduled"})
 	// PodScheduleFailures counts how many pods could not be scheduled.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
 	// PodScheduleErrors counts how many pods could not be scheduled due to a scheduler error.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleErrors = scheduleAttempts.With(metrics.Labels{"result": "error"})
 	SchedulingLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
@@ -341,6 +344,9 @@ func Register() {
 			legacyregistry.MustRegister(metric)
 		}
 		volumeschedulingmetrics.RegisterVolumeSchedulingMetrics()
+		PodScheduleSuccesses = scheduleAttempts.With(metrics.Labels{"result": "scheduled"})
+		PodScheduleFailures = scheduleAttempts.With(metrics.Labels{"result": "unschedulable"})
+		PodScheduleErrors = scheduleAttempts.With(metrics.Labels{"result": "error"})
 	})
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -335,6 +335,8 @@ func New(client clientset.Interface,
 		configProducerArgs: &frameworkplugins.ConfigProducerArgs{},
 	}
 
+	metrics.Register()
+
 	var sched *Scheduler
 	source := options.schedulerAlgorithmSource
 	switch {
@@ -366,7 +368,6 @@ func New(client clientset.Interface,
 	default:
 		return nil, fmt.Errorf("unsupported algorithm source: %v", source)
 	}
-	metrics.Register()
 	// Additional tweaks to the config produced by the configurator.
 	sched.Recorder = recorder
 	sched.DisablePreemption = options.disablePreemption


### PR DESCRIPTION
Cherry pick of #87692 on release-1.17.

#87692: Fix pending_pods, schedule_attempts_total was not recorded

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.