### PR TITLE
Enable running cpu-mgr-multiNUMA e2e tests with Topology manager

### DIFF
--- a/test/e2e_node/cpu_manager_test.go
+++ b/test/e2e_node/cpu_manager_test.go
@@ -258,16 +258,295 @@ func enableCPUManagerInKubelet(f *framework.Framework, cleanStateFile bool) (old
 	return oldCfg
 }
 
-func runCPUManagerTests(f *framework.Framework) {
-	var cpuCap, cpuAlloc int64
-	var oldCfg *kubeletconfig.KubeletConfiguration
+func runGuPodTest(f *framework.Framework) {
+	var ctnAttrs []ctnAttribute
+	var cpu1 int
+	var err error
+	var cpuList []int
+	var pod *v1.Pod
+	var expAllowedCPUsListRegex string
+
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "gu-container",
+			cpuRequest: "1000m",
+			cpuLimit:   "1000m",
+		},
+	}
+	pod = makeCPUManagerPod("gu-pod", ctnAttrs)
+	pod = f.PodClient().CreateSync(pod)
+
+	ginkgo.By("checking if the expected cpuset was assigned")
+	cpu1 = 1
+	if isHTEnabled() {
+		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
+		cpu1 = cpuList[1]
+	} else if isMultiNUMA() {
+		cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
+		cpu1 = cpuList[1]
+	}
+	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
+	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod.Spec.Containers[0].Name, pod.Name)
+
+	ginkgo.By("by deleting the pods and waiting for container removal")
+	deletePods(f, []string{pod.Name})
+	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+}
+
+func runNonGuPodTest(f *framework.Framework, cpuCap int64) {
+	var ctnAttrs []ctnAttribute
+	var err error
+	var pod *v1.Pod
+	var expAllowedCPUsListRegex string
+
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "non-gu-container",
+			cpuRequest: "100m",
+			cpuLimit:   "200m",
+		},
+	}
+	pod = makeCPUManagerPod("non-gu-pod", ctnAttrs)
+	pod = f.PodClient().CreateSync(pod)
+
+	ginkgo.By("checking if the expected cpuset was assigned")
+	expAllowedCPUsListRegex = fmt.Sprintf("^0-%d\n$", cpuCap-1)
+	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod.Spec.Containers[0].Name, pod.Name)
+
+	ginkgo.By("by deleting the pods and waiting for container removal")
+	deletePods(f, []string{pod.Name})
+	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+}
+
+func runMultipleGuNonGuPods(f *framework.Framework, cpuCap int64, cpuAlloc int64) {
+
 	var cpuListString, expAllowedCPUsListRegex string
 	var cpuList []int
-	var cpu1, cpu2 int
+	var cpu1 int
 	var cset cpuset.CPUSet
 	var err error
 	var ctnAttrs []ctnAttribute
-	var pod, pod1, pod2 *v1.Pod
+	var pod1, pod2 *v1.Pod
+
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "gu-container",
+			cpuRequest: "1000m",
+			cpuLimit:   "1000m",
+		},
+	}
+	pod1 = makeCPUManagerPod("gu-pod", ctnAttrs)
+	pod1 = f.PodClient().CreateSync(pod1)
+
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "non-gu-container",
+			cpuRequest: "200m",
+			cpuLimit:   "300m",
+		},
+	}
+	pod2 = makeCPUManagerPod("non-gu-pod", ctnAttrs)
+	pod2 = f.PodClient().CreateSync(pod2)
+
+	ginkgo.By("checking if the expected cpuset was assigned")
+	cpu1 = 1
+	if isHTEnabled() {
+		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
+		cpu1 = cpuList[1]
+	} else if isMultiNUMA() {
+		cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
+		cpu1 = cpuList[1]
+	}
+	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
+	err = f.PodClient().MatchContainerOutput(pod1.Name, pod1.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod1.Spec.Containers[0].Name, pod1.Name)
+
+	cpuListString = "0"
+	if cpuAlloc > 2 {
+		cset = cpuset.MustParse(fmt.Sprintf("0-%d", cpuCap-1))
+		cpuListString = fmt.Sprintf("%s", cset.Difference(cpuset.NewCPUSet(cpu1)))
+	}
+	expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", cpuListString)
+	err = f.PodClient().MatchContainerOutput(pod2.Name, pod2.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod2.Spec.Containers[0].Name, pod2.Name)
+	ginkgo.By("by deleting the pods and waiting for container removal")
+	deletePods(f, []string{pod1.Name, pod2.Name})
+	waitForContainerRemoval(pod1.Spec.Containers[0].Name, pod1.Name, pod1.Namespace)
+	waitForContainerRemoval(pod2.Spec.Containers[0].Name, pod2.Name, pod2.Namespace)
+}
+
+func runMultipleCPUGuPod(f *framework.Framework) {
+	var cpuListString, expAllowedCPUsListRegex string
+	var cpuList []int
+	var cset cpuset.CPUSet
+	var err error
+	var ctnAttrs []ctnAttribute
+	var pod *v1.Pod
+
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "gu-container",
+			cpuRequest: "2000m",
+			cpuLimit:   "2000m",
+		},
+	}
+	pod = makeCPUManagerPod("gu-pod", ctnAttrs)
+	pod = f.PodClient().CreateSync(pod)
+
+	ginkgo.By("checking if the expected cpuset was assigned")
+	cpuListString = "1-2"
+	if isMultiNUMA() {
+		cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
+		if !isHTEnabled() {
+			cset = cpuset.MustParse(fmt.Sprintf("%d-%d", cpuList[1], cpuList[2]))
+		} else {
+			cset = cpuset.MustParse(getCPUSiblingList(int64(cpuList[1])))
+		}
+		cpuListString = fmt.Sprintf("%s", cset)
+	} else if isHTEnabled() {
+		cpuListString = "2-3"
+		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
+		if cpuList[1] != 1 {
+			cset = cpuset.MustParse(getCPUSiblingList(1))
+			cpuListString = fmt.Sprintf("%s", cset)
+		}
+	}
+	expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", cpuListString)
+	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod.Spec.Containers[0].Name, pod.Name)
+
+	ginkgo.By("by deleting the pods and waiting for container removal")
+	deletePods(f, []string{pod.Name})
+	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+}
+
+func runMultipleCPUContainersGuPod(f *framework.Framework) {
+
+	var expAllowedCPUsListRegex string
+	var cpuList []int
+	var cpu1, cpu2 int
+	var err error
+	var ctnAttrs []ctnAttribute
+	var pod *v1.Pod
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "gu-container1",
+			cpuRequest: "1000m",
+			cpuLimit:   "1000m",
+		},
+		{
+			ctnName:    "gu-container2",
+			cpuRequest: "1000m",
+			cpuLimit:   "1000m",
+		},
+	}
+	pod = makeCPUManagerPod("gu-pod", ctnAttrs)
+	pod = f.PodClient().CreateSync(pod)
+
+	ginkgo.By("checking if the expected cpuset was assigned")
+	cpu1, cpu2 = 1, 2
+	if isHTEnabled() {
+		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
+		if cpuList[1] != 1 {
+			cpu1, cpu2 = cpuList[1], 1
+		}
+		if isMultiNUMA() {
+			cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
+			cpu2 = cpuList[1]
+		}
+	} else if isMultiNUMA() {
+		cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
+		cpu1, cpu2 = cpuList[1], cpuList[2]
+	}
+	expAllowedCPUsListRegex = fmt.Sprintf("^%d|%d\n$", cpu1, cpu2)
+	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod.Spec.Containers[0].Name, pod.Name)
+
+	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[1].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod.Spec.Containers[1].Name, pod.Name)
+
+	ginkgo.By("by deleting the pods and waiting for container removal")
+	deletePods(f, []string{pod.Name})
+	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+	waitForContainerRemoval(pod.Spec.Containers[1].Name, pod.Name, pod.Namespace)
+}
+
+func runMultipleGuPods(f *framework.Framework) {
+	var expAllowedCPUsListRegex string
+	var cpuList []int
+	var cpu1, cpu2 int
+	var err error
+	var ctnAttrs []ctnAttribute
+	var pod1, pod2 *v1.Pod
+
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "gu-container1",
+			cpuRequest: "1000m",
+			cpuLimit:   "1000m",
+		},
+	}
+	pod1 = makeCPUManagerPod("gu-pod1", ctnAttrs)
+	pod1 = f.PodClient().CreateSync(pod1)
+
+	ctnAttrs = []ctnAttribute{
+		{
+			ctnName:    "gu-container2",
+			cpuRequest: "1000m",
+			cpuLimit:   "1000m",
+		},
+	}
+	pod2 = makeCPUManagerPod("gu-pod2", ctnAttrs)
+	pod2 = f.PodClient().CreateSync(pod2)
+
+	ginkgo.By("checking if the expected cpuset was assigned")
+	cpu1, cpu2 = 1, 2
+	if isHTEnabled() {
+		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
+		if cpuList[1] != 1 {
+			cpu1, cpu2 = cpuList[1], 1
+		}
+		if isMultiNUMA() {
+			cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
+			cpu2 = cpuList[1]
+		}
+	} else if isMultiNUMA() {
+		cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
+		cpu1, cpu2 = cpuList[1], cpuList[2]
+	}
+	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
+	err = f.PodClient().MatchContainerOutput(pod1.Name, pod1.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod1.Spec.Containers[0].Name, pod1.Name)
+
+	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu2)
+	err = f.PodClient().MatchContainerOutput(pod2.Name, pod2.Spec.Containers[0].Name, expAllowedCPUsListRegex)
+	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
+		pod2.Spec.Containers[0].Name, pod2.Name)
+	ginkgo.By("by deleting the pods and waiting for container removal")
+	deletePods(f, []string{pod1.Name, pod2.Name})
+	waitForContainerRemoval(pod1.Spec.Containers[0].Name, pod1.Name, pod1.Namespace)
+	waitForContainerRemoval(pod2.Spec.Containers[0].Name, pod2.Name, pod2.Namespace)
+}
+
+func runCPUManagerTests(f *framework.Framework) {
+	var cpuCap, cpuAlloc int64
+	var oldCfg *kubeletconfig.KubeletConfiguration
+	var expAllowedCPUsListRegex string
+	var cpuList []int
+	var cpu1 int
+	var err error
+	var ctnAttrs []ctnAttribute
+	var pod *v1.Pod
 
 	ginkgo.It("should assign CPUs as expected based on the Pod spec", func() {
 		cpuCap, cpuAlloc, _ = getLocalNodeCPUDetails(f)
@@ -281,104 +560,13 @@ func runCPUManagerTests(f *framework.Framework) {
 		oldCfg = enableCPUManagerInKubelet(f, true)
 
 		ginkgo.By("running a non-Gu pod")
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "non-gu-container",
-				cpuRequest: "100m",
-				cpuLimit:   "200m",
-			},
-		}
-		pod = makeCPUManagerPod("non-gu-pod", ctnAttrs)
-		pod = f.PodClient().CreateSync(pod)
-
-		ginkgo.By("checking if the expected cpuset was assigned")
-		expAllowedCPUsListRegex = fmt.Sprintf("^0-%d\n$", cpuCap-1)
-		err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod.Spec.Containers[0].Name, pod.Name)
-
-		ginkgo.By("by deleting the pods and waiting for container removal")
-		deletePods(f, []string{pod.Name})
-		waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+		runNonGuPodTest(f, cpuCap)
 
 		ginkgo.By("running a Gu pod")
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "gu-container",
-				cpuRequest: "1000m",
-				cpuLimit:   "1000m",
-			},
-		}
-		pod = makeCPUManagerPod("gu-pod", ctnAttrs)
-		pod = f.PodClient().CreateSync(pod)
-
-		ginkgo.By("checking if the expected cpuset was assigned")
-		cpu1 = 1
-		if isHTEnabled() {
-			cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-			cpu1 = cpuList[1]
-		} else if isMultiNUMA() {
-			cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
-			cpu1 = cpuList[1]
-		}
-		expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
-		err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod.Spec.Containers[0].Name, pod.Name)
-
-		ginkgo.By("by deleting the pods and waiting for container removal")
-		deletePods(f, []string{pod.Name})
-		waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+		runGuPodTest(f)
 
 		ginkgo.By("running multiple Gu and non-Gu pods")
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "gu-container",
-				cpuRequest: "1000m",
-				cpuLimit:   "1000m",
-			},
-		}
-		pod1 = makeCPUManagerPod("gu-pod", ctnAttrs)
-		pod1 = f.PodClient().CreateSync(pod1)
-
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "non-gu-container",
-				cpuRequest: "200m",
-				cpuLimit:   "300m",
-			},
-		}
-		pod2 = makeCPUManagerPod("non-gu-pod", ctnAttrs)
-		pod2 = f.PodClient().CreateSync(pod2)
-
-		ginkgo.By("checking if the expected cpuset was assigned")
-		cpu1 = 1
-		if isHTEnabled() {
-			cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-			cpu1 = cpuList[1]
-		} else if isMultiNUMA() {
-			cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
-			cpu1 = cpuList[1]
-		}
-		expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
-		err = f.PodClient().MatchContainerOutput(pod1.Name, pod1.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod1.Spec.Containers[0].Name, pod1.Name)
-
-		cpuListString = "0"
-		if cpuAlloc > 2 {
-			cset = cpuset.MustParse(fmt.Sprintf("0-%d", cpuCap-1))
-			cpuListString = fmt.Sprintf("%s", cset.Difference(cpuset.NewCPUSet(cpu1)))
-		}
-		expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", cpuListString)
-		err = f.PodClient().MatchContainerOutput(pod2.Name, pod2.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod2.Spec.Containers[0].Name, pod2.Name)
-
-		ginkgo.By("by deleting the pods and waiting for container removal")
-		deletePods(f, []string{pod1.Name, pod2.Name})
-		waitForContainerRemoval(pod1.Spec.Containers[0].Name, pod1.Name, pod1.Namespace)
-		waitForContainerRemoval(pod2.Spec.Containers[0].Name, pod2.Name, pod2.Namespace)
+		runMultipleGuNonGuPods(f, cpuCap, cpuAlloc)
 
 		// Skip rest of the tests if CPU capacity < 3.
 		if cpuCap < 3 {
@@ -386,138 +574,13 @@ func runCPUManagerTests(f *framework.Framework) {
 		}
 
 		ginkgo.By("running a Gu pod requesting multiple CPUs")
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "gu-container",
-				cpuRequest: "2000m",
-				cpuLimit:   "2000m",
-			},
-		}
-		pod = makeCPUManagerPod("gu-pod", ctnAttrs)
-		pod = f.PodClient().CreateSync(pod)
-
-		ginkgo.By("checking if the expected cpuset was assigned")
-		cpuListString = "1-2"
-		if isMultiNUMA() {
-			cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
-			if !isHTEnabled() {
-				cset = cpuset.MustParse(fmt.Sprintf("%d,%d", cpuList[1], cpuList[2]))
-			} else {
-				cset = cpuset.MustParse(getCPUSiblingList(int64(cpuList[1])))
-			}
-			cpuListString = fmt.Sprintf("%s", cset)
-		} else if isHTEnabled() {
-			cpuListString = "2-3"
-			cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-			if cpuList[1] != 1 {
-				cset = cpuset.MustParse(getCPUSiblingList(1))
-				cpuListString = fmt.Sprintf("%s", cset)
-			}
-		}
-		expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", cpuListString)
-		err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod.Spec.Containers[0].Name, pod.Name)
-
-		ginkgo.By("by deleting the pods and waiting for container removal")
-		deletePods(f, []string{pod.Name})
-		waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+		runMultipleCPUGuPod(f)
 
 		ginkgo.By("running a Gu pod with multiple containers requesting integer CPUs")
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "gu-container1",
-				cpuRequest: "1000m",
-				cpuLimit:   "1000m",
-			},
-			{
-				ctnName:    "gu-container2",
-				cpuRequest: "1000m",
-				cpuLimit:   "1000m",
-			},
-		}
-		pod = makeCPUManagerPod("gu-pod", ctnAttrs)
-		pod = f.PodClient().CreateSync(pod)
-
-		ginkgo.By("checking if the expected cpuset was assigned")
-		cpu1, cpu2 = 1, 2
-		if isHTEnabled() {
-			cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-			if cpuList[1] != 1 {
-				cpu1, cpu2 = cpuList[1], 1
-			}
-			if isMultiNUMA() {
-				cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
-				cpu2 = cpuList[1]
-			}
-		} else if isMultiNUMA() {
-			cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
-			cpu1, cpu2 = cpuList[1], cpuList[2]
-		}
-		expAllowedCPUsListRegex = fmt.Sprintf("^%d|%d\n$", cpu1, cpu2)
-		err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod.Spec.Containers[0].Name, pod.Name)
-
-		err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[1].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod.Spec.Containers[1].Name, pod.Name)
-
-		ginkgo.By("by deleting the pods and waiting for container removal")
-		deletePods(f, []string{pod.Name})
-		waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
-		waitForContainerRemoval(pod.Spec.Containers[1].Name, pod.Name, pod.Namespace)
+		runMultipleCPUContainersGuPod(f)
 
 		ginkgo.By("running multiple Gu pods")
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "gu-container1",
-				cpuRequest: "1000m",
-				cpuLimit:   "1000m",
-			},
-		}
-		pod1 = makeCPUManagerPod("gu-pod1", ctnAttrs)
-		pod1 = f.PodClient().CreateSync(pod1)
-
-		ctnAttrs = []ctnAttribute{
-			{
-				ctnName:    "gu-container2",
-				cpuRequest: "1000m",
-				cpuLimit:   "1000m",
-			},
-		}
-		pod2 = makeCPUManagerPod("gu-pod2", ctnAttrs)
-		pod2 = f.PodClient().CreateSync(pod2)
-
-		ginkgo.By("checking if the expected cpuset was assigned")
-		cpu1, cpu2 = 1, 2
-		if isHTEnabled() {
-			cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-			if cpuList[1] != 1 {
-				cpu1, cpu2 = cpuList[1], 1
-			}
-			if isMultiNUMA() {
-				cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
-				cpu2 = cpuList[1]
-			}
-		} else if isMultiNUMA() {
-			cpuList = cpuset.MustParse(getCoreSiblingList(0)).ToSlice()
-			cpu1, cpu2 = cpuList[1], cpuList[2]
-		}
-		expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
-		err = f.PodClient().MatchContainerOutput(pod1.Name, pod1.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod1.Spec.Containers[0].Name, pod1.Name)
-
-		expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu2)
-		err = f.PodClient().MatchContainerOutput(pod2.Name, pod2.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-		framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-			pod2.Spec.Containers[0].Name, pod2.Name)
-
-		ginkgo.By("by deleting the pods and waiting for container removal")
-		deletePods(f, []string{pod1.Name, pod2.Name})
-		waitForContainerRemoval(pod1.Spec.Containers[0].Name, pod1.Name, pod1.Namespace)
-		waitForContainerRemoval(pod2.Spec.Containers[0].Name, pod2.Name, pod2.Namespace)
+		runMultipleGuPods(f)
 
 		ginkgo.By("test for automatically remove inactive pods from cpumanager state file.")
 		// First running a Gu Pod,

--- a/test/e2e_node/topology_manager_test.go
+++ b/test/e2e_node/topology_manager_test.go
@@ -34,7 +34,6 @@ import (
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 	kubeletconfig "k8s.io/kubernetes/pkg/kubelet/apis/config"
 	"k8s.io/kubernetes/pkg/kubelet/cm/cpumanager"
-	"k8s.io/kubernetes/pkg/kubelet/cm/cpuset"
 	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager"
 	"k8s.io/kubernetes/pkg/kubelet/types"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -92,12 +91,6 @@ func detectSRIOVDevices() int {
 	framework.ExpectNoError(err)
 
 	return devCount
-}
-
-// makeTopologyMangerPod returns a pod with the provided tmCtnAttributes.
-func makeTopologyManagerPod(podName string, tmCtnAttributes []tmCtnAttribute) *v1.Pod {
-	cpusetCmd := "grep Cpus_allowed_list /proc/self/status | cut -f2 && sleep 1d"
-	return makeTopologyManagerTestPod(podName, cpusetCmd, tmCtnAttributes)
 }
 
 func makeTopologyManagerTestPod(podName, podCmd string, tmCtnAttributes []tmCtnAttribute) *v1.Pod {
@@ -315,109 +308,17 @@ func validatePodAlignment(f *framework.Framework, pod *v1.Pod, envInfo *testEnvI
 
 func runTopologyManagerPolicySuiteTests(f *framework.Framework) {
 	var cpuCap, cpuAlloc int64
-	var cpuListString, expAllowedCPUsListRegex string
-	var cpuList []int
-	var cpu1, cpu2 int
-	var cset cpuset.CPUSet
-	var err error
-	var ctnAttrs []tmCtnAttribute
-	var pod, pod1, pod2 *v1.Pod
 
 	cpuCap, cpuAlloc, _ = getLocalNodeCPUDetails(f)
 
 	ginkgo.By("running a non-Gu pod")
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "non-gu-container",
-			cpuRequest: "100m",
-			cpuLimit:   "200m",
-		},
-	}
-	pod = makeTopologyManagerPod("non-gu-pod", ctnAttrs)
-	pod = f.PodClient().CreateSync(pod)
-
-	ginkgo.By("checking if the expected cpuset was assigned")
-	expAllowedCPUsListRegex = fmt.Sprintf("^0-%d\n$", cpuCap-1)
-	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod.Spec.Containers[0].Name, pod.Name)
-
-	ginkgo.By("by deleting the pods and waiting for container removal")
-	deletePods(f, []string{pod.Name})
-	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+	runNonGuPodTest(f, cpuCap)
 
 	ginkgo.By("running a Gu pod")
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "gu-container",
-			cpuRequest: "1000m",
-			cpuLimit:   "1000m",
-		},
-	}
-	pod = makeTopologyManagerPod("gu-pod", ctnAttrs)
-	pod = f.PodClient().CreateSync(pod)
-
-	ginkgo.By("checking if the expected cpuset was assigned")
-	cpu1 = 1
-	if isHTEnabled() {
-		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-		cpu1 = cpuList[1]
-	}
-	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
-	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod.Spec.Containers[0].Name, pod.Name)
-
-	ginkgo.By("by deleting the pods and waiting for container removal")
-	deletePods(f, []string{pod.Name})
-	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+	runGuPodTest(f)
 
 	ginkgo.By("running multiple Gu and non-Gu pods")
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "gu-container",
-			cpuRequest: "1000m",
-			cpuLimit:   "1000m",
-		},
-	}
-	pod1 = makeTopologyManagerPod("gu-pod", ctnAttrs)
-	pod1 = f.PodClient().CreateSync(pod1)
-
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "non-gu-container",
-			cpuRequest: "200m",
-			cpuLimit:   "300m",
-		},
-	}
-	pod2 = makeTopologyManagerPod("non-gu-pod", ctnAttrs)
-	pod2 = f.PodClient().CreateSync(pod2)
-
-	ginkgo.By("checking if the expected cpuset was assigned")
-	cpu1 = 1
-	if isHTEnabled() {
-		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-		cpu1 = cpuList[1]
-	}
-	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
-	err = f.PodClient().MatchContainerOutput(pod1.Name, pod1.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod1.Spec.Containers[0].Name, pod1.Name)
-
-	cpuListString = "0"
-	if cpuAlloc > 2 {
-		cset = cpuset.MustParse(fmt.Sprintf("0-%d", cpuCap-1))
-		cpuListString = fmt.Sprintf("%s", cset.Difference(cpuset.NewCPUSet(cpu1)))
-	}
-	expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", cpuListString)
-	err = f.PodClient().MatchContainerOutput(pod2.Name, pod2.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod2.Spec.Containers[0].Name, pod2.Name)
-
-	ginkgo.By("by deleting the pods and waiting for container removal")
-	deletePods(f, []string{pod1.Name, pod2.Name})
-	waitForContainerRemoval(pod1.Spec.Containers[0].Name, pod1.Name, pod1.Namespace)
-	waitForContainerRemoval(pod2.Spec.Containers[0].Name, pod2.Name, pod2.Namespace)
+	runMultipleGuNonGuPods(f, cpuCap, cpuAlloc)
 
 	// Skip rest of the tests if CPU capacity < 3.
 	if cpuCap < 3 {
@@ -425,118 +326,13 @@ func runTopologyManagerPolicySuiteTests(f *framework.Framework) {
 	}
 
 	ginkgo.By("running a Gu pod requesting multiple CPUs")
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "gu-container",
-			cpuRequest: "2000m",
-			cpuLimit:   "2000m",
-		},
-	}
-	pod = makeTopologyManagerPod("gu-pod", ctnAttrs)
-	pod = f.PodClient().CreateSync(pod)
-
-	ginkgo.By("checking if the expected cpuset was assigned")
-	cpuListString = "1-2"
-	if isHTEnabled() {
-		cpuListString = "2-3"
-		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-		if cpuList[1] != 1 {
-			cset = cpuset.MustParse(getCPUSiblingList(1))
-			cpuListString = fmt.Sprintf("%s", cset)
-		}
-	}
-	expAllowedCPUsListRegex = fmt.Sprintf("^%s\n$", cpuListString)
-	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod.Spec.Containers[0].Name, pod.Name)
-
-	ginkgo.By("by deleting the pods and waiting for container removal")
-	deletePods(f, []string{pod.Name})
-	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
+	runMultipleCPUGuPod(f)
 
 	ginkgo.By("running a Gu pod with multiple containers requesting integer CPUs")
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "gu-container1",
-			cpuRequest: "1000m",
-			cpuLimit:   "1000m",
-		},
-		{
-			ctnName:    "gu-container2",
-			cpuRequest: "1000m",
-			cpuLimit:   "1000m",
-		},
-	}
-	pod = makeTopologyManagerPod("gu-pod", ctnAttrs)
-	pod = f.PodClient().CreateSync(pod)
-
-	ginkgo.By("checking if the expected cpuset was assigned")
-	cpu1, cpu2 = 1, 2
-	if isHTEnabled() {
-		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-		if cpuList[1] != 1 {
-			cpu1, cpu2 = cpuList[1], 1
-		}
-	}
-
-	expAllowedCPUsListRegex = fmt.Sprintf("^%d|%d\n$", cpu1, cpu2)
-	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod.Spec.Containers[0].Name, pod.Name)
-
-	err = f.PodClient().MatchContainerOutput(pod.Name, pod.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod.Spec.Containers[1].Name, pod.Name)
-
-	ginkgo.By("by deleting the pods and waiting for container removal")
-	deletePods(f, []string{pod.Name})
-	waitForContainerRemoval(pod.Spec.Containers[0].Name, pod.Name, pod.Namespace)
-	waitForContainerRemoval(pod.Spec.Containers[1].Name, pod.Name, pod.Namespace)
+	runMultipleCPUContainersGuPod(f)
 
 	ginkgo.By("running multiple Gu pods")
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "gu-container1",
-			cpuRequest: "1000m",
-			cpuLimit:   "1000m",
-		},
-	}
-	pod1 = makeTopologyManagerPod("gu-pod1", ctnAttrs)
-	pod1 = f.PodClient().CreateSync(pod1)
-
-	ctnAttrs = []tmCtnAttribute{
-		{
-			ctnName:    "gu-container2",
-			cpuRequest: "1000m",
-			cpuLimit:   "1000m",
-		},
-	}
-	pod2 = makeTopologyManagerPod("gu-pod2", ctnAttrs)
-	pod2 = f.PodClient().CreateSync(pod2)
-
-	ginkgo.By("checking if the expected cpuset was assigned")
-	cpu1, cpu2 = 1, 2
-	if isHTEnabled() {
-		cpuList = cpuset.MustParse(getCPUSiblingList(0)).ToSlice()
-		if cpuList[1] != 1 {
-			cpu1, cpu2 = cpuList[1], 1
-		}
-	}
-
-	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu1)
-	err = f.PodClient().MatchContainerOutput(pod1.Name, pod1.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod1.Spec.Containers[0].Name, pod1.Name)
-
-	expAllowedCPUsListRegex = fmt.Sprintf("^%d\n$", cpu2)
-	err = f.PodClient().MatchContainerOutput(pod2.Name, pod2.Spec.Containers[0].Name, expAllowedCPUsListRegex)
-	framework.ExpectNoError(err, "expected log not found in container [%s] of pod [%s]",
-		pod2.Spec.Containers[0].Name, pod2.Name)
-
-	ginkgo.By("by deleting the pods and waiting for container removal")
-	deletePods(f, []string{pod1.Name, pod2.Name})
-	waitForContainerRemoval(pod1.Spec.Containers[0].Name, pod1.Name, pod1.Namespace)
-	waitForContainerRemoval(pod2.Spec.Containers[0].Name, pod2.Name, pod2.Namespace)
+	runMultipleGuPods(f)
 }
 
 func waitForAllContainerRemoval(podName, podNS string) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind cleanup


**What this PR does / why we need it**:
Currently, TopologyManager e2e tests have a copy of CPU Manager e2e test code and does not support MultiNUMA support. This PR addresses both these issues by code-refactor and re-use.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
