### PR TITLE
[UseNetworkResourceInDifferentTenant] Fix bug of setting incorrect subscription id on azure network resource clients.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -570,7 +570,7 @@ func (az *Cloud) configAzureClients(
 		vmssVMClientConfig.Authorizer = multiTenantServicePrincipalTokenAuthorizer
 	}
 
-	// If uses network resources in different AAD Tenant, update Authorizer for network resources client config
+	// If uses network resources in different AAD Tenant, update SubscriptionID and Authorizer for network resources client config
 	if networkResourceServicePrincipalToken != nil {
 		networkResourceServicePrincipalTokenAuthorizer := autorest.NewBearerAuthorizer(networkResourceServicePrincipalToken)
 		routeClientConfig.Authorizer = networkResourceServicePrincipalTokenAuthorizer
@@ -579,6 +579,13 @@ func (az *Cloud) configAzureClients(
 		loadBalancerClientConfig.Authorizer = networkResourceServicePrincipalTokenAuthorizer
 		securityGroupClientConfig.Authorizer = networkResourceServicePrincipalTokenAuthorizer
 		publicIPClientConfig.Authorizer = networkResourceServicePrincipalTokenAuthorizer
+
+		routeClientConfig.SubscriptionID = az.Config.NetworkResourceSubscriptionID
+		subnetClientConfig.SubscriptionID = az.Config.NetworkResourceSubscriptionID
+		routeTableClientConfig.SubscriptionID = az.Config.NetworkResourceSubscriptionID
+		loadBalancerClientConfig.SubscriptionID = az.Config.NetworkResourceSubscriptionID
+		securityGroupClientConfig.SubscriptionID = az.Config.NetworkResourceSubscriptionID
+		publicIPClientConfig.SubscriptionID = az.Config.NetworkResourceSubscriptionID
 	}
 
 	// Initialize all azure clients based on client config

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -98,7 +98,7 @@ func (az *Cloud) getAvailabilitySetID(resourceGroup, availabilitySetName string)
 func (az *Cloud) getFrontendIPConfigID(lbName, rgName, fipConfigName string) string {
 	return fmt.Sprintf(
 		frontendIPConfigIDTemplate,
-		az.SubscriptionID,
+		az.getNetworkResourceSubscriptionID(),
 		rgName,
 		lbName,
 		fipConfigName)
@@ -108,7 +108,7 @@ func (az *Cloud) getFrontendIPConfigID(lbName, rgName, fipConfigName string) str
 func (az *Cloud) getBackendPoolID(lbName, rgName, backendPoolName string) string {
 	return fmt.Sprintf(
 		backendPoolIDTemplate,
-		az.SubscriptionID,
+		az.getNetworkResourceSubscriptionID(),
 		rgName,
 		lbName,
 		backendPoolName)
@@ -118,10 +118,18 @@ func (az *Cloud) getBackendPoolID(lbName, rgName, backendPoolName string) string
 func (az *Cloud) getLoadBalancerProbeID(lbName, rgName, lbRuleName string) string {
 	return fmt.Sprintf(
 		loadBalancerProbeIDTemplate,
-		az.SubscriptionID,
+		az.getNetworkResourceSubscriptionID(),
 		rgName,
 		lbName,
 		lbRuleName)
+}
+
+// getNetworkResourceSubscriptionID returns the subscription id which hosts network resources
+func (az *Cloud) getNetworkResourceSubscriptionID() string {
+	if az.Config.UsesNetworkResourceInDifferentTenant() {
+		return az.NetworkResourceSubscriptionID
+	}
+	return az.SubscriptionID
 }
 
 func (az *Cloud) mapLoadBalancerNameToVMSet(lbName string, clusterName string) (vmSetName string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
For feature of using network resource in different tenant, this PR is to fix bug of setting incorrect subscription id on azure network resource clients.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None.

**Special notes for your reviewer**:
The bug is introduced by refactoring of my previous PR. Sorry about that.
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
