### PR TITLE
Fix a scheduler e2e bug on PodTopologySpread scoring

### DIFF
--- a/test/e2e/scheduling/priorities.go
+++ b/test/e2e/scheduling/priorities.go
@@ -378,7 +378,7 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 				PodConfig: pausePodConfig{
 					Name:         podLabel,
 					Namespace:    ns,
-					Labels:       map[string]string{podLabel: ""},
+					Labels:       map[string]string{podLabel: "foo"},
 					NodeSelector: map[string]string{topologyKey: nodeNames[0]},
 				},
 			}
@@ -388,7 +388,9 @@ var _ = SIGDescribe("SchedulerPriorities [Serial]", func() {
 			podCfg := pausePodConfig{
 				Name:      "test-pod",
 				Namespace: ns,
-				Labels:    map[string]string{podLabel: ""},
+				// The labels shouldn't match the preceding ReplicaSet, otherwise it will
+				// be claimed as orphan of the ReplicaSet.
+				Labels: map[string]string{podLabel: "bar"},
 				Affinity: &v1.Affinity{
 					NodeAffinity: &v1.NodeAffinity{
 						RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test
/sig scheduling

**What this PR does / why we need it**:

When creating a plain Pod in e2e test, we shouldn't let its labels match an existing ReplicaSet's labelSelector. In that case, the plain Pod would be claimed as an orphan of the RS, but then garbage collected as it's actually not owned by the RS.

**Which issue(s) this PR fixes**:

Part of #88494. 

(Fix [sig-scheduling] SchedulerPriorities [Serial] PodTopologySpread Scoring validates pod should be preferably scheduled to node which makes the matching pods more evenly distributed)

**Special notes for your reviewer**:

It's an e2e bug instead of sig-app bug, see #88550 .

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```