### PR TITLE
Fix etcd issues on ARM

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -45,13 +45,20 @@ kube::etcd::validate() {
     exit 1
   fi
 
+  # need set the env of "ETCD_UNSUPPORTED_ARCH" on unstable arch.
+  arch=$(uname -m)
+  if [[ $arch =~ aarch* ]]; then
+	  export ETCD_UNSUPPORTED_ARCH=arm64
+  elif [[ $arch =~ arm* ]]; then
+	  export ETCD_UNSUPPORTED_ARCH=arm
+  fi
   # validate installed version is at least equal to minimum
-  version=$(etcd --version | grep Version | tail -n +1 | head -n 1 | cut -d " " -f 3)
+  version=$(etcd --version | grep Version | head -n 1 | cut -d " " -f 3)
   if [[ $(kube::etcd::version "${ETCD_VERSION}") -gt $(kube::etcd::version "${version}") ]]; then
    export PATH=${KUBE_ROOT}/third_party/etcd:${PATH}
    hash etcd
    echo "${PATH}"
-   version=$(etcd --version | head -n 1 | cut -d " " -f 3)
+   version=$(etcd --version | grep Version | head -n 1 | cut -d " " -f 3)
    if [[ $(kube::etcd::version "${ETCD_VERSION}") -gt $(kube::etcd::version "${version}") ]]; then
     kube::log::usage "etcd version ${ETCD_VERSION} or greater required."
     kube::log::info "You can use 'hack/install-etcd.sh' to install a copy in third_party/."


### PR DESCRIPTION
- On unstable arch like ARM, etcd needs the "ETCD_UNSUPPORTED_ARCH" to be set
  `# etcd --version
   etcd on unsupported platform without ETCD_UNSUPPORTED_ARCH=arm64 set`

- `tail -n +1 | head -n 1` is unnecessary, `head -n 1` is enough.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
