### PR TITLE
Add --dry-run=server|client|none to more kubectl commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/BUILD
@@ -41,6 +41,7 @@ go_test(
         "//staging/src/k8s.io/cli-runtime/pkg/resource:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
     ],

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/cli-runtime/pkg/resource"
 	"k8s.io/client-go/rest/fake"
 	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
 )
 
@@ -42,6 +43,7 @@ func fakecmd() *cobra.Command {
 		DisableFlagsInUseLine: true,
 		Run:                   func(cmd *cobra.Command, args []string) {},
 	}
+	cmdutil.AddDryRunFlag(cmd)
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -583,6 +583,34 @@ run_pod_tests() {
   }
 }
 __EOF__
+  kube::test::get_object_assert "node node-v1-test" "{{range.items}}{{if .metadata.annotations.a}}found{{end}}{{end}}:" ':'
+
+  # Dry-run command
+  kubectl replace --dry-run=server -f - "${kube_flags[@]}" << __EOF__
+{
+  "kind": "Node",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "node-v1-test",
+    "annotations": {"a":"b"},
+    "resourceVersion": "0"
+  }
+}
+__EOF__
+  kubectl replace --dry-run=client -f - "${kube_flags[@]}" << __EOF__
+{
+  "kind": "Node",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "node-v1-test",
+    "annotations": {"a":"b"},
+    "resourceVersion": "0"
+  }
+}
+__EOF__
+  kube::test::get_object_assert "node node-v1-test" "{{range.items}}{{if .metadata.annotations.a}}found{{end}}{{end}}:" ':'
+
+  # Command
   kubectl replace -f - "${kube_flags[@]}" << __EOF__
 {
   "kind": "Node",

--- a/test/cmd/delete.sh
+++ b/test/cmd/delete.sh
@@ -32,6 +32,15 @@ run_kubectl_delete_allnamespaces_tests() {
   kubectl create configmap "two" --namespace="${ns_two}"
   kubectl label configmap "one" --namespace="${ns_one}" deletetest=true
   kubectl label configmap "two" --namespace="${ns_two}" deletetest=true
+
+  # dry-run
+  kubectl delete configmap --dry-run=client -l deletetest=true --all-namespaces
+  kubectl delete configmap --dry-run=server -l deletetest=true --all-namespaces
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_one}"
+  kube::test::get_object_assert configmap "{{range.items}}{{${id_field:?}}}:{{end}}" 'one:'
+  kubectl config set-context "${CONTEXT}" --namespace="${ns_two}"
+  kube::test::get_object_assert configmap "{{range.items}}{{${id_field:?}}}:{{end}}" 'two:'
+
   kubectl delete configmap -l deletetest=true --all-namespaces
 
   # no configmaps should be in either of those namespaces

--- a/test/cmd/node-management.sh
+++ b/test/cmd/node-management.sh
@@ -75,6 +75,10 @@ __EOF__
   # taint/untaint
   # Pre-condition: node doesn't have dedicated=foo:PreferNoSchedule taint
   kube::test::get_object_assert "nodes 127.0.0.1" '{{range .spec.taints}}{{if eq .key \"dedicated\"}}{{.key}}={{.value}}:{{.effect}}{{end}}{{end}}' "" # expect no output
+  # Dry-run
+  kubectl taint node 127.0.0.1 --dry-run=client dedicated=foo:PreferNoSchedule
+  kubectl taint node 127.0.0.1 --dry-run=server dedicated=foo:PreferNoSchedule
+  kube::test::get_object_assert "nodes 127.0.0.1" '{{range .spec.taints}}{{if eq .key \"dedicated\"}}{{.key}}={{.value}}:{{.effect}}{{end}}{{end}}' "" # expect no output
   # taint can add a taint (<key>=<value>:<effect>)
   kubectl taint node 127.0.0.1 dedicated=foo:PreferNoSchedule
   kube::test::get_object_assert "nodes 127.0.0.1" '{{range .spec.taints}}{{if eq .key \"dedicated\"}}{{.key}}={{.value}}:{{.effect}}{{end}}{{end}}' "dedicated=foo:PreferNoSchedule"
@@ -82,6 +86,10 @@ __EOF__
   kubectl taint node 127.0.0.1 dedicated-
   # taint can add a taint (<key>:<effect>)
   kubectl taint node 127.0.0.1 dedicated:PreferNoSchedule
+  kube::test::get_object_assert "nodes 127.0.0.1" '{{range .spec.taints}}{{if eq .key \"dedicated\"}}{{.key}}={{.value}}:{{.effect}}{{end}}{{end}}' "dedicated=<no value>:PreferNoSchedule"
+  # Dry-run remove a taint
+  kubectl taint node 127.0.0.1 --dry-run=client dedicated-
+  kubectl taint node 127.0.0.1 --dry-run=server dedicated-
   kube::test::get_object_assert "nodes 127.0.0.1" '{{range .spec.taints}}{{if eq .key \"dedicated\"}}{{.key}}={{.value}}:{{.effect}}{{end}}{{end}}' "dedicated=<no value>:PreferNoSchedule"
   # taint can remove a taint
   kubectl taint node 127.0.0.1 dedicated-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds the `--dry-run` flag for client-side and server-side dry-run to kubectl commands:
- delete
- taint
- replace

Dry-running these commands is useful to see what would happen without persisting the change.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/85652

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --dry-run to kubectl delete, taint, replace
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/0015-dry-run.md
```

/sig cli
cc @apelisse 
/priority important-soon