### PR TITLE
Fix: golint errors about func name in pkg/apis/scheduling module

### DIFF
--- a/pkg/apis/scheduling/v1/defaults.go
+++ b/pkg/apis/scheduling/v1/defaults.go
@@ -28,9 +28,9 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-// SetDefaults_PriorityClass sets additional defaults compared to its counterpart
+// SetDefaultsPriorityClass sets additional defaults compared to its counterpart
 // in extensions.
-func SetDefaults_PriorityClass(obj *v1.PriorityClass) {
+func SetDefaultsPriorityClass(obj *v1.PriorityClass) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.NonPreemptingPriority) && obj.PreemptionPolicy == nil {
 		preemptLowerPriority := apiv1.PreemptLowerPriority
 		obj.PreemptionPolicy = &preemptLowerPriority

--- a/pkg/apis/scheduling/v1/zz_generated.defaults.go
+++ b/pkg/apis/scheduling/v1/zz_generated.defaults.go
@@ -35,7 +35,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_PriorityClass(in *v1.PriorityClass) {
-	SetDefaults_PriorityClass(in)
+	SetDefaultsPriorityClass(in)
 }
 
 func SetObjectDefaults_PriorityClassList(in *v1.PriorityClassList) {

--- a/pkg/apis/scheduling/v1alpha1/defaults.go
+++ b/pkg/apis/scheduling/v1alpha1/defaults.go
@@ -28,9 +28,9 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-// SetDefaults_PriorityClass sets additional defaults compared to its counterpart
+// SetDefaultsPriorityClass sets additional defaults compared to its counterpart
 // in extensions.
-func SetDefaults_PriorityClass(obj *v1alpha1.PriorityClass) {
+func SetDefaultsPriorityClass(obj *v1alpha1.PriorityClass) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.NonPreemptingPriority) && obj.PreemptionPolicy == nil {
 		preemptLowerPriority := apiv1.PreemptLowerPriority
 		obj.PreemptionPolicy = &preemptLowerPriority

--- a/pkg/apis/scheduling/v1alpha1/zz_generated.defaults.go
+++ b/pkg/apis/scheduling/v1alpha1/zz_generated.defaults.go
@@ -35,7 +35,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_PriorityClass(in *v1alpha1.PriorityClass) {
-	SetDefaults_PriorityClass(in)
+	SetDefaultsPriorityClass(in)
 }
 
 func SetObjectDefaults_PriorityClassList(in *v1alpha1.PriorityClassList) {

--- a/pkg/apis/scheduling/v1beta1/defaults.go
+++ b/pkg/apis/scheduling/v1beta1/defaults.go
@@ -28,9 +28,9 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
-// SetDefaults_PriorityClass sets additional defaults compared to its counterpart
+// SetDefaultsPriorityClass sets additional defaults compared to its counterpart
 // in extensions.
-func SetDefaults_PriorityClass(obj *v1beta1.PriorityClass) {
+func SetDefaultsPriorityClass(obj *v1beta1.PriorityClass) {
 	if utilfeature.DefaultFeatureGate.Enabled(features.NonPreemptingPriority) && obj.PreemptionPolicy == nil {
 		preemptLowerPriority := apiv1.PreemptLowerPriority
 		obj.PreemptionPolicy = &preemptLowerPriority

--- a/pkg/apis/scheduling/v1beta1/zz_generated.defaults.go
+++ b/pkg/apis/scheduling/v1beta1/zz_generated.defaults.go
@@ -35,7 +35,7 @@ func RegisterDefaults(scheme *runtime.Scheme) error {
 }
 
 func SetObjectDefaults_PriorityClass(in *v1beta1.PriorityClass) {
-	SetDefaults_PriorityClass(in)
+	SetDefaultsPriorityClass(in)
 }
 
 func SetObjectDefaults_PriorityClassList(in *v1beta1.PriorityClassList) {


### PR DESCRIPTION
**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
> To fix some golint errors for packages in `pkg/apis/scheduling`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
> Fixes some parts of #68026

**Special notes for your reviewer**:
> NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
