### PR TITLE
Create ReplicationController lifecycle test - +7 endpoint coverage

### DIFF
--- a/test/e2e/apps/BUILD
+++ b/test/e2e/apps/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//pkg/master/ports:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -256,7 +256,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 
 		// Delete ReplicationController
 		ginkgo.By("deleting ReplicationControllers by collection")
-		err = f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).DeleteCollection(context.TODO(), &metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-rc-static=true"})
+		err = f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-rc-static=true"})
 		framework.ExpectNoError(err, "Failed to delete ReplicationControllers")
 
 		ginkgo.By("waiting for ReplicationController to have a DELETED watchEvent")

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -256,9 +256,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 
 		ginkgo.By("waiting for ReplicationController is have a DeletionTimestamp")
 		for event := range rcWatchChan {
-			rc, ok := event.Object.(*v1.ReplicationController)
-			framework.ExpectEqual(ok, true, "Unable to convert type of ReplicationController watch event")
-			if rc.ObjectMeta.DeletionTimestamp != nil {
+			if event.Type == "DELETED" {
 				break
 			}
 		}

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -134,7 +134,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		framework.ExpectNoError(err, "Failed to create ReplicationController")
 
 		// setup a watch for the RC
-		rcWatchTimeoutSeconds := int64(60)
+		rcWatchTimeoutSeconds := int64(180)
 		rcWatch, err := f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).Watch(context.TODO(), metav1.ListOptions{LabelSelector: "test-rc-static=true", TimeoutSeconds: &rcWatchTimeoutSeconds})
 		framework.ExpectNoError(err, "Failed to setup watch on newly created ReplicationController")
 
@@ -259,7 +259,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		err = f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).DeleteCollection(context.TODO(), &metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-rc-static=true"})
 		framework.ExpectNoError(err, "Failed to delete ReplicationControllers")
 
-		ginkgo.By("waiting for ReplicationController is have a DeletionTimestamp")
+		ginkgo.By("waiting for ReplicationController to have a DELETED event")
 		for event := range rcWatchChan {
 			if event.Type == "DELETED" {
 				break

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -248,7 +248,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 				break
 			}
 		}
-		time.Sleep(1 * time.Second)
+		time.Sleep(10 * time.Second)
 
 		// Get the ReplicationController to check that it's deleted
 		_, err = f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).Get(context.TODO(), testRcName, metav1.GetOptions{})

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -17,28 +17,28 @@ limitations under the License.
 package apps
 
 import (
-	"encoding/json"
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/dynamic"
 	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/kubernetes/pkg/controller/replication"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	"k8s.io/client-go/dynamic"
 
 	"github.com/onsi/ginkgo"
 )
@@ -107,7 +107,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 
 		rcTest := v1.ReplicationController{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: testRcName,
+				Name:   testRcName,
 				Labels: map[string]string{"test-rc-static": "true"},
 			},
 			Spec: v1.ReplicationControllerSpec{
@@ -115,12 +115,12 @@ var _ = SIGDescribe("ReplicationController", func() {
 				Selector: map[string]string{"test-rc-static": "true"},
 				Template: &v1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: testRcName,
+						Name:   testRcName,
 						Labels: map[string]string{"test-rc-static": "true"},
 					},
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{
-							Name: testRcName,
+							Name:  testRcName,
 							Image: "nginx",
 						}},
 					},
@@ -158,7 +158,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 
 		rcStatusPatchPayload, err := json.Marshal(map[string]interface{}{
 			"status": map[string]interface{}{
-				"readyReplicas": 0,
+				"readyReplicas":     0,
 				"availableReplicas": 0,
 			},
 		})

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -179,7 +179,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 
 		rcScalePatchPayload, err := json.Marshal(autoscalingv1.Scale{
 			Spec: autoscalingv1.ScaleSpec{
-				Replicas: 2,
+				Replicas: testRcMaxReplicaCount,
 			},
 		})
 		framework.ExpectNoError(err, "Failed to marshal json of replicationcontroller label patch")

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -262,13 +262,6 @@ var _ = SIGDescribe("ReplicationController", func() {
 				break
 			}
 		}
-		ginkgo.By("waiting for 10 seconds to ensure that it's deleted")
-		time.Sleep(10 * time.Second)
-
-		// Get the ReplicationController to check that it's deleted
-		ginkgo.By("fetching the ReplicationController to ensure that it's deleted")
-		_, err = f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).Get(context.TODO(), testRcName, metav1.GetOptions{})
-		framework.ExpectError(err, "Failed to delete ReplicationController")
 	})
 })
 

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -141,9 +141,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 		rcWatchChan := rcWatch.ResultChan()
 
 		ginkgo.By("waiting for available Replicas")
-		for event := range rcWatchChan {
-			rc, ok := event.Object.(*v1.ReplicationController)
-			framework.ExpectEqual(ok, true, "Unable to convert type of ReplicationController watch event")
+		for watchEvent := range rcWatchChan {
+			rc, ok := watchEvent.Object.(*v1.ReplicationController)
+			framework.ExpectEqual(ok, true, "Unable to convert type of ReplicationController watch watchEvent")
 			if rc.Status.Replicas == testRcInitialReplicaCount && rc.Status.ReadyReplicas == testRcInitialReplicaCount {
 				break
 			}
@@ -198,9 +198,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 		var rcFromWatch *v1.ReplicationController
 		ginkgo.By("waiting for ReplicationController's scale to be the max amount")
 		foundRcWithMaxScale := false
-		for event := range rcWatchChan {
-			rc, ok := event.Object.(*v1.ReplicationController)
-			framework.ExpectEqual(ok, true, "Unable to convert type of ReplicationController watch event")
+		for watchEvent := range rcWatchChan {
+			rc, ok := watchEvent.Object.(*v1.ReplicationController)
+			framework.ExpectEqual(ok, true, "Unable to convert type of ReplicationController watch watchEvent")
 			if rc.ObjectMeta.Name == testRcName && rc.ObjectMeta.Namespace == testRcNamespace && rc.Status.Replicas == testRcMaxReplicaCount && rc.Status.ReadyReplicas == testRcMaxReplicaCount {
 				foundRcWithMaxScale = true
 				rcFromWatch = rc
@@ -227,9 +227,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 		framework.ExpectEqual(rcStatus.Status.ReadyReplicas, int32(1), "ReplicationControllerStatus readyReplicas does not equal 1")
 
 		ginkgo.By(fmt.Sprintf("waiting for ReplicationController readyReplicas to be equal to %v", testRcMaxReplicaCount))
-		for event := range rcWatchChan {
-			rc, ok := event.Object.(*v1.ReplicationController)
-			framework.ExpectEqual(ok, true, "unable to convert type of ReplicationController watch event")
+		for watchEvent := range rcWatchChan {
+			rc, ok := watchEvent.Object.(*v1.ReplicationController)
+			framework.ExpectEqual(ok, true, "unable to convert type of ReplicationController watch watchEvent")
 			if rc.Status.Replicas == testRcMaxReplicaCount && rc.Status.ReadyReplicas == testRcMaxReplicaCount {
 				break
 			}
@@ -259,9 +259,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 		err = f.ClientSet.CoreV1().ReplicationControllers(testRcNamespace).DeleteCollection(context.TODO(), &metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "test-rc-static=true"})
 		framework.ExpectNoError(err, "Failed to delete ReplicationControllers")
 
-		ginkgo.By("waiting for ReplicationController to have a DELETED event")
-		for event := range rcWatchChan {
-			if event.Type == "DELETED" {
+		ginkgo.By("waiting for ReplicationController to have a DELETED watchEvent")
+		for watchEvent := range rcWatchChan {
+			if watchEvent.Type == "DELETED" {
 				break
 			}
 		}

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -175,7 +175,7 @@ var _ = SIGDescribe("ReplicationController", func() {
 		framework.ExpectEqual(rcStatus.Status.ReadyReplicas, int32(0), "ReplicationControllerStatus's readyReplicas does not equal 0")
 
 		ginkgo.By("fetching ReplicationController status")
-		rcStatusUnstructured, err := dc.Resource(rcResource).Namespace(testRcNamespace).Get(testRcName, metav1.GetOptions{}, "status")
+		rcStatusUnstructured, err := dc.Resource(rcResource).Namespace(testRcNamespace).Get(context.TODO(), testRcName, metav1.GetOptions{}, "status")
 		framework.ExpectNoError(err, "Failed to fetch ReplicationControllerStatus")
 
 		rcStatusUjson, err := json.Marshal(rcStatusUnstructured)


### PR DESCRIPTION
- [x] [APISnoop mock ticket](https://github.com/cncf/apisnoop/pull/289)
- [x] [mock template ticket](https://github.com/kubernetes/kubernetes/issues/88302)
- [x] [PR](#)
- [ ] [promotion](https://github.com/kubernetes/kubernetes/issues/88302)
  - [ ] [update and improve](https://github.com/kubernetes/kubernetes/pull/89746)

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a test to test the following untested endpoints:
+ replaceCoreV1NamespacedReplicationControllerStatus
+ readCoreV1NamespacedReplicationControllerStatus
+ patchCoreV1NamespacedReplicationControllerStatus
+ patchCoreV1NamespacedReplicationControllerScale
+ patchCoreV1NamespacedReplicationController
+ listCoreV1ReplicationControllerForAllNamespaces
+ deleteCoreV1CollectionNamespacedReplicationController

**Which issue(s) this PR fixes**:
Fixes #88302

**Special notes for your reviewer**:
Adds +7 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing