### PR TITLE
Automated cherry pick of #87117: kube-proxy crash when load balancers use a different IP family

### DIFF
--- a/pkg/proxy/service.go
+++ b/pkg/proxy/service.go
@@ -136,12 +136,10 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 		stickyMaxAgeSeconds = int(*service.Spec.SessionAffinityConfig.ClientIP.TimeoutSeconds)
 	}
 	info := &BaseServiceInfo{
-		clusterIP: net.ParseIP(service.Spec.ClusterIP),
-		port:      int(port.Port),
-		protocol:  port.Protocol,
-		nodePort:  int(port.NodePort),
-		// Deep-copy in case the service instance changes
-		loadBalancerStatus:     *service.Status.LoadBalancer.DeepCopy(),
+		clusterIP:              net.ParseIP(service.Spec.ClusterIP),
+		port:                   int(port.Port),
+		protocol:               port.Protocol,
+		nodePort:               int(port.NodePort),
 		sessionAffinityType:    service.Spec.SessionAffinity,
 		stickyMaxAgeSeconds:    stickyMaxAgeSeconds,
 		onlyNodeLocalEndpoints: onlyNodeLocalEndpoints,
@@ -153,9 +151,11 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 		info.loadBalancerSourceRanges = make([]string, len(service.Spec.LoadBalancerSourceRanges))
 		copy(info.loadBalancerSourceRanges, service.Spec.LoadBalancerSourceRanges)
 		copy(info.externalIPs, service.Spec.ExternalIPs)
+		// Deep-copy in case the service instance changes
+		info.loadBalancerStatus = *service.Status.LoadBalancer.DeepCopy()
 	} else {
 		// Filter out the incorrect IP version case.
-		// If ExternalIPs and LoadBalancerSourceRanges on service contains incorrect IP versions,
+		// If ExternalIPs, LoadBalancerSourceRanges and LoadBalancerStatus Ingress on service contains incorrect IP versions,
 		// only filter out the incorrect ones.
 		var incorrectIPs []string
 		info.externalIPs, incorrectIPs = utilproxy.FilterIncorrectIPVersion(service.Spec.ExternalIPs, *sct.isIPv6Mode)
@@ -165,6 +165,22 @@ func (sct *ServiceChangeTracker) newBaseServiceInfo(port *v1.ServicePort, servic
 		info.loadBalancerSourceRanges, incorrectIPs = utilproxy.FilterIncorrectCIDRVersion(service.Spec.LoadBalancerSourceRanges, *sct.isIPv6Mode)
 		if len(incorrectIPs) > 0 {
 			utilproxy.LogAndEmitIncorrectIPVersionEvent(sct.recorder, "loadBalancerSourceRanges", strings.Join(incorrectIPs, ","), service.Namespace, service.Name, service.UID)
+		}
+		// Obtain Load Balancer Ingress IPs
+		var ips []string
+		for _, ing := range service.Status.LoadBalancer.Ingress {
+			ips = append(ips, ing.IP)
+		}
+		if len(ips) > 0 {
+			correctIPs, incorrectIPs := utilproxy.FilterIncorrectIPVersion(ips, *sct.isIPv6Mode)
+			if len(incorrectIPs) > 0 {
+				utilproxy.LogAndEmitIncorrectIPVersionEvent(sct.recorder, "Load Balancer ingress IPs", strings.Join(incorrectIPs, ","), service.Namespace, service.Name, service.UID)
+			}
+			// Create the LoadBalancerStatus with the filtererd IPs
+			for _, ip := range correctIPs {
+				info.loadBalancerStatus.Ingress = append(info.loadBalancerStatus.Ingress, v1.LoadBalancerIngress{IP: ip})
+
+			}
 		}
 	}
 

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -547,6 +547,34 @@ func TestFilterIncorrectIPVersion(t *testing.T) {
 		expectIncorrect []string
 	}{
 		{
+			desc:            "empty input IPv4",
+			ipString:        []string{},
+			wantIPv6:        false,
+			expectCorrect:   nil,
+			expectIncorrect: nil,
+		},
+		{
+			desc:            "empty input IPv6",
+			ipString:        []string{},
+			wantIPv6:        true,
+			expectCorrect:   nil,
+			expectIncorrect: nil,
+		},
+		{
+			desc:            "want IPv4 and receive IPv6",
+			ipString:        []string{"fd00:20::1"},
+			wantIPv6:        false,
+			expectCorrect:   nil,
+			expectIncorrect: []string{"fd00:20::1"},
+		},
+		{
+			desc:            "want IPv6 and receive IPv4",
+			ipString:        []string{"192.168.200.2"},
+			wantIPv6:        true,
+			expectCorrect:   nil,
+			expectIncorrect: []string{"192.168.200.2"},
+		},
+		{
 			desc:            "want IPv6 and receive IPv4 and IPv6",
 			ipString:        []string{"192.168.200.2", "192.1.34.23", "fd00:20::1", "2001:db9::3"},
 			wantIPv6:        true,
@@ -590,13 +618,15 @@ func TestFilterIncorrectIPVersion(t *testing.T) {
 		},
 	}
 
-	for i := range testCases {
-		correct, incorrect := FilterIncorrectIPVersion(testCases[i].ipString, testCases[i].wantIPv6)
-		if !reflect.DeepEqual(testCases[i].expectCorrect, correct) {
-			t.Errorf("Test %v failed: expected %v, got %v", testCases[i].desc, testCases[i].expectCorrect, correct)
-		}
-		if !reflect.DeepEqual(testCases[i].expectIncorrect, incorrect) {
-			t.Errorf("Test %v failed: expected %v, got %v", testCases[i].desc, testCases[i].expectIncorrect, incorrect)
-		}
+	for _, testcase := range testCases {
+		t.Run(testcase.desc, func(t *testing.T) {
+			correct, incorrect := FilterIncorrectIPVersion(testcase.ipString, testcase.wantIPv6)
+			if !reflect.DeepEqual(testcase.expectCorrect, correct) {
+				t.Errorf("Test %v failed: expected %v, got %v", testcase.desc, testcase.expectCorrect, correct)
+			}
+			if !reflect.DeepEqual(testcase.expectIncorrect, incorrect) {
+				t.Errorf("Test %v failed: expected %v, got %v", testcase.desc, testcase.expectIncorrect, incorrect)
+			}
+		})
 	}
 }

--- a/pkg/proxy/util/utils_test.go
+++ b/pkg/proxy/util/utils_test.go
@@ -537,3 +537,66 @@ func TestShuffleStrings(t *testing.T) {
 		}
 	}
 }
+
+func TestFilterIncorrectIPVersion(t *testing.T) {
+	testCases := []struct {
+		desc            string
+		ipString        []string
+		wantIPv6        bool
+		expectCorrect   []string
+		expectIncorrect []string
+	}{
+		{
+			desc:            "want IPv6 and receive IPv4 and IPv6",
+			ipString:        []string{"192.168.200.2", "192.1.34.23", "fd00:20::1", "2001:db9::3"},
+			wantIPv6:        true,
+			expectCorrect:   []string{"fd00:20::1", "2001:db9::3"},
+			expectIncorrect: []string{"192.168.200.2", "192.1.34.23"},
+		},
+		{
+			desc:            "want IPv4 and receive IPv4 and IPv6",
+			ipString:        []string{"192.168.200.2", "192.1.34.23", "fd00:20::1", "2001:db9::3"},
+			wantIPv6:        false,
+			expectCorrect:   []string{"192.168.200.2", "192.1.34.23"},
+			expectIncorrect: []string{"fd00:20::1", "2001:db9::3"},
+		},
+		{
+			desc:            "want IPv4 and receive IPv4 only",
+			ipString:        []string{"192.168.200.2", "192.1.34.23"},
+			wantIPv6:        false,
+			expectCorrect:   []string{"192.168.200.2", "192.1.34.23"},
+			expectIncorrect: nil,
+		},
+		{
+			desc:            "want IPv6 and receive IPv4 only",
+			ipString:        []string{"192.168.200.2", "192.1.34.23"},
+			wantIPv6:        true,
+			expectCorrect:   nil,
+			expectIncorrect: []string{"192.168.200.2", "192.1.34.23"},
+		},
+		{
+			desc:            "want IPv4 and receive IPv6 only",
+			ipString:        []string{"fd00:20::1", "2001:db9::3"},
+			wantIPv6:        false,
+			expectCorrect:   nil,
+			expectIncorrect: []string{"fd00:20::1", "2001:db9::3"},
+		},
+		{
+			desc:            "want IPv6 and receive IPv6 only",
+			ipString:        []string{"fd00:20::1", "2001:db9::3"},
+			wantIPv6:        true,
+			expectCorrect:   []string{"fd00:20::1", "2001:db9::3"},
+			expectIncorrect: nil,
+		},
+	}
+
+	for i := range testCases {
+		correct, incorrect := FilterIncorrectIPVersion(testCases[i].ipString, testCases[i].wantIPv6)
+		if !reflect.DeepEqual(testCases[i].expectCorrect, correct) {
+			t.Errorf("Test %v failed: expected %v, got %v", testCases[i].desc, testCases[i].expectCorrect, correct)
+		}
+		if !reflect.DeepEqual(testCases[i].expectIncorrect, incorrect) {
+			t.Errorf("Test %v failed: expected %v, got %v", testCases[i].desc, testCases[i].expectIncorrect, incorrect)
+		}
+	}
+}


### PR DESCRIPTION
Cherry pick of #87117 on release-1.17.

#87117: kube-proxy crash when load balancers use a different IP family