### PR TITLE
kubeadm: update embedded CA in kubeconfig files on renewal

### DIFF
--- a/cmd/kubeadm/app/phases/certs/renewal/BUILD
+++ b/cmd/kubeadm/app/phases/certs/renewal/BUILD
@@ -41,6 +41,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
+        "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util/certs:go_default_library",
         "//cmd/kubeadm/app/util/kubeconfig:go_default_library",
         "//cmd/kubeadm/app/util/pkiutil:go_default_library",

--- a/cmd/kubeadm/app/phases/certs/renewal/manager.go
+++ b/cmd/kubeadm/app/phases/certs/renewal/manager.go
@@ -154,7 +154,8 @@ func NewManager(cfg *kubeadmapi.ClusterConfiguration, kubernetesDir string) (*Ma
 	// create a CertificateRenewHandler for each kubeConfig file
 	for _, kubeConfig := range kubeConfigs {
 		// create a ReadWriter for certificates embedded in kubeConfig files
-		kubeConfigReadWriter := newKubeconfigReadWriter(kubernetesDir, kubeConfig.fileName)
+		kubeConfigReadWriter := newKubeconfigReadWriter(kubernetesDir, kubeConfig.fileName,
+			rm.cfg.CertificatesDir, kubeadmconstants.CACertAndKeyBaseName)
 
 		// adds the certificateRenewHandler.
 		// Certificates embedded kubeConfig files in are indexed by fileName, that is a well know constant defined


### PR DESCRIPTION
**What this PR does / why we need it**:
While kubeadm does not support CA rotation,
the users might still attempt to perform this manually.
For kubeconfig files, updating to a new CA is not reflected
and users need to embed the new CA PEM manually.

On kubeconfig cert renewal, always keep the embedded CA
in sync with the one on disk.

Includes a couple of typo fixes.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes kubernetes/kubeadm#2027

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: on kubeconfig certificate renewal, keep the embedded CA in sync with the one on disk
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

@kubernetes/sig-cluster-lifecycle-pr-reviews 
/assign @fabriziopandini 
/priority important-longterm

somewhere in between:
/kind bug
and
/kind feature
