### PR TITLE
Remove tallclair from some OWNERS files

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -199,7 +199,6 @@ aliases:
     - Random-Liu
     - dchen1107
     - derekwaynecarr
-    - tallclair
     - vishh
     - yujuhong
   sig-node-reviewers:
@@ -213,7 +212,6 @@ aliases:
     - pmorie
     - resouer
     - sjenning
-    - tallclair
     - vishh
     - yifan-gu
     - yujuhong

--- a/pkg/api/testing/OWNERS
+++ b/pkg/api/testing/OWNERS
@@ -20,7 +20,6 @@ reviewers:
 - zmerlynn
 - justinsb
 - pwittrock
-- tallclair
 - yifan-gu
 - eparis
 - soltysh

--- a/pkg/apis/apps/OWNERS
+++ b/pkg/apis/apps/OWNERS
@@ -10,7 +10,6 @@ reviewers:
 - sttts
 - saad-ali
 - ncdc
-- tallclair
 - dims
 - errordeveloper
 - mml

--- a/pkg/client/OWNERS
+++ b/pkg/client/OWNERS
@@ -32,7 +32,6 @@ reviewers:
 - janetkuo
 - justinsb
 - ncdc
-- tallclair
 - yifan-gu
 - eparis
 - mwielgus

--- a/pkg/kubelet/OWNERS
+++ b/pkg/kubelet/OWNERS
@@ -4,11 +4,11 @@ approvers:
 - Random-Liu
 - dchen1107
 - derekwaynecarr
-- tallclair
 - vishh
 - yujuhong
 reviewers:
 - sig-node-reviewers
+- tallclair
 labels:
 - area/kubelet
 - sig/node

--- a/pkg/kubelet/cm/OWNERS
+++ b/pkg/kubelet/cm/OWNERS
@@ -4,7 +4,6 @@ approvers:
 - Random-Liu
 - dchen1107
 - derekwaynecarr
-- tallclair
 - vishh
 - yujuhong
 - ConnorDoyle

--- a/pkg/kubelet/prober/OWNERS
+++ b/pkg/kubelet/prober/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- tallclair
+- sig-node-approvers

--- a/pkg/kubelet/server/OWNERS
+++ b/pkg/kubelet/server/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+- tallclair
+- cheftako

--- a/pkg/master/OWNERS
+++ b/pkg/master/OWNERS
@@ -31,7 +31,6 @@ reviewers:
 - janetkuo
 - justinsb
 - ncdc
-- tallclair
 - mwielgus
 - timothysc
 - soltysh

--- a/pkg/registry/OWNERS
+++ b/pkg/registry/OWNERS
@@ -29,7 +29,6 @@ reviewers:
 - justinsb
 - pwittrock
 - ncdc
-- tallclair
 - eparis
 - mwielgus
 - timothysc

--- a/staging/src/k8s.io/api/apps/OWNERS
+++ b/staging/src/k8s.io/api/apps/OWNERS
@@ -10,7 +10,6 @@ reviewers:
 - sttts
 - saad-ali
 - ncdc
-- tallclair
 - dims
 - errordeveloper
 - mml

--- a/staging/src/k8s.io/apimachinery/OWNERS
+++ b/staging/src/k8s.io/apimachinery/OWNERS
@@ -22,6 +22,5 @@ reviewers:
 - sttts
 - ncdc
 - logicalhan
-- tallclair
 labels:
 - sig/api-machinery

--- a/staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
+++ b/staging/src/k8s.io/apimachinery/pkg/api/resource/OWNERS
@@ -9,7 +9,6 @@ reviewers:
 - mikedanese
 - saad-ali
 - janetkuo
-- tallclair
 - eparis
 - xiang90
 - mbohlool

--- a/staging/src/k8s.io/apiserver/OWNERS
+++ b/staging/src/k8s.io/apiserver/OWNERS
@@ -15,7 +15,6 @@ reviewers:
 - liggitt
 - sttts
 - ncdc
-- tallclair
 - enj
 - hzxuzhonghu
 - CaoShuFeng

--- a/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
+++ b/staging/src/k8s.io/apiserver/pkg/storage/OWNERS
@@ -15,7 +15,6 @@ reviewers:
 - mikedanese
 - liggitt
 - ncdc
-- tallclair
 - timothysc
 - hongchaodeng
 - krousey

--- a/staging/src/k8s.io/cri-api/pkg/OWNERS
+++ b/staging/src/k8s.io/cri-api/pkg/OWNERS
@@ -7,7 +7,6 @@ approvers:
 - Random-Liu
 - dchen1107
 - derekwaynecarr
-- tallclair
 - vishh
 - yujuhong
 reviewers:

--- a/test/e2e/apimachinery/OWNERS
+++ b/test/e2e/apimachinery/OWNERS
@@ -22,6 +22,5 @@ reviewers:
 - sttts
 - ncdc
 - logicalhan
-- tallclair
 labels:
 - sig/api-machinery


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Remove myself from some owners files. These are mostly areas that I don't feel I have enough expertise to give a good review. I'm trying to cut down on my review noise, to better focus on the areas I have more expertise in.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig node