### PR TITLE
Test PodTopologySpread.{PreFilter,PreScore} instead of internal pre-processing

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/BUILD
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/BUILD
@@ -41,6 +41,8 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -29,16 +29,17 @@ type topologyPair struct {
 
 // topologySpreadConstraint is an internal version for v1.TopologySpreadConstraint
 // and where the selector is parsed.
+// Fields are exported for comparison during testing.
 type topologySpreadConstraint struct {
-	maxSkew     int32
-	topologyKey string
-	selector    labels.Selector
+	MaxSkew     int32
+	TopologyKey string
+	Selector    labels.Selector
 }
 
-// nodeLabelsMatchSpreadConstraints checks if ALL topology keys in spread constraints are present in node labels.
+// nodeLabelsMatchSpreadConstraints checks if ALL topology keys in spread Constraints are present in node labels.
 func nodeLabelsMatchSpreadConstraints(nodeLabels map[string]string, constraints []topologySpreadConstraint) bool {
 	for _, c := range constraints {
-		if _, ok := nodeLabels[c.topologyKey]; !ok {
+		if _, ok := nodeLabels[c.TopologyKey]; !ok {
 			return false
 		}
 	}
@@ -54,9 +55,9 @@ func filterTopologySpreadConstraints(constraints []v1.TopologySpreadConstraint, 
 				return nil, err
 			}
 			result = append(result, topologySpreadConstraint{
-				maxSkew:     c.MaxSkew,
-				topologyKey: c.TopologyKey,
-				selector:    selector,
+				MaxSkew:     c.MaxSkew,
+				TopologyKey: c.TopologyKey,
+				Selector:    selector,
 			})
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -29,26 +29,26 @@ import (
 	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/nodeinfo"
-	schedulernodeinfo "k8s.io/kubernetes/pkg/scheduler/nodeinfo"
 )
 
 const preFilterStateKey = "PreFilter" + Name
 
 // preFilterState computed at PreFilter and used at Filter.
-// It combines tpKeyToCriticalPaths and tpPairToMatchNum to represent:
+// It combines TpKeyToCriticalPaths and TpPairToMatchNum to represent:
 // (1) critical paths where the least pods are matched on each spread constraint.
 // (2) number of pods matched on each spread constraint.
 // A nil preFilterState denotes it's not set at all (in PreFilter phase);
 // An empty preFilterState object denotes it's a legit state and is set in PreFilter phase.
+// Fields are exported for comparison during testing.
 type preFilterState struct {
-	constraints []topologySpreadConstraint
+	Constraints []topologySpreadConstraint
 	// We record 2 critical paths instead of all critical paths here.
-	// criticalPaths[0].matchNum always holds the minimum matching number.
-	// criticalPaths[1].matchNum is always greater or equal to criticalPaths[0].matchNum, but
+	// criticalPaths[0].MatchNum always holds the minimum matching number.
+	// criticalPaths[1].MatchNum is always greater or equal to criticalPaths[0].MatchNum, but
 	// it's not guaranteed to be the 2nd minimum match number.
-	tpKeyToCriticalPaths map[string]*criticalPaths
-	// tpPairToMatchNum is keyed with topologyPair, and valued with the number of matching pods.
-	tpPairToMatchNum map[topologyPair]int32
+	TpKeyToCriticalPaths map[string]*criticalPaths
+	// TpPairToMatchNum is keyed with topologyPair, and valued with the number of matching pods.
+	TpPairToMatchNum map[topologyPair]int32
 }
 
 // Clone makes a copy of the given state.
@@ -58,26 +58,19 @@ func (s *preFilterState) Clone() framework.StateData {
 		return nil
 	}
 	copy := preFilterState{
-		// constraints are shared because they don't change.
-		constraints:          s.constraints,
-		tpKeyToCriticalPaths: make(map[string]*criticalPaths, len(s.tpKeyToCriticalPaths)),
-		tpPairToMatchNum:     make(map[topologyPair]int32, len(s.tpPairToMatchNum)),
+		// Constraints are shared because they don't change.
+		Constraints:          s.Constraints,
+		TpKeyToCriticalPaths: make(map[string]*criticalPaths, len(s.TpKeyToCriticalPaths)),
+		TpPairToMatchNum:     make(map[topologyPair]int32, len(s.TpPairToMatchNum)),
 	}
-	for tpKey, paths := range s.tpKeyToCriticalPaths {
-		copy.tpKeyToCriticalPaths[tpKey] = &criticalPaths{paths[0], paths[1]}
+	for tpKey, paths := range s.TpKeyToCriticalPaths {
+		copy.TpKeyToCriticalPaths[tpKey] = &criticalPaths{paths[0], paths[1]}
 	}
-	for tpPair, matchNum := range s.tpPairToMatchNum {
+	for tpPair, matchNum := range s.TpPairToMatchNum {
 		copyPair := topologyPair{key: tpPair.key, value: tpPair.value}
-		copy.tpPairToMatchNum[copyPair] = matchNum
+		copy.TpPairToMatchNum[copyPair] = matchNum
 	}
 	return &copy
-}
-
-type criticalPath struct {
-	// topologyValue denotes the topology value mapping to topology key.
-	topologyValue string
-	// matchNum denotes the number of matching pods.
-	matchNum int32
 }
 
 // CAVEAT: the reason that `[2]criticalPath` can work is based on the implementation of current
@@ -86,38 +79,44 @@ type criticalPath struct {
 // Fact 2: each node is evaluated on a separate copy of the preFilterState during its preemption cycle.
 // If we plan to turn to a more complex algorithm like "arbitrary pods on multiple nodes", this
 // structure needs to be revisited.
-type criticalPaths [2]criticalPath
+// Fields are exported for comparison during testing.
+type criticalPaths [2]struct {
+	// TopologyValue denotes the topology value mapping to topology key.
+	TopologyValue string
+	// MatchNum denotes the number of matching pods.
+	MatchNum int32
+}
 
 func newCriticalPaths() *criticalPaths {
-	return &criticalPaths{{matchNum: math.MaxInt32}, {matchNum: math.MaxInt32}}
+	return &criticalPaths{{MatchNum: math.MaxInt32}, {MatchNum: math.MaxInt32}}
 }
 
 func (paths *criticalPaths) update(tpVal string, num int32) {
 	// first verify if `tpVal` exists or not
 	i := -1
-	if tpVal == paths[0].topologyValue {
+	if tpVal == paths[0].TopologyValue {
 		i = 0
-	} else if tpVal == paths[1].topologyValue {
+	} else if tpVal == paths[1].TopologyValue {
 		i = 1
 	}
 
 	if i >= 0 {
 		// `tpVal` exists
-		paths[i].matchNum = num
-		if paths[0].matchNum > paths[1].matchNum {
+		paths[i].MatchNum = num
+		if paths[0].MatchNum > paths[1].MatchNum {
 			// swap paths[0] and paths[1]
 			paths[0], paths[1] = paths[1], paths[0]
 		}
 	} else {
 		// `tpVal` doesn't exist
-		if num < paths[0].matchNum {
+		if num < paths[0].MatchNum {
 			// update paths[1] with paths[0]
 			paths[1] = paths[0]
 			// update paths[0]
-			paths[0].topologyValue, paths[0].matchNum = tpVal, num
-		} else if num < paths[1].matchNum {
+			paths[0].TopologyValue, paths[0].MatchNum = tpVal, num
+		} else if num < paths[1].MatchNum {
 			// update paths[1]
-			paths[1].topologyValue, paths[1].matchNum = tpVal, num
+			paths[1].TopologyValue, paths[1].MatchNum = tpVal, num
 		}
 	}
 }
@@ -126,40 +125,31 @@ func (s *preFilterState) updateWithPod(updatedPod, preemptorPod *v1.Pod, node *v
 	if s == nil || updatedPod.Namespace != preemptorPod.Namespace || node == nil {
 		return
 	}
-	if !nodeLabelsMatchSpreadConstraints(node.Labels, s.constraints) {
+	if !nodeLabelsMatchSpreadConstraints(node.Labels, s.Constraints) {
 		return
 	}
 
 	podLabelSet := labels.Set(updatedPod.Labels)
-	for _, constraint := range s.constraints {
-		if !constraint.selector.Matches(podLabelSet) {
+	for _, constraint := range s.Constraints {
+		if !constraint.Selector.Matches(podLabelSet) {
 			continue
 		}
 
-		k, v := constraint.topologyKey, node.Labels[constraint.topologyKey]
+		k, v := constraint.TopologyKey, node.Labels[constraint.TopologyKey]
 		pair := topologyPair{key: k, value: v}
-		s.tpPairToMatchNum[pair] = s.tpPairToMatchNum[pair] + delta
+		s.TpPairToMatchNum[pair] = s.TpPairToMatchNum[pair] + delta
 
-		s.tpKeyToCriticalPaths[k].update(v, s.tpPairToMatchNum[pair])
+		s.TpKeyToCriticalPaths[k].update(v, s.TpPairToMatchNum[pair])
 	}
 }
 
 // PreFilter invoked at the prefilter extension point.
 func (pl *PodTopologySpread) PreFilter(ctx context.Context, cycleState *framework.CycleState, pod *v1.Pod) *framework.Status {
-	var s *preFilterState
-	var allNodes []*nodeinfo.NodeInfo
-	var err error
-
-	if allNodes, err = pl.sharedLister.NodeInfos().List(); err != nil {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("failed to list NodeInfos: %v", err))
+	s, err := pl.calPreFilterState(pod)
+	if err != nil {
+		return framework.NewStatus(framework.Error, err.Error())
 	}
-
-	if s, err = calPreFilterState(pod, allNodes); err != nil {
-		return framework.NewStatus(framework.Error, fmt.Sprintf("Error calculating preFilterState of PodTopologySpread Plugin: %v", err))
-	}
-
 	cycleState.Write(preFilterStateKey, s)
-
 	return nil
 }
 
@@ -206,9 +196,13 @@ func getPreFilterState(cycleState *framework.CycleState) (*preFilterState, error
 }
 
 // calPreFilterState computes preFilterState describing how pods are spread on topologies.
-func calPreFilterState(pod *v1.Pod, allNodes []*schedulernodeinfo.NodeInfo) (*preFilterState, error) {
+func (pl *PodTopologySpread) calPreFilterState(pod *v1.Pod) (*preFilterState, error) {
+	allNodes, err := pl.sharedLister.NodeInfos().List()
+	if err != nil {
+		return nil, fmt.Errorf("listing NodeInfos: %v", err)
+	}
 	// We have feature gating in APIServer to strip the spec
-	// so don't need to re-check feature gate, just check length of constraints.
+	// so don't need to re-check feature gate, just check length of Constraints.
 	constraints, err := filterTopologySpreadConstraints(pod.Spec.TopologySpreadConstraints, v1.DoNotSchedule)
 	if err != nil {
 		return nil, err
@@ -222,13 +216,13 @@ func calPreFilterState(pod *v1.Pod, allNodes []*schedulernodeinfo.NodeInfo) (*pr
 	// TODO(Huang-Wei): It might be possible to use "make(map[topologyPair]*int32)".
 	// In that case, need to consider how to init each tpPairToCount[pair] in an atomic fashion.
 	s := preFilterState{
-		constraints:          constraints,
-		tpKeyToCriticalPaths: make(map[string]*criticalPaths, len(constraints)),
-		tpPairToMatchNum:     make(map[topologyPair]int32),
+		Constraints:          constraints,
+		TpKeyToCriticalPaths: make(map[string]*criticalPaths, len(constraints)),
+		TpPairToMatchNum:     make(map[topologyPair]int32),
 	}
 	addTopologyPairMatchNum := func(pair topologyPair, num int32) {
 		lock.Lock()
-		s.tpPairToMatchNum[pair] += num
+		s.TpPairToMatchNum[pair] += num
 		lock.Unlock()
 	}
 
@@ -245,7 +239,7 @@ func calPreFilterState(pod *v1.Pod, allNodes []*schedulernodeinfo.NodeInfo) (*pr
 			return
 		}
 
-		// Ensure current node's labels contains all topologyKeys in 'constraints'.
+		// Ensure current node's labels contains all topologyKeys in 'Constraints'.
 		if !nodeLabelsMatchSpreadConstraints(node.Labels, constraints) {
 			return
 		}
@@ -257,11 +251,11 @@ func calPreFilterState(pod *v1.Pod, allNodes []*schedulernodeinfo.NodeInfo) (*pr
 				if existingPod.DeletionTimestamp != nil || existingPod.Namespace != pod.Namespace {
 					continue
 				}
-				if constraint.selector.Matches(labels.Set(existingPod.Labels)) {
+				if constraint.Selector.Matches(labels.Set(existingPod.Labels)) {
 					matchTotal++
 				}
 			}
-			pair := topologyPair{key: constraint.topologyKey, value: node.Labels[constraint.topologyKey]}
+			pair := topologyPair{key: constraint.TopologyKey, value: node.Labels[constraint.TopologyKey]}
 			addTopologyPairMatchNum(pair, matchTotal)
 		}
 	}
@@ -269,11 +263,11 @@ func calPreFilterState(pod *v1.Pod, allNodes []*schedulernodeinfo.NodeInfo) (*pr
 
 	// calculate min match for each topology pair
 	for i := 0; i < len(constraints); i++ {
-		key := constraints[i].topologyKey
-		s.tpKeyToCriticalPaths[key] = newCriticalPaths()
+		key := constraints[i].TopologyKey
+		s.TpKeyToCriticalPaths[key] = newCriticalPaths()
 	}
-	for pair, num := range s.tpPairToMatchNum {
-		s.tpKeyToCriticalPaths[pair.key].update(pair.value, num)
+	for pair, num := range s.TpPairToMatchNum {
+		s.TpKeyToCriticalPaths[pair.key].update(pair.value, num)
 	}
 
 	return &s, nil
@@ -292,38 +286,38 @@ func (pl *PodTopologySpread) Filter(ctx context.Context, cycleState *framework.C
 	}
 
 	// However, "empty" preFilterState is legit which tolerates every toSchedule Pod.
-	if len(s.tpPairToMatchNum) == 0 || len(s.constraints) == 0 {
+	if len(s.TpPairToMatchNum) == 0 || len(s.Constraints) == 0 {
 		return nil
 	}
 
 	podLabelSet := labels.Set(pod.Labels)
-	for _, c := range s.constraints {
-		tpKey := c.topologyKey
-		tpVal, ok := node.Labels[c.topologyKey]
+	for _, c := range s.Constraints {
+		tpKey := c.TopologyKey
+		tpVal, ok := node.Labels[c.TopologyKey]
 		if !ok {
 			klog.V(5).Infof("node '%s' doesn't have required label '%s'", node.Name, tpKey)
 			return framework.NewStatus(framework.Unschedulable, ErrReasonConstraintsNotMatch)
 		}
 
 		selfMatchNum := int32(0)
-		if c.selector.Matches(podLabelSet) {
+		if c.Selector.Matches(podLabelSet) {
 			selfMatchNum = 1
 		}
 
 		pair := topologyPair{key: tpKey, value: tpVal}
-		paths, ok := s.tpKeyToCriticalPaths[tpKey]
+		paths, ok := s.TpKeyToCriticalPaths[tpKey]
 		if !ok {
 			// error which should not happen
-			klog.Errorf("internal error: get paths from key %q of %#v", tpKey, s.tpKeyToCriticalPaths)
+			klog.Errorf("internal error: get paths from key %q of %#v", tpKey, s.TpKeyToCriticalPaths)
 			continue
 		}
 		// judging criteria:
 		// 'existing matching num' + 'if self-match (1 or 0)' - 'global min matching num' <= 'maxSkew'
-		minMatchNum := paths[0].matchNum
-		matchNum := s.tpPairToMatchNum[pair]
+		minMatchNum := paths[0].MatchNum
+		matchNum := s.TpPairToMatchNum[pair]
 		skew := matchNum + selfMatchNum - minMatchNum
-		if skew > c.maxSkew {
-			klog.V(5).Infof("node '%s' failed spreadConstraint[%s]: matchNum(%d) + selfMatchNum(%d) - minMatchNum(%d) > maxSkew(%d)", node.Name, tpKey, matchNum, selfMatchNum, minMatchNum, c.maxSkew)
+		if skew > c.MaxSkew {
+			klog.V(5).Infof("node '%s' failed spreadConstraint[%s]: MatchNum(%d) + selfMatchNum(%d) - minMatchNum(%d) > maxSkew(%d)", node.Name, tpKey, matchNum, selfMatchNum, minMatchNum, c.MaxSkew)
 			return framework.NewStatus(framework.Unschedulable, ErrReasonConstraintsNotMatch)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

In general, it is good practice to test public APIs instead of unexported functions.
I'm also reducing the use of reflect in favor of cmp, so that it's easier to spot differences when debugging.

**Which issue(s) this PR fixes**:

This will make my life easier for #80639

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```