### PR TITLE
Fix golint errors in pkg/controller/garbagecollector

### DIFF
--- a/pkg/controller/garbagecollector/dump.go
+++ b/pkg/controller/garbagecollector/dump.go
@@ -122,6 +122,7 @@ namespace=%v
 	}
 }
 
+// NewGonumVertex creates a new gonumVertex.
 func NewGonumVertex(node *node, nodeID int64) *gonumVertex {
 	gv, err := schema.ParseGroupVersion(node.identity.APIVersion)
 	if err != nil {
@@ -140,6 +141,7 @@ func NewGonumVertex(node *node, nodeID int64) *gonumVertex {
 	}
 }
 
+// NewMissingGonumVertex creates a new gonumVertex.
 func NewMissingGonumVertex(ownerRef metav1.OwnerReference, nodeID int64) *gonumVertex {
 	gv, err := schema.ParseGroupVersion(ownerRef.APIVersion)
 	if err != nil {
@@ -242,6 +244,7 @@ func toGonumGraphForObj(uidToNode map[types.UID]*node, uids ...types.UID) graph.
 	return toGonumGraph(interestingNodes)
 }
 
+// NewDebugHandler creates a new debugHTTPHandler.
 func NewDebugHandler(controller *GarbageCollector) http.Handler {
 	return &debugHTTPHandler{controller: controller}
 }

--- a/pkg/controller/garbagecollector/garbagecollector.go
+++ b/pkg/controller/garbagecollector/garbagecollector.go
@@ -43,6 +43,7 @@ import (
 	_ "k8s.io/client-go/kubernetes"
 )
 
+// ResourceResyncTime defines the resync period of the garbage collector's informers.
 const ResourceResyncTime time.Duration = 0
 
 // GarbageCollector runs reflectors to watch for changes of managed API
@@ -70,6 +71,7 @@ type GarbageCollector struct {
 	workerLock sync.RWMutex
 }
 
+// NewGarbageCollector creates a new GarbageCollector.
 func NewGarbageCollector(
 	metadataClient metadata.Interface,
 	mapper resettableRESTMapper,
@@ -120,6 +122,7 @@ func (gc *GarbageCollector) resyncMonitors(deletableResources map[schema.GroupVe
 	return nil
 }
 
+// Run starts garbage collector workers.
 func (gc *GarbageCollector) Run(workers int, stopCh <-chan struct{}) {
 	defer utilruntime.HandleCrash()
 	defer gc.attemptToDelete.ShutDown()
@@ -272,6 +275,7 @@ func waitForStopOrTimeout(stopCh <-chan struct{}, timeout time.Duration) <-chan 
 	return stopChWithTimeout
 }
 
+// IsSynced returns true if dependencyGraphBuilder is synced.
 func (gc *GarbageCollector) IsSynced() bool {
 	return gc.dependencyGraphBuilder.IsSynced()
 }

--- a/pkg/controller/garbagecollector/garbagecollector_test.go
+++ b/pkg/controller/garbagecollector/garbagecollector_test.go
@@ -55,7 +55,7 @@ type testRESTMapper struct {
 	meta.RESTMapper
 }
 
-func (_ *testRESTMapper) Reset() {}
+func (*testRESTMapper) Reset() {}
 
 func TestGarbageCollectorConstruction(t *testing.T) {
 	config := &restclient.Config{}
@@ -928,16 +928,16 @@ type fakeServerResources struct {
 	InterfaceUsedCount int
 }
 
-func (_ *fakeServerResources) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+func (*fakeServerResources) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
 	return nil, nil
 }
 
 // Deprecated: use ServerGroupsAndResources instead.
-func (_ *fakeServerResources) ServerResources() ([]*metav1.APIResourceList, error) {
+func (*fakeServerResources) ServerResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
 }
 
-func (_ *fakeServerResources) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+func (*fakeServerResources) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
 	return nil, nil, nil
 }
 
@@ -966,6 +966,6 @@ func (f *fakeServerResources) getInterfaceUsedCount() int {
 	return f.InterfaceUsedCount
 }
 
-func (_ *fakeServerResources) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+func (*fakeServerResources) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
 	return nil, nil
 }

--- a/pkg/controller/garbagecollector/graph.go
+++ b/pkg/controller/garbagecollector/graph.go
@@ -98,32 +98,32 @@ func (n *node) isDeletingDependents() bool {
 	return n.deletingDependents
 }
 
-func (ownerNode *node) addDependent(dependent *node) {
-	ownerNode.dependentsLock.Lock()
-	defer ownerNode.dependentsLock.Unlock()
-	ownerNode.dependents[dependent] = struct{}{}
+func (n *node) addDependent(dependent *node) {
+	n.dependentsLock.Lock()
+	defer n.dependentsLock.Unlock()
+	n.dependents[dependent] = struct{}{}
 }
 
-func (ownerNode *node) deleteDependent(dependent *node) {
-	ownerNode.dependentsLock.Lock()
-	defer ownerNode.dependentsLock.Unlock()
-	delete(ownerNode.dependents, dependent)
+func (n *node) deleteDependent(dependent *node) {
+	n.dependentsLock.Lock()
+	defer n.dependentsLock.Unlock()
+	delete(n.dependents, dependent)
 }
 
-func (ownerNode *node) dependentsLength() int {
-	ownerNode.dependentsLock.RLock()
-	defer ownerNode.dependentsLock.RUnlock()
-	return len(ownerNode.dependents)
+func (n *node) dependentsLength() int {
+	n.dependentsLock.RLock()
+	defer n.dependentsLock.RUnlock()
+	return len(n.dependents)
 }
 
 // Note that this function does not provide any synchronization guarantees;
 // items could be added to or removed from ownerNode.dependents the moment this
 // function returns.
-func (ownerNode *node) getDependents() []*node {
-	ownerNode.dependentsLock.RLock()
-	defer ownerNode.dependentsLock.RUnlock()
+func (n *node) getDependents() []*node {
+	n.dependentsLock.RLock()
+	defer n.dependentsLock.RUnlock()
 	var ret []*node
-	for dep := range ownerNode.dependents {
+	for dep := range n.dependents {
 		ret = append(ret, dep)
 	}
 	return ret

--- a/pkg/controller/garbagecollector/graph_builder.go
+++ b/pkg/controller/garbagecollector/graph_builder.go
@@ -67,8 +67,8 @@ type event struct {
 	gvk    schema.GroupVersionKind
 }
 
-// GraphBuilder: based on the events supplied by the informers, GraphBuilder updates
-// uidToNode, a graph that caches the dependencies as we know, and enqueues
+// GraphBuilder processes events supplied by the informers, updates uidToNode,
+// a graph that caches the dependencies as we know, and enqueues
 // items to the attemptToDelete and attemptToOrphan.
 type GraphBuilder struct {
 	restMapper meta.RESTMapper

--- a/pkg/controller/garbagecollector/patch.go
+++ b/pkg/controller/garbagecollector/patch.go
@@ -92,6 +92,7 @@ type objectForFinalizersPatch struct {
 	ObjectMetaForFinalizersPatch `json:"metadata"`
 }
 
+// ObjectMetaForFinalizersPatch defines object meta struct for finalizers patch operation.
 type ObjectMetaForFinalizersPatch struct {
 	ResourceVersion string   `json:"resourceVersion"`
 	Finalizers      []string `json:"finalizers"`
@@ -101,6 +102,7 @@ type objectForPatch struct {
 	ObjectMetaForPatch `json:"metadata"`
 }
 
+// ObjectMetaForPatch defines object meta struct for patch operation.
 type ObjectMetaForPatch struct {
 	ResourceVersion string                  `json:"resourceVersion"`
 	OwnerReferences []metav1.OwnerReference `json:"ownerReferences"`


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This fixes golint errors in the following file:

    pkg/controller/garbagecollector/dump.go
    pkg/controller/garbagecollector/garbagecollector.go
    pkg/controller/garbagecollector/garbagecollector_test.go
    pkg/controller/garbagecollector/graph.go
    pkg/controller/garbagecollector/graph_builder.go
    pkg/controller/garbagecollector/patch.go

**Which issue(s) this PR fixes**:
Part of #68026

**Special notes for your reviewer**:
The pkg/controller/garbagecollector is still in .golint_failures list due to the following errors:

    pkg/controller/garbagecollector/dump.go:125:47: exported func NewGonumVertex returns unexported type *garbagecollector.gonumVertex, which can be annoying to use
    pkg/controller/garbagecollector/dump.go:143:74: exported func NewMissingGonumVertex returns unexported type *garbagecollector.gonumVertex, which can be annoying to use
I believe that gonumVertex is intentionally unexported.

    pkg/controller/garbagecollector/garbagecollector.go:619:1: comment on exported method GarbageCollector.GraphHasUID should be of the form "GraphHasUID ..."
I believe that this error a false positive.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
Errors from golint:
pkg/controller/garbagecollector/dump.go:125:1: exported function NewGonumVertex should have comment or be unexported
pkg/controller/garbagecollector/dump.go:143:1: exported function NewMissingGonumVertex should have comment or be unexported
pkg/controller/garbagecollector/dump.go:245:1: exported function NewDebugHandler should have comment or be unexported
pkg/controller/garbagecollector/garbagecollector.go:46:7: exported const ResourceResyncTime should have comment or be unexported
pkg/controller/garbagecollector/garbagecollector.go:73:1: exported function NewGarbageCollector should have comment or be unexported
pkg/controller/garbagecollector/garbagecollector.go:123:1: exported method GarbageCollector.Run should have comment or be unexported
pkg/controller/garbagecollector/garbagecollector.go:275:1: exported method GarbageCollector.IsSynced should have comment or be unexported
pkg/controller/garbagecollector/garbagecollector_test.go:58:1: receiver name should not be an underscore, omit the name if it is unused
pkg/controller/garbagecollector/garbagecollector_test.go:931:1: receiver name should not be an underscore, omit the name if it is unused
pkg/controller/garbagecollector/garbagecollector_test.go:936:1: receiver name should not be an underscore, omit the name if it is unused
pkg/controller/garbagecollector/garbagecollector_test.go:940:1: receiver name should not be an underscore, omit the name if it is unused
pkg/controller/garbagecollector/garbagecollector_test.go:969:1: receiver name should not be an underscore, omit the name if it is unused
pkg/controller/garbagecollector/graph_builder.go:70:1: comment on exported type GraphBuilder should be of the form "GraphBuilder ..." (with optional leading article)
pkg/controller/garbagecollector/graph.go:101:1: receiver name ownerNode should be consistent with previous receiver name n for node
pkg/controller/garbagecollector/graph.go:107:1: receiver name ownerNode should be consistent with previous receiver name n for node
pkg/controller/garbagecollector/graph.go:113:1: receiver name ownerNode should be consistent with previous receiver name n for node
pkg/controller/garbagecollector/graph.go:122:1: receiver name ownerNode should be consistent with previous receiver name n for node
pkg/controller/garbagecollector/patch.go:95:6: exported type ObjectMetaForFinalizersPatch should have comment or be unexported
pkg/controller/garbagecollector/patch.go:104:6: exported type ObjectMetaForPatch should have comment or be unexported
```
