### PR TITLE
kubelet allows using an unspecified IP addresses as node-ip

### DIFF
--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -589,7 +589,9 @@ func validateNodeIP(nodeIP net.IP) error {
 		return fmt.Errorf("nodeIP can't be a link-local unicast address")
 	}
 	if nodeIP.IsUnspecified() {
-		return fmt.Errorf("nodeIP can't be an all zeros address")
+		// Unspecified addresses are used to autodetect the node IP address
+		// https://github.com/kubernetes/kubernetes/pull/85850
+		return nil
 	}
 
 	addrs, err := net.InterfaceAddrs()

--- a/pkg/kubelet/kubelet_node_status_test.go
+++ b/pkg/kubelet/kubelet_node_status_test.go
@@ -1885,12 +1885,12 @@ func TestValidateNodeIPParam(t *testing.T) {
 		},
 		{
 			nodeIP:   "0.0.0.0",
-			success:  false,
+			success:  true,
 			testName: "Unspecified IPv4 address",
 		},
 		{
 			nodeIP:   "::",
-			success:  false,
+			success:  true,
 			testName: "Unspecified IPv6 address",
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

It was introduced in ce68edf70099642389f4712bec3a1fa773661fdf 
a mechanism to autodetect the node ip address based on the node-ip
flag, using an unspecified address.

It turns out that it wasn't working because of the validation function
didn't allow us to use an unspecified address.

```
Feb 14 16:09:53 ip-192-168-0-135 kubelet[12423]: E0214 16:09:53.757388   12423 kubelet_node_status.go:520] Failed to set some node status fields: failed to validate nodeIP: nodeIP can't be an all zeros address
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

xref: https://github.com/kubernetes/kubernetes/pull/85850

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
