### PR TITLE
Check Annotations map against nil for ConfigMapLock#Update()

### DIFF
--- a/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
+++ b/staging/src/k8s.io/client-go/tools/leaderelection/resourcelock/configmaplock.go
@@ -86,6 +86,9 @@ func (cml *ConfigMapLock) Update(ler LeaderElectionRecord) error {
 	if err != nil {
 		return err
 	}
+	if cml.cm.Annotations == nil {
+		cml.cm.Annotations = make(map[string]string)
+	}
 	cml.cm.Annotations[LeaderElectionRecordAnnotationKey] = string(recordBytes)
 	cml.cm, err = cml.Client.ConfigMaps(cml.ConfigMapMeta.Namespace).Update(cml.cm)
 	return err


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #87800 reported, in some scenario when ConfigMapLock#Update() is called, the Annotations map is not allocated, leading to panic.

This PR allocates the map if needed.

**Which issue(s) this PR fixes**:
Fixes #87800

**Special notes for your reviewer**:


```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
