### PR TITLE
Graduate PodTopologySpread to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -503,7 +503,7 @@ const (
 	EndpointSliceProxying featuregate.Feature = "EndpointSliceProxying"
 
 	// owner: @Huang-Wei
-	// alpha: v1.16
+	// beta: v1.18
 	//
 	// Schedule pods evenly across available topology domains.
 	EvenPodsSpread featuregate.Feature = "EvenPodsSpread"
@@ -618,7 +618,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	IPv6DualStack:                                  {Default: false, PreRelease: featuregate.Alpha},
 	EndpointSlice:                                  {Default: true, PreRelease: featuregate.Beta},
 	EndpointSliceProxying:                          {Default: false, PreRelease: featuregate.Alpha},
-	EvenPodsSpread:                                 {Default: false, PreRelease: featuregate.Alpha},
+	EvenPodsSpread:                                 {Default: true, PreRelease: featuregate.Beta},
 	StartupProbe:                                   {Default: true, PreRelease: featuregate.Beta},
 	AllowInsecureBackendProxy:                      {Default: true, PreRelease: featuregate.Beta},
 	PodDisruptionBudget:                            {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/scheduler/algorithmprovider/registry_test.go
+++ b/pkg/scheduler/algorithmprovider/registry_test.go
@@ -56,6 +56,7 @@ func TestClusterAutoscalerProvider(t *testing.T) {
 				{Name: noderesources.FitName},
 				{Name: nodeports.Name},
 				{Name: interpodaffinity.Name},
+				{Name: podtopologyspread.Name},
 			},
 		},
 		Filter: &schedulerapi.PluginSet{
@@ -74,6 +75,7 @@ func TestClusterAutoscalerProvider(t *testing.T) {
 				{Name: volumebinding.Name},
 				{Name: volumezone.Name},
 				{Name: interpodaffinity.Name},
+				{Name: podtopologyspread.Name},
 			},
 		},
 		PreScore: &schedulerapi.PluginSet{
@@ -81,6 +83,7 @@ func TestClusterAutoscalerProvider(t *testing.T) {
 				{Name: interpodaffinity.Name},
 				{Name: defaultpodtopologyspread.Name},
 				{Name: tainttoleration.Name},
+				{Name: podtopologyspread.Name},
 			},
 		},
 		Score: &schedulerapi.PluginSet{
@@ -93,6 +96,7 @@ func TestClusterAutoscalerProvider(t *testing.T) {
 				{Name: nodepreferavoidpods.Name, Weight: 10000},
 				{Name: defaultpodtopologyspread.Name, Weight: 1},
 				{Name: tainttoleration.Name, Weight: 1},
+				{Name: podtopologyspread.Name, Weight: 1},
 			},
 		},
 		Bind: &schedulerapi.PluginSet{

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -1423,6 +1423,7 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 			{Name: "NodeResourcesFit"},
 			{Name: "NodePorts"},
 			{Name: "InterPodAffinity"},
+			{Name: "PodTopologySpread"},
 		},
 		"FilterPlugin": {
 			{Name: "NodeUnschedulable"},
@@ -1439,11 +1440,13 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 			{Name: "VolumeBinding"},
 			{Name: "VolumeZone"},
 			{Name: "InterPodAffinity"},
+			{Name: "PodTopologySpread"},
 		},
 		"PreScorePlugin": {
 			{Name: "InterPodAffinity"},
 			{Name: "DefaultPodTopologySpread"},
 			{Name: "TaintToleration"},
+			{Name: "PodTopologySpread"},
 		},
 		"ScorePlugin": {
 			{Name: "NodeResourcesBalancedAllocation", Weight: 1},
@@ -1454,6 +1457,7 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 			{Name: "NodePreferAvoidPods", Weight: 10000},
 			{Name: "DefaultPodTopologySpread", Weight: 1},
 			{Name: "TaintToleration", Weight: 1},
+			{Name: "PodTopologySpread", Weight: 1},
 		},
 		"BindPlugin": {{Name: "DefaultBinder"}},
 	}
@@ -1483,6 +1487,7 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 					{Name: "NodeResourcesFit"},
 					{Name: "NodePorts"},
 					{Name: "InterPodAffinity"},
+					{Name: "PodTopologySpread"},
 				},
 				"FilterPlugin": {
 					{Name: "NodeUnschedulable"},
@@ -1499,11 +1504,13 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 					{Name: "VolumeBinding"},
 					{Name: "VolumeZone"},
 					{Name: "InterPodAffinity"},
+					{Name: "PodTopologySpread"},
 				},
 				"PreScorePlugin": {
 					{Name: "InterPodAffinity"},
 					{Name: "DefaultPodTopologySpread"},
 					{Name: "TaintToleration"},
+					{Name: "PodTopologySpread"},
 				},
 				"ScorePlugin": {
 					{Name: "NodeResourcesBalancedAllocation", Weight: 1},
@@ -1514,6 +1521,7 @@ func TestAlgorithmProviderCompatibility(t *testing.T) {
 					{Name: "NodePreferAvoidPods", Weight: 10000},
 					{Name: "DefaultPodTopologySpread", Weight: 1},
 					{Name: "TaintToleration", Weight: 1},
+					{Name: "PodTopologySpread", Weight: 1},
 				},
 				"BindPlugin": {{Name: "DefaultBinder"}},
 			},

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -105,6 +105,7 @@ func TestSchedulerCreationFromConfigMap(t *testing.T) {
 				"PreFilterPlugin": {
 					{Name: "NodeResourcesFit"},
 					{Name: "NodePorts"},
+					{Name: "PodTopologySpread"},
 					{Name: "InterPodAffinity"},
 				},
 				"FilterPlugin": {
@@ -121,15 +122,18 @@ func TestSchedulerCreationFromConfigMap(t *testing.T) {
 					{Name: "AzureDiskLimits"},
 					{Name: "VolumeBinding"},
 					{Name: "VolumeZone"},
+					{Name: "PodTopologySpread"},
 					{Name: "InterPodAffinity"},
 				},
 				"PreScorePlugin": {
+					{Name: "PodTopologySpread"},
 					{Name: "InterPodAffinity"},
 					{Name: "DefaultPodTopologySpread"},
 					{Name: "TaintToleration"},
 				},
 				"ScorePlugin": {
 					{Name: "NodeResourcesBalancedAllocation", Weight: 1},
+					{Name: "PodTopologySpread", Weight: 1},
 					{Name: "ImageLocality", Weight: 1},
 					{Name: "InterPodAffinity", Weight: 1},
 					{Name: "NodeResourcesLeastAllocated", Weight: 1},
@@ -191,6 +195,7 @@ kind: Policy
 				"PreFilterPlugin": {
 					{Name: "NodeResourcesFit"},
 					{Name: "NodePorts"},
+					{Name: "PodTopologySpread"},
 					{Name: "InterPodAffinity"},
 				},
 				"FilterPlugin": {
@@ -207,15 +212,18 @@ kind: Policy
 					{Name: "AzureDiskLimits"},
 					{Name: "VolumeBinding"},
 					{Name: "VolumeZone"},
+					{Name: "PodTopologySpread"},
 					{Name: "InterPodAffinity"},
 				},
 				"PreScorePlugin": {
+					{Name: "PodTopologySpread"},
 					{Name: "InterPodAffinity"},
 					{Name: "DefaultPodTopologySpread"},
 					{Name: "TaintToleration"},
 				},
 				"ScorePlugin": {
 					{Name: "NodeResourcesBalancedAllocation", Weight: 1},
+					{Name: "PodTopologySpread", Weight: 1},
 					{Name: "ImageLocality", Weight: 1},
 					{Name: "InterPodAffinity", Weight: 1},
 					{Name: "NodeResourcesLeastAllocated", Weight: 1},


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

This PR includes the necessary change to enable featuregate `EvenPodsSpread` to be beta, by default. Additionally, e2e tests covering basic happy paths have been added.

- [x] Enable PodTopologySpread in `kube_features.go`
- [x] PreFilter & Filter
- [x] PreScore & Score
- [x] Preemption 

**Which issue(s) this PR fixes**:

Fixes #88168

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
The feature PodTopologySpread (featuregate `EvenPodsSpread`) has been enabled by default in 1.18.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
 - [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20190221-pod-topology-spread.md
```
