### PR TITLE
Lower ssa auto-enablement to 10%

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -35,7 +35,7 @@ const DefaultMaxUpdateManagers int = 10
 
 // DefaultTrackOnCreateProbability defines the default probability that the field management of an object
 // starts being tracked from the object's creation, instead of from the first time the object is applied to.
-const DefaultTrackOnCreateProbability float32 = 1
+const DefaultTrackOnCreateProbability float32 = 0.1
 
 // Managed groups a fieldpath.ManagedFields together with the timestamps associated with each operation.
 type Managed interface {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
experiment to measure impact of ssa probability on e2e runs

e2e timeout flakes [rose sharply on 1/24](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-01-31&ci=0&pr=1&job=e2e-gce%24&test=Garbage%7CDisruption). It was unclear whether this was due to server-side apply (SSA) being auto-enabled at 50% in https://github.com/kubernetes/kubernetes/pull/87500, or an informer fix landed in #86015 which also increased update watch event rates.

The increased watch traffic from #86015 was mitigated in https://github.com/kubernetes/kubernetes/pull/87957

Server-side apply enablement was increased to 100% in https://github.com/kubernetes/kubernetes/pull/87984

e2e timeout flakes are [still severe as of 2/11](https://storage.googleapis.com/k8s-gubernator/triage/index.html?date=2020-02-11&ci=0&pr=1&job=e2e-gce%24&test=Garbage%7CDisruption).

I would suggest dropping SSA back to 10% to try to get back to our pre-1/24 CI levels. If that proves effective, then we can increase it to 100% in a branch and iterate there to understand what is impacting test runs without blocking master development.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/hold