### PR TITLE
Prefer apps version over deprecated extensions

### DIFF
--- a/cmd/kube-apiserver/app/aggregator.go
+++ b/cmd/kube-apiserver/app/aggregator.go
@@ -247,10 +247,6 @@ type priority struct {
 // That ripples out every bit as far as you'd expect, so for 1.7 we'll include the list here instead of being built up during storage.
 var apiVersionPriorities = map[schema.GroupVersion]priority{
 	{Group: "", Version: "v1"}: {group: 18000, version: 1},
-	// extensions is above the rest for CLI compatibility, though the level of unqualified resource compatibility we
-	// can reasonably expect seems questionable.
-	{Group: "extensions", Version: "v1beta1"}: {group: 17900, version: 1},
-	// to my knowledge, nothing below here collides
 	{Group: "apps", Version: "v1"}:                               {group: 17800, version: 15},
 	{Group: "events.k8s.io", Version: "v1beta1"}:                 {group: 17750, version: 5},
 	{Group: "authentication.k8s.io", Version: "v1"}:              {group: 17700, version: 15},
@@ -264,6 +260,7 @@ var apiVersionPriorities = map[schema.GroupVersion]priority{
 	{Group: "batch", Version: "v1beta1"}:                         {group: 17400, version: 9},
 	{Group: "batch", Version: "v2alpha1"}:                        {group: 17400, version: 9},
 	{Group: "certificates.k8s.io", Version: "v1beta1"}:           {group: 17300, version: 9},
+	{Group: "extensions", Version: "v1beta1"}:                    {group: 17250, version: 1},
 	{Group: "networking.k8s.io", Version: "v1"}:                  {group: 17200, version: 15},
 	{Group: "networking.k8s.io", Version: "v1beta1"}:             {group: 17200, version: 9},
 	{Group: "policy", Version: "v1beta1"}:                        {group: 17100, version: 9},

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -413,6 +413,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 	// TODO: describe the priority all the way down in the RESTStorageProviders and plumb it back through the various discovery
 	// handlers that we have.
 	restStorageProviders := []RESTStorageProvider{
+		appsrest.RESTStorageProvider{},
 		auditregistrationrest.RESTStorageProvider{},
 		authenticationrest.RESTStorageProvider{Authenticator: c.GenericConfig.Authentication.Authenticator, APIAudiences: c.GenericConfig.Authentication.APIAudiences},
 		authorizationrest.RESTStorageProvider{Authorizer: c.GenericConfig.Authorization.Authorizer, RuleResolver: c.GenericConfig.RuleResolver},
@@ -430,9 +431,6 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		settingsrest.RESTStorageProvider{},
 		storagerest.RESTStorageProvider{},
 		flowcontrolrest.RESTStorageProvider{},
-		// keep apps after extensions so legacy clients resolve the extensions versions of shared resource names.
-		// See https://github.com/kubernetes/kubernetes/issues/42392
-		appsrest.RESTStorageProvider{},
 		admissionregistrationrest.RESTStorageProvider{},
 		eventsrest.RESTStorageProvider{TTL: c.ExtraConfig.EventTTL},
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Due to backwards compatibility issues (https://github.com/kubernetes/kubernetes/issues/42392)
introduced in 1.6 when adding new API group we've set extensions to be preferred group over apps
(https://github.com/kubernetes/kubernetes/pull/43553/).

Now that extensions is entirely deprecated (https://github.com/kubernetes/kubernetes/issues/43214) it's time to revert this change and prefer correct API groups.

**Special notes for your reviewer**:
/assign @deads2k @liggitt 

**Does this PR introduce a user-facing change?**:
```release-note
Prefer apps over extensions in discovery
```
