### PR TITLE
fix typos error in handlers_test.go file

### DIFF
--- a/pkg/kubelet/lifecycle/handlers_test.go
+++ b/pkg/kubelet/lifecycle/handlers_test.go
@@ -133,8 +133,8 @@ func (f *fakeHTTP) Get(url string) (*http.Response, error) {
 }
 
 func TestRunHandlerHttp(t *testing.T) {
-	fakeHttp := fakeHTTP{}
-	handlerRunner := NewHandlerRunner(&fakeHttp, &fakeContainerCommandRunner{}, nil)
+	fakeHTTPGetter := fakeHTTP{}
+	handlerRunner := NewHandlerRunner(&fakeHTTPGetter, &fakeContainerCommandRunner{}, nil)
 
 	containerID := kubecontainer.ContainerID{Type: "test", ID: "abc1234"}
 	containerName := "containerFoo"
@@ -160,8 +160,8 @@ func TestRunHandlerHttp(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
-	if fakeHttp.url != "http://foo:8080/bar" {
-		t.Errorf("unexpected url: %s", fakeHttp.url)
+	if fakeHTTPGetter.url != "http://foo:8080/bar" {
+		t.Errorf("unexpected url: %s", fakeHTTPGetter.url)
 	}
 }
 
@@ -227,8 +227,8 @@ func TestRunHandlerHttpFailure(t *testing.T) {
 	expectedResp := http.Response{
 		Body: ioutil.NopCloser(strings.NewReader(expectedErr.Error())),
 	}
-	fakeHttp := fakeHTTP{err: expectedErr, resp: &expectedResp}
-	handlerRunner := NewHandlerRunner(&fakeHttp, &fakeContainerCommandRunner{}, nil)
+	fakeHTTPGetter := fakeHTTP{err: expectedErr, resp: &expectedResp}
+	handlerRunner := NewHandlerRunner(&fakeHTTPGetter, &fakeContainerCommandRunner{}, nil)
 	containerName := "containerFoo"
 	containerID := kubecontainer.ContainerID{Type: "test", ID: "abc1234"}
 	container := v1.Container{
@@ -255,7 +255,7 @@ func TestRunHandlerHttpFailure(t *testing.T) {
 	if msg != expectedErrMsg {
 		t.Errorf("unexpected error message: %q; expected %q", msg, expectedErrMsg)
 	}
-	if fakeHttp.url != "http://foo:8080/bar" {
-		t.Errorf("unexpected url: %s", fakeHttp.url)
+	if fakeHTTPGetter.url != "http://foo:8080/bar" {
+		t.Errorf("unexpected url: %s", fakeHTTPGetter.url)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
fix typos error to make it better: 
-  to change variable `fakeHttp` to `fakeHTTPGetter` make it conforms to golint specification.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
xref  #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
