### PR TITLE
fix staticcheck errors in vendor/k8s.io/legacy-cloud-providers/aws.

### DIFF
--- a/hack/.staticcheck_failures
+++ b/hack/.staticcheck_failures
@@ -112,5 +112,4 @@ vendor/k8s.io/kubectl/pkg/cmd/util/editor
 vendor/k8s.io/kubectl/pkg/cmd/wait
 vendor/k8s.io/kubectl/pkg/describe/versioned
 vendor/k8s.io/kubectl/pkg/scale
-vendor/k8s.io/legacy-cloud-providers/aws
 vendor/k8s.io/metrics/pkg/client/custom_metrics

--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws_fakes.go
@@ -488,12 +488,6 @@ func (elb *FakeELB) ModifyLoadBalancerAttributes(*elb.ModifyLoadBalancerAttribut
 	panic("Not implemented")
 }
 
-// expectDescribeLoadBalancers is not implemented but is required for interface
-// conformance
-func (elb *FakeELB) expectDescribeLoadBalancers(loadBalancerName string) {
-	panic("Not implemented")
-}
-
 // FakeELBV2 is a fake ELBV2 client used for testing
 type FakeELBV2 struct {
 	aws *FakeAWSServices


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>


**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
cleanup staticcheck errors, it says as below:
```
vendor/k8s.io/legacy-cloud-providers/aws/aws_fakes.go:493:21: func (*FakeELB).expectDescribeLoadBalancers is unused (U1000)
```

**Which issue(s) this PR fixes**:
Ref:#81657

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
