### PR TITLE
Fix docker/journald logging conformance

### DIFF
--- a/pkg/kubelet/dockershim/docker_legacy_service.go
+++ b/pkg/kubelet/dockershim/docker_legacy_service.go
@@ -81,8 +81,8 @@ func (d *dockerService) GetContainerLogs(_ context.Context, pod *v1.Pod, contain
 	if logOptions.LimitBytes != nil {
 		// stdout and stderr share the total write limit
 		max := *logOptions.LimitBytes
-		stderr = limitedWriter(stderr, &max)
-		stdout = limitedWriter(stdout, &max)
+		stderr = sharedLimitWriter(stderr, &max)
+		stdout = sharedLimitWriter(stdout, &max)
 	}
 	sopts := libdocker.StreamOptions{
 		OutputStream: stdout,

--- a/pkg/kubelet/dockershim/docker_legacy_service.go
+++ b/pkg/kubelet/dockershim/docker_legacy_service.go
@@ -18,6 +18,7 @@ package dockershim
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubetypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
 	"k8s.io/kubernetes/pkg/kubelet/kuberuntime"
 
@@ -76,12 +78,23 @@ func (d *dockerService) GetContainerLogs(_ context.Context, pod *v1.Pod, contain
 		opts.Tail = strconv.FormatInt(*logOptions.TailLines, 10)
 	}
 
+	if logOptions.LimitBytes != nil {
+		// stdout and stderr share the total write limit
+		max := *logOptions.LimitBytes
+		stderr = limitedWriter(stderr, &max)
+		stdout = limitedWriter(stdout, &max)
+	}
 	sopts := libdocker.StreamOptions{
 		OutputStream: stdout,
 		ErrorStream:  stderr,
 		RawTerminal:  container.Config.Tty,
 	}
-	return d.client.Logs(containerID.ID, opts, sopts)
+	err = d.client.Logs(containerID.ID, opts, sopts)
+	if errors.Is(err, errMaximumWrite) {
+		klog.V(2).Infof("finished logs, hit byte limit %d", *logOptions.LimitBytes)
+		err = nil
+	}
+	return err
 }
 
 // GetContainerLogTail attempts to read up to MaxContainerTerminationMessageLogLength

--- a/pkg/kubelet/dockershim/helpers.go
+++ b/pkg/kubelet/dockershim/helpers.go
@@ -426,7 +426,7 @@ func (w sharedWriteLimiter) Write(p []byte) (int, error) {
 	return n, err
 }
 
-func limitedWriter(w io.Writer, limit *int64) io.Writer {
+func sharedLimitWriter(w io.Writer, limit *int64) io.Writer {
 	if w == nil {
 		return nil
 	}

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -389,7 +389,7 @@ func TestLimitedWriter(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			limit := tc.limit
-			w := limitedWriter(&tc.w, &limit)
+			w := sharedLimitWriter(&tc.w, &limit)
 			n, err := w.Write([]byte(tc.toWrite))
 			if int64(n) > max(0, tc.limit) {
 				t.Fatalf("bytes written (%d) exceeds limit (%d)", n, tc.limit)
@@ -421,8 +421,8 @@ func TestLimitedWriter(t *testing.T) {
 		var (
 			b1, b2 bytes.Buffer
 			limit  = int64(10)
-			w1     = limitedWriter(&b1, &limit)
-			w2     = limitedWriter(&b2, &limit)
+			w1     = sharedLimitWriter(&b1, &limit)
+			w2     = sharedLimitWriter(&b2, &limit)
 			ch     = make(chan struct{})
 			wg     sync.WaitGroup
 		)

--- a/pkg/kubelet/dockershim/helpers_test.go
+++ b/pkg/kubelet/dockershim/helpers_test.go
@@ -17,7 +17,10 @@ limitations under the License.
 package dockershim
 
 import (
+	"bytes"
+	"errors"
 	"fmt"
+	"sync"
 	"testing"
 
 	dockertypes "github.com/docker/docker/api/types"
@@ -331,4 +334,105 @@ func TestGenerateMountBindings(t *testing.T) {
 	result := generateMountBindings(mounts)
 
 	assert.Equal(t, expectedResult, result)
+}
+
+func TestLimitedWriter(t *testing.T) {
+	max := func(x, y int64) int64 {
+		if x > y {
+			return x
+		}
+		return y
+	}
+	for name, tc := range map[string]struct {
+		w        bytes.Buffer
+		toWrite  string
+		limit    int64
+		wants    string
+		wantsErr error
+	}{
+		"nil": {},
+		"neg": {
+			toWrite:  "a",
+			wantsErr: errMaximumWrite,
+			limit:    -1,
+		},
+		"1byte-over": {
+			toWrite:  "a",
+			wantsErr: errMaximumWrite,
+		},
+		"1byte-maxed": {
+			toWrite: "a",
+			wants:   "a",
+			limit:   1,
+		},
+		"1byte-under": {
+			toWrite: "a",
+			wants:   "a",
+			limit:   2,
+		},
+		"6byte-over": {
+			toWrite:  "foobar",
+			wants:    "foo",
+			limit:    3,
+			wantsErr: errMaximumWrite,
+		},
+		"6byte-maxed": {
+			toWrite: "foobar",
+			wants:   "foobar",
+			limit:   6,
+		},
+		"6byte-under": {
+			toWrite: "foobar",
+			wants:   "foobar",
+			limit:   20,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			limit := tc.limit
+			w := limitedWriter(&tc.w, &limit)
+			n, err := w.Write([]byte(tc.toWrite))
+			if int64(n) > max(0, tc.limit) {
+				t.Fatalf("bytes written (%d) exceeds limit (%d)", n, tc.limit)
+			}
+			if (err != nil) != (tc.wantsErr != nil) {
+				if err != nil {
+					t.Fatal("unexpected error:", err)
+				}
+				t.Fatal("expected error:", err)
+			}
+			if err != nil {
+				if !errors.Is(err, tc.wantsErr) {
+					t.Fatal("expected error: ", tc.wantsErr, " instead of: ", err)
+				}
+				if !errors.Is(err, errMaximumWrite) {
+					return
+				}
+				// check contents for errMaximumWrite
+			}
+			if s := tc.w.String(); s != tc.wants {
+				t.Fatalf("expected %q instead of %q", tc.wants, s)
+			}
+		})
+	}
+
+	// test concurrency. run this test a bunch of times to attempt to flush
+	// out any data races or concurrency issues.
+	for i := 0; i < 1000; i++ {
+		var (
+			b1, b2 bytes.Buffer
+			limit  = int64(10)
+			w1     = limitedWriter(&b1, &limit)
+			w2     = limitedWriter(&b2, &limit)
+			ch     = make(chan struct{})
+			wg     sync.WaitGroup
+		)
+		wg.Add(2)
+		go func() { defer wg.Done(); <-ch; w1.Write([]byte("hello")) }()
+		go func() { defer wg.Done(); <-ch; w2.Write([]byte("world")) }()
+		close(ch)
+		wg.Wait()
+		if limit != 0 {
+			t.Fatalf("expected max limit to be reached, instead of %d", limit)
+		}
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:
Fixes a failing conformance test.

**Which issue(s) this PR fixes**:
Fixes #86367

**Special notes for your reviewer**:

The implementation of the docker legacy logger on master completely ignores a "byte limit" option that might be set for a log request. This PR resolves that ignorance by implementing a write limiter that attempts to only output up to the specified limit. The API for the byte limit itself is documented pretty loosely, more as a soft limit vs. a hard limit.

The docker client API doesn't appear to make any promises about how stdout/stderr are written to. e.g. are the streams written to concurrently? or one at a time (serially)? The solution here is defensive against the ambiguity of the docker API and tracks updates to the limit via sync/atomic functions. That said, via this PR it's possible (depending on the underlying docker client impl) that more bytes may be written than *actually* specified by the "byte limit" in the log request. However, the k8s API seem to be forgiving - as previously mentioned - by phrasing "byte limit" as a soft/best-effort limit. This PR does just that.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
