### PR TITLE
[1.17] build: Enable kube-cross image-building on K8s Infra

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -127,6 +127,18 @@ aliases:
     - hoegaarden # Patch Release Team
     - justaugustus # SIG Chair
     - tpepper # SIG Chair / Patch Release Team
+  build-image-approvers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx
+  build-image-reviewers:
+    - BenTheElder
+    - cblecker
+    - dims
+    - justaugustus
+    - listx
 
   sig-storage-reviewers:
     - saad-ali

--- a/build/OWNERS
+++ b/build/OWNERS
@@ -4,6 +4,7 @@ reviewers:
   - bentheelder
   - cblecker
   - fejta
+  - justaugustus
   - lavalamp
   - spiffxp
 approvers:

--- a/build/build-image/Dockerfile
+++ b/build/build-image/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # This file creates a standard build environment for building Kubernetes
-FROM k8s.gcr.io/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
+FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:KUBE_BUILD_IMAGE_CROSS_TAG
 
 # Mark this as a kube-build container
 RUN touch /kube-build-image

--- a/build/build-image/OWNERS
+++ b/build/build-image/OWNERS
@@ -1,0 +1,10 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+approvers:
+  - build-image-approvers
+reviewers:
+  - build-image-reviewers
+
+labels:
+  - sig/release
+  - area/release-eng

--- a/build/build-image/cross/Makefile
+++ b/build/build-image/cross/Makefile
@@ -14,15 +14,22 @@
 
 .PHONY:	build push
 
-REGISTRY?=staging-k8s.gcr.io
-IMAGE=$(REGISTRY)/kube-cross
-TAG=$(shell cat VERSION)
+STAGING_REGISTRY?=gcr.io/k8s-staging-build-image
+PROD_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
+IMAGE=kube-cross
 
+TAG?=kubernetes-$(shell git describe --tags --match='v*' --abbrev=14)
+KUBE_CROSS_VERSION=$(shell cat VERSION)
 
-all: push
+all: build push
 
 build:
-	docker build --pull -t $(IMAGE):$(TAG) .
+	docker build \
+		-t $(STAGING_REGISTRY)/$(IMAGE):$(TAG) \
+		-t $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION) \
+		-t $(PROD_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION) \
+		.
 
-push: build
-	docker push $(IMAGE):$(TAG)
+push:
+	docker push $(STAGING_REGISTRY)/$(IMAGE):$(TAG)
+	docker push $(STAGING_REGISTRY)/$(IMAGE):$(KUBE_CROSS_VERSION)

--- a/build/build-image/cross/cloudbuild.yaml
+++ b/build/build-image/cross/cloudbuild.yaml
@@ -1,0 +1,13 @@
+# See https://cloud.google.com/cloud-build/docs/build-config
+timeout: 1200s
+options:
+  substitution_option: ALLOW_LOOSE
+steps:
+  - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20191019-6567e5c'
+    entrypoint: make
+    env:
+    - DOCKER_CLI_EXPERIMENTAL=enabled
+    args:
+    - all
+images:
+  - 'gcr.io/$PROJECT_ID/kube-cross:kubernetes-${_GIT_TAG}'

--- a/build/pause/Makefile
+++ b/build/pause/Makefile
@@ -29,7 +29,7 @@ ARCH ?= amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 
 CFLAGS = -Os -Wall -Werror -static -DVERSION=v$(TAG)-$(REV)
-KUBE_CROSS_IMAGE ?= k8s.gcr.io/kube-cross
+KUBE_CROSS_IMAGE ?= us.gcr.io/k8s-artifacts-prod/build-image/kube-cross
 KUBE_CROSS_VERSION ?= $(shell cat ../build-image/cross/VERSION)
 
 BIN = pause


### PR DESCRIPTION
Cherry pick of #88562 on release-1.17.
Required to allow referencing [`kube-cross` images stored on K8s Infra](https://github.com/kubernetes/release/issues/1133).

#88562: build: Enable kube-cross image-building on K8s Infra

/kind feature cleanup
/sig release
/area release-eng
/priority important-soon

```release-note
build: Enable kube-cross image-building on K8s Infra
```

---

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.