### PR TITLE
LogResult if there is an error

### DIFF
--- a/test/e2e/storage/utils/host_exec.go
+++ b/test/e2e/storage/utils/host_exec.go
@@ -160,6 +160,9 @@ func (h *hostExecutor) exec(cmd string, node *v1.Node) (Result, error) {
 // the command exits non-zero.
 func (h *hostExecutor) IssueCommandWithResult(cmd string, node *v1.Node) (string, error) {
 	result, err := h.exec(cmd, node)
+	if err != nil {
+		LogResult(result)
+	}
 	return result.Stdout, err
 }
 


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
While investigating a [flake](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/85000/pull-kubernetes-e2e-kind/1225772294031282177), I found that the output of the command that had failed and caused the flake was discarded:

```
ï¿½[1mSTEPï¿½[0m: Creating block device on node "kind-worker" using path "/tmp/local-volume-test-81d11b8a-7ba9-4864-80a8-61daf0ed0778"
Feb  7 13:34:40.406: INFO: ExecWithOptions {Command:[nsenter --mount=/rootfs/proc/1/ns/mnt -- sh -c mkdir -p /tmp/local-volume-test-81d11b8a-7ba9-4864-80a8-61daf0ed0778 && dd if=/dev/zero of=/tmp/local-volume-test-81d11b8a-7ba9-4864-80a8-61daf0ed0778/file bs=4096 count=5120 && losetup -f /tmp/local-volume-test-81d11b8a-7ba9-4864-80a8-61daf0ed0778/file] Namespace:persistent-local-volumes-test-1842 PodName:hostexec-kind-worker-xgvtm ContainerName:agnhost Stdin:<nil> CaptureStdout:true CaptureStderr:true PreserveWhitespace:true}
Feb  7 13:34:40.406: INFO: >>> kubeConfig: /root/.kube/kind-test-config
Feb  7 13:34:41.157: FAIL: Unexpected error:
    <exec.CodeExitError>: {
        Err: {
            s: "command terminated with exit code 1",
        },
        Code: 1,
    }
    command terminated with exit code 1
occurred

Full Stack Trace
k8s.io/kubernetes/test/e2e/storage/utils.(*ltrMgr).createAndSetupLoopDevice(0xc00257a120, 0xc000730780, 0x3b, 0xc000bd8600, 0x1400000)
        test/e2e/storage/utils/local.go:133 +0x47e
k8s.io/kubernetes/test/e2e/storage/utils.(*ltrMgr).setupLocalVolumeBlock(0xc00257a120, 0xc000bd8600, 0x0, 0x0)
        test/e2e/storage/utils/local.go:146 +0x64
...
```

This means there is no way to debug the flake. This will log the command stdout and stderr if there is an error for these storage tests.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
