### PR TITLE
test/e2e/node: fix selinux test failure

### DIFF
--- a/test/e2e/node/security_context.go
+++ b/test/e2e/node/security_context.go
@@ -26,7 +26,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -252,10 +252,11 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	pod.Spec.SecurityContext.SELinuxOptions = &v1.SELinuxOptions{
 		Level: "s0:c0,c1",
 	}
-
 	f.TestContainerOutput("Pod with same MCS label reading test file", pod, 0, []string{testContent})
+
 	// Confirm that the same pod with a different MCS
 	// label cannot access the volume
+	ginkgo.By("confirming a container with a different MCS label is unable to read the file")
 	pod = scTestPod(hostIPC, hostPID)
 	pod.Spec.Volumes = volumes
 	pod.Spec.Containers[0].VolumeMounts = volumeMounts
@@ -269,7 +270,10 @@ func testPodSELinuxLabeling(f *framework.Framework, hostIPC bool, hostPID bool) 
 	err = f.WaitForPodRunning(pod.Name)
 	framework.ExpectNoError(err, "Error waiting for pod to run %v", pod)
 
-	content, err = tk.ReadFileViaContainer(pod.Name, "test-container", testFilePath)
-	framework.ExpectNoError(err, "Error reading file via container")
-	gomega.Expect(content).NotTo(gomega.ContainSubstring(testContent))
+	// for this to work, SELinux should be in enforcing mode, so let's check that
+	isEnforced, err := tk.ReadFileViaContainer(pod.Name, "test-container", "/sys/fs/selinux/enforce")
+	if err == nil && isEnforced == "1" {
+		_, err = tk.ReadFileViaContainer(pod.Name, "test-container", testFilePath)
+		framework.ExpectError(err, "expecting SELinux to not let the container with different MCS label to read the file")
+	}
 }


### PR DESCRIPTION
_(this is a carry of #88145, some initial discussion is in there)_

Commit 69a473be3 broke the test case (that was checking
that a file from a volume can't be read) by adding a
(wrong) assumption that error should be nil.

Fix the assumption (we *do* expect the error here).
Note that we were checking file contents before; now when
we check the error from read, checking the contents is
redundant.

The other issue with the test is SELinux should be in enforcing
mode for this to work, so let's check that first to avoid
false positives.

While at it, add test case description (`gingko.By()`).

/kind failing-test
fixes #87901

```release-note
NONE
```