### PR TITLE
kubelet: add remote OOM metric

### DIFF
--- a/pkg/kubelet/remote/BUILD
+++ b/pkg/kubelet/remote/BUILD
@@ -16,6 +16,7 @@ go_library(
     ],
     importpath = "k8s.io/kubernetes/pkg/kubelet/remote",
     deps = [
+        "//pkg/kubelet/remote/metrics:go_default_library",
         "//pkg/kubelet/util:go_default_library",
         "//pkg/kubelet/util/logreduction:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis:go_default_library",
@@ -38,6 +39,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/kubelet/remote/fake:all-srcs",
+        "//pkg/kubelet/remote/metrics:all-srcs",
     ],
     tags = ["automanaged"],
 )

--- a/pkg/kubelet/remote/metrics/BUILD
+++ b/pkg/kubelet/remote/metrics/BUILD
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["metrics.go"],
+    importpath = "k8s.io/kubernetes/pkg/kubelet/remote/metrics",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/component-base/metrics:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/kubelet/remote/metrics/metrics.go
+++ b/pkg/kubelet/remote/metrics/metrics.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"k8s.io/component-base/metrics"
+	"k8s.io/component-base/metrics/legacyregistry"
+)
+
+const (
+	// RemoteContainerOOM contains a counter for container OOMs
+	RemoteContainerOOM = "remote_container_oom"
+
+	// Keep the "kubelet" subsystem for backward compatibility.
+	kubeletSubsystem = "kubelet"
+)
+
+var (
+	// RemoteContainerOOMCounter collects operation counts by operation type.
+	RemoteContainerOOMCounter = metrics.NewCounterVec(
+		&metrics.CounterOpts{
+			Subsystem:      kubeletSubsystem,
+			Name:           RemoteContainerOOM,
+			Help:           "Cumulative number of Remote container OOMs.",
+			StabilityLevel: metrics.ALPHA,
+		},
+		[]string{"operation_type"},
+	)
+)
+
+var registerMetrics sync.Once
+
+// Register all metrics.
+func Register() {
+	registerMetrics.Do(func() {
+		legacyregistry.MustRegister(RemoteContainerOOMCounter)
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds a counter metric to the Kubelet remote runtime to count OOM's. This will allow for an accurate counter to be propagated to the monitoring stack to notify users their cluster may need to be scaled.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Adds a `remote_container_oom` (remote_ is the 'crio/remote' container runtime API) metric to keep track of OOMs from the container runtime.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

@kubernetes/sig-node-pr-reviews 
cc @sjenning @derekwaynecarr 
/sig node