### PR TITLE
Fix non-ascii characters in test/e2e/storage

### DIFF
--- a/test/e2e/storage/empty_dir_wrapper.go
+++ b/test/e2e/storage/empty_dir_wrapper.go
@@ -193,7 +193,7 @@ var _ = utils.SIGDescribe("EmptyDir wrapper volumes", func() {
 
 	// Slow by design [~150 Seconds].
 	// This test uses deprecated GitRepo VolumeSource so it MUST not be promoted to Conformance.
-	// To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod’s container.
+	// To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod's container.
 	// This projected volume maps approach can also be tested with secrets and downwardapi VolumeSource but are less prone to the race problem.
 	ginkgo.It("should not cause race condition when used for git_repo [Serial] [Slow]", func() {
 		gitURL, gitRepo, cleanup := createGitServer(f)

--- a/test/e2e/storage/testsuites/base_test.go
+++ b/test/e2e/storage/testsuites/base_test.go
@@ -26,7 +26,7 @@ import (
 // intersection of the intervals (if it exists) and return the minimum of the intersection
 // to be used as the claim size for the test.
 // if value not set, that means there's no minimum or maximum size limitation and we set default size for it.
-// Considerate all corner case as followed：
+// Considerate all corner case as followed:
 // first: A,B is regular value and ? means unspecified
 // second: C,D is regular value and ? means unspecified
 // ----------------------------------------------------------------


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

These characters are changed unintentionally if other parts of these
files are changed. It is better to fix them to avoid that.

NOTE: I faced such issue during https://github.com/kubernetes/kubernetes/pull/86679

Ref: https://github.com/kubernetes/kubernetes/issues/87679

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
