### PR TITLE
Add stress test to repeatedly restart Pods with PVCs in parallel

### DIFF
--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -177,7 +177,7 @@ func MakeSecPod(podConfig *Config) (*v1.Pod, error) {
 	if len(podConfig.Command) == 0 {
 		podConfig.Command = "trap exit TERM; while true; do sleep 1; done"
 	}
-	podName := "security-context-" + string(uuid.NewUUID())
+	podName := "pod-" + string(uuid.NewUUID())
 	if podConfig.FsGroup == nil {
 		podConfig.FsGroup = func(i int64) *int64 {
 			return &i

--- a/test/e2e/storage/csi_volumes.go
+++ b/test/e2e/storage/csi_volumes.go
@@ -31,29 +31,13 @@ var csiTestDrivers = []func() testsuites.TestDriver{
 	// Don't run tests with mock driver (drivers.InitMockCSIDriver), it does not provide persistent storage.
 }
 
-// List of testSuites to be executed in below loop
-var csiTestSuites = []func() testsuites.TestSuite{
-	testsuites.InitEphemeralTestSuite,
-	testsuites.InitVolumesTestSuite,
-	testsuites.InitVolumeIOTestSuite,
-	testsuites.InitVolumeModeTestSuite,
-	testsuites.InitSubPathTestSuite,
-	testsuites.InitProvisioningTestSuite,
-	testsuites.InitSnapshottableTestSuite,
-	testsuites.InitMultiVolumeTestSuite,
-	testsuites.InitDisruptiveTestSuite,
-	testsuites.InitVolumeExpandTestSuite,
-	testsuites.InitVolumeLimitsTestSuite,
-	testsuites.InitTopologyTestSuite,
-}
-
 // This executes testSuites for csi volumes.
 var _ = utils.SIGDescribe("CSI Volumes", func() {
 	for _, initDriver := range csiTestDrivers {
 		curDriver := initDriver()
 
 		ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
-			testsuites.DefineTestSuite(curDriver, csiTestSuites)
+			testsuites.DefineTestSuite(curDriver, testsuites.CSISuites)
 		})
 	}
 })

--- a/test/e2e/storage/drivers/csi.go
+++ b/test/e2e/storage/drivers/csi.go
@@ -426,6 +426,10 @@ func InitGcePDCSIDriver() testsuites.TestDriver {
 			},
 			RequiredAccessModes: []v1.PersistentVolumeAccessMode{v1.ReadWriteOnce},
 			TopologyKeys:        []string{GCEPDCSIZoneTopologyKey},
+			StressTestOptions: &testsuites.StressTestOptions{
+				NumPods:     10,
+				NumRestarts: 10,
+			},
 		},
 	}
 }

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -130,21 +130,6 @@ type driverDefinition struct {
 	ClientNodeName string
 }
 
-// List of testSuites to be executed for each external driver.
-var csiTestSuites = []func() testsuites.TestSuite{
-	testsuites.InitEphemeralTestSuite,
-	testsuites.InitMultiVolumeTestSuite,
-	testsuites.InitProvisioningTestSuite,
-	testsuites.InitSnapshottableTestSuite,
-	testsuites.InitSubPathTestSuite,
-	testsuites.InitVolumeIOTestSuite,
-	testsuites.InitVolumeModeTestSuite,
-	testsuites.InitVolumesTestSuite,
-	testsuites.InitVolumeExpandTestSuite,
-	testsuites.InitDisruptiveTestSuite,
-	testsuites.InitVolumeLimitsTestSuite,
-}
-
 func init() {
 	e2econfig.Flags.Var(testDriverParameter{}, "storage.testdriver", "name of a .yaml or .json file that defines a driver for storage testing, can be used more than once")
 }
@@ -182,7 +167,7 @@ func AddDriverDefinition(filename string) error {
 
 	description := "External Storage " + testsuites.GetDriverNameWithFeatureTags(driver)
 	ginkgo.Describe(description, func() {
-		testsuites.DefineTestSuite(driver, csiTestSuites)
+		testsuites.DefineTestSuite(driver, testsuites.CSISuites)
 	})
 
 	return nil

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -48,27 +48,13 @@ var testDrivers = []func() testsuites.TestDriver{
 	drivers.InitLocalDriverWithVolumeType(utils.LocalVolumeGCELocalSSD),
 }
 
-// List of testSuites to be executed in below loop
-var testSuites = []func() testsuites.TestSuite{
-	testsuites.InitVolumesTestSuite,
-	testsuites.InitVolumeIOTestSuite,
-	testsuites.InitVolumeModeTestSuite,
-	testsuites.InitSubPathTestSuite,
-	testsuites.InitProvisioningTestSuite,
-	testsuites.InitMultiVolumeTestSuite,
-	testsuites.InitVolumeExpandTestSuite,
-	testsuites.InitDisruptiveTestSuite,
-	testsuites.InitVolumeLimitsTestSuite,
-	testsuites.InitTopologyTestSuite,
-}
-
 // This executes testSuites for in-tree volumes.
 var _ = utils.SIGDescribe("In-tree Volumes", func() {
 	for _, initDriver := range testDrivers {
 		curDriver := initDriver()
 
 		ginkgo.Context(testsuites.GetDriverNameWithFeatureTags(curDriver), func() {
-			testsuites.DefineTestSuite(curDriver, testSuites)
+			testsuites.DefineTestSuite(curDriver, testsuites.BaseSuites)
 		})
 	}
 })

--- a/test/e2e/storage/testsuites/BUILD
+++ b/test/e2e/storage/testsuites/BUILD
@@ -10,6 +10,7 @@ go_library(
         "multivolume.go",
         "provisioning.go",
         "snapshottable.go",
+        "stress.go",
         "subpath.go",
         "testdriver.go",
         "topology.go",

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -60,6 +60,27 @@ func init() {
 
 type opCounts map[string]int64
 
+// BaseSuites is a list of storage test suites that work for in-tree and CSI drivers
+var BaseSuites = []func() TestSuite{
+	InitVolumesTestSuite,
+	InitVolumeIOTestSuite,
+	InitVolumeModeTestSuite,
+	InitSubPathTestSuite,
+	InitProvisioningTestSuite,
+	InitMultiVolumeTestSuite,
+	InitVolumeExpandTestSuite,
+	InitDisruptiveTestSuite,
+	InitVolumeLimitsTestSuite,
+	InitTopologyTestSuite,
+	InitStressTestSuite,
+}
+
+// CSISuites is a list of storage test suites that work only for CSI drivers
+var CSISuites = append(BaseSuites,
+	InitEphemeralTestSuite,
+	InitSnapshottableTestSuite,
+)
+
 // TestSuite represents an interface for a set of tests which works with TestDriver
 type TestSuite interface {
 	// GetTestSuiteInfo returns the TestSuiteInfo for this TestSuite

--- a/test/e2e/storage/testsuites/stress.go
+++ b/test/e2e/storage/testsuites/stress.go
@@ -1,0 +1,197 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This suite tests volumes under stress conditions
+
+package testsuites
+
+import (
+	"context"
+	"sync"
+
+	"github.com/onsi/ginkgo"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	errors "k8s.io/apimachinery/pkg/util/errors"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
+)
+
+type stressTestSuite struct {
+	tsInfo TestSuiteInfo
+}
+
+type stressTest struct {
+	config        *PerTestConfig
+	driverCleanup func()
+
+	intreeOps   opCounts
+	migratedOps opCounts
+
+	resources []*VolumeResource
+	pods      []*v1.Pod
+	// stop and wait for any async routines
+	wg      sync.WaitGroup
+	stopChs []chan struct{}
+}
+
+var _ TestSuite = &stressTestSuite{}
+
+// InitStressTestSuite returns stressTestSuite that implements TestSuite interface
+func InitStressTestSuite() TestSuite {
+	return &stressTestSuite{
+		tsInfo: TestSuiteInfo{
+			Name:       "stress",
+			FeatureTag: "[Feature: VolumeStress]",
+			TestPatterns: []testpatterns.TestPattern{
+				testpatterns.DefaultFsDynamicPV,
+				testpatterns.BlockVolModeDynamicPV,
+			},
+		},
+	}
+}
+
+func (t *stressTestSuite) GetTestSuiteInfo() TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *stressTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {
+}
+
+func (t *stressTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+	var (
+		dInfo = driver.GetDriverInfo()
+		cs    clientset.Interface
+	)
+
+	ginkgo.BeforeEach(func() {
+		// Check preconditions.
+		ok := false
+		_, ok = driver.(DynamicPVTestDriver)
+		if !ok {
+			e2eskipper.Skipf("Driver %s doesn't support %v -- skipping", dInfo.Name, pattern.VolType)
+		}
+
+		if !driver.GetDriverInfo().Capabilities[CapBlock] && pattern.VolMode == v1.PersistentVolumeBlock {
+			e2eskipper.Skipf("Driver %q does not support block volume mode - skipping", driver.GetDriverInfo().Name)
+		}
+	})
+
+	// This intentionally comes after checking the preconditions because it
+	// registers its own BeforeEach which creates the namespace. Beware that it
+	// also registers an AfterEach which renders f unusable. Any code using
+	// f must run inside an It or Context callback.
+	f := framework.NewDefaultFramework("stress")
+
+	init := func() *stressTest {
+		cs = f.ClientSet
+		l := &stressTest{}
+
+		// Now do the more expensive test initialization.
+		l.config, l.driverCleanup = driver.PrepareTest(f)
+		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
+		l.resources = []*VolumeResource{}
+		l.pods = []*v1.Pod{}
+		l.stopChs = []chan struct{}{}
+
+		return l
+	}
+
+	cleanup := func(l *stressTest) {
+		var errs []error
+
+		framework.Logf("Stopping and waiting for all test routines to finish")
+		for _, stopCh := range l.stopChs {
+			close(stopCh)
+		}
+		l.wg.Wait()
+
+		for _, pod := range l.pods {
+			framework.Logf("Deleting pod %v", pod.Name)
+			err := e2epod.DeletePodWithWait(cs, pod)
+			errs = append(errs, err)
+		}
+
+		for _, resource := range l.resources {
+			errs = append(errs, resource.CleanupResource())
+		}
+
+		errs = append(errs, tryFunc(l.driverCleanup))
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleaning up resource")
+		validateMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName, l.intreeOps, l.migratedOps)
+	}
+
+	ginkgo.It("multiple pods should access different volumes repeatedly [Slow] [Serial]", func() {
+		const (
+			numPods = 10
+			// number of times each Pod should start
+			numPodStarts = 10
+		)
+
+		var err error
+
+		l := init()
+		defer func() {
+			cleanup(l)
+		}()
+
+		for i := 0; i < numPods; i++ {
+			framework.Logf("Creating resources for pod %v/%v", i, numPods)
+			r := CreateVolumeResource(driver, l.config, pattern, t.GetTestSuiteInfo().SupportedSizeRange)
+			l.resources = append(l.resources, r)
+			l.pods = append(l.pods, e2epod.MakeSecPod(f.Namespace.Name,
+				[]*v1.PersistentVolumeClaim{r.Pvc},
+				nil, false, "", false, false, e2epv.SELinuxLabel, nil))
+			l.stopChs = append(l.stopChs, make(chan struct{}))
+		}
+
+		// Restart pod repeatedly
+		for i := 0; i < numPods; i++ {
+			podIndex := i
+			l.wg.Add(1)
+			go func() {
+				defer ginkgo.GinkgoRecover()
+				defer l.wg.Done()
+				for j := 0; j < numPodStarts; j++ {
+					select {
+					case <-l.stopChs[podIndex]:
+						return
+					default:
+						pod := l.pods[podIndex]
+						framework.Logf("Pod %v, Iteration %v/%v", podIndex, j, numPodStarts)
+						_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+						framework.ExpectNoError(err)
+
+						err = e2epod.WaitForPodRunningInNamespace(cs, pod)
+						framework.ExpectNoError(err)
+
+						// TODO: write data per pod and validate it everytime
+
+						err = e2epod.DeletePodWithWait(f.ClientSet, pod)
+						framework.ExpectNoError(err)
+					}
+				}
+			}()
+		}
+
+		l.wg.Wait()
+	})
+}

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -188,6 +188,17 @@ type DriverInfo struct {
 	// Only relevant if TopologyKeys is set. Defaults to 1.
 	// Example: multi-zonal disk requires at least 2 allowed topologies.
 	NumAllowedTopologies int
+	// [Optional] Scale parameters for stress tests.
+	StressTestOptions *StressTestOptions
+}
+
+// StressTestOptions contains parameters used for stress tests.
+type StressTestOptions struct {
+	// Number of pods to create in the test. This may also create
+	// up to 1 volume per pod.
+	NumPods int
+	// Number of times to restart each Pod.
+	NumRestarts int
 }
 
 // PerTestConfig represents parameters that control test execution.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add a volume stress test that creates many Pods with PVCs and restarts them in parallel. This test can help verify that drivers handle timeouts and retries correctly, as well handle and manage multiple volume operations in parallel.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
