### PR TITLE
list on cache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -146,6 +146,12 @@ const (
 	//
 	// Allows label and field based indexes in apiserver watch cache to accelerate list operations.
 	SelectorIndex featuregate.Feature = "SelectorIndex"
+
+	// owner: @jpbetz @jfbai
+	// alpha: v1.18
+	//
+	// Enables consistent reads from watch cache
+	WatchCacheConsistentReads featuregate.Feature = "WatchCacheConsistentReads"
 )
 
 func init() {
@@ -156,20 +162,21 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	StreamingProxyRedirects: {Default: true, PreRelease: featuregate.Beta},
-	ValidateProxyRedirects:  {Default: true, PreRelease: featuregate.Beta},
-	AdvancedAuditing:        {Default: true, PreRelease: featuregate.GA},
-	DynamicAuditing:         {Default: false, PreRelease: featuregate.Alpha},
-	APIResponseCompression:  {Default: true, PreRelease: featuregate.Beta},
-	APIListChunking:         {Default: true, PreRelease: featuregate.Beta},
-	DryRun:                  {Default: true, PreRelease: featuregate.Beta},
-	RemainingItemCount:      {Default: true, PreRelease: featuregate.Beta},
-	ServerSideApply:         {Default: true, PreRelease: featuregate.Beta},
-	StorageVersionHash:      {Default: true, PreRelease: featuregate.Beta},
-	WinOverlay:              {Default: false, PreRelease: featuregate.Alpha},
-	WinDSR:                  {Default: false, PreRelease: featuregate.Alpha},
-	WatchBookmark:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	APIPriorityAndFairness:  {Default: false, PreRelease: featuregate.Alpha},
-	RemoveSelfLink:          {Default: false, PreRelease: featuregate.Alpha},
-	SelectorIndex:           {Default: false, PreRelease: featuregate.Alpha},
+	StreamingProxyRedirects:   {Default: true, PreRelease: featuregate.Beta},
+	ValidateProxyRedirects:    {Default: true, PreRelease: featuregate.Beta},
+	AdvancedAuditing:          {Default: true, PreRelease: featuregate.GA},
+	DynamicAuditing:           {Default: false, PreRelease: featuregate.Alpha},
+	APIResponseCompression:    {Default: true, PreRelease: featuregate.Beta},
+	APIListChunking:           {Default: true, PreRelease: featuregate.Beta},
+	DryRun:                    {Default: true, PreRelease: featuregate.Beta},
+	RemainingItemCount:        {Default: true, PreRelease: featuregate.Beta},
+	ServerSideApply:           {Default: true, PreRelease: featuregate.Beta},
+	StorageVersionHash:        {Default: true, PreRelease: featuregate.Beta},
+	WinOverlay:                {Default: false, PreRelease: featuregate.Alpha},
+	WinDSR:                    {Default: false, PreRelease: featuregate.Alpha},
+	WatchBookmark:             {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	APIPriorityAndFairness:    {Default: false, PreRelease: featuregate.Alpha},
+	RemoveSelfLink:            {Default: false, PreRelease: featuregate.Alpha},
+	SelectorIndex:             {Default: false, PreRelease: featuregate.Alpha},
+	WatchCacheConsistentReads: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -328,6 +328,9 @@ func (d *dummyStorage) GuaranteedUpdate(_ context.Context, _ string, _ runtime.O
 func (d *dummyStorage) Count(_ string) (int64, error) {
 	return 0, fmt.Errorf("unimplemented")
 }
+func (d *dummyStorage) GetLastRevision(_ context.Context, key string) (string, error) {
+	return "", fmt.Errorf("unimplemented")
+}
 
 func TestListWithLimitAndRV0(t *testing.T) {
 	backingStorage := &dummyStorage{}

--- a/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/interfaces.go
@@ -242,4 +242,7 @@ type Interface interface {
 
 	// Count returns number of different entries under the key (generally being path prefix).
 	Count(key string) (int64, error)
+
+	// GetLastRevision returns the key-value store revision when the request was applied.
+	GetLastRevision(ctx context.Context, key string) (string, error)
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

By using cache to decrease the time cost of List call with no resource version attached.

This approach ensures that apiserver return the result as same as from the backend storage.

In our test cluster (10k nodes and 8k pods), time cost comparison,

|  ops | etcd  | cacher  |
|---|---|---|
|  list pods | 35.948s  |  9.500s |
| list nodes  |  7.537s | 0.941s  |
|  describe nodes |  4.147s | 0.423s  |

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
/assign @wojtek-t