### PR TITLE
Change migrated-to annoation key to follow best practices by removing beta

### DIFF
--- a/pkg/controller/volume/persistentvolume/util/util.go
+++ b/pkg/controller/volume/persistentvolume/util/util.go
@@ -69,7 +69,7 @@ const (
 	// through the CSIMigration feature flags. When this annotation is set the
 	// Kubernetes components will "stand-down" and the external-provisioner will
 	// act on the objects
-	AnnMigratedTo = "volume.beta.kubernetes.io/migrated-to"
+	AnnMigratedTo = "pv.kubernetes.io/migrated-to"
 
 	// AnnStorageProvisioner annotation is added to a PVC that is supposed to be dynamically
 	// provisioned. Its value is name of volume plugin that is supposed to provision


### PR DESCRIPTION
This has not made it into any official release and just sat in master for a couple days before we caught it. I think it's safe to change.

/kind api-change
/kind cleanup
/assign @msau42 @liggitt @saad-ali 


```release-note
CSI Migration migration annotation key is now `kubernetes.io/migrated-to`
```