### PR TITLE
de-prioritize unschedulable pods

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -102,6 +102,7 @@ func (sched *Scheduler) addNodeToCache(obj interface{}) {
 	}
 
 	klog.V(3).Infof("add event for node %q", node.Name)
+	sched.SchedulingQueue.RestorePodPriorities()
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(queue.NodeAdd)
 }
 
@@ -129,6 +130,7 @@ func (sched *Scheduler) updateNodeInCache(oldObj, newObj interface{}) {
 	if sched.SchedulingQueue.NumUnschedulablePods() == 0 {
 		sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(queue.Unknown)
 	} else if event := nodeSchedulingPropertiesChange(newNode, oldNode); event != "" {
+		sched.SchedulingQueue.RestorePodPriorities()
 		sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(event)
 	}
 }
@@ -285,6 +287,7 @@ func (sched *Scheduler) deletePodFromCache(obj interface{}) {
 		klog.Errorf("scheduler cache RemovePod failed: %v", err)
 	}
 
+	sched.SchedulingQueue.RestorePodPriorities()
 	sched.SchedulingQueue.MoveAllToActiveOrBackoffQueue(queue.AssignedPodDelete)
 }
 

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -175,7 +175,7 @@ func (c *Configurator) create() (*Scheduler, error) {
 		return nil, errors.New("at least one profile is required")
 	}
 	// Profiles are required to have equivalent queue sort plugins.
-	lessFn := profiles[c.profiles[0].SchedulerName].Framework.QueueSortFunc()
+	lessFn := profiles[c.profiles[0].SchedulerName].Framework.DynamicQueueSortFunc()
 	podQueue := internalqueue.NewSchedulingQueue(
 		lessFn,
 		internalqueue.WithPodInitialBackoffDuration(time.Duration(c.podInitialBackoffSeconds)*time.Second),

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
@@ -44,6 +44,18 @@ func (pl *PrioritySort) Less(pInfo1, pInfo2 *framework.PodInfo) bool {
 	return (p1 > p2) || (p1 == p2 && pInfo1.Timestamp.Before(pInfo2.Timestamp))
 }
 
+// DynamicLess is the function used by the activeQ heap algorithm with de-prioritize
+// unschedulable pods feature to sort pods. It sorts pods based on their dynamic priority.
+// When dynamic priorities are equal, it uses PodInfo.timestamp
+func (pl *PrioritySort) DynamicLess(pInfo1, pInfo2 *framework.PodInfo) bool {
+	p1 := pInfo1.DynamicPriority
+	p2 := pInfo2.DynamicPriority
+	if p1 < 0 && p2 < 0 {
+		return (p1 < p2) || (p1 == p2 && pInfo1.Timestamp.Before(pInfo2.Timestamp))
+	}
+	return (p1 > p2) || (p1 == p2 && pInfo1.Timestamp.Before(pInfo2.Timestamp))
+}
+
 // New initializes a new plugin and returns it.
 func New(plArgs *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
 	return &PrioritySort{}, nil

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -309,6 +309,20 @@ func (f *framework) QueueSortFunc() LessFunc {
 	return f.queueSortPlugins[0].Less
 }
 
+func (f *framework) DynamicQueueSortFunc() LessFunc {
+	if f == nil {
+		// If framework is nil, simply keep their order unchanged.
+		// NOTE: this is primarily for tests.
+		return func(_, _ *PodInfo) bool { return false }
+	}
+
+	if len(f.queueSortPlugins) == 0 {
+		panic("No QueueSort plugin is registered in the framework.")
+	}
+
+	return f.queueSortPlugins[0].DynamicLess
+}
+
 // RunPreFilterPlugins runs the set of configured PreFilter plugins. It returns
 // *Status and its code is set to non-success if any of the plugins returns
 // anything but Success. If a non-success status is returned, then the scheduling

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -226,6 +226,9 @@ type PodInfo struct {
 	// It shouldn't be updated once initialized. It's used to record the e2e scheduling
 	// latency for a pod.
 	InitialAttemptTimestamp time.Time
+	// The dynamic priority of pod.
+	// It's used to store de-prioritized value when pod is unschedulable.
+	DynamicPriority int32
 }
 
 // DeepCopy returns a deep copy of the PodInfo object.
@@ -235,6 +238,7 @@ func (podInfo *PodInfo) DeepCopy() *PodInfo {
 		Timestamp:               podInfo.Timestamp,
 		Attempts:                podInfo.Attempts,
 		InitialAttemptTimestamp: podInfo.InitialAttemptTimestamp,
+		DynamicPriority:         podInfo.DynamicPriority,
 	}
 }
 
@@ -248,6 +252,8 @@ type QueueSortPlugin interface {
 	Plugin
 	// Less are used to sort pods in the scheduling queue.
 	Less(*PodInfo, *PodInfo) bool
+	// DynamicLess are used to sort pods with dynamic priority in the scheduling queue.
+	DynamicLess(*PodInfo, *PodInfo) bool
 }
 
 // PreFilterExtensions is an interface that is included in plugins that allow specifying
@@ -411,6 +417,10 @@ type Framework interface {
 	FrameworkHandle
 	// QueueSortFunc returns the function to sort pods in scheduling queue
 	QueueSortFunc() LessFunc
+
+	// DynamicQueueSortFunc returns the function to sort pods with dynamic priority
+	// in scheduling queue
+	DynamicQueueSortFunc() LessFunc
 
 	// RunPreFilterPlugins runs the set of configured prefilter plugins. It returns
 	// *Status and its code is set to non-success if any of the plugins returns

--- a/pkg/scheduler/internal/heap/heap.go
+++ b/pkg/scheduler/internal/heap/heap.go
@@ -152,6 +152,18 @@ func (h *Heap) Add(obj interface{}) error {
 	return nil
 }
 
+func (h *Heap) Fix(obj interface{}) error {
+	key, err := h.data.keyFunc(obj)
+	if err != nil {
+		return cache.KeyError{Obj: obj, Err: err}
+	}
+	if _, exists := h.data.items[key]; exists {
+		h.data.items[key].obj = obj
+		heap.Fix(h.data, h.data.items[key].index)
+	}
+	return nil
+}
+
 // AddIfNotPresent inserts an item, and puts it in the queue. If an item with
 // the key is present in the map, no changes is made to the item.
 func (h *Heap) AddIfNotPresent(obj interface{}) error {


### PR DESCRIPTION
**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
This PR is trying to de-prioritize unschedulable pods to avoid them slow down the scheduling latency of the same or lower priority pods. Also it will resume the priority of deprioritized pods when cap added or pod deleted to make room.

> **Keep to de-prioritize unschedulable pods**
- _First podAttempt:_ dynamic-priority=priority/2
- _N podAttempts:_ dynamic-priority=dynamic-priority/(2^N)
- _N > M:_ dynamic-priority=-1-priority

> **Resume the original priority for those de-prioritized pods when receive events about capacity adding**
- Receive pod deletion events
- Receive node addition events
- Node status changed from NotReady to Ready**

**Which issue(s) this PR fixes**:
Fixes #85792

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE