### PR TITLE
Update PodIP after sandbox creation

### DIFF
--- a/pkg/kubelet/container/testing/fake_runtime.go
+++ b/pkg/kubelet/container/testing/fake_runtime.go
@@ -224,7 +224,11 @@ func (f *FakeRuntime) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 	return pods, f.Err
 }
 
-func (f *FakeRuntime) SyncPod(pod *v1.Pod, _ *kubecontainer.PodStatus, _ []v1.Secret, backOff *flowcontrol.Backoff) (result kubecontainer.PodSyncResult) {
+func (f *FakeRuntime) SyncPodSandbox(pod *v1.Pod, _ *kubecontainer.PodStatus) (result kubecontainer.PodSyncResult, podIPs []string, podSandboxID string) {
+	return
+}
+
+func (f *FakeRuntime) SyncPodContainers(pod *v1.Pod, podStatus *kubecontainer.PodStatus, pullSecrets []v1.Secret, backOff *flowcontrol.Backoff, podIPs []string, podSandboxID string) (result kubecontainer.PodSyncResult) {
 	f.Lock()
 	defer f.Unlock()
 

--- a/pkg/kubelet/container/testing/runtime_mock.go
+++ b/pkg/kubelet/container/testing/runtime_mock.go
@@ -72,7 +72,11 @@ func (r *Mock) GetPods(all bool) ([]*kubecontainer.Pod, error) {
 	return args.Get(0).([]*kubecontainer.Pod), args.Error(1)
 }
 
-func (r *Mock) SyncPod(pod *v1.Pod, status *kubecontainer.PodStatus, secrets []v1.Secret, backOff *flowcontrol.Backoff) kubecontainer.PodSyncResult {
+func (f *Mock) SyncPodSandbox(pod *v1.Pod, _ *kubecontainer.PodStatus) (result kubecontainer.PodSyncResult, podIPs []string, podSandboxID string) {
+	return
+}
+
+func (r *Mock) SyncPodContainers(pod *v1.Pod, status *kubecontainer.PodStatus, secrets []v1.Secret, backOff *flowcontrol.Backoff, podIPs []string, podSandboxID string) kubecontainer.PodSyncResult {
 	args := r.Called(pod, status, secrets, backOff)
 	return args.Get(0).(kubecontainer.PodSyncResult)
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -514,7 +514,8 @@ func TestSyncPod(t *testing.T) {
 	}
 
 	backOff := flowcontrol.NewBackOff(time.Second, time.Minute)
-	result := m.SyncPod(pod, &kubecontainer.PodStatus{}, []v1.Secret{}, backOff)
+	result, podIPs, sandboxID := m.SyncPodSandbox(pod, &kubecontainer.PodStatus{})
+	result = m.SyncPodContainers(pod, &kubecontainer.PodStatus{}, []v1.Secret{}, backOff, podIPs, sandboxID)
 	assert.NoError(t, result.Error())
 	assert.Equal(t, 2, len(fakeRuntime.Containers))
 	assert.Equal(t, 2, len(fakeImage.Images))
@@ -604,7 +605,8 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	// 1. should only create the init container.
 	podStatus, err := m.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	result := m.SyncPod(pod, podStatus, []v1.Secret{}, backOff)
+	result, podIPs, sandboxID := m.SyncPodSandbox(pod, podStatus)
+	result = m.SyncPodContainers(pod, podStatus, []v1.Secret{}, backOff, podIPs, sandboxID)
 	assert.NoError(t, result.Error())
 	expected := []*cRecord{
 		{name: initContainers[0].Name, attempt: 0, state: runtimeapi.ContainerState_CONTAINER_RUNNING},
@@ -614,7 +616,8 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	// 2. should not create app container because init container is still running.
 	podStatus, err = m.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	result = m.SyncPod(pod, podStatus, []v1.Secret{}, backOff)
+	result, podIPs, sandboxID = m.SyncPodSandbox(pod, podStatus)
+	result = m.SyncPodContainers(pod, podStatus, []v1.Secret{}, backOff, podIPs, sandboxID)
 	assert.NoError(t, result.Error())
 	verifyContainerStatuses(t, fakeRuntime, expected, "init container still running; do nothing")
 
@@ -622,14 +625,15 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	// Stop init container instance 0.
 	sandboxIDs, err := m.getSandboxIDByPodUID(pod.UID, nil)
 	require.NoError(t, err)
-	sandboxID := sandboxIDs[0]
+	sandboxID = sandboxIDs[0]
 	initID0, err := fakeRuntime.GetContainerID(sandboxID, initContainers[0].Name, 0)
 	require.NoError(t, err)
 	fakeRuntime.StopContainer(initID0, 0)
 	// Sync again.
 	podStatus, err = m.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	result = m.SyncPod(pod, podStatus, []v1.Secret{}, backOff)
+	result, podIPs, sandboxID = m.SyncPodSandbox(pod, podStatus)
+	result = m.SyncPodContainers(pod, podStatus, []v1.Secret{}, backOff, podIPs, sandboxID)
 	assert.NoError(t, result.Error())
 	expected = []*cRecord{
 		{name: initContainers[0].Name, attempt: 0, state: runtimeapi.ContainerState_CONTAINER_EXITED},
@@ -644,7 +648,8 @@ func TestSyncPodWithInitContainers(t *testing.T) {
 	// Sync again.
 	podStatus, err = m.GetPodStatus(pod.UID, pod.Name, pod.Namespace)
 	assert.NoError(t, err)
-	result = m.SyncPod(pod, podStatus, []v1.Secret{}, backOff)
+	result, podIPs, sandboxID = m.SyncPodSandbox(pod, podStatus)
+	result = m.SyncPodContainers(pod, podStatus, []v1.Secret{}, backOff, podIPs, sandboxID)
 	assert.NoError(t, result.Error())
 	expected = []*cRecord{
 		// The first init container instance is purged and no longer visible.


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR splits SyncPod into two phases: the first phase creates sandbox, if needed.
PodStatus is updated after the first step.
The second step is to create various containers.

I introduce a map within kubeGenericRuntimeManager to handle the pod UID and podActions mapping so that podActions struct is not leaked to other classes.

**Which issue(s) this PR fixes**:
Fixes #85966

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
