### PR TITLE
Fix gce-cos-master-reboot test

### DIFF
--- a/test/e2e/cloud/gcp/reboot.go
+++ b/test/e2e/cloud/gcp/reboot.go
@@ -114,7 +114,22 @@ var _ = SIGDescribe("Reboot [Disruptive] [Feature:Reboot]", func() {
 	ginkgo.It("each node by switching off the network interface and ensure they function upon switch on", func() {
 		// switch the network interface off for a while to simulate a network outage
 		// We sleep 10 seconds to give some time for ssh command to cleanly finish before network is down.
-		testReboot(f.ClientSet, "nohup sh -c 'sleep 10 && sudo ip link set eth0 down && sleep 120 && sudo ip link set eth0 up && (sudo dhclient || true)' >/dev/null 2>&1 &", nil)
+		cmd := "nohup sh -c '" +
+			"sleep 10; " +
+			"echo Shutting down eth0 | sudo tee /dev/kmsg; " +
+			"sudo ip link set eth0 down | sudo tee /dev/kmsg; " +
+			"sleep 120; " +
+			"echo Starting up eth0 | sudo tee /dev/kmsg; " +
+			"sudo ip link set eth0 up | sudo tee /dev/kmsg; " +
+			"sleep 10; " +
+			"echo Retrying starting up eth0 | sudo tee /dev/kmsg; " +
+			"sudo ip link set eth0 up | sudo tee /dev/kmsg; " +
+			"echo Running dhclient | sudo tee /dev/kmsg; " +
+			"sudo dhclient | sudo tee /dev/kmsg; " +
+			"echo Starting systemd-networkd | sudo tee /dev/kmsg; " +
+			"sudo systemctl restart systemd-networkd | sudo tee /dev/kmsg" +
+			"' >/dev/null 2>&1 &"
+		testReboot(f.ClientSet, cmd, nil)
 	})
 
 	ginkgo.It("each node by dropping all inbound packets for a while and ensure they function afterwards", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Adding additional steps to network restart to ensure it restarts.
Also directing output to serial port to make the test debuggable.

**Which issue(s) this PR fixes**:
Fixes #86787 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
