### PR TITLE
Do not execute detaching in bakoff duration, avoid volume is deleted …

### DIFF
--- a/pkg/controller/volume/attachdetach/reconciler/reconciler.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler.go
@@ -175,6 +175,11 @@ func (rc *reconciler) reconcile() {
 				continue
 			}
 
+			if rc.attacherDetacher.IsDetachBackoffError(attachedVolume.AttachedVolume) {
+				klog.V(5).Infof("Volume %v on node %v is not needed detaching until next backoff retry", attachedVolume.VolumeName, attachedVolume.NodeName)
+				continue
+			}
+
 			// Before triggering volume detach, mark volume as detached and update the node status
 			// If it fails to update node status, skip detach volume
 			err = rc.actualStateOfWorld.RemoveVolumeFromReportAsAttached(attachedVolume.VolumeName, attachedVolume.NodeName)

--- a/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
+++ b/pkg/controller/volume/attachdetach/reconciler/reconciler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package reconciler
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -344,6 +345,92 @@ func Test_Run_Negative_OneDesiredVolumeAttachThenDetachWithUnmountedVolumeUpdate
 	waitForAttachCallCount(t, 1 /* expectedAttachCallCount */, fakePlugin)
 	verifyNewDetacherCallCount(t, false /* expectZeroNewDetacherCallCount */, fakePlugin)
 	waitForDetachCallCount(t, 0 /* expectedDetachCallCount */, fakePlugin)
+}
+
+func Test_Run_Negative_OneDesiredVolumeAttachAndDetachWithErrorThenRetryAttachTheVolumeToSameNode(t *testing.T) {
+	// Arrange
+	// create plugin for test detach failed
+	// (re-write detach function : fail to detach and return an detach error)
+	volumePluginMgr, fakePlugin := volumetesting.GetTestVolumePluginMgr(t)
+	dsw := cache.NewDesiredStateOfWorld(volumePluginMgr)
+	asw := cache.NewActualStateOfWorld(volumePluginMgr)
+	fakeKubeClient := controllervolumetesting.CreateTestClient()
+	fakeRecorder := &record.FakeRecorder{}
+	fakeHandler := volumetesting.NewBlockVolumePathHandler()
+	ad := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
+		fakeKubeClient,
+		volumePluginMgr,
+		fakeRecorder,
+		false, /* checkNodeCapabilitiesBeforeMount */
+		fakeHandler))
+	nsu := statusupdater.NewFakeNodeStatusUpdater(false /* returnError */)
+	reconciler := NewReconciler(
+		reconcilerLoopPeriod, maxWaitForUnmountDuration, syncLoopPeriod, false, dsw, asw, ad, nsu, fakeRecorder)
+
+	podName := "pod-uid"
+	volumeName := v1.UniqueVolumeName("volume-name")
+	volumeSpec := controllervolumetesting.GetTestVolumeSpec(string(volumeName), volumeName)
+	nodeName := k8stypes.NodeName("node-name")
+	dsw.AddNode(nodeName, false /*keepTerminatedPodVolumes*/)
+	volumeExists := dsw.VolumeExists(volumeName, nodeName)
+	if volumeExists {
+		t.Fatalf(
+			"Volume %q/node %q should not exist, but it does.",
+			volumeName,
+			nodeName)
+	}
+	fakePlugin.SetDetachError(fmt.Errorf("fake error occurred, %s -> %s ", nodeName, volumeName))
+
+	generatedVolumeName, podErr := dsw.AddPod(types.UniquePodName(podName), controllervolumetesting.NewPod(podName, podName), volumeSpec, nodeName)
+	if podErr != nil {
+		t.Fatalf("AddPod failed. Expected: <no error> Actual: <%v>", podErr)
+	}
+
+	// Act
+	ch := make(chan struct{})
+	go reconciler.Run(ch)
+	defer close(ch)
+
+	// Assert
+	waitForAttachCallCount(t, 1 /* expectedCallCount */, fakePlugin)
+	waitForNewAttacherCallCount(t, 1 /* expectedCallCount */, fakePlugin)
+	verifyNewAttacherCallCount(t, false /* expectZeroNewAttacherCallCount */, fakePlugin)
+	waitForAttachCallCount(t, 1 /* expectedAttachCallCount */, fakePlugin)
+	verifyNewDetacherCallCount(t, true /* expectZeroNewDetacherCallCount */, fakePlugin)
+	waitForDetachCallCount(t, 0 /* expectedDetachCallCount */, fakePlugin)
+	// we expect 1 volume is in UpdateStatusFor cache
+	verifyNodesToUpdateStatusFor(t, 1 /* expectedCallCount */, nodeName, asw)
+
+	nodesForVolume := asw.GetNodesForAttachedVolume(generatedVolumeName)
+
+	// Act
+	podToDelete := podName
+	dsw.DeletePod(types.UniquePodName(podToDelete), generatedVolumeName, nodesForVolume[0])
+	volumeExists = dsw.VolumeExists(generatedVolumeName, nodesForVolume[0])
+	if volumeExists {
+		t.Fatalf(
+			"Deleted pod %q from volume %q/node %q. Volume should also be deleted but it still exists.",
+			podToDelete,
+			generatedVolumeName,
+			nodesForVolume[0])
+	}
+
+	// Assert
+	waitForNewDetacherCallCount(t, 1 /* expectedCallCount */, fakePlugin)
+	verifyNewAttacherCallCount(t, false /* expectZeroNewAttacherCallCount */, fakePlugin)
+	waitForAttachCallCount(t, 1 /* expectedAttachCallCount */, fakePlugin)
+	verifyNewDetacherCallCount(t, false /* expectZeroNewDetacherCallCount */, fakePlugin)
+	waitForDetachCallCount(t, 1 /* expectedDetachCallCount */, fakePlugin)
+
+	// sleep 2s,make sure that reconciler will detach fail some times and get exponential Back off error
+	time.Sleep(2 * time.Second)
+	_, podErr = dsw.AddPod(types.UniquePodName(podName), controllervolumetesting.NewPod(podName, podName), volumeSpec, nodeName)
+	if podErr != nil {
+		t.Fatalf("AddPod failed. Expected: <no error> Actual: <%v>", podErr)
+	}
+
+	// we still expect 1 volume is in UpdateStatusFor cache after delete pod and re-add pod to the same node
+	verifyNodesToUpdateStatusFor(t, 1 /* expectedCallCount */, nodeName, asw)
 }
 
 // Creates a volume with accessMode ReadWriteMany
@@ -1202,4 +1289,21 @@ func retryWithExponentialBackOff(initialDuration time.Duration, fn wait.Conditio
 		Steps:    6,
 	}
 	return wait.ExponentialBackoff(backoff, fn)
+}
+
+func verifyNodesToUpdateStatusFor(
+	t *testing.T,
+	expectedCallCount int,
+	nodeName k8stypes.NodeName,
+	asw cache.ActualStateOfWorld) {
+
+	nodesToUpdateStatusFor := asw.GetVolumesToReportAttached()
+	volumes := nodesToUpdateStatusFor[nodeName]
+	count := len(volumes)
+	if expectedCallCount != count {
+		t.Fatalf("Wrong volumes count in AttachedList. Expected: <%v> Actual: <%v>",
+			expectedCallCount,
+			count,
+		)
+	}
 }

--- a/pkg/volume/testing/testing.go
+++ b/pkg/volume/testing/testing.go
@@ -377,6 +377,8 @@ type FakeVolumePlugin struct {
 	ProvisionDelaySeconds  int
 	SupportsRemount        bool
 
+	DetachError error
+
 	// Add callbacks as needed
 	WaitForAttachHook func(spec *Spec, devicePath string, pod *v1.Pod, spectimeout time.Duration) (string, error)
 	UnmountDeviceHook func(globalMountPath string) error
@@ -412,6 +414,7 @@ func (plugin *FakeVolumePlugin) getFakeVolume(list *[]*FakeVolume) *FakeVolume {
 	volume := &FakeVolume{
 		WaitForAttachHook: plugin.WaitForAttachHook,
 		UnmountDeviceHook: plugin.UnmountDeviceHook,
+		DetachError:       plugin.DetachError,
 	}
 	volume.VolumesAttached = make(map[string]types.NodeName)
 	volume.DeviceMountState = make(map[string]string)
@@ -668,6 +671,10 @@ func (plugin *FakeVolumePlugin) VolumeLimitKey(spec *Spec) string {
 	return plugin.LimitKey
 }
 
+func (plugin *FakeVolumePlugin) SetDetachError(err error) {
+	plugin.DetachError = err
+}
+
 // FakeBasicVolumePlugin implements a basic volume plugin. It wrappers on
 // FakeVolumePlugin but implements VolumePlugin interface only.
 // It is useful to test logic involving plugin interfaces.
@@ -820,6 +827,8 @@ type FakeVolume struct {
 	VolumesAttached  map[string]types.NodeName
 	DeviceMountState map[string]string
 	VolumeMountState map[string]string
+
+	DetachError error
 
 	// Add callbacks as needed
 	WaitForAttachHook func(spec *Spec, devicePath string, pod *v1.Pod, spectimeout time.Duration) (string, error)
@@ -1250,6 +1259,9 @@ func (fv *FakeVolume) Detach(volumeName string, nodeName types.NodeName) error {
 	fv.Lock()
 	defer fv.Unlock()
 	fv.DetachCallCount++
+	if fv.DetachError != nil {
+		return fv.DetachError
+	}
 	if _, exist := fv.VolumesAttached[volumeName]; !exist {
 		return fmt.Errorf("Trying to detach volume %q that is not attached to the node %q", volumeName, nodeName)
 	}

--- a/pkg/volume/util/operationexecutor/operation_executor.go
+++ b/pkg/volume/util/operationexecutor/operation_executor.go
@@ -147,6 +147,8 @@ type OperationExecutor interface {
 	ReconstructVolumeOperation(volumeMode v1.PersistentVolumeMode, plugin volume.VolumePlugin, mapperPlugin volume.BlockVolumePlugin, uid types.UID, podName volumetypes.UniquePodName, volumeSpecName string, volumePath string, pluginName string) (*volume.Spec, error)
 	// CheckVolumeExistenceOperation checks volume existence
 	CheckVolumeExistenceOperation(volumeSpec *volume.Spec, mountPath, volumeName string, mounter mount.Interface, uniqueVolumeName v1.UniqueVolumeName, podName volumetypes.UniquePodName, podUID types.UID, attachable volume.AttachableVolumePlugin) (bool, error)
+
+	IsDetachBackoffError(volumeToDetach AttachedVolume) bool
 }
 
 // NewOperationExecutor returns a new instance of OperationExecutor.
@@ -655,6 +657,10 @@ func (oe *operationExecutor) IsOperationPending(
 	podName volumetypes.UniquePodName,
 	nodeName types.NodeName) bool {
 	return oe.pendingOperations.IsOperationPending(volumeName, podName, nodeName)
+}
+
+func (oe *operationExecutor) IsDetachBackoffError(volumeToDetach AttachedVolume) bool {
+	return oe.pendingOperations.IsDetachBackoffError(volumeToDetach.VolumeName, "", "")
 }
 
 func (oe *operationExecutor) AttachVolume(


### PR DESCRIPTION
…from attached list, but not added back soon because of detaching with ExponentialBackoff.

What type of PR is this?
/kind bug

What this PR does / why we need it:
check volume if in backofferror duration before RemoveVolumeFromReportAsAttached， if in backofferror duration, skip RemoveVolumeFromReportAsAttached and detach，thus ensuring the volume which is failed to detach do not delete from node.status.VolumesAttached, and then the sts pod on same node will be "Running"

Which issue(s) this PR fixes:
Fixes #88565 and #72181

Special notes for your reviewer:
@malc0lm

Does this PR introduce a user-facing change?:
NONE
