### PR TITLE
Update Release Engineering OWNERS

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -121,7 +121,6 @@ aliases:
     - justaugustus # SIG Chair
     - tpepper # SIG Chair / Patch Release Team
   release-engineering-reviewers:
-    - aleksandra-malinowska # Patch Release Team
     - calebamiles # SIG Chair
     - cpanato # Branch Manager
     - feiskyer # Patch Release Team

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -123,9 +123,11 @@ aliases:
   release-engineering-reviewers:
     - aleksandra-malinowska # Patch Release Team
     - calebamiles # SIG Chair
+    - cpanato # Branch Manager
     - feiskyer # Patch Release Team
     - hoegaarden # Patch Release Team
     - justaugustus # SIG Chair
+    - saschagrunert # Branch Manager
     - tpepper # SIG Chair / Patch Release Team
 
   sig-storage-reviewers:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
- Add Branch Managers to release-engineering-reviewers
- Remove aleksandra-malinowska from Patch Release Team (https://github.com/kubernetes/sig-release/issues/987)

/assign @tpepper @calebamiles @liggitt 
cc: @kubernetes/release-engineering 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
