### PR TITLE
kubemark: move a channel send out of critical section

### DIFF
--- a/pkg/kubemark/controller.go
+++ b/pkg/kubemark/controller.go
@@ -195,11 +195,11 @@ func (kubemarkController *KubemarkController) SetNodeGroupSize(nodeGroup string,
 		}
 	case delta > 0:
 		kubemarkController.nodeGroupQueueSizeLock.Lock()
+		kubemarkController.nodeGroupQueueSize[nodeGroup] += delta
+		kubemarkController.nodeGroupQueueSizeLock.Unlock()
 		for i := 0; i < delta; i++ {
-			kubemarkController.nodeGroupQueueSize[nodeGroup]++
 			kubemarkController.createNodeQueue <- nodeGroup
 		}
-		kubemarkController.nodeGroupQueueSizeLock.Unlock()
 	}
 
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
In pkg/kubemark/controller.go, the usage of `kubemarkController.createNodeQueue` and `kubemarkController.nodeGroupQueueSizeLock` follows the pattern below:
```Go
// Goroutine 1
Lock()
ch <- value // Line A
Unlock()

// Goroutine 2
for {
  <-ch
  Lock() // Line B
  Unlock()
}
```

If Goroutine 1 blocks at Line A and Goroutine 2 blocks at Line B, a circular wait is triggered. 

It is bug-prone to use channel in critical section, especially when this channel has only one send and one receive. Even though the channel has 1000 buffer, this is still risky because buffer can be full, in current workload or in future workload.


**Special notes for your reviewer**:
It may seem that this patch changes the semantic of related code. It is possible that `kubemarkController.nodeGroupQueueSize` in critical section is updated, but the change to `kubemarkController.createNodeQueue` is delayed. However, this is fine because even before this Pull Request, these two objects are not synchronized. Below are all the usages of these two objects:

_Note that Line 338 and line 339 can be interleaved with line 160-170 or line 197-202 (before this PR)._ 

https://github.com/kubernetes/kubernetes/blob/d5e0a941aa4d1c096dde753e02a06fe85e33b81c/pkg/kubemark/controller.go#L335-L351

https://github.com/kubernetes/kubernetes/blob/d5e0a941aa4d1c096dde753e02a06fe85e33b81c/pkg/kubemark/controller.go#L160-L170

https://github.com/kubernetes/kubernetes/blob/d5e0a941aa4d1c096dde753e02a06fe85e33b81c/pkg/kubemark/controller.go#L197-L202

This "unsynchronization" is fine because only `kubemarkController.nodeGroupQueueSize` influences other part of the program:


**Does this PR introduce a user-facing change?**:
```release-note
NONE
```