### PR TITLE
Make DisruptionController eviction tests serial to avoid flakes

### DIFF
--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -148,7 +148,14 @@ var _ = SIGDescribe("DisruptionController", func() {
 		if c.shouldDeny {
 			expectation = "should not allow an eviction"
 		}
-		ginkgo.It(fmt.Sprintf("evictions: %s => %s", c.description, expectation), func() {
+		// tests with exclusive set to true relies on HostPort to make sure
+		// only one pod from the replicaset is assigned to each node. This
+		// requires these tests to be run serially.
+		var serial string
+		if c.exclusive {
+			serial = " [Serial]"
+		}
+		ginkgo.It(fmt.Sprintf("evictions: %s => %s%s", c.description, expectation, serial), func() {
 			if c.skipForBigClusters {
 				e2eskipper.SkipUnlessNodeCountIsAtMost(bigClusterSize - 1)
 			}


### PR DESCRIPTION

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
The eviction tests for the DisruptionController are flaky as reported in #87194. The cause of the flakiness is that some of the eviction tests rely on setting the `HostPort` on pods to create situations where only a subset of the created pods can be scheduled. The issue arise when other tests are running at the same time that also schedule pods using the same `HostPort`. In these situations, none of the pods can be scheduled and the tests times out. This labels the tests that use `HostPort` as serial so they will not be running concurrently with other tests that might interfere.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
@kubernetes/sig-apps-pr-reviews 
@janetkuo @kow3ns 
