### PR TITLE
Initialize http Request Header before RoundTrip to avoid panic

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1536,7 +1536,7 @@ func headersForConfig(c *restclient.Config, url *url.URL) (http.Header, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, err := rt.RoundTrip(&http.Request{URL: url}); err != nil {
+	if _, err := rt.RoundTrip(&http.Request{Header: make(http.Header), URL: url}); err != nil {
 		return nil, err
 	}
 	return extract.Header, nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**: This test panics if authenticated with a credential plugin https://kubernetes.io/docs/reference/access-authn-authz/authentication/#client-go-credential-plugins due to a bug in the credential plugin code (see https://github.com/kubernetes/kubernetes/pull/88060 for details) where it can try to write to a nil map.

To avoid this, make sure a nil map is never passed to RoundTrip in case it's the exec RoundTripper.

I guess this function is deliberately leaving Headers unset because its purpose is to find out what headers are added to an http request by wrappers and such so that websocket requests can then include the same headers. Anyway it's better to initialize Headers to an empty map instead of leaving it nil.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
