### PR TITLE
Respect ignore-volume-az option in admission plugin

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -726,6 +726,11 @@ func (os *OpenStack) GetLabelsForVolume(ctx context.Context, pv *v1.PersistentVo
 		return nil, nil
 	}
 
+	// if volume az is to be ignored we should return nil from here
+	if os.bsOpts.IgnoreVolumeAZ {
+		return nil, nil
+	}
+
 	// Get Volume
 	volume, err := os.getVolume(pv.Spec.Cinder.VolumeID)
 	if err != nil {


### PR DESCRIPTION
We appear to be respecting this options when provisioning the volume
but when PV is admitted the zone/region fields get added back to the
PV and hence defeating the purpose of the option.

/sig storage
/area openstack

cc @dims @zetaab 
