### PR TITLE
support status.active & status.failed as job field selectors

### DIFF
--- a/pkg/apis/batch/v1/conversion.go
+++ b/pkg/apis/batch/v1/conversion.go
@@ -29,7 +29,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	return scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Job"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", "status.successful":
+			case "metadata.name", "metadata.namespace", "status.successful", "status.active", "status.failed":
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label %q not supported for Job", label)

--- a/pkg/registry/batch/job/strategy.go
+++ b/pkg/registry/batch/job/strategy.go
@@ -316,6 +316,8 @@ func JobToSelectableFields(job *batch.Job) fields.Set {
 	objectMetaFieldsSet := generic.ObjectMetaFieldsSet(&job.ObjectMeta, true)
 	specificFieldsSet := fields.Set{
 		"status.successful": strconv.Itoa(int(job.Status.Succeeded)),
+		"status.active":     strconv.Itoa(int(job.Status.Active)),
+		"status.failed":     strconv.Itoa(int(job.Status.Failed)),
 	}
 	return generic.MergeFieldsSets(objectMetaFieldsSet, specificFieldsSet)
 }


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
Extend the possible field-selectors to allow distinguishing jobs per status.
Currently the only option to distinguish jobs by status is by comparing the number of completed pods (`status.successful!=0` vs `status.successful==0`),  but further distinction of non-completed jobs (`failed` and `active`) is desirable.

**Which issue(s) this PR fixes**:
#86352

**Special notes for your reviewer**:
n/a

**Does this PR introduce a user-facing change?**:

```release-note
allow job field-selectors status.active & status.failed
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
n/a
