### PR TITLE
Seeing a flake on statefulset deadlock test; run it serially

### DIFF
--- a/test/e2e/apps/statefulset.go
+++ b/test/e2e/apps/statefulset.go
@@ -241,7 +241,7 @@ var _ = SIGDescribe("StatefulSet", func() {
 
 		// This can't be Conformance yet because it depends on a default
 		// StorageClass and a dynamic provisioner.
-		ginkgo.It("should not deadlock when a pod's predecessor fails", func() {
+		ginkgo.It("[Serial] should not deadlock when a pod's predecessor fails", func() {
 			ginkgo.By("Creating statefulset " + ssName + " in namespace " + ns)
 			e2epv.SkipIfNoDefaultStorageClass(c)
 			*(ss.Spec.Replicas) = 2


### PR DESCRIPTION
/kind failing-test
/kind flake

I'm seeing statefulset flakes/failures on `pull-kops-e2e-kubernetes-aws` and thought running Serially would perhaps be beneficial.