### PR TITLE
Extended CRD Validation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -67,6 +67,7 @@ properties:
     x-kubernetes-list-map-keys: ["a", "b"]
     items:
       type: object
+      required: ["a", "b"]
       properties:
         a:
           type: integer
@@ -86,6 +87,7 @@ properties:
     x-kubernetes-list-map-keys: ["a", "b"]
     items:
       type: object
+      required: ["a", "b"]
       properties:
         a:
           type: integer
@@ -106,9 +108,9 @@ kind: Foo
 apiVersion: tests.example.com/v1beta1
 metadata:
   name: foo
-correct-map: [{"a":1,"b":1,c:"1"},{"a":1,"b":2,c:"2"},{"a":1,c:"3"}]
+correct-map: [{"a":1,"b":1,c:"1"},{"a":1,"b":2,c:"2"},{"a":1,"b":3,c:"3"}]
 correct-set: [{"a":1,"b":1},{"a":1,"b":2},{"a":1},{"a":1,"b":4}]
-invalid-map: [{"a":1,"b":1,c:"1"},{"a":1,"b":2,c:"2"},{"a":1,c:"3"},{"a":1,"b":1,c:"4"}]
+invalid-map: [{"a":1,"b":1,c:"1"},{"a":1,"b":2,c:"2"},{"a":1,"b":3,c:"3"},{"a":1,"b":1,c:"4"}]
 invalid-set: [{"a":1,"b":1},{"a":1,"b":2},{"a":1},{"a":1,"b":4},{"a":1,"b":1}]
 `
 )

--- a/test/integration/apiserver/apply/apply_crd_test.go
+++ b/test/integration/apiserver/apply/apply_crd_test.go
@@ -191,12 +191,12 @@ func TestApplyCRDStructuralSchema(t *testing.T) {
 										"type": "string"
 									},
 									"protocol": {
-										"type": "string",
-										"nullable": true
+										"type": "string"
 									}
 								},
 								"required": [
-									"containerPort"
+									"containerPort",
+									"protocol"
 								],
 								"type": "object"
 							}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

CRD schemas that define map or set keys must follow:
1) Key fields have default if they are not required
2) Key fields are not nullable
3) The whole map item must not be nullable.
4) The whole set item must not be nullable.

On update of a CRD we first check that these 3 rules are fulfilled. If not, we know that we have an old CRD in front of us that didn't know about these restriction yet. We then don't require them to apply. But if they are fulfilled, they must stay fulfilled on update.

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

Work towards https://github.com/kubernetes/kubernetes/issues/84724 (together with https://github.com/kubernetes/kubernetes/pull/84920).

Slack discussion: https://kubernetes.slack.com/archives/C0EG7JC6T/p1579697545127700

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CustomResourceDefinition schemas that use `x-kubernetes-list-map-keys` to specify properties that uniquely identify list items must make those properties required or have a default value, to ensure those properties are present for all list items. See https://kubernetes.io/docs/reference/using-api/api-concepts/#merge-strategy for details.
```
