### PR TITLE
kube-aggregator: increase log level of AggregationController API group logging

### DIFF
--- a/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/controllers/openapi/controller.go
@@ -102,9 +102,9 @@ func (c *AggregationController) processNextWorkItem() bool {
 	if aggregator.IsLocalAPIService(key.(string)) {
 		// for local delegation targets that are aggregated once per second, log at
 		// higher level to avoid flooding the log
-		klog.V(5).Infof("OpenAPI AggregationController: Processing item %s", key)
+		klog.V(6).Infof("OpenAPI AggregationController: Processing item %s", key)
 	} else {
-		klog.Infof("OpenAPI AggregationController: Processing item %s", key)
+		klog.V(4).Infof("OpenAPI AggregationController: Processing item %s", key)
 	}
 
 	action, err := c.syncHandler(key.(string))


### PR DESCRIPTION
These `OpenAPI AggregationController: Processing item <key>` lines in setups with aggregated API servers don't help to diagnose problems, but are just noise in the logs. Loglevel 4 makes sure they don't appear in normal production environments.