### PR TITLE
Allow container visitor to operate on selected container types

### DIFF
--- a/pkg/registry/core/pod/strategy.go
+++ b/pkg/registry/core/pod/strategy.go
@@ -387,7 +387,7 @@ func LogLocation(
 
 func podHasContainerWithName(pod *api.Pod, containerName string) bool {
 	var hasContainer bool
-	podutil.VisitContainers(&pod.Spec, func(c *api.Container) bool {
+	podutil.VisitContainers(&pod.Spec, podutil.DefaultContainers, func(c *api.Container, containerType podutil.ContainerType) bool {
 		if c.Name == containerName {
 			hasContainer = true
 			return false
@@ -554,7 +554,7 @@ func validateContainer(container string, pod *api.Pod) (string, error) {
 			return "", errors.NewBadRequest(fmt.Sprintf("a container name must be specified for pod %s", pod.Name))
 		default:
 			var containerNames []string
-			podutil.VisitContainers(&pod.Spec, func(c *api.Container) bool {
+			podutil.VisitContainers(&pod.Spec, podutil.DefaultContainers, func(c *api.Container, containerType podutil.ContainerType) bool {
 				containerNames = append(containerNames, c.Name)
 				return true
 			})

--- a/pkg/security/podsecuritypolicy/provider.go
+++ b/pkg/security/podsecuritypolicy/provider.go
@@ -111,7 +111,7 @@ func (s *simpleProvider) MutatePod(pod *api.Pod) error {
 	}
 
 	var retErr error
-	podutil.VisitContainers(&pod.Spec, func(c *api.Container) bool {
+	podutil.VisitContainers(&pod.Spec, podutil.AllContainers, func(c *api.Container, containerType podutil.ContainerType) bool {
 		retErr = s.mutateContainer(pod, c)
 		if retErr != nil {
 			return false


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Over #79176, there was some discussion on how container visitor should be enhanced starting with this comment:
#79176 (comment)

In this PR, we propose passing container types to VisitContainers func so that the caller can decide which container type(s) are of interest to the caller.

The visitor would be given the container type it is visiting.

I open this PR to solicit discussion and give V2 suffix to related type / func.
When we get agreement on the approach, I will retrofit current API.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
