### PR TITLE
condense various if conditions in a single condition

### DIFF
--- a/pkg/controller/service/controller.go
+++ b/pkg/controller/service/controller.go
@@ -564,26 +564,13 @@ func portSlicesEqualForLB(x, y []*v1.ServicePort) bool {
 
 func portEqualForLB(x, y *v1.ServicePort) bool {
 	// TODO: Should we check name?  (In theory, an LB could expose it)
-	if x.Name != y.Name {
+	if x.Name != y.Name ||
+		x.Protocol != y.Protocol ||
+		x.Port != y.Port ||
+		x.NodePort != y.NodePort ||
+		x.TargetPort != y.TargetPort {
 		return false
 	}
-
-	if x.Protocol != y.Protocol {
-		return false
-	}
-
-	if x.Port != y.Port {
-		return false
-	}
-
-	if x.NodePort != y.NodePort {
-		return false
-	}
-
-	if x.TargetPort != y.TargetPort {
-		return false
-	}
-
 	return true
 }
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Here I attempt to condense various if-statements into a single statements. Both the changes are trying to do the same. i.e `return false if any of the condition fails`. This can be better expressed in a single statement that I propose rather than using multiple statements. 
 
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
