### PR TITLE
kubeadm: remove 'kubeadm upgrade node config' command when v1.18 is released

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/node.go
+++ b/cmd/kubeadm/app/cmd/upgrade/node.go
@@ -93,10 +93,6 @@ func NewCmdNode() *cobra.Command {
 	// command help, adding --skip-phases flag and by adding phases subcommands
 	nodeRunner.BindToCommand(cmd)
 
-	// upgrade node config command is subject to GA deprecation policy, so we should deprecate it
-	// and keep it here for one year or three releases - the longer of the two - starting from v1.15 included
-	cmd.AddCommand(NewCmdUpgradeNodeConfig())
-
 	return cmd
 }
 
@@ -194,42 +190,4 @@ func (d *nodeData) Client() clientset.Interface {
 // KustomizeDir returns the folder where kustomize patches for static pod manifest are stored
 func (d *nodeData) KustomizeDir() string {
 	return d.kustomizeDir
-}
-
-// NewCmdUpgradeNodeConfig returns the cobra.Command for downloading the new/upgrading the kubelet configuration from the kubelet-config-1.X
-// ConfigMap in the cluster
-// TODO: to remove when 1.18 is released
-func NewCmdUpgradeNodeConfig() *cobra.Command {
-	nodeOptions := newNodeOptions()
-	nodeRunner := workflow.NewRunner()
-
-	cmd := &cobra.Command{
-		Use:        "config",
-		Short:      "Download the kubelet configuration from the cluster ConfigMap kubelet-config-1.X, where X is the minor version of the kubelet",
-		Deprecated: "use \"kubeadm upgrade node\" instead",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			// This is required for preserving the old behavior of `kubeadm upgrade node config`.
-			// The new implementation exposed as a phase under `kubeadm upgrade node` infers the target
-			// kubelet config version from the kubeadm-config ConfigMap
-			if len(nodeOptions.kubeletVersion) == 0 {
-				return errors.New("the --kubelet-version argument is required")
-			}
-
-			return nodeRunner.Run(args)
-		},
-	}
-
-	// adds flags to the node command
-	addUpgradeNodeFlags(cmd.Flags(), nodeOptions)
-
-	// initialize the workflow runner with the list of phases
-	nodeRunner.AppendPhase(phases.NewKubeletConfigPhase())
-
-	// sets the data builder function, that will be used by the runner
-	// both when running the entire workflow or single phases
-	nodeRunner.SetDataInitializer(func(cmd *cobra.Command, args []string) (workflow.RunData, error) {
-		return newNodeData(cmd, args, nodeOptions)
-	})
-
-	return cmd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`kubeadm upgrade node config` command is subject to GA deprecation policy.
It has been deprecated since v1.15 and should be removed when v1.18 is released.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref kubernetes/kubeadm#2022

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: remove 'kubeadm upgrade node config' command since it was deprecated in v1.15, please use 'kubeadm upgrade node phase kubelet-config' instead
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
