### PR TITLE
fix lint issue: avoid using reflect.DeepEqual with errors

### DIFF
--- a/pkg/controller/service/controller_test.go
+++ b/pkg/controller/service/controller_test.go
@@ -648,7 +648,7 @@ func TestProcessServiceCreateOrUpdateK8sError(t *testing.T) {
 				return true, nil, tc.k8sErr
 			})
 
-			if err := controller.processServiceCreateOrUpdate(svc, svcName); !reflect.DeepEqual(err, tc.expectErr) {
+			if err := controller.processServiceCreateOrUpdate(svc, svcName); err.Error() != tc.expectErr.Error() {
 				t.Fatalf("processServiceCreateOrUpdate() = %v, want %v", err, tc.expectErr)
 			}
 			if tc.expectErr == nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This will fix a lint issue. Our end goal in the comparison is to compare the error messages only. So rather than using reflect.DeepEqual, it better if do a string string comparison. This way its more explict about what we are comparing.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc: @MrHohn 