### PR TITLE
Add CSI block volume directory cleanup

### DIFF
--- a/pkg/volume/csi/BUILD
+++ b/pkg/volume/csi/BUILD
@@ -17,6 +17,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/features:go_default_library",
+        "//pkg/util/removeall:go_default_library",
         "//pkg/volume:go_default_library",
         "//pkg/volume/csi/nodeinfomanager:go_default_library",
         "//pkg/volume/util:go_default_library",

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -466,7 +466,7 @@ func (m *csiBlockMapper) cleanupOrphanDeviceFiles() error {
 		publishDir = publishPath
 	}
 	if err := os.Remove(publishDir); err != nil && !os.IsNotExist(err) {
-		return errors.New(log("failed to publish directory [%s]: %v", publishDir, err))
+		return errors.New(log("failed to remove publish directory [%s]: %v", publishDir, err))
 	}
 
 	// Remove artifacts of NodeStage.

--- a/pkg/volume/csi/csi_util.go
+++ b/pkg/volume/csi/csi_util.go
@@ -108,20 +108,24 @@ func log(msg string, parts ...interface{}) string {
 	return fmt.Sprintf(fmt.Sprintf("%s: %s", CSIPluginName, msg), parts...)
 }
 
+// getVolumePluginDir returns the path where CSI plugin keeps metadata for given volume
+func getVolumePluginDir(specVolID string, host volume.VolumeHost) string {
+	sanitizedSpecVolID := utilstrings.EscapeQualifiedName(specVolID)
+	return filepath.Join(host.GetVolumeDevicePluginDir(CSIPluginName), sanitizedSpecVolID)
+}
+
 // getVolumeDevicePluginDir returns the path where the CSI plugin keeps the
 // symlink for a block device associated with a given specVolumeID.
 // path: plugins/kubernetes.io/csi/volumeDevices/{specVolumeID}/dev
 func getVolumeDevicePluginDir(specVolID string, host volume.VolumeHost) string {
-	sanitizedSpecVolID := utilstrings.EscapeQualifiedName(specVolID)
-	return filepath.Join(host.GetVolumeDevicePluginDir(CSIPluginName), sanitizedSpecVolID, "dev")
+	return filepath.Join(getVolumePluginDir(specVolID, host), "dev")
 }
 
 // getVolumeDeviceDataDir returns the path where the CSI plugin keeps the
 // volume data for a block device associated with a given specVolumeID.
 // path: plugins/kubernetes.io/csi/volumeDevices/{specVolumeID}/data
 func getVolumeDeviceDataDir(specVolID string, host volume.VolumeHost) string {
-	sanitizedSpecVolID := utilstrings.EscapeQualifiedName(specVolID)
-	return filepath.Join(host.GetVolumeDevicePluginDir(CSIPluginName), sanitizedSpecVolID, "data")
+	return filepath.Join(getVolumePluginDir(specVolID, host), "data")
 }
 
 // hasReadWriteOnce returns true if modes contains v1.ReadWriteOnce

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -19,6 +19,9 @@ package fake
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
 	"strings"
 
 	csipb "github.com/container-storage-interface/spec/lib/go/csi"
@@ -172,14 +175,29 @@ func (f *NodeClient) NodePublishVolume(ctx context.Context, req *csipb.NodePubli
 		return nil, timeoutErr
 	}
 
-	f.nodePublishedVolumes[req.GetVolumeId()] = CSIVolume{
+	// "Creation of target_path is the responsibility of the SP."
+	// Our plugin depends on it.
+	if req.VolumeCapability.GetBlock() != nil {
+		if err := ioutil.WriteFile(req.TargetPath, []byte{}, 0644); err != nil {
+			return nil, fmt.Errorf("cannot create target path %s for block file: %s", req.TargetPath, err)
+		}
+	} else {
+		if err := os.MkdirAll(req.TargetPath, 0755); err != nil {
+			return nil, fmt.Errorf("cannot create target directory %s for mount: %s", req.TargetPath, err)
+		}
+	}
+
+	publishedVolume := CSIVolume{
 		VolumeHandle:    req.GetVolumeId(),
 		Path:            req.GetTargetPath(),
 		DeviceMountPath: req.GetStagingTargetPath(),
 		VolumeContext:   req.GetVolumeContext(),
 		FSType:          req.GetVolumeCapability().GetMount().GetFsType(),
-		MountFlags:      req.GetVolumeCapability().GetMount().MountFlags,
 	}
+	if req.GetVolumeCapability().GetMount() != nil {
+		publishedVolume.MountFlags = req.GetVolumeCapability().GetMount().MountFlags
+	}
+	f.nodePublishedVolumes[req.GetVolumeId()] = publishedVolume
 	return &csipb.NodePublishVolumeResponse{}, nil
 }
 
@@ -196,6 +214,12 @@ func (f *NodeClient) NodeUnpublishVolume(ctx context.Context, req *csipb.NodeUnp
 		return nil, errors.New("missing target path")
 	}
 	delete(f.nodePublishedVolumes, req.GetVolumeId())
+
+	// "The SP MUST delete the file or directory it created at this path."
+	if err := os.Remove(req.TargetPath); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("failed to remove publish path %s: %s", req.TargetPath, err)
+	}
+
 	return &csipb.NodeUnpublishVolumeResponse{}, nil
 }
 

--- a/pkg/volume/csi/fake/fake_client.go
+++ b/pkg/volume/csi/fake/fake_client.go
@@ -192,9 +192,9 @@ func (f *NodeClient) NodePublishVolume(ctx context.Context, req *csipb.NodePubli
 		Path:            req.GetTargetPath(),
 		DeviceMountPath: req.GetStagingTargetPath(),
 		VolumeContext:   req.GetVolumeContext(),
-		FSType:          req.GetVolumeCapability().GetMount().GetFsType(),
 	}
 	if req.GetVolumeCapability().GetMount() != nil {
+		publishedVolume.FSType = req.GetVolumeCapability().GetMount().FsType
 		publishedVolume.MountFlags = req.GetVolumeCapability().GetMount().MountFlags
 	}
 	f.nodePublishedVolumes[req.GetVolumeId()] = publishedVolume


### PR DESCRIPTION
CSI volume plugin creates number of files/directories when processing block volumes. These files must be cleaned when the plugin is done with the volume, i.e. at the end on `TearDownDevice` or when `SetupDevice` fails.

I added unit tests covering both `SetupDevice` failure and full lifetime of a CSI block volume from `SetupDevice` trough `MapPodDevice`, `UnmapPodDevice` and `TearDownDevice` to check that there are no orphan files.

Some changes to fake CSI client were necessary to create / delete publish path by the fake driver.

/kind bug

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #87977 #79780

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed cleaning of CSI raw block volumes.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

@msau42 @gnufied 