### PR TITLE
fix duplicate FailedMount events when using multiple volumes

### DIFF
--- a/pkg/kubelet/volumemanager/volume_manager.go
+++ b/pkg/kubelet/volumemanager/volume_manager.go
@@ -393,6 +393,11 @@ func (vm *volumeManager) WaitForAttachAndMount(pod *v1.Pod) error {
 			return nil
 		}
 
+		// The volumes should be sorted to generate the same error
+		// so that the event can be duplicated
+		sort.Strings(unmountedVolumes)
+		sort.Strings(unattachedVolumes)
+
 		return fmt.Errorf(
 			"unmounted volumes=%v, unattached volumes=%v: %s",
 			unmountedVolumes,


### PR DESCRIPTION


**What type of PR is this?**
 /kind bug


**What this PR does / why we need it**:
fix duplicate FailedMount events when using multiple volumes

**Which issue(s) this PR fixes**:

Fixes #https://github.com/kubernetes/kubernetes/issues/88226

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/sig storage