### PR TITLE
[Scheduler Framework]Remove `FilteredNodesStatuses` argument from `PreScore`'s interface

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -203,7 +203,7 @@ func (g *genericScheduler) Schedule(ctx context.Context, state *framework.CycleS
 	}
 
 	// Run "prescore" plugins.
-	prescoreStatus := g.framework.RunPreScorePlugins(ctx, state, pod, filteredNodes, filteredNodesStatuses)
+	prescoreStatus := g.framework.RunPreScorePlugins(ctx, state, pod, filteredNodes)
 	if !prescoreStatus.IsSuccess() {
 		return result, prescoreStatus.AsError()
 	}

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -1144,11 +1144,11 @@ func TestZeroRequest(t *testing.T) {
 
 			ctx := context.Background()
 			state := framework.NewCycleState()
-			_, filteredNodesStatuses, err := scheduler.findNodesThatFitPod(ctx, state, test.pod)
+			_, _, err = scheduler.findNodesThatFitPod(ctx, state, test.pod)
 			if err != nil {
 				t.Fatalf("error filtering nodes: %+v", err)
 			}
-			scheduler.framework.RunPreScorePlugins(ctx, state, test.pod, test.nodes, filteredNodesStatuses)
+			scheduler.framework.RunPreScorePlugins(ctx, state, test.pod, test.nodes)
 			list, err := scheduler.prioritizeNodes(
 				ctx,
 				state,

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
@@ -19,6 +19,7 @@ package defaultpodtopologyspread
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/klog"
 
 	v1 "k8s.io/api/core/v1"
@@ -178,7 +179,7 @@ func (pl *DefaultPodTopologySpread) ScoreExtensions() framework.ScoreExtensions 
 }
 
 // PreScore builds and writes cycle state used by Score and NormalizeScore.
-func (pl *DefaultPodTopologySpread) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node, _ framework.NodeToStatusMap) *framework.Status {
+func (pl *DefaultPodTopologySpread) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
 	var selector labels.Selector
 	informerFactory := pl.handle.SharedInformerFactory()
 	selector = getSelector(

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_perf_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_perf_test.go
@@ -73,7 +73,7 @@ func BenchmarkTestSelectorSpreadPriority(b *testing.B) {
 
 			for i := 0; i < b.N; i++ {
 				state := framework.NewCycleState()
-				status := plugin.PreScore(ctx, state, pod, allNodes, nil)
+				status := plugin.PreScore(ctx, state, pod, allNodes)
 				if !status.IsSuccess() {
 					b.Fatalf("unexpected error: %v", status)
 				}

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go
@@ -386,7 +386,7 @@ func TestDefaultPodTopologySpreadScore(t *testing.T) {
 				handle: fh,
 			}
 
-			status := plugin.PreScore(ctx, state, test.pod, nodes, nil)
+			status := plugin.PreScore(ctx, state, test.pod, nodes)
 			if !status.IsSuccess() {
 				t.Fatalf("unexpected error: %v", status)
 			}
@@ -638,7 +638,7 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 			}
 
 			state := framework.NewCycleState()
-			status := plugin.PreScore(ctx, state, test.pod, nodes, nil)
+			status := plugin.PreScore(ctx, state, test.pod, nodes)
 			if !status.IsSuccess() {
 				t.Fatalf("unexpected error: %v", status)
 			}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/klog"
@@ -172,7 +172,6 @@ func (pl *InterPodAffinity) PreScore(
 	cycleState *framework.CycleState,
 	pod *v1.Pod,
 	nodes []*v1.Node,
-	_ framework.NodeToStatusMap,
 ) *framework.Status {
 	if len(nodes) == 0 {
 		// No nodes to score.

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
@@ -523,7 +523,7 @@ func TestPreferredAffinity(t *testing.T) {
 				hardPodAffinityWeight: 1,
 			}
 
-			status := p.PreScore(context.Background(), state, test.pod, test.nodes, nil)
+			status := p.PreScore(context.Background(), state, test.pod, test.nodes)
 			if !status.IsSuccess() {
 				t.Errorf("unexpected error: %v", status)
 			}
@@ -631,7 +631,7 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes, nil)
+			status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes)
 			if !status.IsSuccess() {
 				t.Errorf("unexpected error: %v", status)
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
@@ -65,7 +65,6 @@ func (rl *ResourceLimits) PreScore(
 	cycleState *framework.CycleState,
 	pod *v1.Pod,
 	nodes []*v1.Node,
-	_ framework.NodeToStatusMap,
 ) *framework.Status {
 	if len(nodes) == 0 {
 		// No nodes to score.

--- a/pkg/scheduler/framework/plugins/noderesources/resource_limits_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_limits_test.go
@@ -152,7 +152,7 @@ func TestResourceLimits(t *testing.T) {
 			for i := range test.nodes {
 				state := framework.NewCycleState()
 				if !test.skipPreScore {
-					status := p.PreScore(context.Background(), state, test.pod, test.nodes, nil)
+					status := p.PreScore(context.Background(), state, test.pod, test.nodes)
 					if !status.IsSuccess() {
 						t.Errorf("unexpected error: %v", status)
 					}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -84,7 +84,6 @@ func (pl *PodTopologySpread) PreScore(
 	cycleState *framework.CycleState,
 	pod *v1.Pod,
 	filteredNodes []*v1.Node,
-	_ framework.NodeToStatusMap,
 ) *framework.Status {
 	allNodes, err := pl.sharedLister.NodeInfos().List()
 	if err != nil {

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -476,7 +476,7 @@ func TestPodTopologySpreadScore(t *testing.T) {
 			snapshot := cache.NewSnapshot(tt.existingPods, allNodes)
 			p := &PodTopologySpread{sharedLister: snapshot}
 
-			status := p.PreScore(context.Background(), state, tt.pod, tt.nodes, nil)
+			status := p.PreScore(context.Background(), state, tt.pod, tt.nodes)
 			if !status.IsSuccess() {
 				t.Errorf("unexpected error: %v", status)
 			}
@@ -546,7 +546,7 @@ func BenchmarkTestPodTopologySpreadScore(b *testing.B) {
 			snapshot := cache.NewSnapshot(existingPods, allNodes)
 			p := &PodTopologySpread{sharedLister: snapshot}
 
-			status := p.PreScore(context.Background(), state, tt.pod, filteredNodes, nil)
+			status := p.PreScore(context.Background(), state, tt.pod, filteredNodes)
 			if !status.IsSuccess() {
 				b.Fatalf("unexpected error: %v", status)
 			}
@@ -605,7 +605,7 @@ func BenchmarkTestDefaultEvenPodsSpreadPriority(b *testing.B) {
 			snapshot := cache.NewSnapshot(existingPods, allNodes)
 			p := &PodTopologySpread{sharedLister: snapshot}
 
-			status := p.PreScore(context.Background(), state, pod, filteredNodes, nil)
+			status := p.PreScore(context.Background(), state, pod, filteredNodes)
 			if !status.IsSuccess() {
 				b.Fatalf("unexpected error: %v", status)
 			}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -100,7 +100,7 @@ func getAllTolerationPreferNoSchedule(tolerations []v1.Toleration) (tolerationLi
 }
 
 // PreScore builds and writes cycle state used by Score and NormalizeScore.
-func (pl *TaintToleration) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node, _ framework.NodeToStatusMap) *framework.Status {
+func (pl *TaintToleration) PreScore(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
 	if len(nodes) == 0 {
 		return nil
 	}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration_test.go
@@ -233,7 +233,7 @@ func TestTaintTolerationScore(t *testing.T) {
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
 
 			p, _ := New(nil, fh)
-			status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes, nil)
+			status := p.(framework.PreScorePlugin).PreScore(context.Background(), state, test.pod, test.nodes)
 			if !status.IsSuccess() {
 				t.Errorf("unexpected error: %v", status)
 			}

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -169,7 +169,7 @@ func (pl *TestPlugin) Filter(ctx context.Context, state *CycleState, pod *v1.Pod
 	return NewStatus(Code(pl.inj.FilterStatus), "injected filter status")
 }
 
-func (pl *TestPlugin) PreScore(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node, filteredNodesStatuses NodeToStatusMap) *Status {
+func (pl *TestPlugin) PreScore(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node) *Status {
 	return NewStatus(Code(pl.inj.PreScoreStatus), "injected status")
 }
 
@@ -1329,7 +1329,7 @@ func TestRecordingMetrics(t *testing.T) {
 		},
 		{
 			name:               "PreScore - Success",
-			action:             func(f Framework) { f.RunPreScorePlugins(context.Background(), state, pod, nil, nil) },
+			action:             func(f Framework) { f.RunPreScorePlugins(context.Background(), state, pod, nil) },
 			wantExtensionPoint: "PreScore",
 			wantStatus:         Success,
 		},
@@ -1385,7 +1385,7 @@ func TestRecordingMetrics(t *testing.T) {
 		},
 		{
 			name:               "PreScore - Error",
-			action:             func(f Framework) { f.RunPreScorePlugins(context.Background(), state, pod, nil, nil) },
+			action:             func(f Framework) { f.RunPreScorePlugins(context.Background(), state, pod, nil) },
 			inject:             injectedResult{PreScoreStatus: int(Error)},
 			wantExtensionPoint: "PreScore",
 			wantStatus:         Error,

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -310,9 +310,8 @@ type PreScorePlugin interface {
 	Plugin
 	// PreScore is called by the scheduling framework after a list of nodes
 	// passed the filtering phase. All prescore plugins must return success or
-	// the pod will be rejected. The filteredNodesStatuses is the set of filtered nodes
-	// and their filter status.
-	PreScore(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node, filteredNodesStatuses NodeToStatusMap) *Status
+	// the pod will be rejected
+	PreScore(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node) *Status
 }
 
 // ScoreExtensions is an interface for Score extended functionality.
@@ -439,9 +438,8 @@ type Framework interface {
 	RunPreFilterExtensionRemovePod(ctx context.Context, state *CycleState, podToSchedule *v1.Pod, podToAdd *v1.Pod, nodeInfo *schedulernodeinfo.NodeInfo) *Status
 
 	// RunPreScorePlugins runs the set of configured pre-score plugins. If any
-	// of these plugins returns any status other than "Success", the given pod is
-	// rejected. The filteredNodeStatuses is the set of filtered nodes and their statuses.
-	RunPreScorePlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node, filteredNodesStatuses NodeToStatusMap) *Status
+	// of these plugins returns any status other than "Success", the given pod is rejected.
+	RunPreScorePlugins(ctx context.Context, state *CycleState, pod *v1.Pod, nodes []*v1.Node) *Status
 
 	// RunScorePlugins runs the set of configured scoring plugins. It returns a map that
 	// stores for each scoring plugin name the corresponding NodeScoreList(s).

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -247,7 +247,7 @@ func (*PreScorePlugin) Name() string {
 }
 
 // PreScore is a test function.
-func (pfp *PreScorePlugin) PreScore(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, _ []*v1.Node, _ framework.NodeToStatusMap) *framework.Status {
+func (pfp *PreScorePlugin) PreScore(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, _ []*v1.Node) *framework.Status {
 	pfp.numPreScoreCalled++
 	if pfp.failPreScore {
 		return framework.NewStatus(framework.Error, fmt.Sprintf("injecting failure for pod %v", pod.Name))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
For keeping semantically correct, `PreScore` plugins don't need to know the output of filtering, aka the argument `FilteredNodesStatuses`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #87523 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove `FilteredNodesStatuses` argument from `PreScore`'s interface.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20180409-scheduling-framework.md
```
