### PR TITLE
apimachinery: Use log level conventions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
+++ b/staging/src/k8s.io/apimachinery/pkg/labels/selector.go
@@ -217,13 +217,13 @@ func (r *Requirement) Matches(ls Labels) bool {
 		}
 		lsValue, err := strconv.ParseInt(ls.Get(r.key), 10, 64)
 		if err != nil {
-			klog.V(10).Infof("ParseInt failed for value %+v in label %+v, %+v", ls.Get(r.key), ls, err)
+			klog.V(5).Infof("ParseInt failed for value %+v in label %+v, %+v", ls.Get(r.key), ls, err)
 			return false
 		}
 
 		// There should be only one strValue in r.strValues, and can be converted to a integer.
 		if len(r.strValues) != 1 {
-			klog.V(10).Infof("Invalid values count %+v of requirement %#v, for 'Gt', 'Lt' operators, exactly one value is required", len(r.strValues), r)
+			klog.V(5).Infof("Invalid values count %+v of requirement %#v, for 'Gt', 'Lt' operators, exactly one value is required", len(r.strValues), r)
 			return false
 		}
 
@@ -231,7 +231,7 @@ func (r *Requirement) Matches(ls Labels) bool {
 		for i := range r.strValues {
 			rValue, err = strconv.ParseInt(r.strValues[i], 10, 64)
 			if err != nil {
-				klog.V(10).Infof("ParseInt failed for value %+v in requirement %#v, for 'Gt', 'Lt' operators, the value must be an integer", r.strValues[i], r)
+				klog.V(5).Infof("ParseInt failed for value %+v in requirement %#v, for 'Gt', 'Lt' operators, the value must be an integer", r.strValues[i], r)
 				return false
 			}
 		}


### PR DESCRIPTION
The SIG Instrumentation has specified conventions for logging
with klog.V() that range from 0 to 5. This commit normalizes log
messages that were in the range 6 to 10.

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
The SIG Instrumentation has specified conventions for logging
with klog.V() that range from 0 to 5. This commit normalizes log
messages that were in the range 6 to 10.
This PR brings the apimachinery code in to alignment with the 
SIG Instrumentation Logging Conventions documented here:
https://github.com/kubernetes/community/blob/master/contributors/devel/sig-instrumentation/logging.md

**Which issue(s) this PR fixes**:

https://github.com/kubernetes/apimachinery/issues/82

**Special notes for your reviewer**:
There should be no difference in functionality aside from log messages.
Some log messages have been assigned lower numbers so they will be
logged at level 5 or below, as '5' is now the convention for the highest 
(trace) level of logging.

**Does this PR introduce a user-facing change?**:

No significant change, as the Logging Convention has already been published.
```release-note
NONE
```