### PR TITLE
Promote: ConfigMap Lifecycle test - +2 conformance endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1663,6 +1663,14 @@
     fail.
   release: v1.14
   file: test/e2e/common/configmap.go
+- testname: ConfigMap lifecycle
+  codename: '[sig-node] ConfigMap should run through a ConfigMap lifecycle [Conformance]'
+  description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching
+    the ConfigMap MUST reflect changes. By fetching all the ConfigMaps via a Label
+    selector it MUST find the ConfigMap by it's static label and updated value. The
+    ConfigMap must be deleted by Collection.
+  release: v1.18
+  file: test/e2e/common/configmap.go
 - testname: DownwardAPI, environment for CPU and memory limits and requests
   codename: '[sig-node] Downward API should provide container''s limits.cpu/memory
     and requests.cpu/memory as env vars [NodeConformance] [Conformance]'

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1669,7 +1669,7 @@
     the ConfigMap MUST reflect changes. By fetching all the ConfigMaps via a Label
     selector it MUST find the ConfigMap by it's static label and updated value. The
     ConfigMap must be deleted by Collection.
-  release: v1.18
+  release: v1.19
   file: test/e2e/common/configmap.go
 - testname: DownwardAPI, environment for CPU and memory limits and requests
   codename: '[sig-node] Downward API should provide container''s limits.cpu/memory

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -157,6 +157,12 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 		framework.ExpectEqual(configMapFromUpdate.Data, configMap.Data)
 	})
 
+	/*
+	   Release : v1.18
+	   Testname: ConfigMap lifecycle
+	   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
+           By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
+	*/
 	ginkgo.It("should run through a ConfigMap lifecycle", func() {
 		testNamespaceName := f.Namespace.Name
 		testConfigMapName := "test-configmap" + string(uuid.NewUUID())
@@ -212,6 +218,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 		}
 		framework.ExpectEqual(testConfigMapFound, true, "failed to find ConfigMap in list")
 
+		// hit the endpoint for delete collection
 		err = f.ClientSet.CoreV1().ConfigMaps(testNamespaceName).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: "test-configmap-static=true",
 		})

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -158,10 +158,10 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 	})
 
 	/*
-		   Release : v1.18
-		   Testname: ConfigMap lifecycle
-		   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
-	           By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
+			   Release : v1.18
+			   Testname: ConfigMap lifecycle
+			   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
+		           By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
 	*/
 	framework.ConformanceIt("should run through a ConfigMap lifecycle", func() {
 		testNamespaceName := f.Namespace.Name

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -163,7 +163,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 	   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
            By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
 	*/
-	ginkgo.It("should run through a ConfigMap lifecycle", func() {
+	framework.ConformanceIt("should run through a ConfigMap lifecycle", func() {
 		testNamespaceName := f.Namespace.Name
 		testConfigMapName := "test-configmap" + string(uuid.NewUUID())
 

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -158,7 +158,7 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 	})
 
 	/*
-			   Release : v1.18
+			   Release : v1.19
 			   Testname: ConfigMap lifecycle
 			   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
 		           By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.

--- a/test/e2e/common/configmap.go
+++ b/test/e2e/common/configmap.go
@@ -158,10 +158,10 @@ var _ = ginkgo.Describe("[sig-node] ConfigMap", func() {
 	})
 
 	/*
-	   Release : v1.18
-	   Testname: ConfigMap lifecycle
-	   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
-           By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
+		   Release : v1.18
+		   Testname: ConfigMap lifecycle
+		   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
+	           By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
 	*/
 	framework.ConformanceIt("should run through a ConfigMap lifecycle", func() {
 		testNamespaceName := f.Namespace.Name


### PR DESCRIPTION
- [x] [mock test ticket](https://github.com/kubernetes/kubernetes/issues/87120)
- [x] [PR](https://github.com/kubernetes/kubernetes/pull/87212)
- [ ] [promotion](#)
  - [ ] [update to improve](https://github.com/kubernetes/kubernetes/pull/89707)

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
`test/e2e/common/configmap.go: "should run through a ConfigMap lifecycle"`

**Special notes for your reviewer**:
Adds +2 conformance endpoint coverage.
Testgrid: [results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=should%20run%20through%20a%20ConfigMap%20lifecycle)
Fixes: #87120

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/area conformance
/area test
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg