### PR TITLE
fix: add non-retriable errors in azure clients

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_retry.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_retry.go
@@ -58,6 +58,8 @@ type Backoff struct {
 	Cap time.Duration
 	// The errors indicate that the request shouldn't do more retrying.
 	NonRetriableErrors []string
+	// The HTTPStatusCode indicates that the request shouldn't do more retrying.
+	NonRetriableHTTPStatusCodes []int
 }
 
 // NewBackoff creates a new Backoff.
@@ -71,10 +73,11 @@ func NewBackoff(duration time.Duration, factor float64, jitter float64, steps in
 	}
 }
 
-// WithNonRetriableErrors returns a new *Backoff with NonRetriableErrors assigned.
-func (b *Backoff) WithNonRetriableErrors(errs []string) *Backoff {
+// WithNonRetriableErrors returns a new *Backoff with NonRetriableErrors, NonRetriableHTTPStatusCodes assigned.
+func (b *Backoff) WithNonRetriableErrors(errs []string, httpStatusCodes []int) *Backoff {
 	newBackoff := *b
 	newBackoff.NonRetriableErrors = errs
+	newBackoff.NonRetriableHTTPStatusCodes = httpStatusCodes
 	return &newBackoff
 }
 
@@ -90,6 +93,11 @@ func (b *Backoff) isNonRetriableError(rerr *Error) bool {
 		}
 	}
 
+	for _, code := range b.NonRetriableHTTPStatusCodes {
+		if rerr.HTTPStatusCode == code {
+			return true
+		}
+	}
 	return false
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Original design will retry on every error(HTTPStatusCode in [400, 499]), this PR adds non-retriable errors in azure clients:
 - 404 StatusNotFound
DisksClient, FileClient
> if disk or file not found, then don't need retry
 - 409 StatusConflict
VirtualMachineScaleSetVMsClient, VirtualMachinesClient
> if there is attach disk conflict error, should stop retry and refresh cache, and k8s volume controller will trigger retry itself

Some non retriable errors are like following:
```
azure_retry.go:175] Backoff retrying GET "https://management.azure.com/subscriptions/xxx/resourceGroups/kubetest-b28d2392-498e-11ea-af8c-fab712ce9f74/providers/Microsoft.Compute/disks/pvc-02d622fa-392f-44f4-b3fc-c8223c33e026?api-version=2019-07-01" with error &{true 404 0001-01-01 00:00:00 +0000 UTC {"error":{"code":"ResourceNotFound","message":"The Resource 'Microsoft.Compute/disks/pvc-02d622fa-392f-44f4-b3fc-c8223c33e026' under resource group 'kubetest-b28d2392-498e-11ea-af8c-fab712ce9f74' was not found."}}}

I0207 11:21:11.508] [pod/csi-azuredisk-controller-bd488bd87-psbf6/azuredisk] I0207 11:05:33.266639       1 azure_retry.go:175] Backoff retrying PUT "https://management.azure.com/subscriptions/xxx/resourceGroups/kubetest-b28d2392-498e-11ea-af8c-fab712ce9f74/providers/Microsoft.Compute/virtualMachineScaleSets/k8s-agentpool-36841236-vmss/virtualMachines/1?api-version=2019-07-01" with error &{true 409 0001-01-01 00:00:00 +0000 UTC {
I0207 11:21:11.508] [pod/csi-azuredisk-controller-bd488bd87-psbf6/azuredisk]   "error": {
I0207 11:21:11.508] [pod/csi-azuredisk-controller-bd488bd87-psbf6/azuredisk]     "code": "ConflictingUserInput",
I0207 11:21:11.534] [pod/csi-azuredisk-controller-bd488bd87-psbf6/azuredisk]     "message": "Disk '/subscriptions/xxx/resourceGroups/kubetest-b28d2392-498e-11ea-af8c-fab712ce9f74/providers/Microsoft.Compute/disks/pvc-5428613e-f000-4761-a3bd-5cd620ab2b39' cannot be attached as the disk is already owned by VM '/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-b28d2392-498e-11ea-af8c-fab712ce9f74/providers/Microsoft.Compute/virtualMachineScaleSets/k8s-agentpool-36841236-vmss/virtualMachines/k8s-agentpool-36841236-vmss_1'."
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: add non-retriable errors in azure clients
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure
