### PR TITLE
Round managedFields times to the nearest second before sorting

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/capmanagers.go
@@ -19,7 +19,6 @@ package fieldmanager
 import (
 	"fmt"
 	"sort"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -78,15 +77,15 @@ func (f *capManagersManager) capUpdateManagers(managed Managed) (newManaged Mana
 
 	// If we have more than the maximum, sort the update entries by time, oldest first.
 	sort.Slice(updaters, func(i, j int) bool {
-		iTime, jTime, nTime := managed.Times()[updaters[i]], managed.Times()[updaters[j]], &metav1.Time{Time: time.Time{}}
-		if iTime == nil {
-			iTime = nTime
+		iTime, jTime, iSeconds, jSeconds := managed.Times()[updaters[i]], managed.Times()[updaters[j]], int64(0), int64(0)
+		if iTime != nil {
+			iSeconds = iTime.Unix()
 		}
-		if jTime == nil {
-			jTime = nTime
+		if jTime != nil {
+			jSeconds = jTime.Unix()
 		}
-		if !iTime.Equal(jTime) {
-			return iTime.Before(jTime)
+		if iSeconds != jSeconds {
+			return iSeconds < jSeconds
 		}
 		return updaters[i] < updaters[j]
 	})

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
-	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -194,15 +193,15 @@ func sortEncodedManagedFields(encodedManagedFields []metav1.ManagedFieldsEntry) 
 			return p.Operation < q.Operation
 		}
 
-		ntime := &metav1.Time{Time: time.Time{}}
-		if p.Time == nil {
-			p.Time = ntime
+		pSeconds, qSeconds := int64(0), int64(0)
+		if p.Time != nil {
+			pSeconds = p.Time.Unix()
 		}
-		if q.Time == nil {
-			q.Time = ntime
+		if q.Time != nil {
+			qSeconds = q.Time.Unix()
 		}
-		if !p.Time.Equal(q.Time) {
-			return p.Time.Before(q.Time)
+		if pSeconds != qSeconds {
+			return pSeconds < qSeconds
 		}
 
 		if p.Manager != q.Manager {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal/managedfields_test.go
@@ -326,6 +326,19 @@ func TestSortEncodedManagedFields(t *testing.T) {
 				{Manager: "e", Operation: metav1.ManagedFieldsOperationUpdate, Time: parseTimeOrPanic("2003-01-01T01:00:00Z")},
 			},
 		},
+		{
+			name: "sort drops nanoseconds",
+			managedFields: []metav1.ManagedFieldsEntry{
+				{Manager: "c", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{time.Date(2000, time.January, 0, 0, 0, 0, 1, time.UTC)}},
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{time.Date(2000, time.January, 0, 0, 0, 0, 2, time.UTC)}},
+				{Manager: "b", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{time.Date(2000, time.January, 0, 0, 0, 0, 3, time.UTC)}},
+			},
+			expected: []metav1.ManagedFieldsEntry{
+				{Manager: "a", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{time.Date(2000, time.January, 0, 0, 0, 0, 2, time.UTC)}},
+				{Manager: "b", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{time.Date(2000, time.January, 0, 0, 0, 0, 3, time.UTC)}},
+				{Manager: "c", Operation: metav1.ManagedFieldsOperationUpdate, Time: &metav1.Time{time.Date(2000, time.January, 0, 0, 0, 0, 1, time.UTC)}},
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig api-machinery
/wg apply
/cc @lavalamp @liggitt 
/priority important-soon

**Which issue(s) this PR fixes**:
Fixes #88031

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```