### PR TITLE
Don't set apparmor annotations unless it's supported

### DIFF
--- a/test/e2e/auth/pod_security_policy.go
+++ b/test/e2e/auth/pod_security_policy.go
@@ -251,12 +251,11 @@ func createAndBindPSP(f *framework.Framework, pspTemplate *policyv1beta1.PodSecu
 }
 
 func restrictedPod(name string) *v1.Pod {
-	return &v1.Pod{
+	pod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				v1.SeccompPodAnnotationKey:                      v1.SeccompProfileRuntimeDefault,
-				apparmor.ContainerAnnotationKeyPrefix + "pause": apparmor.ProfileRuntimeDefault,
+				v1.SeccompPodAnnotationKey: v1.SeccompProfileRuntimeDefault,
 			},
 		},
 		Spec: v1.PodSpec{
@@ -271,6 +270,10 @@ func restrictedPod(name string) *v1.Pod {
 			}},
 		},
 	}
+	if isAppArmorSupported() {
+		pod.Annotations[apparmor.ContainerAnnotationKeyPrefix+"pause"] = apparmor.ProfileRuntimeDefault
+	}
+	return pod
 }
 
 // privilegedPSPInPolicy creates a PodSecurityPolicy (in the "policy" API Group) that allows everything.
@@ -311,14 +314,12 @@ func privilegedPSP(name string) *policyv1beta1.PodSecurityPolicy {
 
 // restrictedPSPInPolicy creates a PodSecurityPolicy (in the "policy" API Group) that is most strict.
 func restrictedPSP(name string) *policyv1beta1.PodSecurityPolicy {
-	return &policyv1beta1.PodSecurityPolicy{
+	psp := &policyv1beta1.PodSecurityPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 			Annotations: map[string]string{
-				seccomp.AllowedProfilesAnnotationKey:  v1.SeccompProfileRuntimeDefault,
-				seccomp.DefaultProfileAnnotationKey:   v1.SeccompProfileRuntimeDefault,
-				apparmor.AllowedProfilesAnnotationKey: apparmor.ProfileRuntimeDefault,
-				apparmor.DefaultProfileAnnotationKey:  apparmor.ProfileRuntimeDefault,
+				seccomp.AllowedProfilesAnnotationKey: v1.SeccompProfileRuntimeDefault,
+				seccomp.DefaultProfileAnnotationKey:  v1.SeccompProfileRuntimeDefault,
 			},
 		},
 		Spec: policyv1beta1.PodSecurityPolicySpec{
@@ -367,6 +368,11 @@ func restrictedPSP(name string) *policyv1beta1.PodSecurityPolicy {
 			ReadOnlyRootFilesystem: false,
 		},
 	}
+	if isAppArmorSupported() {
+		psp.Annotations[apparmor.AllowedProfilesAnnotationKey] = apparmor.ProfileRuntimeDefault
+		psp.Annotations[apparmor.DefaultProfileAnnotationKey] = apparmor.ProfileRuntimeDefault
+	}
+	return psp
 }
 
 func boolPtr(b bool) *bool {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

These 2 tests fail on distros that don't support apparmor (any --node-os-distro other than gci or ubuntu)
```
[Fail] [sig-auth] PodSecurityPolicy [AfterEach] should enforce the restricted policy.PodSecurityPolicy 
/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/auth/pod_security_policy.go:91

[Fail] [sig-auth] PodSecurityPolicy [AfterEach] should allow pods under the privileged policy.PodSecurityPolicy 
/kubernetes/_output/local/go/src/k8s.io/kubernetes/test/e2e/auth/pod_security_policy.go:110
```

See during the 'should allow' test a test pod that should be allowed is stuck because AppArmor is not enabled on my nodes:
```
~ $ k describe po -A
Name:         allowed
Namespace:    podsecuritypolicy-9494
Priority:     0
Node:         127.0.0.1/127.0.0.1
Start Time:   Fri, 14 Feb 2020 03:28:28 +0000
Labels:       <none>
Annotations:  container.apparmor.security.beta.kubernetes.io/pause: runtime/default
              kubernetes.io/psp: podsecuritypolicy-9494-restrictive
              seccomp.security.alpha.kubernetes.io/pod: runtime/default
Status:       Pending
Reason:       AppArmor
Message:      Cannot enforce AppArmor: AppArmor is not enabled on the host
```

Mainly the issue is setting DefaultProfileAnnotationKey on the PSP.

After this patch to remove all irrelevant apparmor annotations when apparmor is disabled, the tests pass.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
