### PR TITLE
tests: Adds configurable docker conf for test

### DIFF
--- a/hack/ginkgo-e2e.sh
+++ b/hack/ginkgo-e2e.sh
@@ -169,6 +169,7 @@ export PATH
   --network="${KUBE_GCE_NETWORK:-${KUBE_GKE_NETWORK:-e2e}}" \
   --node-tag="${NODE_TAG:-}" \
   --master-tag="${MASTER_TAG:-}" \
+  --docker-config-file="${DOCKER_CONFIG_FILE:-}" \
   --dns-domain="${KUBE_DNS_DOMAIN:-cluster.local}" \
   --ginkgo.slowSpecThreshold="${GINKGO_SLOW_SPEC_THRESHOLD:-300}" \
   ${KUBE_CONTAINER_RUNTIME:+"--container-runtime=${KUBE_CONTAINER_RUNTIME}"} \

--- a/test/e2e/common/runtime.go
+++ b/test/e2e/common/runtime.go
@@ -19,6 +19,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"path"
 	"time"
 
@@ -294,7 +295,12 @@ while true; do sleep 1; done
 		}
 	}
 }`
-
+					// we might be told to use a different docker config JSON.
+					if framework.TestContext.DockerConfigFile != "" {
+						contents, err := ioutil.ReadFile(framework.TestContext.DockerConfigFile)
+						framework.ExpectNoError(err)
+						auth = string(contents)
+					}
 					secret := &v1.Secret{
 						Data: map[string][]byte{v1.DockerConfigJsonKey: []byte(auth)},
 						Type: v1.SecretTypeDockerConfigJson,

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -173,6 +173,9 @@ type TestContextType struct {
 
 	// SpecSummaryOutput is the file to write ginkgo.SpecSummary objects to as tests complete. Useful for debugging and test introspection.
 	SpecSummaryOutput string
+
+	// DockerConfigFile is a file that contains credentials which can be used to pull images from certain private registries, needed for a test.
+	DockerConfigFile string
 }
 
 // NodeKillerConfig describes configuration of NodeKiller -- a utility to
@@ -302,6 +305,7 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 
 	flags.StringVar(&TestContext.ProgressReportURL, "progress-report-url", "", "The URL to POST progress updates to as the suite runs to assist in aiding integrations. If empty, no messages sent.")
 	flags.StringVar(&TestContext.SpecSummaryOutput, "spec-dump", "", "The file to dump all ginkgo.SpecSummary to after tests run. If empty, no objects are saved/printed.")
+	flags.StringVar(&TestContext.DockerConfigFile, "docker-config-file", "", "A file that contains credentials which can be used to pull images from certain private registries, needed for a test.")
 }
 
 // RegisterClusterFlags registers flags specific to the cluster e2e test suite.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind failing-test

/sig windows
/sig testing

**What this PR does / why we need it**:

The image ``gcr.io/authenticated-image-pulling/windows-nanoserver:v1`` is not a manifest list, and it is only useful for Windows Server 1809, which means that the test ``should be able to pull from private registry with secret`` will fail for environments with Windows Server 1903, 1909, or any other future version we might want to test.

This PR adds the the ability to have an alternative private image to pull by using a configurable docker config file which contains the necessary credentials needed to pull the image.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #84609
Fixes #87785

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
