### PR TITLE
WIP: Add 20% random jitter to client-go's backoff

### DIFF
--- a/staging/src/k8s.io/client-go/rest/request_test.go
+++ b/staging/src/k8s.io/client-go/rest/request_test.go
@@ -1305,7 +1305,18 @@ func TestBackoffLifecycle(t *testing.T) {
 
 	// Test backoff recovery and increase.  This correlates to the constants
 	// which are used in the server implementation returning StatusOK above.
-	seconds := []int{0, 1, 2, 4, 8, 0, 1, 2, 4, 0}
+	wait := []time.Duration{
+		0,
+		time.Second,
+		time.Duration(1821921541),
+		time.Duration(3829704523),
+		time.Duration(7420502481),
+		0,
+		time.Second,
+		time.Duration(1821921541),
+		time.Duration(3829704523),
+		0,
+	}
 	request := c.Verb("POST").Prefix("backofftest").Suffix("abc")
 	clock := clock.FakeClock{}
 	request.backoff = &URLBackoff{
@@ -1316,11 +1327,12 @@ func TestBackoffLifecycle(t *testing.T) {
 			&clock,
 		)}
 
-	for _, sec := range seconds {
+	for _, w := range wait {
 		thisBackoff := request.backoff.CalculateBackoff(request.URL())
 		t.Logf("Current backoff %v", thisBackoff)
-		if thisBackoff != time.Duration(sec)*time.Second {
-			t.Errorf("Backoff is %v instead of %v", thisBackoff, sec)
+
+		if thisBackoff != w {
+			t.Errorf("Backoff is %v, expected %v", thisBackoff, w)
 		}
 		now := clock.Now()
 		request.DoRaw(context.Background())

--- a/staging/src/k8s.io/client-go/rest/urlbackoff_test.go
+++ b/staging/src/k8s.io/client-go/rest/urlbackoff_test.go
@@ -66,8 +66,13 @@ func TestURLBackoffFunctionality(t *testing.T) {
 	}
 
 	for i, sec := range seconds {
+		expectBaseSeconds := time.Duration(sec) * time.Second
 		backoffSec := myBackoff.CalculateBackoff(parse("http://1.2.3.4:100"))
-		if backoffSec < time.Duration(sec)*time.Second || backoffSec > time.Duration(sec+5)*time.Second {
+		minimumPossibleBackOff := time.Duration(time.Duration(float64(expectBaseSeconds) * (1 - (flowcontrol.DefaultJitterRatio / 2))))
+
+		// TODO(vllry) check upper bound
+		// Why is sec+5 significant?
+		if backoffSec < minimumPossibleBackOff || backoffSec > time.Duration(sec+5)*time.Second {
 			t.Errorf("Backoff out of range %v: %v %v", i, sec, backoffSec)
 		}
 		myBackoff.UpdateBackoff(parse("http://1.2.3.4:100/responseCodeForFuncTest"), nil, returnCodes[i])

--- a/staging/src/k8s.io/client-go/util/flowcontrol/backoff_test.go
+++ b/staging/src/k8s.io/client-go/util/flowcontrol/backoff_test.go
@@ -27,15 +27,27 @@ func TestSlowBackoff(t *testing.T) {
 	id := "_idSlow"
 	tc := clock.NewFakeClock(time.Now())
 	step := time.Second
-	maxDuration := 50 * step
+	maxDuration := 50 * time.Second
 
 	b := NewFakeBackOff(step, maxDuration, tc)
-	cases := []time.Duration{0, 1, 2, 4, 8, 16, 32, 50, 50, 50}
-	for ix, c := range cases {
+	cases := []time.Duration{
+		0,
+		time.Second,
+		time.Duration(1821921541),
+		time.Duration(3829704523),
+		time.Duration(7420502481),
+		time.Duration(16163802019),
+		time.Duration(33183721708),
+		time.Duration(52105195668),
+		time.Duration(53075613903),
+		time.Duration(48446678492),
+	}
+	for ix, expect := range cases {
 		tc.Step(step)
-		w := b.Get(id)
-		if w != c*step {
-			t.Errorf("input: '%d': expected %s, got %s", ix, c*step, w)
+		wait := b.Get(id)
+
+		if wait != expect {
+			t.Errorf("input: '%d': expected %s, got %s", ix, expect, wait)
 		}
 		b.Next(id, tc.Now())
 	}
@@ -79,21 +91,26 @@ func TestBackoffHighWaterMark(t *testing.T) {
 	id := "_idHiWaterMark"
 	tc := clock.NewFakeClock(time.Now())
 	step := time.Second
-	maxDuration := 5 * step
-	b := NewFakeBackOff(step, maxDuration, tc)
+	maxBaseDuration := time.Duration(5 * step)
+	maxJitterOffset := time.Duration(0.5 * (float64(maxBaseDuration) * DefaultJitterRatio))
+	b := NewFakeBackOff(step, maxBaseDuration, tc)
 
-	// get to backoff = maxDuration
-	for i := 0; i <= int(maxDuration/step); i++ {
+	// get to backoff = maxBaseDuration
+	for i := 0; i <= int(maxBaseDuration/step); i++ {
 		tc.Step(step)
 		b.Next(id, tc.Now())
 	}
 
-	// backoff high watermark expires after 2*maxDuration
-	tc.Step(maxDuration + step)
+	// backoff high watermark expires after 2*maxBaseDuration
+	tc.Step(maxBaseDuration + step)
 	b.Next(id, tc.Now())
 
-	if b.Get(id) != maxDuration {
-		t.Errorf("expected Backoff to stay at high watermark %s got %s", maxDuration, b.Get(id))
+	currentBackOff := b.Get(id)
+	minBackOff := maxBaseDuration - maxJitterOffset
+	maxBackOff := maxBaseDuration + maxJitterOffset
+
+	if currentBackOff < minBackOff || currentBackOff > maxBackOff {
+		t.Errorf("expected Backoff to stay at high watermark %s to %s, got %s", minBackOff, maxBackOff, b.Get(id))
 	}
 }
 
@@ -129,53 +146,55 @@ func TestIsInBackOffSinceUpdate(t *testing.T) {
 	id := "_idIsInBackOffSinceUpdate"
 	tc := clock.NewFakeClock(time.Now())
 	step := time.Second
-	maxDuration := 10 * step
-	b := NewFakeBackOff(step, maxDuration, tc)
+	maxBaseDuration := 10 * step
+	b := NewFakeBackOff(step, maxBaseDuration, tc)
 	startTime := tc.Now()
 
 	cases := []struct {
 		tick      time.Duration
 		inBackOff bool
-		value     int
+		value     time.Duration
 	}{
 		{tick: 0, inBackOff: false, value: 0},
-		{tick: 1, inBackOff: false, value: 1},
-		{tick: 2, inBackOff: true, value: 2},
-		{tick: 3, inBackOff: false, value: 2},
-		{tick: 4, inBackOff: true, value: 4},
-		{tick: 5, inBackOff: true, value: 4},
-		{tick: 6, inBackOff: true, value: 4},
-		{tick: 7, inBackOff: false, value: 4},
-		{tick: 8, inBackOff: true, value: 8},
-		{tick: 9, inBackOff: true, value: 8},
-		{tick: 10, inBackOff: true, value: 8},
-		{tick: 11, inBackOff: true, value: 8},
-		{tick: 12, inBackOff: true, value: 8},
-		{tick: 13, inBackOff: true, value: 8},
-		{tick: 14, inBackOff: true, value: 8},
-		{tick: 15, inBackOff: false, value: 8},
-		{tick: 16, inBackOff: true, value: 10},
-		{tick: 17, inBackOff: true, value: 10},
-		{tick: 18, inBackOff: true, value: 10},
-		{tick: 19, inBackOff: true, value: 10},
-		{tick: 20, inBackOff: true, value: 10},
-		{tick: 21, inBackOff: true, value: 10},
-		{tick: 22, inBackOff: true, value: 10},
-		{tick: 23, inBackOff: true, value: 10},
-		{tick: 24, inBackOff: true, value: 10},
-		{tick: 25, inBackOff: false, value: 10},
-		{tick: 26, inBackOff: true, value: 10},
-		{tick: 27, inBackOff: true, value: 10},
-		{tick: 28, inBackOff: true, value: 10},
-		{tick: 29, inBackOff: true, value: 10},
-		{tick: 30, inBackOff: true, value: 10},
-		{tick: 31, inBackOff: true, value: 10},
-		{tick: 32, inBackOff: true, value: 10},
-		{tick: 33, inBackOff: true, value: 10},
-		{tick: 34, inBackOff: true, value: 10},
-		{tick: 35, inBackOff: false, value: 10},
-		{tick: 56, inBackOff: false, value: 0},
-		{tick: 57, inBackOff: false, value: 1},
+		{tick: 1, inBackOff: false, value: time.Second},
+		{tick: 2, inBackOff: true, value: time.Duration(1821921541)},
+		{tick: 3, inBackOff: false, value: time.Duration(3829704523)},
+		{tick: 4, inBackOff: true, value: time.Duration(3829704523)},
+		{tick: 5, inBackOff: true, value: time.Duration(3829704523)},
+		{tick: 6, inBackOff: true, value: time.Duration(3829704523)},
+		{tick: 7, inBackOff: false, value: time.Duration(3829704523)},
+		{tick: 8, inBackOff: true, value: time.Duration(7420502481)},
+		{tick: 9, inBackOff: true, value: time.Duration(7420502481)},
+		{tick: 10, inBackOff: true, value: time.Duration(7420502481)},
+		{tick: 11, inBackOff: true, value: time.Duration(7420502481)},
+		{tick: 12, inBackOff: true, value: time.Duration(7420502481)},
+		{tick: 13, inBackOff: true, value: time.Duration(7420502481)},
+		{tick: 14, inBackOff: true, value: time.Duration(7420502481)},
+		{tick: 15, inBackOff: false, value: time.Duration(7420502481)},
+		{tick: 16, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 17, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 18, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 19, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 20, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 21, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 22, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 23, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 24, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 25, inBackOff: true, value: time.Duration(10891312320)},
+		{tick: 26, inBackOff: false, value: time.Duration(10264825586)},
+		{tick: 27, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 28, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 29, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 30, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 31, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 32, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 33, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 34, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 35, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 36, inBackOff: true, value: time.Duration(10264825586)},
+		{tick: 37, inBackOff: false, value: time.Duration(10264825586)},
+		{tick: 58, inBackOff: false, value: 0},
+		{tick: 59, inBackOff: false, value: time.Second},
 	}
 
 	for _, c := range cases {
@@ -184,8 +203,11 @@ func TestIsInBackOffSinceUpdate(t *testing.T) {
 			t.Errorf("expected IsInBackOffSinceUpdate %v got %v at tick %s", c.inBackOff, b.IsInBackOffSinceUpdate(id, tc.Now()), c.tick*step)
 		}
 
-		if c.inBackOff && (time.Duration(c.value)*step != b.Get(id)) {
-			t.Errorf("expected backoff value=%s got %s at tick %s", time.Duration(c.value)*step, b.Get(id), c.tick*step)
+		expectBaseBackoff := time.Duration(c.value)
+		wait := b.Get(id)
+
+		if c.inBackOff && wait != expectBaseBackoff {
+			t.Errorf("expected backoff %s, got %s at tick %s", expectBaseBackoff, wait, c.tick*step)
 		}
 
 		if !c.inBackOff {


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:
This goal of this PR is to add random jitter to client-go's backoff.

The current form of this PR introduces an unconfigurable, additive 20% jitter to each backoff cycle.

**Which issue(s) this PR fixes**:
Fixes #87915

**Special notes for your reviewer**:
The exact implementation and behavior is open to debate.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
