### PR TITLE
Better error message for type error in strategic patch

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/converter.go
@@ -220,7 +220,7 @@ func fromUnstructured(sv, dv reflect.Value) error {
 	case reflect.Interface:
 		return interfaceFromUnstructured(sv, dv)
 	default:
-		return fmt.Errorf("unrecognized type: %v", dt.Kind())
+		return fmt.Errorf("can't convert type %v -> %v", st.Kind(), dt.Kind())
 	}
 }
 
@@ -520,7 +520,7 @@ func toUnstructured(sv, dv reflect.Value) error {
 	case reflect.Interface:
 		return interfaceToUnstructured(sv, dv)
 	default:
-		return fmt.Errorf("unrecognized type: %v", st.Kind())
+		return fmt.Errorf("can't convert value %#v of type %v -> %v", sv, st.Kind(), dv.Type().Kind())
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/patch.go
@@ -466,7 +466,9 @@ func strategicPatchObject(
 ) error {
 	originalObjMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(originalObject)
 	if err != nil {
-		return err
+		return errors.NewInvalid(schema.GroupKind{}, "", field.ErrorList{
+			field.Invalid(field.NewPath("patch"), "", err.Error()),
+		})
 	}
 
 	patchMap := make(map[string]interface{})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Since @cben is out, I am sending this PR which is based on his previous PR (73695).

Improves server-side error message from unexpected types in strategic patch (also shown by kubectl apply and sometimes by kubectl edit #26050).

In a large patch (especially via kubectl apply), this will help locating the problem.
See #73692 for details.

**Which issue(s) this PR fixes**:
Fixes #73692

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
