### PR TITLE
Add init containers log to cluster dump info

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -286,9 +286,13 @@ func (o *ClusterInfoDumpOptions) Run() error {
 
 		for ix := range pods.Items {
 			pod := &pods.Items[ix]
+			initcontainers := pod.Spec.InitContainers
 			containers := pod.Spec.Containers
 			writer := setupOutputWriter(o.OutputDir, o.Out, path.Join(namespace, pod.Name, "logs"), ".txt")
 
+			for i := range initcontainers {
+				printContainer(writer, initcontainers[i], pod)
+			}
 			for i := range containers {
 				printContainer(writer, containers[i], pod)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
Add init-container to cluster dump info. I believe the this https://github.com/kubernetes/kubernetes/pull/44088 PR hasn't consider add init-container since the feature of init-container is not GA at that moment. Someone has point out this and I think it's ok to add the init-container log.  Like https://github.com/kubernetes/kubernetes/issues/88310 said.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/88310

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add init containers log to cluster dump info.
```
