### PR TITLE
Create an OWNERS alias for net-driver-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -219,6 +219,11 @@ aliases:
     - krmayankk
     - mattjmcnaughton
     - matthyx
+
+  sig-network-driver-approvers:
+    - dcbw
+    - freehan
+
   sig-network-approvers:
     - andrewsykim
     - bowei

--- a/pkg/kubelet/dockershim/network/OWNERS
+++ b/pkg/kubelet/dockershim/network/OWNERS
@@ -1,10 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- thockin
-- dchen1107
-- freehan
-- dcbw
+- sig-network-driver-approvers
 emeritus_approvers:
 - matchstick
 reviewers:

--- a/pkg/kubelet/network/OWNERS
+++ b/pkg/kubelet/network/OWNERS
@@ -1,8 +1,7 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- dchen1107
-- sig-network-approvers
+- sig-network-driver-approvers
 emeritus_approvers:
 - matchstick
 reviewers:


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

Supersedes #87727

```release-note
NONE
```
