### PR TITLE
Reorder conditions in FindMatchingVolume to avoid calling volumeutil.CheckNodeAffinity in trivial cases

### DIFF
--- a/pkg/controller/volume/persistentvolume/util/util.go
+++ b/pkg/controller/volume/persistentvolume/util/util.go
@@ -211,9 +211,14 @@ func FindMatchingVolume(
 			// Skip volumes in the excluded list
 			continue
 		}
+		if volume.Spec.ClaimRef != nil && !IsVolumeBoundToClaim(volume, claim) {
+			continue
+		}
 
 		volumeQty := volume.Spec.Capacity[v1.ResourceStorage]
-
+		if volumeQty.Cmp(requestedQty) < 0 {
+			continue
+		}
 		// filter out mismatching volumeModes
 		if CheckVolumeModeMismatches(&claim.Spec, &volume.Spec) {
 			continue
@@ -230,6 +235,8 @@ func FindMatchingVolume(
 		if node != nil {
 			// Scheduler path, check that the PV NodeAffinity
 			// is satisfied by the node
+			// volumeutil.CheckNodeAffinity is the most expensive call in this loop.
+			// We should check cheaper conditions first or consider optimizing this function.
 			err := volumeutil.CheckNodeAffinity(volume, node.Labels)
 			if err != nil {
 				nodeAffinityValid = false
@@ -237,13 +244,6 @@ func FindMatchingVolume(
 		}
 
 		if IsVolumeBoundToClaim(volume, claim) {
-			// this claim and volume are pre-bound; return
-			// the volume if the size request is satisfied,
-			// otherwise continue searching for a match
-			if volumeQty.Cmp(requestedQty) < 0 {
-				continue
-			}
-
 			// If PV node affinity is invalid, return no match.
 			// This means the prebound PV (and therefore PVC)
 			// is not suitable for this node.
@@ -263,7 +263,6 @@ func FindMatchingVolume(
 
 		// filter out:
 		// - volumes in non-available phase
-		// - volumes bound to another claim
 		// - volumes whose labels don't match the claim's selector, if specified
 		// - volumes in Class that is not requested
 		// - volumes whose NodeAffinity does not match the node
@@ -272,8 +271,6 @@ func FindMatchingVolume(
 			// satisfies matching criteria will be updated to available, binding
 			// them now has high chance of encountering unnecessary failures
 			// due to API conflicts.
-			continue
-		} else if volume.Spec.ClaimRef != nil {
 			continue
 		} else if selector != nil && !selector.Matches(labels.Set(volume.Labels)) {
 			continue
@@ -293,11 +290,9 @@ func FindMatchingVolume(
 			}
 		}
 
-		if volumeQty.Cmp(requestedQty) >= 0 {
-			if smallestVolume == nil || smallestVolumeQty.Cmp(volumeQty) > 0 {
-				smallestVolume = volume
-				smallestVolumeQty = volumeQty
-			}
+		if smallestVolume == nil || smallestVolumeQty.Cmp(volumeQty) > 0 {
+			smallestVolume = volume
+			smallestVolumeQty = volumeQty
 		}
 	}
 

--- a/test/utils/runners.go
+++ b/test/utils/runners.go
@@ -1385,12 +1385,11 @@ func CreatePodWithPersistentVolume(client clientset.Interface, namespace string,
 			createError = fmt.Errorf("error creating PV: %s", err)
 			return
 		}
-		// We need to update status separately, as creating persistentvolumes resets status to the default one
-		// (so with Status.Phase will be equal to PersistentVolumePhase).
+		// We need to update statuses separately, as creating pv/pvc resets status to the default one.
 		if _, err := client.CoreV1().PersistentVolumes().UpdateStatus(context.TODO(), pv, metav1.UpdateOptions{}); err != nil {
 			lock.Lock()
 			defer lock.Unlock()
-			createError = fmt.Errorf("error creating PV: %s", err)
+			createError = fmt.Errorf("error updating PV status: %s", err)
 			return
 		}
 
@@ -1398,6 +1397,12 @@ func CreatePodWithPersistentVolume(client clientset.Interface, namespace string,
 			lock.Lock()
 			defer lock.Unlock()
 			createError = fmt.Errorf("error creating PVC: %s", err)
+			return
+		}
+		if _, err := client.CoreV1().PersistentVolumeClaims(namespace).UpdateStatus(context.TODO(), pvc, metav1.UpdateOptions{}); err != nil {
+			lock.Lock()
+			defer lock.Unlock()
+			createError = fmt.Errorf("error updating PVC status: %s", err)
 			return
 		}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR changes order of calls inside of FindMatchingVolume to avoid calling volumeutil.CheckNodeAffinity (the most expensive call in that function) in trivial cases (i.e. too small volumes or the ones that are already bound to some other PVC).

Benchmarks:
Before:
```
BenchmarkSchedulingWaitForFirstConsumerPVs/500Nodes/500Pods-12         	    1000	 176657944 ns/op
```

After:
```
BenchmarkSchedulingWaitForFirstConsumerPVs/500Nodes/500Pods-12         	    1000	  64176345 ns/op
```


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
