### PR TITLE
Add e2e test to test Except clause in NetworkPolicy

### DIFF
--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -1306,6 +1306,71 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			})
 		})
 
+		ginkgo.It("should enforce except clause while egress access to server in CIDR block [Feature:NetworkPolicy]", func() {
+			protocolUDP := v1.ProtocolUDP
+
+			// Getting podServer's status to get podServer's IP, to create the CIDR with except clause
+			podServerStatus, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Get(context.TODO(), podServer.Name, metav1.GetOptions{})
+			if err != nil {
+				framework.ExpectNoError(err, "Error occurred while getting pod status.")
+			}
+
+			podServerAllowCIDR := fmt.Sprintf("%s/24", podServerStatus.Status.PodIP)
+			// Exclude podServer's IP with an Except clause
+			podServerExceptList := []string{fmt.Sprintf("%s/32", podServerStatus.Status.PodIP)}
+
+			// client-a can connect to server prior to applying the NetworkPolicy
+			ginkgo.By("Creating client-a which should be able to contact the server.", func() {
+				testCanConnect(f, f.Namespace, "client-a", service, 80)
+			})
+
+			policyAllowCIDRWithExcept := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: f.Namespace.Name,
+					Name:      "deny-client-a-via-except-cidr-egress-rule",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					// Apply this policy to the client.
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pod-name": "client-a",
+						},
+					},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+					// Allow traffic to only one CIDR block except subnet which includes Server.
+					Egress: []networkingv1.NetworkPolicyEgressRule{
+						{
+							Ports: []networkingv1.NetworkPolicyPort{
+								// Allow DNS look-ups
+								{
+									Protocol: &protocolUDP,
+									Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+								},
+							},
+						},
+						{
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									IPBlock: &networkingv1.IPBlock{
+										CIDR:   podServerAllowCIDR,
+										Except: podServerExceptList,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			policyAllowCIDRWithExcept, err = f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(context.TODO(), policyAllowCIDRWithExcept, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Error occurred while creating policy: policyAllowCIDRWithExcept.")
+			defer cleanupNetworkPolicy(f, policyAllowCIDRWithExcept)
+
+			ginkgo.By("Creating client-a which should no longer be able to contact the server.", func() {
+				testCannotConnect(f, f.Namespace, "client-a", service, 80)
+			})
+		})
+
 		ginkgo.It("should enforce policies to check ingress and egress policies can be controlled independently based on PodSelector [Feature:NetworkPolicy]", func() {
 			var serviceA, serviceB *v1.Service
 			var podA, podB *v1.Pod


### PR DESCRIPTION
Add a new e2e test to test the Except clauses in IPBlock CIDR based NetworkPolicies. This test adds an egress rule which allows client to connect to a CIDR which includes the ServerPod's IP, however carves an except subnet which excludes this ServerPod.

Fixes #88300 

**Does this PR introduce a user-facing change?**:
 
```
NONE
```