### PR TITLE
Fix: cmd/kubeadm Typos in some error messages, comments and a method name

### DIFF
--- a/cmd/kubeadm/app/util/kustomize/strategicmerge.go
+++ b/cmd/kubeadm/app/util/kustomize/strategicmerge.go
@@ -80,13 +80,13 @@ func newStrategicMergeSliceFromBytes(in []byte) (strategicMergeSlice, error) {
 						return err
 					}
 
-					// Get the stategicMergeSlice for the item
+					// Get the strategicMergeSlice for the item
 					itemU, err := newStrategicMergeSliceFromBytes(itemJSON)
 					if err != nil {
 						return err
 					}
 
-					// append the stategicMergeSlice for the item to the stategicMergeSlice
+					// append the strategicMergeSlice for the item to the strategicMergeSlice
 					result = append(result, itemU...)
 
 					return nil

--- a/cmd/kubeadm/app/util/output/output.go
+++ b/cmd/kubeadm/app/util/output/output.go
@@ -30,7 +30,7 @@ import (
 // TextOutput describes the plain text output
 const TextOutput = "text"
 
-// TextPrintFlags is an iterface to handle custom text output
+// TextPrintFlags is an interface to handle custom text output
 type TextPrintFlags interface {
 	ToPrinter(outputFormat string) (Printer, error)
 }

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -219,7 +219,7 @@ func TestRemoveContainers(t *testing.T) {
 				t.Errorf("unexpected RemoveContainers errors: %v, criSocket: %s, containers: %v", err, tc.criSocket, tc.containers)
 			}
 			if tc.isError && err == nil {
-				t.Errorf("unexpected RemoveContnainers success, criSocket: %s, containers: %v", tc.criSocket, tc.containers)
+				t.Errorf("unexpected RemoveContainers success, criSocket: %s, containers: %v", tc.criSocket, tc.containers)
 			}
 		})
 	}

--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -608,7 +608,7 @@ func TestSetDefaultReplicationControllerInitContainers(t *testing.T) {
 
 	assertImagePullPolicy := func(got, expected *v1.Container) error {
 		if got.ImagePullPolicy != expected.ImagePullPolicy {
-			return fmt.Errorf("different image pull poicy: got <%v>, expected <%v>", got.ImagePullPolicy, expected.ImagePullPolicy)
+			return fmt.Errorf("different image pull policy: got <%v>, expected <%v>", got.ImagePullPolicy, expected.ImagePullPolicy)
 		}
 		return nil
 	}

--- a/pkg/apis/core/v1/register.go
+++ b/pkg/apis/core/v1/register.go
@@ -33,7 +33,7 @@ func init() {
 	localSchemeBuilder.Register(addDefaultingFuncs, addConversionFuncs)
 }
 
-// TODO: remove these global varialbes
+// TODO: remove these global variables
 // GroupName is the group name use in this package
 const GroupName = ""
 

--- a/pkg/apis/flowcontrol/validation/validation.go
+++ b/pkg/apis/flowcontrol/validation/validation.go
@@ -382,7 +382,7 @@ func ValidatePriorityLevelConfigurationSpec(spec *flowcontrol.PriorityLevelConfi
 	return allErrs
 }
 
-// ValidateLimitedPriorityLevelConfiguration validates the configuration for an exeuction-limited priority level
+// ValidateLimitedPriorityLevelConfiguration validates the configuration for an execution-limited priority level
 func ValidateLimitedPriorityLevelConfiguration(lplc *flowcontrol.LimitedPriorityLevelConfiguration, fldPath *field.Path) field.ErrorList {
 	var allErrs field.ErrorList
 	if lplc.AssuredConcurrencyShares <= 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
> To fix some typos in some error messages and comments

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
> Fixes #

**Special notes for your reviewer**:
> NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
> NONE