### PR TITLE
Delete TODO in `image_gc_manager`

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -185,7 +185,6 @@ func (im *realImageGCManager) Start() {
 	}, 5*time.Minute, wait.NeverStop)
 
 	// Start a goroutine periodically updates image cache.
-	// TODO(random-liu): Merge this with the previous loop.
 	go wait.Until(func() {
 		images, err := im.runtime.ListImages()
 		if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I think the TODO here may have actually been unnecessary. There isn't a
ton of interest around merging
https://github.com/kubernetes/kubernetes/pull/87425, which contains a
fix. Delete the TODO so we don't devote time to working on this area in
the future.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@Random-Liu mind accepting either this pr or https://github.com/kubernetes/kubernetes/pull/87425? Thanks :)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
