### PR TITLE
Fix pkg/registry typos in some error message, variable names etc

### DIFF
--- a/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
+++ b/pkg/registry/autoscaling/horizontalpodautoscaler/storage/storage_test.go
@@ -205,9 +205,9 @@ func TestUpdateStatus(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	obj, err := storage.Get(ctx, "foo", &metav1.GetOptions{})
-	autosclaerOut := obj.(*autoscaling.HorizontalPodAutoscaler)
+	autoscalerOut := obj.(*autoscaling.HorizontalPodAutoscaler)
 	// only compare the meaningful update b/c we can't compare due to metadata
-	if !apiequality.Semantic.DeepEqual(autoscalerIn.Status, autosclaerOut.Status) {
-		t.Errorf("unexpected object: %s", diff.ObjectDiff(autoscalerIn, autosclaerOut))
+	if !apiequality.Semantic.DeepEqual(autoscalerIn.Status, autoscalerOut.Status) {
+		t.Errorf("unexpected object: %s", diff.ObjectDiff(autoscalerIn, autoscalerOut))
 	}
 }

--- a/pkg/registry/core/service/ipallocator/controller/repair_test.go
+++ b/pkg/registry/core/service/ipallocator/controller/repair_test.go
@@ -270,13 +270,13 @@ func TestShouldWorkOnSecondary(t *testing.T) {
 
 			fakeClient := makeFakeClientSet()
 			primaryRegistry := makeRangeRegistry(t, tc.primaryNet.String())
-			var secondaryRegistery *mockRangeRegistry
+			var secondaryRegistry *mockRangeRegistry
 
 			if tc.secondaryNet != nil {
-				secondaryRegistery = makeRangeRegistry(t, tc.secondaryNet.String())
+				secondaryRegistry = makeRangeRegistry(t, tc.secondaryNet.String())
 			}
 
-			repair := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), tc.primaryNet, primaryRegistry, tc.secondaryNet, secondaryRegistery)
+			repair := NewRepair(0, fakeClient.CoreV1(), fakeClient.CoreV1(), tc.primaryNet, primaryRegistry, tc.secondaryNet, secondaryRegistry)
 			if repair.shouldWorkOnSecondary() != tc.expectedResult {
 				t.Errorf("shouldWorkOnSecondary should be %v and found %v", tc.expectedResult, repair.shouldWorkOnSecondary())
 			}

--- a/pkg/registry/core/service/strategy_test.go
+++ b/pkg/registry/core/service/strategy_test.go
@@ -196,7 +196,7 @@ func TestBeforeUpdate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name: "change selectpor",
+			name: "change selector",
 			tweakSvc: func(oldSvc, newSvc *api.Service) {
 				newSvc.Spec.Selector = map[string]string{"newkey": "newvalue"}
 			},

--- a/pkg/registry/networking/ingress/storage/storage_test.go
+++ b/pkg/registry/networking/ingress/storage/storage_test.go
@@ -164,7 +164,7 @@ func TestUpdate(t *testing.T) {
 			})
 			return object
 		},
-		// invalid updateFunc: ObjeceMeta is not to be tampered with.
+		// invalid updateFunc: ObjectMeta is not to be tampered with.
 		func(obj runtime.Object) runtime.Object {
 			object := obj.(*networking.Ingress)
 			object.Name = ""

--- a/pkg/registry/networking/ingress/strategy.go
+++ b/pkg/registry/networking/ingress/strategy.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/kubernetes/pkg/apis/networking/validation"
 )
 
-// ingressStrategy implements verification logic for Replication Ingresss.
+// ingressStrategy implements verification logic for Replication Ingress.
 type ingressStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator

--- a/pkg/registry/storage/volumeattachment/strategy_test.go
+++ b/pkg/registry/storage/volumeattachment/strategy_test.go
@@ -174,7 +174,7 @@ func TestVolumeAttachmentStatusStrategy(t *testing.T) {
 	expectedVolumeAttachment := statusVolumeAttachment.DeepCopy()
 	StatusStrategy.PrepareForUpdate(ctx, statusVolumeAttachment, volumeAttachment)
 	if !apiequality.Semantic.DeepEqual(statusVolumeAttachment, expectedVolumeAttachment) {
-		t.Errorf("unexpected objects differerence after modifying status: %v", diff.ObjectDiff(statusVolumeAttachment, expectedVolumeAttachment))
+		t.Errorf("unexpected objects difference after modifying status: %v", diff.ObjectDiff(statusVolumeAttachment, expectedVolumeAttachment))
 	}
 
 	// spec and metadata modifications should be dropped
@@ -192,7 +192,7 @@ func TestVolumeAttachmentStatusStrategy(t *testing.T) {
 
 	StatusStrategy.PrepareForUpdate(ctx, newVolumeAttachment, volumeAttachment)
 	if !apiequality.Semantic.DeepEqual(newVolumeAttachment, volumeAttachment) {
-		t.Errorf("unexpected objects differerence after modifying spec: %v", diff.ObjectDiff(newVolumeAttachment, volumeAttachment))
+		t.Errorf("unexpected objects difference after modifying spec: %v", diff.ObjectDiff(newVolumeAttachment, volumeAttachment))
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup

**What this PR does / why we need it**:
> To fix pkg/registry Typos in comments, error messages, test case name meta

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
> Fixes #

**Special notes for your reviewer**:
> NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
> NONE