### PR TITLE
PodTopologySpread plugin now excludes terminatingPods

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -611,7 +611,7 @@ func TestGenericScheduler(t *testing.T) {
 			wErr:  fmt.Errorf("error while running score plugin for pod \"2\": %+v", errPrioritize),
 		},
 		{
-			name: "test even pods spread predicate - 2 nodes with maxskew=1",
+			name: "test podtopologyspread plugin - 2 nodes with maxskew=1",
 			registerPlugins: []st.RegisterPluginFunc{
 				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				st.RegisterPluginAsExtensions(
@@ -659,7 +659,7 @@ func TestGenericScheduler(t *testing.T) {
 			wErr:          nil,
 		},
 		{
-			name: "test even pods spread predicate - 3 nodes with maxskew=2",
+			name: "test podtopologyspread plugin - 3 nodes with maxskew=2",
 			registerPlugins: []st.RegisterPluginFunc{
 				st.RegisterQueueSortPlugin(queuesort.Name, queuesort.New),
 				st.RegisterPluginAsExtensions(
@@ -854,7 +854,6 @@ func makeScheduler(nodes []*v1.Node, fns ...st.RegisterPluginFunc) *genericSched
 		schedulerapi.DefaultPercentageOfNodesToScore, false)
 	cache.UpdateSnapshot(s.(*genericScheduler).nodeInfoSnapshot)
 	return s.(*genericScheduler)
-
 }
 
 func TestFindFitAllError(t *testing.T) {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -255,7 +255,8 @@ func calPreFilterState(pod *v1.Pod, allNodes []*schedulernodeinfo.NodeInfo) (*pr
 			matchTotal := int32(0)
 			// nodeInfo.Pods() can be empty; or all pods don't fit
 			for _, existingPod := range nodeInfo.Pods() {
-				if existingPod.Namespace != pod.Namespace {
+				// Bypass terminating Pod (see #87621).
+				if existingPod.DeletionTimestamp != nil || existingPod.Namespace != pod.Namespace {
 					continue
 				}
 				if constraint.selector.Matches(labels.Set(existingPod.Labels)) {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -135,6 +135,10 @@ func (pl *PodTopologySpread) PostFilter(
 			// <matchSum> indicates how many pods (on current node) match the <constraint>.
 			matchSum := int64(0)
 			for _, existingPod := range nodeInfo.Pods() {
+				// Bypass terminating Pod (see #87621).
+				if existingPod.DeletionTimestamp != nil || existingPod.Namespace != pod.Namespace {
+					continue
+				}
 				if c.selector.Matches(labels.Set(existingPod.Labels)) {
 					matchSum++
 				}

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -171,6 +171,13 @@ func (p *PodWrapper) Priority(val int32) *PodWrapper {
 	return p
 }
 
+// Terminating sets the inner pod's deletionTimestamp to current timestamp.
+func (p *PodWrapper) Terminating() *PodWrapper {
+	now := metav1.Now()
+	p.DeletionTimestamp = &now
+	return p
+}
+
 // ZeroTerminationGracePeriod sets the TerminationGracePeriodSeconds of the inner pod to zero.
 func (p *PodWrapper) ZeroTerminationGracePeriod() *PodWrapper {
 	p.Spec.TerminationGracePeriodSeconds = &zero


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

The background is discussed at #87632 

In short, all scheduler (filter) plugins take terminating Pods into consideration, however, for some particular case (e.g., PodTopologySpread), it may be reasonable to exclude the terminating Pods.

**Which issue(s) this PR fixes**:

Fixes #86037

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
PodTopologySpread plugin now excludes terminatingPods when making scheduling decisions.
```

/cc @ahg-g @alculquicondor 