### PR TITLE
Promote: PodTemplate Lifecycle test - +3 conformance endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1234,6 +1234,15 @@
     StorageClass or a dynamic provisioner.
   release: v1.9
   file: test/e2e/apps/statefulset.go
+- testname: ConfigMap lifecycle
+  codename: '[sig-architecture] PodTemplates should run the lifecycle of PodTemplates
+    [Conformance]'
+  description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching
+    the ConfigMap MUST reflect changes. By fetching all the ConfigMaps via a Label
+    selector it MUST find the ConfigMap by it's static label and updated value. The
+    ConfigMap must be deleted by Collection.
+  release: v1.18
+  file: test/e2e/common/podtemplates.go
 - testname: Service account tokens auto mount optionally
   codename: '[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]'
   description: Ensure that Service Account keys are mounted into the Pod only when

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1234,13 +1234,13 @@
     StorageClass or a dynamic provisioner.
   release: v1.9
   file: test/e2e/apps/statefulset.go
-- testname: ConfigMap lifecycle
+- testname: PodTemplate lifecycle
   codename: '[sig-architecture] PodTemplates should run the lifecycle of PodTemplates
     [Conformance]'
-  description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching
-    the ConfigMap MUST reflect changes. By fetching all the ConfigMaps via a Label
-    selector it MUST find the ConfigMap by it's static label and updated value. The
-    ConfigMap must be deleted by Collection.
+  description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching
+    the PodTemplate MUST reflect changes. By fetching all the PodTemplates via a Label
+    selector it MUST find the PodTemplate by it's static label and updated value.
+    The PodTemplate must be deleted.
   release: v1.18
   file: test/e2e/common/podtemplates.go
 - testname: Service account tokens auto mount optionally

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1234,15 +1234,6 @@
     StorageClass or a dynamic provisioner.
   release: v1.9
   file: test/e2e/apps/statefulset.go
-- testname: PodTemplate lifecycle
-  codename: '[sig-architecture] PodTemplates should run the lifecycle of PodTemplates
-    [Conformance]'
-  description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching
-    the PodTemplate MUST reflect changes. By fetching all the PodTemplates via a Label
-    selector it MUST find the PodTemplate by it's static label and updated value.
-    The PodTemplate must be deleted.
-  release: v1.19
-  file: test/e2e/common/podtemplates.go
 - testname: Service account tokens auto mount optionally
   codename: '[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]'
   description: Ensure that Service Account keys are mounted into the Pod only when
@@ -1695,6 +1686,14 @@
     visible at runtime in the container.
   release: v1.9
   file: test/e2e/common/downward_api.go
+- testname: PodTemplate lifecycle
+  codename: '[sig-node] PodTemplates should run the lifecycle of PodTemplates [Conformance]'
+  description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching
+    the PodTemplate MUST reflect changes. By fetching all the PodTemplates via a Label
+    selector it MUST find the PodTemplate by it's static label and updated value.
+    The PodTemplate must be deleted.
+  release: v1.19
+  file: test/e2e/common/podtemplates.go
 - testname: LimitRange, resources
   codename: '[sig-scheduling] LimitRange should create a LimitRange with defaults
     and ensure pod has those defaults applied. [Conformance]'

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1241,7 +1241,7 @@
     the PodTemplate MUST reflect changes. By fetching all the PodTemplates via a Label
     selector it MUST find the PodTemplate by it's static label and updated value.
     The PodTemplate must be deleted.
-  release: v1.18
+  release: v1.19
   file: test/e2e/common/podtemplates.go
 - testname: Service account tokens auto mount optionally
   codename: '[sig-auth] ServiceAccounts should allow opting out of API token automount  [Conformance]'

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -31,8 +31,13 @@ import (
 
 var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 	f := framework.NewDefaultFramework("podtemplate")
-
-	ginkgo.It("should run the lifecycle of PodTemplates", func() {
+	/*
+	   Release : v1.18
+	   Testname: ConfigMap lifecycle
+	   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
+	          By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
+	*/
+	framework.ConformanceIt("should run the lifecycle of PodTemplates", func() {
 		testNamespaceName := f.Namespace.Name
 		podTemplateName := "nginx-pod-template-" + string(uuid.NewUUID())
 

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -35,7 +35,7 @@ var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 	   Release : v1.18
 	   Testname: PodTemplate lifecycle
 	   Description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching the PodTemplate MUST reflect changes.
-	          By fetching all the PodTemplates via a Label selector it MUST find the PodTemplate by it's static label and updated value. The PodTemplate must be deleted by Collection.
+	          By fetching all the PodTemplates via a Label selector it MUST find the PodTemplate by it's static label and updated value. The PodTemplate must be deleted.
 	*/
 	framework.ConformanceIt("should run the lifecycle of PodTemplates", func() {
 		testNamespaceName := f.Namespace.Name

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -32,7 +32,7 @@ import (
 var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 	f := framework.NewDefaultFramework("podtemplate")
 	/*
-	   Release : v1.18
+	   Release : v1.19
 	   Testname: PodTemplate lifecycle
 	   Description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching the PodTemplate MUST reflect changes.
 	          By fetching all the PodTemplates via a Label selector it MUST find the PodTemplate by it's static label and updated value. The PodTemplate must be deleted.

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -33,9 +33,9 @@ var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
 	f := framework.NewDefaultFramework("podtemplate")
 	/*
 	   Release : v1.18
-	   Testname: ConfigMap lifecycle
-	   Description: Attempt to create a ConfigMap. Patch the created ConfigMap. Fetching the ConfigMap MUST reflect changes.
-	          By fetching all the ConfigMaps via a Label selector it MUST find the ConfigMap by it's static label and updated value. The ConfigMap must be deleted by Collection.
+	   Testname: PodTemplate lifecycle
+	   Description: Attempt to create a PodTemplate. Patch the created PodTemplate. Fetching the PodTemplate MUST reflect changes.
+	          By fetching all the PodTemplates via a Label selector it MUST find the PodTemplate by it's static label and updated value. The PodTemplate must be deleted by Collection.
 	*/
 	framework.ConformanceIt("should run the lifecycle of PodTemplates", func() {
 		testNamespaceName := f.Namespace.Name

--- a/test/e2e/common/podtemplates.go
+++ b/test/e2e/common/podtemplates.go
@@ -29,7 +29,7 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-var _ = ginkgo.Describe("[sig-architecture] PodTemplates", func() {
+var _ = ginkgo.Describe("[sig-node] PodTemplates", func() {
 	f := framework.NewDefaultFramework("podtemplate")
 	/*
 	   Release : v1.19


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:  
`test/e2e/common/podtemplates.go: "should run the lifecycle of PodTemplates"`

**Special notes for your reviewer**:
Adds +3 conformance test coverage.
Testgrid: [results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=should%20run%20the%20lifecycle%20of%20PodTemplates)
Fixes: #86141

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/area conformance
/area test
@kubernetes/sig-architecture-pr-reviews
@kubernetes/cncf-conformance-wg