### PR TITLE
Delete TODO around implementing rate limiting to protect against DOS

### DIFF
--- a/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
+++ b/pkg/kubelet/pluginmanager/pluginwatcher/plugin_watcher.go
@@ -191,7 +191,6 @@ func (w *Watcher) handlePluginRegistration(socketPath string) error {
 	if runtime.GOOS == "windows" {
 		socketPath = util.NormalizePath(socketPath)
 	}
-	//TODO: Implement rate limiting to mitigate any DOS kind of attacks.
 	// Update desired state of world list of plugins
 	// If the socket path does exist in the desired world cache, there's still
 	// a possibility that it has been deleted and recreated again before it is


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
From discussions in https://github.com/kubernetes/kubernetes/pull/83784,
it appears there actually isn't a ton of risk around a DOS. Delete the
TODO.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@saad-ali if you don't mind, please accept either this PR or #83784, and then I'll close the other one. Thanks :)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
