### PR TITLE
Support injecting errors for `FakeImageService`

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -30,6 +30,7 @@ type FakeImageService struct {
 
 	FakeImageSize uint64
 	Called        []string
+	Errors        map[string][]error
 	Images        map[string]*runtimeapi.Image
 
 	pulledImages []*pulledImage
@@ -87,11 +88,34 @@ func stringInSlice(s string, list []string) bool {
 	return false
 }
 
+func (r *FakeImageService) InjectError(f string, err error) {
+	r.Lock()
+	defer r.Unlock()
+	r.Errors[f] = append(r.Errors[f], err)
+}
+
+// caller of popError must grab a lock.
+func (r *FakeImageService) popError(f string) error {
+	if r.Errors == nil {
+		return nil
+	}
+	errs := r.Errors[f]
+	if len(errs) == 0 {
+		return nil
+	}
+	err, errs := errs[0], errs[1:]
+	r.Errors[f] = errs
+	return err
+}
+
 func (r *FakeImageService) ListImages(filter *runtimeapi.ImageFilter) ([]*runtimeapi.Image, error) {
 	r.Lock()
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ListImages")
+	if err := r.popError("ListImages"); err != nil {
+		return nil, err
+	}
 
 	images := make([]*runtimeapi.Image, 0)
 	for _, img := range r.Images {
@@ -111,6 +135,9 @@ func (r *FakeImageService) ImageStatus(image *runtimeapi.ImageSpec) (*runtimeapi
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ImageStatus")
+	if err := r.popError("ImageStatus"); err != nil {
+		return nil, err
+	}
 
 	return r.Images[image.Image], nil
 }
@@ -120,6 +147,9 @@ func (r *FakeImageService) PullImage(image *runtimeapi.ImageSpec, auth *runtimea
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "PullImage")
+	if err := r.popError("PullImage"); err != nil {
+		return "", err
+	}
 
 	r.pulledImages = append(r.pulledImages, &pulledImage{imageSpec: image, authConfig: auth})
 	// ImageID should be randomized for real container runtime, but here just use
@@ -137,6 +167,9 @@ func (r *FakeImageService) RemoveImage(image *runtimeapi.ImageSpec) error {
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "RemoveImage")
+	if err := r.popError("RemoveImage"); err != nil {
+		return err
+	}
 
 	// Remove the image
 	delete(r.Images, image.Image)
@@ -150,6 +183,9 @@ func (r *FakeImageService) ImageFsInfo() ([]*runtimeapi.FilesystemUsage, error) 
 	defer r.Unlock()
 
 	r.Called = append(r.Called, "ImageFsInfo")
+	if err := r.popError("ImageFsInfo"); err != nil {
+		return nil, err
+	}
 
 	return r.FakeFilesystemUsage, nil
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We want `FakeImageService` to support injecting errors similar to
`FakeRuntimeService`. These injected errors will be returned on the next
call to the given function.

We will use the ability to inject errors to more thoroughly test
the image management component of the KubeRuntimeManager.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
