### PR TITLE
Automated cherry pick of #87630: add a flag in azure auth module to omit spn: prefix in

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/BUILD
@@ -10,7 +10,10 @@ go_test(
     name = "go_default_test",
     srcs = ["azure_test.go"],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/Azure/go-autorest/autorest/adal:go_default_library"],
+    deps = [
+        "//vendor/github.com/Azure/go-autorest/autorest/adal:go_default_library",
+        "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",
+    ],
 )
 
 go_library(

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/README.md
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/README.md
@@ -38,7 +38,13 @@ This plugin provides an integration with Azure Active Directory device flow. If 
    * Replace `APISERVER_APPLICATION_ID` with the application ID of your `apiserver` application ID
    * Be sure to also (create and) select a context that uses above user
 
- 6. The access token is acquired when first `kubectl` command is executed
+6. (Optionally) the AAD token has `aud` claim with `spn:` prefix. To omit that, add following auth configuration:
+
+   ```
+     --auth-provider-arg=config-mode="1"
+   ```
+
+ 7. The access token is acquired when first `kubectl` command is executed
 
    ```
    kubectl get pods


### PR DESCRIPTION
Cherry pick of #87630 on release-1.15.

#87630: add a flag in azure auth module to omit spn: prefix in

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.