### PR TITLE
Add `ListPluginArgs` and `BuildArgs` method

### DIFF
--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -120,6 +120,11 @@ func (pl *machine2PrioritizerPlugin) Name() string {
 	return "Machine2Prioritizer"
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (pl *machine2PrioritizerPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pl *machine2PrioritizerPlugin) Score(_ context.Context, _ *framework.CycleState, _ *v1.Pod, nodeName string) (int64, *framework.Status) {
 	score := 10
 	if nodeName == "machine2" {
@@ -147,6 +152,11 @@ type FakeExtender struct {
 
 func (f *FakeExtender) Name() string {
 	return "FakeExtender"
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*FakeExtender) BuildArgs() interface{} {
+	return nil
 }
 
 func (f *FakeExtender) IsIgnorable() bool {

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -76,6 +76,11 @@ func (pl *trueFilterPlugin) Name() string {
 	return "TrueFilter"
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*trueFilterPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *trueFilterPlugin) Filter(_ context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	return nil
@@ -93,6 +98,11 @@ func (pl *falseFilterPlugin) Name() string {
 	return "FalseFilter"
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*falseFilterPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *falseFilterPlugin) Filter(_ context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	return framework.NewStatus(framework.Unschedulable, ErrReasonFake)
@@ -108,6 +118,11 @@ type matchFilterPlugin struct{}
 // Name returns name of the plugin.
 func (pl *matchFilterPlugin) Name() string {
 	return "MatchFilter"
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*matchFilterPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 // Filter invoked at the filter extension point.
@@ -134,6 +149,11 @@ func (pl *noPodsFilterPlugin) Name() string {
 	return "NoPodsFilter"
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*noPodsFilterPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *noPodsFilterPlugin) Filter(_ context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	if len(nodeInfo.Pods()) == 0 {
@@ -157,6 +177,11 @@ type fakeFilterPlugin struct {
 // Name returns name of the plugin.
 func (pl *fakeFilterPlugin) Name() string {
 	return "FakeFilter"
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*fakeFilterPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 // Filter invoked at the filter extension point.
@@ -191,6 +216,11 @@ func (pl *numericMapPlugin) Name() string {
 	return "NumericMap"
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*numericMapPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pl *numericMapPlugin) Score(_ context.Context, _ *framework.CycleState, _ *v1.Pod, nodeName string) (int64, *framework.Status) {
 	score, err := strconv.Atoi(nodeName)
 	if err != nil {
@@ -213,6 +243,11 @@ func newReverseNumericMapPlugin() framework.PluginFactory {
 
 func (pl *reverseNumericMapPlugin) Name() string {
 	return "ReverseNumericMap"
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*reverseNumericMapPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 func (pl *reverseNumericMapPlugin) Score(_ context.Context, _ *framework.CycleState, _ *v1.Pod, nodeName string) (int64, *framework.Status) {
@@ -256,6 +291,11 @@ func (pl *trueMapPlugin) Name() string {
 	return "TrueMap"
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*trueMapPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pl *trueMapPlugin) Score(_ context.Context, _ *framework.CycleState, _ *v1.Pod, _ string) (int64, *framework.Status) {
 	return 1, nil
 }
@@ -283,6 +323,11 @@ func newFalseMapPlugin() framework.PluginFactory {
 
 func (pl *falseMapPlugin) Name() string {
 	return "FalseMap"
+}
+
+// BuildArgsreturns the args that were used to build the plugin.
+func (*falseMapPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 func (pl *falseMapPlugin) Score(_ context.Context, _ *framework.CycleState, _ *v1.Pod, _ string) (int64, *framework.Status) {

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -484,6 +484,11 @@ func (t *TestPlugin) Name() string {
 	return t.name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (t *TestPlugin) Score(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) (int64, *framework.Status) {
 	return 1, nil
 }

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -46,6 +46,11 @@ func (b DefaultBinder) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (DefaultBinder) BuildArgs() interface{} {
+	return nil
+}
+
 // Bind binds pods to nodes using the k8s client.
 func (b DefaultBinder) Bind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
 	klog.V(3).Infof("Attempting to bind %v/%v to %v", p.Namespace, p.Name, nodeName)

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
@@ -57,6 +57,11 @@ func (pl *DefaultPodTopologySpread) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*DefaultPodTopologySpread) BuildArgs() interface{} {
+	return nil
+}
+
 // preScoreState computed at PreScore and used at Score.
 type preScoreState struct {
 	selector labels.Selector

--- a/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
+++ b/pkg/scheduler/framework/plugins/examples/multipoint/multipoint.go
@@ -39,6 +39,11 @@ func (mc CommunicatingPlugin) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (CommunicatingPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 type stateData struct {
 	data string
 }

--- a/pkg/scheduler/framework/plugins/examples/prebind/prebind.go
+++ b/pkg/scheduler/framework/plugins/examples/prebind/prebind.go
@@ -39,6 +39,11 @@ func (sr StatelessPreBindExample) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (StatelessPreBindExample) BuildArgs() interface{} {
+	return nil
+}
+
 // PreBind is the functions invoked by the framework at "prebind" extension point.
 func (sr StatelessPreBindExample) PreBind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
 	if pod == nil {

--- a/pkg/scheduler/framework/plugins/examples/stateful/stateful.go
+++ b/pkg/scheduler/framework/plugins/examples/stateful/stateful.go
@@ -47,6 +47,11 @@ func (mp *MultipointExample) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*MultipointExample) BuildArgs() interface{} {
+	return nil
+}
+
 // Reserve is the functions invoked by the framework at "reserve" extension point.
 func (mp *MultipointExample) Reserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
 	// Reserve is not called concurrently, and so we don't need to lock.

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
@@ -51,6 +51,11 @@ func (pl *ImageLocality) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*ImageLocality) BuildArgs() interface{} {
+	return nil
+}
+
 // Score invoked at the score extension point.
 func (pl *ImageLocality) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)

--- a/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
+++ b/pkg/scheduler/framework/plugins/nodeaffinity/node_affinity.go
@@ -50,6 +50,11 @@ func (pl *NodeAffinity) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*NodeAffinity) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *NodeAffinity) Filter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	node := nodeInfo.Node()

--- a/pkg/scheduler/framework/plugins/nodelabel/node_label.go
+++ b/pkg/scheduler/framework/plugins/nodelabel/node_label.go
@@ -61,22 +61,24 @@ func validateNoConflict(presentLabels []string, absentLabels []string) error {
 	return nil
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (pl *NodeLabel) BuildArgs() interface{} {
+	return pl.Args
+}
+
 // New initializes a new plugin and returns it.
 func New(plArgs *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
-	args := Args{}
-	if err := framework.DecodeInto(plArgs, &args); err != nil {
+	pl := &NodeLabel{handle: handle}
+	if err := framework.DecodeInto(plArgs, &pl.Args); err != nil {
 		return nil, err
 	}
-	if err := validateNoConflict(args.PresentLabels, args.AbsentLabels); err != nil {
+	if err := validateNoConflict(pl.PresentLabels, pl.AbsentLabels); err != nil {
 		return nil, err
 	}
-	if err := validateNoConflict(args.PresentLabelsPreference, args.AbsentLabelsPreference); err != nil {
+	if err := validateNoConflict(pl.PresentLabelsPreference, pl.AbsentLabelsPreference); err != nil {
 		return nil, err
 	}
-	return &NodeLabel{
-		handle: handle,
-		Args:   args,
-	}, nil
+	return pl, nil
 }
 
 // NodeLabel checks whether a pod can fit based on the node labels which match a filter that it requests.

--- a/pkg/scheduler/framework/plugins/nodename/node_name.go
+++ b/pkg/scheduler/framework/plugins/nodename/node_name.go
@@ -43,6 +43,11 @@ func (pl *NodeName) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*NodeName) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *NodeName) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	if nodeInfo.Node() == nil {

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -56,6 +56,11 @@ func (pl *NodePorts) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*NodePorts) BuildArgs() interface{} {
+	return nil
+}
+
 // getContainerPorts returns the used host ports of Pods: if 'port' was used, a 'port:true' pair
 // will be in the result; but it does not resolve port conflict.
 func getContainerPorts(pods ...*v1.Pod) []*v1.ContainerPort {

--- a/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods.go
+++ b/pkg/scheduler/framework/plugins/nodepreferavoidpods/node_prefer_avoid_pods.go
@@ -43,6 +43,11 @@ func (pl *NodePreferAvoidPods) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*NodePreferAvoidPods) BuildArgs() interface{} {
+	return nil
+}
+
 // Score invoked at the score extension point.
 func (pl *NodePreferAvoidPods) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	nodeInfo, err := pl.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation.go
@@ -45,6 +45,11 @@ func (ba *BalancedAllocation) Name() string {
 	return BalancedAllocationName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*BalancedAllocation) BuildArgs() interface{} {
+	return nil
+}
+
 // Score invoked at the score extension point.
 func (ba *BalancedAllocation) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	nodeInfo, err := ba.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)

--- a/pkg/scheduler/framework/plugins/noderesources/fit.go
+++ b/pkg/scheduler/framework/plugins/noderesources/fit.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -44,6 +44,7 @@ const (
 
 // Fit is a plugin that checks if a node has sufficient resources.
 type Fit struct {
+	FitArgs
 	ignoredResources sets.String
 }
 
@@ -254,14 +255,18 @@ func fitsRequest(podRequest *preFilterState, nodeInfo *schedulernodeinfo.NodeInf
 	return insufficientResources
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (fit *Fit) BuildArgs() interface{} {
+	return fit.FitArgs
+}
+
 // NewFit initializes a new plugin and returns it.
 func NewFit(plArgs *runtime.Unknown, _ framework.FrameworkHandle) (framework.Plugin, error) {
-	args := &FitArgs{}
-	if err := framework.DecodeInto(plArgs, args); err != nil {
+	fit := &Fit{}
+	if err := framework.DecodeInto(plArgs, &fit.FitArgs); err != nil {
 		return nil, err
 	}
 
-	fit := &Fit{}
-	fit.ignoredResources = sets.NewString(args.IgnoredResources...)
+	fit.ignoredResources = sets.NewString(fit.FitArgs.IgnoredResources...)
 	return fit, nil
 }

--- a/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/least_allocated.go
@@ -41,6 +41,11 @@ func (la *LeastAllocated) Name() string {
 	return LeastAllocatedName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*LeastAllocated) BuildArgs() interface{} {
+	return nil
+}
+
 // Score invoked at the score extension point.
 func (la *LeastAllocated) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	nodeInfo, err := la.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)

--- a/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
+++ b/pkg/scheduler/framework/plugins/noderesources/most_allocated.go
@@ -41,6 +41,11 @@ func (ma *MostAllocated) Name() string {
 	return MostAllocatedName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*MostAllocated) BuildArgs() interface{} {
+	return nil
+}
+
 // Score invoked at the Score extension point.
 func (ma *MostAllocated) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
 	nodeInfo, err := ma.handle.SnapshotSharedLister().NodeInfos().Get(nodeName)

--- a/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
@@ -59,6 +59,11 @@ func (rl *ResourceLimits) Name() string {
 	return ResourceLimitsName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*ResourceLimits) BuildArgs() interface{} {
+	return nil
+}
+
 // PreScore builds and writes cycle state used by Score and NormalizeScore.
 func (rl *ResourceLimits) PreScore(
 	pCtx context.Context,

--- a/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
+++ b/pkg/scheduler/framework/plugins/nodeunschedulable/node_unschedulable.go
@@ -48,6 +48,11 @@ func (pl *NodeUnschedulable) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*NodeUnschedulable) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *NodeUnschedulable) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	if nodeInfo == nil || nodeInfo.Node() == nil {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -68,6 +68,11 @@ func (pl *CSILimits) Name() string {
 	return CSIName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*CSILimits) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *CSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	// If the new pod doesn't have any volume attached to it, the predicate will always be true

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -195,6 +195,11 @@ func (pl *nonCSILimits) Name() string {
 	return pl.name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*nonCSILimits) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *nonCSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	// If a pod doesn't have any volume attached to it, the predicate will always be true.

--- a/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/plugin.go
@@ -49,6 +49,11 @@ func (pl *PodTopologySpread) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*PodTopologySpread) BuildArgs() interface{} {
+	return nil
+}
+
 // New initializes a new plugin and returns it.
 func New(_ *runtime.Unknown, h framework.FrameworkHandle) (framework.Plugin, error) {
 	if h.SnapshotSharedLister() == nil {

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
@@ -35,6 +35,11 @@ func (pl *PrioritySort) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*PrioritySort) BuildArgs() interface{} {
+	return nil
+}
+
 // Less is the function used by the activeQ heap algorithm to sort pods.
 // It sorts pods based on their priority. When priorities are equal, it uses
 // PodInfo.timestamp.
@@ -45,6 +50,6 @@ func (pl *PrioritySort) Less(pInfo1, pInfo2 *framework.PodInfo) bool {
 }
 
 // New initializes a new plugin and returns it.
-func New(plArgs *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
+func New(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
 	return &PrioritySort{}, nil
 }

--- a/pkg/scheduler/framework/plugins/registry.go
+++ b/pkg/scheduler/framework/plugins/registry.go
@@ -53,11 +53,11 @@ func NewInTreeRegistry() framework.Registry {
 		nodeaffinity.Name:                          nodeaffinity.New,
 		podtopologyspread.Name:                     podtopologyspread.New,
 		nodeunschedulable.Name:                     nodeunschedulable.New,
-		noderesources.FitName:                      noderesources.NewFit,
+		noderesources.FitName:                      noderesources.NewFit, //
 		noderesources.BalancedAllocationName:       noderesources.NewBalancedAllocation,
 		noderesources.MostAllocatedName:            noderesources.NewMostAllocated,
 		noderesources.LeastAllocatedName:           noderesources.NewLeastAllocated,
-		noderesources.RequestedToCapacityRatioName: noderesources.NewRequestedToCapacityRatio,
+		noderesources.RequestedToCapacityRatioName: noderesources.NewRequestedToCapacityRatio, //
 		noderesources.ResourceLimitsName:           noderesources.NewResourceLimits,
 		volumebinding.Name:                         volumebinding.New,
 		volumerestrictions.Name:                    volumerestrictions.New,
@@ -67,9 +67,9 @@ func NewInTreeRegistry() framework.Registry {
 		nodevolumelimits.GCEPDName:                 nodevolumelimits.NewGCEPD,
 		nodevolumelimits.AzureDiskName:             nodevolumelimits.NewAzureDisk,
 		nodevolumelimits.CinderName:                nodevolumelimits.NewCinder,
-		interpodaffinity.Name:                      interpodaffinity.New,
-		nodelabel.Name:                             nodelabel.New,
-		serviceaffinity.Name:                       serviceaffinity.New,
+		interpodaffinity.Name:                      interpodaffinity.New, //
+		nodelabel.Name:                             nodelabel.New,        //
+		serviceaffinity.Name:                       serviceaffinity.New,  //
 		queuesort.Name:                             queuesort.New,
 		defaultbinder.Name:                         defaultbinder.New,
 	}

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
@@ -72,6 +72,11 @@ func (s *preFilterState) Clone() framework.StateData {
 	return &copy
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (pl *ServiceAffinity) BuildArgs() interface{} {
+	return pl.args
+}
+
 // New initializes a new plugin and returns it.
 func New(plArgs *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin, error) {
 	args := Args{}

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -51,6 +51,11 @@ func (pl *TaintToleration) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*TaintToleration) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 func (pl *TaintToleration) Filter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeInfo *nodeinfo.NodeInfo) *framework.Status {
 	if nodeInfo == nil || nodeInfo.Node() == nil {

--- a/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
+++ b/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go
@@ -48,6 +48,11 @@ func (pl *VolumeBinding) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*VolumeBinding) BuildArgs() interface{} {
+	return nil
+}
+
 func podHasPVCs(pod *v1.Pod) bool {
 	for _, vol := range pod.Spec.Volumes {
 		if vol.PersistentVolumeClaim != nil {

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -43,6 +43,11 @@ func (pl *VolumeRestrictions) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*VolumeRestrictions) BuildArgs() interface{} {
+	return nil
+}
+
 func isVolumeConflict(volume v1.Volume, pod *v1.Pod) bool {
 	// fast path if there is no conflict checking targets.
 	if volume.GCEPersistentDisk == nil && volume.AWSElasticBlockStore == nil && volume.RBD == nil && volume.ISCSI == nil {

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone.go
@@ -54,6 +54,11 @@ func (pl *VolumeZone) Name() string {
 	return Name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*VolumeZone) BuildArgs() interface{} {
+	return nil
+}
+
 // Filter invoked at the filter extension point.
 //
 // It evaluates if a pod can fit due to the volumes it requests, given

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -880,6 +880,22 @@ func (f *framework) ListPlugins() map[string][]config.Plugin {
 	return nil
 }
 
+func (f *framework) ListPluginArgs() map[string]interface{} {
+	m := make(map[string]interface{})
+	for _, e := range f.getExtensionPoints(&config.Plugins{}) {
+		plugins := reflect.ValueOf(e.slicePtr).Elem()
+		for i := 0; i < plugins.Len(); i++ {
+			name := plugins.Index(i).Interface().(Plugin).Name()
+			args := plugins.Index(i).Interface().(Plugin).BuildArgs()
+			m[name] = args
+		}
+	}
+	if len(m) > 0 {
+		return m
+	}
+	return nil
+}
+
 // ClientSet returns a kubernetes clientset.
 func (f *framework) ClientSet() clientset.Interface {
 	return f.clientSet

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -91,6 +91,11 @@ func (pl *TestScoreWithNormalizePlugin) Name() string {
 	return pl.name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestScoreWithNormalizePlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pl *TestScoreWithNormalizePlugin) NormalizeScore(ctx context.Context, state *CycleState, pod *v1.Pod, scores NodeScoreList) *Status {
 	return injectNormalizeRes(pl.inj, scores)
 }
@@ -113,6 +118,11 @@ func (pl *TestScorePlugin) Name() string {
 	return pl.name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestScorePlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pl *TestScorePlugin) Score(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string) (int64, *Status) {
 	return setScoreRes(pl.inj)
 }
@@ -126,6 +136,11 @@ type PluginNotImplementingScore struct{}
 
 func (pl *PluginNotImplementingScore) Name() string {
 	return pluginNotImplementingScore
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*PluginNotImplementingScore) BuildArgs() interface{} {
+	return nil
 }
 
 // TestPlugin implements all Plugin interfaces.
@@ -147,6 +162,11 @@ func (e *TestPluginPreFilterExtension) RemovePod(ctx context.Context, state *Cyc
 
 func (pl *TestPlugin) Name() string {
 	return pl.name
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 func (pl *TestPlugin) Score(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string) (int64, *Status) {
@@ -202,6 +222,11 @@ func (pl *TestPreFilterPlugin) Name() string {
 	return preFilterPluginName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestPreFilterPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pl *TestPreFilterPlugin) PreFilter(ctx context.Context, state *CycleState, p *v1.Pod) *Status {
 	pl.PreFilterCalled++
 	return nil
@@ -220,6 +245,11 @@ type TestPreFilterWithExtensionsPlugin struct {
 
 func (pl *TestPreFilterWithExtensionsPlugin) Name() string {
 	return preFilterWithExtensionsPluginName
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestPreFilterWithExtensionsPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 func (pl *TestPreFilterWithExtensionsPlugin) PreFilter(ctx context.Context, state *CycleState, p *v1.Pod) *Status {
@@ -250,6 +280,11 @@ func (dp *TestDuplicatePlugin) Name() string {
 	return duplicatePluginName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestDuplicatePlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (dp *TestDuplicatePlugin) PreFilter(ctx context.Context, state *CycleState, p *v1.Pod) *Status {
 	return nil
 }
@@ -272,6 +307,12 @@ type TestPermitPlugin struct {
 func (pp *TestPermitPlugin) Name() string {
 	return permitPlugin
 }
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestPermitPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pp *TestPermitPlugin) Permit(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string) (*Status, time.Duration) {
 	return NewStatus(Wait, ""), time.Duration(10 * time.Second)
 }
@@ -289,6 +330,11 @@ func (pl *TestQueueSortPlugin) Name() string {
 	return queueSortPlugin
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*TestQueueSortPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func (pl *TestQueueSortPlugin) Less(_, _ *PodInfo) bool {
 	return false
 }
@@ -304,6 +350,11 @@ type TestBindPlugin struct{}
 
 func (t TestBindPlugin) Name() string {
 	return bindPlugin
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (TestBindPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 func (t TestBindPlugin) Bind(ctx context.Context, state *CycleState, p *v1.Pod, nodeName string) *Status {

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -209,6 +209,7 @@ type WaitingPod interface {
 
 // Plugin is the parent type for all the scheduling framework plugins.
 type Plugin interface {
+	BuildArgs() interface{}
 	Name() string
 }
 
@@ -491,6 +492,9 @@ type Framework interface {
 
 	// ListPlugins returns a map of extension point name to list of configured Plugins.
 	ListPlugins() map[string][]config.Plugin
+
+	// ListPluginArgs returns a map of extension point name to list of user defined plugin config args.
+	ListPluginArgs() map[string]interface{}
 }
 
 // FrameworkHandle provides data and some tools that plugins can use. It is

--- a/pkg/scheduler/framework/v1alpha1/registry_test.go
+++ b/pkg/scheduler/framework/v1alpha1/registry_test.go
@@ -101,6 +101,11 @@ func (p *mockNoopPlugin) Name() string {
 	return "MockNoop"
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*mockNoopPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 func NewMockNoopPluginFactory() PluginFactory {
 	return func(_ *runtime.Unknown, _ FrameworkHandle) (Plugin, error) {
 		return &mockNoopPlugin{}, nil

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -144,6 +144,11 @@ func (sp *ScorePlugin) Name() string {
 	return scorePluginName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*ScorePlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // reset returns name of the score plugin.
 func (sp *ScorePlugin) reset() {
 	sp.failScore = false
@@ -176,6 +181,11 @@ func (sp *ScoreWithNormalizePlugin) Name() string {
 	return scoreWithNormalizePluginName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*ScoreWithNormalizePlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // reset returns name of the score plugin.
 func (sp *ScoreWithNormalizePlugin) reset() {
 	sp.numScoreCalled = 0
@@ -203,6 +213,11 @@ func (fp *FilterPlugin) Name() string {
 	return filterPluginName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*FilterPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // reset is used to reset filter plugin.
 func (fp *FilterPlugin) reset() {
 	fp.numFilterCalled = 0
@@ -226,6 +241,11 @@ func (rp *ReservePlugin) Name() string {
 	return reservePluginName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*ReservePlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // Reserve is a test function that returns an error or nil, depending on the
 // value of "failReserve".
 func (rp *ReservePlugin) Reserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) *framework.Status {
@@ -244,6 +264,11 @@ func (rp *ReservePlugin) reset() {
 // Name returns name of the plugin.
 func (*PreScorePlugin) Name() string {
 	return preScorePluginName
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*PreScorePlugin) BuildArgs() interface{} {
+	return nil
 }
 
 // PreScore is a test function.
@@ -265,6 +290,11 @@ func (pfp *PreScorePlugin) reset() {
 // Name returns name of the plugin.
 func (pp *PreBindPlugin) Name() string {
 	return preBindPluginName
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*PreBindPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 // PreBind is a test function that returns (true, nil) or errors for testing.
@@ -290,6 +320,11 @@ const bindPluginAnnotation = "bindPluginName"
 
 func (bp *BindPlugin) Name() string {
 	return bp.PluginName
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*BindPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 func (bp *BindPlugin) Bind(ctx context.Context, state *framework.CycleState, p *v1.Pod, nodeName string) *framework.Status {
@@ -321,6 +356,11 @@ func (pp *PostBindPlugin) Name() string {
 	return pp.name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*PostBindPlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // PostBind is a test function, which counts the number of times called.
 func (pp *PostBindPlugin) PostBind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
 	pp.numPostBindCalled++
@@ -337,6 +377,11 @@ func (pp *PostBindPlugin) reset() {
 // Name returns name of the plugin.
 func (pp *PreFilterPlugin) Name() string {
 	return prefilterPluginName
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*PreFilterPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 // Extensions returns the PreFilterExtensions interface.
@@ -368,6 +413,11 @@ func (up *UnreservePlugin) Name() string {
 	return up.name
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*UnreservePlugin) BuildArgs() interface{} {
+	return nil
+}
+
 // Unreserve is a test function that returns an error or nil, depending on the
 // value of "failUnreserve".
 func (up *UnreservePlugin) Unreserve(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) {
@@ -385,6 +435,11 @@ func (up *UnreservePlugin) reset() {
 // Name returns name of the plugin.
 func (pp *PermitPlugin) Name() string {
 	return pp.name
+}
+
+// BuildArgs returns the args that were used to build the plugin.
+func (*PermitPlugin) BuildArgs() interface{} {
+	return nil
 }
 
 // Permit implements the permit test plugin.

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -82,6 +82,11 @@ func (fp *tokenFilter) Name() string {
 	return tokenFilterName
 }
 
+// BuildArgs returns the args that were used to build the plugin.
+func (*tokenFilter) BuildArgs() interface{} {
+	return nil
+}
+
 func (fp *tokenFilter) Filter(ctx context.Context, state *framework.CycleState, pod *v1.Pod,
 	nodeInfo *schedulernodeinfo.NodeInfo) *framework.Status {
 	if fp.Tokens > 0 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Add method `ListPluginArgs` to `Framework` and method `BuildArgs` to `Plugin` for testing plugin configs.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs #88027 

**Special notes for your reviewer**:
This pr just add the method for writing tests.
The real test will be added in a follow-up pr.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
action required: Add `BuildArgs` method to scheduler framework's `Plugin` interface
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
