### PR TITLE
test/e2e/framework/:remove TODO and use framework.SingleCallTimeout

### DIFF
--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -54,7 +54,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	clientset "k8s.io/client-go/kubernetes"
-	scheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	"k8s.io/kubernetes/test/e2e/framework/testfiles"
@@ -113,11 +113,6 @@ const (
 
 	// poll is how often to Poll pods, nodes and claims.
 	poll = 2 * time.Second
-
-	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
-	// transient failures from failing tests.
-	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
-	singleCallTimeout = 5 * time.Minute
 )
 
 // TestLogger is an interface for log.
@@ -876,7 +871,7 @@ func getPortURL(client clientset.Interface, ns, name string, svcPort int) (strin
 	// unschedulable, since the master doesn't run kube-proxy. Without
 	// kube-proxy NodePorts won't work.
 	var nodes *v1.NodeList
-	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
+	if wait.PollImmediate(poll, framework.SingleCallTimeout, func() (bool, error) {
 		nodes, err = client.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{FieldSelector: fields.Set{
 			"spec.unschedulable": "false",
 		}.AsSelector().String()})

--- a/test/e2e/framework/kubelet/stats.go
+++ b/test/e2e/framework/kubelet/stats.go
@@ -216,7 +216,7 @@ func getNodeRuntimeOperationErrorRate(c clientset.Interface, node string) (NodeR
 
 // GetStatsSummary contacts kubelet for the container information.
 func GetStatsSummary(c clientset.Interface, nodeName string) (*kubeletstatsv1alpha1.Summary, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), e2emetrics.SingleCallTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), framework.SingleCallTimeout)
 	defer cancel()
 
 	data, err := c.CoreV1().RESTClient().Get().

--- a/test/e2e/framework/metrics/latencies.go
+++ b/test/e2e/framework/metrics/latencies.go
@@ -20,13 +20,6 @@ import (
 	"time"
 )
 
-const (
-	// SingleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
-	// transient failures from failing tests.
-	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
-	SingleCallTimeout = 5 * time.Minute
-)
-
 // PodLatencyData encapsulates pod startup latency information.
 type PodLatencyData struct {
 	// Name of the pod

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -41,7 +41,6 @@ const (
 
 	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
-	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
 	singleCallTimeout = 5 * time.Minute
 
 	// ssh port

--- a/test/e2e/framework/pod/wait.go
+++ b/test/e2e/framework/pod/wait.go
@@ -61,7 +61,6 @@ const (
 
 	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
-	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
 	singleCallTimeout = 5 * time.Minute
 
 	// Some pods can take much longer to get ready due to volume attach/detach latency.

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -46,7 +46,6 @@ const (
 
 	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
-	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
 	singleCallTimeout = 5 * time.Minute
 )
 

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -125,7 +125,6 @@ const (
 
 	// SingleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
 	// transient failures from failing tests.
-	// TODO: client should not apply this timeout to Watch calls. Increased from 30s until that is fixed.
 	SingleCallTimeout = 5 * time.Minute
 
 	// NodeReadyInitialTimeout is how long nodes have to be "ready" when a test begins. They should already


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:https://github.com/kubernetes/kubernetes/issues/86763

**Special notes for your reviewer**:

this constant singleCallTimeout seems to be used in a lot of *.go files in test/e2e/framework
```
e2e/framework/util.go:	// SingleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/util.go:	SingleCallTimeout = 5 * time.Minute
e2e/framework/ssh/ssh.go:	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/ssh/ssh.go:	singleCallTimeout = 5 * time.Minute
e2e/framework/ssh/ssh.go:	if wait.PollImmediate(pollNodeInterval, singleCallTimeout, func() (bool, error) {
e2e/framework/metrics/latencies.go:	// SingleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/metrics/latencies.go:	SingleCallTimeout = 5 * time.Minute
e2e/framework/pod/resource.go:		ctx, cancel := context.WithTimeout(context.Background(), singleCallTimeout)
e2e/framework/pod/wait.go:	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/pod/wait.go:	singleCallTimeout = 5 * time.Minute
e2e/framework/node/resource.go:	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/node/resource.go:	singleCallTimeout = 5 * time.Minute
e2e/framework/node/wait.go:	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
e2e/framework/kubelet/stats.go:	ctx, cancel := context.WithTimeout(context.Background(), e2emetrics.SingleCallTimeout)
e2e/framework/ingress/ingress_utils.go:	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/ingress/ingress_utils.go:	singleCallTimeout = 5 * time.Minute
e2e/framework/ingress/ingress_utils.go:	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
e2e/framework/resource_usage_gatherer.go:	ctx, cancel := context.WithTimeout(context.Background(), SingleCallTimeout)
``` 

SingleCallTimeout is 5 minutes, i think that the TODO can be safely removed now.
we can use framework.SingleCallTimeout  in these files not to redefine this same variable again.

but 
```
e2e/framework/ssh/ssh.go:	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/ssh/ssh.go:	singleCallTimeout = 5 * time.Minute
e2e/framework/ssh/ssh.go:	if wait.PollImmediate(pollNodeInterval, singleCallTimeout, func() (bool, error) {
e2e/framework/pod/resource.go:		ctx, cancel := context.WithTimeout(context.Background(), singleCallTimeout)
e2e/framework/pod/wait.go:	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/pod/wait.go:	singleCallTimeout = 5 * time.Minute
e2e/framework/node/resource.go:	// singleCallTimeout is how long to try single API calls (like 'get' or 'list'). Used to prevent
e2e/framework/node/resource.go:	singleCallTimeout = 5 * time.Minute
e2e/framework/node/wait.go:	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
```
we can't use it due to  it will cause import circular dependency problems.
so,keep it and I can update other files

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
