### PR TITLE
Only set admission review reponse patch type if the patch is not empty

### DIFF
--- a/test/images/agnhost/webhook/configmap.go
+++ b/test/images/agnhost/webhook/configmap.go
@@ -97,8 +97,10 @@ func mutateConfigmaps(ar v1.AdmissionReview) *v1.AdmissionResponse {
 		reviewResponse.Patch = []byte(configMapPatch2)
 	}
 
-	pt := v1.PatchTypeJSONPatch
-	reviewResponse.PatchType = &pt
+	if len(reviewResponse.Patch) != 0 {
+		pt := v1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
+	}
 
 	return &reviewResponse
 }

--- a/test/images/agnhost/webhook/customresource.go
+++ b/test/images/agnhost/webhook/customresource.go
@@ -56,8 +56,10 @@ func mutateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 	if cr.Data["mutation-stage-1"] == "yes" {
 		reviewResponse.Patch = []byte(customResourcePatch2)
 	}
-	pt := v1.PatchTypeJSONPatch
-	reviewResponse.PatchType = &pt
+	if len(reviewResponse.Patch) != 0 {
+		pt := v1.PatchTypeJSONPatch
+		reviewResponse.PatchType = &pt
+	}
 	return &reviewResponse
 }
 


### PR DESCRIPTION
Otherwise it fails the webhook call [here](https://github.com/kubernetes/kubernetes/blob/845b23232125caeb67eb30659ff482404a3d3735/staging/src/k8s.io/apiserver/pkg/admission/plugin/webhook/request/admissionreview.go#L68).

/kind bug
/sig api-machinery
/release-note-none
/assign @jennybuckley 