### PR TITLE
Windows specific kubelet flags in kubeadm-flags.env

### DIFF
--- a/cmd/kubeadm/app/constants/constants.go
+++ b/cmd/kubeadm/app/constants/constants.go
@@ -265,9 +265,6 @@ const (
 	// DefaultEtcdVersion indicates the default etcd version that kubeadm uses
 	DefaultEtcdVersion = "3.4.3-0"
 
-	// PauseVersion indicates the default pause image version for kubeadm
-	PauseVersion = "3.2"
-
 	// Etcd defines variable used internally when referring to etcd component
 	Etcd = "etcd"
 	// KubeAPIServer defines variable used internally when referring to kube-apiserver component

--- a/cmd/kubeadm/app/constants/constants_unix.go
+++ b/cmd/kubeadm/app/constants/constants_unix.go
@@ -21,4 +21,7 @@ package constants
 const (
 	// DefaultDockerCRISocket defines the default Docker CRI socket
 	DefaultDockerCRISocket = "/var/run/dockershim.sock"
+
+	// PauseVersion indicates the default pause image version for kubeadm
+	PauseVersion = "3.2"
 )

--- a/cmd/kubeadm/app/images/BUILD
+++ b/cmd/kubeadm/app/images/BUILD
@@ -8,14 +8,23 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["images.go"],
+    srcs = [
+        "images.go",
+        "images_unix.go",
+        "images_windows.go",
+    ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/images",
     deps = [
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:windows": [
+            "//cmd/kubeadm/app/apis/kubeadm/v1beta2:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(

--- a/cmd/kubeadm/app/images/images.go
+++ b/cmd/kubeadm/app/images/images.go
@@ -84,11 +84,6 @@ func GetEtcdImage(cfg *kubeadmapi.ClusterConfiguration) string {
 	return GetGenericImage(etcdImageRepository, constants.Etcd, etcdImageTag)
 }
 
-// GetPauseImage returns the image for the "pause" container
-func GetPauseImage(cfg *kubeadmapi.ClusterConfiguration) string {
-	return GetGenericImage(cfg.ImageRepository, "pause", constants.PauseVersion)
-}
-
 // GetControlPlaneImages returns a list of container images kubeadm expects to use on a control plane node
 func GetControlPlaneImages(cfg *kubeadmapi.ClusterConfiguration) []string {
 	imgs := []string{}

--- a/cmd/kubeadm/app/images/images_unix.go
+++ b/cmd/kubeadm/app/images/images_unix.go
@@ -1,7 +1,7 @@
-// +build windows
+// +build !windows
 
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,12 +16,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package constants
+package images
 
-const (
-	// DefaultDockerCRISocket defines the default Docker CRI socket
-	DefaultDockerCRISocket = "npipe:////./pipe/docker_engine"
-
-	// PauseVersion indicates the default pause image version for kubeadm
-	PauseVersion = "1.3.0"
+import (
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
 )
+
+// GetPauseImage returns the image for the "pause" container
+func GetPauseImage(cfg *kubeadmapi.ClusterConfiguration) string {
+	return GetGenericImage(cfg.ImageRepository, "pause", constants.PauseVersion)
+}

--- a/cmd/kubeadm/app/images/images_windows.go
+++ b/cmd/kubeadm/app/images/images_windows.go
@@ -1,0 +1,34 @@
+// +build windows
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package images
+
+import (
+	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	kubeadmapiv1beta2 "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm/v1beta2"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+)
+
+// GetPauseImage returns the image for the "pause" container
+func GetPauseImage(cfg *kubeadmapi.ClusterConfiguration) string {
+	//If user has configured the cluster to use a different image repository, use that for the Windows pause image.
+	if cfg.ImageRepository != kubeadmapiv1beta2.DefaultImageRepository {
+		return GetGenericImage(cfg.ImageRepository, "pause", constants.PauseVersion)
+	}
+	return GetGenericImage("mcr.microsoft.com/oss/kubernetes", "pause", constants.PauseVersion)
+}

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -6,6 +6,8 @@ go_library(
         "config.go",
         "dynamic.go",
         "flags.go",
+        "flags_unix.go",
+        "flags_windows.go",
         "kubelet.go",
     ],
     importpath = "k8s.io/kubernetes/cmd/kubeadm/app/phases/kubelet",

--- a/cmd/kubeadm/app/phases/kubelet/flags_unix.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_unix.go
@@ -1,0 +1,51 @@
+// +build !windows
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"k8s.io/klog"
+	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
+	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
+)
+
+// buildKubeletArgMap takes a kubeletFlagsOpts object and builds based on that a string-string map with flags
+// that should be given to the local Linux kubelet daemon.
+func buildKubeletArgMap(opts kubeletFlagsOpts) map[string]string {
+	kubeletFlags := buildKubeletArgMapCommon(opts)
+
+	// TODO: Conditionally set `--cgroup-driver` to either `systemd` or `cgroupfs` for CRI other than Docker
+	if opts.nodeRegOpts.CRISocket == constants.DefaultDockerCRISocket {
+		driver, err := kubeadmutil.GetCgroupDriverDocker(opts.execer)
+		if err != nil {
+			klog.Warningf("cannot automatically assign a '--cgroup-driver' value when starting the Kubelet: %v\n", err)
+		} else {
+			kubeletFlags["cgroup-driver"] = driver
+		}
+	}
+
+	ok, err := opts.isServiceActiveFunc("systemd-resolved")
+	if err != nil {
+		klog.Warningf("cannot determine if systemd-resolved is active: %v\n", err)
+	}
+	if ok {
+		kubeletFlags["resolv-conf"] = "/run/systemd/resolve/resolv.conf"
+	}
+
+	return kubeletFlags
+}

--- a/cmd/kubeadm/app/phases/kubelet/flags_windows.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags_windows.go
@@ -1,7 +1,7 @@
 // +build windows
 
 /*
-Copyright 2019 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,12 +16,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package constants
+package kubelet
 
-const (
-	// DefaultDockerCRISocket defines the default Docker CRI socket
-	DefaultDockerCRISocket = "npipe:////./pipe/docker_engine"
-
-	// PauseVersion indicates the default pause image version for kubeadm
-	PauseVersion = "1.3.0"
-)
+// buildKubeletArgMap takes a kubeletFlagsOpts object and builds based on that a string-string map with flags
+// that should be given to the local Windows kubelet daemon.
+func buildKubeletArgMap(opts kubeletFlagsOpts) map[string]string {
+	return buildKubeletArgMapCommon(opts)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
kubeadm writes an environment file that's Linux specific. This PR removes the Linux specific flags and adds Windows specific values when kubeadm is being run on a Windows node. 

What is currently populated in a Windows node:
```
KUBELET_KUBEADM_ARGS="--cgroup-driver= --network-plugin=cni --pod-infra-container-image=k8s.gcr.io/pause:3.1"
```

What would be populated with the changes: 
```
KUBELET_KUBEADM_ARGS="--network-plugin=cni --pod-infra-container-image=mcr.microsoft.com/k8s/core/pause:1.2.0"
```

**Special notes for your reviewer**:
The concept of ENV files doesn't exist for native Windows services. The way to leverage the changes in this PR would be to use something like [nssm](https://nssm.cc/) to run a script that will execute the kubelet after reading the env file. With this approach, it will enable cluster api to override kubelet flags via metadata on Windows nodes. 

**Does this PR introduce a user-facing change?**:
```release-note
kubeadm: support Windows specific kubelet flags in kubeadm-flags.env
```
