### PR TITLE
cluster: Add justaugustus as reviewer

### DIFF
--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -3,6 +3,7 @@
 reviewers:
   - bentheelder
   - eparis
+  - justaugustus
   - Katharine
   - mikedanese
   - zmerlynn
@@ -18,3 +19,4 @@ emeritus_approvers:
   - jbeda
 labels:
 - sig/cluster-lifecycle
+- area/release-eng


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Similar to @dims' [PR](https://github.com/kubernetes/kubernetes/pull/83516), I'd like to assist in removing the `cluster/` directory.
I've been reviewing PRs and making tweaks to the `gce/` provisioning scripts therein and I'd also like to be able to keep an eye on/help mitigate changes that can affect releng or CI (e.g., `get-kube.sh`).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @dims @spiffxp 
/cc @BenTheElder @Katharine 
/area release-eng
/priority important-soon