### PR TITLE
Wire --filename flag to exec

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec_test.go
@@ -103,7 +103,7 @@ func TestPodAndContainer(t *testing.T) {
 		{
 			p:             &ExecOptions{},
 			args:          []string{"foo", "cmd"},
-			argsLenAtDash: -1,
+			argsLenAtDash: 1,
 			expectedPod:   "foo",
 			expectedArgs:  []string{"cmd"},
 			name:          "cmd, w/o flags",
@@ -112,7 +112,7 @@ func TestPodAndContainer(t *testing.T) {
 		{
 			p:             &ExecOptions{},
 			args:          []string{"foo", "cmd"},
-			argsLenAtDash: 1,
+			argsLenAtDash: -1,
 			expectedPod:   "foo",
 			expectedArgs:  []string{"cmd"},
 			name:          "cmd, cmd is behind dash",

--- a/test/cmd/exec.sh
+++ b/test/cmd/exec.sh
@@ -81,14 +81,14 @@ run_kubectl_exec_resource_name_tests() {
   # POD test-pod is exists this is shouldn't have output not found
   kube::test::if_has_not_string "${output_message}" 'not found'
   # These must be pass the validate
-  kube::test::if_has_not_string "${output_message}" 'pod or type/name must be specified'
-  
+  kube::test::if_has_not_string "${output_message}" 'pod, type/name or --filename must be specified'
+
   output_message=$(! kubectl exec replicaset/frontend date 2>&1)
   # Replicaset frontend is valid and exists will select the first pod.
   # and Shouldn't have output not found
   kube::test::if_has_not_string "${output_message}" 'not found'
   # These must be pass the validate
-  kube::test::if_has_not_string "${output_message}" 'pod or type/name must be specified'
+  kube::test::if_has_not_string "${output_message}" 'pod, type/name or --filename must be specified'
 
   # Clean up
   kubectl delete pods/test-pod


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Expand `kubectl exec` with capability to specify `--filename` when exec-ing into a pod. 

**Special notes for your reviewer**:
/assign @deads2k 
since you requested this

**Does this PR introduce a user-facing change?**:
```release-note
Allow user to specify resource using --filename flag when invoking kubectl exec
```
