### PR TITLE
Cleanup --dry-run values in tests, docs, and scripts

### DIFF
--- a/cluster/gce/upgrade.sh
+++ b/cluster/gce/upgrade.sh
@@ -518,7 +518,7 @@ function update-coredns-config() {
   if test "$(printf '%s\n' ${CURRENT_COREDNS_VERSION} ${NEW_COREDNS_VERSION} | sort -V | head -n 1)" != ${NEW_COREDNS_VERSION}; then
      echo "== Upgrading the CoreDNS ConfigMap =="
      ${download_dir}/corefile-tool-${host_arch} migrate --from ${CURRENT_COREDNS_VERSION} --to ${NEW_COREDNS_VERSION} --corefile ${download_dir}/Corefile-old > ${download_dir}/Corefile
-     ${KUBE_ROOT}/cluster/kubectl.sh -n kube-system create configmap coredns --from-file ${download_dir}/Corefile -o yaml --dry-run | ${KUBE_ROOT}/cluster/kubectl.sh apply -f -
+     ${KUBE_ROOT}/cluster/kubectl.sh -n kube-system create configmap coredns --from-file ${download_dir}/Corefile -o yaml --dry-run=client | ${KUBE_ROOT}/cluster/kubectl.sh apply -f -
   else
      # In case of a downgrade, a custom CoreDNS Corefile will be overwritten by a default Corefile. In that case,
      # the user will need to manually modify the resulting (default) Corefile after the downgrade is complete.

--- a/pkg/kubectl/cmd/auth/reconcile.go
+++ b/pkg/kubectl/cmd/auth/reconcile.go
@@ -104,9 +104,9 @@ func NewCmdReconcile(f cmdutil.Factory, streams genericclioptions.IOStreams) *co
 	o.PrintFlags.AddFlags(cmd)
 
 	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, "identifying the resource to reconcile.")
-	cmd.Flags().BoolVar(&o.DryRun, "dry-run", o.DryRun, "If true, display results but do not submit changes")
 	cmd.Flags().BoolVar(&o.RemoveExtraPermissions, "remove-extra-permissions", o.RemoveExtraPermissions, "If true, removes extra permissions added to roles")
 	cmd.Flags().BoolVar(&o.RemoveExtraSubjects, "remove-extra-subjects", o.RemoveExtraSubjects, "If true, removes extra subjects added to rolebindings")
+	cmdutil.AddDryRunFlag(cmd)
 
 	return cmd
 }
@@ -120,6 +120,8 @@ func (o *ReconcileOptions) Complete(cmd *cobra.Command, f cmdutil.Factory, args 
 	if len(args) > 0 {
 		return errors.New("no arguments are allowed")
 	}
+
+	o.DryRun = getClientSideDryRun(cmd)
 
 	namespace, enforceNamespace, err := f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
@@ -327,4 +329,15 @@ func (o *ReconcileOptions) printResults(object runtime.Object,
 			}
 		}
 	}
+}
+
+func getClientSideDryRun(cmd *cobra.Command) bool {
+	dryRunStrategy, err := cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		klog.Fatalf("error accessing --dry-run flag for command %s: %v", cmd.Name(), err)
+	}
+	if dryRunStrategy == cmdutil.DryRunServer {
+		klog.Fatalf("--dry-run=server for command %s is not supported yet", cmd.Name())
+	}
+	return dryRunStrategy == cmdutil.DryRunClient
 }

--- a/staging/src/k8s.io/kubectl/docs/book/pages/imperative_porcelain/creating_resources.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/imperative_porcelain/creating_resources.md
@@ -83,8 +83,8 @@ kubectl create secret generic my-secret --from-file=path/to/bar
 {% endmethod %}
 
 {% panel style="success", title="Bootstrapping Config" %}
-Imperative commands can be used to bootstrap config by using `--dry-run -o yaml`.
-`kubectl create secret generic my-secret --from-file=path/to/bar --dry-run -o yaml`
+Imperative commands can be used to bootstrap config by using `--dry-run=client -o yaml`.
+`kubectl create secret generic my-secret --from-file=path/to/bar --dry-run=client -o yaml`
 {% endpanel %}
 
 {% method %}

--- a/staging/src/k8s.io/kubectl/docs/book/pages/imperative_porcelain/introduction.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/imperative_porcelain/introduction.md
@@ -9,7 +9,7 @@ use cases, imperative porcelain commands may be helpful for development or debug
 issues.  These commands are particularly helpful for learning about Kubernetes when coming
 from an imperative system.
 
-**Note:** Some imperative commands can be run with `--dry-run -o yaml` to display the declarative
+**Note:** Some imperative commands can be run with `--dry-run=client -o yaml` to display the declarative
 form.
 
 This section describes imperative commands that will generate or patch Resource Config.

--- a/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
@@ -29,7 +29,7 @@ List the Kubernetes *Deployment* Resources that are in the kube-system namespace
 ```bash
 kubectl get deployments --namespace kube-system
 ```
- 
+
 ```bash
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 event-exporter-v0.2.3    1         1         1            1           14d
@@ -51,7 +51,7 @@ Print detailed information about the kube-dns Deployment in the kube-system name
 ```bash
 kubectl describe deployment kube-dns --namespace kube-system
 ```
-   
+
 ```bash
 Name:                   kube-dns
 Namespace:              kube-system
@@ -126,7 +126,7 @@ due to the serialization process of go objects.
 
 {% sample lang="yaml" %}
 ```bash
-kubectl create deployment nginx --dry-run -o yaml --image nginx
+kubectl create deployment nginx --dry-run=client -o yaml --image nginx
 ```
 
 ```yaml

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -73,7 +73,7 @@ func NewCmdCreateClusterRole(f cmdutil.Factory, ioStreams genericclioptions.IOSt
 		AggregationRule:   map[string]string{},
 	}
 	cmd := &cobra.Command{
-		Use:                   "clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] [--dry-run]",
+		Use:                   "clusterrole NAME --verb=verb --resource=resource.group [--resource-name=resourcename] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 clusterRoleLong,
 		Long:                  clusterRoleLong,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -48,7 +48,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptio
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]",
+		Use:                   "clusterrolebinding NAME --clusterrole=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a ClusterRoleBinding for a particular ClusterRole"),
 		Long:                  clusterRoleBindingLong,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -69,7 +69,7 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]",
+		Use:                   "configmap NAME [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"cm"},
 		Short:                 i18n.T("Create a configmap from a local file, directory or literal value"),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -50,7 +50,7 @@ func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericclioptions.IOStr
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "deployment NAME --image=image [--dry-run]",
+		Use:                   "deployment NAME --image=image [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"deploy"},
 		Short:                 i18n.T("Create a deployment with the specified name."),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -48,7 +48,7 @@ func NewCmdCreateNamespace(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "namespace NAME [--dry-run]",
+		Use:                   "namespace NAME [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"ns"},
 		Short:                 i18n.T("Create a namespace with the specified name"),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -53,7 +53,7 @@ func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericcliopti
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run]",
+		Use:                   "poddisruptionbudget NAME --selector=SELECTOR --min-available=N [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"pdb"},
 		Short:                 i18n.T("Create a pod disruption budget with the specified name."),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -38,7 +38,7 @@ var (
 
 		# Create a priorityclass named default-priority that considered as the global default priority
 		kubectl create priorityclass default-priority --value=1000 --global-default=true --description="default priority"
-		
+
 		# Create a priorityclass named high-priority that can not preempt pods with lower priority
 		kubectl create priorityclass high-priority --value=1000 --description="high priority" --preemption-policy="Never"`))
 )
@@ -55,7 +55,7 @@ func NewCmdCreatePriorityClass(f cmdutil.Factory, ioStreams genericclioptions.IO
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "priorityclass NAME --value=VALUE --global-default=BOOL [--dry-run]",
+		Use:                   "priorityclass NAME --value=VALUE --global-default=BOOL [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"pc"},
 		Short:                 i18n.T("Create a priorityclass with the specified name."),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -51,7 +51,7 @@ func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=bool]",
+		Use:                   "quota NAME [--hard=key1=value1,key2=value2] [--scopes=Scope1,Scope2] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"resourcequota"},
 		Short:                 i18n.T("Create a quota with the specified name."),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -152,7 +152,7 @@ func NewCmdCreateRole(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) 
 	o := NewCreateRoleOptions(ioStreams)
 
 	cmd := &cobra.Command{
-		Use:                   "role NAME --verb=verb --resource=resource.group/subresource [--resource-name=resourcename] [--dry-run]",
+		Use:                   "role NAME --verb=verb --resource=resource.group/subresource [--resource-name=resourcename] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 roleLong,
 		Long:                  roleLong,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -48,7 +48,7 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOSt
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]",
+		Use:                   "rolebinding NAME --clusterrole=NAME|--role=NAME [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a RoleBinding for a particular Role or ClusterRole"),
 		Long:                  roleBindingLong,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -85,7 +85,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericclioptions.IO
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run]",
+		Use:                   "generic NAME [--type=string] [--from-file=[key=]source] [--from-literal=key1=value1] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a secret from a local file, directory or literal value"),
 		Long:                  secretLong,
@@ -172,7 +172,7 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericcliopt
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-literal=key1=value1] [--dry-run]",
+		Use:                   "docker-registry NAME --docker-username=user --docker-password=password --docker-email=email [--docker-server=string] [--from-literal=key1=value1] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a secret for use with a Docker registry"),
 		Long:                  secretForDockerRegistryLong,
@@ -265,7 +265,7 @@ func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "tls NAME --cert=path/to/cert/file --key=path/to/key/file [--dry-run]",
+		Use:                   "tls NAME --cert=path/to/cert/file --key=path/to/key/file [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a TLS secret"),
 		Long:                  secretForTLSLong,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -73,7 +73,7 @@ func NewCmdCreateServiceClusterIP(f cmdutil.Factory, ioStreams genericclioptions
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run]",
+		Use:                   "clusterip NAME [--tcp=<port>:<targetPort>] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a ClusterIP service."),
 		Long:                  serviceClusterIPLong,
@@ -147,7 +147,7 @@ func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericclioptions.
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "nodeport NAME [--tcp=port:targetPort] [--dry-run]",
+		Use:                   "nodeport NAME [--tcp=port:targetPort] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a NodePort service."),
 		Long:                  serviceNodePortLong,
@@ -218,7 +218,7 @@ func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, ioStreams genericcliopti
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "loadbalancer NAME [--tcp=port:targetPort] [--dry-run]",
+		Use:                   "loadbalancer NAME [--tcp=port:targetPort] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create a LoadBalancer service."),
 		Long:                  serviceLoadBalancerLong,
@@ -291,7 +291,7 @@ func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericcliopti
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "externalname NAME --external-name external.name [--dry-run]",
+		Use:                   "externalname NAME --external-name external.name [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Create an ExternalName service."),
 		Long:                  serviceExternalNameLong,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
@@ -48,7 +48,7 @@ func NewCmdCreateServiceAccount(f cmdutil.Factory, ioStreams genericclioptions.I
 	}
 
 	cmd := &cobra.Command{
-		Use:                   "serviceaccount NAME [--dry-run]",
+		Use:                   "serviceaccount NAME [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Aliases:               []string{"sa"},
 		Short:                 i18n.T("Create a service account with the specified name"),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_undo.go
@@ -62,7 +62,7 @@ var (
 		kubectl rollout undo daemonset/abc --to-revision=3
 
 		# Rollback to the previous deployment with dry-run
-		kubectl rollout undo --dry-run=true deployment/abc`)
+		kubectl rollout undo --dry-run=server deployment/abc`)
 )
 
 // NewRolloutUndoOptions returns an initialized UndoOptions instance

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -299,7 +299,7 @@ func (o *RunOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 	}
 
 	if o.Attach && o.DryRunStrategy != cmdutil.DryRunNone {
-		return cmdutil.UsageErrorf(cmd, "--dry-run can't be used with attached containers options (--attach, --stdin, or --tty)")
+		return cmdutil.UsageErrorf(cmd, "--dry-run=[server|client] can't be used with attached containers options (--attach, --stdin, or --tty)")
 	}
 
 	if err := verifyImagePullPolicy(cmd); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
@@ -72,8 +72,8 @@ var (
         Note: currently selectors can only be set on Service objects.`)
 	selectorExample = templates.Examples(`
         # set the labels and selector before creating a deployment/service pair.
-        kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
-        kubectl create deployment my-dep -o yaml --dry-run | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -`)
+        kubectl create service clusterip my-svc --clusterip="None" -o yaml --dry-run=client | kubectl set selector --local -f - 'environment=qa' -o yaml | kubectl create -f -
+        kubectl create deployment my-dep -o yaml --dry-run=client | kubectl label --local -f - environment=qa -o yaml | kubectl create -f -`)
 )
 
 // NewSelectorOptions returns an initialized SelectorOptions instance

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -48,7 +48,7 @@ var (
 	kubectl set subject rolebinding admin --user=user1 --user=user2 --group=group1
 
 	# Print the result (in yaml format) of updating rolebinding subjects from a local, without hitting the server
-	kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run | kubectl set subject --local -f - --user=foo -o yaml`)
+	kubectl create rolebinding admin --role=admin --user=admin -o yaml --dry-run=client | kubectl set subject --local -f - --user=foo -o yaml`)
 )
 
 type updateSubjects func(existings []rbacv1.Subject, targets []rbacv1.Subject) (bool, []rbacv1.Subject)
@@ -93,7 +93,7 @@ func NewSubjectOptions(streams genericclioptions.IOStreams) *SubjectOptions {
 func NewCmdSubject(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewSubjectOptions(streams)
 	cmd := &cobra.Command{
-		Use:                   "subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run]",
+		Use:                   "subject (-f FILENAME | TYPE NAME) [--user=username] [--group=groupname] [--serviceaccount=namespace:serviceaccountname] [--dry-run=server|client|none]",
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Update User, Group or ServiceAccount in a RoleBinding/ClusterRoleBinding"),
 		Long:                  subjectLong,

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -723,21 +723,21 @@ run_create_secret_tests() {
     output_message=$(! kubectl get secrets mysecret 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${output_message}" 'secrets "mysecret" not found'
     # Command
-    output_message=$(kubectl create "${kube_flags[@]}" secret generic mysecret --dry-run --from-literal=foo=bar -o jsonpath='{.metadata.namespace}' --namespace=user-specified)
+    output_message=$(kubectl create "${kube_flags[@]}" secret generic mysecret --dry-run=client --from-literal=foo=bar -o jsonpath='{.metadata.namespace}' --namespace=user-specified)
+    kube::test::if_has_string "${output_message}" 'user-specified'
     # Post-condition: mysecret still not created since --dry-run was used
     # Output from 'create' command should contain the specified --namespace value
     failure_message=$(! kubectl get secrets mysecret 2>&1 "${kube_flags[@]}")
     kube::test::if_has_string "${failure_message}" 'secrets "mysecret" not found'
-    kube::test::if_has_string "${output_message}" 'user-specified'
     # Command
-    output_message=$(kubectl create "${kube_flags[@]}" secret generic mysecret --dry-run --from-literal=foo=bar -o jsonpath='{.metadata.namespace}')
+    output_message=$(kubectl create "${kube_flags[@]}" secret generic mysecret --dry-run=client --from-literal=foo=bar -o jsonpath='{.metadata.namespace}')
     # Post-condition: jsonpath for .metadata.namespace should be empty for object since --namespace was not explicitly specified
     kube::test::if_empty_string "${output_message}"
 
 
     # check to make sure that replace correctly PUTs to a URL
     kubectl create configmap tester-update-cm -o json --dry-run=client | kubectl create "${kube_flags[@]}" --raw /api/v1/namespaces/default/configmaps -f -
-    output_message=$(kubectl create configmap tester-update-cm --from-literal=key1=config1 -o json --dry-run | kubectl replace "${kube_flags[@]}" --raw /api/v1/namespaces/default/configmaps/tester-update-cm -f -)
+    output_message=$(kubectl create configmap tester-update-cm --from-literal=key1=config1 -o json --dry-run=client | kubectl replace "${kube_flags[@]}" --raw /api/v1/namespaces/default/configmaps/tester-update-cm -f -)
     # the message should show the body returned which will include a UID not present in the input
     kube::test::if_has_string "${output_message}" 'uid'
     # if the PUT was well-formed, the server will now have a key and value we can retrieve on GET
@@ -761,7 +761,7 @@ run_secrets_test() {
   kube::log::status "Testing secrets"
 
   # Ensure dry run succeeds and includes kind, apiVersion and data, and doesn't require a server connection
-  output_message=$(kubectl create secret generic test --from-literal=key1=value1 --dry-run -o yaml --server=example.com --v=6)
+  output_message=$(kubectl create secret generic test --from-literal=key1=value1 --dry-run=client -o yaml --server=example.com --v=6)
   kube::test::if_has_string "${output_message}" 'kind: Secret'
   kube::test::if_has_string "${output_message}" 'apiVersion: v1'
   kube::test::if_has_string "${output_message}" 'key1: dmFsdWUx'
@@ -936,7 +936,7 @@ run_service_tests() {
 
   # Set selector of a local file without talking to the server
   kubectl set selector -f test/e2e/testing-manifests/guestbook/redis-master-service.yaml role=padawan --local -o yaml "${kube_flags[@]}"
-  kubectl set selector -f test/e2e/testing-manifests/guestbook/redis-master-service.yaml role=padawan --dry-run -o yaml "${kube_flags[@]}"
+  kubectl set selector -f test/e2e/testing-manifests/guestbook/redis-master-service.yaml role=padawan --dry-run=client -o yaml "${kube_flags[@]}"
   # Set command to change the selector.
   kubectl set selector -f test/e2e/testing-manifests/guestbook/redis-master-service.yaml role=padawan
   # prove role=padawan
@@ -1330,7 +1330,7 @@ run_rc_tests() {
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" ''
   # Set resources of a local file without talking to the server
   kubectl set resources -f hack/testdata/deployment-multicontainer-resources.yaml -c=perl --limits=cpu=300m --requests=cpu=300m --local -o yaml "${kube_flags[@]}"
-  ! kubectl set resources -f hack/testdata/deployment-multicontainer-resources.yaml -c=perl --limits=cpu=300m --requests=cpu=300m --dry-run -o yaml "${kube_flags[@]}" || exit 1
+  ! kubectl set resources -f hack/testdata/deployment-multicontainer-resources.yaml -c=perl --limits=cpu=300m --requests=cpu=300m --dry-run=client -o yaml "${kube_flags[@]}" || exit 1
   # Create a deployment
   kubectl create -f hack/testdata/deployment-multicontainer-resources.yaml "${kube_flags[@]}"
   kube::test::get_object_assert deployment "{{range.items}}{{$id_field}}:{{end}}" 'nginx-deployment-resources:'
@@ -1352,7 +1352,8 @@ run_rc_tests() {
   kube::test::get_object_assert deployment "{{range.items}}{{(index .spec.template.spec.containers 1).resources.limits.cpu}}:{{end}}" "300m:"
   kube::test::get_object_assert deployment "{{range.items}}{{(index .spec.template.spec.containers 1).resources.requests.cpu}}:{{end}}" "300m:"
   # Show dry-run works on running deployments
-  kubectl set resources deployment nginx-deployment-resources -c=perl --limits=cpu=400m --requests=cpu=400m --dry-run -o yaml "${kube_flags[@]}"
+  kubectl set resources deployment nginx-deployment-resources -c=perl --limits=cpu=400m --requests=cpu=400m --dry-run=client -o yaml "${kube_flags[@]}"
+  kubectl set resources deployment nginx-deployment-resources -c=perl --limits=cpu=400m --requests=cpu=400m --dry-run=server -o yaml "${kube_flags[@]}"
   ! kubectl set resources deployment nginx-deployment-resources -c=perl --limits=cpu=400m --requests=cpu=400m --local -o yaml "${kube_flags[@]}" || exit 1
   kube::test::get_object_assert deployment "{{range.items}}{{(index .spec.template.spec.containers 0).resources.limits.cpu}}:{{end}}" "200m:"
   kube::test::get_object_assert deployment "{{range.items}}{{(index .spec.template.spec.containers 1).resources.limits.cpu}}:{{end}}" "300m:"

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -808,6 +808,14 @@ runTests() {
 
   # kubectl auth reconcile
   if kube::test::if_supports_resource "${clusterroles}" ; then
+    # dry-run command
+    kubectl auth reconcile --dry-run=client "${kube_flags[@]}" -f test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
+    kube::test::get_object_assert 'rolebindings -n some-other-random -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" ''
+    kube::test::get_object_assert 'roles -n some-other-random -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" ''
+    kube::test::get_object_assert 'clusterrolebindings -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" ''
+    kube::test::get_object_assert 'clusterroles -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" ''
+
+    # command
     kubectl auth reconcile "${kube_flags[@]}" -f test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml
     kube::test::get_object_assert 'rolebindings -n some-other-random -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" 'testing-RB:'
     kube::test::get_object_assert 'roles -n some-other-random -l test-cmd=auth' "{{range.items}}{{$id_field}}:{{end}}" 'testing-R:'

--- a/test/cmd/template-output.sh
+++ b/test/cmd/template-output.sh
@@ -35,31 +35,31 @@ run_template_output_tests() {
   kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" 'valid-pod:'
 
   # check that patch command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" patch --dry-run pods/valid-pod -p '{"patched":"value3"}' --type=merge --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" patch --dry-run=client pods/valid-pod -p '{"patched":"value3"}' --type=merge --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that label command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" label --dry-run pods/valid-pod label=value --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" label --dry-run=client pods/valid-pod label=value --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that annotate command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" annotate --dry-run pods/valid-pod annotation=value --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" annotate --dry-run=client pods/valid-pod annotation=value --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that apply command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" apply --dry-run -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" apply --dry-run=client -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that create command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create -f test/fixtures/doc-yaml/admin/limitrange/valid-pod.yaml --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that autoscale command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" autoscale --max=2 -f hack/testdata/scale-deploy-1.yaml --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" autoscale --max=2 -f hack/testdata/scale-deploy-1.yaml --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'scale-1:'
 
   # check that expose command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" expose -f hack/testdata/redis-slave-replicaset.yaml --save-config --port=80 --target-port=8000 --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" expose -f hack/testdata/redis-slave-replicaset.yaml --save-config --port=80 --target-port=8000 --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'redis-slave:'
 
   # check that convert command supports --template output
@@ -67,7 +67,7 @@ run_template_output_tests() {
   kube::test::if_has_string "${output_message}" 'nginx:'
 
   # check that run command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" run --dry-run --template="{{ .metadata.name }}:" pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)')
+  output_message=$(kubectl "${kube_flags[@]:?}" run --dry-run=client --template="{{ .metadata.name }}:" pi --image=perl --restart=OnFailure -- perl -Mbignum=bpi -wle 'print bpi(2000)')
   kube::test::if_has_string "${output_message}" 'pi:'
 
   # check that taint command supports --template output
@@ -78,11 +78,11 @@ run_template_output_tests() {
 
   # check that "apply set-last-applied" command supports --template output
   kubectl "${kube_flags[@]:?}" create -f test/e2e/testing-manifests/statefulset/cassandra/controller.yaml
-  output_message=$(kubectl "${kube_flags[@]:?}" apply set-last-applied -f test/e2e/testing-manifests/statefulset/cassandra/controller.yaml --dry-run --create-annotation --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" apply set-last-applied -f test/e2e/testing-manifests/statefulset/cassandra/controller.yaml --dry-run=client --create-annotation --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'cassandra:'
 
   # check that "auth reconcile" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" auth reconcile --dry-run -f test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" auth reconcile --dry-run=client -f test/fixtures/pkg/kubectl/cmd/auth/rbac-resource-plus.yaml --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'testing-CR:testing-CRB:testing-RB:testing-R:'
 
   # check that "create clusterrole" command supports --template output
@@ -94,7 +94,7 @@ run_template_output_tests() {
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create configmap" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create configmap cm --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create configmap cm --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'cm:'
 
   # check that "create deployment" command supports --template output
@@ -122,87 +122,87 @@ spec:
             command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
           restartPolicy: OnFailure
 EOF
-  output_message=$(kubectl "${kube_flags[@]:?}" create job foo --from=cronjob/pi --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create job foo --from=cronjob/pi --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create namespace" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create ns bar --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create ns bar --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'bar:'
 
   # check that "create namespace" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create rolebinding foo --clusterrole=myclusterrole --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create rolebinding foo --clusterrole=myclusterrole --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create role" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create role --dry-run --template="{{ .metadata.name }}:" --verb get myrole --resource pods)
+  output_message=$(kubectl "${kube_flags[@]:?}" create role --dry-run=client --template="{{ .metadata.name }}:" --verb get myrole --resource pods)
   kube::test::if_has_string "${output_message}" 'myrole:'
 
   # check that "create quota" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create quota foo --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create quota foo --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create priorityclass" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create priorityclass foo --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create priorityclass foo --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create poddisruptionbudget" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create poddisruptionbudget foo --dry-run --selector=foo --min-available=1 --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create poddisruptionbudget foo --dry-run=client --selector=foo --min-available=1 --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create serviceaccount" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create serviceaccount foo --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create serviceaccount foo --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "set env" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" set env pod/valid-pod --dry-run A=B --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" set env pod/valid-pod --dry-run=client A=B --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that "set image" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" set image pod/valid-pod --dry-run kubernetes-serve-hostname=nginx --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" set image pod/valid-pod --dry-run=client kubernetes-serve-hostname=nginx --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that "set resources" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" set resources pod/valid-pod --limits=memory=256Mi --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" set resources pod/valid-pod --limits=memory=256Mi --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that "set selector" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" set selector -f hack/testdata/kubernetes-service.yaml A=B --local --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" set selector -f hack/testdata/kubernetes-service.yaml A=B --local --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'kubernetes:'
 
   # check that "set serviceaccount" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" set serviceaccount pod/valid-pod deployer --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" set serviceaccount pod/valid-pod deployer --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'valid-pod:'
 
   # check that "set subject" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" set subject clusterrolebinding/foo --user=foo --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" set subject clusterrolebinding/foo --user=foo --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create secret docker-registry" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create secret docker-registry foo --docker-username user --docker-password pass --docker-email foo@bar.baz --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create secret docker-registry foo --docker-username user --docker-password pass --docker-email foo@bar.baz --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create secret generic" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create secret generic foo --from-literal=key1=value1 --dry-run --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create secret generic foo --from-literal=key1=value1 --dry-run=client --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create secret tls" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create secret tls --dry-run foo --key=hack/testdata/tls.key --cert=hack/testdata/tls.crt --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create secret tls --dry-run=client foo --key=hack/testdata/tls.key --cert=hack/testdata/tls.crt --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create service clusterip" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create service clusterip foo --dry-run --tcp=8080 --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create service clusterip foo --dry-run=client --tcp=8080 --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create service externalname" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create service externalname foo --dry-run --external-name=bar --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create service externalname foo --dry-run=client --external-name=bar --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create service loadbalancer" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create service loadbalancer foo --dry-run --tcp=8080 --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create service loadbalancer foo --dry-run=client --tcp=8080 --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "create service nodeport" command supports --template output
-  output_message=$(kubectl "${kube_flags[@]:?}" create service nodeport foo --dry-run --tcp=8080 --template="{{ .metadata.name }}:")
+  output_message=$(kubectl "${kube_flags[@]:?}" create service nodeport foo --dry-run=client --tcp=8080 --template="{{ .metadata.name }}:")
   kube::test::if_has_string "${output_message}" 'foo:'
 
   # check that "config view" ouputs "yaml" as its default output format
@@ -234,7 +234,7 @@ EOF
 
   # check that running a command with both a --template flag and a
   # non-template --output prefers the non-template output value
-  output_message=$(kubectl "${kube_flags[@]:?}" create configmap cm --dry-run --template="{{ .metadata.name }}:" --output yaml)
+  output_message=$(kubectl "${kube_flags[@]:?}" create configmap cm --dry-run=client --template="{{ .metadata.name }}:" --output yaml)
   kube::test::if_has_string "${output_message}" 'kind: ConfigMap'
 
   # cleanup


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind cleanup

**What this PR does / why we need it**:

This PR updates the `--dry-run` values to use `client` or `server` values where appropriate in tests, docs, and scripts. 

We need this because the flag `--dry-run` without a value and `--dry-run=true|false` are deprecated and should be removed.

**Which issue(s) this PR fixes**:

Cleanup for https://github.com/kubernetes/kubernetes/issues/85652.

Part of https://github.com/kubernetes/kubernetes/issues/86526.

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/community/blob/master/keps/sig-api-machinery/0015-dry-run.md
```

/sig cli
cc @apelisse 
/priority important-soon