### PR TITLE
Check that ImageInspect pointer is not nil

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -415,7 +415,7 @@ func (ds *dockerService) ContainerStatus(_ context.Context, req *runtimeapi.Cont
 
 	labels, annotations := extractLabels(r.Config.Labels)
 	imageName := r.Config.Image
-	if len(ir.RepoTags) > 0 {
+	if ir != nil && len(ir.RepoTags) > 0 {
 		imageName = ir.RepoTags[0]
 	}
 	status := &runtimeapi.ContainerStatus{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
As Gabe mentioned over #84214, if image is absent, accessing ir.RepoTags would panic.

This PR adds the nil check against ImageInspect pointer.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
