### PR TITLE
Use NodeSelector instead of NodeName in hostexec Pod

### DIFF
--- a/test/e2e/framework/pod/node_selection.go
+++ b/test/e2e/framework/pod/node_selection.go
@@ -79,3 +79,11 @@ func SetAffinity(nodeSelection *NodeSelection, nodeName string) {
 func SetAntiAffinity(nodeSelection *NodeSelection, nodeName string) {
 	setNodeAffinityRequirement(nodeSelection, v1.NodeSelectorOpNotIn, nodeName)
 }
+
+// SetNodeAffinity modifies the given pod object with
+// NodeAffinity to the given node name.
+func SetNodeAffinity(pod *v1.Pod, nodeName string) {
+	nodeSelection := &NodeSelection{}
+	SetAffinity(nodeSelection, nodeName)
+	pod.Spec.Affinity = nodeSelection.Affinity
+}

--- a/test/e2e/storage/utils/host_exec.go
+++ b/test/e2e/storage/utils/host_exec.go
@@ -71,9 +71,14 @@ func (h *hostExecutor) launchNodeExecPod(node string) *v1.Pod {
 	f := h.Framework
 	cs := f.ClientSet
 	ns := f.Namespace
+
 	hostExecPod := e2epod.NewExecPodSpec(ns.Name, "", true)
 	hostExecPod.GenerateName = fmt.Sprintf("hostexec-%s-", node)
-	hostExecPod.Spec.NodeName = node
+	// Use NodeAffinity instead of NodeName so that pods will not
+	// be immediately Failed by kubelet if it's out of space. Instead
+	// Pods will be pending in the scheduler until there is space freed
+	// up.
+	e2epod.SetNodeAffinity(hostExecPod, node)
 	hostExecPod.Spec.Volumes = []v1.Volume{
 		{
 			// Required to enter into host mount namespace via nsenter.


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Using NodeName causes the Pod to bypass the scheduler and if the Node is full, kubelet immediately marks the Pod as failed. By going through the scheduler, the Pod will remain pending until Node resources are freed up. Tests may still flake if it takes too long for space to be freed from the node though.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Addresses #87855

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
