### PR TITLE
GCP credential provider: Don't pre-check scopes

### DIFF
--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -235,27 +235,8 @@ func (g *containerRegistryProvider) Enabled() bool {
 		klog.V(2).Infof("'default' service account does not exist. Found following service accounts: %q", string(value))
 		return false
 	}
-	url := metadataScopes + "?alt=json"
-	value = runWithBackoff(func() ([]byte, error) {
-		value, err := credentialprovider.ReadUrl(url, g.Client, metadataHeader)
-		if err != nil {
-			klog.V(2).Infof("Failed to Get scopes in default service account from gce metadata server: %v", err)
-		}
-		return value, err
-	})
-	var scopes []string
-	if err := json.Unmarshal(value, &scopes); err != nil {
-		klog.Errorf("Failed to unmarshal scopes: %v", err)
-		return false
-	}
-	for _, v := range scopes {
-		// cloudPlatformScope implies storage scope.
-		if strings.HasPrefix(v, storageScopePrefix) || strings.HasPrefix(v, cloudPlatformScopePrefix) {
-			return true
-		}
-	}
-	klog.Warningf("Google container registry is disabled, no storage scope is available: %s", value)
-	return false
+
+	return true
 }
 
 // tokenBlob is used to decode the JSON blob containing an access token


### PR DESCRIPTION
Currently, the GCP docker credentials provider checks the scopes available from the instance metadata server when deciding whether or not to register itself as a credential provider.  If it doesn't find the `devstorage` or `cloud-platform` scopes, it bails out.

The `?alt=json` query param used by this check is supported by the GCE Metadata Server, but not the GKE or Appengine Metadata Server. This will be fixed for GKE, but it also seems safe to just remove this scope check; insufficient scopes are only one of many reasons that a GCR container fetch could be unauthorized.  Rather than checking every reason up front, we can just rely on the actual fetch attempt to fail if the available scopes aren't sufficient.

/kind cleanup

```release-note
NONE
```