### PR TITLE
Make MetricCollector configurable for scheduler benchmark tests

### DIFF
--- a/test/integration/scheduler_perf/scheduler_perf_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_test.go
@@ -19,13 +19,13 @@ package benchmark
 import (
 	"fmt"
 	"io/ioutil"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	"k8s.io/client-go/tools/cache"
+	coreinformers "k8s.io/client-go/informers/core/v1"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/component-base/featuregate"
 	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/klog"
@@ -39,11 +39,13 @@ const (
 )
 
 var (
-	defaultMetrics = []string{
-		"scheduler_scheduling_algorithm_predicate_evaluation_seconds",
-		"scheduler_scheduling_algorithm_priority_evaluation_seconds",
-		"scheduler_binding_duration_seconds",
-		"scheduler_e2e_scheduling_duration_seconds",
+	defaultMetricsCollectorConfig = metricsCollectorConfig{
+		Metrics: []string{
+			"scheduler_scheduling_algorithm_predicate_evaluation_seconds",
+			"scheduler_scheduling_algorithm_priority_evaluation_seconds",
+			"scheduler_binding_duration_seconds",
+			"scheduler_e2e_scheduling_duration_seconds",
+		},
 	}
 )
 
@@ -52,8 +54,8 @@ var (
 //
 // It specifies nodes and pods in the cluster before running the test. It also specifies the pods to
 // schedule during the test. The config can be as simple as just specify number of nodes/pods, where
-// default spec will be applied. It also allows the user to specify a pod spec template for more compicated
-// test cases.
+// default spec will be applied. It also allows the user to specify a pod spec template for more
+// complicated test cases.
 //
 // It also specifies the metrics to be collected after the test. If nothing is specified, default metrics
 // such as scheduling throughput and latencies will be collected.
@@ -68,6 +70,8 @@ type testCase struct {
 	PodsToSchedule podCase
 	// optional, feature gates to set before running the test
 	FeatureGates map[featuregate.Feature]bool
+	// optional, replaces default defaultMetricsCollectorConfig if supplied.
+	MetricsCollectorConfig *metricsCollectorConfig
 }
 
 type nodeCase struct {
@@ -100,6 +104,11 @@ type testParams struct {
 	NumPodsToSchedule int
 }
 
+type testDataCollector interface {
+	run(stopCh chan struct{})
+	collect() []DataItem
+}
+
 func BenchmarkPerfScheduling(b *testing.B) {
 	dataItems := DataItems{Version: "v1"}
 	tests := getSimpleTestCases(configFile)
@@ -119,119 +128,97 @@ func BenchmarkPerfScheduling(b *testing.B) {
 }
 
 func perfScheduling(test testCase, b *testing.B) []DataItem {
-	var nodeStrategy testutils.PrepareNodeStrategy = &testutils.TrivialNodePrepareStrategy{}
-	if test.Nodes.NodeAllocatableStrategy != nil {
-		nodeStrategy = test.Nodes.NodeAllocatableStrategy
-	} else if test.Nodes.LabelNodePrepareStrategy != nil {
-		nodeStrategy = test.Nodes.LabelNodePrepareStrategy
-	} else if test.Nodes.UniqueNodeLabelStrategy != nil {
-		nodeStrategy = test.Nodes.UniqueNodeLabelStrategy
-	}
-
-	setupPodStrategy := getPodStrategy(test.InitPods)
-	testPodStrategy := getPodStrategy(test.PodsToSchedule)
-
-	var nodeSpec *v1.Node
-	if test.Nodes.NodeTemplatePath != nil {
-		nodeSpec = getNodeSpecFromFile(test.Nodes.NodeTemplatePath)
-	}
-
 	finalFunc, podInformer, clientset := mustSetupScheduler()
 	defer finalFunc()
 
-	var nodePreparer testutils.TestNodePreparer
-	if nodeSpec != nil {
-		nodePreparer = framework.NewIntegrationTestNodePreparerWithNodeSpec(
-			clientset,
-			[]testutils.CountToStrategy{{Count: test.Nodes.Num, Strategy: nodeStrategy}},
-			nodeSpec,
-		)
-	} else {
-		nodePreparer = framework.NewIntegrationTestNodePreparer(
-			clientset,
-			[]testutils.CountToStrategy{{Count: test.Nodes.Num, Strategy: nodeStrategy}},
-			"scheduler-perf-",
-		)
-	}
-
+	nodePreparer := getNodePreparer(test.Nodes, clientset)
 	if err := nodePreparer.PrepareNodes(); err != nil {
 		klog.Fatalf("%v", err)
 	}
 	defer nodePreparer.CleanupNodes()
 
-	config := testutils.NewTestPodCreatorConfig()
-	config.AddStrategy(setupNamespace, test.InitPods.Num, setupPodStrategy)
-	podCreator := testutils.NewTestPodCreator(clientset, config)
-	podCreator.CreatePods()
+	createPods(setupNamespace, test.InitPods, clientset)
+	waitNumPodsScheduled(test.InitPods.Num, podInformer)
 
+	// start benchmark
+	b.ResetTimer()
+
+	// Start test data collectors.
+	stopCh := make(chan struct{})
+	collectors := getTestDataCollectors(test, podInformer, b)
+	for _, collector := range collectors {
+		go collector.run(stopCh)
+	}
+
+	// Schedule the main workload
+	createPods(testNamespace, test.PodsToSchedule, clientset)
+	waitNumPodsScheduled(test.InitPods.Num+test.PodsToSchedule.Num, podInformer)
+
+	close(stopCh)
+	// Note: without this line we're taking the overhead of defer() into account.
+	b.StopTimer()
+
+	var dataItems []DataItem
+	for _, collector := range collectors {
+		dataItems = append(dataItems, collector.collect()...)
+	}
+	return dataItems
+}
+
+func waitNumPodsScheduled(num int, podInformer coreinformers.PodInformer) {
 	for {
 		scheduled, err := getScheduledPods(podInformer)
 		if err != nil {
 			klog.Fatalf("%v", err)
 		}
-		if len(scheduled) >= test.InitPods.Num {
+		if len(scheduled) >= num {
 			break
 		}
-		klog.Infof("got %d existing pods, required: %d", len(scheduled), test.InitPods.Num)
+		klog.Infof("got %d existing pods, required: %d", len(scheduled), num)
 		time.Sleep(1 * time.Second)
 	}
+}
 
-	scheduled := int32(0)
-	completedCh := make(chan struct{})
-	podInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: func(old, cur interface{}) {
-			curPod := cur.(*v1.Pod)
-			oldPod := old.(*v1.Pod)
+func getTestDataCollectors(tc testCase, podInformer coreinformers.PodInformer, b *testing.B) []testDataCollector {
+	collectors := []testDataCollector{newThroughputCollector(podInformer, map[string]string{"Name": b.Name()})}
+	metricsCollectorConfig := defaultMetricsCollectorConfig
+	if tc.MetricsCollectorConfig != nil {
+		metricsCollectorConfig = *tc.MetricsCollectorConfig
+	}
+	collectors = append(collectors, newMetricsCollector(metricsCollectorConfig, map[string]string{"Name": b.Name()}))
+	return collectors
+}
 
-			if len(oldPod.Spec.NodeName) == 0 && len(curPod.Spec.NodeName) > 0 {
-				if atomic.AddInt32(&scheduled, 1) >= int32(test.PodsToSchedule.Num) {
-					completedCh <- struct{}{}
-				}
-			}
-		},
-	})
+func getNodePreparer(nc nodeCase, clientset clientset.Interface) testutils.TestNodePreparer {
+	var nodeStrategy testutils.PrepareNodeStrategy = &testutils.TrivialNodePrepareStrategy{}
+	if nc.NodeAllocatableStrategy != nil {
+		nodeStrategy = nc.NodeAllocatableStrategy
+	} else if nc.LabelNodePrepareStrategy != nil {
+		nodeStrategy = nc.LabelNodePrepareStrategy
+	} else if nc.UniqueNodeLabelStrategy != nil {
+		nodeStrategy = nc.UniqueNodeLabelStrategy
+	}
 
-	// start benchmark
-	b.ResetTimer()
+	if nc.NodeTemplatePath != nil {
+		return framework.NewIntegrationTestNodePreparerWithNodeSpec(
+			clientset,
+			[]testutils.CountToStrategy{{Count: nc.Num, Strategy: nodeStrategy}},
+			getNodeSpecFromFile(nc.NodeTemplatePath),
+		)
+	}
+	return framework.NewIntegrationTestNodePreparer(
+		clientset,
+		[]testutils.CountToStrategy{{Count: nc.Num, Strategy: nodeStrategy}},
+		"scheduler-perf-",
+	)
+}
 
-	// Start measuring throughput
-	stopCh := make(chan struct{})
-	throughputCollector := newThroughputCollector(podInformer)
-	go throughputCollector.run(stopCh)
-
-	// Scheduling the main workload
-	config = testutils.NewTestPodCreatorConfig()
-	config.AddStrategy(testNamespace, test.PodsToSchedule.Num, testPodStrategy)
-	podCreator = testutils.NewTestPodCreator(clientset, config)
+func createPods(ns string, pc podCase, clientset clientset.Interface) {
+	strategy := getPodStrategy(pc)
+	config := testutils.NewTestPodCreatorConfig()
+	config.AddStrategy(ns, pc.Num, strategy)
+	podCreator := testutils.NewTestPodCreator(clientset, config)
 	podCreator.CreatePods()
-
-	<-completedCh
-	close(stopCh)
-
-	// Note: without this line we're taking the overhead of defer() into account.
-	b.StopTimer()
-
-	setNameLabel := func(dataItem *DataItem) DataItem {
-		if dataItem.Labels == nil {
-			dataItem.Labels = map[string]string{}
-		}
-		dataItem.Labels["Name"] = b.Name()
-		return *dataItem
-	}
-
-	dataItems := []DataItem{
-		setNameLabel(throughputCollector.collect()),
-	}
-
-	for _, metric := range defaultMetrics {
-		dataItem := newMetricsCollector(metric).collect()
-		if dataItem == nil {
-			continue
-		}
-		dataItems = append(dataItems, setNameLabel(dataItem))
-	}
-
-	return dataItems
 }
 
 func getPodStrategy(pc podCase) testutils.TestPodCreateStrategy {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
* Make the metricsCollector configurable through test YAML files.This allows certain test cases to define their own set of metrics to collect. For example,
```
- template:
    desc: SchedulingBasic
    metricsCollector:
      metrics:
        - "MY_METRIC_1"
        - "MY_METRIC_2"
    initPods:
      podTemplatePath: config/pod-default.yaml
    podsToSchedule:
      podTemplatePath: config/pod-default.yaml
```
* Using the same pattern, we can add and customize other test data collectors if needed. For instance, we can have a custom collector that evaluates the effectiveness of even pod spreading.
 * Wrapped some lengthy and distracting logic into helper functions
 * Previously there are two different ways to check pods are scheduled. Now it's unified to a simple `waitNumPodsScheduled` function.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

cc @ahg-g @ingvagabund 
