### PR TITLE
Add unit and integration tests for running multiple scheduling profiles

### DIFF
--- a/pkg/scheduler/testing/BUILD
+++ b/pkg/scheduler/testing/BUILD
@@ -15,6 +15,7 @@ go_library(
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/testing/wrappers.go
+++ b/pkg/scheduler/testing/wrappers.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var zero int64
@@ -147,6 +148,18 @@ func (p *PodWrapper) Obj() *v1.Pod {
 // Name sets `s` as the name of the inner pod.
 func (p *PodWrapper) Name(s string) *PodWrapper {
 	p.SetName(s)
+	return p
+}
+
+// UID sets `s` as the UID of the inner pod.
+func (p *PodWrapper) UID(s string) *PodWrapper {
+	p.SetUID(types.UID(s))
+	return p
+}
+
+// SchedulerName sets `s` as the scheduler name of the inner pod.
+func (p *PodWrapper) SchedulerName(s string) *PodWrapper {
+	p.Spec.SchedulerName = s
 	return p
 }
 
@@ -360,6 +373,12 @@ func (n *NodeWrapper) Obj() *v1.Node {
 // Name sets `s` as the name of the inner pod.
 func (n *NodeWrapper) Name(s string) *NodeWrapper {
 	n.SetName(s)
+	return n
+}
+
+// UID sets `s` as the UID of the inner pod.
+func (n *NodeWrapper) UID(s string) *NodeWrapper {
+	n.SetUID(types.UID(s))
 	return n
 }
 

--- a/test/integration/scheduler/BUILD
+++ b/test/integration/scheduler/BUILD
@@ -49,6 +49,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",

--- a/test/integration/scheduler/util.go
+++ b/test/integration/scheduler/util.go
@@ -242,8 +242,8 @@ func initDisruptionController(t *testing.T, testCtx *testContext) *disruption.Di
 
 // initTest initializes a test environment and creates master and scheduler with default
 // configuration.
-func initTest(t *testing.T, nsPrefix string) *testContext {
-	return initTestScheduler(t, initTestMaster(t, nsPrefix, nil), true, nil)
+func initTest(t *testing.T, nsPrefix string, opts ...scheduler.Option) *testContext {
+	return initTestSchedulerWithOptions(t, initTestMaster(t, nsPrefix, nil), true, nil, time.Second, opts...)
 }
 
 // initTestDisablePreemption initializes a test environment and creates master and scheduler with default


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add unit tests for:

- Processing multiple profiles from a configuration file
- Creating a scheduler with multiple profiles
- Running a scheduler with multiple profiles. We check for distinct scheduling outputs and different scheduler names in the events.

Add integration test for:
- Running a scheduler with multiple profiles. We check for:
  - Correct scheduler name in events
  - Pods with no scheduler name being picked up by the default profile
  - Pods with a scheduler name that doesn't match a profile are ignored.

**Which issue(s) this PR fixes**:

Fixes #85737

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-scheduling/20200114-multi-scheduling-profiles.md
```
