### PR TITLE
Check ProxierHealthServer parameter against nil

### DIFF
--- a/pkg/proxy/healthcheck/proxier_health.go
+++ b/pkg/proxy/healthcheck/proxier_health.go
@@ -81,16 +81,25 @@ func newProxierHealthServer(listener listener, httpServerFactory httpServerFacto
 
 // Updated updates the lastUpdated timestamp.
 func (hs *ProxierHealthServer) Updated() {
+	if hs == nil {
+		return
+	}
 	hs.lastUpdated.Store(hs.clock.Now())
 }
 
 // QueuedUpdate updates the lastQueued timestamp.
 func (hs *ProxierHealthServer) QueuedUpdate() {
+	if hs == nil {
+		return
+	}
 	hs.lastQueued.Store(hs.clock.Now())
 }
 
 // Run starts the healthz http server and returns.
 func (hs *ProxierHealthServer) Run() {
+	if hs == nil {
+		return
+	}
 	serveMux := http.NewServeMux()
 	serveMux.Handle("/healthz", healthzHandler{hs: hs})
 	server := hs.httpFactory.New(hs.addr, serveMux)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As #87854 described, the ProxierHealthServer parameter would be nil when config.HealthzBindAddress is empty.

This PR adds check of the ProxierHealthServer parameter against nil.

**Which issue(s) this PR fixes**:
Fixes #87854

**Special notes for your reviewer**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
