### PR TITLE
add myself to hack/OWNERS

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -15,6 +15,7 @@ reviewers:
   - vishh
   - xichengliudui
   - zmerlynn
+  - mikedanese
 approvers:
   - bentheelder
   - cblecker
@@ -32,5 +33,6 @@ approvers:
   - sttts
   - vishh
   - zmerlynn
+  - mikedanese
 emeritus_approvers:
   - jbeda


### PR DESCRIPTION
I have 140 commits in this directory and I get a lot of cleanup reviews
and want to be able to approve changes to hack/.golint_failures (removals).

0e69316b delete unused cache
b9c7007c enable token review when openapi is generated
d5bbc35d make deps-approvers the approvers of sample-cli-plugin/Godeps
4186abf7 bzl: fix update-bazel.sh
7b472296 remove deprecated /proxy paths
b9738404 gke-certificates-controller: rm -rf
49610655 cluster: remove unused functions
1e2b6442 cluster: move logging library to hack/
bef68f7d cluster: build gci mounter like other go binaries
fe7ba9e7 kubeadm: use kubelet bootstrap instead of reimplementing
3c39173e fixit: break sig-cluster-lifecycle tests into subpackage
64f77ebf enable race detection on integration tests
cdcfa35c promote tls-bootstrap to beta
ff4a814c migrate set generation to go genrule
3600d495 delete benchmark integration tests that don't work at all
21617a60 don't use build tags to mark integration tests
59fc948a bump rules_go and go version for bazel builds
ba5c2855 bazel: implement git build stamping
ad42b429 move kubeadm api group testing to kubeadm package
c8ce55fe Revert "Merge pull request #41132 from kubernetes/revert-40893-kubelet-auth"
cbe5bd97 bump gazel to v14
86d94937 remove second CA used for kubelet auth in favor of webhook auth
04a7880b update repo local config to allow redirects from gopkg.in
44b72465 autogenerated
96c146c8 promote certificates.k8s.io to beta
087016dd update gazel to v8
837eee43 pin gazel to v3
e225625a add a configuration for kubelet to register as a node with taints
584689f1 implement kubectl procelain csr commands
93f737ea fix verify-bazel.sh on mac and windows
5dc7554a bazel: implement set-gen as a bazel genrule
61bd6aa6 remove docs/user-guide from bindata search path
224e32bc make godep licenses/copyright check case insensitive
1cd29689 godep: vendor go-bindata
d380cb1d fix realpath issue on mac
ea632fa8 Revert "disable bazel build"
27116c68 rename build/ to build-tools/
ee15c80d disable bazel build
999c9677 ignore BUILD in the flags-underscore.py validation
b250a880 don't check BUILD file when verifying godeps
a2eec91a add bazel presubmits to verify BUILD files are up to date
c17a8a77 kubectl: apply prune should fallback to basic delete when a resource has no reaper
25e4dcce kubeadm: fix conversion macros and add kubeadm to round trip testing
6d17a878 kubectl: add two more test of kubectl apply --prune
62960aac add a test for kubectl apply --prune
6339d915 add a test to test-cmd.sh for apply -f with label selector
b421bf43 build kube-discovery and kubeadm with release
0c76cf5c fix hack/verify-codegen.sh
9f379df7 add an option to controller-manager to auto approve all CSRs
95e2e299 move kube-dns to the cluster/addons/ directory
f3de21bd move integration tests into individual pacakges
af0177ef cleanup hack/verify-govet.sh to throttle process creation
2c93ea5d Merge pull request #27289 from mikedanese/split-verify
ee34c769 split verify out of unit/integration suite
d046275a now that go test runs iteration loops, use that instead of custom executor
1ef19062 Merge pull request #26197 from wonderfly/update_default_master_image
fbf6bbc4 Merge pull request #25596 from derekparker/inotify
3e1c0b59 run kube-addon-manager in a pod
c5cc0c34 Merge pull request #24277 from ihmccreery/upgrade-timeout
132c4271 add linux fastbuild option to ./build/release.sh
2857baa7 use defaults in test-dockerized for etcd prefix and api versions
695211e2 Merge pull request #21105 from caesarxuchao/watchCacheForIntegration
2172e0de Merge pull request #21108 from mml/slow-flake
1478cf34 Merge pull request #21090 from ihmccreery/feature-reboot
b3172a4c kubelet: add a pidfile
b1743a68 this is a manual reversion of #20702
5b270551 Merge pull request #19378 from ihmccreery/remove-update-jobs
b7438274 Merge pull request #19659 from ihmccreery/timeout-reboot
a6589f7d hack: ignore cluster/env.sh in boilerplate check
f71657d9 retrofit the scheduler with the leader election client.
bf763bba Merge pull request #19498 from pwittrock/nodelabels
22cfa5ea build: move some of hack/lib/ into a new cluster/lib/
b174fc9c Merge pull request #18994 from bprashanth/flannel_suite
a09d85bd expose master count configuration in a cli option on apiserver
c2753d75 bump ci go version to 1.5.2
0655e65b fall back to old behavior when deciding mem availablity during build
1d9d11c8 run kube-proxy in a static pod
91de3a12 cleanup some nits in hack/get-build.sh
cd79c6c0 fix unbound variable error in hace/get-build.sh
5e64590f renable enable var to correct name and only use it when needed
9bdb860e add apigroup installer and tests
e6d3b47e add componentconfig api group to autogen stuff
88008de9 Merge pull request #16459 from mikedanese/enable-exp
d28d1344 Merge pull request #16533 from ihmccreery/upgrade-test-fixes
33435225 enable deployment and daemonset in gce upgrade tests
7cbf249b Merge pull request #15836 from wojtek-t/codecgen_from_godeps
92404e7c add upgrade test between 1.0 and 1.1 for gce
95b8394a Merge pull request #15861 from mikedanese/upgrade-num-minion
ece5779f increase NUM_MINIONS for jenkins gce upgrade test
b8b35afa actually promote daemonset simple test out of flaky and skip all daemonset tests in gke
d379a360 copy directory not contents of directory
402e68e0 add slow test for terminated pod garbage collection
c0943f11 add intermediate e2e runs to gce upgrade
10d56ff1 promote simple daemonset test out of flaky
b635fc53 Merge pull request #15228 from mesosphere/sttts-conformance-tags
392f33e4 Merge pull request #14054 from mikedanese/register-master
fa60bbe8 add flag to kubelet to ignore the cidr passed down by the apiserver on the master
53e14c7a diff all of pkg/ when verifying swagerspec instead of just pkg/api/
05ef8ed2 Merge pull request #15104 from mikedanese/ds-e2e
fe820fc4 break up daemonset test into two tests
833be48d enable all experimental flags with one controller
905e9716 be explicit about minion group size in upgrade test
ae7d3d5a add gce-upgrade to jenkins/e2e.sh
376faea1 add pod garbage collection
b0457bee Merge pull request #13058 from mvdan/go1.5
a48f2182 Merge pull request #13754 from tummychow/labels-deps
1fec1993 Merge pull request #13824 from kubernetes/revert-13547-hpa-kubeup
fa40ced8 move contrib/for-tests to test/images
f0618758 updating all references in .sh scripts
83266970 rewrite all links to prs to k8s links
fb02b33e fix build
8e48431c Revert "demote to flaky tests from parallel e2e"
b56edd13 Merge pull request #11727 from ZJU-SEL/build-nonstatic-hyperkube
cf4cb1a6 Merge pull request #10474 from kargakis/scale-multiple-controllers
e376a094 demote to flaky service tests from parallel e2e
7c47d6bd Merge pull request #12009 from smarterclayton/fix_cmd_config
0269e2ba Merge pull request #11941 from GoogleCloudPlatform/enact_version_md
94a387d5 Revert "Improve conversion to support multiple packages"
1a613c43 Merge pull request #9971 from smarterclayton/make_conversion_more_flexible
0ae48c44 Merge pull request #11927 from wojtek-t/remove_shell_services
59a1dd42 Merge pull request #11789 from mbforbes/nodesNetwork
6294070c Merge pull request #11803 from wojtek-t/move_back_from_flaky
daa6d4dd Merge pull request #11285 from liggitt/ca
9f16fd90 Merge pull request #11860 from ingvagabund/delimiter-for-X-option-eparis
c0acfbcd Merge pull request #11421 from nikhiljindal/exposeServcPort
ae1c8e55 Merge pull request #11737 from thockin/cleanup-remove-v1beta3
01ee1b86 Merge pull request #10840 from jbeda/master
d4d99deb make mungedoc exit 1 if manual changes are needed and wire up erro message.
337772a9 fix all tests
055115a1 fake realpath, and standardize treatment of trailing / of dirs in gendoc
b4514ee1 fix run-gendocs to point to new repo location
c053b9a5 add documentation and script on how to get recent and "nightly" builds
719870fd add publishing of latest-green.txt to jenkins e2e tests on success
1e130e07 remove --machines from code and docs
dbb47fe2 remove e2e run before cluster upgrade
de55e17f e2e test cluster stability during upgrade
c9fcf45f fix bad cmd-test for patch.
9f915325 fix error where we can't use patch and add cmd-test for patch and file update

/kind cleanup

```release-note
NONE
```