### PR TITLE
Add a unit test verifying potential racing between sched queue and cache

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -93,6 +93,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1161,7 +1161,6 @@ func TestSchedulerCacheRacingWithQueue(t *testing.T) {
 
 	// Our goal is to ensure the scheduling of p2 is based on the the snapshot
 	// that p1.label has been updated (to "bar").
-	// cache.UpdateSnapshot(emptySnapshot)
 	pods, err := emptySnapshot.Pods().List(labels.NewSelector())
 	if err != nil {
 		t.Fatalf("cannot get pods from snapshot: %v", err)
@@ -1171,7 +1170,7 @@ func TestSchedulerCacheRacingWithQueue(t *testing.T) {
 	}
 	// TODO: uncomment the following section and ensure the test always passes, i.e. run
 	// go test k8s.io/kubernetes/pkg/scheduler/ -run ^TestSchedulerCacheRacingWithQueue$ -count=20
-	// if _, ok := pods[0].Labels["bar"]; !ok {
-	// 	t.Errorf("expect label 'bar' to be present in pod %q in the snapshot, but got %v", pods[0].Name, pods[0].Labels)
-	// }
+	if _, ok := pods[0].Labels["bar"]; !ok {
+		t.Errorf("expect label 'bar' to be present in pod %q in the snapshot, but got %v", pods[0].Name, pods[0].Labels)
+	}
 }

--- a/pkg/scheduler/testing/BUILD
+++ b/pkg/scheduler/testing/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var zero int64
@@ -153,6 +154,12 @@ func (p *PodWrapper) Name(s string) *PodWrapper {
 // Namespace sets `s` as the namespace of the inner pod.
 func (p *PodWrapper) Namespace(s string) *PodWrapper {
 	p.SetNamespace(s)
+	return p
+}
+
+// UID sets `s` as the UID of the inner pod.
+func (p *PodWrapper) UID(s types.UID) *PodWrapper {
+	p.SetUID(s)
 	return p
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/kind flake
/sig scheduling

**What this PR does / why we need it**:

Follow up on https://github.com/kubernetes/kubernetes/pull/87845#discussion_r375519706.

Basically, if two Pod events (one on `assignedPod`, one on `unassignedPod`) were generated in order, and dispatched to scheduler following that order, the current scheduler logic doesn't guarantee the scheduling of latter `unassignedPod` is based on the snapshot which has handled the preceding `assignedPod`, because the caching is a separate goroutine, there could be timing issue.

This PR creates a UT exercising potential timing issues. I intentionally commented out the last couple of lines; otherwise, it would flake - which reveals the aforementioned problem.

```
⇒  go test k8s.io/kubernetes/pkg/scheduler/ -run ^TestSchedulerCacheRacingWithQueue$ -count=20
--- FAIL: TestSchedulerCacheRacingWithQueue (0.11s)
    scheduler_test.go:1173: expect label 'bar' to be present in pod "p1" in the snapshot, but got map[foo:]
--- FAIL: TestSchedulerCacheRacingWithQueue (0.10s)
    scheduler_test.go:1173: expect label 'bar' to be present in pod "p1" in the snapshot, but got map[foo:]
FAIL
FAIL	k8s.io/kubernetes/pkg/scheduler	5.285s
FAIL

⇒  go test k8s.io/kubernetes/pkg/scheduler/ -run ^TestSchedulerCacheRacingWithQueue$ -count=10
--- FAIL: TestSchedulerCacheRacingWithQueue (0.10s)
    scheduler_test.go:1175: expect label 'bar' to be present in pod "p1" in the snapshot, but got map[foo:]
FAIL
FAIL	k8s.io/kubernetes/pkg/scheduler	2.470s
FAIL

⇒  go test k8s.io/kubernetes/pkg/scheduler/ -run ^TestSchedulerCacheRacingWithQueue$ -count=5
ok  	k8s.io/kubernetes/pkg/scheduler	1.083s
```

**Special notes for your reviewer**:

Before we gave a "fix", I'd like to brainstorm if we're ok with current behavior.

If we think the current behavior is as expected, this PR can still be merged (with those lines commented out), and act as an example for testing eventHandlers.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
