### PR TITLE
Move 'path' package usage to 'path/filepath' (repeat the #87713)

### DIFF
--- a/pkg/volume/csi/csi_plugin_test.go
+++ b/pkg/volume/csi/csi_plugin_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 
@@ -376,7 +375,7 @@ func TestPluginConstructVolumeSpec(t *testing.T) {
 			csiMounter := mounter.(*csiMountMgr)
 
 			// rebuild spec
-			spec, err := plug.ConstructVolumeSpec("test-pv", path.Dir(csiMounter.GetPath()))
+			spec, err := plug.ConstructVolumeSpec("test-pv", filepath.Dir(csiMounter.GetPath()))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -508,7 +507,7 @@ func TestPluginConstructVolumeSpecWithInline(t *testing.T) {
 			csiMounter := mounter.(*csiMountMgr)
 
 			// rebuild spec
-			spec, err := plug.ConstructVolumeSpec("test-pv", path.Dir(csiMounter.GetPath()))
+			spec, err := plug.ConstructVolumeSpec("test-pv", filepath.Dir(csiMounter.GetPath()))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -636,7 +635,7 @@ func TestPluginNewMounter(t *testing.T) {
 			}
 
 			// ensure data file is created
-			dataDir := path.Dir(mounter.GetPath())
+			dataDir := filepath.Dir(mounter.GetPath())
 			dataFile := filepath.Join(dataDir, volDataFileName)
 			if _, err := os.Stat(dataFile); err != nil {
 				if os.IsNotExist(err) {
@@ -775,7 +774,7 @@ func TestPluginNewMounterWithInline(t *testing.T) {
 				}
 
 				// ensure data file is created
-				dataDir := path.Dir(mounter.GetPath())
+				dataDir := filepath.Dir(mounter.GetPath())
 				dataFile := filepath.Join(dataDir, volDataFileName)
 				if _, err := os.Stat(dataFile); err != nil {
 					if os.IsNotExist(err) {
@@ -834,7 +833,7 @@ func TestPluginNewUnmounter(t *testing.T) {
 	}
 
 	if err := saveVolumeData(
-		path.Dir(dir),
+		filepath.Dir(dir),
 		volDataFileName,
 		map[string]string{
 			volDataKey.specVolID:  pv.ObjectMeta.Name,

--- a/pkg/volume/csi/csi_test.go
+++ b/pkg/volume/csi/csi_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"math/rand"
 	"os"
-	"path"
 	"path/filepath"
 	"testing"
 	"time"
@@ -422,14 +421,14 @@ func TestCSI_VolumeAll(t *testing.T) {
 			}
 			t.Log("csiTest.VolumeAll mounter.Setup(fsGroup) done OK")
 
-			dataFile := filepath.Join(path.Dir(mounter.GetPath()), volDataFileName)
+			dataFile := filepath.Join(filepath.Dir(mounter.GetPath()), volDataFileName)
 			if _, err := os.Stat(dataFile); err != nil {
 				t.Fatalf("csiTest.VolumeAll meatadata JSON file not found: %s", dataFile)
 			}
 			t.Log("csiTest.VolumeAll JSON datafile generated OK:", dataFile)
 
 			// ******** Volume Reconstruction ************* //
-			volPath := path.Dir(csiMounter.GetPath())
+			volPath := filepath.Dir(csiMounter.GetPath())
 			t.Log("csiTest.VolumeAll entering plugin.ConstructVolumeSpec for path", volPath)
 			spec, err := volPlug.ConstructVolumeSpec(test.volName, volPath)
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:

The change will protect project consistency.
This PR repeat the fix of #87713 (commit is 76c8964) that are submitted by @kkmsft, and reviewed by @andyzhangx.
This PR fixes the csi files that are not touched by original PR.
In the original PR said
> In case of windows, the path package functions such as 'Dir' returns faulty directory path.
> For eg: 'path.Dir' on 'c:\var\lib\kubelet\pods' returns '.', where as the result should have been 'c:\var\lib\kubelet'. The filepath package returns the right values.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related with #87713

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
