### PR TITLE
Honor status.podIP over status.podIPs and node.spec.podCIDR over node.spec.PodCIDRs when mismatched

### DIFF
--- a/pkg/apis/core/v1/conversion.go
+++ b/pkg/apis/core/v1/conversion.go
@@ -253,9 +253,13 @@ func Convert_v1_PodStatus_To_core_PodStatus(in *v1.PodStatus, out *core.PodStatu
 		return err
 	}
 
-	// If both fields (v1.PodIPs and v1.PodIP) are provided, then test v1.PodIP == v1.PodIPs[0]
+	// If both fields (v1.PodIPs and v1.PodIP) are provided and differ, then PodIP is authoritative for compatibility with older kubelets
 	if (len(in.PodIP) > 0 && len(in.PodIPs) > 0) && (in.PodIP != in.PodIPs[0].IP) {
-		return fmt.Errorf("conversion Error: v1.PodIP(%v) != v1.PodIPs[0](%v)", in.PodIP, in.PodIPs[0].IP)
+		out.PodIPs = []core.PodIP{
+			{
+				IP: in.PodIP,
+			},
+		}
 	}
 	// at the this point, autoConvert copied v1.PodIPs -> core.PodIPs
 	// if v1.PodIPs was empty but v1.PodIP is not, then set core.PodIPs[0] with v1.PodIP
@@ -321,9 +325,9 @@ func Convert_v1_NodeSpec_To_core_NodeSpec(in *v1.NodeSpec, out *core.NodeSpec, s
 	if err := autoConvert_v1_NodeSpec_To_core_NodeSpec(in, out, s); err != nil {
 		return err
 	}
-	// If both fields (v1.PodCIDRs and v1.PodCIDR) are provided, then test v1.PodCIDR == v1.PodCIDRs[0]
+	// If both fields (v1.PodCIDRs and v1.PodCIDR) are provided and differ, then PodCIDR is authoritative for compatibility with older clients
 	if (len(in.PodCIDR) > 0 && len(in.PodCIDRs) > 0) && (in.PodCIDR != in.PodCIDRs[0]) {
-		return fmt.Errorf("conversion Error: v1.PodCIDR(%v) != v1.CIDRs[0](%v)", in.PodCIDR, in.PodCIDRs[0])
+		out.PodCIDRs = []string{in.PodCIDR}
 	}
 
 	// at the this point, autoConvert copied v1.PodCIDRs -> core.PodCIDRs


### PR DESCRIPTION
**What type of PR is this?**
/kind api-change
/kind bug

**What this PR does / why we need it**:

### When status.podIP and status.podIPs[0] do not agree, honor status.podIP as the older API field, rather than failing to convert.

This is required to support Kubelets < 1.16 running against API servers >= 1.16.

Kubelets >= 1.16 set both podIP and podIPs:
https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/kubelet/kubelet_pods.go#L1386-L1396

Kubelets < 1.16 only set podIP:
https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/kubelet/kubelet_pods.go#L1384-L1385

However, since kubelets update pod status with a patch API request, existing unknown fields are preserved. That means a 1.15 kubelet, when trying to modify a podIP, will only update the podIP field and not podIPs.

### When node.spec.podCIDR and node.spec.podCIDRs[0] do not agree, honor node.spec.podCIDR as the older API field, rather than failing to convert.

prior to 1.16, the rangeAllocator and cloudCIDRAllocator controllers updated node.spec.podCIDR using a patch:
https://github.com/kubernetes/kubernetes/blob/release-1.15/pkg/controller/nodeipam/ipam/adapter.go#L92-L106

in 1.16+, there are three methods to update node specs, all of which use patch:
* https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/util/node/node.go#L194-L207
* https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/util/node/node.go#L179-L186
* https://github.com/kubernetes/kubernetes/blob/release-1.16/pkg/controller/nodeipam/ipam/adapter.go#L94-L106

These patch methods either just set the old node.spec.podCIDR field, or they set both the old and new podCIDR/podCIDRs field (for paths that are multi-CIDR-aware).

**Which issue(s) this PR fixes**:
Fixes #88494

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a regression with clients prior to 1.15 not being able to update podIP in pod status, or podCIDR in node spec, against >= 1.16 API servers
```

/cc @thockin @khenidak 
/sig network