### PR TITLE
Fixed bug where jsonpath expression with nested range produces wrong output

### DIFF
--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -29,11 +29,11 @@ import (
 type JSONPath struct {
 	name       string
 	parser     *Parser
-	stack      [][]reflect.Value // push and pop values in different scopes
-	cur        []reflect.Value   // current scope values
 	beginRange int
 	inRange    int
 	endRange   int
+
+	lastEndNode *Node
 
 	allowMissingKeys bool
 }
@@ -81,12 +81,12 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 		return nil, fmt.Errorf("%s is an incomplete jsonpath template", j.name)
 	}
 
-	j.cur = []reflect.Value{reflect.ValueOf(data)}
+	cur := []reflect.Value{reflect.ValueOf(data)}
 	nodes := j.parser.Root.Nodes
 	fullResult := [][]reflect.Value{}
 	for i := 0; i < len(nodes); i++ {
 		node := nodes[i]
-		results, err := j.walk(j.cur, node)
+		results, err := j.walk(cur, node)
 		if err != nil {
 			return nil, err
 		}
@@ -94,24 +94,31 @@ func (j *JSONPath) FindResults(data interface{}) ([][]reflect.Value, error) {
 		// encounter an end node, break the current block
 		if j.endRange > 0 && j.endRange <= j.inRange {
 			j.endRange--
+			j.lastEndNode = &nodes[i]
 			break
 		}
 		// encounter a range node, start a range loop
 		if j.beginRange > 0 {
 			j.beginRange--
 			j.inRange++
-			for k, value := range results {
+			for _, value := range results {
 				j.parser.Root.Nodes = nodes[i+1:]
-				if k == len(results)-1 {
-					j.inRange--
-				}
 				nextResults, err := j.FindResults(value.Interface())
 				if err != nil {
 					return nil, err
 				}
 				fullResult = append(fullResult, nextResults...)
 			}
-			break
+			j.inRange--
+
+			// Fast forward to resume processing after the most recent end node that was encountered
+			for k := i + 1; k < len(nodes); k++ {
+				if &nodes[k] == j.lastEndNode {
+					i = k
+					break
+				}
+			}
+			continue
 		}
 		fullResult = append(fullResult, results)
 	}
@@ -212,17 +219,11 @@ func (j *JSONPath) evalIdentifier(input []reflect.Value, node *IdentifierNode) (
 	results := []reflect.Value{}
 	switch node.Name {
 	case "range":
-		j.stack = append(j.stack, j.cur)
 		j.beginRange++
 		results = input
 	case "end":
-		if j.endRange < j.inRange { // inside a loop, break the current block
+		if j.inRange > 0 {
 			j.endRange++
-			break
-		}
-		// the loop is about to end, pop value and continue the following execution
-		if len(j.stack) > 0 {
-			j.cur, j.stack = j.stack[len(j.stack)-1], j.stack[:len(j.stack)-1]
 		} else {
 			return results, fmt.Errorf("not in range, nothing to end")
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixed a bug where executing a kubectl command with a jsonpath output expression that has a nested range would ignore expressions following the nested range

I made changes to correctly handle nested ranges in JSONPath expressions and added unit tests for various nested 2-level and 3-level range scenarios.

Example:
```
kubectl get pod -o jsonpath='{range.items[*]}{@.metadata.name}{","}{range@.status.conditions[*]}{@.type}{" "}{end}{","}{@.metadata.name}{"\n"}{end}'
```

Old output (some parts of the expression are missing after the {end} identifier):
```
nginx1,Initialized Ready ContainersReady PodScheduled nginx2,Initialized Ready ContainersReady PodScheduled nginx3,Initialized Ready ContainersReady PodScheduled ,nginx3
```

New output (correct output now):
```
nginx1,Initialized Ready ContainersReady PodScheduled ,nginx1
nginx2,Initialized Ready ContainersReady PodScheduled ,nginx2
nginx3,Initialized Ready ContainersReady PodScheduled ,nginx3
```

**Which issue(s) this PR fixes**:
Fixes #86130 

**Special notes for your reviewer**:
The main problem was on line 114, where it was breaking after a range was finished.  The fix was to keep track of the point where the end occurred and "fast-forward" `i` to that point after the range is finished so it can continue processing from there and not break out of the loop.

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a bug where executing a kubectl command with a jsonpath output expression that has a nested range would ignore expressions following the nested range.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
