### PR TITLE
Allow system:serviceaccounts to read the SA discovery endpoints

### DIFF
--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/BUILD
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/authentication/serviceaccount:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authentication/user:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
+++ b/plugin/pkg/auth/authorizer/rbac/bootstrappolicy/policy.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/authentication/serviceaccount"
 	"k8s.io/apiserver/pkg/authentication/user"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	rbacv1helpers "k8s.io/kubernetes/pkg/apis/rbac/v1"
@@ -488,8 +489,6 @@ func ClusterRoles() []rbacv1.ClusterRole {
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountIssuerDiscovery) {
 		// Add the cluster role for reading the ServiceAccountIssuerDiscovery endpoints
-		// but do not bind it explicitly. Leave the decision of who can read it up
-		// to cluster admins.
 		roles = append(roles, rbacv1.ClusterRole{
 			ObjectMeta: metav1.ObjectMeta{Name: "system:service-account-issuer-discovery"},
 			Rules: []rbacv1.PolicyRule{
@@ -575,6 +574,20 @@ func ClusterRoleBindings() []rbacv1.ClusterRoleBinding {
 			ObjectMeta: metav1.ObjectMeta{Name: systemNodeRoleName},
 			RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: systemNodeRoleName},
 		},
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.ServiceAccountIssuerDiscovery) {
+		// Allow all in-cluster workloads (via their service accounts) to read the OIDC discovery endpoints.
+		// Users with certain forms of write access (create pods, create secrets, create service accounts, etc)
+		// can gain access to a service account identity which would allow them to access this information.
+		// This includes the issuer URL, which is already present in the SA token JWT.  Similarly, SAs can
+		// already gain this same info via introspection of their own token.  Since this discovery endpoint
+		// points to what issued all service account tokens, it seems fitting for SAs to have this access.
+		// Defer to the cluster admin with regard to binding directly to all authenticated and/or
+		// unauthenticated users.
+		rolebindings = append(rolebindings,
+			rbacv1helpers.NewClusterBinding("system:service-account-issuer-discovery").Groups(serviceaccount.AllServiceAccountsGroup).BindingOrDie(),
+		)
 	}
 
 	addClusterRoleBindingLabel(rolebindings)


### PR DESCRIPTION
This change allows all service accounts to read the service account issuer discovery endpoints.

This guarantees that in-cluster services can rely on this info being available to them.

Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug

/assign @mtaufen @liggitt @mikedanese 
@kubernetes/sig-auth-pr-reviews

/sig auth
/milestone v1.18
/priority important-soon

```release-note
NONE
```