### PR TITLE
Build kubemark image on the ARCH other than AMD64

### DIFF
--- a/cluster/images/kubemark/Dockerfile
+++ b/cluster/images/kubemark/Dockerfile
@@ -14,6 +14,7 @@
 
 # The line below points to distroless/base as of 2019-11-15. The SHA should be
 # kept in sycn with distroless_base definition in the WORKSPACE file.
-FROM gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5
+
+FROM BASEIMAGE
 
 COPY kubemark /kubemark

--- a/cluster/images/kubemark/Makefile
+++ b/cluster/images/kubemark/Makefile
@@ -21,11 +21,32 @@
 #   make REGISTRY=$VAR
 REGISTRY := $(if $(REGISTRY),$(REGISTRY),staging-k8s.gcr.io)
 IMAGE_TAG := $(if $(IMAGE_TAG),$(IMAGE_TAG),latest)
+TEMP_DIR:=$(shell mktemp -d)
+ARCH?=amd64
+
+ifeq ($(ARCH),amd64)
+    BASEIMAGE?=gcr.io/distroless/base@sha256:7fa7445dfbebae4f4b7ab0e6ef99276e96075ae42584af6286ba080750d6dfe5
+endif
+ifeq ($(ARCH),arm)
+    BASEIMAGE?=k8s.gcr.io/debian-base-arm:v1.0.0
+endif
+ifeq ($(ARCH),arm64)
+    BASEIMAGE?=k8s.gcr.io/debian-base-arm64:v1.0.0
+endif
+ifeq ($(ARCH),ppc64le)
+    BASEIMAGE?=k8s.gcr.io/debian-base-ppc64le:v1.0.0
+endif
+ifeq ($(ARCH),s390x)
+    BASEIMAGE?=k8s.gcr.io/debian-base-s390x:v1.0.0
+endif
 
 all: gcloudpush
 
 build:
-	docker build --pull -t $(REGISTRY)/kubemark:$(IMAGE_TAG) .
+	cp -r ./* ${TEMP_DIR}
+	cd ${TEMP_DIR} && sed -i.bak "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
+
+	docker build --pull -t $(REGISTRY)/kubemark:$(IMAGE_TAG) $(TEMP_DIR)
 
 gcloudpush: build
 	docker push $(REGISTRY)/kubemark:$(IMAGE_TAG)


### PR DESCRIPTION
`distroless` image is not ready on the ARCH other than AMD64, multi-arch
support of `distroless` has been discussed for more than half year, and
is still pending.

This should not block us to run kubemark on that architectures. The change
makes us able to build kubemark images for other architectures, not consistent
but functional works.

see https://github.com/bazelbuild/rules_docker/issues/300  and https://github.com/GoogleContainerTools/distroless/issues/406

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
