### PR TITLE
Reduce overhead of error message formatting and allocation for NodeResource filter

### DIFF
--- a/pkg/kubelet/lifecycle/BUILD
+++ b/pkg/kubelet/lifecycle/BUILD
@@ -49,7 +49,6 @@ go_test(
         "//pkg/kubelet/util/format:go_default_library",
         "//pkg/scheduler/framework/plugins/nodename:go_default_library",
         "//pkg/scheduler/framework/plugins/nodeports:go_default_library",
-        "//pkg/scheduler/framework/plugins/noderesources:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",

--- a/pkg/kubelet/lifecycle/predicate.go
+++ b/pkg/kubelet/lifecycle/predicate.go
@@ -178,7 +178,10 @@ func removeMissingExtendedResources(pod *v1.Pod, nodeInfo *schedulernodeinfo.Nod
 // InsufficientResourceError is an error type that indicates what kind of resource limit is
 // hit and caused the unfitting failure.
 type InsufficientResourceError struct {
-	noderesources.InsufficientResource
+	ResourceName v1.ResourceName
+	Requested    int64
+	Used         int64
+	Capacity     int64
 }
 
 func (e *InsufficientResourceError) Error() string {
@@ -224,7 +227,12 @@ func GeneralPredicates(pod *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) ([]Pre
 
 	var reasons []PredicateFailureReason
 	for _, r := range noderesources.Fits(pod, nodeInfo, nil) {
-		reasons = append(reasons, &InsufficientResourceError{InsufficientResource: r})
+		reasons = append(reasons, &InsufficientResourceError{
+			ResourceName: r.ResourceName,
+			Requested:    r.Requested,
+			Used:         r.Used,
+			Capacity:     r.Capacity,
+		})
 	}
 
 	if !pluginhelper.PodMatchesNodeSelectorAndAffinityTerms(pod, nodeInfo.Node()) {

--- a/pkg/kubelet/lifecycle/predicate_test.go
+++ b/pkg/kubelet/lifecycle/predicate_test.go
@@ -26,7 +26,6 @@ import (
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodename"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodeports"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/noderesources"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
@@ -208,8 +207,8 @@ func TestGeneralPredicates(t *testing.T) {
 			fits: false,
 			wErr: nil,
 			reasons: []PredicateFailureReason{
-				&InsufficientResourceError{InsufficientResource: noderesources.InsufficientResource{ResourceName: v1.ResourceCPU, Requested: 8, Used: 5, Capacity: 10}},
-				&InsufficientResourceError{InsufficientResource: noderesources.InsufficientResource{ResourceName: v1.ResourceMemory, Requested: 10, Used: 19, Capacity: 20}},
+				&InsufficientResourceError{ResourceName: v1.ResourceCPU, Requested: 8, Used: 5, Capacity: 10},
+				&InsufficientResourceError{ResourceName: v1.ResourceMemory, Requested: 10, Used: 19, Capacity: 20},
 			},
 			name: "not enough cpu and memory resource",
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
CA reported that during their migration to the Framework, a slight drop in filter simulations performance was noticed, ClusterAutoscaler profiles show that was due to excessive allocation and error message formatting (which we didn't have to do in the old predicates code).

This PR avoids this overhead for common resources (memory, CPU and storage). This overhead still exist for extended resources.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @losipiuk @alculquicondor 