### PR TITLE
Remove the unsupported CloudProviderBackoffMode from Azure cloud provider config

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_backoff.go
@@ -104,10 +104,6 @@ func (az *Cloud) ListVirtualMachines(resourceGroup string) ([]compute.VirtualMac
 // getPrivateIPsForMachine is wrapper for optional backoff getting private ips
 // list of a node by name
 func (az *Cloud) getPrivateIPsForMachine(nodeName types.NodeName) ([]string, error) {
-	if az.Config.shouldOmitCloudProviderBackoff() {
-		return az.vmSet.GetPrivateIPsByNodeName(string(nodeName))
-	}
-
 	return az.getPrivateIPsForMachineWithRetry(nodeName)
 }
 
@@ -131,10 +127,6 @@ func (az *Cloud) getPrivateIPsForMachineWithRetry(nodeName types.NodeName) ([]st
 }
 
 func (az *Cloud) getIPForMachine(nodeName types.NodeName) (string, string, error) {
-	if az.Config.shouldOmitCloudProviderBackoff() {
-		return az.vmSet.GetIPByNodeName(string(nodeName))
-	}
-
 	return az.GetIPForMachineWithRetry(nodeName)
 }
 
@@ -398,8 +390,4 @@ func (az *Cloud) CreateOrUpdateVMSS(resourceGroupName string, VMScaleSetName str
 	}
 
 	return nil
-}
-
-func (cfg *Config) shouldOmitCloudProviderBackoff() bool {
-	return cfg.CloudProviderBackoffMode == backoffModeV2
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/azure_client_config.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/azure_client_config.go
@@ -32,12 +32,6 @@ type ClientConfig struct {
 	Authorizer              autorest.Authorizer
 	RateLimitConfig         *RateLimitConfig
 	Backoff                 *retry.Backoff
-
-	// Depracated configures (retry.Backoff is preferred).
-	// Those configurations would be removed after all Azure clients are moved to new implementations.
-	CloudProviderBackoffRetries    int
-	CloudProviderBackoffDuration   int
-	ShouldOmitCloudProviderBackoff bool
 }
 
 // WithRateLimiter returns a new ClientConfig with rateLimitConfig set.


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup
/sig cloud-provider
/area provider-azure
/priority important-soon

**What this PR does / why we need it**:

Remove the unsupported CloudProviderBackoffMode from Azure cloud provider config. Since the clients from Azure Go SDK has been reimplemented in cloud provider, CloudProviderBackoffMode is not used anymore. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
cloud provider config CloudProviderBackoffMode has been removed since it won't be used anymore.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
