### PR TITLE
tests: Replaces mounttest images used with agnhost (part 4)

### DIFF
--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -40,8 +40,6 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-var mountImage = imageutils.GetE2EImage(imageutils.Mounttest)
-
 var _ = SIGDescribe("ServiceAccounts", func() {
 	f := framework.NewDefaultFramework("svcaccounts")
 
@@ -388,7 +386,7 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 			pod := &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{Name: tc.PodName},
 				Spec: v1.PodSpec{
-					Containers:                   []v1.Container{{Name: "token-test", Image: mountImage}},
+					Containers:                   []v1.Container{{Name: "token-test", Image: imageutils.GetE2EImage(imageutils.Agnhost)}},
 					RestartPolicy:                v1.RestartPolicyNever,
 					ServiceAccountName:           tc.ServiceAccountName,
 					AutomountServiceAccountToken: tc.AutomountPodSpec,

--- a/test/e2e/common/configmap_volume.go
+++ b/test/e2e/common/configmap_volume.go
@@ -162,9 +162,9 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 				},
 				Containers: []v1.Container{
 					{
-						Name:    containerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volume/data-1"},
+						Name:  containerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volume/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      volumeName,
@@ -249,9 +249,9 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 				},
 				Containers: []v1.Container{
 					{
-						Name:    containerName1,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volume/data-1"},
+						Name:  containerName1,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volume/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      volumeName,
@@ -395,9 +395,9 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 				},
 				Containers: []v1.Container{
 					{
-						Name:    deleteContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/delete/data-1"},
+						Name:  deleteContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/delete/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
@@ -407,9 +407,9 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 						},
 					},
 					{
-						Name:    updateContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/update/data-3"},
+						Name:  updateContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/update/data-3"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
@@ -419,9 +419,9 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 						},
 					},
 					{
-						Name:    createContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1"},
+						Name:  createContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
@@ -526,8 +526,8 @@ var _ = ginkgo.Describe("[sig-storage] ConfigMap", func() {
 				Containers: []v1.Container{
 					{
 						Name:  "configmap-volume-test",
-						Image: imageutils.GetE2EImage(imageutils.Mounttest),
-						Args:  []string{"--file_content=/etc/configmap-volume/data-1"},
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--file_content=/etc/configmap-volume/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      volumeName,
@@ -671,8 +671,9 @@ func doConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool, fsGroup 
 			Containers: []v1.Container{
 				{
 					Name:  "configmap-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						"--file_content=/etc/configmap-volume/data-1",
 						"--file_mode=/etc/configmap-volume/data-1"},
 					VolumeMounts: []v1.VolumeMount{
@@ -753,8 +754,10 @@ func doConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fsGroup int
 			Containers: []v1.Container{
 				{
 					Name:  "configmap-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
-					Args: []string{"--file_content=/etc/configmap-volume/path/to/data-2",
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args: []string{
+						"mounttest",
+						"--file_content=/etc/configmap-volume/path/to/data-2",
 						"--file_mode=/etc/configmap-volume/path/to/data-2"},
 					VolumeMounts: []v1.VolumeMount{
 						{
@@ -824,9 +827,9 @@ func createNonOptionalConfigMapPod(f *framework.Framework, volumeMountPath, podN
 			},
 			Containers: []v1.Container{
 				{
-					Name:    createContainerName,
-					Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-					Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1"},
+					Name:  createContainerName,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      createVolumeName,
@@ -886,9 +889,9 @@ func createNonOptionalConfigMapPodWithConfig(f *framework.Framework, volumeMount
 			},
 			Containers: []v1.Container{
 				{
-					Name:    createContainerName,
-					Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-					Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1"},
+					Name:  createContainerName,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/configmap-volumes/create/data-1"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      createVolumeName,

--- a/test/e2e/common/downwardapi_volume.go
+++ b/test/e2e/common/downwardapi_volume.go
@@ -273,9 +273,9 @@ func downwardAPIVolumePodForModeTest(name, filePath string, itemMode, defaultMod
 
 	pod.Spec.Containers = []v1.Container{
 		{
-			Name:    "client-container",
-			Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-			Command: []string{"/mounttest", "--file_mode=" + filePath},
+			Name:  "client-container",
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"mounttest", "--file_mode=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
@@ -299,9 +299,9 @@ func downwardAPIVolumePodForSimpleTest(name string, filePath string) *v1.Pod {
 
 	pod.Spec.Containers = []v1.Container{
 		{
-			Name:    "client-container",
-			Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-			Command: []string{"/mounttest", "--file_content=" + filePath},
+			Name:  "client-container",
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"mounttest", "--file_content=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
@@ -330,9 +330,9 @@ func downwardAPIVolumeForDefaultContainerResources(name string, filePath string)
 func downwardAPIVolumeBaseContainers(name, filePath string) []v1.Container {
 	return []v1.Container{
 		{
-			Name:    name,
-			Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-			Command: []string{"/mounttest", "--file_content=" + filePath},
+			Name:  name,
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"mounttest", "--file_content=" + filePath},
 			Resources: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("250m"),
@@ -358,9 +358,9 @@ func downwardAPIVolumeBaseContainers(name, filePath string) []v1.Container {
 func downwardAPIVolumeDefaultBaseContainer(name, filePath string) []v1.Container {
 	return []v1.Container{
 		{
-			Name:    name,
-			Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-			Command: []string{"/mounttest", "--file_content=" + filePath},
+			Name:  name,
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"mounttest", "--file_content=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
@@ -377,9 +377,9 @@ func downwardAPIVolumePodForUpdateTest(name string, labels, annotations map[stri
 
 	pod.Spec.Containers = []v1.Container{
 		{
-			Name:    "client-container",
-			Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
+			Name:  "client-container",
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"mounttest", "--break_on_expected_content=false", "--retry_time=120", "--file_content_in_loop=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",

--- a/test/e2e/common/empty_dir.go
+++ b/test/e2e/common/empty_dir.go
@@ -35,8 +35,7 @@ const (
 )
 
 var (
-	testImageRootUid    = imageutils.GetE2EImage(imageutils.Mounttest)
-	testImageNonRootUid = imageutils.GetE2EImage(imageutils.MounttestUser)
+	nonRootUid = int64(1001)
 )
 
 var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
@@ -50,27 +49,27 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		})
 
 		ginkgo.It("new files should be created with FSGroup ownership when container is root", func() {
-			doTestSetgidFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
+			doTestSetgidFSGroup(f, 0, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("new files should be created with FSGroup ownership when container is non-root", func() {
-			doTestSetgidFSGroup(f, testImageNonRootUid, v1.StorageMediumMemory)
+			doTestSetgidFSGroup(f, nonRootUid, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("nonexistent volume subPath should have the correct mode and owner using FSGroup", func() {
-			doTestSubPathFSGroup(f, testImageNonRootUid, v1.StorageMediumMemory)
+			doTestSubPathFSGroup(f, nonRootUid, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("files with FSGroup ownership should support (root,0644,tmpfs)", func() {
-			doTest0644FSGroup(f, testImageRootUid, v1.StorageMediumMemory)
+			doTest0644FSGroup(f, 0, v1.StorageMediumMemory)
 		})
 
 		ginkgo.It("volume on default medium should have the correct mode using FSGroup", func() {
-			doTestVolumeModeFSGroup(f, testImageRootUid, v1.StorageMediumDefault)
+			doTestVolumeModeFSGroup(f, 0, v1.StorageMediumDefault)
 		})
 
 		ginkgo.It("volume on tmpfs should have the correct mode using FSGroup", func() {
-			doTestVolumeModeFSGroup(f, testImageRootUid, v1.StorageMediumMemory)
+			doTestVolumeModeFSGroup(f, 0, v1.StorageMediumMemory)
 		})
 	})
 
@@ -81,7 +80,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("volume on tmpfs should have the correct mode [LinuxOnly] [NodeConformance]", func() {
-		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumMemory)
+		doTestVolumeMode(f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -91,7 +90,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
-		doTest0644(f, testImageRootUid, v1.StorageMediumMemory)
+		doTest0644(f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -101,7 +100,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
-		doTest0666(f, testImageRootUid, v1.StorageMediumMemory)
+		doTest0666(f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -111,7 +110,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
-		doTest0777(f, testImageRootUid, v1.StorageMediumMemory)
+		doTest0777(f, 0, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -121,7 +120,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (non-root,0644,tmpfs) [LinuxOnly] [NodeConformance]", func() {
-		doTest0644(f, testImageNonRootUid, v1.StorageMediumMemory)
+		doTest0644(f, nonRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -131,7 +130,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (non-root,0666,tmpfs) [LinuxOnly] [NodeConformance]", func() {
-		doTest0666(f, testImageNonRootUid, v1.StorageMediumMemory)
+		doTest0666(f, nonRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -141,7 +140,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID, or the medium = 'Memory'.
 	*/
 	framework.ConformanceIt("should support (non-root,0777,tmpfs) [LinuxOnly] [NodeConformance]", func() {
-		doTest0777(f, testImageNonRootUid, v1.StorageMediumMemory)
+		doTest0777(f, nonRootUid, v1.StorageMediumMemory)
 	})
 
 	/*
@@ -151,7 +150,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions.
 	*/
 	framework.ConformanceIt("volume on default medium should have the correct mode [LinuxOnly] [NodeConformance]", func() {
-		doTestVolumeMode(f, testImageRootUid, v1.StorageMediumDefault)
+		doTestVolumeMode(f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -161,7 +160,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (root,0644,default) [LinuxOnly] [NodeConformance]", func() {
-		doTest0644(f, testImageRootUid, v1.StorageMediumDefault)
+		doTest0644(f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -171,7 +170,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (root,0666,default) [LinuxOnly] [NodeConformance]", func() {
-		doTest0666(f, testImageRootUid, v1.StorageMediumDefault)
+		doTest0666(f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -181,7 +180,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (root,0777,default) [LinuxOnly] [NodeConformance]", func() {
-		doTest0777(f, testImageRootUid, v1.StorageMediumDefault)
+		doTest0777(f, 0, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -191,7 +190,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (non-root,0644,default) [LinuxOnly] [NodeConformance]", func() {
-		doTest0644(f, testImageNonRootUid, v1.StorageMediumDefault)
+		doTest0644(f, nonRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -201,7 +200,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (non-root,0666,default) [LinuxOnly] [NodeConformance]", func() {
-		doTest0666(f, testImageNonRootUid, v1.StorageMediumDefault)
+		doTest0666(f, nonRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -211,7 +210,7 @@ var _ = ginkgo.Describe("[sig-storage] EmptyDir volumes", func() {
 		This test is marked LinuxOnly since Windows does not support setting specific file permissions, or running as UID / GID.
 	*/
 	framework.ConformanceIt("should support (non-root,0777,default) [LinuxOnly] [NodeConformance]", func() {
-		doTest0777(f, testImageNonRootUid, v1.StorageMediumDefault)
+		doTest0777(f, nonRootUid, v1.StorageMediumDefault)
 	})
 
 	/*
@@ -301,14 +300,15 @@ const (
 	volumeName    = "test-volume"
 )
 
-func doTestSetgidFSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTestSetgidFSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod      = testPodWithVolume(testImageRootUid, volumePath, source)
+		pod      = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--new_file_0660=%v", filePath),
 		fmt.Sprintf("--file_perm=%v", filePath),
@@ -330,14 +330,15 @@ func doTestSetgidFSGroup(f *framework.Framework, image string, medium v1.Storage
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTestSubPathFSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		subPath = "test-sub"
 		source  = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod     = testPodWithVolume(image, volumePath, source)
+		pod     = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--file_perm=%v", volumePath),
 		fmt.Sprintf("--file_owner=%v", volumePath),
@@ -362,13 +363,14 @@ func doTestSubPathFSGroup(f *framework.Framework, image string, medium v1.Storag
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTestVolumeModeFSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTestVolumeModeFSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		source = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod    = testPodWithVolume(testImageRootUid, volumePath, source)
+		pod    = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--file_perm=%v", volumePath),
 	}
@@ -386,14 +388,15 @@ func doTestVolumeModeFSGroup(f *framework.Framework, image string, medium v1.Sto
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0644FSGroup(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTest0644FSGroup(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod      = testPodWithVolume(image, volumePath, source)
+		pod      = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--new_file_0644=%v", filePath),
 		fmt.Sprintf("--file_perm=%v", filePath),
@@ -413,13 +416,14 @@ func doTest0644FSGroup(f *framework.Framework, image string, medium v1.StorageMe
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTestVolumeMode(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTestVolumeMode(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		source = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod    = testPodWithVolume(testImageRootUid, volumePath, source)
+		pod    = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--file_perm=%v", volumePath),
 	}
@@ -434,14 +438,15 @@ func doTestVolumeMode(f *framework.Framework, image string, medium v1.StorageMed
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0644(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTest0644(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod      = testPodWithVolume(image, volumePath, source)
+		pod      = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--new_file_0644=%v", filePath),
 		fmt.Sprintf("--file_perm=%v", filePath),
@@ -458,14 +463,15 @@ func doTest0644(f *framework.Framework, image string, medium v1.StorageMedium) {
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0666(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTest0666(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod      = testPodWithVolume(image, volumePath, source)
+		pod      = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--new_file_0666=%v", filePath),
 		fmt.Sprintf("--file_perm=%v", filePath),
@@ -482,14 +488,15 @@ func doTest0666(f *framework.Framework, image string, medium v1.StorageMedium) {
 	f.TestContainerOutput(msg, pod, 0, out)
 }
 
-func doTest0777(f *framework.Framework, image string, medium v1.StorageMedium) {
+func doTest0777(f *framework.Framework, uid int64, medium v1.StorageMedium) {
 	var (
 		filePath = path.Join(volumePath, "test-file")
 		source   = &v1.EmptyDirVolumeSource{Medium: medium}
-		pod      = testPodWithVolume(image, volumePath, source)
+		pod      = testPodWithVolume(uid, volumePath, source)
 	)
 
 	pod.Spec.Containers[0].Args = []string{
+		"mounttest",
 		fmt.Sprintf("--fs_type=%v", volumePath),
 		fmt.Sprintf("--new_file_0777=%v", filePath),
 		fmt.Sprintf("--file_perm=%v", filePath),
@@ -514,9 +521,11 @@ func formatMedium(medium v1.StorageMedium) string {
 	return "node default medium"
 }
 
-func testPodWithVolume(image, path string, source *v1.EmptyDirVolumeSource) *v1.Pod {
+// testPodWithVolume creates a Pod that runs as the given UID and with the given empty dir source mounted at the given path.
+// If the uid is 0, the Pod will run as its default user (root).
+func testPodWithVolume(uid int64, path string, source *v1.EmptyDirVolumeSource) *v1.Pod {
 	podName := "pod-" + string(uuid.NewUUID())
-	return &v1.Pod{
+	pod := &v1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Pod",
 			APIVersion: "v1",
@@ -528,7 +537,7 @@ func testPodWithVolume(image, path string, source *v1.EmptyDirVolumeSource) *v1.
 			Containers: []v1.Container{
 				{
 					Name:  containerName,
-					Image: image,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -553,4 +562,10 @@ func testPodWithVolume(image, path string, source *v1.EmptyDirVolumeSource) *v1.
 			},
 		},
 	}
+
+	if uid != 0 {
+		pod.Spec.SecurityContext.RunAsUser = &uid
+	}
+
+	return pod
 }

--- a/test/e2e/common/host_path.go
+++ b/test/e2e/common/host_path.go
@@ -53,6 +53,7 @@ var _ = ginkgo.Describe("[sig-storage] HostPath", func() {
 		pod := testPodWithHostVol(volumePath, source, false)
 
 		pod.Spec.Containers[0].Args = []string{
+			"mounttest",
 			fmt.Sprintf("--fs_type=%v", volumePath),
 			fmt.Sprintf("--file_mode=%v", volumePath),
 		}
@@ -73,11 +74,13 @@ var _ = ginkgo.Describe("[sig-storage] HostPath", func() {
 		pod := testPodWithHostVol(volumePath, source, privileged)
 
 		pod.Spec.Containers[0].Args = []string{
+			"mounttest",
 			fmt.Sprintf("--new_file_0644=%v", filePath),
 			fmt.Sprintf("--file_mode=%v", filePath),
 		}
 
 		pod.Spec.Containers[1].Args = []string{
+			"mounttest",
 			fmt.Sprintf("--file_content_in_loop=%v", filePath),
 			fmt.Sprintf("--retry_time=%d", retryDuration),
 		}
@@ -108,12 +111,14 @@ var _ = ginkgo.Describe("[sig-storage] HostPath", func() {
 		container := &pod.Spec.Containers[0]
 		container.VolumeMounts[0].SubPath = subPath
 		container.Args = []string{
+			"mounttest",
 			fmt.Sprintf("--new_file_0644=%v", filePathInWriter),
 			fmt.Sprintf("--file_mode=%v", filePathInWriter),
 		}
 
 		// Read it from outside the subPath from container 1
 		pod.Spec.Containers[1].Args = []string{
+			"mounttest",
 			fmt.Sprintf("--file_content_in_loop=%v", filePathInReader),
 			fmt.Sprintf("--retry_time=%d", retryDuration),
 		}
@@ -156,7 +161,8 @@ func testPodWithHostVol(path string, source *v1.HostPathVolumeSource, privileged
 			Containers: []v1.Container{
 				{
 					Name:  containerName1,
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"mounttest"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -169,7 +175,8 @@ func testPodWithHostVol(path string, source *v1.HostPathVolumeSource, privileged
 				},
 				{
 					Name:  containerName2,
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"mounttest"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,

--- a/test/e2e/common/projected_configmap.go
+++ b/test/e2e/common/projected_configmap.go
@@ -167,9 +167,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 				},
 				Containers: []v1.Container{
 					{
-						Name:    containerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volume/data-1"},
+						Name:  containerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volume/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      volumeName,
@@ -322,9 +322,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 				},
 				Containers: []v1.Container{
 					{
-						Name:    deleteContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volumes/delete/data-1"},
+						Name:  deleteContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volumes/delete/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
@@ -334,9 +334,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 						},
 					},
 					{
-						Name:    updateContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volumes/update/data-3"},
+						Name:  updateContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volumes/update/data-3"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
@@ -346,9 +346,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 						},
 					},
 					{
-						Name:    createContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volumes/create/data-1"},
+						Name:  createContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-configmap-volumes/create/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
@@ -466,8 +466,8 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 				Containers: []v1.Container{
 					{
 						Name:  "projected-configmap-volume-test",
-						Image: imageutils.GetE2EImage(imageutils.Mounttest),
-						Args:  []string{"--file_content=/etc/projected-configmap-volume/data-1"},
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--file_content=/etc/projected-configmap-volume/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      volumeName,
@@ -556,8 +556,9 @@ func doProjectedConfigMapE2EWithoutMappings(f *framework.Framework, asUser bool,
 			Containers: []v1.Container{
 				{
 					Name:  "projected-configmap-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						"--file_content=/etc/projected-configmap-volume/data-1",
 						"--file_mode=/etc/projected-configmap-volume/data-1"},
 					VolumeMounts: []v1.VolumeMount{
@@ -643,8 +644,10 @@ func doProjectedConfigMapE2EWithMappings(f *framework.Framework, asUser bool, fs
 			Containers: []v1.Container{
 				{
 					Name:  "projected-configmap-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
-					Args: []string{"--file_content=/etc/projected-configmap-volume/path/to/data-2",
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args: []string{
+						"mounttest",
+						"--file_content=/etc/projected-configmap-volume/path/to/data-2",
 						"--file_mode=/etc/projected-configmap-volume/path/to/data-2"},
 					VolumeMounts: []v1.VolumeMount{
 						{

--- a/test/e2e/common/projected_downwardapi.go
+++ b/test/e2e/common/projected_downwardapi.go
@@ -272,9 +272,9 @@ func projectedDownwardAPIVolumePodForModeTest(name, filePath string, itemMode, d
 
 	pod.Spec.Containers = []v1.Container{
 		{
-			Name:    "client-container",
-			Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-			Command: []string{"/mounttest", "--file_mode=" + filePath},
+			Name:  "client-container",
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"mounttest", "--file_mode=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",
@@ -298,9 +298,9 @@ func projectedDownwardAPIVolumePodForUpdateTest(name string, labels, annotations
 
 	pod.Spec.Containers = []v1.Container{
 		{
-			Name:    "client-container",
-			Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-			Command: []string{"/mounttest", "--break_on_expected_content=false", "--retry_time=1200", "--file_content_in_loop=" + filePath},
+			Name:  "client-container",
+			Image: imageutils.GetE2EImage(imageutils.Agnhost),
+			Args:  []string{"mounttest", "--break_on_expected_content=false", "--retry_time=1200", "--file_content_in_loop=" + filePath},
 			VolumeMounts: []v1.VolumeMount{
 				{
 					Name:      "podinfo",

--- a/test/e2e/common/projected_secret.go
+++ b/test/e2e/common/projected_secret.go
@@ -174,8 +174,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 				Containers: []v1.Container{
 					{
 						Name:  "secret-volume-test",
-						Image: imageutils.GetE2EImage(imageutils.Mounttest),
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
 						Args: []string{
+							"mounttest",
 							"--file_content=/etc/projected-secret-volume/data-1",
 							"--file_mode=/etc/projected-secret-volume/data-1"},
 						VolumeMounts: []v1.VolumeMount{
@@ -324,9 +325,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 				},
 				Containers: []v1.Container{
 					{
-						Name:    deleteContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-secret-volumes/delete/data-1"},
+						Name:  deleteContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-secret-volumes/delete/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
@@ -336,9 +337,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 						},
 					},
 					{
-						Name:    updateContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-secret-volumes/update/data-3"},
+						Name:  updateContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-secret-volumes/update/data-3"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
@@ -348,9 +349,9 @@ var _ = ginkgo.Describe("[sig-storage] Projected secret", func() {
 						},
 					},
 					{
-						Name:    createContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-secret-volumes/create/data-1"},
+						Name:  createContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/projected-secret-volumes/create/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
@@ -466,8 +467,9 @@ func doProjectedSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int
 			Containers: []v1.Container{
 				{
 					Name:  "projected-secret-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						"--file_content=/etc/projected-secret-volume/data-1",
 						"--file_mode=/etc/projected-secret-volume/data-1"},
 					VolumeMounts: []v1.VolumeMount{
@@ -549,8 +551,9 @@ func doProjectedSecretE2EWithMapping(f *framework.Framework, mode *int32) {
 			Containers: []v1.Container{
 				{
 					Name:  "projected-secret-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						"--file_content=/etc/projected-secret-volume/new-path-data-1",
 						"--file_mode=/etc/projected-secret-volume/new-path-data-1"},
 					VolumeMounts: []v1.VolumeMount{

--- a/test/e2e/common/secrets_volume.go
+++ b/test/e2e/common/secrets_volume.go
@@ -164,8 +164,9 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 				Containers: []v1.Container{
 					{
 						Name:  "secret-volume-test",
-						Image: imageutils.GetE2EImage(imageutils.Mounttest),
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
 						Args: []string{
+							"mounttest",
 							"--file_content=/etc/secret-volume/data-1",
 							"--file_mode=/etc/secret-volume/data-1"},
 						VolumeMounts: []v1.VolumeMount{
@@ -290,9 +291,9 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 				},
 				Containers: []v1.Container{
 					{
-						Name:    deleteContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/delete/data-1"},
+						Name:  deleteContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/delete/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      deleteVolumeName,
@@ -302,9 +303,9 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 						},
 					},
 					{
-						Name:    updateContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/update/data-3"},
+						Name:  updateContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/update/data-3"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      updateVolumeName,
@@ -314,9 +315,9 @@ var _ = ginkgo.Describe("[sig-storage] Secrets", func() {
 						},
 					},
 					{
-						Name:    createContainerName,
-						Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-						Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/create/data-1"},
+						Name:  createContainerName,
+						Image: imageutils.GetE2EImage(imageutils.Agnhost),
+						Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/create/data-1"},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      createVolumeName,
@@ -484,8 +485,9 @@ func doSecretE2EWithoutMapping(f *framework.Framework, defaultMode *int32, secre
 			Containers: []v1.Container{
 				{
 					Name:  "secret-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						"--file_content=/etc/secret-volume/data-1",
 						"--file_mode=/etc/secret-volume/data-1"},
 					VolumeMounts: []v1.VolumeMount{
@@ -558,8 +560,9 @@ func doSecretE2EWithMapping(f *framework.Framework, mode *int32) {
 			Containers: []v1.Container{
 				{
 					Name:  "secret-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						"--file_content=/etc/secret-volume/new-path-data-1",
 						"--file_mode=/etc/secret-volume/new-path-data-1"},
 					VolumeMounts: []v1.VolumeMount{
@@ -615,9 +618,9 @@ func createNonOptionalSecretPod(f *framework.Framework, volumeMountPath, podName
 			},
 			Containers: []v1.Container{
 				{
-					Name:    createContainerName,
-					Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-					Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/create/data-1"},
+					Name:  createContainerName,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/create/data-1"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      createVolumeName,
@@ -676,9 +679,9 @@ func createNonOptionalSecretPodWithSecret(f *framework.Framework, volumeMountPat
 			},
 			Containers: []v1.Container{
 				{
-					Name:    createContainerName,
-					Image:   imageutils.GetE2EImage(imageutils.Mounttest),
-					Command: []string{"/mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/create/data-1"},
+					Name:  createContainerName,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
+					Args:  []string{"mounttest", "--break_on_expected_content=false", containerTimeoutArg, "--file_content_in_loop=/etc/secret-volumes/create/data-1"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      createVolumeName,

--- a/test/e2e/common/util.go
+++ b/test/e2e/common/util.go
@@ -64,8 +64,6 @@ var CommonImageWhiteList = sets.NewString(
 	imageutils.GetE2EImage(imageutils.Agnhost),
 	imageutils.GetE2EImage(imageutils.BusyBox),
 	imageutils.GetE2EImage(imageutils.IpcUtils),
-	imageutils.GetE2EImage(imageutils.Mounttest),
-	imageutils.GetE2EImage(imageutils.MounttestUser),
 	imageutils.GetE2EImage(imageutils.Nginx),
 	imageutils.GetE2EImage(imageutils.Httpd),
 	imageutils.GetE2EImage(imageutils.VolumeNFSServer),
@@ -74,17 +72,16 @@ var CommonImageWhiteList = sets.NewString(
 )
 
 type testImagesStruct struct {
-	AgnhostImage   string
-	BusyBoxImage   string
-	KittenImage    string
-	MounttestImage string
-	NautilusImage  string
-	NginxImage     string
-	NginxNewImage  string
-	HttpdImage     string
-	HttpdNewImage  string
-	PauseImage     string
-	RedisImage     string
+	AgnhostImage  string
+	BusyBoxImage  string
+	KittenImage   string
+	NautilusImage string
+	NginxImage    string
+	NginxNewImage string
+	HttpdImage    string
+	HttpdNewImage string
+	PauseImage    string
+	RedisImage    string
 }
 
 var testImages testImagesStruct
@@ -94,7 +91,6 @@ func init() {
 		imageutils.GetE2EImage(imageutils.Agnhost),
 		imageutils.GetE2EImage(imageutils.BusyBox),
 		imageutils.GetE2EImage(imageutils.Kitten),
-		imageutils.GetE2EImage(imageutils.Mounttest),
 		imageutils.GetE2EImage(imageutils.Nautilus),
 		imageutils.GetE2EImage(imageutils.Nginx),
 		imageutils.GetE2EImage(imageutils.NginxNew),

--- a/test/e2e/storage/ephemeral_volume.go
+++ b/test/e2e/storage/ephemeral_volume.go
@@ -37,7 +37,6 @@ import (
 var (
 	volumePath = "/test-volume"
 	volumeName = "test-volume"
-	mountImage = imageutils.GetE2EImage(imageutils.Mounttest)
 )
 
 var _ = utils.SIGDescribe("Ephemeralstorage", func() {
@@ -85,7 +84,7 @@ func testEphemeralVolumePod(f *framework.Framework, volumeType string, source *v
 			Containers: []v1.Container{
 				{
 					Name:  fmt.Sprintf("test-container-subpath-%s", suffix),
-					Image: mountImage,
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -50,7 +50,7 @@ var (
 	probeFilePath   = probeVolumePath + "/probe-file"
 	fileName        = "test-file"
 	retryDuration   = 20
-	mountImage      = imageutils.GetE2EImage(imageutils.Mounttest)
+	mountImage      = imageutils.GetE2EImage(imageutils.Agnhost)
 )
 
 type subPathTestSuite struct {
@@ -532,6 +532,7 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 				{
 					Name:  fmt.Sprintf("test-init-subpath-%s", suffix),
 					Image: mountImage,
+					Args:  []string{"mounttest"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -548,6 +549,7 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 				{
 					Name:  fmt.Sprintf("test-init-volume-%s", suffix),
 					Image: mountImage,
+					Args:  []string{"mounttest"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -565,6 +567,7 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 				{
 					Name:  fmt.Sprintf("test-container-subpath-%s", suffix),
 					Image: mountImage,
+					Args:  []string{"mounttest"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -581,6 +584,7 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 				{
 					Name:  fmt.Sprintf("test-container-volume-%s", suffix),
 					Image: mountImage,
+					Args:  []string{"mounttest"},
 					VolumeMounts: []v1.VolumeMount{
 						{
 							Name:      volumeName,
@@ -614,8 +618,8 @@ func SubpathTestPod(f *framework.Framework, subpath, volumeType string, source *
 }
 
 func containerIsUnused(container *v1.Container) bool {
-	// mountImage with nil Args does nothing. Leave everything else
-	return container.Image == mountImage && container.Args == nil
+	// mountImage with nil Args or with just "mounttest" as Args does nothing. Leave everything else
+	return container.Image == mountImage && (container.Args == nil || (len(container.Args) == 1 && container.Args[0] == "mounttest"))
 }
 
 // removeUnusedContainers removes containers from a SubpathTestPod that aren't
@@ -678,6 +682,7 @@ func setInitCommand(pod *v1.Pod, command string) {
 
 func setWriteCommand(file string, container *v1.Container) {
 	container.Args = []string{
+		"mounttest",
 		fmt.Sprintf("--new_file_0644=%v", file),
 		fmt.Sprintf("--file_mode=%v", file),
 	}
@@ -690,6 +695,7 @@ func addSubpathVolumeContainer(container *v1.Container, volumeMount v1.VolumeMou
 
 func addMultipleWrites(container *v1.Container, file1 string, file2 string) {
 	container.Args = []string{
+		"mounttest",
 		fmt.Sprintf("--new_file_0644=%v", file1),
 		fmt.Sprintf("--new_file_0666=%v", file2),
 	}
@@ -706,6 +712,7 @@ func testMultipleReads(f *framework.Framework, pod *v1.Pod, containerIndex int, 
 
 func setReadCommand(file string, container *v1.Container) {
 	container.Args = []string{
+		"mounttest",
 		fmt.Sprintf("--file_content_in_loop=%v", file),
 		fmt.Sprintf("--retry_time=%d", retryDuration),
 	}

--- a/test/e2e/upgrades/configmaps.go
+++ b/test/e2e/upgrades/configmaps.go
@@ -106,8 +106,9 @@ func (t *ConfigMapUpgradeTest) testPod(f *framework.Framework) {
 			Containers: []v1.Container{
 				{
 					Name:  "configmap-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						fmt.Sprintf("--file_content=%s/data", volumeMountPath),
 						fmt.Sprintf("--file_mode=%s/data", volumeMountPath),
 					},

--- a/test/e2e/upgrades/secrets.go
+++ b/test/e2e/upgrades/secrets.go
@@ -102,8 +102,9 @@ func (t *SecretUpgradeTest) testPod(f *framework.Framework) {
 			Containers: []v1.Container{
 				{
 					Name:  "secret-volume-test",
-					Image: imageutils.GetE2EImage(imageutils.Mounttest),
+					Image: imageutils.GetE2EImage(imageutils.Agnhost),
 					Args: []string{
+						"mounttest",
 						fmt.Sprintf("--file_content=%s/data", volumeMountPath),
 						fmt.Sprintf("--file_mode=%s/data", volumeMountPath),
 					},

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -158,10 +158,6 @@ const (
 	JessieDnsutils
 	// Kitten image
 	Kitten
-	// Mounttest image
-	Mounttest
-	// MounttestUser image
-	MounttestUser
 	// Nautilus image
 	Nautilus
 	// NFSProvisioner image
@@ -224,8 +220,6 @@ func initImageConfigs() map[int]Config {
 	configs[IpcUtils] = Config{e2eRegistry, "ipc-utils", "1.0"}
 	configs[JessieDnsutils] = Config{e2eRegistry, "jessie-dnsutils", "1.0"}
 	configs[Kitten] = Config{e2eRegistry, "kitten", "1.0"}
-	configs[Mounttest] = Config{e2eRegistry, "mounttest", "1.0"}
-	configs[MounttestUser] = Config{e2eRegistry, "mounttest-user", "1.0"}
 	configs[Nautilus] = Config{e2eRegistry, "nautilus", "1.0"}
 	configs[NFSProvisioner] = Config{quayIncubator, "nfs-provisioner", "v2.2.2"}
 	configs[Nginx] = Config{dockerLibraryRegistry, "nginx", "1.14-alpine"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

/sig testing
/sig windows
/area conformance

**What this PR does / why we need it**:

Quite a few images are only used a few times in a few tests. Thus, the images are being centralized into the agnhost image, reducing the number of images that have to be pulled and used.

This PR replaces the usage of the following images with agnhost:

- mounttest
- mounttest-user

Additionally, removes the usage of the ``mounttest-user`` image and removes it from ``kubernetes/test/images``. ``RunAsUser`` is set instead of having that image.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related: #76342

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
