### PR TITLE
Update Abdullah as the scheduling feature approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -456,7 +456,7 @@ aliases:
     - andrewsykim     # Cloud Provider
     - bgrant0607      # Architecture
     - brancz          # Instrumentation
-    - bsalamat        # Scheduling
+    - ahg-g           # Scheduling
     - calebamiles     # Release
     - caseydavenport  # Network
     - countspongebob  # Scalability


### PR DESCRIPTION
/kind cleanup
/sig scheduling

Update Abdullah as the scheduling feature approver, then we don't need to bother Bobby for approving `pkg/features/kube_features.go`.

/assign @liggitt 
cc/ @ahg-g  

```release-note
NONE
```