### PR TITLE
build: Enable kube-cross image-building on K8s Infra

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -128,6 +128,18 @@ aliases:
     - justaugustus # SIG Chair
     - saschagrunert # Branch Manager
     - tpepper # SIG Chair / Patch Release Team
+  build-image-approvers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx
+  build-image-reviewers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx
 
   sig-storage-reviewers:
     - saad-ali

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -4,6 +4,7 @@ reviewers:
   - bentheelder
   - cblecker
   - fejta
+  - justaugustus
   - lavalamp
   - spiffxp
 approvers:

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file creates a standard build environment for building Kubernetes
-FROM k8s.gcr.io/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
+FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
 
 # Mark this as a kube-build container
 RUN touch /kube-build-image

--- a/build/build-image/OWNERS
+++ b/build/build-image/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - build-image-approvers
+reviewers:
+  - build-image-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -14,15 +14,22 @@
 
 .PHONY:	build push
 
-REGISTRY?=staging-k8s.gcr.io
-IMAGE=$(REGISTRY)/kube-cross
-TAG=$(shell cat VERSION)
+STAGING_REGISTRY?=gcr.io/k8s-staging-build-image
+PROD_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
+IMAGE=kube-cross
 
+TAG?=kubernetes-$(shell git describe --tags --match='v*' --abbrev=14)
+KUBE_CROSS_VERSION=$(shell cat VERSION)
 
-all: push
+all: build push
 
 build:
-	docker build --pull -t $(IMAGE):$(TAG) .
+	docker build \
+		-t $(STAGING_REGISTRY)/$(IMAGE):$(TAG) \
+		-t $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION) \
+		-t $(PROD_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION) \
+		.
 
-push: build
-	docker push $(IMAGE):$(TAG)
+push:
+	docker push $(STAGING_REGISTRY)/$(IMAGE):$(TAG)
+	docker push $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION)

--- a/build/build-image/cross/cloudbuild.yaml
+++ b/build/build-image/cross/cloudbuild.yaml
@@ -1,0 +1,13 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20191019-6567e5c'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    args:
+    - all
+images:
+  - 'gcr.io/$PROJECT_ID/kube-cross:kubernetes-${_GIT_TAG}'

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -27,7 +27,7 @@ ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 CFLAGS = -Os -Wall -Werror -static -DVERSION=v$(TAG)-$(REV)
-KUBE_CROSS_IMAGE ?= k8s.gcr.io/kube-cross
+KUBE_CROSS_IMAGE ?= us.gcr.io/k8s-artifacts-prod/build-image/kube-cross
 KUBE_CROSS_VERSION ?= $(shell cat ../build-image/cross/VERSION)
 
 BIN = pause

--- a/test/images/sample-apiserver/Dockerfile
+++ b/test/images/sample-apiserver/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/kube-cross:v1.13.6-1 as build_k8s_1_17_sample_apiserver
+FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.6-1 as build_k8s_1_17_sample_apiserver
 
 ENV GOPATH /go
 RUN mkdir -p ${GOPATH}/src ${GOPATH}/bin


### PR DESCRIPTION
**What type of PR is this?**
/kind feature cleanup

**What this PR does / why we need it**:
One of the follow-up items in our quarterly golang update is to transition ownership of Golang bumps to the @kubernetes/release-engineering group. Part of the Golang bump is updating the `kube-cross` image, which today can only be done by a few Googlers (@BenTheElder, @javier-b-perez, @listx (maybe)).

This PR:
- build: Add OWNERS on build-image/

  Here we're primarily concerned with the kube-cross image, though we
  may expand scope at a later time.

  Adding the following reviewers/approvers:
  - BenTheElder
  - cblecker
  - dims
  - justaugustus
  - listx

  Once we've defined policies for handling these images, we'll expand the
  scope of this group to include Release Engineering.
- Add justaugustus as reviewer on `build/` (to start identifying other locations where we can use the community image promoter)
- Enable kube-cross push/pull from K8s Infra GCR
  - Search/replace Google Infra kube-cross locations for K8s Infra
  - Update kube-cross make targets
    - Don't attempt to pre-pull image (docker build --pull)
      This prevents CI failures when the image under test doesn't exist
      yet in the registry.
    - 'make all' now builds and pushes the kube-cross image
    - Allow 'TAG' to be specified via env var
    - Use 'KUBE_CROSS_VERSION' to represent the kube-cross version
    - Tag kube-cross images with both a kubernetes version
        ('git describe') and a kube-cross version
  - Add a GCB (Google Cloud Build) config file (cloudbuild.yaml)


/assign @BenTheElder @liggitt @cblecker @dims 
/milestone v1.18
/priority important-soon

ref: https://github.com/kubernetes/release/issues/1133, https://github.com/kubernetes/release/issues/1134

**Special notes for your reviewer**:
/hold pending:
- [x] Adding cloudbuild.yaml to the kube-cross directory (this PR)
- [x] (https://github.com/kubernetes/k8s.io/pull/603) Add Release Engineering OWNERS to k8s.io:
  - groups.yaml update
  - k8s-infra-staging-build-image OWNERS
- [x] (https://github.com/kubernetes/k8s.io/pull/608) Backfill and promotion of _most recent_ kube-cross images (current kube-cross for each active release branch)
- [x] (https://github.com/kubernetes/test-infra/pull/16494) k/test-infra PR to enable image pushing  

**Does this PR introduce a user-facing change?**:
```release-note
build: Enable kube-cross image-building on K8s Infra
```