### PR TITLE
Switch flexvolume_node_setup.sh from kubelet RO port to healthz port

### DIFF
--- a/cluster/gce/gci/flexvolume_node_setup.sh
+++ b/cluster/gce/gci/flexvolume_node_setup.sh
@@ -56,10 +56,10 @@ umount_silent() {
 # Waits for kubelet to restart for 1 minute.
 kubelet_wait() {
   timeout=60
-  kubelet_readonly_port=10255
+  healthz_port=10248
   until [[ $timeout -eq 0 ]]; do
     printf "."
-    if [[ $( curl -s http://localhost:${kubelet_readonly_port}/healthz ) == "ok" ]]; then
+    if [[ $( curl -s http://localhost:${healthz_port}/healthz ) == "ok" ]]; then
       return 0
     fi
     sleep 1


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Move flexvolume_node_setup.sh script off the kubelet read only port to the healthz port.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
