### PR TITLE
append_or_replace_prefixed_line in /cluster/gce/gci/configure-helper.…

### DIFF
--- a/cluster/gce/gci/BUILD
+++ b/cluster/gce/gci/BUILD
@@ -7,6 +7,7 @@ go_test(
     srcs = [
         "apiserver_etcd_test.go",
         "apiserver_kms_test.go",
+        "append_or_replace_prefixed_line_test.go",
         "audit_policy_test.go",
         "configure_helper_test.go",
     ],
@@ -26,6 +27,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/audit/policy:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
     ],

--- a/cluster/gce/gci/append_or_replace_prefixed_line_test.go
+++ b/cluster/gce/gci/append_or_replace_prefixed_line_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gci
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestAppendOrReplacePrefix(t *testing.T) {
+	testCases := []struct {
+		desc                string
+		prefix              string
+		suffix              string
+		initialFileContents string
+		want                string
+	}{
+		{
+			desc:   "simple string and empty file",
+			prefix: "hello",
+			suffix: "world",
+			want: `helloworld
+`,
+		},
+		{
+			desc:   "simple string and non empty file",
+			prefix: "hello",
+			suffix: "world",
+			initialFileContents: `jelloworld
+chelloworld
+`,
+			want: `jelloworld
+chelloworld
+helloworld
+`,
+		},
+		{
+			desc:   "simple string and file already contains prefix",
+			prefix: "hello",
+			suffix: "world",
+			initialFileContents: `helloworld
+helloworld
+jelloworld
+chelloworld
+`,
+			want: `jelloworld
+chelloworld
+helloworld
+`,
+		},
+		{
+			desc:   "simple string and file already contains prefix with content between the prefix and suffix",
+			prefix: "hello",
+			suffix: "world",
+			initialFileContents: `hellocontentsworld
+jelloworld
+chelloworld
+`,
+			want: `jelloworld
+chelloworld
+helloworld
+`,
+		},
+		{
+			desc:   "simple string and file already contains prefix with prefix == suffix",
+			prefix: "hello",
+			suffix: "world",
+			initialFileContents: `hellohello
+jelloworld
+chelloworld
+`,
+			want: `jelloworld
+chelloworld
+helloworld
+`,
+		},
+		{
+			desc:   "string with quotes and = and empty file",
+			prefix: `'"$argon2id$v=19"'`,
+			suffix: "admin",
+			want: `"$argon2id$v=19"admin
+`,
+		},
+		{
+			desc:   "string with quotes and = and non empty file",
+			prefix: `'"$argon2id$v=19"'`,
+			suffix: "admin",
+			initialFileContents: `jelloworld
+chelloworld
+`,
+			want: `jelloworld
+chelloworld
+"$argon2id$v=19"admin
+`,
+		},
+		{
+			desc:   "string with quotes and = and file already contains prefix",
+			prefix: `'"$argon2id$v=19"'`,
+			suffix: "admin",
+			initialFileContents: `"$argon2id$v=19"admin
+"$argon2id$v=19"admin
+helloworld
+jelloworld
+`,
+			want: `helloworld
+jelloworld
+"$argon2id$v=19"admin
+`,
+		},
+		{
+			desc:   "string with quotes and = and file already contains prefix with content between the prefix and suffix",
+			prefix: `'"$argon2id$v=19"'`,
+			suffix: "admin",
+			initialFileContents: `"$argon2id$v=19"contentsadmin
+helloworld
+jelloworld
+`,
+			want: `helloworld
+jelloworld
+"$argon2id$v=19"admin
+`,
+		},
+		{
+			desc:   "string with quotes and = and file already contains prefix with prefix == suffix",
+			prefix: `'"$argon2id$v=19"'`,
+			suffix: "admin",
+			initialFileContents: `"$argon2id$v=19""$argon2id$v=19"
+helloworld
+jelloworld
+`,
+			want: `helloworld
+jelloworld
+"$argon2id$v=19"admin
+`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			f, err := ioutil.TempFile("", "append_or_replace_test")
+			if err != nil {
+				t.Fatalf("Failed to create temp file: %v", err)
+			}
+			defer os.Remove(f.Name())
+			if _, err := f.WriteString(tc.initialFileContents); err != nil {
+				t.Fatalf("Failed to write to file: %v", err)
+			}
+			f.Close()
+			args := fmt.Sprintf("source configure-helper.sh; append_or_replace_prefixed_line %s %s %s", f.Name(), tc.prefix, tc.suffix)
+			cmd := exec.Command("bash", "-c", args)
+			stderr, err := cmd.CombinedOutput()
+			if err != nil {
+				t.Fatalf("Failed to run command: %v: %s", err, stderr)
+			}
+			got, err := ioutil.ReadFile(f.Name())
+			if err != nil {
+				t.Fatalf("Failed to read file contents: %v", err)
+			}
+			if diff := cmp.Diff(string(got), tc.want); diff != "" {
+				t.Errorf("File contents: got=%s, want=%s, diff=%s", got, tc.want, diff)
+			}
+		})
+	}
+
+}

--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -464,7 +464,7 @@ function append_or_replace_prefixed_line {
   local -r tmpfile="$(mktemp -t filtered.XXXX --tmpdir=${dirname})"
 
   touch "${file}"
-  awk "substr(\$0,0,length(\"${prefix}\")) != \"${prefix}\" { print }" "${file}" > "${tmpfile}"
+  awk -v pfx="${prefix}" 'substr($0,1,length(pfx)) != pfx { print }' "${file}" > "${tmpfile}"
   echo "${prefix}${suffix}" >> "${tmpfile}"
   mv "${tmpfile}" "${file}"
 }


### PR DESCRIPTION
…sh fails for prefixes that contain double quotes and = sign.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
append_or_replace_prefixed_line will fail for prefixes that contain double quotes and $ sign.
For example if we pass in the following input:-
```
append_or_replace_prefixed_line "testfile.csv" '"xy="' "za" 
``` 
It will fail with the following error:-
```
awk: cmd. line:1: substr($0,0,length(""xy="")) != ""xy="" { print }
awk: cmd. line:1:                        ^ syntax error
awk: cmd. line:1: substr($0,0,length(""xy="")) != ""xy="" { print }
awk: cmd. line:1:                           ^ 2 is invalid as number of arguments for length
```
Updating the awk to use command-line variable assignment solves this issue. Also added some tests to confirm that the fix works. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign @awly @immutableT  