### PR TITLE
version/verflag: support JSON and YAML output format

### DIFF
--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -17,6 +17,7 @@ require (
 	k8s.io/client-go v0.0.0
 	k8s.io/klog v1.0.0
 	k8s.io/utils v0.0.0-20200229041039-0a110f9eb7ab
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (

--- a/staging/src/k8s.io/component-base/version/verflag/BUILD
+++ b/staging/src/k8s.io/component-base/version/verflag/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Implement support for printing out rich version information in JSON or
YAML format, similar to what kubectl, kubeadm et al. have. The
'--version' command line flag now supports two new values, namely 'json'
and 'yaml', that enable the new output formats.

**Which issue(s) this PR fixes**:
Fixes #86779

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The --version flag can be set to 'json' or 'yaml' in order to print out rich version information in JSON or YAML format, respectively. An example:
$ kubelet --version=json
{
    "major": "1",
    "minor": "18",
    "gitVersion": "v1.18.0-alpha.5.30+9c2e343fc26ab5",
    "gitCommit": "9c2e343fc26ab5c05e8e9e51e0d409073777ac2a",
    "gitTreeState": "clean",
    "buildDate": "2020-02-13T16:44:58Z",
    "goVersion": "go1.13.7",
    "compiler": "gc",
    "platform": "linux/amd64"
  }
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
