### PR TITLE
Kubectl cluster-info dump changed to write valid JSON to stdout

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_example.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/examples/client-go/pkg/client/clientset/versioned/typed/cr/v1/fake/fake_example.go
@@ -64,7 +64,10 @@ func (c *FakeExamples) List(ctx context.Context, opts v1.ListOptions) (result *c
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &crv1.ExampleList{ListMeta: obj.(*crv1.ExampleList).ListMeta}
+	list := &crv1.ExampleList{
+		TypeMeta: obj.(*crv1.ExampleList).TypeMeta,
+		ListMeta: obj.(*crv1.ExampleList).ListMeta,
+	}
 	for _, item := range obj.(*crv1.ExampleList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1/fake/fake_customresourcedefinition.go
@@ -61,7 +61,10 @@ func (c *FakeCustomResourceDefinitions) List(ctx context.Context, opts v1.ListOp
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &apiextensionsv1.CustomResourceDefinitionList{ListMeta: obj.(*apiextensionsv1.CustomResourceDefinitionList).ListMeta}
+	list := &apiextensionsv1.CustomResourceDefinitionList{
+		TypeMeta: obj.(*apiextensionsv1.CustomResourceDefinitionList).TypeMeta,
+		ListMeta: obj.(*apiextensionsv1.CustomResourceDefinitionList).ListMeta,
+	}
 	for _, item := range obj.(*apiextensionsv1.CustomResourceDefinitionList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1/fake/fake_customresourcedefinition.go
@@ -61,7 +61,10 @@ func (c *FakeCustomResourceDefinitions) List(ctx context.Context, opts v1.ListOp
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.CustomResourceDefinitionList{ListMeta: obj.(*v1beta1.CustomResourceDefinitionList).ListMeta}
+	list := &v1beta1.CustomResourceDefinitionList{
+		TypeMeta: obj.(*v1beta1.CustomResourceDefinitionList).TypeMeta,
+		ListMeta: obj.(*v1beta1.CustomResourceDefinitionList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.CustomResourceDefinitionList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_mutatingwebhookconfiguration.go
@@ -61,7 +61,10 @@ func (c *FakeMutatingWebhookConfigurations) List(ctx context.Context, opts v1.Li
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &admissionregistrationv1.MutatingWebhookConfigurationList{ListMeta: obj.(*admissionregistrationv1.MutatingWebhookConfigurationList).ListMeta}
+	list := &admissionregistrationv1.MutatingWebhookConfigurationList{
+		TypeMeta: obj.(*admissionregistrationv1.MutatingWebhookConfigurationList).TypeMeta,
+		ListMeta: obj.(*admissionregistrationv1.MutatingWebhookConfigurationList).ListMeta,
+	}
 	for _, item := range obj.(*admissionregistrationv1.MutatingWebhookConfigurationList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1/fake/fake_validatingwebhookconfiguration.go
@@ -61,7 +61,10 @@ func (c *FakeValidatingWebhookConfigurations) List(ctx context.Context, opts v1.
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &admissionregistrationv1.ValidatingWebhookConfigurationList{ListMeta: obj.(*admissionregistrationv1.ValidatingWebhookConfigurationList).ListMeta}
+	list := &admissionregistrationv1.ValidatingWebhookConfigurationList{
+		TypeMeta: obj.(*admissionregistrationv1.ValidatingWebhookConfigurationList).TypeMeta,
+		ListMeta: obj.(*admissionregistrationv1.ValidatingWebhookConfigurationList).ListMeta,
+	}
 	for _, item := range obj.(*admissionregistrationv1.ValidatingWebhookConfigurationList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_mutatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_mutatingwebhookconfiguration.go
@@ -61,7 +61,10 @@ func (c *FakeMutatingWebhookConfigurations) List(ctx context.Context, opts v1.Li
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.MutatingWebhookConfigurationList{ListMeta: obj.(*v1beta1.MutatingWebhookConfigurationList).ListMeta}
+	list := &v1beta1.MutatingWebhookConfigurationList{
+		TypeMeta: obj.(*v1beta1.MutatingWebhookConfigurationList).TypeMeta,
+		ListMeta: obj.(*v1beta1.MutatingWebhookConfigurationList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.MutatingWebhookConfigurationList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_validatingwebhookconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1/fake/fake_validatingwebhookconfiguration.go
@@ -61,7 +61,10 @@ func (c *FakeValidatingWebhookConfigurations) List(ctx context.Context, opts v1.
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.ValidatingWebhookConfigurationList{ListMeta: obj.(*v1beta1.ValidatingWebhookConfigurationList).ListMeta}
+	list := &v1beta1.ValidatingWebhookConfigurationList{
+		TypeMeta: obj.(*v1beta1.ValidatingWebhookConfigurationList).TypeMeta,
+		ListMeta: obj.(*v1beta1.ValidatingWebhookConfigurationList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.ValidatingWebhookConfigurationList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_controllerrevision.go
@@ -64,7 +64,10 @@ func (c *FakeControllerRevisions) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &appsv1.ControllerRevisionList{ListMeta: obj.(*appsv1.ControllerRevisionList).ListMeta}
+	list := &appsv1.ControllerRevisionList{
+		TypeMeta: obj.(*appsv1.ControllerRevisionList).TypeMeta,
+		ListMeta: obj.(*appsv1.ControllerRevisionList).ListMeta,
+	}
 	for _, item := range obj.(*appsv1.ControllerRevisionList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_daemonset.go
@@ -64,7 +64,10 @@ func (c *FakeDaemonSets) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &appsv1.DaemonSetList{ListMeta: obj.(*appsv1.DaemonSetList).ListMeta}
+	list := &appsv1.DaemonSetList{
+		TypeMeta: obj.(*appsv1.DaemonSetList).TypeMeta,
+		ListMeta: obj.(*appsv1.DaemonSetList).ListMeta,
+	}
 	for _, item := range obj.(*appsv1.DaemonSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_deployment.go
@@ -65,7 +65,10 @@ func (c *FakeDeployments) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &appsv1.DeploymentList{ListMeta: obj.(*appsv1.DeploymentList).ListMeta}
+	list := &appsv1.DeploymentList{
+		TypeMeta: obj.(*appsv1.DeploymentList).TypeMeta,
+		ListMeta: obj.(*appsv1.DeploymentList).ListMeta,
+	}
 	for _, item := range obj.(*appsv1.DeploymentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_replicaset.go
@@ -65,7 +65,10 @@ func (c *FakeReplicaSets) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &appsv1.ReplicaSetList{ListMeta: obj.(*appsv1.ReplicaSetList).ListMeta}
+	list := &appsv1.ReplicaSetList{
+		TypeMeta: obj.(*appsv1.ReplicaSetList).TypeMeta,
+		ListMeta: obj.(*appsv1.ReplicaSetList).ListMeta,
+	}
 	for _, item := range obj.(*appsv1.ReplicaSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1/fake/fake_statefulset.go
@@ -65,7 +65,10 @@ func (c *FakeStatefulSets) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &appsv1.StatefulSetList{ListMeta: obj.(*appsv1.StatefulSetList).ListMeta}
+	list := &appsv1.StatefulSetList{
+		TypeMeta: obj.(*appsv1.StatefulSetList).TypeMeta,
+		ListMeta: obj.(*appsv1.StatefulSetList).ListMeta,
+	}
 	for _, item := range obj.(*appsv1.StatefulSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_controllerrevision.go
@@ -64,7 +64,10 @@ func (c *FakeControllerRevisions) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.ControllerRevisionList{ListMeta: obj.(*v1beta1.ControllerRevisionList).ListMeta}
+	list := &v1beta1.ControllerRevisionList{
+		TypeMeta: obj.(*v1beta1.ControllerRevisionList).TypeMeta,
+		ListMeta: obj.(*v1beta1.ControllerRevisionList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.ControllerRevisionList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_deployment.go
@@ -64,7 +64,10 @@ func (c *FakeDeployments) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.DeploymentList{ListMeta: obj.(*v1beta1.DeploymentList).ListMeta}
+	list := &v1beta1.DeploymentList{
+		TypeMeta: obj.(*v1beta1.DeploymentList).TypeMeta,
+		ListMeta: obj.(*v1beta1.DeploymentList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.DeploymentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake/fake_statefulset.go
@@ -64,7 +64,10 @@ func (c *FakeStatefulSets) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.StatefulSetList{ListMeta: obj.(*v1beta1.StatefulSetList).ListMeta}
+	list := &v1beta1.StatefulSetList{
+		TypeMeta: obj.(*v1beta1.StatefulSetList).TypeMeta,
+		ListMeta: obj.(*v1beta1.StatefulSetList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.StatefulSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_controllerrevision.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_controllerrevision.go
@@ -64,7 +64,10 @@ func (c *FakeControllerRevisions) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta2.ControllerRevisionList{ListMeta: obj.(*v1beta2.ControllerRevisionList).ListMeta}
+	list := &v1beta2.ControllerRevisionList{
+		TypeMeta: obj.(*v1beta2.ControllerRevisionList).TypeMeta,
+		ListMeta: obj.(*v1beta2.ControllerRevisionList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta2.ControllerRevisionList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_daemonset.go
@@ -64,7 +64,10 @@ func (c *FakeDaemonSets) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta2.DaemonSetList{ListMeta: obj.(*v1beta2.DaemonSetList).ListMeta}
+	list := &v1beta2.DaemonSetList{
+		TypeMeta: obj.(*v1beta2.DaemonSetList).TypeMeta,
+		ListMeta: obj.(*v1beta2.DaemonSetList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta2.DaemonSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_deployment.go
@@ -64,7 +64,10 @@ func (c *FakeDeployments) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta2.DeploymentList{ListMeta: obj.(*v1beta2.DeploymentList).ListMeta}
+	list := &v1beta2.DeploymentList{
+		TypeMeta: obj.(*v1beta2.DeploymentList).TypeMeta,
+		ListMeta: obj.(*v1beta2.DeploymentList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta2.DeploymentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_replicaset.go
@@ -64,7 +64,10 @@ func (c *FakeReplicaSets) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta2.ReplicaSetList{ListMeta: obj.(*v1beta2.ReplicaSetList).ListMeta}
+	list := &v1beta2.ReplicaSetList{
+		TypeMeta: obj.(*v1beta2.ReplicaSetList).TypeMeta,
+		ListMeta: obj.(*v1beta2.ReplicaSetList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta2.ReplicaSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/apps/v1beta2/fake/fake_statefulset.go
@@ -64,7 +64,10 @@ func (c *FakeStatefulSets) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta2.StatefulSetList{ListMeta: obj.(*v1beta2.StatefulSetList).ListMeta}
+	list := &v1beta2.StatefulSetList{
+		TypeMeta: obj.(*v1beta2.StatefulSetList).TypeMeta,
+		ListMeta: obj.(*v1beta2.StatefulSetList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta2.StatefulSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/fake/fake_auditsink.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/auditregistration/v1alpha1/fake/fake_auditsink.go
@@ -61,7 +61,10 @@ func (c *FakeAuditSinks) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.AuditSinkList{ListMeta: obj.(*v1alpha1.AuditSinkList).ListMeta}
+	list := &v1alpha1.AuditSinkList{
+		TypeMeta: obj.(*v1alpha1.AuditSinkList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.AuditSinkList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.AuditSinkList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake/fake_horizontalpodautoscaler.go
@@ -64,7 +64,10 @@ func (c *FakeHorizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOpt
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &autoscalingv1.HorizontalPodAutoscalerList{ListMeta: obj.(*autoscalingv1.HorizontalPodAutoscalerList).ListMeta}
+	list := &autoscalingv1.HorizontalPodAutoscalerList{
+		TypeMeta: obj.(*autoscalingv1.HorizontalPodAutoscalerList).TypeMeta,
+		ListMeta: obj.(*autoscalingv1.HorizontalPodAutoscalerList).ListMeta,
+	}
 	for _, item := range obj.(*autoscalingv1.HorizontalPodAutoscalerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta1/fake/fake_horizontalpodautoscaler.go
@@ -64,7 +64,10 @@ func (c *FakeHorizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOpt
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v2beta1.HorizontalPodAutoscalerList{ListMeta: obj.(*v2beta1.HorizontalPodAutoscalerList).ListMeta}
+	list := &v2beta1.HorizontalPodAutoscalerList{
+		TypeMeta: obj.(*v2beta1.HorizontalPodAutoscalerList).TypeMeta,
+		ListMeta: obj.(*v2beta1.HorizontalPodAutoscalerList).ListMeta,
+	}
 	for _, item := range obj.(*v2beta1.HorizontalPodAutoscalerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_horizontalpodautoscaler.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/autoscaling/v2beta2/fake/fake_horizontalpodautoscaler.go
@@ -64,7 +64,10 @@ func (c *FakeHorizontalPodAutoscalers) List(ctx context.Context, opts v1.ListOpt
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v2beta2.HorizontalPodAutoscalerList{ListMeta: obj.(*v2beta2.HorizontalPodAutoscalerList).ListMeta}
+	list := &v2beta2.HorizontalPodAutoscalerList{
+		TypeMeta: obj.(*v2beta2.HorizontalPodAutoscalerList).TypeMeta,
+		ListMeta: obj.(*v2beta2.HorizontalPodAutoscalerList).ListMeta,
+	}
 	for _, item := range obj.(*v2beta2.HorizontalPodAutoscalerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1/fake/fake_job.go
@@ -64,7 +64,10 @@ func (c *FakeJobs) List(ctx context.Context, opts v1.ListOptions) (result *batch
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &batchv1.JobList{ListMeta: obj.(*batchv1.JobList).ListMeta}
+	list := &batchv1.JobList{
+		TypeMeta: obj.(*batchv1.JobList).TypeMeta,
+		ListMeta: obj.(*batchv1.JobList).ListMeta,
+	}
 	for _, item := range obj.(*batchv1.JobList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v1beta1/fake/fake_cronjob.go
@@ -64,7 +64,10 @@ func (c *FakeCronJobs) List(ctx context.Context, opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.CronJobList{ListMeta: obj.(*v1beta1.CronJobList).ListMeta}
+	list := &v1beta1.CronJobList{
+		TypeMeta: obj.(*v1beta1.CronJobList).TypeMeta,
+		ListMeta: obj.(*v1beta1.CronJobList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.CronJobList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake/fake_cronjob.go
@@ -64,7 +64,10 @@ func (c *FakeCronJobs) List(ctx context.Context, opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v2alpha1.CronJobList{ListMeta: obj.(*v2alpha1.CronJobList).ListMeta}
+	list := &v2alpha1.CronJobList{
+		TypeMeta: obj.(*v2alpha1.CronJobList).TypeMeta,
+		ListMeta: obj.(*v2alpha1.CronJobList).ListMeta,
+	}
 	for _, item := range obj.(*v2alpha1.CronJobList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest.go
@@ -61,7 +61,10 @@ func (c *FakeCertificateSigningRequests) List(ctx context.Context, opts v1.ListO
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.CertificateSigningRequestList{ListMeta: obj.(*v1beta1.CertificateSigningRequestList).ListMeta}
+	list := &v1beta1.CertificateSigningRequestList{
+		TypeMeta: obj.(*v1beta1.CertificateSigningRequestList).TypeMeta,
+		ListMeta: obj.(*v1beta1.CertificateSigningRequestList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.CertificateSigningRequestList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1/fake/fake_lease.go
@@ -64,7 +64,10 @@ func (c *FakeLeases) List(ctx context.Context, opts v1.ListOptions) (result *coo
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &coordinationv1.LeaseList{ListMeta: obj.(*coordinationv1.LeaseList).ListMeta}
+	list := &coordinationv1.LeaseList{
+		TypeMeta: obj.(*coordinationv1.LeaseList).TypeMeta,
+		ListMeta: obj.(*coordinationv1.LeaseList).ListMeta,
+	}
 	for _, item := range obj.(*coordinationv1.LeaseList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_lease.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/coordination/v1beta1/fake/fake_lease.go
@@ -64,7 +64,10 @@ func (c *FakeLeases) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.LeaseList{ListMeta: obj.(*v1beta1.LeaseList).ListMeta}
+	list := &v1beta1.LeaseList{
+		TypeMeta: obj.(*v1beta1.LeaseList).TypeMeta,
+		ListMeta: obj.(*v1beta1.LeaseList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.LeaseList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_componentstatus.go
@@ -61,7 +61,10 @@ func (c *FakeComponentStatuses) List(ctx context.Context, opts v1.ListOptions) (
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.ComponentStatusList{ListMeta: obj.(*corev1.ComponentStatusList).ListMeta}
+	list := &corev1.ComponentStatusList{
+		TypeMeta: obj.(*corev1.ComponentStatusList).TypeMeta,
+		ListMeta: obj.(*corev1.ComponentStatusList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.ComponentStatusList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_configmap.go
@@ -64,7 +64,10 @@ func (c *FakeConfigMaps) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.ConfigMapList{ListMeta: obj.(*corev1.ConfigMapList).ListMeta}
+	list := &corev1.ConfigMapList{
+		TypeMeta: obj.(*corev1.ConfigMapList).TypeMeta,
+		ListMeta: obj.(*corev1.ConfigMapList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.ConfigMapList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_endpoints.go
@@ -64,7 +64,10 @@ func (c *FakeEndpoints) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.EndpointsList{ListMeta: obj.(*corev1.EndpointsList).ListMeta}
+	list := &corev1.EndpointsList{
+		TypeMeta: obj.(*corev1.EndpointsList).TypeMeta,
+		ListMeta: obj.(*corev1.EndpointsList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.EndpointsList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_event.go
@@ -64,7 +64,10 @@ func (c *FakeEvents) List(ctx context.Context, opts v1.ListOptions) (result *cor
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.EventList{ListMeta: obj.(*corev1.EventList).ListMeta}
+	list := &corev1.EventList{
+		TypeMeta: obj.(*corev1.EventList).TypeMeta,
+		ListMeta: obj.(*corev1.EventList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.EventList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_limitrange.go
@@ -64,7 +64,10 @@ func (c *FakeLimitRanges) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.LimitRangeList{ListMeta: obj.(*corev1.LimitRangeList).ListMeta}
+	list := &corev1.LimitRangeList{
+		TypeMeta: obj.(*corev1.LimitRangeList).TypeMeta,
+		ListMeta: obj.(*corev1.LimitRangeList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.LimitRangeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace.go
@@ -61,7 +61,10 @@ func (c *FakeNamespaces) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.NamespaceList{ListMeta: obj.(*corev1.NamespaceList).ListMeta}
+	list := &corev1.NamespaceList{
+		TypeMeta: obj.(*corev1.NamespaceList).TypeMeta,
+		ListMeta: obj.(*corev1.NamespaceList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.NamespaceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_node.go
@@ -61,7 +61,10 @@ func (c *FakeNodes) List(ctx context.Context, opts v1.ListOptions) (result *core
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.NodeList{ListMeta: obj.(*corev1.NodeList).ListMeta}
+	list := &corev1.NodeList{
+		TypeMeta: obj.(*corev1.NodeList).TypeMeta,
+		ListMeta: obj.(*corev1.NodeList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.NodeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolume.go
@@ -61,7 +61,10 @@ func (c *FakePersistentVolumes) List(ctx context.Context, opts v1.ListOptions) (
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.PersistentVolumeList{ListMeta: obj.(*corev1.PersistentVolumeList).ListMeta}
+	list := &corev1.PersistentVolumeList{
+		TypeMeta: obj.(*corev1.PersistentVolumeList).TypeMeta,
+		ListMeta: obj.(*corev1.PersistentVolumeList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.PersistentVolumeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_persistentvolumeclaim.go
@@ -64,7 +64,10 @@ func (c *FakePersistentVolumeClaims) List(ctx context.Context, opts v1.ListOptio
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.PersistentVolumeClaimList{ListMeta: obj.(*corev1.PersistentVolumeClaimList).ListMeta}
+	list := &corev1.PersistentVolumeClaimList{
+		TypeMeta: obj.(*corev1.PersistentVolumeClaimList).TypeMeta,
+		ListMeta: obj.(*corev1.PersistentVolumeClaimList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.PersistentVolumeClaimList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod.go
@@ -64,7 +64,10 @@ func (c *FakePods) List(ctx context.Context, opts v1.ListOptions) (result *corev
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.PodList{ListMeta: obj.(*corev1.PodList).ListMeta}
+	list := &corev1.PodList{
+		TypeMeta: obj.(*corev1.PodList).TypeMeta,
+		ListMeta: obj.(*corev1.PodList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.PodList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_podtemplate.go
@@ -64,7 +64,10 @@ func (c *FakePodTemplates) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.PodTemplateList{ListMeta: obj.(*corev1.PodTemplateList).ListMeta}
+	list := &corev1.PodTemplateList{
+		TypeMeta: obj.(*corev1.PodTemplateList).TypeMeta,
+		ListMeta: obj.(*corev1.PodTemplateList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.PodTemplateList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_replicationcontroller.go
@@ -65,7 +65,10 @@ func (c *FakeReplicationControllers) List(ctx context.Context, opts v1.ListOptio
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.ReplicationControllerList{ListMeta: obj.(*corev1.ReplicationControllerList).ListMeta}
+	list := &corev1.ReplicationControllerList{
+		TypeMeta: obj.(*corev1.ReplicationControllerList).TypeMeta,
+		ListMeta: obj.(*corev1.ReplicationControllerList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.ReplicationControllerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_resourcequota.go
@@ -64,7 +64,10 @@ func (c *FakeResourceQuotas) List(ctx context.Context, opts v1.ListOptions) (res
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.ResourceQuotaList{ListMeta: obj.(*corev1.ResourceQuotaList).ListMeta}
+	list := &corev1.ResourceQuotaList{
+		TypeMeta: obj.(*corev1.ResourceQuotaList).TypeMeta,
+		ListMeta: obj.(*corev1.ResourceQuotaList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.ResourceQuotaList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_secret.go
@@ -64,7 +64,10 @@ func (c *FakeSecrets) List(ctx context.Context, opts v1.ListOptions) (result *co
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.SecretList{ListMeta: obj.(*corev1.SecretList).ListMeta}
+	list := &corev1.SecretList{
+		TypeMeta: obj.(*corev1.SecretList).TypeMeta,
+		ListMeta: obj.(*corev1.SecretList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.SecretList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_service.go
@@ -64,7 +64,10 @@ func (c *FakeServices) List(ctx context.Context, opts v1.ListOptions) (result *c
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.ServiceList{ListMeta: obj.(*corev1.ServiceList).ListMeta}
+	list := &corev1.ServiceList{
+		TypeMeta: obj.(*corev1.ServiceList).TypeMeta,
+		ListMeta: obj.(*corev1.ServiceList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.ServiceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_serviceaccount.go
@@ -65,7 +65,10 @@ func (c *FakeServiceAccounts) List(ctx context.Context, opts v1.ListOptions) (re
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &corev1.ServiceAccountList{ListMeta: obj.(*corev1.ServiceAccountList).ListMeta}
+	list := &corev1.ServiceAccountList{
+		TypeMeta: obj.(*corev1.ServiceAccountList).TypeMeta,
+		ListMeta: obj.(*corev1.ServiceAccountList).ListMeta,
+	}
 	for _, item := range obj.(*corev1.ServiceAccountList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/fake/fake_endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1alpha1/fake/fake_endpointslice.go
@@ -64,7 +64,10 @@ func (c *FakeEndpointSlices) List(ctx context.Context, opts v1.ListOptions) (res
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.EndpointSliceList{ListMeta: obj.(*v1alpha1.EndpointSliceList).ListMeta}
+	list := &v1alpha1.EndpointSliceList{
+		TypeMeta: obj.(*v1alpha1.EndpointSliceList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.EndpointSliceList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.EndpointSliceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/fake/fake_endpointslice.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/discovery/v1beta1/fake/fake_endpointslice.go
@@ -64,7 +64,10 @@ func (c *FakeEndpointSlices) List(ctx context.Context, opts v1.ListOptions) (res
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.EndpointSliceList{ListMeta: obj.(*v1beta1.EndpointSliceList).ListMeta}
+	list := &v1beta1.EndpointSliceList{
+		TypeMeta: obj.(*v1beta1.EndpointSliceList).TypeMeta,
+		ListMeta: obj.(*v1beta1.EndpointSliceList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.EndpointSliceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/events/v1beta1/fake/fake_event.go
@@ -64,7 +64,10 @@ func (c *FakeEvents) List(ctx context.Context, opts v1.ListOptions) (result *v1b
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.EventList{ListMeta: obj.(*v1beta1.EventList).ListMeta}
+	list := &v1beta1.EventList{
+		TypeMeta: obj.(*v1beta1.EventList).TypeMeta,
+		ListMeta: obj.(*v1beta1.EventList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.EventList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_daemonset.go
@@ -64,7 +64,10 @@ func (c *FakeDaemonSets) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.DaemonSetList{ListMeta: obj.(*v1beta1.DaemonSetList).ListMeta}
+	list := &v1beta1.DaemonSetList{
+		TypeMeta: obj.(*v1beta1.DaemonSetList).TypeMeta,
+		ListMeta: obj.(*v1beta1.DaemonSetList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.DaemonSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment.go
@@ -64,7 +64,10 @@ func (c *FakeDeployments) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.DeploymentList{ListMeta: obj.(*v1beta1.DeploymentList).ListMeta}
+	list := &v1beta1.DeploymentList{
+		TypeMeta: obj.(*v1beta1.DeploymentList).TypeMeta,
+		ListMeta: obj.(*v1beta1.DeploymentList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.DeploymentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_ingress.go
@@ -64,7 +64,10 @@ func (c *FakeIngresses) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.IngressList{ListMeta: obj.(*v1beta1.IngressList).ListMeta}
+	list := &v1beta1.IngressList{
+		TypeMeta: obj.(*v1beta1.IngressList).TypeMeta,
+		ListMeta: obj.(*v1beta1.IngressList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.IngressList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_networkpolicy.go
@@ -64,7 +64,10 @@ func (c *FakeNetworkPolicies) List(ctx context.Context, opts v1.ListOptions) (re
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.NetworkPolicyList{ListMeta: obj.(*v1beta1.NetworkPolicyList).ListMeta}
+	list := &v1beta1.NetworkPolicyList{
+		TypeMeta: obj.(*v1beta1.NetworkPolicyList).TypeMeta,
+		ListMeta: obj.(*v1beta1.NetworkPolicyList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.NetworkPolicyList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_podsecuritypolicy.go
@@ -61,7 +61,10 @@ func (c *FakePodSecurityPolicies) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.PodSecurityPolicyList{ListMeta: obj.(*v1beta1.PodSecurityPolicyList).ListMeta}
+	list := &v1beta1.PodSecurityPolicyList{
+		TypeMeta: obj.(*v1beta1.PodSecurityPolicyList).TypeMeta,
+		ListMeta: obj.(*v1beta1.PodSecurityPolicyList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.PodSecurityPolicyList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_replicaset.go
@@ -64,7 +64,10 @@ func (c *FakeReplicaSets) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.ReplicaSetList{ListMeta: obj.(*v1beta1.ReplicaSetList).ListMeta}
+	list := &v1beta1.ReplicaSetList{
+		TypeMeta: obj.(*v1beta1.ReplicaSetList).TypeMeta,
+		ListMeta: obj.(*v1beta1.ReplicaSetList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.ReplicaSetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_flowschema.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_flowschema.go
@@ -61,7 +61,10 @@ func (c *FakeFlowSchemas) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FlowSchemaList{ListMeta: obj.(*v1alpha1.FlowSchemaList).ListMeta}
+	list := &v1alpha1.FlowSchemaList{
+		TypeMeta: obj.(*v1alpha1.FlowSchemaList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.FlowSchemaList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.FlowSchemaList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_prioritylevelconfiguration.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/flowcontrol/v1alpha1/fake/fake_prioritylevelconfiguration.go
@@ -61,7 +61,10 @@ func (c *FakePriorityLevelConfigurations) List(ctx context.Context, opts v1.List
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.PriorityLevelConfigurationList{ListMeta: obj.(*v1alpha1.PriorityLevelConfigurationList).ListMeta}
+	list := &v1alpha1.PriorityLevelConfigurationList{
+		TypeMeta: obj.(*v1alpha1.PriorityLevelConfigurationList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.PriorityLevelConfigurationList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.PriorityLevelConfigurationList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1/fake/fake_networkpolicy.go
@@ -64,7 +64,10 @@ func (c *FakeNetworkPolicies) List(ctx context.Context, opts v1.ListOptions) (re
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &networkingv1.NetworkPolicyList{ListMeta: obj.(*networkingv1.NetworkPolicyList).ListMeta}
+	list := &networkingv1.NetworkPolicyList{
+		TypeMeta: obj.(*networkingv1.NetworkPolicyList).TypeMeta,
+		ListMeta: obj.(*networkingv1.NetworkPolicyList).ListMeta,
+	}
 	for _, item := range obj.(*networkingv1.NetworkPolicyList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingress.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/networking/v1beta1/fake/fake_ingress.go
@@ -64,7 +64,10 @@ func (c *FakeIngresses) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.IngressList{ListMeta: obj.(*v1beta1.IngressList).ListMeta}
+	list := &v1beta1.IngressList{
+		TypeMeta: obj.(*v1beta1.IngressList).TypeMeta,
+		ListMeta: obj.(*v1beta1.IngressList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.IngressList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1alpha1/fake/fake_runtimeclass.go
@@ -61,7 +61,10 @@ func (c *FakeRuntimeClasses) List(ctx context.Context, opts v1.ListOptions) (res
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.RuntimeClassList{ListMeta: obj.(*v1alpha1.RuntimeClassList).ListMeta}
+	list := &v1alpha1.RuntimeClassList{
+		TypeMeta: obj.(*v1alpha1.RuntimeClassList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.RuntimeClassList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.RuntimeClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_runtimeclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/node/v1beta1/fake/fake_runtimeclass.go
@@ -61,7 +61,10 @@ func (c *FakeRuntimeClasses) List(ctx context.Context, opts v1.ListOptions) (res
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.RuntimeClassList{ListMeta: obj.(*v1beta1.RuntimeClassList).ListMeta}
+	list := &v1beta1.RuntimeClassList{
+		TypeMeta: obj.(*v1beta1.RuntimeClassList).TypeMeta,
+		ListMeta: obj.(*v1beta1.RuntimeClassList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.RuntimeClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_poddisruptionbudget.go
@@ -64,7 +64,10 @@ func (c *FakePodDisruptionBudgets) List(ctx context.Context, opts v1.ListOptions
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.PodDisruptionBudgetList{ListMeta: obj.(*v1beta1.PodDisruptionBudgetList).ListMeta}
+	list := &v1beta1.PodDisruptionBudgetList{
+		TypeMeta: obj.(*v1beta1.PodDisruptionBudgetList).TypeMeta,
+		ListMeta: obj.(*v1beta1.PodDisruptionBudgetList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.PodDisruptionBudgetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_podsecuritypolicy.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_podsecuritypolicy.go
@@ -61,7 +61,10 @@ func (c *FakePodSecurityPolicies) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.PodSecurityPolicyList{ListMeta: obj.(*v1beta1.PodSecurityPolicyList).ListMeta}
+	list := &v1beta1.PodSecurityPolicyList{
+		TypeMeta: obj.(*v1beta1.PodSecurityPolicyList).TypeMeta,
+		ListMeta: obj.(*v1beta1.PodSecurityPolicyList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.PodSecurityPolicyList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrole.go
@@ -61,7 +61,10 @@ func (c *FakeClusterRoles) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &rbacv1.ClusterRoleList{ListMeta: obj.(*rbacv1.ClusterRoleList).ListMeta}
+	list := &rbacv1.ClusterRoleList{
+		TypeMeta: obj.(*rbacv1.ClusterRoleList).TypeMeta,
+		ListMeta: obj.(*rbacv1.ClusterRoleList).ListMeta,
+	}
 	for _, item := range obj.(*rbacv1.ClusterRoleList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_clusterrolebinding.go
@@ -61,7 +61,10 @@ func (c *FakeClusterRoleBindings) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &rbacv1.ClusterRoleBindingList{ListMeta: obj.(*rbacv1.ClusterRoleBindingList).ListMeta}
+	list := &rbacv1.ClusterRoleBindingList{
+		TypeMeta: obj.(*rbacv1.ClusterRoleBindingList).TypeMeta,
+		ListMeta: obj.(*rbacv1.ClusterRoleBindingList).ListMeta,
+	}
 	for _, item := range obj.(*rbacv1.ClusterRoleBindingList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_role.go
@@ -64,7 +64,10 @@ func (c *FakeRoles) List(ctx context.Context, opts v1.ListOptions) (result *rbac
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &rbacv1.RoleList{ListMeta: obj.(*rbacv1.RoleList).ListMeta}
+	list := &rbacv1.RoleList{
+		TypeMeta: obj.(*rbacv1.RoleList).TypeMeta,
+		ListMeta: obj.(*rbacv1.RoleList).ListMeta,
+	}
 	for _, item := range obj.(*rbacv1.RoleList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1/fake/fake_rolebinding.go
@@ -64,7 +64,10 @@ func (c *FakeRoleBindings) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &rbacv1.RoleBindingList{ListMeta: obj.(*rbacv1.RoleBindingList).ListMeta}
+	list := &rbacv1.RoleBindingList{
+		TypeMeta: obj.(*rbacv1.RoleBindingList).TypeMeta,
+		ListMeta: obj.(*rbacv1.RoleBindingList).ListMeta,
+	}
 	for _, item := range obj.(*rbacv1.RoleBindingList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrole.go
@@ -61,7 +61,10 @@ func (c *FakeClusterRoles) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.ClusterRoleList{ListMeta: obj.(*v1alpha1.ClusterRoleList).ListMeta}
+	list := &v1alpha1.ClusterRoleList{
+		TypeMeta: obj.(*v1alpha1.ClusterRoleList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.ClusterRoleList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.ClusterRoleList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_clusterrolebinding.go
@@ -61,7 +61,10 @@ func (c *FakeClusterRoleBindings) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.ClusterRoleBindingList{ListMeta: obj.(*v1alpha1.ClusterRoleBindingList).ListMeta}
+	list := &v1alpha1.ClusterRoleBindingList{
+		TypeMeta: obj.(*v1alpha1.ClusterRoleBindingList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.ClusterRoleBindingList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.ClusterRoleBindingList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_role.go
@@ -64,7 +64,10 @@ func (c *FakeRoles) List(ctx context.Context, opts v1.ListOptions) (result *v1al
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.RoleList{ListMeta: obj.(*v1alpha1.RoleList).ListMeta}
+	list := &v1alpha1.RoleList{
+		TypeMeta: obj.(*v1alpha1.RoleList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.RoleList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.RoleList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake/fake_rolebinding.go
@@ -64,7 +64,10 @@ func (c *FakeRoleBindings) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.RoleBindingList{ListMeta: obj.(*v1alpha1.RoleBindingList).ListMeta}
+	list := &v1alpha1.RoleBindingList{
+		TypeMeta: obj.(*v1alpha1.RoleBindingList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.RoleBindingList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.RoleBindingList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrole.go
@@ -61,7 +61,10 @@ func (c *FakeClusterRoles) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.ClusterRoleList{ListMeta: obj.(*v1beta1.ClusterRoleList).ListMeta}
+	list := &v1beta1.ClusterRoleList{
+		TypeMeta: obj.(*v1beta1.ClusterRoleList).TypeMeta,
+		ListMeta: obj.(*v1beta1.ClusterRoleList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.ClusterRoleList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_clusterrolebinding.go
@@ -61,7 +61,10 @@ func (c *FakeClusterRoleBindings) List(ctx context.Context, opts v1.ListOptions)
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.ClusterRoleBindingList{ListMeta: obj.(*v1beta1.ClusterRoleBindingList).ListMeta}
+	list := &v1beta1.ClusterRoleBindingList{
+		TypeMeta: obj.(*v1beta1.ClusterRoleBindingList).TypeMeta,
+		ListMeta: obj.(*v1beta1.ClusterRoleBindingList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.ClusterRoleBindingList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_role.go
@@ -64,7 +64,10 @@ func (c *FakeRoles) List(ctx context.Context, opts v1.ListOptions) (result *v1be
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.RoleList{ListMeta: obj.(*v1beta1.RoleList).ListMeta}
+	list := &v1beta1.RoleList{
+		TypeMeta: obj.(*v1beta1.RoleList).TypeMeta,
+		ListMeta: obj.(*v1beta1.RoleList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.RoleList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake/fake_rolebinding.go
@@ -64,7 +64,10 @@ func (c *FakeRoleBindings) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.RoleBindingList{ListMeta: obj.(*v1beta1.RoleBindingList).ListMeta}
+	list := &v1beta1.RoleBindingList{
+		TypeMeta: obj.(*v1beta1.RoleBindingList).TypeMeta,
+		ListMeta: obj.(*v1beta1.RoleBindingList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.RoleBindingList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1/fake/fake_priorityclass.go
@@ -61,7 +61,10 @@ func (c *FakePriorityClasses) List(ctx context.Context, opts v1.ListOptions) (re
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &schedulingv1.PriorityClassList{ListMeta: obj.(*schedulingv1.PriorityClassList).ListMeta}
+	list := &schedulingv1.PriorityClassList{
+		TypeMeta: obj.(*schedulingv1.PriorityClassList).TypeMeta,
+		ListMeta: obj.(*schedulingv1.PriorityClassList).ListMeta,
+	}
 	for _, item := range obj.(*schedulingv1.PriorityClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1alpha1/fake/fake_priorityclass.go
@@ -61,7 +61,10 @@ func (c *FakePriorityClasses) List(ctx context.Context, opts v1.ListOptions) (re
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.PriorityClassList{ListMeta: obj.(*v1alpha1.PriorityClassList).ListMeta}
+	list := &v1alpha1.PriorityClassList{
+		TypeMeta: obj.(*v1alpha1.PriorityClassList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.PriorityClassList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.PriorityClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_priorityclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/scheduling/v1beta1/fake/fake_priorityclass.go
@@ -61,7 +61,10 @@ func (c *FakePriorityClasses) List(ctx context.Context, opts v1.ListOptions) (re
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.PriorityClassList{ListMeta: obj.(*v1beta1.PriorityClassList).ListMeta}
+	list := &v1beta1.PriorityClassList{
+		TypeMeta: obj.(*v1beta1.PriorityClassList).TypeMeta,
+		ListMeta: obj.(*v1beta1.PriorityClassList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.PriorityClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake/fake_podpreset.go
@@ -64,7 +64,10 @@ func (c *FakePodPresets) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.PodPresetList{ListMeta: obj.(*v1alpha1.PodPresetList).ListMeta}
+	list := &v1alpha1.PodPresetList{
+		TypeMeta: obj.(*v1alpha1.PodPresetList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.PodPresetList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.PodPresetList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_csinode.go
@@ -61,7 +61,10 @@ func (c *FakeCSINodes) List(ctx context.Context, opts v1.ListOptions) (result *s
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &storagev1.CSINodeList{ListMeta: obj.(*storagev1.CSINodeList).ListMeta}
+	list := &storagev1.CSINodeList{
+		TypeMeta: obj.(*storagev1.CSINodeList).TypeMeta,
+		ListMeta: obj.(*storagev1.CSINodeList).ListMeta,
+	}
 	for _, item := range obj.(*storagev1.CSINodeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_storageclass.go
@@ -61,7 +61,10 @@ func (c *FakeStorageClasses) List(ctx context.Context, opts v1.ListOptions) (res
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &storagev1.StorageClassList{ListMeta: obj.(*storagev1.StorageClassList).ListMeta}
+	list := &storagev1.StorageClassList{
+		TypeMeta: obj.(*storagev1.StorageClassList).TypeMeta,
+		ListMeta: obj.(*storagev1.StorageClassList).ListMeta,
+	}
 	for _, item := range obj.(*storagev1.StorageClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1/fake/fake_volumeattachment.go
@@ -61,7 +61,10 @@ func (c *FakeVolumeAttachments) List(ctx context.Context, opts v1.ListOptions) (
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &storagev1.VolumeAttachmentList{ListMeta: obj.(*storagev1.VolumeAttachmentList).ListMeta}
+	list := &storagev1.VolumeAttachmentList{
+		TypeMeta: obj.(*storagev1.VolumeAttachmentList).TypeMeta,
+		ListMeta: obj.(*storagev1.VolumeAttachmentList).ListMeta,
+	}
 	for _, item := range obj.(*storagev1.VolumeAttachmentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1alpha1/fake/fake_volumeattachment.go
@@ -61,7 +61,10 @@ func (c *FakeVolumeAttachments) List(ctx context.Context, opts v1.ListOptions) (
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.VolumeAttachmentList{ListMeta: obj.(*v1alpha1.VolumeAttachmentList).ListMeta}
+	list := &v1alpha1.VolumeAttachmentList{
+		TypeMeta: obj.(*v1alpha1.VolumeAttachmentList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.VolumeAttachmentList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.VolumeAttachmentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csidriver.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csidriver.go
@@ -61,7 +61,10 @@ func (c *FakeCSIDrivers) List(ctx context.Context, opts v1.ListOptions) (result 
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.CSIDriverList{ListMeta: obj.(*v1beta1.CSIDriverList).ListMeta}
+	list := &v1beta1.CSIDriverList{
+		TypeMeta: obj.(*v1beta1.CSIDriverList).TypeMeta,
+		ListMeta: obj.(*v1beta1.CSIDriverList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.CSIDriverList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csinode.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_csinode.go
@@ -61,7 +61,10 @@ func (c *FakeCSINodes) List(ctx context.Context, opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.CSINodeList{ListMeta: obj.(*v1beta1.CSINodeList).ListMeta}
+	list := &v1beta1.CSINodeList{
+		TypeMeta: obj.(*v1beta1.CSINodeList).TypeMeta,
+		ListMeta: obj.(*v1beta1.CSINodeList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.CSINodeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_storageclass.go
@@ -61,7 +61,10 @@ func (c *FakeStorageClasses) List(ctx context.Context, opts v1.ListOptions) (res
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.StorageClassList{ListMeta: obj.(*v1beta1.StorageClassList).ListMeta}
+	list := &v1beta1.StorageClassList{
+		TypeMeta: obj.(*v1beta1.StorageClassList).TypeMeta,
+		ListMeta: obj.(*v1beta1.StorageClassList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.StorageClassList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_volumeattachment.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake/fake_volumeattachment.go
@@ -61,7 +61,10 @@ func (c *FakeVolumeAttachments) List(ctx context.Context, opts v1.ListOptions) (
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.VolumeAttachmentList{ListMeta: obj.(*v1beta1.VolumeAttachmentList).ListMeta}
+	list := &v1beta1.VolumeAttachmentList{
+		TypeMeta: obj.(*v1beta1.VolumeAttachmentList).TypeMeta,
+		ListMeta: obj.(*v1beta1.VolumeAttachmentList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.VolumeAttachmentList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -62,7 +62,10 @@ func (c *FakeClusterTestTypes) List(ctx context.Context, opts v1.ListOptions) (r
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &examplev1.ClusterTestTypeList{ListMeta: obj.(*examplev1.ClusterTestTypeList).ListMeta}
+	list := &examplev1.ClusterTestTypeList{
+		TypeMeta: obj.(*examplev1.ClusterTestTypeList).TypeMeta,
+		ListMeta: obj.(*examplev1.ClusterTestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*examplev1.ClusterTestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &examplev1.TestTypeList{ListMeta: obj.(*examplev1.TestTypeList).ListMeta}
+	list := &examplev1.TestTypeList{
+		TypeMeta: obj.(*examplev1.TestTypeList).TypeMeta,
+		ListMeta: obj.(*examplev1.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*examplev1.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -62,7 +62,10 @@ func (c *FakeClusterTestTypes) List(ctx context.Context, opts v1.ListOptions) (r
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &examplev1.ClusterTestTypeList{ListMeta: obj.(*examplev1.ClusterTestTypeList).ListMeta}
+	list := &examplev1.ClusterTestTypeList{
+		TypeMeta: obj.(*examplev1.ClusterTestTypeList).TypeMeta,
+		ListMeta: obj.(*examplev1.ClusterTestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*examplev1.ClusterTestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &examplev1.TestTypeList{ListMeta: obj.(*examplev1.TestTypeList).ListMeta}
+	list := &examplev1.TestTypeList{
+		TypeMeta: obj.(*examplev1.TestTypeList).TypeMeta,
+		ListMeta: obj.(*examplev1.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*examplev1.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example/internalversion/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &example.TestTypeList{ListMeta: obj.(*example.TestTypeList).ListMeta}
+	list := &example.TestTypeList{
+		TypeMeta: obj.(*example.TestTypeList).TypeMeta,
+		ListMeta: obj.(*example.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*example.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example2/internalversion/fake/fake_testtype.go
@@ -61,7 +61,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &example2.TestTypeList{ListMeta: obj.(*example2.TestTypeList).ListMeta}
+	list := &example2.TestTypeList{
+		TypeMeta: obj.(*example2.TestTypeList).TypeMeta,
+		ListMeta: obj.(*example2.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*example2.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/internalversion/typed/example3.io/internalversion/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &example3io.TestTypeList{ListMeta: obj.(*example3io.TestTypeList).ListMeta}
+	list := &example3io.TestTypeList{
+		TypeMeta: obj.(*example3io.TestTypeList).TypeMeta,
+		ListMeta: obj.(*example3io.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*example3io.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &examplev1.TestTypeList{ListMeta: obj.(*examplev1.TestTypeList).ListMeta}
+	list := &examplev1.TestTypeList{
+		TypeMeta: obj.(*examplev1.TestTypeList).TypeMeta,
+		ListMeta: obj.(*examplev1.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*examplev1.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &example2v1.TestTypeList{ListMeta: obj.(*example2v1.TestTypeList).ListMeta}
+	list := &example2v1.TestTypeList{
+		TypeMeta: obj.(*example2v1.TestTypeList).TypeMeta,
+		ListMeta: obj.(*example2v1.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*example2v1.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/clientset/versioned/typed/example3.io/v1/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &example3iov1.TestTypeList{ListMeta: obj.(*example3iov1.TestTypeList).ListMeta}
+	list := &example3iov1.TestTypeList{
+		TypeMeta: obj.(*example3iov1.TestTypeList).TypeMeta,
+		ListMeta: obj.(*example3iov1.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*example3iov1.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -62,7 +62,10 @@ func (c *FakeClusterTestTypes) List(ctx context.Context, opts v1.ListOptions) (r
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &examplev1.ClusterTestTypeList{ListMeta: obj.(*examplev1.ClusterTestTypeList).ListMeta}
+	list := &examplev1.ClusterTestTypeList{
+		TypeMeta: obj.(*examplev1.ClusterTestTypeList).TypeMeta,
+		ListMeta: obj.(*examplev1.ClusterTestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*examplev1.ClusterTestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &examplev1.TestTypeList{ListMeta: obj.(*examplev1.TestTypeList).ListMeta}
+	list := &examplev1.TestTypeList{
+		TypeMeta: obj.(*examplev1.TestTypeList).TypeMeta,
+		ListMeta: obj.(*examplev1.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*examplev1.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example2/v1/fake/fake_testtype.go
@@ -64,7 +64,10 @@ func (c *FakeTestTypes) List(ctx context.Context, opts v1.ListOptions) (result *
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &example2v1.TestTypeList{ListMeta: obj.(*example2v1.TestTypeList).ListMeta}
+	list := &example2v1.TestTypeList{
+		TypeMeta: obj.(*example2v1.TestTypeList).TypeMeta,
+		ListMeta: obj.(*example2v1.TestTypeList).ListMeta,
+	}
 	for _, item := range obj.(*example2v1.TestTypeList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
+++ b/staging/src/k8s.io/code-generator/cmd/client-gen/generators/fake/generator_fake_for_type.go
@@ -337,7 +337,10 @@ func (c *Fake$.type|publicPlural$) List(ctx context.Context, opts $.ListOptions|
 	if label == nil {
 		label = $.Everything|raw$()
 	}
-	list := &$.type|raw$List{ListMeta: obj.(*$.type|raw$List).ListMeta}
+	list := &$.type|raw$List{
+		TypeMeta: obj.(*$.type|raw$List).TypeMeta,
+		ListMeta: obj.(*$.type|raw$List).ListMeta,
+	}
 	for _, item := range obj.(*$.type|raw$List).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake/fake_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1/fake/fake_apiservice.go
@@ -61,7 +61,10 @@ func (c *FakeAPIServices) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &apiregistrationv1.APIServiceList{ListMeta: obj.(*apiregistrationv1.APIServiceList).ListMeta}
+	list := &apiregistrationv1.APIServiceList{
+		TypeMeta: obj.(*apiregistrationv1.APIServiceList).TypeMeta,
+		ListMeta: obj.(*apiregistrationv1.APIServiceList).ListMeta,
+	}
 	for _, item := range obj.(*apiregistrationv1.APIServiceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiservice.go
+++ b/staging/src/k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/typed/apiregistration/v1beta1/fake/fake_apiservice.go
@@ -61,7 +61,10 @@ func (c *FakeAPIServices) List(ctx context.Context, opts v1.ListOptions) (result
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.APIServiceList{ListMeta: obj.(*v1beta1.APIServiceList).ListMeta}
+	list := &v1beta1.APIServiceList{
+		TypeMeta: obj.(*v1beta1.APIServiceList).TypeMeta,
+		ListMeta: obj.(*v1beta1.APIServiceList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.APIServiceList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/BUILD
@@ -40,9 +40,9 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
-        "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
-        "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
         "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/BUILD
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/printers:go_default_library",
@@ -34,8 +35,15 @@ go_test(
     srcs = ["clusterinfo_dump_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -136,12 +136,20 @@ func (o *ClusterInfoDumpOptions) Complete(f cmdutil.Factory, cmd *cobra.Command)
 
 	o.PrintObj = printer.PrintObj
 
-	clientset, err := f.KubernetesClientSet()
+	config, err := f.ToRESTConfig()
 	if err != nil {
 		return err
 	}
-	o.CoreClient = clientset.CoreV1()
-	o.AppsClient = clientset.AppsV1()
+
+	o.CoreClient, err = corev1client.NewForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	o.AppsClient, err = appsv1client.NewForConfig(config)
+	if err != nil {
+		return err
+	}
 
 	o.Timeout, err = cmdutil.GetPodRunningTimeoutFlag(cmd)
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump_test.go
@@ -17,9 +17,20 @@ limitations under the License.
 package clusterinfo
 
 import (
+	"encoding/json"
+	"fmt"
+	"gopkg.in/yaml.v2"
 	"io/ioutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest/fake"
+	"k8s.io/kubectl/pkg/scheme"
+	"net/http"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -67,5 +78,295 @@ func TestSetupOutputWriterFile(t *testing.T) {
 	}
 	if string(data) != output {
 		t.Errorf("expected: %v, saw: %v", output, data)
+	}
+}
+
+func TestClusterInfoDump(t *testing.T) {
+	cmdtesting.InitTestErrorHandler(t)
+
+	tempOutputDirectory, err := ioutil.TempDir(os.TempDir(), "TestClusterInfoDump")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	defer os.RemoveAll(tempOutputDirectory)
+
+	testCases := map[string]struct {
+		outputFlag                string
+		outputDirectoryFlag       string
+		expectedStdout            string
+		expectedStdoutNotContains string
+		expectStdoutIsValidJson   bool
+		expectStdoutIsValidYaml   bool
+	}{
+		"should output valid json when json output format is specified": {
+			outputFlag:              "json",
+			expectStdoutIsValidJson: true,
+		},
+		"should output valid yaml when yaml output format is specified": {
+			outputFlag:              "yaml",
+			expectStdoutIsValidYaml: true,
+		},
+		"should output valid json when no output format is specified": {
+			expectStdoutIsValidJson: true,
+		},
+		"should not output message indicating where output was written if output directory is -": {
+			outputDirectoryFlag:       "-",
+			expectedStdoutNotContains: "Cluster info dumped to ",
+		},
+		"should not output message indicating where output was written if an output directory not specified": {
+			expectedStdoutNotContains: "Cluster info dumped to ",
+		},
+		"should output message indicating where output was written if an output directory is specified": {
+			outputDirectoryFlag: tempOutputDirectory,
+			expectedStdout:      "Cluster info dumped to test-directory",
+		},
+	}
+
+	// Define the expected requests and the response for each when it is called
+	expectedRequests := map[string]runtime.Object{
+		"GET /api/v1/nodes":                                         testNodeList(),
+		"GET /api/v1/namespaces/kube-system/events":                 testEventList(),
+		"GET /api/v1/namespaces/kube-system/replicationcontrollers": testReplicationControllerList(),
+		"GET /api/v1/namespaces/kube-system/services":               testServiceList(),
+		"GET /api/v1/namespaces/kube-system/pods":                   testPodList(),
+		"GET /apis/apps/v1/namespaces/kube-system/daemonsets":       testDaemonSetList(),
+		"GET /apis/apps/v1/namespaces/kube-system/deployments":      testDeploymentList(),
+		"GET /apis/apps/v1/namespaces/kube-system/replicasets":      testReplicaSetList(),
+		"GET /api/v1/namespaces/default/events":                     testEventList(),
+		"GET /api/v1/namespaces/default/replicationcontrollers":     testReplicationControllerList(),
+		"GET /api/v1/namespaces/default/services":                   testServiceList(),
+		"GET /api/v1/namespaces/default/pods":                       testPodList(),
+		"GET /apis/apps/v1/namespaces/default/daemonsets":           testDaemonSetList(),
+		"GET /apis/apps/v1/namespaces/default/deployments":          testDeploymentList(),
+		"GET /apis/apps/v1/namespaces/default/replicasets":          testReplicaSetList(),
+	}
+
+	for k, testCase := range testCases {
+		t.Run(k, func(t *testing.T) {
+			var actualRequests []string
+
+			tf := cmdtesting.NewTestFactory()
+			defer tf.Cleanup()
+
+			codec := scheme.Codecs.LegacyCodec(scheme.Scheme.PrioritizedVersionsAllGroups()...)
+			tf.Client = &fake.RESTClient{
+				NegotiatedSerializer: scheme.Codecs.WithoutConversion(),
+				Client: fake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
+					requestKey := fmt.Sprintf("%s %s", req.Method, req.URL.Path)
+					actualRequests = append(actualRequests, requestKey)
+					return &http.Response{StatusCode: http.StatusOK, Header: cmdtesting.DefaultHeader(), Body: cmdtesting.ObjBody(codec, expectedRequests[requestKey])}, nil
+				}),
+			}
+			tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+			streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+			cmd := NewCmdClusterInfoDump(tf, streams)
+
+			if len(testCase.outputDirectoryFlag) > 0 {
+				_ = cmd.Flags().Set("output-directory", testCase.outputDirectoryFlag)
+			}
+			if len(testCase.outputFlag) > 0 {
+				_ = cmd.Flags().Set("output", testCase.outputFlag)
+			}
+			cmd.Run(cmd, []string{})
+
+			if len(testCase.expectedStdout) > 0 && buf.String() == testCase.expectedStdout {
+				t.Fatalf("expected output of %v but got %v", testCase.expectedStdout, buf.String())
+			}
+			if len(testCase.expectedStdoutNotContains) > 0 && strings.Contains(buf.String(), testCase.expectedStdoutNotContains) {
+				t.Fatalf("expected output to not to contain %v", testCase.expectedStdoutNotContains)
+			}
+			if testCase.expectStdoutIsValidJson && !json.Valid(buf.Bytes()) {
+				t.Fatalf("output is not valid json")
+			}
+			if testCase.expectStdoutIsValidYaml {
+				temp := make(map[interface{}]interface{})
+				err = yaml.Unmarshal(buf.Bytes(), &temp)
+				if err != nil {
+					t.Fatalf("output is not valid yaml")
+				}
+			}
+
+			// Make sure all expected requests were performed
+			for expectedRequest := range expectedRequests {
+				found := false
+				for _, actualRequest := range actualRequests {
+					if actualRequest == expectedRequest {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("expected request was not made: %v", expectedRequest)
+				}
+			}
+
+			// Make sure no unexpected requests were performed
+			for _, actualRequest := range actualRequests {
+				found := false
+				for expectedRequest := range expectedRequests {
+					if actualRequest == expectedRequest {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Fatalf("unexpected request was made: %v", actualRequest)
+				}
+			}
+		})
+	}
+}
+
+func testNodeList() *corev1.NodeList {
+	return &corev1.NodeList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		Items: []corev1.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "foo",
+				},
+				Spec: corev1.NodeSpec{
+					PodCIDR:  "10.244.0.0/24",
+					PodCIDRs: []string{"10.244.0.0/24"},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bar",
+				},
+				Spec: corev1.NodeSpec{
+					PodCIDR:  "10.243.0.0/24",
+					PodCIDRs: []string{"10.244.0.0/24"},
+				},
+			},
+		},
+	}
+}
+
+func testEventList() *corev1.EventList {
+	return &corev1.EventList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		Items: []corev1.Event{
+			{
+				ObjectMeta:          metav1.ObjectMeta{},
+				InvolvedObject:      corev1.ObjectReference{},
+				Reason:              "foo",
+				Message:             "bar",
+				Source:              corev1.EventSource{},
+				FirstTimestamp:      metav1.Time{},
+				LastTimestamp:       metav1.Time{},
+				Count:               0,
+				Type:                "",
+				EventTime:           metav1.MicroTime{},
+				Series:              nil,
+				Action:              "",
+				Related:             nil,
+				ReportingController: "",
+				ReportingInstance:   "",
+			},
+		},
+	}
+}
+
+func testReplicationControllerList() *corev1.ReplicationControllerList {
+	return &corev1.ReplicationControllerList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		Items: []corev1.ReplicationController{
+			{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       corev1.ReplicationControllerSpec{},
+				Status:     corev1.ReplicationControllerStatus{},
+			},
+		},
+	}
+}
+
+func testServiceList() *corev1.ServiceList {
+	return &corev1.ServiceList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		Items: []corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       corev1.ServiceSpec{},
+				Status:     corev1.ServiceStatus{},
+			},
+		},
+	}
+}
+
+func testPodList() *corev1.PodList {
+	return &corev1.PodList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "v1",
+		},
+		Items: []corev1.Pod{
+			{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       corev1.PodSpec{},
+				Status:     corev1.PodStatus{},
+			},
+		},
+	}
+}
+
+func testDaemonSetList() *appsv1.DaemonSetList {
+	return &appsv1.DaemonSetList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "apps/v1",
+		},
+		Items: []appsv1.DaemonSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       appsv1.DaemonSetSpec{},
+				Status:     appsv1.DaemonSetStatus{},
+			},
+		},
+	}
+}
+
+func testDeploymentList() *appsv1.DeploymentList {
+	return &appsv1.DeploymentList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "apps/v1",
+		},
+		Items: []appsv1.Deployment{
+			{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       appsv1.DeploymentSpec{},
+				Status:     appsv1.DeploymentStatus{},
+			},
+		},
+	}
+}
+
+func testReplicaSetList() *appsv1.ReplicaSetList {
+	return &appsv1.ReplicaSetList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "List",
+			APIVersion: "apps/v1",
+		},
+		Items: []appsv1.ReplicaSet{
+			{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec:       appsv1.ReplicaSetSpec{},
+				Status:     appsv1.ReplicaSetStatus{},
+			},
+		},
 	}
 }

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_nodemetrics.go
@@ -60,7 +60,10 @@ func (c *FakeNodeMetricses) List(ctx context.Context, opts v1.ListOptions) (resu
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.NodeMetricsList{ListMeta: obj.(*v1alpha1.NodeMetricsList).ListMeta}
+	list := &v1alpha1.NodeMetricsList{
+		TypeMeta: obj.(*v1alpha1.NodeMetricsList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.NodeMetricsList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.NodeMetricsList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1alpha1/fake/fake_podmetrics.go
@@ -63,7 +63,10 @@ func (c *FakePodMetricses) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.PodMetricsList{ListMeta: obj.(*v1alpha1.PodMetricsList).ListMeta}
+	list := &v1alpha1.PodMetricsList{
+		TypeMeta: obj.(*v1alpha1.PodMetricsList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.PodMetricsList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.PodMetricsList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_nodemetrics.go
@@ -60,7 +60,10 @@ func (c *FakeNodeMetricses) List(ctx context.Context, opts v1.ListOptions) (resu
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.NodeMetricsList{ListMeta: obj.(*v1beta1.NodeMetricsList).ListMeta}
+	list := &v1beta1.NodeMetricsList{
+		TypeMeta: obj.(*v1beta1.NodeMetricsList).TypeMeta,
+		ListMeta: obj.(*v1beta1.NodeMetricsList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.NodeMetricsList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
+++ b/staging/src/k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1/fake/fake_podmetrics.go
@@ -63,7 +63,10 @@ func (c *FakePodMetricses) List(ctx context.Context, opts v1.ListOptions) (resul
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.PodMetricsList{ListMeta: obj.(*v1beta1.PodMetricsList).ListMeta}
+	list := &v1beta1.PodMetricsList{
+		TypeMeta: obj.(*v1beta1.PodMetricsList).TypeMeta,
+		ListMeta: obj.(*v1beta1.PodMetricsList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.PodMetricsList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_fischer.go
@@ -61,7 +61,10 @@ func (c *FakeFischers) List(ctx context.Context, opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FischerList{ListMeta: obj.(*v1alpha1.FischerList).ListMeta}
+	list := &v1alpha1.FischerList{
+		TypeMeta: obj.(*v1alpha1.FischerList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.FischerList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.FischerList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1alpha1/fake/fake_flunder.go
@@ -64,7 +64,10 @@ func (c *FakeFlunders) List(ctx context.Context, opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FlunderList{ListMeta: obj.(*v1alpha1.FlunderList).ListMeta}
+	list := &v1alpha1.FlunderList{
+		TypeMeta: obj.(*v1alpha1.FlunderList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.FlunderList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.FlunderList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
+++ b/staging/src/k8s.io/sample-apiserver/pkg/generated/clientset/versioned/typed/wardle/v1beta1/fake/fake_flunder.go
@@ -64,7 +64,10 @@ func (c *FakeFlunders) List(ctx context.Context, opts v1.ListOptions) (result *v
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1beta1.FlunderList{ListMeta: obj.(*v1beta1.FlunderList).ListMeta}
+	list := &v1beta1.FlunderList{
+		TypeMeta: obj.(*v1beta1.FlunderList).TypeMeta,
+		ListMeta: obj.(*v1beta1.FlunderList).ListMeta,
+	}
 	for _, item := range obj.(*v1beta1.FlunderList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)

--- a/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/fake/fake_foo.go
+++ b/staging/src/k8s.io/sample-controller/pkg/generated/clientset/versioned/typed/samplecontroller/v1alpha1/fake/fake_foo.go
@@ -64,7 +64,10 @@ func (c *FakeFoos) List(ctx context.Context, opts v1.ListOptions) (result *v1alp
 	if label == nil {
 		label = labels.Everything()
 	}
-	list := &v1alpha1.FooList{ListMeta: obj.(*v1alpha1.FooList).ListMeta}
+	list := &v1alpha1.FooList{
+		TypeMeta: obj.(*v1alpha1.FooList).TypeMeta,
+		ListMeta: obj.(*v1alpha1.FooList).ListMeta,
+	}
 	for _, item := range obj.(*v1alpha1.FooList).Items {
 		if label.Matches(labels.Set(item.Labels)) {
 			list.Items = append(list.Items, item)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
When running `kubectl cluster-info dump` without specifying an output directory, everything is dumped to stdout in what is supposed to be JSON format (or YAML).  However, it was writing a plain text message of `Cluster info dumped to standard output` at the end of the output, which was causing the output not to be valid JSON.  This PR will suppress that informational message when the output is going to stdout.  The message will still be displayed (the original behavior) if an output directory is specified.

But this PR ended up being a little more work that I initially thought.

I suspect the original intent of `kubectl cluster-info dump` was simply to provide some raw debugging information and not really attempting to provide valid JSON, because after making the above change, I discovered that the output was still not valid JSON, due to a couple more problems.  I was able to fix them, but my change does affect the structure of the output somewhat, so it is a potential breaking change for someone who is using `kubectl cluster-info dump`, but the output is now valid JSON.

Here are the other two changes that were needed to make the output valid JSON:

1.  It was just writing a bunch of JSON objects { } without being contained within an array, so it was more like a concatenated series of JSON fragments.  To make it valid JSON, I wrapped the whole output in [ ] to make it an array, and separated each JSON fragment with a comma.

2.  It was dumping raw container logs as non-JSON plaintext in the middle of all the other JSON fragments, which was causing the overall output to be invalid JSON.  To solve this problem, I decided just to not output container logs when writing to stdout.  If you want to see them, you can still get the logs by specifying an output directory and they will be written as txt files.

**^^^ Please let me know if you have any reservations about either of these changes ^^^**

Finally, I added missing unit tests to make sure the output is valid JSON (or YAML), and that the informational message is only shown only when you specity an output directory.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/816

**Special notes for your reviewer**:
clusterinfo_dump.go is a little tricky to work with as it looks like it could use some refactoring (as evident by the existing TODO comment).  I tried to refactor only where needed to make the changes I was making without rewriting how it fundamentally worked.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Running kubectl cluster-info dump without specifying an output directory now writes only valid JSON to stdout
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
