### PR TITLE
Fix a scheduler e2e bug on Preemption

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -836,10 +836,14 @@ func initPausePod(f *framework.Framework, conf pausePodConfig) *v1.Pod {
 				},
 			},
 			Tolerations:                   conf.Tolerations,
-			NodeName:                      conf.NodeName,
 			PriorityClassName:             conf.PriorityClassName,
 			TerminationGracePeriodSeconds: &gracePeriod,
 		},
+	}
+	// TODO: setting the Pod's nodeAffinity instead of setting .spec.nodeName works around the
+	// Preemption e2e flake (#88441), but we should investigate deeper to get to the bottom of it.
+	if len(conf.NodeName) != 0 {
+		e2epod.SetNodeAffinity(&pod.Spec, conf.NodeName)
 	}
 	if conf.Resources != nil {
 		pod.Spec.Containers[0].Resources = *conf.Resources

--- a/test/e2e/scheduling/preemption.go
+++ b/test/e2e/scheduling/preemption.go
@@ -214,14 +214,14 @@ var _ = SIGDescribe("SchedulerPreemption [Serial]", func() {
 			if len(pods) == 0 {
 				priorityName = lowPriorityClassName
 			}
-			pods[i] = createPausePod(f, pausePodConfig{
+			pods = append(pods, createPausePod(f, pausePodConfig{
 				Name:              fmt.Sprintf("pod%d-%v", i, priorityName),
 				PriorityClassName: priorityName,
 				Resources: &v1.ResourceRequirements{
 					Requests: podRes,
 				},
 				NodeName: node.Name,
-			})
+			}))
 			framework.Logf("Created pod: %v", pods[i].Name)
 		}
 		if len(pods) < 2 {


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind failing-test
/sig scheduling

**What this PR does / why we need it**:

Two parts in this PR:

- The first one removes usage of assigning `.spec.nodeName` directly; instead, use NodeAffinity to let it go through scheduler. BTW: a lot of "pod ran to completion" errors surfaced recently, I believe @msau42 and @liggitt encountered this as well.
- The second part resolves an "index out of range" problem

**Which issue(s) this PR fixes**:

Part of #88441.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```