### PR TITLE
Check getNodeInfoError against nil

### DIFF
--- a/pkg/volume/csi/csi_client.go
+++ b/pkg/volume/csi/csi_client.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -161,9 +160,8 @@ func (c *csiDriverClient) NodeGetInfo(ctx context.Context) (
 		if nodeID != "" {
 			return true, nil
 		}
-		// kubelet plugin registration service not implemented is a terminal error, no need to retry
-		if strings.Contains(getNodeInfoError.Error(), "no handler registered for plugin type") {
-			return false, getNodeInfoError
+		if getNodeInfoError != nil {
+			klog.Warningf("Error calling CSI NodeGetInfo(): %v", getNodeInfoError.Error())
 		}
 		// Continue with exponential backoff
 		return false, nil

--- a/pkg/volume/csi/csi_client_test.go
+++ b/pkg/volume/csi/csi_client_test.go
@@ -26,6 +26,7 @@ import (
 	csipbv1 "github.com/container-storage-interface/spec/lib/go/csi"
 	api "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/pkg/volume"
 	"k8s.io/kubernetes/pkg/volume/csi/fake"
 	volumetypes "k8s.io/kubernetes/pkg/volume/util/types"
@@ -313,6 +314,7 @@ func TestClientNodeGetInfo(t *testing.T) {
 		expectedMaxVolumePerNode   int64
 		expectedAccessibleTopology map[string]string
 		mustFail                   bool
+		mustTimeout                bool
 		err                        error
 	}{
 		{
@@ -325,6 +327,13 @@ func TestClientNodeGetInfo(t *testing.T) {
 			name:     "grpc error",
 			mustFail: true,
 			err:      errors.New("grpc error"),
+		},
+		{
+			name:                       "test empty nodeId",
+			mustTimeout:                true,
+			expectedNodeID:             "",
+			expectedMaxVolumePerNode:   16,
+			expectedAccessibleTopology: map[string]string{"com.example.csi-topology/zone": "zone1"},
 		},
 	}
 
@@ -349,7 +358,13 @@ func TestClientNodeGetInfo(t *testing.T) {
 		}
 
 		nodeID, maxVolumePerNode, accessibleTopology, err := client.NodeGetInfo(context.Background())
-		checkErr(t, tc.mustFail, err)
+		if tc.mustTimeout {
+			if wait.ErrWaitTimeout.Error() != err.Error() {
+				t.Errorf("should have timed out : %s", tc.name)
+			}
+		} else {
+			checkErr(t, tc.mustFail, err)
+		}
 
 		if nodeID != tc.expectedNodeID {
 			t.Errorf("expected nodeID: %v; got: %v", tc.expectedNodeID, nodeID)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #87806 reported, csiDriverClient#NodeGetInfo would crash calling getNodeInfoError.Error() because getNodeInfoError may be nil.

The cloud provider may not give facility for determining the cause of error when kubelet segfault's

This PR adds check for getNodeInfoError against nil.

**Which issue(s) this PR fixes**:
Fixes #87806

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
