### PR TITLE
Ensure webhook/quota/deny admission comes last

### DIFF
--- a/pkg/kubeapiserver/options/BUILD
+++ b/pkg/kubeapiserver/options/BUILD
@@ -89,6 +89,7 @@ go_test(
         "admission_test.go",
         "authentication_test.go",
         "authorization_test.go",
+        "plugins_test.go",
     ],
     data = [
         "testdata/client-expired.pem",

--- a/pkg/kubeapiserver/options/plugins.go
+++ b/pkg/kubeapiserver/options/plugins.go
@@ -86,11 +86,15 @@ var AllOrderedPlugins = []string{
 	storageobjectinuseprotection.PluginName, // StorageObjectInUseProtection
 	gc.PluginName,                           // OwnerReferencesPermissionEnforcement
 	resize.PluginName,                       // PersistentVolumeClaimResize
-	mutatingwebhook.PluginName,              // MutatingAdmissionWebhook
-	validatingwebhook.PluginName,            // ValidatingAdmissionWebhook
-	runtimeclass.PluginName,                 //RuntimeClass
-	resourcequota.PluginName,                // ResourceQuota
-	deny.PluginName,                         // AlwaysDeny
+	runtimeclass.PluginName,                 // RuntimeClass
+
+	// new admission plugins should generally be inserted above here
+	// webhook, resourcequota, and deny plugins must go at the end
+
+	mutatingwebhook.PluginName,   // MutatingAdmissionWebhook
+	validatingwebhook.PluginName, // ValidatingAdmissionWebhook
+	resourcequota.PluginName,     // ResourceQuota
+	deny.PluginName,              // AlwaysDeny
 }
 
 // RegisterAllAdmissionPlugins registers all admission plugins and

--- a/pkg/kubeapiserver/options/plugins_test.go
+++ b/pkg/kubeapiserver/options/plugins_test.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestAdmissionPluginOrder(t *testing.T) {
+	// Ensure the last four admission plugins listed are webhooks, quota, and deny
+	allplugins := strings.Join(AllOrderedPlugins, ",")
+	expectSuffix := ",MutatingAdmissionWebhook,ValidatingAdmissionWebhook,ResourceQuota,AlwaysDeny"
+	if !strings.HasSuffix(allplugins, expectSuffix) {
+		t.Fatalf("AllOrderedPlugins must end with ...%s", expectSuffix)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I've seen a few accidental attempts to add new plugins at the end of the list. Clarify where they should go and test for it.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig api-machinery
/cc @enj