### PR TITLE
Refresh discovery server resources for memCacheClient in parallel

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache.go
@@ -190,16 +190,29 @@ func (d *memCacheClient) refreshLocked() error {
 		return err
 	}
 
+	wg := &sync.WaitGroup{}
+	resultLock := &sync.Mutex{}
 	rl := map[string]*cacheEntry{}
 	for _, g := range gl.Groups {
 		for _, v := range g.Versions {
-			r, err := d.serverResourcesForGroupVersion(v.GroupVersion)
-			rl[v.GroupVersion] = &cacheEntry{r, err}
-			if err != nil {
-				utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", v.GroupVersion, err))
-			}
+			gv := v.GroupVersion
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer utilruntime.HandleCrash()
+
+				r, err := d.serverResourcesForGroupVersion(gv)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", gv, err))
+				}
+
+				resultLock.Lock()
+				defer resultLock.Unlock()
+				rl[gv] = &cacheEntry{r, err}
+			}()
 		}
 	}
+	wg.Wait()
 
 	d.groupToServerResources, d.groupList = rl, gl
 	d.cacheValid = true

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -205,16 +205,22 @@ func TestServerGroupsFails(t *testing.T) {
 func TestPartialPermanentFailure(t *testing.T) {
 	fake := &fakeDiscovery{
 		groupList: &metav1.APIGroupList{
-			Groups: []metav1.APIGroup{{
-				Name: "astronomy",
-				Versions: []metav1.GroupVersionForDiscovery{{
-					GroupVersion: "astronomy/v8beta1",
-					Version:      "v8beta1",
-				}, {
-					GroupVersion: "astronomy2/v8beta1",
-					Version:      "v8beta1",
-				}},
-			}},
+			Groups: []metav1.APIGroup{
+				{
+					Name: "astronomy",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+				{
+					Name: "astronomy2",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy2/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+			},
 		},
 		resourceMap: map[string]*resourceMapEntry{
 			"astronomy/v8beta1": {
@@ -286,16 +292,22 @@ func TestPartialPermanentFailure(t *testing.T) {
 func TestPartialRetryableFailure(t *testing.T) {
 	fake := &fakeDiscovery{
 		groupList: &metav1.APIGroupList{
-			Groups: []metav1.APIGroup{{
-				Name: "astronomy",
-				Versions: []metav1.GroupVersionForDiscovery{{
-					GroupVersion: "astronomy/v8beta1",
-					Version:      "v8beta1",
-				}, {
-					GroupVersion: "astronomy2/v8beta1",
-					Version:      "v8beta1",
-				}},
-			}},
+			Groups: []metav1.APIGroup{
+				{
+					Name: "astronomy",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+				{
+					Name: "astronomy2",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy2/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+			},
 		},
 		resourceMap: map[string]*resourceMapEntry{
 			"astronomy/v8beta1": {


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

Run discovery API calls in parallel to reduce for in-memory discovery client. Reduces each cache refresh from ~15 seconds to ~ 2 seconds.

This helps e2e tests since they are run in parallel and some remove CRDs at the same others are being run, forcing the cache to be refreshed often.

In e2e tests we're seeing a groupVersion list length of around 27, which means we are 27 API calls in series.

See https://github.com/kubernetes/kubernetes/issues/87668 and https://github.com/kubernetes/kubernetes/pull/88297 for debugging details.

There might be other ways to optimize this further, but running the requests in parallel is an obvious win, so would like to merge this before pursuing other optimizations.

Last 9 `pull-kubernetes-e2e-gce` runs below. No GC failures. This is with SSA at 10%

[1230671712341725185](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230671712341725185) - pass - 53m18s
[1230729716571312129](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230729716571312129) - pass - 49m35s
[1230742932269568000](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230742932269568000) - pass - 47m0s
[1230756271573962752](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230756271573962752) - pass - 45m38s
[1230767966954459136](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230767966954459136) - pass - 51m17s
[1230781434029936640](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230781434029936640) - 12 In-tree Volumes failures - 48m41s
[1230885123486912512](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230885123486912512) - 1 volume mount failure - 50m28s
[1230899588768993280](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230899588768993280) - 1 volume mount failure - 51m12s
[1230916073155465216](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88382/pull-kubernetes-e2e-gce/1230916073155465216) - pass - 49m40s

From https://github.com/kubernetes/kubernetes/pull/88297 here are the last 9 runs with SSA at 100%. No GC failures.

[1230746203231096836](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230746203231096836) - pass - 1h1m41s
[1230762058010595328](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230762058010595328) - 1 volume/CSIDriver failure - 1h0m17s
[1230778298858999808](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230778298858999808) - 15  In-tree Volumes failures - 50m16s
[1230885241724342272](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230885241724342272) - pass - 51m50s
[1230899588773187585](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230899588773187585) - pass - 52m36s
[1230919719050022912](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230919719050022912) - pass - 57m56s
[1230949943569551360](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230949943569551360) - 1 In-tree Volumes failures, 2 PersistentVolumes-local failures - 59m57s
[1230966546394779648](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230966546394779648/) - 1 CRD publish OpenAPI failure, 58m36s
[1230985169494609921](https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88297/pull-kubernetes-e2e-gce/1230985169494609921/) - pass - 55m29s


**Which issue(s) this PR fixes**:

Fixes #87668

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
