### PR TITLE
Mutable nodeAffinity for PVs

### DIFF
--- a/pkg/apis/core/validation/validation.go
+++ b/pkg/apis/core/validation/validation.go
@@ -1867,11 +1867,6 @@ func ValidatePersistentVolumeUpdate(newPv, oldPv *core.PersistentVolume) field.E
 	}
 	allErrs = append(allErrs, ValidateImmutableField(newPv.Spec.VolumeMode, oldPv.Spec.VolumeMode, field.NewPath("volumeMode"))...)
 
-	// Allow setting NodeAffinity if oldPv NodeAffinity was not set
-	if oldPv.Spec.NodeAffinity != nil {
-		allErrs = append(allErrs, ValidateImmutableField(newPv.Spec.NodeAffinity, oldPv.Spec.NodeAffinity, field.NewPath("nodeAffinity"))...)
-	}
-
 	return allErrs
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change
/kind feature

**What this PR does / why we need it**:

Allows to update/remove nodeAffinity for existing PVs.

See #69528 and https://github.com/LINBIT/linstor-csi/pull/56 for more details

**Which issue(s) this PR fixes**:

Fixes #69528

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

NONE

```release-note
Allow updating nodeAffinity terms for PersistentVolumes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
