### PR TITLE
ipvs: only attempt setting of sysctlconnreuse on supported kernels

### DIFF
--- a/cmd/kube-proxy/app/server_others.go
+++ b/cmd/kube-proxy/app/server_others.go
@@ -276,6 +276,7 @@ func newProxyServer(
 				healthzServer,
 				config.IPVS.Scheduler,
 				config.NodePortAddresses,
+				kernelHandler,
 			)
 		} else {
 			var localDetector proxyutiliptables.LocalTrafficDetector
@@ -306,6 +307,7 @@ func newProxyServer(
 				healthzServer,
 				config.IPVS.Scheduler,
 				config.NodePortAddresses,
+				kernelHandler,
 			)
 		}
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Christopher M. Luciano <cmluciano@us.ibm.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This builds on previous work but only sets the sysctlConnReuse value
if the kernel is known to be above 4.19. To avoid calling GetKernelVersion
twice, I store the value from the CanUseIPVS method and then check the version
constraint at time of expected sysctl call.

**Which issue(s) this PR fixes**:
Supplants: #82066
xref: #71114

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:

```release-note
ipvs: only attempt setting of sysctlconnreuse on supported kernels
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
