### PR TITLE
 kubeadm-flags.env contains deprecated kubelet flags

### DIFF
--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/flags_test.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_test.go
@@ -165,7 +165,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"network-plugin": "cni",
-				"cgroup-driver":  "systemd",
 			},
 		},
 		{
@@ -179,7 +178,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"network-plugin": "cni",
-				"cgroup-driver":  "cgroupfs",
 			},
 		},
 		{
@@ -236,7 +234,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			expected: map[string]string{
 				"container-runtime":          "remote",
 				"container-runtime-endpoint": "/var/run/containerd.sock",
-				"resolv-conf":                "/run/systemd/resolve/resolv.conf",
 			},
 		},
 		{
@@ -251,7 +248,6 @@ func TestBuildKubeletArgMap(t *testing.T) {
 			},
 			expected: map[string]string{
 				"network-plugin":            "cni",
-				"cgroup-driver":             "cgroupfs",
 				"pod-infra-container-image": "gcr.io/pause:3.1",
 			},
 		},


### PR DESCRIPTION
kubeadm-flags.env contains deprecated kubelet flags
Refs: https://github.com/kubernetes/kubeadm/issues/949