### PR TITLE
e2e topology manager: single-numa-node multi container tests

### DIFF
--- a/test/e2e_node/numa_alignment.go
+++ b/test/e2e_node/numa_alignment.go
@@ -180,6 +180,7 @@ func makeEnvMap(logs string) (map[string]string, error) {
 type testEnvInfo struct {
 	numaNodes         int
 	sriovResourceName string
+	policy            string
 }
 
 func containerWantsDevices(cnt *v1.Container, envInfo *testEnvInfo) bool {

--- a/test/e2e_node/numa_alignment.go
+++ b/test/e2e_node/numa_alignment.go
@@ -44,8 +44,7 @@ func (R *numaPodResources) CheckAlignment() bool {
 		}
 	}
 	for _, devNode := range R.PCIDevsToNUMANode {
-		// TODO: explain -1
-		if devNode != -1 && nodeNum != devNode {
+		if nodeNum != devNode {
 			return false
 		}
 	}

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -83,7 +83,7 @@ func detectCoresPerSocket() int {
 }
 
 func detectSRIOVDevices() int {
-	outData, err := exec.Command("/bin/sh", "-c", "ls /sys/bus/pci/devices/*/sriov_totalvfs | wc -w").Output()
+	outData, err := exec.Command("/bin/sh", "-c", "ls /sys/bus/pci/devices/*/physfn | wc -w").Output()
 	framework.ExpectNoError(err)
 
 	devCount, err := strconv.Atoi(strings.TrimSpace(string(outData)))
@@ -728,7 +728,7 @@ func runTopologyManagerTests(f *framework.Framework) {
 			e2eskipper.Skipf("this test is meant to run on a system with at least 4 cores per socket")
 		}
 		if sriovdevCount == 0 {
-			e2eskipper.Skipf("this test is meant to run on a system with at least one SRIOV device")
+			e2eskipper.Skipf("this test is meant to run on a system with at least one configured VF from SRIOV device")
 		}
 
 		configMap := getSRIOVDevicePluginConfigMap(framework.TestContext.SriovdpConfigMapFile)

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -778,6 +778,69 @@ func runTopologyManagerNodeAlignmentSuiteTests(f *framework.Framework, configMap
 		// testing more complex conditions require knowledge about the system cpu+bus topology
 	}
 
+	// multi-container tests
+	if sriovResourceAmount >= 4 {
+		ginkgo.By(fmt.Sprintf("Successfully admit one guaranteed pods, each with two containers, each with 2 cores, 1 %s device", sriovResourceName))
+		ctnAttrs = []tmCtnAttribute{
+			{
+				ctnName:       "gu-container-0",
+				cpuRequest:    "2000m",
+				cpuLimit:      "2000m",
+				deviceName:    sriovResourceName,
+				deviceRequest: "1",
+				deviceLimit:   "1",
+			},
+			{
+				ctnName:       "gu-container-1",
+				cpuRequest:    "2000m",
+				cpuLimit:      "2000m",
+				deviceName:    sriovResourceName,
+				deviceRequest: "1",
+				deviceLimit:   "1",
+			},
+		}
+		runTopologyManagerPositiveTest(f, 1, ctnAttrs, hwinfo)
+
+		ginkgo.By(fmt.Sprintf("Successfully admit two guaranteed pods, each with two containers, each with 1 core, 1 %s device", sriovResourceName))
+		ctnAttrs = []tmCtnAttribute{
+			{
+				ctnName:       "gu-container-0",
+				cpuRequest:    "1000m",
+				cpuLimit:      "1000m",
+				deviceName:    sriovResourceName,
+				deviceRequest: "1",
+				deviceLimit:   "1",
+			},
+			{
+				ctnName:       "gu-container-1",
+				cpuRequest:    "1000m",
+				cpuLimit:      "1000m",
+				deviceName:    sriovResourceName,
+				deviceRequest: "1",
+				deviceLimit:   "1",
+			},
+		}
+		runTopologyManagerPositiveTest(f, 2, ctnAttrs, hwinfo)
+
+		ginkgo.By(fmt.Sprintf("Successfully admit two guaranteed pods, each with two containers, both with with 2 cores, one with 1 %s device", sriovResourceName))
+		ctnAttrs = []tmCtnAttribute{
+			{
+				ctnName:       "gu-container-dev",
+				cpuRequest:    "2000m",
+				cpuLimit:      "2000m",
+				deviceName:    sriovResourceName,
+				deviceRequest: "1",
+				deviceLimit:   "1",
+			},
+			{
+				ctnName:    "gu-container-nodev",
+				cpuRequest: "2000m",
+				cpuLimit:   "2000m",
+			},
+		}
+		runTopologyManagerPositiveTest(f, 2, ctnAttrs, hwinfo)
+	}
+
 	// overflow NUMA node capacity: cores
 	numCores := 1 + (threadsPerCore * coreCount)
 	excessCoresReq := fmt.Sprintf("%dm", numCores*1000)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This is a followup of https://github.com/kubernetes/kubernetes/pull/87645 . I'm working to add more e2e tests for the topology manager
to fix the issue https://github.com/kubernetes/kubernetes/issues/83481
This PR adds minor fixes and improvements that didn't make it into https://github.com/kubernetes/kubernetes/pull/87645 and adds e2e node tests for multi-container pods.

**Which issue(s) this PR fixes**:
Related to https://github.com/kubernetes/kubernetes/issues/83481

**Special notes for your reviewer**:
N/A

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```