### PR TITLE
Revert "log-dump.sh: allow to dump extra log files"

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -51,7 +51,6 @@ readonly kern_logfile="kern.log"
 readonly initd_logfiles="docker/log"
 readonly supervisord_logfiles="kubelet.log supervisor/supervisord.log supervisor/kubelet-stdout.log supervisor/kubelet-stderr.log supervisor/docker-stdout.log supervisor/docker-stderr.log"
 readonly systemd_services="kubelet kubelet-monitor kube-container-runtime-monitor ${LOG_DUMP_SYSTEMD_SERVICES:-docker}"
-readonly extra_log_files="${LOG_DUMP_EXTRA_FILES:-}"
 readonly dump_systemd_journal="${LOG_DUMP_SYSTEMD_JOURNAL:-false}"
 # Log files found in WINDOWS_LOGS_DIR on Windows nodes:
 readonly windows_node_logfiles="kubelet.log kube-proxy.log docker.log"
@@ -141,7 +140,6 @@ function save-logs() {
     local opt_systemd_services="${4:-""}"
     local on_master="${5:-"false"}"
 
-    files="${files} ${extra_log_files}"
     if [[ -n "${use_custom_instance_list}" ]]; then
       if [[ -n "${LOG_DUMP_SAVE_LOGS:-}" ]]; then
         files="${files} ${LOG_DUMP_SAVE_LOGS:-}"
@@ -476,7 +474,6 @@ function dump_nodes_with_logexporter() {
   sed -i'' -e "s@{{.GCSPath}}@${gcs_artifacts_dir}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
   sed -i'' -e "s@{{.EnableHollowNodeLogs}}@${enable_hollow_node_logs}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
   sed -i'' -e "s@{{.DumpSystemdJournal}}@${dump_systemd_journal}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
-  sed -i'' -e "s@{{.ExtraLogFiles}}@${extra_log_files}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
 
   # Create the logexporter namespace, service-account secret and the logexporter daemonset within that namespace.
   KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"

--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -50,7 +50,6 @@ spec:
         - --gcloud-auth-file-path=/etc/service-account/service-account.json
         - --enable-hollow-node-logs={{.EnableHollowNodeLogs}}
         - --dump-systemd-journal={{.DumpSystemdJournal}}
-        - --extra-log-files={{.ExtraLogFiles}}
         - --sleep-duration=24h
         - --alsologtostderr
         volumeMounts:


### PR DESCRIPTION
This reverts commit c43b940586062cb905d4fc7510fd785ccee339f0.

It breaks log-exporter, it started setting new flag but the logexporter version hasn't been bumped, which results in the following error:
```
flag provided but not defined: -extra-log-files
Usage of logexporter:
  -alsologtostderr
    	log to standard error as well as files
  -cloud-provider string
    	Cloud provider for this node (gce/gke/aws/kubemark/..)
  -dump-systemd-journal
    	Whether to dump the full systemd journal
  -enable-hollow-node-logs
    	Enable uploading hollow node logs too. Relevant only for kubemark nodes
  -gcloud-auth-file-path string
    	Path to gcloud service account file, for authenticating gsutil to write to GCS bucket (default "/etc/service-account/service-account.json")
  -gcs-path string
    	Path to the GCS directory under which to upload logs, for eg: gs://my-logs-bucket/logs
  -journal-path string
    	Path where the systemd journal dir is mounted (default "/var/log/journal")
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -logtostderr
    	log to standard error instead of files
  -node-name string
    	Name of the node this log exporter is running on
  -sleep-duration duration
    	Duration to sleep before exiting with success. Useful for making pods schedule with hard anti-affinity when run as a job on a k8s cluster (default 1m0s)
  -stderrthreshold value
    	logs at or above this threshold go to stderr
  -v value
    	log level for V logs
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
```

```release-note
NONE
```