### PR TITLE
Add oomichi to hack/OWNERS file

### DIFF
--- a/hack/OWNERS
+++ b/hack/OWNERS
@@ -16,6 +16,7 @@ reviewers:
   - xichengliudui
   - zmerlynn
   - mikedanese
+  - oomichi
 approvers:
   - bentheelder
   - cblecker
@@ -34,5 +35,6 @@ approvers:
   - vishh
   - zmerlynn
   - mikedanese
+  - oomichi
 emeritus_approvers:
   - jbeda


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

I much prefer to check proposing PRs automatically before human reviewing effort, then I've changed code under hack/ like the following:

19daee7e604 Add import-aliases check for e2e framework
1b165fc4404 Enable verify-import-aliases check in CI
47a4d1a8ece Rename MetricsForE2E for golint failure
ad988085f69 Add code check for framework.ExpectEqual()
5628b6b50ef Replace mapfile with kube::util::read-array
d5bc1ae8aa9 Make the check strict to use ExpectNoError()
63e0507fd92 Check e2e test code to use ExpectError()
496a18febc3 Add hack/verify-test-code.sh
52885a8ec3b Check conformance test should not call any Skip
08dc0564809 Replace `false` with `exit 1`
c76bb083577 Enable conformance requirement check
3d646675077 Add check-conformance-test-requirements.go
da7c9f70c3c Fix golint failures under test/e2e/[..]/gce
1fcab198218 Fix golint failures for e2e/[..]/kubemark
ede54776978 Enable StorageObjectInUseProtection by default
215dee7dd2e Fix golint under test/e2e/framework/ingress
36b80a4c612 Fix golint failures on e2e/[..]/(aws|azure)
302ec985911 Fix golint failures on handlers/negotiation
89f6f1d0cc9 Fix golint failures under e2e/framework/metrics
60ded1d54a3 Fix golint failures of test/e2e/framework/timer
4a91b593ba7 Use kube::util::array_contains() in hack
c32d1acbb95 Add check-file-in-alphabetical-order for cleanup
aa6e5c8d420 Make FAIL_SWAP_ON warning message clear
122d881c01d Add signal handler for catching Ctrl-C on hack/e2e
c39e231c29e Fix indent of ginkgo-e2e.sh

I'd like to propose myself to be reviewer/approver of hack/ to have more responsibility.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
