### PR TITLE
Add unit tests for human readable duration functions

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/duration/duration_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/duration/duration_test.go
@@ -45,3 +45,82 @@ func TestHumanDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestHumanDurationBoundaries(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{d: -2 * time.Second, want: "<invalid>"},
+		{d: -2*time.Second + 1, want: "0s"},
+		{d: 0, want: "0s"},
+		{d: time.Second - time.Millisecond, want: "0s"},
+		{d: 2*time.Minute - time.Millisecond, want: "119s"},
+		{d: 2 * time.Minute, want: "2m"},
+		{d: 2*time.Minute + time.Second, want: "2m1s"},
+		{d: 10*time.Minute - time.Millisecond, want: "9m59s"},
+		{d: 10 * time.Minute, want: "10m"},
+		{d: 10*time.Minute + time.Second, want: "10m"},
+		{d: 3*time.Hour - time.Millisecond, want: "179m"},
+		{d: 3 * time.Hour, want: "3h"},
+		{d: 3*time.Hour + time.Minute, want: "3h1m"},
+		{d: 8*time.Hour - time.Millisecond, want: "7h59m"},
+		{d: 8 * time.Hour, want: "8h"},
+		{d: 8*time.Hour + 59*time.Minute, want: "8h"},
+		{d: 2*24*time.Hour - time.Millisecond, want: "47h"},
+		{d: 2 * 24 * time.Hour, want: "2d"},
+		{d: 2*24*time.Hour + time.Hour, want: "2d1h"},
+		{d: 8*24*time.Hour - time.Millisecond, want: "7d23h"},
+		{d: 8 * 24 * time.Hour, want: "8d"},
+		{d: 8*24*time.Hour + 23*time.Hour, want: "8d"},
+		{d: 2*365*24*time.Hour - time.Millisecond, want: "729d"},
+		{d: 2 * 365 * 24 * time.Hour, want: "2y0d"},
+		{d: 2*365*24*time.Hour + 23*time.Hour, want: "2y0d"},
+		{d: 3 * 365 * 24 * time.Hour, want: "3y0d"},
+		{d: 8*365*24*time.Hour - time.Millisecond, want: "7y364d"},
+		{d: 8 * 365 * 24 * time.Hour, want: "8y"},
+		{d: 8*365*24*time.Hour + 364*24*time.Hour, want: "8y"},
+		{d: 9 * 365 * 24 * time.Hour, want: "9y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.d.String(), func(t *testing.T) {
+			if got := HumanDuration(tt.d); got != tt.want {
+				t.Errorf("HumanDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShortHumanDurationBoundaries(t *testing.T) {
+	tests := []struct {
+		d    time.Duration
+		want string
+	}{
+		{d: -2 * time.Second, want: "<invalid>"},
+		{d: -2*time.Second + 1, want: "0s"},
+		{d: 0, want: "0s"},
+		{d: time.Second - time.Millisecond, want: "0s"},
+		{d: time.Second, want: "1s"},
+		{d: 2*time.Second - time.Millisecond, want: "1s"},
+		{d: time.Minute - time.Millisecond, want: "59s"},
+		{d: time.Minute, want: "1m"},
+		{d: 2*time.Minute - time.Millisecond, want: "1m"},
+		{d: time.Hour - time.Millisecond, want: "59m"},
+		{d: time.Hour, want: "1h"},
+		{d: 2*time.Hour - time.Millisecond, want: "1h"},
+		{d: 24*time.Hour - time.Millisecond, want: "23h"},
+		{d: 24 * time.Hour, want: "1d"},
+		{d: 2*24*time.Hour - time.Millisecond, want: "1d"},
+		{d: 365*24*time.Hour - time.Millisecond, want: "364d"},
+		{d: 365 * 24 * time.Hour, want: "1y"},
+		{d: 2*365*24*time.Hour - time.Millisecond, want: "1y"},
+		{d: 2 * 365 * 24 * time.Hour, want: "2y"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.d.String(), func(t *testing.T) {
+			if got := ShortHumanDuration(tt.d); got != tt.want {
+				t.Errorf("ShortHumanDuration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Added unit tests for human readable duration formatting

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There are currently no unit tests around duration formatting, so this PR is adding them.

**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
```release-notes
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
NONE
