### PR TITLE
Update pod status if last update is too old

### DIFF
--- a/pkg/kubelet/status/status_manager.go
+++ b/pkg/kubelet/status/status_manager.go
@@ -70,6 +70,7 @@ type manager struct {
 	// apiStatusVersions must only be accessed from the sync thread.
 	apiStatusVersions map[kubetypes.MirrorPodUID]uint64
 	podDeletionSafety PodDeletionSafetyProvider
+	lastUpdateTime    *time.Time
 }
 
 // PodStatusProvider knows how to provide status for a pod. It's intended to be used by other components
@@ -125,6 +126,7 @@ func NewManager(kubeClient clientset.Interface, podManager kubepod.Manager, podD
 		podStatusChannel:  make(chan podStatusSyncRequest, 1000), // Buffer up to 1000 statuses
 		apiStatusVersions: make(map[kubetypes.MirrorPodUID]uint64),
 		podDeletionSafety: podDeletionSafety,
+		lastUpdateTime:    nil,
 	}
 }
 
@@ -429,9 +431,22 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	}
 
 	normalizeStatus(pod, &status)
+
 	// The intent here is to prevent concurrent updates to a pod's status from
 	// clobbering each other so the phase of a pod progresses monotonically.
-	if isCached && isPodStatusByKubeletEqual(&cachedStatus.status, &status) && !forceUpdate {
+	shouldUpdate := forceUpdate
+	if !shouldUpdate && m.lastUpdateTime != nil {
+		duration := time.Now().Sub(*m.lastUpdateTime)
+		klog.V(3).Infof("it has been %v since last update.", duration)
+		// if the last update is too old (more than 200 seconds ago), we need to update status
+		// to handle the situation of connectivity being returned to the node.
+		if duration > 200*time.Second {
+			klog.V(3).Infof("going to update, pod %s", pod.Name)
+			shouldUpdate = true
+		}
+	}
+
+	if isCached && isPodStatusByKubeletEqual(&cachedStatus.status, &status) && !shouldUpdate {
 		klog.V(3).Infof("Ignoring same status for pod %q, status: %+v", format.Pod(pod), status)
 		return false // No new status.
 	}
@@ -448,6 +463,8 @@ func (m *manager) updateStatusInternal(pod *v1.Pod, status v1.PodStatus, forceUp
 	case m.podStatusChannel <- podStatusSyncRequest{pod.UID, newStatus}:
 		klog.V(5).Infof("Status Manager: adding pod: %q, with status: (%d, %v) to podStatusChannel",
 			pod.UID, newStatus.version, newStatus.status)
+		t := time.Now()
+		m.lastUpdateTime = &t
 		return true
 	default:
 		// Let the periodic syncBatch handle the update if the channel is full.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

As #80968 reported, Kubelet may mark pods as not ready after connectivity is returned to the node.

This PR adds field, lastUpdateTime, to manager class so that we can update status if the last update is too old.

Note: versionedPodStatus only has version, not the time when the pod status is created.

Prior to this PR, the forceUpdate parameter is determined by :
```
	m.updateStatusInternal(pod, status, pod.DeletionTimestamp != nil)
```
In normal case, pod.DeletionTimestamp is nil, leading to forceUpdate being false which may lead to early return from updateStatusInternal:

```
       if isCached && isPodStatusByKubeletEqual(&cachedStatus.status, &status) && !forceUpdate {
                klog.V(3).Infof("Ignoring same status for pod %q, status: %+v", format.Pod(pod), status)
                return false // No new status.
```
This would result in pod status not being updated for extended period of time.

**Which issue(s) this PR fixes**:
Fixes #80968

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
