### PR TITLE
Automated cherry pick of #87692: Fix pending_pods, schedule_attempts_total was not recorded

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -60,10 +60,13 @@ var (
 			StabilityLevel: metrics.ALPHA,
 		}, []string{"result"})
 	// PodScheduleSuccesses counts how many pods were scheduled.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleSuccesses = scheduleAttempts.With(prometheus.Labels{"result": "scheduled"})
 	// PodScheduleFailures counts how many pods could not be scheduled.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleFailures = scheduleAttempts.With(prometheus.Labels{"result": "unschedulable"})
 	// PodScheduleErrors counts how many pods could not be scheduled due to a scheduler error.
+	// This metric will be initialized again in Register() to assure the metric is not no-op metric.
 	PodScheduleErrors = scheduleAttempts.With(prometheus.Labels{"result": "error"})
 	SchedulingLatency = metrics.NewSummaryVec(
 		&metrics.SummaryOpts{
@@ -252,6 +255,9 @@ func Register() {
 			legacyregistry.MustRegister(metric)
 		}
 		volumescheduling.RegisterVolumeSchedulingMetrics()
+		PodScheduleSuccesses = scheduleAttempts.With(prometheus.Labels{"result": "scheduled"})
+		PodScheduleFailures = scheduleAttempts.With(prometheus.Labels{"result": "unschedulable"})
+		PodScheduleErrors = scheduleAttempts.With(prometheus.Labels{"result": "error"})
 	})
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -187,6 +187,9 @@ func New(client clientset.Interface,
 	for _, opt := range opts {
 		opt(&options)
 	}
+
+	metrics.Register()
+
 	// Set up the configurator which can create schedulers from configs.
 	configurator := factory.NewConfigFactory(&factory.ConfigFactoryArgs{
 		Client:                         client,
@@ -290,7 +293,6 @@ func initPolicyFromConfigMap(client clientset.Interface, policyRef *kubeschedule
 
 // NewFromConfig returns a new scheduler using the provided Config.
 func NewFromConfig(config *factory.Config) *Scheduler {
-	metrics.Register()
 	return &Scheduler{
 		SchedulerCache:      config.SchedulerCache,
 		Algorithm:           config.Algorithm,


### PR DESCRIPTION
Cherry pick of #87692 on release-1.16.

#87692: Fix pending_pods, schedule_attempts_total was not recorded

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.