### PR TITLE
Implement smarter endpoints batching

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -596,6 +596,8 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,D
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,DeprecatedControllerConfiguration,RegisterRetryCount
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointControllerConfiguration,ConcurrentEndpointSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointControllerConfiguration,EndpointUpdatesBatchPeriod
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointControllerConfiguration,EndpointUpdatesBurst
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointControllerConfiguration,EndpointUpdatesQPS
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointSliceControllerConfiguration,ConcurrentServiceEndpointSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointSliceControllerConfiguration,MaxEndpointsPerSlice
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,GarbageCollectorControllerConfiguration,ConcurrentGCSyncs

--- a/cmd/kube-controller-manager/app/core.go
+++ b/cmd/kube-controller-manager/app/core.go
@@ -383,7 +383,8 @@ func startEndpointController(ctx ControllerContext) (http.Handler, bool, error) 
 		ctx.InformerFactory.Core().V1().Services(),
 		ctx.InformerFactory.Core().V1().Endpoints(),
 		ctx.ClientBuilder.ClientOrDie("endpoint-controller"),
-		ctx.ComponentConfig.EndpointController.EndpointUpdatesBatchPeriod.Duration,
+		ctx.ComponentConfig.EndpointController.EndpointUpdatesQPS,
+		ctx.ComponentConfig.EndpointController.EndpointUpdatesBurst,
 	).Run(int(ctx.ComponentConfig.EndpointController.ConcurrentEndpointSyncs), ctx.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -241,6 +241,8 @@ func TestAddFlags(t *testing.T) {
 		EndpointController: &EndpointControllerOptions{
 			&endpointconfig.EndpointControllerConfiguration{
 				ConcurrentEndpointSyncs: 10,
+				EndpointUpdatesQPS:      50.0,
+				EndpointUpdatesBurst:    1,
 			},
 		},
 		EndpointSliceController: &EndpointSliceControllerOptions{
@@ -474,6 +476,8 @@ func TestApplyTo(t *testing.T) {
 			},
 			EndpointController: endpointconfig.EndpointControllerConfiguration{
 				ConcurrentEndpointSyncs: 10,
+				EndpointUpdatesQPS:      50.0,
+				EndpointUpdatesBurst:    1,
 			},
 			EndpointSliceController: endpointsliceconfig.EndpointSliceControllerConfiguration{
 				ConcurrentServiceEndpointSyncs: 10,

--- a/pkg/controller/endpoint/config/types.go
+++ b/pkg/controller/endpoint/config/types.go
@@ -33,4 +33,11 @@ type EndpointControllerConfiguration struct {
 	// in that period, they will be batched to a single endpoint update.
 	// Default 0 value means that each pod update triggers an endpoint update.
 	EndpointUpdatesBatchPeriod metav1.Duration
+
+	// EndpointUpdatesQPS defines a max number of pod-triggered endpoints updates.
+	EndpointUpdatesQPS float64
+
+	// EndpointUpdatesBurst defines a number of first pod-triggered endpoints updates that can be generated
+	// without additional delay.
+	EndpointUpdatesBurst int
 }

--- a/pkg/controller/endpoint/config/v1alpha1/defaults.go
+++ b/pkg/controller/endpoint/config/v1alpha1/defaults.go
@@ -33,4 +33,13 @@ func RecommendedDefaultEndpointControllerConfiguration(obj *kubectrlmgrconfigv1a
 	if obj.ConcurrentEndpointSyncs == 0 {
 		obj.ConcurrentEndpointSyncs = 5
 	}
+
+	if obj.EndpointUpdatesQPS == 0.0 {
+		// Default 50.0 value matches default kube-api-qps limit for endpoint-controller.
+		obj.EndpointUpdatesQPS = 50.0
+	}
+
+	if obj.EndpointUpdatesBurst == 0 {
+		obj.EndpointUpdatesBurst = 1
+	}
 }

--- a/pkg/controller/endpoint/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/endpoint/config/v1alpha1/zz_generated.conversion.go
@@ -61,12 +61,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1alpha1_EndpointControllerConfiguration_To_config_EndpointControllerConfiguration(in *v1alpha1.EndpointControllerConfiguration, out *config.EndpointControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentEndpointSyncs = in.ConcurrentEndpointSyncs
 	out.EndpointUpdatesBatchPeriod = in.EndpointUpdatesBatchPeriod
+	out.EndpointUpdatesQPS = in.EndpointUpdatesQPS
+	out.EndpointUpdatesBurst = in.EndpointUpdatesBurst
 	return nil
 }
 
 func autoConvert_config_EndpointControllerConfiguration_To_v1alpha1_EndpointControllerConfiguration(in *config.EndpointControllerConfiguration, out *v1alpha1.EndpointControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentEndpointSyncs = in.ConcurrentEndpointSyncs
 	out.EndpointUpdatesBatchPeriod = in.EndpointUpdatesBatchPeriod
+	out.EndpointUpdatesQPS = in.EndpointUpdatesQPS
+	out.EndpointUpdatesBurst = in.EndpointUpdatesBurst
 	return nil
 }
 

--- a/staging/src/k8s.io/client-go/util/workqueue/BUILD
+++ b/staging/src/k8s.io/client-go/util/workqueue/BUILD
@@ -20,7 +20,6 @@ go_test(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/golang.org/x/time/rate:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -298,6 +298,13 @@ type EndpointControllerConfiguration struct {
 	// Processing of pod changes will be delayed by this duration to join them with potential
 	// upcoming updates and reduce the overall number of endpoints updates.
 	EndpointUpdatesBatchPeriod metav1.Duration
+
+	// EndpointUpdatesQPS defines a max number of pod-triggered endpoints updates.
+	EndpointUpdatesQPS float64
+
+	// EndpointUpdatesBurst defines a number of first pod-triggered endpoints updates that can be generated
+	// without additional delay.
+	EndpointUpdatesBurst int
 }
 
 // EndpointSliceControllerConfiguration contains elements describing


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR implements smarter endpoints batching than the one that is already implemented.
It allows to set two parameters: burst B and rate limit R. This will allow first B updates to services without any delay and rate limits next to R.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/hold

/assign @wojtek-t