### PR TITLE
gce-addons: Make sure default/limit-range doesn't get overridden

### DIFF
--- a/cluster/gce/addons/limit-range/limit-range.yaml
+++ b/cluster/gce/addons/limit-range/limit-range.yaml
@@ -3,6 +3,8 @@ kind: "LimitRange"
 metadata:
   name: "limits"
   namespace: default
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
 spec:
   limits:
     - type: "Container"


### PR DESCRIPTION
On cluster update, the limit-range in the default namespace gets overridden, which can cause problems for customers.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
