### PR TITLE
e2e-scheduling: skip PodOverhead if not enabled

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -133,6 +133,13 @@ func SkipUnlessLocalEphemeralStorageEnabled() {
 	}
 }
 
+// SkipIfPodOverheadDisabled skips test if PodOverhead feature gate is not enabled.
+func SkipIfPodOverheadDisabled() {
+	if !utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
+		skipInternalf(1, "Only supported when %v feature is enabled", features.PodOverhead)
+	}
+}
+
 // SkipIfMissingResource skips if the gvr resource is missing.
 func SkipIfMissingResource(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string) {
 	resourceClient := dynamicClient.Resource(gvr).Namespace(namespace)

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -217,6 +217,9 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		var beardsecond v1.ResourceName = "example.com/beardsecond"
 
 		ginkgo.BeforeEach(func() {
+			// Skip the test if featuregate not enabled
+			e2eskipper.SkipIfPodOverheadDisabled()
+
 			WaitForStableCluster(cs, masterNodes)
 			ginkgo.By("Add RuntimeClass and fake resource")
 


### PR DESCRIPTION

 /kind bug

**What this PR does / why we need it**:

The test does not check for the status of the feature gate.  When disabled, the test will fail. While the default will change to enabled soon, we should still check for its status and skip if needed.

**Which issue(s) this PR fixes**:
partially addresses https://github.com/kubernetes/kubernetes/issues/88441
```release-note
NONE
```
