### PR TITLE
Make Azure clients only retry on specified HTTP status codes

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -801,7 +801,7 @@ func TestReconcileSecurityGroupEtagMismatch(t *testing.T) {
 		HTTPStatusCode: http.StatusPreconditionFailed,
 		RawError:       errPreconditionFailedEtagMismatch,
 	}
-	assert.Equal(t, err, expectedError.Error())
+	assert.Equal(t, expectedError.Error(), err)
 }
 
 func TestReconcilePublicIPWithNewService(t *testing.T) {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/azure_armclient_test.go
@@ -154,7 +154,7 @@ func TestSendAsync(t *testing.T) {
 	assert.Nil(t, response)
 	assert.Equal(t, 1, count)
 	assert.NotNil(t, rerr)
-	assert.Equal(t, true, rerr.Retriable)
+	assert.Equal(t, false, rerr.Retriable)
 }
 
 func TestNormalizeAzureRegion(t *testing.T) {
@@ -236,7 +236,7 @@ func TestDeleteResourceAsync(t *testing.T) {
 	count := 0
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		count++
-		http.Error(w, "failed", http.StatusForbidden)
+		http.Error(w, "failed", http.StatusInternalServerError)
 	}))
 
 	backoff := &retry.Backoff{Steps: 3}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error.go
@@ -38,6 +38,15 @@ const (
 var (
 	// The function to get current time.
 	now = time.Now
+
+	// StatusCodesForRetry are a defined group of status code for which the client will retry.
+	StatusCodesForRetry = []int{
+		http.StatusRequestTimeout,      // 408
+		http.StatusInternalServerError, // 500
+		http.StatusBadGateway,          // 502
+		http.StatusServiceUnavailable,  // 503
+		http.StatusGatewayTimeout,      // 504
+	}
 )
 
 // Error indicates an error returned by Azure APIs.
@@ -184,18 +193,21 @@ func getHTTPStatusCode(resp *http.Response) int {
 // shouldRetryHTTPRequest determines if the request is retriable.
 func shouldRetryHTTPRequest(resp *http.Response, err error) bool {
 	if resp != nil {
-		// HTTP 412 (StatusPreconditionFailed) means etag mismatch
-		// HTTP 400 (BadRequest) means the request cannot be accepted, hence we shouldn't retry.
-		if resp.StatusCode == http.StatusPreconditionFailed || resp.StatusCode == http.StatusBadRequest {
-			return false
+		for _, code := range StatusCodesForRetry {
+			if resp.StatusCode == code {
+				return true
+			}
 		}
 
-		// HTTP 4xx (except 412) or 5xx suggests we should retry.
-		if 399 < resp.StatusCode && resp.StatusCode < 600 {
+		// should retry on <200, error>.
+		if isSuccessHTTPResponse(resp) && err != nil {
 			return true
 		}
+
+		return false
 	}
 
+	// should retry when error is not nil and no http.Response.
 	if err != nil {
 		return true
 	}
@@ -222,6 +234,24 @@ func getRetryAfter(resp *http.Response) time.Duration {
 		dur = t.Sub(now())
 	}
 	return dur
+}
+
+// GetErrorWithRetriableHTTPStatusCodes gets an error with RetriableHTTPStatusCodes.
+// It is used to retry on some HTTPStatusCodes.
+func GetErrorWithRetriableHTTPStatusCodes(resp *http.Response, err error, retriableHTTPStatusCodes []int) *Error {
+	rerr := GetError(resp, err)
+	if rerr == nil {
+		return nil
+	}
+
+	for _, code := range retriableHTTPStatusCodes {
+		if rerr.HTTPStatusCode == code {
+			rerr.Retriable = true
+			break
+		}
+	}
+
+	return rerr
 }
 
 // GetStatusNotFoundAndForbiddenIgnoredError gets an error with StatusNotFound and StatusForbidden ignored.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/retry/azure_error_test.go
@@ -73,7 +73,7 @@ func TestGetError(t *testing.T) {
 			code: http.StatusSeeOther,
 			err:  fmt.Errorf("some error"),
 			expected: &Error{
-				Retriable:      true,
+				Retriable:      false,
 				HTTPStatusCode: http.StatusSeeOther,
 				RawError:       fmt.Errorf("some error"),
 			},
@@ -82,7 +82,7 @@ func TestGetError(t *testing.T) {
 			code:       http.StatusTooManyRequests,
 			retryAfter: 100,
 			expected: &Error{
-				Retriable:      true,
+				Retriable:      false,
 				HTTPStatusCode: http.StatusTooManyRequests,
 				RetryAfter:     now().Add(100 * time.Second),
 				RawError:       fmt.Errorf("some error"),
@@ -156,7 +156,7 @@ func TestGetStatusNotFoundAndForbiddenIgnoredError(t *testing.T) {
 			code: http.StatusSeeOther,
 			err:  fmt.Errorf("some error"),
 			expected: &Error{
-				Retriable:      true,
+				Retriable:      false,
 				HTTPStatusCode: http.StatusSeeOther,
 				RawError:       fmt.Errorf("some error"),
 			},
@@ -165,7 +165,7 @@ func TestGetStatusNotFoundAndForbiddenIgnoredError(t *testing.T) {
 			code:       http.StatusTooManyRequests,
 			retryAfter: 100,
 			expected: &Error{
-				Retriable:      true,
+				Retriable:      false,
 				HTTPStatusCode: http.StatusTooManyRequests,
 				RetryAfter:     now().Add(100 * time.Second),
 				RawError:       fmt.Errorf("some error"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind bug

**What this PR does / why we need it**:

Make Azure clients only retry on specified HTTP status codes

Refer the HTTP status codes for retry from go-autorest [here](https://github.com/Azure/go-autorest/blob/5e7a399d8bbf4953ab0c8e3167d7fd535fd74ce1/autorest/client.go#L46-L54).

```go
	// StatusCodesForRetry are a defined group of status code for which the client will retry
	StatusCodesForRetry = []int{
		http.StatusRequestTimeout,      // 408
		http.StatusInternalServerError, // 500
		http.StatusBadGateway,          // 502
		http.StatusServiceUnavailable,  // 503
		http.StatusGatewayTimeout,      // 504
	}
```

Note `http.StatusTooManyRequests` is removed from go-autorest list because we don't want to retry on http.StatusTooManyRequests.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Make Azure clients only retry on specified HTTP status codes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/area provider/azure
/sig cloud-provider
/kind bug
/priority important-soon
/assign @andyzhangx 