### PR TITLE
Use canonical URL for the krew project

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/extending_kubectl/discovering_plugins.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/extending_kubectl/discovering_plugins.md
@@ -3,13 +3,13 @@
 {% endpanel %}
 
 {% panel style="info", title="TL;DR" %}
-- [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation) is a kubernetes sub-project to discover and manage plugins
+- [krew.sigs.k8s.io](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) is a kubernetes sub-project to discover and manage plugins
 {% endpanel %}
 
 # Krew
 
 By design, `kubectl` does not install plugins. This task is left to the kubernetes sub-project
-[sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation) which needs to be installed separately.
+[krew.sigs.k8s.io](https://krew.sigs.k8s.io/docs/user-guide/setup/install/) which needs to be installed separately.
 Krew helps to
 
 - discover plugins
@@ -21,7 +21,7 @@ Krew helps to
 Krew should be used as a kubectl plugin. To set yourself up to using krew, you need to do two things:
 
 1. Install git
-1. Install krew as described on the project page [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation).
+1. Install krew as described on the project page [krew.sigs.k8s.io](https://krew.sigs.k8s.io/docs/user-guide/setup/install/).
 1. Add the krew bin folder to your `PATH` environment variable. For example, in bash `export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"`.
 
 ## Krew capabilities

--- a/staging/src/k8s.io/kubectl/docs/book/pages/extending_kubectl/discovering_plugins.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/extending_kubectl/discovering_plugins.md
@@ -3,13 +3,13 @@
 {% endpanel %}
 
 {% panel style="info", title="TL;DR" %}
-- [krew.dev](https://github.com/kubernetes-sigs/krew/#installation) is a kubernetes sub-project to discover and manage plugins
+- [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation) is a kubernetes sub-project to discover and manage plugins
 {% endpanel %}
 
 # Krew
 
 By design, `kubectl` does not install plugins. This task is left to the kubernetes sub-project
-[krew.dev](https://github.com/kubernetes-sigs/krew/#installation) which needs to be installed separately.
+[sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation) which needs to be installed separately.
 Krew helps to
 
 - discover plugins
@@ -21,7 +21,7 @@ Krew helps to
 Krew should be used as a kubectl plugin. To set yourself up to using krew, you need to do two things:
 
 1. Install git
-1. Install krew as described on the project page [krew.dev](https://github.com/kubernetes-sigs/krew/#installation).
+1. Install krew as described on the project page [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation).
 1. Add the krew bin folder to your `PATH` environment variable. For example, in bash `export PATH="${KREW_ROOT:-$HOME/.krew}/bin:$PATH"`.
 
 ## Krew capabilities

--- a/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
@@ -222,4 +222,4 @@ kubectl plugin list
 
 {% endmethod %}
 
-The easiest way to discover and install plugins is via the kubernetes sub-project [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation).
+The easiest way to discover and install plugins is via the kubernetes sub-project [krew.sigs.k8s.io](https://krew.sigs.k8s.io/docs/user-guide/setup/install/).

--- a/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/kubectl_book/getting_started.md
@@ -222,4 +222,4 @@ kubectl plugin list
 
 {% endmethod %}
 
-The easiest way to discover and install plugins is via the kubernetes sub-project [krew.dev](https://github.com/kubernetes-sigs/krew/#installation).
+The easiest way to discover and install plugins is via the kubernetes sub-project [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation).

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -41,7 +41,7 @@ var (
 		Please refer to the documentation and examples for more information about how write your own plugins.
 
 		The easiest way to discover and install plugins is via the kubernetes sub-project krew.
-		To install krew, visit [krew.dev](https://github.com/kubernetes-sigs/krew/#installation)`)
+		To install krew, visit [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation)`)
 
 	pluginListLong = templates.LongDesc(`
 		List all available plugin files on a user's PATH.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/plugin/plugin.go
@@ -41,7 +41,7 @@ var (
 		Please refer to the documentation and examples for more information about how write your own plugins.
 
 		The easiest way to discover and install plugins is via the kubernetes sub-project krew.
-		To install krew, visit [sigs.k8s.io/krew](https://sigs.k8s.io/krew/#installation)`)
+		To install krew, visit [krew.sigs.k8s.io](https://krew.sigs.k8s.io/docs/user-guide/setup/install/)`)
 
 	pluginListLong = templates.LongDesc(`
 		List all available plugin files on a user's PATH.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind documentation

**What this PR does / why we need it**:
In official documentation, we should always use the canonical URL for kubernetes projects. I messed this up a bit in https://github.com/kubernetes/kubernetes/pull/88577 where  I used

- krew.dev which is just a privately owned redirect
- github.com/kubernetes-sigs/krew which is not the official URL either

So I'd like to consistently change that to `sigs.k8s.io/krew`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubectl/issues/829

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
