### PR TITLE
Fix initialization bug in `FakeImageService`

### DIFF
--- a/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
+++ b/staging/src/k8s.io/cri-api/pkg/apis/testing/fake_image_service.go
@@ -65,6 +65,7 @@ func (r *FakeImageService) SetFakeFilesystemUsage(usage []*runtimeapi.Filesystem
 func NewFakeImageService() *FakeImageService {
 	return &FakeImageService{
 		Called: make([]string, 0),
+		Errors: make(map[string][]error),
 		Images: make(map[string]*runtimeapi.Image),
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When adding this functionality in
https://github.com/kubernetes/kubernetes/pull/88372, I forgot to
allocate a map for the `Errors` field when constructing the object. As a
result, trying to actually use the `InjectError` method failed (as I
noticed when I started trying to write tests to actually use
`InjectError`). Fortunately, `FakeImageService` is only used in tests...
but still, we should fix this issue.

Fixing in a separate diff from the one which will add additional test
coverage (and actually use `InjectError`), because I don't like having
non-working code in master.

We could also revert the original commit and then re-merge with this
fix, but that seems like unnecessary work given we already have a fix
ready to go.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
