### PR TITLE
Separate containerd install from config, and other cleanups

### DIFF
--- a/cluster/gce/windows/configure.ps1
+++ b/cluster/gce/windows/configure.ps1
@@ -132,6 +132,7 @@ try {
   Download-HelperScripts
 
   DownloadAndInstall-Crictl
+  Configure-Crictl
   Setup-ContainerRuntime
   DownloadAndInstall-AuthPlugin
   DownloadAndInstall-KubernetesBinaries
@@ -140,7 +141,7 @@ try {
   Create-KubeproxyKubeconfig
   Set-PodCidr
   Configure-HostNetworkingService
-  Configure-CniNetworking
+  Prepare-CniNetworking
   Configure-HostDnsConf
   Configure-GcePdTools
   Configure-Kubelet


### PR DESCRIPTION
/kind cleanup

The current Windows GCE startup scripts mix installation and configuration steps in the same function for crictl and containerd. This is problematic because if we pre-install these binaries on the Windows nodes, then the current code will detect that they're installed and exit the function, skipping necessary configuration steps.

This PR separates installation from configuration, along with several other small cleanups.

```release-note
NONE
```