### PR TITLE
Automated cherry pick of #77795: Remove selected IP from backup-volfile-servers list to avoid

### DIFF
--- a/pkg/volume/glusterfs/glusterfs.go
+++ b/pkg/volume/glusterfs/glusterfs.go
@@ -383,19 +383,26 @@ func (b *glusterfsMounter) setUpAtInternal(dir string) error {
 
 	}
 
-	//Add backup-volfile-servers and auto_unmount options.
-	options = append(options, "backup-volfile-servers="+dstrings.Join(addrlist[:], ":"))
-	options = append(options, "auto_unmount")
-
-	mountOptions := volutil.JoinMountOptions(b.mountOptions, options)
-
-	// with `backup-volfile-servers` mount option in place, it is not required to
-	// iterate over all the servers in the addrlist. A mount attempt with this option
-	// will fetch all the servers mentioned in the backup-volfile-servers list.
-	// Refer to backup-volfile-servers @ http://docs.gluster.org/en/latest/Administrator%20Guide/Setting%20Up%20Clients/
-
 	if (len(addrlist) > 0) && (addrlist[0] != "") {
 		ip := addrlist[rand.Intn(len(addrlist))]
+
+		// Add backup-volfile-servers and auto_unmount options.
+		// When ip is also in backup-volfile-servers, there will be a warning:
+		// "gf_remember_backup_volfile_server] 0-glusterfs: failed to set volfile server: File exists".
+		addr.Delete(ip)
+		backups := addr.List()
+		// Avoid an invalid empty backup-volfile-servers option.
+		if len(backups) > 0 {
+			options = append(options, "backup-volfile-servers="+dstrings.Join(addrlist[:], ":"))
+		}
+		options = append(options, "auto_unmount")
+
+		mountOptions := volutil.JoinMountOptions(b.mountOptions, options)
+		// with `backup-volfile-servers` mount option in place, it is not required to
+		// iterate over all the servers in the addrlist. A mount attempt with this option
+		// will fetch all the servers mentioned in the backup-volfile-servers list.
+		// Refer to backup-volfile-servers @ http://docs.gluster.org/en/latest/Administrator%20Guide/Setting%20Up%20Clients/
+
 		errs = b.mounter.Mount(ip+":"+b.path, dir, "glusterfs", mountOptions)
 		if errs == nil {
 			klog.Infof("successfully mounted directory %s", dir)


### PR DESCRIPTION
Cherry pick of #77795 on release-1.15.

#77795: Remove selected IP from backup-volfile-servers list to avoid

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.