### PR TITLE
Shrink mutation detection critical section

### DIFF
--- a/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
+++ b/staging/src/k8s.io/client-go/tools/cache/mutation_detector.go
@@ -68,7 +68,13 @@ type defaultCacheMutationDetector struct {
 	name   string
 	period time.Duration
 
-	lock       sync.Mutex
+	// compareLock ensures only a single call to CompareObjects runs at a time
+	compareObjectsLock sync.Mutex
+
+	// addLock guards addedObjs between AddObject and CompareObjects
+	addedObjsLock sync.Mutex
+	addedObjs     []cacheObj
+
 	cachedObjs []cacheObj
 
 	retainDuration     time.Duration
@@ -118,15 +124,22 @@ func (d *defaultCacheMutationDetector) AddObject(obj interface{}) {
 	if obj, ok := obj.(runtime.Object); ok {
 		copiedObj := obj.DeepCopyObject()
 
-		d.lock.Lock()
-		defer d.lock.Unlock()
-		d.cachedObjs = append(d.cachedObjs, cacheObj{cached: obj, copied: copiedObj})
+		d.addedObjsLock.Lock()
+		defer d.addedObjsLock.Unlock()
+		d.addedObjs = append(d.addedObjs, cacheObj{cached: obj, copied: copiedObj})
 	}
 }
 
 func (d *defaultCacheMutationDetector) CompareObjects() {
-	d.lock.Lock()
-	defer d.lock.Unlock()
+	d.compareObjectsLock.Lock()
+	defer d.compareObjectsLock.Unlock()
+
+	// move addedObjs into cachedObjs under lock
+	// this keeps the critical section small to avoid blocking AddObject while we compare cachedObjs
+	d.addedObjsLock.Lock()
+	d.cachedObjs = append(d.cachedObjs, d.addedObjs...)
+	d.addedObjs = nil
+	d.addedObjsLock.Unlock()
 
 	altered := false
 	for i, obj := range d.cachedObjs {


### PR DESCRIPTION
We run the mutation detector in test jobs to ensure no shared informers event handlers mutate shared objects.

The detector intercepts every informer add/update call, and synchronously adds the incoming object to a list along with a deepcopy of the original. Periodically, it iterates over that list and compares the original and copied objects.

Even though we flush that list periodically, that comparison can take a long time under load and when the list is large (O(seconds) in peak parallel e2e jobs). Currently, AddObject blocks while that comparison is happening.

This PR detaches AddObject from the expensive comparison to avoid blocking informers.

Prior to this PR, tracing showed many AddObject calls were delayed more than 100ms, some significantly:

  | apiserver | controller-manager
-- | -- | --
AddObject calls delayed over 100ms | 767 | 1,867
P50 of AddObject over 100ms | 0.855s | 0.677s
P90 of AddObject over 100ms | 2.806s | 2.454s
P99 of AddObject over 100ms | 4.345s | 4.522
max AddObject delay | 5.873s | 6.454s

After this PR, no calls to AddObject were delayed enough to show up in tracing at 10ms.

```release-note
NONE
```