### PR TITLE
Initialize http Request Header before Set to avoid panic

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go
@@ -225,6 +225,9 @@ func (r *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("getting credentials: %v", err)
 	}
 	if creds.token != "" {
+		if req.Header == nil {
+			req.Header = make(http.Header)
+		}
 		req.Header.Set("Authorization", "Bearer "+creds.token)
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
While running Conformance tests using a credential plugin https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins, I saw panics like this:
```
•! Panic in Spec Teardown (AfterEach) [46.608 seconds]
[k8s.io] Pods
/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:687
  should support remote command execution over websockets [NodeConformance] [Conformance] [AfterEach]
  /go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/framework.go:692

  Test Panicked
  assignment to entry in nil map
  /usr/local/go/src/runtime/map_faststr.go:204

  Full Stack Trace
  	/usr/local/go/src/runtime/panic.go:522 +0x1b5
  net/textproto.MIMEHeader.Set(...)
  	/usr/local/go/src/net/textproto/header.go:22
  net/http.Header.Set(...)
  	/usr/local/go/src/net/http/header.go:37
  k8s.io/kubernetes/vendor/k8s.io/client-go/plugin/pkg/client/auth/exec.(*roundTripper).RoundTrip(0xc0027d0dc0, 0xc002a68b00, 0xc0029e61c8, 0x53fc880, 0xc0027d0dc0)
  	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/vendor/k8s.io/client-go/plugin/pkg/client/auth/exec/exec.go:217 +0x407
  k8s.io/kubernetes/test/e2e/framework.headersForConfig(0xc0004e83c0, 0xc001aeb300, 0x0, 0x0, 0x10)
  	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:4221 +0xc1
  k8s.io/kubernetes/test/e2e/framework.OpenWebSocketForURL(0xc001aeb300, 0xc0004e83c0, 0xc0027d2e40, 0x1, 0x1, 0xc0027d07e0, 0x1, 0x2)
  	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/framework/util.go:4239 +0x1a7
  k8s.io/kubernetes/test/e2e/common.glob..func17.7()
  	/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/common/pods.go:574 +0x757
  k8s.io/kubernetes/vendor/github.com/onsi/ginkgo/internal/leafnodes.(*runner).runSync(0xc0002e2de0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
  	_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e.go:244 +0x237
  k8s.io/kubernetes/test/e2e.TestE2E(0xc001b2b400)
  	_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/e2e_test.go:96 +0x2b
  testing.tRunner(0xc001b2b400, 0x4d03688)
  	/usr/local/go/src/testing/testing.go:865 +0xc0
  created by testing.(*T).Run
  	/usr/local/go/src/testing/testing.go:916 +0x35a
```
These happen because the test creates an HTTP Request with a nil Header: https://github.com/kubernetes/kubernetes/blob/release-1.14/test/e2e/framework/util.go#L4221.

The test should not create requests with a nil header. I'll fix it in a separate PR. edit: https://github.com/kubernetes/kubernetes/pull/88064

But the exec auth plugin should also tolerate receiving requests with nil Headers. Hence this PR.

The 1.17+ version of this test doesn't panic because as of 1.17 all requests are given at least a User-Agent header: https://github.com/kubernetes/kubernetes/commit/300daa13a48044f8bb2b406c9289df2dae9ff0ed .

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**: See also https://stackoverflow.com/questions/41416017/assignment-to-entry-in-nil-map-when-using-http-header-with-echo-golang

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
