### PR TITLE
WIP: Avoid setting Pod.Spec.NodeName in e2es

### DIFF
--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -86,7 +86,6 @@ func CreateSecPod(client clientset.Interface, namespace string, pvclaims []*v1.P
 func CreateSecPodWithNodeSelection(client clientset.Interface, namespace string, pvclaims []*v1.PersistentVolumeClaim, inlineVolumeSources []*v1.VolumeSource, isPrivileged bool, command string, hostIPC bool, hostPID bool, seLinuxLabel *v1.SELinuxOptions, fsGroup *int64, node NodeSelection, timeout time.Duration) (*v1.Pod, error) {
 	pod := MakeSecPod(namespace, pvclaims, inlineVolumeSources, isPrivileged, command, hostIPC, hostPID, seLinuxLabel, fsGroup)
 	// Setting node
-	pod.Spec.NodeName = node.Name
 	pod.Spec.NodeSelector = node.Selector
 	pod.Spec.Affinity = node.Affinity
 

--- a/test/e2e/framework/pod/node_selection.go
+++ b/test/e2e/framework/pod/node_selection.go
@@ -23,7 +23,6 @@ import (
 // NodeSelection specifies where to run a pod, using a combination of fixed node name,
 // node selector and/or affinity.
 type NodeSelection struct {
-	Name     string
 	Selector map[string]string
 	Affinity *v1.Affinity
 }

--- a/test/e2e/framework/volume/fixtures.go
+++ b/test/e2e/framework/volume/fixtures.go
@@ -129,8 +129,6 @@ type TestConfig struct {
 	WaitForCompletion bool
 	// ServerNodeName is the spec.nodeName to run server pod on.  Default is any node.
 	ServerNodeName string
-	// ClientNodeName is the spec.nodeName to run client pod on.  Default is any node.
-	ClientNodeName string
 	// NodeSelector to use in pod spec (server, client and injector pods).
 	NodeSelector map[string]string
 }
@@ -388,7 +386,6 @@ func runVolumeTesterPod(client clientset.Interface, config TestConfig, podSuffix
 			TerminationGracePeriodSeconds: &gracePeriod,
 			SecurityContext:               GeneratePodSecurityContext(fsGroup, seLinuxOptions),
 			Volumes:                       []v1.Volume{},
-			NodeName:                      config.ClientNodeName,
 			NodeSelector:                  config.NodeSelector,
 		},
 	}

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -174,10 +174,10 @@ func (h *hostpathCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.Per
 	node, err := e2enode.GetRandomReadySchedulableNode(cs)
 	framework.ExpectNoError(err)
 	config := &testsuites.PerTestConfig{
-		Driver:         h,
-		Prefix:         "hostpath",
-		Framework:      f,
-		ClientNodeName: node.Name,
+		Driver:             h,
+		Prefix:             "hostpath",
+		Framework:          f,
+		ClientNodeSelector: map[string]string{v1.LabelHostname: node.Name},
 	}
 
 	o := utils.PatchCSIOptions{
@@ -298,10 +298,10 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 	node, err := e2enode.GetRandomReadySchedulableNode(cs)
 	framework.ExpectNoError(err)
 	config := &testsuites.PerTestConfig{
-		Driver:         m,
-		Prefix:         "mock",
-		Framework:      f,
-		ClientNodeName: node.Name,
+		Driver:             m,
+		Prefix:             "mock",
+		Framework:          f,
+		ClientNodeSelector: map[string]string{v1.LabelHostname: node.Name},
 	}
 
 	containerArgs := []string{"--name=csi-mock-" + f.UniqueName}
@@ -323,7 +323,7 @@ func (m *mockCSIDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTest
 		DriverContainerName:      "mock",
 		DriverContainerArguments: containerArgs,
 		ProvisionerContainerName: "csi-provisioner",
-		NodeName:                 config.ClientNodeName,
+		NodeName:                 node.Name,
 		PodInfo:                  m.podInfo,
 		CanAttach:                &m.attachable,
 		VolumeLifecycleModes: &[]storagev1beta1.VolumeLifecycleMode{

--- a/test/e2e/storage/external/BUILD
+++ b/test/e2e/storage/external/BUILD
@@ -6,6 +6,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/storage/external",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -329,10 +330,10 @@ func (d *driverDefinition) GetCSIDriverName(config *testsuites.PerTestConfig) st
 
 func (d *driverDefinition) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
 	config := &testsuites.PerTestConfig{
-		Driver:         d,
-		Prefix:         "external",
-		Framework:      f,
-		ClientNodeName: d.ClientNodeName,
+		Driver:             d,
+		Prefix:             "external",
+		Framework:          f,
+		ClientNodeSelector: map[string]string{v1.LabelHostname: d.ClientNodeName},
 	}
 	return config, func() {}
 }

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -177,9 +177,9 @@ var _ = utils.SIGDescribe("Flexvolumes", func() {
 		node, err = e2enode.GetRandomReadySchedulableNode(f.ClientSet)
 		framework.ExpectNoError(err)
 		config = volume.TestConfig{
-			Namespace:      ns.Name,
-			Prefix:         "flex",
-			ClientNodeName: node.Name,
+			Namespace:    ns.Name,
+			Prefix:       "flex",
+			NodeSelector: map[string]string{v1.LabelHostname: node.Name},
 		}
 		suffix = ns.Name
 	})

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -550,8 +550,8 @@ func testPDPod(diskNames []string, targetNode types.NodeName, readOnly bool, num
 			Name: "pd-test-" + string(uuid.NewUUID()),
 		},
 		Spec: v1.PodSpec{
-			Containers: containers,
-			NodeName:   string(targetNode),
+			Containers:   containers,
+			NodeSelector: map[string]string{v1.LabelHostname: string(targetNode)},
 		},
 	}
 

--- a/test/e2e/storage/persistent_volumes-local.go
+++ b/test/e2e/storage/persistent_volumes-local.go
@@ -987,7 +987,8 @@ func makeLocalPodWithNodeName(config *localTestConfig, volume *localTestVolume, 
 	if pod == nil {
 		return
 	}
-	pod.Spec.NodeName = nodeName
+	// Use NodeSelector instead of NodeName so that the pod runs through the scheduler
+	pod.Spec.NodeSelector = map[string]string{v1.LabelHostname: nodeName}
 	return
 }
 

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -429,10 +429,9 @@ func convertTestConfig(in *PerTestConfig) volume.TestConfig {
 	}
 
 	return volume.TestConfig{
-		Namespace:      in.Framework.Namespace.Name,
-		Prefix:         in.Prefix,
-		ClientNodeName: in.ClientNodeName,
-		NodeSelector:   in.ClientNodeSelector,
+		Namespace:    in.Framework.Namespace.Name,
+		Prefix:       in.Prefix,
+		NodeSelector: in.ClientNodeSelector,
 	}
 }
 

--- a/test/e2e/storage/testsuites/disruptive.go
+++ b/test/e2e/storage/testsuites/disruptive.go
@@ -160,7 +160,7 @@ func (s *disruptiveTestSuite) DefineTests(driver TestDriver, pattern testpattern
 						pvcs = append(pvcs, l.resource.Pvc)
 					}
 					ginkgo.By("Creating a pod with pvc")
-					l.pod, err = e2epod.CreateSecPodWithNodeSelection(l.cs, l.ns.Name, pvcs, inlineSources, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)
+					l.pod, err = e2epod.CreateSecPodWithNodeSelection(l.cs, l.ns.Name, pvcs, inlineSources, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}, framework.PodStartTimeout)
 					framework.ExpectNoError(err, "While creating pods for kubelet restart test")
 
 					if pattern.VolMode == v1.PersistentVolumeBlock && t.runTestBlock != nil {

--- a/test/e2e/storage/testsuites/ephemeral.go
+++ b/test/e2e/storage/testsuites/ephemeral.go
@@ -100,7 +100,7 @@ func (p *ephemeralTestSuite) DefineTests(driver TestDriver, pattern testpatterns
 			Client:     l.config.Framework.ClientSet,
 			Namespace:  f.Namespace.Name,
 			DriverName: eDriver.GetCSIDriverName(l.config),
-			Node:       e2epod.NodeSelection{Name: l.config.ClientNodeName},
+			Node:       e2epod.NodeSelection{Selector: l.config.ClientNodeSelector},
 			GetVolume: func(volumeNumber int) (map[string]string, bool, bool) {
 				return eDriver.GetVolume(l.config, volumeNumber)
 			},
@@ -290,7 +290,6 @@ func StartInPodWithInlineVolume(c clientset.Interface, ns, podName, command stri
 			},
 		},
 		Spec: v1.PodSpec{
-			NodeName:     node.Name,
 			NodeSelector: node.Selector,
 			Affinity:     node.Affinity,
 			Containers: []v1.Container{

--- a/test/e2e/storage/testsuites/multivolume.go
+++ b/test/e2e/storage/testsuites/multivolume.go
@@ -149,7 +149,7 @@ func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatter
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, pvcs, true /* sameNode */)
+			e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}, pvcs, true /* sameNode */)
 	})
 
 	// This tests below configuration:
@@ -177,11 +177,11 @@ func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatter
 		if len(nodes.Items) < 2 {
 			e2eskipper.Skipf("Number of available nodes is less than 2 - skipping")
 		}
-		if l.config.ClientNodeName != "" {
+		if l.config.ClientNodeSelector[v1.LabelHostname] != "" {
 			e2eskipper.Skipf("Driver %q requires to deploy on a specific node - skipping", l.driver.GetDriverInfo().Name)
 		}
 		// For multi-node tests there must be enough nodes with the same toopology to schedule the pods
-		nodeSelection := e2epod.NodeSelection{Name: l.config.ClientNodeName}
+		nodeSelection := e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}
 		topologyKeys := dInfo.TopologyKeys
 		if len(topologyKeys) != 0 {
 			if err = ensureTopologyRequirements(&nodeSelection, nodes, l.cs, topologyKeys, 2); err != nil {
@@ -239,7 +239,7 @@ func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatter
 		}
 
 		TestAccessMultipleVolumesAcrossPodRecreation(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, pvcs, true /* sameNode */)
+			e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}, pvcs, true /* sameNode */)
 	})
 
 	// This tests below configuration (only <block, filesystem> pattern is tested):
@@ -271,11 +271,11 @@ func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatter
 		if len(nodes.Items) < 2 {
 			e2eskipper.Skipf("Number of available nodes is less than 2 - skipping")
 		}
-		if l.config.ClientNodeName != "" {
+		if l.config.ClientNodeSelector[v1.LabelHostname] != "" {
 			e2eskipper.Skipf("Driver %q requires to deploy on a specific node - skipping", l.driver.GetDriverInfo().Name)
 		}
 		// For multi-node tests there must be enough nodes with the same toopology to schedule the pods
-		nodeSelection := e2epod.NodeSelection{Name: l.config.ClientNodeName}
+		nodeSelection := e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}
 		topologyKeys := dInfo.TopologyKeys
 		if len(topologyKeys) != 0 {
 			if err = ensureTopologyRequirements(&nodeSelection, nodes, l.cs, topologyKeys, 2); err != nil {
@@ -324,7 +324,7 @@ func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatter
 
 		// Test access to the volume from pods on different node
 		TestConcurrentAccessToSingleVolume(l.config.Framework, l.cs, l.ns.Name,
-			e2epod.NodeSelection{Name: l.config.ClientNodeName}, resource.Pvc, numPods, true /* sameNode */)
+			e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}, resource.Pvc, numPods, true /* sameNode */)
 	})
 
 	// This tests below configuration:
@@ -348,11 +348,11 @@ func (t *multiVolumeTestSuite) DefineTests(driver TestDriver, pattern testpatter
 		if len(nodes.Items) < numPods {
 			e2eskipper.Skipf(fmt.Sprintf("Number of available nodes is less than %d - skipping", numPods))
 		}
-		if l.config.ClientNodeName != "" {
+		if l.config.ClientNodeSelector[v1.LabelHostname] != "" {
 			e2eskipper.Skipf("Driver %q requires to deploy on a specific node - skipping", l.driver.GetDriverInfo().Name)
 		}
 		// For multi-node tests there must be enough nodes with the same toopology to schedule the pods
-		nodeSelection := e2epod.NodeSelection{Name: l.config.ClientNodeName}
+		nodeSelection := e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}
 		topologyKeys := dInfo.TopologyKeys
 		if len(topologyKeys) != 0 {
 			if err = ensureTopologyRequirements(&nodeSelection, nodes, l.cs, topologyKeys, 2); err != nil {

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -151,7 +151,7 @@ func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatt
 
 		ginkgo.By("starting a pod to use the claim")
 		command := "echo 'hello world' > /mnt/test/data"
-		pod := StartInPodWithVolume(cs, pvc.Namespace, pvc.Name, "pvc-snapshottable-tester", command, e2epod.NodeSelection{Name: config.ClientNodeName})
+		pod := StartInPodWithVolume(cs, pvc.Namespace, pvc.Name, "pvc-snapshottable-tester", command, e2epod.NodeSelection{Selector: config.ClientNodeSelector})
 		defer StopPod(cs, pod)
 
 		err = e2epv.WaitForPersistentVolumeClaimPhase(v1.ClaimBound, cs, pvc.Namespace, pvc.Name, framework.Poll, framework.ClaimProvisionTimeout)

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -150,11 +150,9 @@ func (s *subPathTestSuite) DefineTests(driver TestDriver, pattern testpatterns.T
 
 		subPath := f.Namespace.Name
 		l.pod = SubpathTestPod(f, subPath, string(volType), l.resource.VolSource, true)
-		l.pod.Spec.NodeName = l.config.ClientNodeName
 		l.pod.Spec.NodeSelector = l.config.ClientNodeSelector
 
 		l.formatPod = volumeFormatPod(f, l.resource.VolSource)
-		l.formatPod.Spec.NodeName = l.config.ClientNodeName
 		l.formatPod.Spec.NodeSelector = l.config.ClientNodeSelector
 
 		l.subPathDir = filepath.Join(volumePath, subPath)

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -205,11 +205,6 @@ type PerTestConfig struct {
 	// The framework instance allocated for the current test.
 	Framework *framework.Framework
 
-	// If non-empty, then pods using a volume will be scheduled
-	// onto the node with this name. Otherwise Kubernetes will
-	// pick a node.
-	ClientNodeName string
-
 	// Some tests also support scheduling pods onto nodes with
 	// these label/value pairs. As not all tests use this field,
 	// a driver that absolutely needs the pods on a specific

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -165,7 +165,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 
 			var err error
 			ginkgo.By("Creating a pod with dynamically provisioned volume")
-			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)
+			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}, framework.PodStartTimeout)
 			defer func() {
 				err = e2epod.DeletePodWithWait(f.ClientSet, l.pod)
 				framework.ExpectNoError(err, "while cleaning up pod already deleted in resize test")
@@ -202,7 +202,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 			l.resource.Pvc = npvc
 
 			ginkgo.By("Creating a new pod with same volume")
-			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)
+			l.pod2, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}, framework.PodStartTimeout)
 			defer func() {
 				err = e2epod.DeletePodWithWait(f.ClientSet, l.pod2)
 				framework.ExpectNoError(err, "while cleaning up pod before exiting resizing test")
@@ -223,7 +223,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 
 			var err error
 			ginkgo.By("Creating a pod with dynamically provisioned volume")
-			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Name: l.config.ClientNodeName}, framework.PodStartTimeout)
+			l.pod, err = e2epod.CreateSecPodWithNodeSelection(f.ClientSet, f.Namespace.Name, []*v1.PersistentVolumeClaim{l.resource.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil, e2epod.NodeSelection{Selector: l.config.ClientNodeSelector}, framework.PodStartTimeout)
 			defer func() {
 				err = e2epod.DeletePodWithWait(f.ClientSet, l.pod)
 				framework.ExpectNoError(err, "while cleaning up pod already deleted in resize test")

--- a/test/e2e/storage/testsuites/volume_io.go
+++ b/test/e2e/storage/testsuites/volume_io.go
@@ -237,7 +237,6 @@ func makePodSpec(config volume.TestConfig, initCmd string, volsrc v1.VolumeSourc
 				},
 			},
 			RestartPolicy: v1.RestartPolicyNever, // want pod to fail if init container fails
-			NodeName:      config.ClientNodeName,
 			NodeSelector:  config.NodeSelector,
 		},
 	}

--- a/test/e2e/storage/testsuites/volumelimits.go
+++ b/test/e2e/storage/testsuites/volumelimits.go
@@ -127,7 +127,7 @@ func (t *volumeLimitsTestSuite) DefineTests(driver TestDriver, pattern testpatte
 		ginkgo.By("Picking a node")
 		// Some CSI drivers are deployed to a single node (e.g csi-hostpath),
 		// so we use that node instead of picking a random one.
-		nodeName := l.config.ClientNodeName
+		nodeName := l.config.ClientNodeSelector[v1.LabelHostname]
 		if nodeName == "" {
 			node, err := e2enode.GetRandomReadySchedulableNode(f.ClientSet)
 			framework.ExpectNoError(err)

--- a/test/e2e/storage/testsuites/volumemode.go
+++ b/test/e2e/storage/testsuites/volumemode.go
@@ -214,7 +214,7 @@ func (t *volumeModeTestSuite) DefineTests(driver TestDriver, pattern testpattern
 				ginkgo.By("Creating pod")
 				pod := e2epod.MakeSecPod(l.ns.Name, []*v1.PersistentVolumeClaim{l.Pvc}, nil, false, "", false, false, e2epv.SELinuxLabel, nil)
 				// Setting node
-				pod.Spec.NodeName = l.config.ClientNodeName
+				pod.Spec.NodeSelector = l.config.ClientNodeSelector
 				pod, err = l.cs.CoreV1().Pods(l.ns.Name).Create(pod)
 				framework.ExpectNoError(err, "Failed to create pod")
 				defer func() {

--- a/test/e2e/storage/testsuites/volumes.go
+++ b/test/e2e/storage/testsuites/volumes.go
@@ -246,7 +246,6 @@ func testScriptInPod(
 			},
 			RestartPolicy: v1.RestartPolicyNever,
 			NodeSelector:  config.ClientNodeSelector,
-			NodeName:      config.ClientNodeName,
 		},
 	}
 	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))

--- a/test/e2e/storage/utils/deployment.go
+++ b/test/e2e/storage/utils/deployment.go
@@ -98,7 +98,10 @@ func PatchCSIDeployment(f *framework.Framework, o PatchCSIOptions, object interf
 		patchContainers(spec.Containers)
 		patchVolumes(spec.Volumes)
 		if o.NodeName != "" {
-			spec.NodeName = o.NodeName
+			// Don't directly set NodeName because it bypasses the scheduler and can
+			// cause kubelet to immediately Fail the pod if there's no space on the
+			// node.
+			spec.NodeSelector = map[string]string{v1.LabelHostname: o.NodeName}
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Setting Pod.Spec.NodeName bypasses the scheduler, which could cause kubelet to Fail the Pod if it's full, causing test flakes. Instead, use NodeSelector so that that the Pod runs through the scheduler and will remain pending until the Node frees up some resources. Tests could still be flaky though if Node resources don't free up in time.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Addresses #87855

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
