### PR TITLE
Create OWNERS file for cluster/log-dump

### DIFF
--- a/cluster/log-dump/OWNERS
+++ b/cluster/log-dump/OWNERS
@@ -1,0 +1,6 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - sig-scalability-reviewers
+approvers:
+  - sig-scalability-approvers


### PR DESCRIPTION
Make sig-scalability-reviewers and sig-scalability-approvers reviewers and approvals of that dir.

Justification: Sig scalability owns the log-exporter that is being configured in this directory.

/kind cleanup

Release notes:
```release-note
NONE
```

