### PR TITLE
Improve SyncService performances

### DIFF
--- a/pkg/proxy/ipvs/proxier_test.go
+++ b/pkg/proxy/ipvs/proxier_test.go
@@ -53,11 +53,16 @@ import (
 const testHostname = "test-hostname"
 
 type fakeIPGetter struct {
-	nodeIPs []net.IP
+	nodeIPs   []net.IP
+	bindedIPs sets.String
 }
 
 func (f *fakeIPGetter) NodeIPs() ([]net.IP, error) {
 	return f.nodeIPs, nil
+}
+
+func (f *fakeIPGetter) BindedIPs() (sets.String, error) {
+	return f.bindedIPs, nil
 }
 
 // fakePortOpener implements portOpener.
@@ -3120,7 +3125,7 @@ func Test_syncService(t *testing.T) {
 				t.Errorf("Case [%d], unexpected add IPVS virtual server error: %v", i, err)
 			}
 		}
-		if err := proxier.syncService(testCases[i].svcName, testCases[i].newVirtualServer, testCases[i].bindAddr); err != nil {
+		if err := proxier.syncService(testCases[i].svcName, testCases[i].newVirtualServer, testCases[i].bindAddr, sets.NewString()); err != nil {
 			t.Errorf("Case [%d], unexpected sync IPVS virtual server error: %v", i, err)
 		}
 		// check


### PR DESCRIPTION
Partially addresses #88212 by making sure we only call EnsureBindAddress when needed (retrieve all addresses bound to the dummy interface only once during a sync).

I'm not sure this is the best approach, and I'm more than happy to modify the PR. The results are very promising.

Flamegraphs before and after patch (showing that EnsureBindAddress is almost gone)
[flamegraphs.tar.gz](https://github.com/kubernetes/kubernetes/files/4209850/flamegraphs.tar.gz)

kube-proxy cpu metric on a large cluster (2000 services with ClusterIP), showing a 30% perf improvement (from 15% of a core to 10% after the patch):
![image](https://user-images.githubusercontent.com/5391707/74606537-8e0fab80-50d1-11ea-81f7-47e62b4edc4a.png)

/sig network
/area ipvs
/kind feature
/assign @andrewsykim 

```release-note
kube-proxy: improve performances in IPVS mode on large clusters
```