### PR TITLE
Backport of PR #81399 to 1.14.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics.go
@@ -26,9 +26,21 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 )
 
+// WebhookRejectionErrorType defines different error types that happen in a webhook rejection.
+type WebhookRejectionErrorType string
+
 const (
 	namespace = "apiserver"
 	subsystem = "admission"
+
+	// WebhookRejectionCallingWebhookError identifies a calling webhook error which causes
+	// a webhook admission to reject a request
+	WebhookRejectionCallingWebhookError WebhookRejectionErrorType = "calling_webhook_error"
+	// WebhookRejectionAPIServerInternalError identifies an apiserver internal error which
+	// causes a webhook admission to reject a request
+	WebhookRejectionAPIServerInternalError WebhookRejectionErrorType = "apiserver_internal_error"
+	// WebhookRejectionNoError identifies a webhook properly rejected a request
+	WebhookRejectionNoError WebhookRejectionErrorType = "no_error"
 )
 
 var (
@@ -102,9 +114,10 @@ func (p pluginHandlerWithMetrics) Validate(a admission.Attributes, o admission.O
 
 // AdmissionMetrics instruments admission with prometheus metrics.
 type AdmissionMetrics struct {
-	step       *metricSet
-	controller *metricSet
-	webhook    *metricSet
+	step             *metricSet
+	controller       *metricSet
+	webhook          *metricSet
+	webhookRejection *prometheus.CounterVec
 }
 
 // newAdmissionMetrics create a new AdmissionMetrics, configured with default metric names.
@@ -125,10 +138,20 @@ func newAdmissionMetrics() *AdmissionMetrics {
 		[]string{"name", "type", "operation", "rejected"},
 		"Admission webhook %s, identified by name and broken out for each operation and API resource and type (validate or admit).", false)
 
+	webhookRejection := prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "webhook_rejection_count",
+			Help:      "Admission webhook rejection count, identified by name and broken out for each admission type (validating or admit) and operation. Additional labels specify an error type (calling_webhook_error or apiserver_internal_error if an error occurred; no_error otherwise) and optionally a non-zero rejection code if the webhook rejects the request with an HTTP status code (honored by the apiserver when the code is greater or equal to 400). Codes greater than 600 are truncated to 600, to keep the metrics cardinality bounded.",
+		},
+		[]string{"name", "type", "operation", "error_type", "rejection_code"})
+
 	step.mustRegister()
 	controller.mustRegister()
 	webhook.mustRegister()
-	return &AdmissionMetrics{step: step, controller: controller, webhook: webhook}
+	prometheus.MustRegister(webhookRejection)
+	return &AdmissionMetrics{step: step, controller: controller, webhook: webhook, webhookRejection: webhookRejection}
 }
 
 func (m *AdmissionMetrics) reset() {
@@ -150,6 +173,16 @@ func (m *AdmissionMetrics) ObserveAdmissionController(elapsed time.Duration, rej
 // ObserveWebhook records admission related metrics for a admission webhook.
 func (m *AdmissionMetrics) ObserveWebhook(elapsed time.Duration, rejected bool, attr admission.Attributes, stepType string, extraLabels ...string) {
 	m.webhook.observe(elapsed, append(extraLabels, stepType, string(attr.GetOperation()), strconv.FormatBool(rejected))...)
+}
+
+// ObserveWebhookRejection records admission related metrics for an admission webhook rejection.
+func (m *AdmissionMetrics) ObserveWebhookRejection(name, stepType, operation string, errorType WebhookRejectionErrorType, rejectionCode int) {
+	// We truncate codes greater than 600 to keep the cardinality bounded.
+	// This should be rarely done by a malfunctioning webhook server.
+	if rejectionCode > 600 {
+		rejectionCode = 600
+	}
+	m.webhookRejection.WithLabelValues(name, stepType, operation, string(errorType), strconv.Itoa(rejectionCode)).Inc()
 }
 
 type metricSet struct {

--- a/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/metrics/metrics_test.go
@@ -78,6 +78,37 @@ func TestObserveWebhook(t *testing.T) {
 	expectHistogramCountTotal(t, "apiserver_admission_webhook_admission_duration_seconds", wantLabels, 1)
 }
 
+func TestObserveWebhookRejection(t *testing.T) {
+	Metrics.reset()
+	Metrics.ObserveWebhookRejection("x", stepAdmit, string(admission.Create), WebhookRejectionNoError, 500)
+	Metrics.ObserveWebhookRejection("x", stepAdmit, string(admission.Create), WebhookRejectionNoError, 654)
+	Metrics.ObserveWebhookRejection("x", stepValidate, string(admission.Update), WebhookRejectionCallingWebhookError, 0)
+	wantLabels := map[string]string{
+		"name":           "x",
+		"operation":      string(admission.Create),
+		"type":           "admit",
+		"error_type":     "no_error",
+		"rejection_code": "500",
+	}
+	wantLabels600 := map[string]string{
+		"name":           "x",
+		"operation":      string(admission.Create),
+		"type":           "admit",
+		"error_type":     "no_error",
+		"rejection_code": "600",
+	}
+	wantLabelsCallingWebhookError := map[string]string{
+		"name":           "x",
+		"operation":      string(admission.Update),
+		"type":           "validate",
+		"error_type":     "calling_webhook_error",
+		"rejection_code": "0",
+	}
+	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabels600, 1)
+	expectCounterValue(t, "apiserver_admission_webhook_rejection_count", wantLabelsCallingWebhookError, 1)
+}
+
 func TestWithMetrics(t *testing.T) {
 	Metrics.reset()
 

--- a/staging/src/k8s.io/apiserver/pkg/util/webhook/error.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/webhook/error.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package webhook
 
-import "fmt"
+import (
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
 
 // ErrCallingWebhook is returned for transport-layer errors calling webhooks. It
 // represents a failure to talk to the webhook, not the webhook rejecting a
@@ -31,4 +35,13 @@ func (e *ErrCallingWebhook) Error() string {
 		return fmt.Sprintf("failed calling webhook %q: %v", e.WebhookName, e.Reason)
 	}
 	return fmt.Sprintf("failed calling webhook %q; no further details available", e.WebhookName)
+}
+
+// ErrWebhookRejection represents a webhook properly rejecting a request.
+type ErrWebhookRejection struct {
+	Status *apierrors.StatusError
+}
+
+func (e *ErrWebhookRejection) Error() string {
+	return e.Status.Error()
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change

**What this PR does / why we need it**:
Webhook observability is important for operating clusters that may create
admission webhooks; at Google, we've had outages due to misconfigured webhooks
failing and blocking control plane operations, and would like to catch such
problems earlier. This change (initially made in 1.16 as PR #81399) adds webhook rejection
metrics, including for those caused by failure of the webhook, to the API
server's prometheus metrics.

**Does this PR introduce a user-facing change?**:
```release-note
The `rejected` label in `apiserver_admission_webhook_admission_duration_seconds` metrics now properly indicates if a request was rejected. Add a new counter metrics `apiserver_admission_webhook_rejection_count` with details about the causing for a webhook rejection.
```