### PR TITLE
Prefer Stable Zone/Region/InstanceType Topology Keys

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -55,27 +55,27 @@ var labelReconcileInfo = []struct {
 	ensureSecondaryExists bool
 }{
 	{
-		// Reconcile the beta and the GA zone label using the beta label as
+		// Reconcile the beta and the GA zone label using the GA label as
 		// the source of truth
-		// TODO: switch the primary key to GA labels in v1.21
-		primaryKey:            v1.LabelZoneFailureDomain,
-		secondaryKey:          v1.LabelZoneFailureDomainStable,
+		// TODO: remove support for secondary key in v1.21
+		primaryKey:            v1.LabelZoneFailureDomainStable,
+		secondaryKey:          v1.LabelZoneFailureDomain,
 		ensureSecondaryExists: true,
 	},
 	{
-		// Reconcile the beta and the stable region label using the beta label as
+		// Reconcile the beta and the stable region label using the GA label as
 		// the source of truth
-		// TODO: switch the primary key to GA labels in v1.21
-		primaryKey:            v1.LabelZoneRegion,
-		secondaryKey:          v1.LabelZoneRegionStable,
+		// TODO: remove support for secondary key in v1.21
+		primaryKey:            v1.LabelZoneRegionStable,
+		secondaryKey:          v1.LabelZoneRegion,
 		ensureSecondaryExists: true,
 	},
 	{
-		// Reconcile the beta and the stable instance-type label using the beta label as
+		// Reconcile the beta and the stable instance-type label using the GA label as
 		// the source of truth
-		// TODO: switch the primary key to GA labels in v1.21
-		primaryKey:            v1.LabelInstanceType,
-		secondaryKey:          v1.LabelInstanceTypeStable,
+		// TODO: remove support for secondary key in v1.21
+		primaryKey:            v1.LabelInstanceTypeStable,
+		secondaryKey:          v1.LabelInstanceType,
 		ensureSecondaryExists: true,
 	},
 }

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -688,9 +688,9 @@ func Test_reconcileNodeLabels(t *testing.T) {
 		{
 			name: "requires reconcile",
 			labels: map[string]string{
-				v1.LabelZoneFailureDomain: "foo",
-				v1.LabelZoneRegion:        "bar",
-				v1.LabelInstanceType:      "the-best-type",
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelInstanceTypeStable:      "the-best-type",
 			},
 			expectedLabels: map[string]string{
 				v1.LabelZoneFailureDomain:       "foo",
@@ -725,12 +725,12 @@ func Test_reconcileNodeLabels(t *testing.T) {
 		{
 			name: "require reconcile -- secondary labels are different from primary",
 			labels: map[string]string{
-				v1.LabelZoneFailureDomain:       "foo",
-				v1.LabelZoneRegion:              "bar",
-				v1.LabelZoneFailureDomainStable: "wrongfoo",
-				v1.LabelZoneRegionStable:        "wrongbar",
-				v1.LabelInstanceType:            "the-best-type",
-				v1.LabelInstanceTypeStable:      "the-wrong-type",
+				v1.LabelZoneFailureDomain:       "wrongfoo",
+				v1.LabelZoneRegion:              "wrongbar",
+				v1.LabelZoneFailureDomainStable: "foo",
+				v1.LabelZoneRegionStable:        "bar",
+				v1.LabelInstanceType:            "the-wrong-type",
+				v1.LabelInstanceTypeStable:      "the-best-type",
 			},
 			expectedLabels: map[string]string{
 				v1.LabelZoneFailureDomain:       "foo",

--- a/pkg/util/node/node.go
+++ b/pkg/util/node/node.go
@@ -143,24 +143,22 @@ func GetNodeIP(client clientset.Interface, hostname string) net.IP {
 // Since there are currently two separate zone keys:
 //   * "failure-domain.beta.kubernetes.io/zone"
 //   * "topology.kubernetes.io/zone"
-// GetZoneKey will first check failure-domain.beta.kubernetes.io/zone and if not exists, will then check
-// topology.kubernetes.io/zone
+// GetZoneKey will first check topology.kubernetes.io/zone and if not exists, will then check
+// failure-domain.beta.kubernetes.io/zone (deprecated and to be removed in v1.21)
 func GetZoneKey(node *v1.Node) string {
 	labels := node.Labels
 	if labels == nil {
 		return ""
 	}
 
-	// TODO: prefer stable labels for zone in v1.18
-	zone, ok := labels[v1.LabelZoneFailureDomain]
+	zone, ok := labels[v1.LabelZoneFailureDomainStable]
 	if !ok {
-		zone, _ = labels[v1.LabelZoneFailureDomainStable]
+		zone, _ = labels[v1.LabelZoneFailureDomain]
 	}
 
-	// TODO: prefer stable labels for region in v1.18
-	region, ok := labels[v1.LabelZoneRegion]
+	region, ok := labels[v1.LabelZoneRegionStable]
 	if !ok {
-		region, _ = labels[v1.LabelZoneRegionStable]
+		region, _ = labels[v1.LabelZoneRegion]
 	}
 
 	if region == "" && zone == "" {

--- a/pkg/util/node/node_test.go
+++ b/pkg/util/node/node_test.go
@@ -186,7 +186,7 @@ func Test_GetZoneKey(t *testing.T) {
 					},
 				},
 			},
-			zone: "region2:\x00:zone2",
+			zone: "region1:\x00:zone1",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In https://github.com/kubernetes/kubernetes/pull/81431 and https://github.com/kubernetes/kubernetes/pull/82049, we added stable versions of the zone/region/instance-type labels but the preferred label was still the beta labels so upgrading clusters don't break. 

Since all v1.17 clusters should have both beta and stable labels, we can start to prefer the new stable labels if both exist. We still ensure the existence of the beta labels so existing users consuming it do not break.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Prefer Stable Zone/Region/InstanceType Topology Keys
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
