### PR TITLE
Automated cherry pick of #87658: Enable selinux tags in make targets

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -700,6 +700,7 @@ kube::golang::build_binaries_for_platform() {
       -gcflags "${gogcflags:-}"
       -asmflags "${goasmflags:-}"
       -ldflags "${goldflags:-}"
+      -tags "${gotags:-}"
     )
     CGO_ENABLED=0 kube::golang::build_some_binaries "${statics[@]}"
   fi
@@ -710,6 +711,7 @@ kube::golang::build_binaries_for_platform() {
       -gcflags "${gogcflags:-}"
       -asmflags "${goasmflags:-}"
       -ldflags "${goldflags:-}"
+      -tags "${gotags:-}"
     )
     kube::golang::build_some_binaries "${nonstatics[@]}"
   fi
@@ -725,6 +727,7 @@ kube::golang::build_binaries_for_platform() {
       -gcflags "${gogcflags:-}" \
       -asmflags "${goasmflags:-}" \
       -ldflags "${goldflags:-}" \
+      -tags "${gotags:-}" \
       -o "${outfile}" \
       "${testpkg}"
   done
@@ -776,7 +779,7 @@ kube::golang::build_binaries() {
     local host_platform
     host_platform=$(kube::golang::host_platform)
 
-    local goflags goldflags goasmflags gogcflags
+    local goflags goldflags goasmflags gogcflags gotags
     # If GOLDFLAGS is unset, then set it to the a default of "-s -w".
     # Disable SC2153 for this, as it will throw a warning that the local
     # variable goldflags will exist, and it suggest changing it to this.
@@ -784,6 +787,10 @@ kube::golang::build_binaries() {
     goldflags="${GOLDFLAGS=-s -w} $(kube::version::ldflags)"
     goasmflags="-trimpath=${KUBE_ROOT}"
     gogcflags="${GOGCFLAGS:-} -trimpath=${KUBE_ROOT}"
+
+    # extract tags if any specified in GOFLAGS
+    # shellcheck disable=SC2001
+    gotags="selinux,$(echo "${GOFLAGS:-}" | sed -e 's|.*-tags=\([^-]*\).*|\1|')"
 
     local -a targets=()
     local arg

--- a/test/typecheck/main.go
+++ b/test/typecheck/main.go
@@ -80,6 +80,9 @@ func newAnalyzer(platform string) *analyzer {
 	ctx.GOOS, ctx.GOARCH = platSplit[0], platSplit[1]
 	ctx.CgoEnabled = true
 
+	// add selinux tag explicitly
+	ctx.BuildTags = append(ctx.BuildTags, "selinux")
+
 	a := &analyzer{
 		platform:  platform,
 		fset:      token.NewFileSet(),


### PR DESCRIPTION
Cherry pick of #87658 on release-1.16.

#87658: Enable selinux tags in make targets

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.