### PR TITLE
Add an option to external storage e2es to use a copy of a pre-installed StorageClass

### DIFF
--- a/test/e2e/storage/external/BUILD
+++ b/test/e2e/storage/external/BUILD
@@ -7,11 +7,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/storage/names:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/config:go_default_library",

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -23,11 +23,11 @@ import (
 	"github.com/pkg/errors"
 
 	storagev1 "k8s.io/api/storage/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/framework/config"
@@ -69,6 +69,10 @@ type driverDefinition struct {
 		// This can be used when the storage class is meant to have
 		// additional parameters.
 		FromFile string
+
+		// FromExistingClassName specifies the name of a pre-installed
+		// StorageClass that will be copied and used for the tests.
+		FromExistingClassName string
 	}
 
 	// SnapshotClass must be set to enable snapshotting tests.
@@ -233,7 +237,7 @@ func (d *driverDefinition) SkipUnsupportedTest(pattern testpatterns.TestPattern)
 	case "":
 		supported = true
 	case testpatterns.DynamicPV:
-		if d.StorageClass.FromName || d.StorageClass.FromFile != "" {
+		if d.StorageClass.FromName || d.StorageClass.FromFile != "" || d.StorageClass.FromExistingClassName != "" {
 			supported = true
 		}
 	case testpatterns.CSIInlineVolume:
@@ -258,39 +262,44 @@ func (d *driverDefinition) SkipUnsupportedTest(pattern testpatterns.TestPattern)
 }
 
 func (d *driverDefinition) GetDynamicProvisionStorageClass(config *testsuites.PerTestConfig, fsType string) *storagev1.StorageClass {
+	var (
+		sc  *storagev1.StorageClass
+		err error
+	)
+
 	f := config.Framework
 
-	if d.StorageClass.FromName {
-		provisioner := d.DriverInfo.Name
-		parameters := map[string]string{}
-		ns := f.Namespace.Name
-		suffix := provisioner + "-sc"
-		if fsType != "" {
-			parameters["csi.storage.k8s.io/fstype"] = fsType
-		}
+	switch {
+	case d.StorageClass.FromName:
+		sc = &storagev1.StorageClass{Provisioner: d.DriverInfo.Name}
+	case d.StorageClass.FromExistingClassName != "":
+		sc, err = f.ClientSet.StorageV1().StorageClasses().Get(d.StorageClass.FromExistingClassName, metav1.GetOptions{})
+		framework.ExpectNoError(err, "getting storage class %s", d.StorageClass.FromExistingClassName)
+	case d.StorageClass.FromFile != "":
+		var ok bool
 
-		return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+		items, err := utils.LoadFromManifests(d.StorageClass.FromFile)
+		framework.ExpectNoError(err, "load storage class from %s", d.StorageClass.FromFile)
+		framework.ExpectEqual(len(items), 1, "exactly one item from %s", d.StorageClass.FromFile)
+
+		err = utils.PatchItems(f, items...)
+		framework.ExpectNoError(err, "patch items")
+
+		sc, ok = items[0].(*storagev1.StorageClass)
+		framework.ExpectEqual(ok, true, "storage class from %s", d.StorageClass.FromFile)
 	}
 
-	items, err := utils.LoadFromManifests(d.StorageClass.FromFile)
-	framework.ExpectNoError(err, "load storage class from %s", d.StorageClass.FromFile)
-	framework.ExpectEqual(len(items), 1, "exactly one item from %s", d.StorageClass.FromFile)
+	framework.ExpectNotEqual(sc, nil, "storage class is unexpectantly nil")
 
-	err = utils.PatchItems(f, items...)
-	framework.ExpectNoError(err, "patch items")
-
-	sc, ok := items[0].(*storagev1.StorageClass)
-	framework.ExpectEqual(ok, true, "storage class from %s", d.StorageClass.FromFile)
-	// Ensure that we can load more than once as required for
-	// GetDynamicProvisionStorageClass by adding a random suffix.
-	sc.Name = names.SimpleNameGenerator.GenerateName(sc.Name + "-")
 	if fsType != "" {
 		if sc.Parameters == nil {
 			sc.Parameters = map[string]string{}
 		}
+		// This limits the external storage test suite to only CSI drivers, which may need to be
+		// reconsidered if we eventually need to move in-tree storage tests out.
 		sc.Parameters["csi.storage.k8s.io/fstype"] = fsType
 	}
-	return sc
+	return testsuites.GetStorageClass(sc.Provisioner, sc.Parameters, sc.VolumeBindingMode, f.Namespace.Name, "e2e-sc")
 }
 
 func (d *driverDefinition) GetSnapshotClass(config *testsuites.PerTestConfig) *unstructured.Unstructured {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently you can configure the external storage e2es to: 1) create a StorageClass with the driver name with no parameters set 2) load a StorageClass manifest from a file.

This PR adds an option to use a copy of a pre-installed StorageClass for testing. This is useful when the Kubernetes distro bundles and preinstalls specific CSI drivers and their StorageClasses.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
