### PR TITLE
Fix wrong alpha version for ValidateProxyRedirects

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -39,7 +39,7 @@ const (
 	StreamingProxyRedirects featuregate.Feature = "StreamingProxyRedirects"
 
 	// owner: @tallclair
-	// alpha: v1.10
+	// alpha: v1.12
 	// beta: v1.14
 	//
 	// ValidateProxyRedirects controls whether the apiserver should validate that redirects are only


### PR DESCRIPTION
This feature gate apparently never made it into 1.10 or 1.11.
https://github.com/kubernetes/kubernetes/pull/69943

~not sure what is needed to get this page changed: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/~
Update: I opened https://github.com/kubernetes/website/issues/19160 to get the featuregate matrix updated.

**What type of PR is this?**
/kind documentation

```release-note
NONE
```

