### PR TITLE
Refine WaitingPod interface for scheduler Permit plugin

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -202,11 +202,9 @@ type WaitingPod interface {
 	// Allow declares the waiting pod is allowed to be scheduled by plugin pluginName.
 	// If this is the last remaining plugin to allow, then a success signal is delivered
 	// to unblock the pod.
-	// Returns true if the allow signal was successfully dealt with, false otherwise.
-	Allow(pluginName string) bool
-	// Reject declares the waiting pod unschedulable. Returns true if the reject signal
-	// was successfully delivered, false otherwise.
-	Reject(msg string) bool
+	Allow(pluginName string)
+	// Reject declares the waiting pod unschedulable.
+	Reject(msg string)
 }
 
 // Plugin is the parent type for all the scheduling framework plugins.


### PR DESCRIPTION
**What type of PR is this?**

/kind design
/sig scheduling

As Allow() and Reject() doesn't really give the final status rather than the internal status channel, it makese no sense to return a `bool` value, which may confuse the consumers.

(If needed, maybe in the future we can expose a read-only channel (<- chan) in the WaitingPod interface, so as to expose the eventual status.

**Does this PR introduce a user-facing change?**:

```release-note
The scheduler Permit extension point doesn't return a boolean value in its Allow() and Reject() functions.
```

/cc @ahg-g