### PR TITLE
Treat replaced events that didn't change resourceVersion as resync events

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
+++ b/staging/src/k8s.io/client-go/tools/cache/shared_informer_test.go
@@ -271,8 +271,8 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 	// source simulates an apiserver object endpoint.
 	source := fcache.NewFakeControllerSource()
 
-	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: "pod1"}})
-	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "pod2"}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", UID: "pod1", ResourceVersion: "1"}})
+	source.Add(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "pod2", ResourceVersion: "2"}})
 
 	// create the shared informer and resync every 1s
 	informer := NewSharedInformer(source, &v1.Pod{}, 1*time.Second).(*sharedIndexInformer)
@@ -301,8 +301,8 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 	}
 
 	// Add pod3, bump pod2 but don't broadcast it, so that the change will be seen only on relist
-	source.AddDropWatch(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: "pod3"}})
-	source.ModifyDropWatch(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "pod2"}})
+	source.AddDropWatch(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", UID: "pod3", ResourceVersion: "3"}})
+	source.ModifyDropWatch(&v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", UID: "pod2", ResourceVersion: "4"}})
 
 	// Ensure that nobody saw any changes
 	for _, listener := range listeners {
@@ -315,7 +315,7 @@ func TestSharedInformerWatchDisruption(t *testing.T) {
 		listener.receivedItemNames = []string{}
 	}
 
-	listenerNoResync.expectedItemNames = sets.NewString("pod1", "pod2", "pod3")
+	listenerNoResync.expectedItemNames = sets.NewString("pod2", "pod3")
 	listenerResync.expectedItemNames = sets.NewString("pod1", "pod2", "pod3")
 
 	// This calls shouldSync, which deletes noResync from the list of syncingListeners


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Restores previous treatment of no-op replaced events on a relist by not propagating them to informer listeners that didn't explicitly request a resync.

There is evidence that listeners that watch everything (like GC) or watch high volume resources (like the disruption controller) are running much more slowly starting ~1/24, which was when https://github.com/kubernetes/kubernetes/pull/86015 merged.

That change meant that on relist, all existing items (even if they hadn't changed), were sent to the informer update handlers, even ones that hadn't requested resync events.

from http://storage.googleapis.com/k8s-metrics/flakes-latest.json:

- [[sig-api-machinery] Garbage collector should not be blocked by dependency circle [Conformance]](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-01-31&ci=0&pr=1&test=%5C%5Bsig%5C-api%5C-machinery%5C%5D%5C%20Garbage%5C%20collector%5C%20should%5C%20not%5C%20be%5C%20blocked%5C%20by%5C%20dependency%5C%20circle%5C%20%5C%5BConformance%5C%5D)
- [[sig-apps] DisruptionController evictions: too few pods, replicaSet, percentage => should not allow an eviction](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-01-31&ci=0&pr=1&test=%5C%5Bsig%5C-apps%5C%5D%5C%20DisruptionController%5C%20evictions%3A%5C%20too%5C%20few%5C%20pods%5C%2C%5C%20replicaSet%5C%2C%5C%20percentage%5C%20%3D%3E%5C%20should%5C%20not%5C%20allow%5C%20an%5C%20eviction)
- [[sig-apps] DisruptionController evictions: maxUnavailable deny evictions, integer => should not allow an eviction](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-01-31&ci=0&pr=1&test=%5C%5Bsig%5C-apps%5C%5D%5C%20DisruptionController%5C%20evictions%3A%5C%20maxUnavailable%5C%20deny%5C%20evictions%5C%2C%5C%20integer%5C%20%3D%3E%5C%20should%5C%20not%5C%20allow%5C%20an%5C%20eviction)
- [[sig-api-machinery] Garbage collector should keep the rc around until all its pods are deleted if the deleteOptions says so [Conformance]](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-01-31&ci=0&pr=1&test=%5C%5Bsig%5C-api%5C-machinery%5C%5D%5C%20Garbage%5C%20collector%5C%20should%5C%20keep%5C%20the%5C%20rc%5C%20around%5C%20until%5C%20all%5C%20its%5C%20pods%5C%20are%5C%20deleted%5C%20if%5C%20the%5C%20deleteOptions%5C%20says%5C%20so%5C%20%5C%5BConformance%5C%5D)
- [[sig-api-machinery] Garbage collector should delete jobs and pods created by cronjob](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-01-31&ci=0&pr=1&test=%5C%5Bsig%5C-api%5C-machinery%5C%5D%5C%20Garbage%5C%20collector%5C%20should%5C%20delete%5C%20jobs%5C%20and%5C%20pods%5C%20created%5C%20by%5C%20cronjob)
- [[sig-api-machinery] Garbage collector should delete RS created by deployment when not orphaning [Conformance]](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-01-31&ci=0&pr=1&test=%5C%5Bsig%5C-api%5C-machinery%5C%5D%5C%20Garbage%5C%20collector%5C%20should%5C%20delete%5C%20RS%5C%20created%5C%20by%5C%20deployment%5C%20when%5C%20not%5C%20orphaning%5C%20%5C%5BConformance%5C%5D)

/cc @deads2k @squeed @lavalamp 

```release-note
NONE
```