### PR TITLE
Utilerrors.Aggregate: Allow using with errors.Is()

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors.go
@@ -28,9 +28,14 @@ type MessageCountMap map[string]int
 
 // Aggregate represents an object that contains multiple errors, but does not
 // necessarily have singular semantic meaning.
+// The aggregate can be used with `errors.Is()` to check for the occurrence of
+// a specific error type.
+// Errors.As() is not supported, because the caller presumably cares about a
+// specific error of potentially multiple that match the given type.
 type Aggregate interface {
 	error
 	Errors() []error
+	Is(error) bool
 }
 
 // NewAggregate converts a slice of errors into an Aggregate interface, which
@@ -71,16 +76,17 @@ func (agg aggregate) Error() string {
 	}
 	seenerrs := sets.NewString()
 	result := ""
-	agg.visit(func(err error) {
+	agg.visit(func(err error) bool {
 		msg := err.Error()
 		if seenerrs.Has(msg) {
-			return
+			return false
 		}
 		seenerrs.Insert(msg)
 		if len(seenerrs) > 1 {
 			result += ", "
 		}
 		result += msg
+		return false
 	})
 	if len(seenerrs) == 1 {
 		return result
@@ -88,19 +94,33 @@ func (agg aggregate) Error() string {
 	return "[" + result + "]"
 }
 
-func (agg aggregate) visit(f func(err error)) {
+func (agg aggregate) Is(target error) bool {
+	return agg.visit(func(err error) bool {
+		return errors.Is(err, target)
+	})
+}
+
+func (agg aggregate) visit(f func(err error) bool) bool {
 	for _, err := range agg {
 		switch err := err.(type) {
 		case aggregate:
-			err.visit(f)
+			if match := err.visit(f); match {
+				return match
+			}
 		case Aggregate:
 			for _, nestedErr := range err.Errors() {
-				f(nestedErr)
+				if match := f(nestedErr); match {
+					return match
+				}
 			}
 		default:
-			f(err)
+			if match := f(err); match {
+				return match
+			}
 		}
 	}
+
+	return false
 }
 
 // Errors is part of the Aggregate interface.

--- a/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/errors/errors_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package errors
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"sort"
@@ -428,5 +429,102 @@ func TestAggregateGoroutines(t *testing.T) {
 				t.Errorf("%d: expected %v, got aggregate containing %v", i, testCase.expected, err)
 			}
 		}
+	}
+}
+
+type alwaysMatchingError struct{}
+
+func (_ alwaysMatchingError) Error() string {
+	return "error"
+}
+
+func (_ alwaysMatchingError) Is(_ error) bool {
+	return true
+}
+
+type someError struct{ msg string }
+
+func (se someError) Error() string {
+	if se.msg != "" {
+		return se.msg
+	}
+	return "err"
+}
+
+func TestAggregateWithErrorsIs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		err          error
+		matchAgainst error
+		expectMatch  bool
+	}{
+		{
+			name:         "no match",
+			err:          aggregate{errors.New("my-error"), errors.New("my-other-error")},
+			matchAgainst: fmt.Errorf("no entry %s", "here"),
+		},
+		{
+			name:         "match via .Is()",
+			err:          aggregate{errors.New("forbidden"), alwaysMatchingError{}},
+			matchAgainst: errors.New("unauthorized"),
+			expectMatch:  true,
+		},
+		{
+			name:         "match via equality",
+			err:          aggregate{errors.New("err"), someError{}},
+			matchAgainst: someError{},
+			expectMatch:  true,
+		},
+		{
+			name:         "match via nested aggregate",
+			err:          aggregate{errors.New("closed today"), aggregate{aggregate{someError{}}}},
+			matchAgainst: someError{},
+			expectMatch:  true,
+		},
+		{
+			name:         "match via wrapped aggregate",
+			err:          fmt.Errorf("wrap: %w", aggregate{errors.New("err"), someError{}}),
+			matchAgainst: someError{},
+			expectMatch:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := errors.Is(tc.err, tc.matchAgainst)
+			if result != tc.expectMatch {
+				t.Errorf("expected match: %t, got match: %t", tc.expectMatch, result)
+			}
+		})
+	}
+}
+
+type accessTrackingError struct {
+	wasAccessed bool
+}
+
+func (accessTrackingError) Error() string {
+	return "err"
+}
+
+func (ate *accessTrackingError) Is(_ error) bool {
+	ate.wasAccessed = true
+	return true
+}
+
+var _ error = &accessTrackingError{}
+
+func TestErrConfigurationInvalidWithErrorsIsShortCircuitsOnFirstMatch(t *testing.T) {
+	errC := aggregate{&accessTrackingError{}, &accessTrackingError{}}
+	_ = errors.Is(errC, &accessTrackingError{})
+
+	var numAccessed int
+	for _, err := range errC {
+		if ate := err.(*accessTrackingError); ate.wasAccessed {
+			numAccessed++
+		}
+	}
+	if numAccessed != 1 {
+		t.Errorf("expected exactly one error to get accessed, got %d", numAccessed)
 	}
 }

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -86,9 +86,39 @@ func (e errConfigurationInvalid) Error() string {
 	return fmt.Sprintf("invalid configuration: %v", utilerrors.NewAggregate(e).Error())
 }
 
-// Errors implements the AggregateError interface
+// Errors implements the utilerrors.Aggregate interface
 func (e errConfigurationInvalid) Errors() []error {
 	return e
+}
+
+// Is implements the utilerrors.Aggregate interface
+func (e errConfigurationInvalid) Is(target error) bool {
+	return e.visit(func(err error) bool {
+		return errors.Is(err, target)
+	})
+}
+
+func (e errConfigurationInvalid) visit(f func(err error) bool) bool {
+	for _, err := range e {
+		switch err := err.(type) {
+		case errConfigurationInvalid:
+			if match := err.visit(f); match {
+				return match
+			}
+		case utilerrors.Aggregate:
+			for _, nestedErr := range err.Errors() {
+				if match := f(nestedErr); match {
+					return match
+				}
+			}
+		default:
+			if match := f(err); match {
+				return match
+			}
+		}
+	}
+
+	return false
 }
 
 // IsConfigurationInvalid returns true if the provided error indicates the configuration is invalid.

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package clientcmd
 
 import (
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -567,5 +569,102 @@ func (c configValidationTest) testAuthInfo(authInfoName string, t *testing.T) {
 		if len(errs) != 0 {
 			t.Errorf("Unexpected error: %v", utilerrors.NewAggregate(errs))
 		}
+	}
+}
+
+type alwaysMatchingError struct{}
+
+func (_ alwaysMatchingError) Error() string {
+	return "error"
+}
+
+func (_ alwaysMatchingError) Is(_ error) bool {
+	return true
+}
+
+type someError struct{ msg string }
+
+func (se someError) Error() string {
+	if se.msg != "" {
+		return se.msg
+	}
+	return "err"
+}
+
+func TestErrConfigurationInvalidWithErrorsIs(t *testing.T) {
+	testCases := []struct {
+		name         string
+		err          error
+		matchAgainst error
+		expectMatch  bool
+	}{
+		{
+			name:         "no match",
+			err:          errConfigurationInvalid{errors.New("my-error"), errors.New("my-other-error")},
+			matchAgainst: fmt.Errorf("no entry %s", "here"),
+		},
+		{
+			name:         "match via .Is()",
+			err:          errConfigurationInvalid{errors.New("forbidden"), alwaysMatchingError{}},
+			matchAgainst: errors.New("unauthorized"),
+			expectMatch:  true,
+		},
+		{
+			name:         "match via equality",
+			err:          errConfigurationInvalid{errors.New("err"), someError{}},
+			matchAgainst: someError{},
+			expectMatch:  true,
+		},
+		{
+			name:         "match via nested aggregate",
+			err:          errConfigurationInvalid{errors.New("closed today"), errConfigurationInvalid{errConfigurationInvalid{someError{}}}},
+			matchAgainst: someError{},
+			expectMatch:  true,
+		},
+		{
+			name:         "match via wrapped aggregate",
+			err:          fmt.Errorf("wrap: %w", errConfigurationInvalid{errors.New("err"), someError{}}),
+			matchAgainst: someError{},
+			expectMatch:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := errors.Is(tc.err, tc.matchAgainst)
+			if result != tc.expectMatch {
+				t.Errorf("expected match: %t, got match: %t", tc.expectMatch, result)
+			}
+		})
+	}
+}
+
+type accessTrackingError struct {
+	wasAccessed bool
+}
+
+func (accessTrackingError) Error() string {
+	return "err"
+}
+
+func (ate *accessTrackingError) Is(_ error) bool {
+	ate.wasAccessed = true
+	return true
+}
+
+var _ error = &accessTrackingError{}
+
+func TestErrConfigurationInvalidWithErrorsIsShortCircuitsOnFirstMatch(t *testing.T) {
+	errC := errConfigurationInvalid{&accessTrackingError{}, &accessTrackingError{}}
+	_ = errors.Is(errC, &accessTrackingError{})
+
+	var numAccessed int
+	for _, err := range errC {
+		if ate := err.(*accessTrackingError); ate.wasAccessed {
+			numAccessed++
+		}
+	}
+	if numAccessed != 1 {
+		t.Errorf("expected exactly one error to get accessed, got %d", numAccessed)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:

Today, using `utilerrors.NewAggregate()`  in combination with `errors.Is()` is annoying, as the `Errors()` method has to be called and then the caller has to iterate over all of them and use `errors.Is`. Making it work for nested aggregates is even more comlicated.

This PR extends the Aggregate with an `Is` method that allows to use it with `errors.Is`

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @liggit @lavalamp 