### PR TITLE
Deprecate PodUnknown phase as it isn't being set anymore.

### DIFF
--- a/pkg/apis/core/types.go
+++ b/pkg/apis/core/types.go
@@ -2226,6 +2226,7 @@ const (
 	PodFailed PodPhase = "Failed"
 	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
 	// to an error in communicating with the host of the pod.
+	// Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
 	PodUnknown PodPhase = "Unknown"
 )
 

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2429,6 +2429,7 @@ const (
 	PodFailed PodPhase = "Failed"
 	// PodUnknown means that for some reason the state of the pod could not be obtained, typically due
 	// to an error in communicating with the host of the pod.
+	// Deprecated: It isn't being set since 2015 (74da3b14b0c0f658b3bb8d2def5094686d0e9095)
 	PodUnknown PodPhase = "Unknown"
 )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind deprecation

**What this PR does / why we need it**:
Since the end of pod cache in 2015 nothing is actually setting pod phase to PodUnknown. Traced this back to https://github.com/kubernetes/kubernetes/commit/74da3b14b0c0f658b3bb8d2def5094686d0e9095 .  Users and developers are confused to how it can get into such state. The deprecation makes it clear it is not being used anymore and gives us the option to remove it in the future.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
PodUnknown phase is now deprecated.
```

@kubernetes/sig-node-api-reviews @rphillips 