### PR TITLE
Fix non-ascii characters in test/e2e_node and test/network.

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -710,7 +710,7 @@ var _ = SIGDescribe("Services", func() {
 	/*
 		Release : v1.9
 		Testname: Kubernetes Service
-		Description: By default when a kubernetes cluster is running there MUST be a ‘kubernetes’ service running in the cluster.
+		Description: By default when a kubernetes cluster is running there MUST be a 'kubernetes' service running in the cluster.
 	*/
 	framework.ConformanceIt("should provide secure master service ", func() {
 		_, err := cs.CoreV1().Services(metav1.NamespaceDefault).Get("kubernetes", metav1.GetOptions{})

--- a/test/e2e_node/startup_probe_test.go
+++ b/test/e2e_node/startup_probe_test.go
@@ -116,7 +116,7 @@ var _ = framework.KubeDescribe("StartupProbe [Serial] [Disruptive]", func() {
 		/*
 			Release : v1.16
 			Testname: Pod liveness probe fails after startup success
-			Description: A Pod is created with failing liveness probe and delayed startup probe that uses ‘exec’ command to cat /temp/health file. The Container is started by creating /tmp/startup after 10 seconds, triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing restart count to 1.
+			Description: A Pod is created with failing liveness probe and delayed startup probe that uses 'exec' command to cat /temp/health file. The Container is started by creating /tmp/startup after 10 seconds, triggering liveness probe to fail. The Pod MUST now be killed and restarted incrementing restart count to 1.
 		*/
 		ginkgo.It("should be restarted by liveness probe after startup probe enables it", func() {
 			cmd := []string{"/bin/sh", "-c", "sleep 10; echo ok >/tmp/startup; sleep 600"}


### PR DESCRIPTION
Signed-off-by: Sakura <longfei.shang@daocloud.io>
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Fix non-ascii characters which are written accidentally.
These characters are changed unintentionally if other parts of these
files are changed. It is better to fix them to avoid that.
**Which issue(s) this PR fixes**:
Ref #87679
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
