### PR TITLE
Add delete priority annotation for ReplicaSet

### DIFF
--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -83,7 +83,7 @@ const (
 	//      1+floor(log_2(ceil(N/SlowStartInitialBatchSize)))
 	SlowStartInitialBatchSize = 1
 )
-const deletePriorityPodAnnotationKey = "controller.kubernetes.io/delete-priority"
+const deletePriorityPodAnnotationKey = "controller.kubernetes.io/replicaset-downscale-priority"
 
 var UpdateTaintBackoff = wait.Backoff{
 	Steps:    5,

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -763,20 +763,20 @@ func (s ActivePods) Less(i, j int) bool {
 		return !podutil.IsPodReady(s[i])
 	}
         // 4. controller.kubernetes.io/delete-priority=1 < controller.kubernetes.io/delete-priority=0
-        //If pod has annotation controller.kubernetes.io/delete-priority the larger is small
-        if s[i].Annotations[deletePriorityPodAnnotationKey] != s[j].Annotations[deletePriorityPodAnnotationKey] {
-                s1, err1 := strconv.Atoi(s[i].Annotations[deletePriorityPodAnnotationKey])
-                s2, err2 := strconv.Atoi(s[j].Annotations[deletePriorityPodAnnotationKey])
-                if err1 == nil && err2 == nil {
-                        return s1 > s2
-                }
-                if err1 != nil && err2 == nil {
-                        return true
-                }
-                if err1 == nil && err2 != nil {
-                        return false
-                }
-        }
+	//If pod has annotation controller.kubernetes.io/delete-priority the larger is small
+	if s[i].Annotations[deletePriorityPodAnnotationKey] != s[j].Annotations[deletePriorityPodAnnotationKey] {
+		s1, err1 := strconv.Atoi(s[i].Annotations[deletePriorityPodAnnotationKey])
+		s2, err2 := strconv.Atoi(s[j].Annotations[deletePriorityPodAnnotationKey])
+		if err1 == nil && err2 == nil {
+			return s1 > s2
+		}
+		if err1 != nil && err2 == nil {
+			return true
+		}
+		if err1 == nil && err2 != nil {
+			return false
+		}
+	}
 	// TODO: take availability into account when we push minReadySeconds information from deployment into pods,
 	//       see https://github.com/kubernetes/kubernetes/issues/22065
 	// 5. Been ready for empty time < less time < more time

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -756,6 +756,12 @@ func (s ActivePods) Less(i, j int) bool {
 		if err1 == nil && err2 == nil {
 			return s1 > s2
 		}
+		if err1 != nil && err2 == nil {
+			return true
+		}
+		if err1 == nil && err2 != nil {
+			return false
+		}
 	}
 	// 1. Unassigned < assigned
 	// If only one of the pods is unassigned, the unassigned one is smaller

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+	"strconv"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -83,7 +84,7 @@ const (
 	//      1+floor(log_2(ceil(N/SlowStartInitialBatchSize)))
 	SlowStartInitialBatchSize = 1
 )
-const DeletePriorityPodAnnotationKey = "controller.alpha.kubernetes.io/delete-priority"
+const deletePriorityPodAnnotationKey = "controller.alpha.kubernetes.io/delete-priority"
 
 var UpdateTaintBackoff = wait.Backoff{
 	Steps:    5,
@@ -750,9 +751,9 @@ func (s ActivePods) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 func (s ActivePods) Less(i, j int) bool {
 	//0. controller.alpha.kubernetes.io/delete-priority=1 < controller.alpha.kubernetes.io/delete-priority=0
 	//If pod has annotation controller.alpha.kubernetes.io/delete-priority the larger is small
-	if s[i].Annotations[DeletePriorityPodAnnotationKey] != s[j].Annotations[DeletePriorityPodAnnotationKey] {
-		s1, err1 := strconv.Atoi(s[i].Annotations[DeletePriorityPodAnnotationKey])
-		s2, err2 := strconv.Atoi(s[j].Annotations[DeletePriorityPodAnnotationKey])
+	if s[i].Annotations[deletePriorityPodAnnotationKey] != s[j].Annotations[deletePriorityPodAnnotationKey] {
+		s1, err1 := strconv.Atoi(s[i].Annotations[deletePriorityPodAnnotationKey])
+		s2, err2 := strconv.Atoi(s[j].Annotations[deletePriorityPodAnnotationKey])
 		if err1 == nil && err2 == nil {
 			return s1 > s2
 		}

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -50,6 +50,7 @@ import (
 	hashutil "k8s.io/kubernetes/pkg/util/hash"
 	taintutils "k8s.io/kubernetes/pkg/util/taints"
 	"k8s.io/utils/integer"
+	"strconv"
 
 	"k8s.io/klog/v2"
 )
@@ -82,6 +83,7 @@ const (
 	//      1+floor(log_2(ceil(N/SlowStartInitialBatchSize)))
 	SlowStartInitialBatchSize = 1
 )
+const DeletePriorityPodAnnotationKey = "controller.alpha.kubernetes.io/delete-priority"
 
 var UpdateTaintBackoff = wait.Backoff{
 	Steps:    5,
@@ -746,6 +748,15 @@ func (s ActivePods) Len() int      { return len(s) }
 func (s ActivePods) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func (s ActivePods) Less(i, j int) bool {
+	//0. controller.alpha.kubernetes.io/delete-priority=1 < controller.alpha.kubernetes.io/delete-priority=0
+	//If pod has annotation controller.alpha.kubernetes.io/delete-priority the larger is small
+	if s[i].Annotations[DeletePriorityPodAnnotationKey] != s[j].Annotations[DeletePriorityPodAnnotationKey] {
+		s1, err1 := strconv.Atoi(s[i].Annotations[DeletePriorityPodAnnotationKey])
+		s2, err2 := strconv.Atoi(s[j].Annotations[DeletePriorityPodAnnotationKey])
+		if err1 == nil && err2 == nil {
+			return s1 > s2
+		}
+	}
 	// 1. Unassigned < assigned
 	// If only one of the pods is unassigned, the unassigned one is smaller
 	if s[i].Spec.NodeName != s[j].Spec.NodeName && (len(s[i].Spec.NodeName) == 0 || len(s[j].Spec.NodeName) == 0) {

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -25,7 +25,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"strconv"
 
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -83,7 +83,7 @@ const (
 	//      1+floor(log_2(ceil(N/SlowStartInitialBatchSize)))
 	SlowStartInitialBatchSize = 1
 )
-const deletePriorityPodAnnotationKey = "controller.alpha.kubernetes.io/delete-priority"
+const deletePriorityPodAnnotationKey = "controller.kubernetes.io/delete-priority"
 
 var UpdateTaintBackoff = wait.Backoff{
 	Steps:    5,
@@ -748,8 +748,8 @@ func (s ActivePods) Len() int      { return len(s) }
 func (s ActivePods) Swap(i, j int) { s[i], s[j] = s[j], s[i] }
 
 func (s ActivePods) Less(i, j int) bool {
-	//0. controller.alpha.kubernetes.io/delete-priority=1 < controller.alpha.kubernetes.io/delete-priority=0
-	//If pod has annotation controller.alpha.kubernetes.io/delete-priority the larger is small
+	//0. controller.kubernetes.io/delete-priority=1 < controller.kubernetes.io/delete-priority=0
+	//If pod has annotation controller.kubernetes.io/delete-priority the larger is small
 	if s[i].Annotations[deletePriorityPodAnnotationKey] != s[j].Annotations[deletePriorityPodAnnotationKey] {
 		s1, err1 := strconv.Atoi(s[i].Annotations[deletePriorityPodAnnotationKey])
 		s2, err2 := strconv.Atoi(s[j].Annotations[deletePriorityPodAnnotationKey])


### PR DESCRIPTION
**What type of PR is this**?

/kind feature

**What this PR does / why we need it**:

For some applications it is necessary that the application can tell Kubernetes which pod can be deleted and which replica has to be protected. The reason for this is that some applications do have stateful sessions and it is not possible to put such an application into Kubernetes because of data or session corruption resulting from "random" down-scale. If the application is able to tell Kubernetes which of the replicas contains no/few/less important active sessions, this would solve many problems. This PR is non-disruptive to the default behavior. Only if the annotation is existing, it will make a difference in deletion order.

The original PR (#75763) was closed and contained a coding error in the sorting function: If one pod was annotated and one was not, it could happen that the annotated pod gets deleted but the not annotated (but less prioritized) one stayed. This issue is fixed in this PR.

**Which issue(s) this PR fixes**:

Fixes #45509

**Special notes for your reviewer**:
For demo see my screencast: https://youtu.be/91APTsEsxIU

**Does this PR introduce a user-facing change?**:
A pod can be annotated with a controller.alpha.kubernetes.io/delete-priority annotation. If the annotation is existing, a high number (low priority) gets deleted first. If one replica does not have this annotation, it gets deleted first.
This PR DOES NOT change any default behavior. Only if the annotation is existing, it will make a difference in deletion order.

```release-note
Added delete priority annotation for ReplicaSet. Not annotated pods get deleted first: HIGH PRIO (low value)> LOW PRIO (high value) > NO PRIO (not annotated). Use "controller.alpha.kubernetes.io/delete-priority" annotation.
```