### PR TITLE
Fix: cmd/kubeadm Typos in some error messages, comments

### DIFF
--- a/cmd/kubeadm/app/util/kustomize/strategicmerge.go
+++ b/cmd/kubeadm/app/util/kustomize/strategicmerge.go
@@ -80,13 +80,13 @@ func newStrategicMergeSliceFromBytes(in []byte) (strategicMergeSlice, error) {
 						return err
 					}
 
-					// Get the stategicMergeSlice for the item
+					// Get the strategicMergeSlice for the item
 					itemU, err := newStrategicMergeSliceFromBytes(itemJSON)
 					if err != nil {
 						return err
 					}
 
-					// append the stategicMergeSlice for the item to the stategicMergeSlice
+					// append the strategicMergeSlice for the item to the strategicMergeSlice
 					result = append(result, itemU...)
 
 					return nil

--- a/cmd/kubeadm/app/util/output/output.go
+++ b/cmd/kubeadm/app/util/output/output.go
@@ -30,7 +30,7 @@ import (
 // TextOutput describes the plain text output
 const TextOutput = "text"
 
-// TextPrintFlags is an iterface to handle custom text output
+// TextPrintFlags is an interface to handle custom text output
 type TextPrintFlags interface {
 	ToPrinter(outputFormat string) (Printer, error)
 }

--- a/cmd/kubeadm/app/util/runtime/runtime_test.go
+++ b/cmd/kubeadm/app/util/runtime/runtime_test.go
@@ -219,7 +219,7 @@ func TestRemoveContainers(t *testing.T) {
 				t.Errorf("unexpected RemoveContainers errors: %v, criSocket: %s, containers: %v", err, tc.criSocket, tc.containers)
 			}
 			if tc.isError && err == nil {
-				t.Errorf("unexpected RemoveContnainers success, criSocket: %s, containers: %v", tc.criSocket, tc.containers)
+				t.Errorf("unexpected RemoveContainers success, criSocket: %s, containers: %v", tc.criSocket, tc.containers)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
> To fix cmd/kubeadm Typos in some error messages, comments

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
> Fixes #

**Special notes for your reviewer**:
> NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
> NONE