### PR TITLE
Set up connection onClose prior to adding to connection map

### DIFF
--- a/staging/src/k8s.io/client-go/util/connrotation/connrotation.go
+++ b/staging/src/k8s.io/client-go/util/connrotation/connrotation.go
@@ -77,11 +77,6 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 
 	closable := &closableConn{Conn: conn}
 
-	// Start tracking the connection
-	d.mu.Lock()
-	d.conns[closable] = struct{}{}
-	d.mu.Unlock()
-
 	// When the connection is closed, remove it from the map. This will
 	// be no-op if the connection isn't in the map, e.g. if CloseAll()
 	// is called.
@@ -90,6 +85,11 @@ func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.
 		delete(d.conns, closable)
 		d.mu.Unlock()
 	}
+
+	// Start tracking the connection
+	d.mu.Lock()
+	d.conns[closable] = struct{}{}
+	d.mu.Unlock()
 
 	return closable, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Ensures all connections opened by the connrotation utility have a non-nil onClose method prior to assigning them to the connection map.

**Which issue(s) this PR fixes**:
Fixes #88063

**Does this PR introduce a user-facing change?**:
```release-note
Fixes kubelet crash in client certificate rotation cases
```

/assign @awly 
/sig auth node