### PR TITLE
test/e2e/node: fix selinux test failure

### DIFF
--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -270,6 +270,6 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	framework.ExpectNoError(err, "Error waiting for pod to run %v", pod)
 
 	content, err = tk.ReadFileViaContainer(pod.Name, "test-container", testFilePath)
-	framework.ExpectNoError(err, "Error reading file via container")
+	framework.ExpectError(err)
 	gomega.Expect(content).NotTo(gomega.ContainSubstring(testContent))
 }


### PR DESCRIPTION
Commit 69a473be3 broke the test case (that was checking
that a file from a volume can't be read) by adding a wrong
assumption that error should be nil.

Fix the assumption and thus the test.

Initially, the check was that the file contents read back is not
the same as it was written. Since we now expect the error
there's no need to check the file contents (it's not read anyway).

/kind failing-test
fixes #87901

```release-note
NONE
```
