### PR TITLE
Improve scheduler CLI description

### DIFF
--- a/cmd/kube-scheduler/app/server.go
+++ b/cmd/kube-scheduler/app/server.go
@@ -75,13 +75,13 @@ func NewSchedulerCommand(registryOptions ...Option) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use: "kube-scheduler",
-		Long: `The Kubernetes scheduler is a policy-rich, topology-aware,
-workload-specific function that significantly impacts availability, performance,
-and capacity. The scheduler needs to take into account individual and collective
-resource requirements, quality of service requirements, hardware/software/policy
-constraints, affinity and anti-affinity specifications, data locality, inter-workload
-interference, deadlines, and so on. Workload-specific requirements will be exposed
-through the API as necessary. See [scheduling](https://kubernetes.io/docs/concepts/scheduling/)
+		Long: `The Kubernetes scheduler is a control plane process which assigns
+Pods to Nodes. The scheduler determines which Nodes are valid placements for
+each Pod in the scheduling queue according to constraints and available
+resources. The scheduler then ranks each valid Node and binds the Pod to a
+suitable Node. Multiple different schedulers may be used within a cluster;
+kube-scheduler is the reference implementation.
+See [scheduling](https://kubernetes.io/docs/concepts/scheduling/)
 for more information about scheduling and the kube-scheduler component.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := runCommand(cmd, args, opts, registryOptions...); err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design

/kind documentation

> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

This PR adds a few explanatory sentences to the kube-scheduler CLI description (which is in turn used to generate the documentation website). To understand why this is needed, let's look at the first few lines of the documentation for other core CLI components from the perspective of a new user or contributor:

> [The kubelet is the primary “node agent” that runs on each node.](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/)

> [The Kubernetes network proxy runs on each node. This reflects services as defined in the Kubernetes API on each node and can do simple TCP, UDP, and SCTP stream forwarding or round robin TCP, UDP, and SCTP forwarding across a set of backends.](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/)

> [The Kubernetes controller manager is a daemon that embeds the core control loops shipped with Kubernetes.](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/)

> [The Kubernetes API server validates and configures data for the api objects which include pods, services, replicationcontrollers, and others. The API Server services REST operations and provides the frontend to the cluster’s shared state through which all other components interact.](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/)

So far, not bad. Some of the descriptions are a little wordy, but in general from reading the first one or two sentences, a new user reading the docs has a basic idea of what each component does.

What about kube-scheduler?

> The Kubernetes scheduler is a policy-rich, topology-aware, workload-specific function that significantly impacts availability, performance, and capacity. The scheduler needs to take into account individual and collective resource requirements, quality of service requirements, hardware/software/policy constraints, affinity and anti-affinity specifications, data locality, inter-workload interference, deadlines, and so on. Workload-specific requirements will be exposed through the API as necessary.

This... is very confusing. A new user reading this doesn't learn what the scheduler actually does, just that it seems to do... _something important?_

I've copied a couple of sentences from https://kubernetes.io/docs/concepts/scheduling/kube-scheduler/#scheduling to clarify the documentation here.

I wonder if the entire paragraph quoted above is really entirely necessary? It reads like the opening paragraph of a requirements specification doc, not the quick help text most people expect from a CLI tool.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
