### PR TITLE
podlogs: include node name in prefix

### DIFF
--- a/test/e2e/framework/podlogs/podlogs.go
+++ b/test/e2e/framework/podlogs/podlogs.go
@@ -133,7 +133,11 @@ func CopyAllLogs(ctx context.Context, cs clientset.Interface, ns string, to LogO
 					var prefix string
 					if to.LogWriter != nil {
 						out = to.LogWriter
-						prefix = name + ": "
+						nodeName := pod.Spec.NodeName
+						if len(nodeName) > 10 {
+							nodeName = nodeName[0:4] + ".." + nodeName[len(nodeName)-4:]
+						}
+						prefix = name + "@" + nodeName + ": "
 					} else {
 						var err error
 						filename := to.LogPathPrefix + pod.ObjectMeta.Name + "-" + c.Name + ".log"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This is useful for logs from daemonset pods because for those it is
often relevant which node they ran on because they interact with
resources or other pods on the host.

To keep the log prefix short, it gets limited to a maximum length of
10 characters.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
