### PR TITLE
Directly convert CRD structuralSchema to smdSchema

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/go.mod
+++ b/staging/src/k8s.io/apiextensions-apiserver/go.mod
@@ -30,6 +30,7 @@ require (
 	k8s.io/klog v1.0.0
 	k8s.io/kube-openapi v0.0.0-20200121204235-bf4fb3bd569c
 	k8s.io/utils v0.0.0-20200117235808-5f6fbceb4c31
+	sigs.k8s.io/structured-merge-diff/v3 v3.0.0-20200207200219-5e70324e7c1c
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/BUILD
@@ -30,6 +30,7 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning:go_default_library",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/validation:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/client/informers/externalversions:go_default_library",
@@ -40,7 +41,6 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/finalizer:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/nonstructuralschema:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi:go_default_library",
-        "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/builder:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/controller/status:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/crdserverscheme:go_default_library",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource:go_default_library",
@@ -91,7 +91,7 @@ go_library(
         "//vendor/github.com/go-openapi/strfmt:go_default_library",
         "//vendor/github.com/go-openapi/validate:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
-        "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
+        "//vendor/k8s.io/kube-openapi/pkg/schemaconv:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/BUILD
@@ -38,6 +38,7 @@ filegroup(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta:all-srcs",
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning:all-srcs",
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd/BUILD
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd/BUILD
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "atom.go",
+        "builder.go",
+    ],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd",
+    importpath = "k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/schema:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/typed:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd/atom.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd/atom.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smd
+
+import (
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+
+	smdschema "sigs.k8s.io/structured-merge-diff/v3/schema"
+)
+
+// toAtom converts a structural schema to smd atom.
+func toAtom(s *schema.Structural, preserveUnknown bool) (*smdschema.Atom, error) {
+	if s.Extensions.XPreserveUnknownFields {
+		preserveUnknown = true
+	}
+	switch s.Generic.Type {
+	case "object":
+		m := &smdschema.Map{
+			Fields:              []smdschema.StructField{},
+			ElementType:         smdschema.TypeRef{},
+			ElementRelationship: smdschema.Separable,
+		}
+		if s.Properties != nil {
+			for k, v := range s.Properties {
+				a, err := toAtom(&v, preserveUnknown)
+				if err != nil {
+					return nil, err
+				}
+				m.Fields = append(m.Fields, smdschema.StructField{
+					Name: k,
+					Type: smdschema.TypeRef{
+						Inlined: *a,
+					},
+				})
+			}
+			// TODO: Add unions once they are supported
+		}
+		if preserveUnknown {
+			m.ElementType.NamedType = &deduced.Name
+		}
+		if s.Extensions.XMapType != nil {
+			if *s.Extensions.XMapType == "atomic" {
+				m.ElementRelationship = smdschema.Atomic
+			} else if *s.Extensions.XMapType == "granular" {
+				m.ElementRelationship = smdschema.Separable
+			} else {
+				return nil, fmt.Errorf("unknown map type %v", *s.Extensions.XMapType)
+			}
+		}
+		if s.Extensions.XEmbeddedResource {
+			m.Fields = mergeStructFields(baseResourceFields, m.Fields)
+		}
+		return &smdschema.Atom{
+			Map: m,
+		}, nil
+	case "array":
+		list := &smdschema.List{
+			ElementType: smdschema.TypeRef{
+				NamedType: &deduced.Name,
+			},
+			ElementRelationship: smdschema.Atomic,
+		}
+		if s.Items != nil {
+			a, err := toAtom(s.Items, preserveUnknown)
+			if err != nil {
+				return nil, err
+			}
+			list.ElementType = smdschema.TypeRef{
+				Inlined: *a,
+			}
+		}
+		if s.Extensions.XListType != nil {
+			if *s.Extensions.XListType == "atomic" {
+				list.ElementRelationship = smdschema.Atomic
+			} else if *s.Extensions.XListType == "set" {
+				list.ElementRelationship = smdschema.Associative
+			} else if *s.Extensions.XListType == "map" {
+				if len(s.Extensions.XListMapKeys) > 0 {
+					list.ElementRelationship = smdschema.Associative
+					list.Keys = s.Extensions.XListMapKeys
+				} else {
+					return nil, fmt.Errorf("missing map keys")
+				}
+			} else {
+				return nil, fmt.Errorf("unknown list type %v", *s.Extensions.XListType)
+			}
+		}
+		return &smdschema.Atom{
+			List: list,
+		}, nil
+	case "number":
+		return &smdschema.Atom{Scalar: ptr(smdschema.Numeric)}, nil
+	case "integer":
+		return &smdschema.Atom{Scalar: ptr(smdschema.Numeric)}, nil
+	case "boolean":
+		return &smdschema.Atom{Scalar: ptr(smdschema.Boolean)}, nil
+	case "string":
+		return &smdschema.Atom{Scalar: ptr(smdschema.String)}, nil
+	case "":
+		if s.Extensions.XIntOrString {
+			return &smdschema.Atom{Scalar: ptr(smdschema.Scalar("untyped"))}, nil
+		} else if preserveUnknown {
+			return &deduced.Atom, nil
+		} else {
+			return nil, fmt.Errorf("type is only optional if x-kubernetes-int-or-string or x-kubernetes-preserve-unknown-fields is true")
+		}
+	default:
+		return nil, fmt.Errorf("type is not valid")
+	}
+}
+
+func ptr(s smdschema.Scalar) *smdschema.Scalar { return &s }
+
+func strPtr(s string) *string { return &s }
+
+var deduced smdschema.TypeDef = smdschema.TypeDef{
+	Name: "__untyped_deduced_",
+	Atom: smdschema.Atom{
+		Scalar: ptr(smdschema.Scalar("untyped")),
+		List: &smdschema.List{
+			ElementType: smdschema.TypeRef{
+				NamedType: strPtr("__untyped_atomic_"),
+			},
+			ElementRelationship: smdschema.Atomic,
+		},
+		Map: &smdschema.Map{
+			ElementType: smdschema.TypeRef{
+				NamedType: strPtr("__untyped_deduced_"),
+			},
+			ElementRelationship: smdschema.Separable,
+		},
+	},
+}
+
+var baseResourceFields = []smdschema.StructField{
+	{
+		Name: "apiVersion",
+		Type: smdschema.TypeRef{
+			Inlined: smdschema.Atom{
+				Scalar: ptr(smdschema.String),
+			},
+		},
+	}, {
+		Name: "kind",
+		Type: smdschema.TypeRef{
+			Inlined: smdschema.Atom{
+				Scalar: ptr(smdschema.String),
+			},
+		},
+	}, {
+		Name: "metadata",
+		Type: smdschema.TypeRef{
+			NamedType: strPtr("io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta"),
+		},
+	},
+}
+
+func mergeStructFields(lhs, rhs []smdschema.StructField) []smdschema.StructField {
+	out := []smdschema.StructField{}
+	lhsNames := map[string]struct{}{}
+	for _, f := range lhs {
+		lhsNames[f.Name] = struct{}{}
+		out = append(out, f)
+	}
+	for _, f := range rhs {
+		if _, ok := lhsNames[f.Name]; !ok {
+			out = append(out, f)
+		}
+	}
+	return out
+}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd/builder.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd/builder.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package smd
+
+import (
+	"fmt"
+
+	"k8s.io/apiextensions-apiserver/pkg/apiserver/schema"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager"
+
+	smdschema "sigs.k8s.io/structured-merge-diff/v3/schema"
+	"sigs.k8s.io/structured-merge-diff/v3/typed"
+)
+
+// TypeConverterBuilder builds a fieldmanager.TypeConverter from structural schemas
+type TypeConverterBuilder struct {
+	schema          *smdschema.Schema
+	preserveUnknown bool
+}
+
+// NewTypeConverterBuilder creates a builder for a fieldmanager.TypeConverter built from structural schemas
+func NewTypeConverterBuilder(s *smdschema.Schema, preserveUnknown bool) *TypeConverterBuilder {
+	return &TypeConverterBuilder{
+		schema:          s,
+		preserveUnknown: preserveUnknown,
+	}
+}
+
+// AddStructural converts a structural schema to an smd typedef, and adds it to an smd schema
+func (b *TypeConverterBuilder) AddStructural(v string, s *schema.Structural) error {
+	if s == nil {
+		return fmt.Errorf("structural schema must not be nil")
+	}
+	a, err := toAtom(s, b.preserveUnknown)
+	if err != nil {
+		return err
+	}
+	if a.Map != nil {
+		a.Map.Fields = mergeStructFields(baseResourceFields, a.Map.Fields)
+	}
+	b.schema.Types = append(b.schema.Types, smdschema.TypeDef{
+		Name: makeVersionNameUniqueForApply(v),
+		Atom: *a,
+	})
+	return nil
+}
+
+// Build creates an implementation of fieldmanager.TypeConverter from the schema
+func (b *TypeConverterBuilder) Build() fieldmanager.TypeConverter {
+	return &typeConverter{
+		Parser: &typed.Parser{
+			Schema: *b.schema,
+		},
+	}
+}
+
+type typeConverter struct {
+	*typed.Parser
+}
+
+// ObjectToTyped implements fieldmanager.TypeConverter
+func (c *typeConverter) ObjectToTyped(obj runtime.Object) (*typed.TypedValue, error) {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return nil, err
+	}
+	t := c.Parser.Type(makeVersionNameUniqueForApply(obj.GetObjectKind().GroupVersionKind().Version))
+	if !t.IsValid() {
+		return typed.DeducedParseableType.FromUnstructured(u)
+	}
+	return t.FromUnstructured(u)
+}
+
+// TypedToObject implements fieldmanager.TypeConverter
+func (c *typeConverter) TypedToObject(val *typed.TypedValue) (runtime.Object, error) {
+	vu := val.AsValue().Unstructured()
+	switch o := vu.(type) {
+	case map[string]interface{}:
+		return &unstructured.Unstructured{Object: o}, nil
+	default:
+		return nil, fmt.Errorf("failed to convert value to unstructured for type %T", vu)
+	}
+}
+
+// makeVersionNameUniqueForApply formats an api version (like '__version_v1_')
+// so it doesn't collide with any other typenames from the static openapi spec
+func makeVersionNameUniqueForApply(v string) string {
+	return fmt.Sprintf("__version_%v_", v)
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
@@ -24,6 +24,7 @@ go_library(
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/v3/merge:go_default_library",
+        "//vendor/sigs.k8s.io/structured-merge-diff/v3/typed:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/structuredmerge.go
@@ -64,15 +64,11 @@ func NewStructuredMergeManager(models openapiproto.Models, objectConverter runti
 }
 
 // NewCRDStructuredMergeManager creates a new Manager specifically for
-// CRDs. This allows for the possibility of fields which are not defined
-// in models, as well as having no models defined at all.
-func NewCRDStructuredMergeManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, gv schema.GroupVersion, hub schema.GroupVersion, preserveUnknownFields bool) (_ Manager, err error) {
-	var typeConverter internal.TypeConverter = internal.DeducedTypeConverter{}
-	if models != nil {
-		typeConverter, err = internal.NewTypeConverter(models, preserveUnknownFields)
-		if err != nil {
-			return nil, err
-		}
+// CRDs. This fieldmanager takes a custom typeConverter as an argument,
+// and uses a default deduced type converter if none is provided.
+func NewCRDStructuredMergeManager(typeConverter TypeConverter, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, gv schema.GroupVersion, hub schema.GroupVersion) (_ Manager, err error) {
+	if typeConverter == nil {
+		typeConverter = internal.DeducedTypeConverter{}
 	}
 	return &structuredMergeManager{
 		typeConverter:   typeConverter,

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -59,6 +59,8 @@ func TestApplyCRDNoSchema(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition.ObjectMeta.Name = "noxunoschemas.mygroup.example.com"
+	noxuDefinition.Spec.Names.Plural = "noxunoschemas"
 
 	noxuDefinition, err = fixtures.CreateNewCustomResourceDefinition(noxuDefinition, apiExtensionClient, dynamicClient)
 	if err != nil {
@@ -153,6 +155,8 @@ func TestApplyCRDStructuralSchema(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewMultipleVersionNoxuCRD(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition.ObjectMeta.Name = "noxustructuralschemas.mygroup.example.com"
+	noxuDefinition.Spec.Names.Plural = "noxustructuralschemas"
 
 	var c apiextensionsv1beta1.CustomResourceValidation
 	err = json.Unmarshal([]byte(`{
@@ -394,6 +398,8 @@ func TestApplyCRDNonStructuralSchema(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition.ObjectMeta.Name = "noxunonstructuralschemas.mygroup.example.com"
+	noxuDefinition.Spec.Names.Plural = "noxunonstructuralschemas"
 
 	var c apiextensionsv1beta1.CustomResourceValidation
 	err = json.Unmarshal([]byte(`{
@@ -632,6 +638,8 @@ func TestApplyCRDUnhandledSchema(t *testing.T) {
 	}
 
 	noxuDefinition := fixtures.NewNoxuCustomResourceDefinition(apiextensionsv1beta1.ClusterScoped)
+	noxuDefinition.ObjectMeta.Name = "noxuunhandledchemas.mygroup.example.com"
+	noxuDefinition.Spec.Names.Plural = "noxuunhandledchemas"
 
 	// This is a schema that kube-openapi ToProtoModels does not handle correctly.
 	// https://github.com/kubernetes/kubernetes/blob/38752f7f99869ed65fb44378360a517649dc2f83/vendor/k8s.io/kube-openapi/pkg/util/proto/document.go#L184

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1169,6 +1169,7 @@ k8s.io/apiextensions-apiserver/pkg/apiserver/schema
 k8s.io/apiextensions-apiserver/pkg/apiserver/schema/defaulting
 k8s.io/apiextensions-apiserver/pkg/apiserver/schema/objectmeta
 k8s.io/apiextensions-apiserver/pkg/apiserver/schema/pruning
+k8s.io/apiextensions-apiserver/pkg/apiserver/schema/smd
 k8s.io/apiextensions-apiserver/pkg/apiserver/validation
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme


### PR DESCRIPTION
**What type of PR is this?**
/kind feature
/sig api-machinery
/wg apply
/priority important-longterm
/cc @apelisse @jpbetz @sttts 

**What this PR does / why we need it**:
Currently we convert the validation field in CRDs into v2 openapi, then into 'proto.Models', then into an smd schema. This causes issues because CRDs are allowed to put v3 openapi in their validation fields, some of which an smd schema could express, but isn't compatible with 'proto.Models', so that information is lost.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```