### PR TITLE
node-e2e testing: fix alias for stack protector kernel config.

### DIFF
--- a/test/e2e_node/system/specs/gke.yaml
+++ b/test/e2e_node/system/specs/gke.yaml
@@ -49,7 +49,7 @@ kernelSpec:
   - name: IP6_NF_IPTABLES
     description: 'Required by kube-proxy.'
   - name: IP_NF_TARGET_REDIRECT
-    alias:
+    aliases:
     - NETFILTER_XT_TARGET_REDIRECT
     description: 'Enabled REDIRECT: all incoming connections are mapped onto
       the incoming interface''s address, causing the packets to come to the
@@ -167,10 +167,11 @@ kernelSpec:
     description: 'Enabled the SECCOMP application API.'
   - name: SECURITY_APPARMOR
     description: 'Enable for AppArmor support.'
-  - name: CC_STACKPROTECTOR_STRONG
-    alias:
-    - CONFIG_CC_STACKPROTECTOR_REGULAR
-      CONFIG_CC_STACKPROTECTOR_ALL
+  - name: CC_STACKPROTECTOR_STRONG # Linux kernel <= 4.17
+    aliases:
+    - CC_STACKPROTECTOR_REGULAR # Linux kernel <= 4.17
+    - CC_STACKPROTECTOR_ALL # Linux kernel <= 4.17
+    - STACKPROTECTOR_STRONG # Linux kernel >= 4.18
     description: 'Add the stack buffer overflow protections.'
   - name: STRICT_DEVMEM
     description: 'Required for blocking the direct physical memory access.'


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:

The current kernel config validation of `STACKPROTECTOR` has multiple issues:
- There is a YAML syntax problem
 ```yaml
    - CONFIG_CC_STACKPROTECTOR_REGULAR
      CONFIG_CC_STACKPROTECTOR_ALL
```
will be concat'ed to `- CONFIG_CC_STACKPROTECTOR_REGULAR CONFIG_CC_STACKPROTECTOR_ALL`

- There is no need for `CONFIG` prefix, as the validator will add it anyway.

https://github.com/kubernetes/system-validators/blob/master/validators/kernel_validator.go#L141-L143

- `CONFIG_CC_STACKPROTECTOR_STRONG` and its two variants were removed in kernel 4.18, `CONFIG_STACKPROTECTOR_STRONG` [was added to replace it](https://github.com/torvalds/linux/commit/050e9baa9dc9fbd9ce2b27f0056990fc9e0a08a0).

**Special notes for your reviewer**:
This fix should be merged before node e2e tests runs on any kernel >= 4.18 on GKE.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
