### PR TITLE
Ensure testing credentials are labeled as such

### DIFF
--- a/cmd/kube-apiserver/app/testing/testdata/README.md
+++ b/cmd/kube-apiserver/app/testing/testdata/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/hack/testdata/README.md
+++ b/hack/testdata/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/pkg/client/testdata/README.md
+++ b/pkg/client/testdata/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/pkg/controller/certificates/signer/testdata/README.md
+++ b/pkg/controller/certificates/signer/testdata/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/pkg/credentialprovider/aws/aws_credentials_test.go
+++ b/pkg/credentialprovider/aws/aws_credentials_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const user = "foo"
-const password = "1234567890abcdef"
+const password = "1234567890abcdef" // Fake value for testing.
 const email = "not@val.id"
 
 // Mock implementation

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -63,6 +63,7 @@ func TestReadDockerConfigFile(t *testing.T) {
 	}
 }
 func TestDockerConfigJsonJSONDecode(t *testing.T) {
+	// Fake values for testing.
 	input := []byte(`{"auths": {"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"}, "http://bar.example.com":{"username": "bar", "password": "baz", "email": "bar@example.com"}}}`)
 
 	expect := DockerConfigJson{
@@ -92,6 +93,7 @@ func TestDockerConfigJsonJSONDecode(t *testing.T) {
 }
 
 func TestDockerConfigJSONDecode(t *testing.T) {
+	// Fake values for testing.
 	input := []byte(`{"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"}, "http://bar.example.com":{"username": "bar", "password": "baz", "email": "bar@example.com"}}`)
 
 	expect := DockerConfig(map[string]DockerConfigEntry{
@@ -126,6 +128,7 @@ func TestDockerConfigEntryJSONDecode(t *testing.T) {
 	}{
 		// simple case, just decode the fields
 		{
+			// Fake values for testing.
 			input: []byte(`{"username": "foo", "password": "bar", "email": "foo@example.com"}`),
 			expect: DockerConfigEntry{
 				Username: "foo",
@@ -148,6 +151,7 @@ func TestDockerConfigEntryJSONDecode(t *testing.T) {
 
 		// auth field overrides username & password
 		{
+			// Fake values for testing.
 			input: []byte(`{"username": "foo", "password": "bar", "auth": "cGluZzpwb25n", "email": "foo@example.com"}`),
 			expect: DockerConfigEntry{
 				Username: "ping",
@@ -284,6 +288,7 @@ func TestDockerConfigEntryJSONCompatibleEncode(t *testing.T) {
 	}{
 		// simple case, just decode the fields
 		{
+			// Fake values for testing.
 			expect: []byte(`{"username":"foo","password":"bar","email":"foo@example.com","auth":"Zm9vOmJhcg=="}`),
 			input: DockerConfigEntry{
 				Username: "foo",

--- a/pkg/credentialprovider/gcp/metadata_test.go
+++ b/pkg/credentialprovider/gcp/metadata_test.go
@@ -45,7 +45,7 @@ func TestDockerKeyringFromGoogleDockerConfigMetadata(t *testing.T) {
 	registryURL := "hello.kubernetes.io"
 	email := "foo@bar.baz"
 	username := "foo"
-	password := "bar"
+	password := "bar" // Fake value for testing.
 	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 	sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
@@ -118,7 +118,7 @@ func TestDockerKeyringFromGoogleDockerConfigMetadataUrl(t *testing.T) {
 	registryURL := "hello.kubernetes.io"
 	email := "foo@bar.baz"
 	username := "foo"
-	password := "bar"
+	password := "bar" // Fake value for testing.
 	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 	sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
@@ -197,7 +197,7 @@ func TestContainerRegistryBasics(t *testing.T) {
 	for _, registryURL := range registryURLs {
 		t.Run(registryURL, func(t *testing.T) {
 			email := "1234@project.gserviceaccount.com"
-			token := &tokenBlob{AccessToken: "ya26.lots-of-indiscernible-garbage"}
+			token := &tokenBlob{AccessToken: "ya26.lots-of-indiscernible-garbage"} // Fake value for testing.
 
 			const (
 				serviceAccountsEndpoint = "/computeMetadata/v1/instance/service-accounts/"

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -193,7 +193,7 @@ func TestDockerKeyringForGlob(t *testing.T) {
 	for i, test := range tests {
 		email := "foo@bar.baz"
 		username := "foo"
-		password := "bar"
+		password := "bar" // Fake value for testing.
 		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 		sampleDockerConfig := fmt.Sprintf(`{
    "%s": {
@@ -261,7 +261,7 @@ func TestKeyringMiss(t *testing.T) {
 	for _, test := range tests {
 		email := "foo@bar.baz"
 		username := "foo"
-		password := "bar"
+		password := "bar" // Fake value for testing.
 		auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 		sampleDockerConfig := fmt.Sprintf(`{
    "%s": {
@@ -289,7 +289,7 @@ func TestKeyringMissWithDockerHubCredentials(t *testing.T) {
 	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
-	password := "bar"
+	password := "bar" // Fake value for testing.
 	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 	sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
@@ -315,7 +315,7 @@ func TestKeyringHitWithUnqualifiedDockerHub(t *testing.T) {
 	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
-	password := "bar"
+	password := "bar" // Fake value for testing.
 	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 	sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
@@ -356,7 +356,7 @@ func TestKeyringHitWithUnqualifiedLibraryDockerHub(t *testing.T) {
 	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
-	password := "bar"
+	password := "bar" // Fake value for testing.
 	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 	sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
@@ -397,7 +397,7 @@ func TestKeyringHitWithQualifiedDockerHub(t *testing.T) {
 	url := defaultRegistryKey
 	email := "foo@bar.baz"
 	username := "foo"
-	password := "bar"
+	password := "bar" // Fake value for testing.
 	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
 	sampleDockerConfig := fmt.Sprintf(`{
    "https://%s": {
@@ -499,13 +499,13 @@ func TestProvidersDockerKeyring(t *testing.T) {
 func TestDockerKeyringLookup(t *testing.T) {
 	ada := AuthConfig{
 		Username: "ada",
-		Password: "smash",
+		Password: "smash", // Fake value for testing.
 		Email:    "ada@example.com",
 	}
 
 	grace := AuthConfig{
 		Username: "grace",
-		Password: "squash",
+		Password: "squash", // Fake value for testing.
 		Email:    "grace@example.com",
 	}
 
@@ -566,7 +566,7 @@ func TestDockerKeyringLookup(t *testing.T) {
 func TestIssue3797(t *testing.T) {
 	rex := AuthConfig{
 		Username: "rex",
-		Password: "tiny arms",
+		Password: "tiny arms", // Fake value for testing.
 		Email:    "rex@example.com",
 	}
 

--- a/pkg/serviceaccount/jwt_test.go
+++ b/pkg/serviceaccount/jwt_test.go
@@ -64,6 +64,7 @@ WwIDAQAB
 //   3. URLSafe Base64-encoding the sha bytes
 const rsaKeyID = "JHJehTTTZlsspKHT-GaJxK7Kd1NQgZJu3fyK6K_QDYU"
 
+// Fake value for testing.
 const rsaPrivateKey = `-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEA249XwEo9k4tM8fMxV7zxOhcrP+WvXn917koM5Qr2ZXs4vo26
 e4ytdlrV0bQ9SlcLpQVSYjIxNfhTZdDt+ecIzshKuv1gKIxbbLQMOuK1eA/4HALy
@@ -94,6 +95,7 @@ X024wzbiw1q07jFCyfQmODzURAx1VNT7QVUMdz/N8vy47/H40AZJ
 `
 
 // openssl ecparam -name prime256v1 -genkey -noout -out ecdsa256.pem
+// Fake value for testing.
 const ecdsaPrivateKey = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIEZmTmUhuanLjPA2CLquXivuwBDHTt5XYwgIr/kA1LtRoAoGCCqGSM49
 AwEHoUQDQgAEH6cuzP8XuD5wal6wf9M6xDljTOPLX2i8uIp/C/ASqiIGUeeKQtX0

--- a/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
+++ b/plugin/pkg/auth/authenticator/token/bootstrap/bootstrap_test.go
@@ -48,6 +48,7 @@ func (l *lister) Get(name string) (*corev1.Secret, error) {
 }
 
 const (
+	// Fake values for testing.
 	tokenID     = "foobar"           // 6 letters
 	tokenSecret = "circumnavigation" // 16 letters
 )

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testdata/README.md
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/cmd/server/testing/testdata/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiserver.local.config/certificates/README.md
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/apiserver.local.config/certificates/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/aes/README.md
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/testdata/valid-configs/aes/README.md
@@ -1,0 +1,1 @@
+Keys and secrets in this directory are generated for testing purposes only.

--- a/staging/src/k8s.io/apiserver/pkg/server/options/testdata/README.md
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/testdata/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/oidc/oidc_test.go
@@ -1546,7 +1546,7 @@ func TestToken(t *testing.T) {
 
 func TestUnmarshalClaimError(t *testing.T) {
 	// Ensure error strings returned by unmarshaling claims don't include the claim.
-	const token = "96bb299a-02e9-11e8-8673-54ee7553240e"
+	const token = "96bb299a-02e9-11e8-8673-54ee7553240e" // Fake token for testing.
 	payload := fmt.Sprintf(`{
 		"token": "%s"
 	}`, token)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1_test.go
@@ -479,7 +479,7 @@ func TestV1WebhookTokenAuthenticator(t *testing.T) {
 			expectedAuthenticated: false,
 		},
 	}
-	token := "my-s3cr3t-t0ken"
+	token := "my-s3cr3t-t0ken" // Fake token for testing.
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			wh, err := newV1TokenAuthenticator(s.URL, clientCert, clientKey, caCert, 0, tt.implicitAuds)

--- a/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
+++ b/staging/src/k8s.io/apiserver/plugin/pkg/authenticator/token/webhook/webhook_v1beta1_test.go
@@ -481,7 +481,7 @@ func TestV1beta1WebhookTokenAuthenticator(t *testing.T) {
 			expectedAuthenticated: false,
 		},
 	}
-	token := "my-s3cr3t-t0ken"
+	token := "my-s3cr3t-t0ken" // Fake token for testing.
 	for _, tt := range tests {
 		t.Run(tt.description, func(t *testing.T) {
 			wh, err := newV1beta1TokenAuthenticator(s.URL, clientCert, clientKey, caCert, 0, tt.implicitAuds)

--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config_test.go
@@ -296,7 +296,7 @@ func TestCertificateData(t *testing.T) {
 
 func TestBasicAuthData(t *testing.T) {
 	username := "myuser"
-	password := "mypass"
+	password := "mypass" // Fake value for testing.
 
 	config := clientcmdapi.NewConfig()
 	config.Clusters["clean"] = &clientcmdapi.Cluster{

--- a/staging/src/k8s.io/client-go/util/cert/testdata/README.md
+++ b/staging/src/k8s.io/client-go/util/cert/testdata/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -136,7 +136,7 @@ func TestSetNonExistentContext(t *testing.T) {
 
 func TestSetIntoExistingStruct(t *testing.T) {
 	expectedConfig := newRedFederalCowHammerConfig()
-	expectedConfig.AuthInfos["red-user"].Password = "new-path-value"
+	expectedConfig.AuthInfos["red-user"].Password = "new-path-value" // Fake value for testing.
 	test := configCommandTest{
 		args:           []string{"set", "users.red-user.password", "new-path-value"},
 		startingConfig: newRedFederalCowHammerConfig(),
@@ -391,7 +391,7 @@ func TestBasicClearsToken(t *testing.T) {
 
 	authInfoWithBasic := clientcmdapi.NewAuthInfo()
 	authInfoWithBasic.Username = "myuser"
-	authInfoWithBasic.Password = "mypass"
+	authInfoWithBasic.Password = "mypass" // Fake value for testing.
 
 	startingConfig := newRedFederalCowHammerConfig()
 	startingConfig.AuthInfos["another-user"] = authInfoWithToken
@@ -411,7 +411,7 @@ func TestBasicClearsToken(t *testing.T) {
 func TestTokenClearsBasic(t *testing.T) {
 	authInfoWithBasic := clientcmdapi.NewAuthInfo()
 	authInfoWithBasic.Username = "myuser"
-	authInfoWithBasic.Password = "mypass"
+	authInfoWithBasic.Password = "mypass" // Fake value for testing.
 
 	authInfoWithToken := clientcmdapi.NewAuthInfo()
 	authInfoWithToken.Token = "token"

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/secret_for_docker_registry_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/secret_for_docker_registry_test.go
@@ -20,11 +20,12 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestSecretForDockerRegistryGenerate(t *testing.T) {
+	// Fake values for testing.
 	username, password, email, server := "test-user", "test-password", "test-user@example.org", "https://index.docker.io/v1/"
 	secretData, err := handleDockerCfgJSONContent(username, password, email, server)
 	if err != nil {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -1484,6 +1484,7 @@ func TestProtocolTranslationUDP(t *testing.T) {
 
 // Test Configuration deserialization (json)
 func TestNewCloudFromJSON(t *testing.T) {
+	// Fake values for testing.
 	config := `{
 		"tenantId": "--tenant-id--",
 		"subscriptionId": "--subscription-id--",

--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_test.go
@@ -95,7 +95,7 @@ func TestReadConfig(t *testing.T) {
 	env := clearEnviron(t)
 	defer resetEnviron(t, env)
 
-	os.Setenv("OS_PASSWORD", "mypass")
+	os.Setenv("OS_PASSWORD", "mypass") // Fake value for testing.
 	defer os.Unsetenv("OS_PASSWORD")
 
 	os.Setenv("OS_TENANT_NAME", "admin")
@@ -174,7 +174,7 @@ func TestReadConfig(t *testing.T) {
 func TestToAuthOptions(t *testing.T) {
 	cfg := Config{}
 	cfg.Global.Username = "user"
-	cfg.Global.Password = "pass"
+	cfg.Global.Password = "pass" // Fake value for testing.
 	cfg.Global.DomainID = "2a73b8f597c04551a0fdc8e95544be8a"
 	cfg.Global.DomainName = "local"
 	cfg.Global.AuthURL = "http://auth.url"
@@ -679,7 +679,7 @@ func TestInstanceIDFromProviderID(t *testing.T) {
 func TestToAuth3Options(t *testing.T) {
 	cfg := Config{}
 	cfg.Global.Username = "user"
-	cfg.Global.Password = "pass"
+	cfg.Global.Password = "pass" // Fake value for testing.
 	cfg.Global.DomainID = "2a73b8f597c04551a0fdc8e95544be8a"
 	cfg.Global.DomainName = "local"
 	cfg.Global.AuthURL = "http://auth.url"

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/fixtures/README.md
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/fixtures/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vsphere_test.go
@@ -75,6 +75,7 @@ W6CzB7pZ9Nj1YLpgzc1r6oONHLokMJJIz/IvkQ==
 -----END CERTIFICATE-----`
 
 // localhostKey is the private key for localhostCert.
+// Fake value for testing.
 var localhostKey = `-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEA1Z5/aTwqY706M34tn60l8ZHkanWDl8mM1pYf4Q7qg3zA9XqW
 LX6S4rTYDYCb4stEasC72lQnbEWHbthiQE76zubP8WOFHdvGR3mjAvHWz4FxvLOT
@@ -206,6 +207,7 @@ func TestReadConfig(t *testing.T) {
 		t.Errorf("Should fail when no config is provided: %s", err)
 	}
 
+	// Fake values for testing.
 	cfg, err := readConfig(strings.NewReader(`
 [Global]
 server = 0.0.0.0
@@ -823,7 +825,7 @@ func TestSecretVSphereConfig(t *testing.T) {
 	var vs *VSphere
 	var (
 		username = "user"
-		password = "password"
+		password = "password" // Fake value for testing.
 	)
 	var testcases = []struct {
 		testName                 string

--- a/test/images/agnhost/porter/README.md
+++ b/test/images/agnhost/porter/README.md
@@ -1,0 +1,1 @@
+Keys in this directory are generated for testing purposes only.

--- a/test/images/volume/rbd/README.md
+++ b/test/images/volume/rbd/README.md
@@ -3,3 +3,7 @@
 * The container needs to run with docker --privileged
 
 block.tar.gz is a small ext2 filesystem created by `create_block.sh` (run as root!)
+
+# Credentials
+
+Credentials in this directory are generated for testing purposes only.

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -45,6 +45,7 @@ import (
 func TestNodeAuthorizer(t *testing.T) {
 	const (
 		// Define credentials
+		// Fake values for testing.
 		tokenMaster      = "master-token"
 		tokenNodeUnknown = "unknown-token"
 		tokenNode1       = "node1-token"

--- a/test/integration/master/synthetic_master_test.go
+++ b/test/integration/master/synthetic_master_test.go
@@ -54,6 +54,7 @@ import (
 )
 
 const (
+	// Fake values for testing.
 	AliceToken string = "abc123" // username: alice.  Present in token file.
 	BobToken   string = "xyz987" // username: bob.  Present in token file.
 )

--- a/test/integration/master/transformation_testcase.go
+++ b/test/integration/master/transformation_testcase.go
@@ -46,7 +46,7 @@ import (
 
 const (
 	secretKey                = "api_key"
-	secretVal                = "086a7ffc-0225-11e8-ba89-0ed5f89f718b"
+	secretVal                = "086a7ffc-0225-11e8-ba89-0ed5f89f718b" // Fake value for testing.
 	encryptionConfigFileName = "encryption.conf"
 	testNamespace            = "secret-encryption-test"
 	testSecret               = "test-secret"

--- a/test/integration/serviceaccount/service_account_test.go
+++ b/test/integration/serviceaccount/service_account_test.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	rootUserName = "root"
-	rootToken    = "root-user-token"
+	rootToken    = "root-user-token" // Fake value for testing.
 
 	readOnlyServiceAccountName  = "ro"
 	readWriteServiceAccountName = "rw"

--- a/test/integration/serving/serving_test.go
+++ b/test/integration/serving/serving_test.go
@@ -89,7 +89,7 @@ func TestComponentSecureServingAndAuth(t *testing.T) {
 	}
 
 	// authenticate to apiserver via bearer token
-	token := "flwqkenfjasasdfmwerasd"
+	token := "flwqkenfjasasdfmwerasd" // Fake token for testing.
 	tokenFile, err := ioutil.TempFile("", "kubeconfig")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Ensure that we label all hard coded testing tokens, passwords, keys and other credentials clearly as test data. We have received a number of HackerOne reports for these credentials, so hopefully these messages will help clarify that these should not be reported.

```release-note
NONE
```

/sig auth