### PR TITLE
Upgrade PodOverhead to beta

### DIFF
--- a/pkg/api/v1/resource/BUILD
+++ b/pkg/api/v1/resource/BUILD
@@ -11,12 +11,9 @@ go_test(
     srcs = ["helpers_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/pkg/api/v1/resource/helpers_test.go
+++ b/pkg/api/v1/resource/helpers_test.go
@@ -24,9 +24,6 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestResourceHelpers(t *testing.T) {
@@ -68,8 +65,6 @@ func TestDefaultResourceHelpers(t *testing.T) {
 }
 
 func TestGetResourceRequest(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	cases := []struct {
 		pod           *v1.Pod
 		cName         string
@@ -273,8 +268,6 @@ func TestExtractResourceValue(t *testing.T) {
 }
 
 func TestPodRequestsAndLimits(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	cases := []struct {
 		pod              *v1.Pod
 		cName            string

--- a/pkg/apis/node/validation/BUILD
+++ b/pkg/apis/node/validation/BUILD
@@ -22,11 +22,8 @@ go_test(
     deps = [
         "//pkg/apis/core:go_default_library",
         "//pkg/apis/node:go_default_library",
-        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],

--- a/pkg/apis/node/validation/validation_test.go
+++ b/pkg/apis/node/validation/validation_test.go
@@ -21,11 +21,8 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/node"
-	"k8s.io/kubernetes/pkg/features"
 	utilpointer "k8s.io/utils/pointer"
 
 	"github.com/stretchr/testify/assert"
@@ -134,9 +131,6 @@ func TestValidateRuntimeUpdate(t *testing.T) {
 }
 
 func TestValidateOverhead(t *testing.T) {
-
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	successCase := []struct {
 		Name     string
 		overhead *node.Overhead

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -481,6 +481,7 @@ const (
 
 	// owner: @egernst
 	// alpha: v1.16
+	// beta: v1.18
 	//
 	// Enables PodOverhead, for accounting pod overheads which are specific to a given RuntimeClass
 	PodOverhead featuregate.Feature = "PodOverhead"
@@ -623,7 +624,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	LocalStorageCapacityIsolationFSQuotaMonitoring: {Default: false, PreRelease: featuregate.Alpha},
 	NonPreemptingPriority:                          {Default: false, PreRelease: featuregate.Alpha},
 	VolumePVCDataSource:                            {Default: true, PreRelease: featuregate.Beta},
-	PodOverhead:                                    {Default: false, PreRelease: featuregate.Alpha},
+	PodOverhead:                                    {Default: true, PreRelease: featuregate.Beta},
 	IPv6DualStack:                                  {Default: false, PreRelease: featuregate.Alpha},
 	EndpointSlice:                                  {Default: true, PreRelease: featuregate.Beta},
 	EndpointSliceProxying:                          {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/scheduler/framework/plugins/noderesources/fit_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit_test.go
@@ -25,10 +25,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
-	"k8s.io/kubernetes/pkg/features"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
@@ -94,8 +91,6 @@ func getErrReason(rn v1.ResourceName) string {
 }
 
 func TestEnoughRequests(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	enoughPodsTests := []struct {
 		pod                       *v1.Pod
 		nodeInfo                  *schedulernodeinfo.NodeInfo
@@ -413,7 +408,6 @@ func TestPreFilterDisabled(t *testing.T) {
 }
 
 func TestNotEnoughRequests(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
 	notEnoughPodsTests := []struct {
 		pod        *v1.Pod
 		nodeInfo   *schedulernodeinfo.NodeInfo
@@ -468,8 +462,6 @@ func TestNotEnoughRequests(t *testing.T) {
 }
 
 func TestStorageRequests(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	storagePodsTests := []struct {
 		pod        *v1.Pod
 		nodeInfo   *schedulernodeinfo.NodeInfo

--- a/pkg/scheduler/nodeinfo/BUILD
+++ b/pkg/scheduler/nodeinfo/BUILD
@@ -27,13 +27,10 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/nodeinfo/node_info_test.go
+++ b/pkg/scheduler/nodeinfo/node_info_test.go
@@ -26,9 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
-	"k8s.io/kubernetes/pkg/features"
 )
 
 func TestNewResource(t *testing.T) {
@@ -543,9 +540,6 @@ func TestNodeInfoClone(t *testing.T) {
 }
 
 func TestNodeInfoAddPod(t *testing.T) {
-
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	nodeName := "test-node"
 	pods := []*v1.Pod{
 		{
@@ -720,9 +714,6 @@ func TestNodeInfoAddPod(t *testing.T) {
 }
 
 func TestNodeInfoRemovePod(t *testing.T) {
-
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	nodeName := "test-node"
 	pods := []*v1.Pod{
 		makeBasePod(t, nodeName, "test-1", "100m", "500", "", []v1.ContainerPort{{HostIP: "127.0.0.1", HostPort: 80, Protocol: "TCP"}}),

--- a/plugin/pkg/admission/runtimeclass/BUILD
+++ b/plugin/pkg/admission/runtimeclass/BUILD
@@ -28,7 +28,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/core:go_default_library",
-        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/node/v1beta1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
@@ -36,8 +35,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
-        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/plugin/pkg/admission/runtimeclass/admission_test.go
+++ b/plugin/pkg/admission/runtimeclass/admission_test.go
@@ -29,10 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authentication/user"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
-	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	"k8s.io/kubernetes/pkg/apis/core"
-	"k8s.io/kubernetes/pkg/features"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -319,8 +316,6 @@ func NewObjectInterfacesForTest() admission.ObjectInterfaces {
 }
 
 func TestValidate(t *testing.T) {
-	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.PodOverhead, true)()
-
 	tests := []struct {
 		name         string
 		runtimeClass *v1beta1.RuntimeClass


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

`PodOverhead` feature is targeting `beta` in 1.18. As part of this graduation, the `PodOverhead` feature-gate will be enabled by default.
 
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

This PR will be removed from hold once remaining criteria for beta status is completed.

**Does this PR introduce a user-facing change?**:
 
```release-note
NONE
```
