### PR TITLE
Add context and options to scale client

### DIFF
--- a/pkg/controller/disruption/disruption.go
+++ b/pkg/controller/disruption/disruption.go
@@ -292,7 +292,7 @@ func (dc *DisruptionController) getScaleController(controllerRef *metav1.OwnerRe
 	}
 	gr := mapping.Resource.GroupResource()
 
-	scale, err := dc.scaleNamespacer.Scales(namespace).Get(gr, controllerRef.Name)
+	scale, err := dc.scaleNamespacer.Scales(namespace).Get(context.TODO(), gr, controllerRef.Name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, nil

--- a/pkg/controller/podautoscaler/horizontal.go
+++ b/pkg/controller/podautoscaler/horizontal.go
@@ -648,7 +648,7 @@ func (a *HorizontalController) reconcileAutoscaler(hpav1Shared *autoscalingv1.Ho
 
 	if rescale {
 		scale.Spec.Replicas = desiredReplicas
-		_, err = a.scaleNamespacer.Scales(hpa.Namespace).Update(targetGR, scale)
+		_, err = a.scaleNamespacer.Scales(hpa.Namespace).Update(context.TODO(), targetGR, scale, metav1.UpdateOptions{})
 		if err != nil {
 			a.eventRecorder.Eventf(hpa, v1.EventTypeWarning, "FailedRescale", "New size: %d; reason: %s; error: %v", desiredReplicas, rescaleReason, err.Error())
 			setCondition(hpa, autoscalingv2.AbleToScale, v1.ConditionFalse, "FailedUpdateScale", "the HPA controller was unable to update the target scale: %v", err)
@@ -1050,7 +1050,7 @@ func (a *HorizontalController) scaleForResourceMappings(namespace, name string, 
 	var firstErr error
 	for i, mapping := range mappings {
 		targetGR := mapping.Resource.GroupResource()
-		scale, err := a.scaleNamespacer.Scales(namespace).Get(targetGR, name)
+		scale, err := a.scaleNamespacer.Scales(namespace).Get(context.TODO(), targetGR, name, metav1.GetOptions{})
 		if err == nil {
 			return scale, targetGR, nil
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"reflect"
@@ -328,7 +329,7 @@ func TestScaleSubresource(t *testing.T) {
 			}
 
 			// get the scale object
-			gottenScale, err := scaleClient.Scales("not-the-default").Get(groupResource, "foo")
+			gottenScale, err := scaleClient.Scales("not-the-default").Get(context.TODO(), groupResource, "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -349,7 +350,7 @@ func TestScaleSubresource(t *testing.T) {
 			// check that spec is updated, but status is not
 			gottenScale.Spec.Replicas = 5
 			gottenScale.Status.Selector = "baz"
-			updatedScale, err := scaleClient.Scales("not-the-default").Update(groupResource, gottenScale)
+			updatedScale, err := scaleClient.Scales("not-the-default").Update(context.TODO(), groupResource, gottenScale, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -842,7 +843,7 @@ func TestSubresourcePatch(t *testing.T) {
 			}
 
 			// Scale.Spec.Replicas = 7 but Scale.Status.Replicas should remain 0
-			gottenScale, err := scaleClient.Scales("not-the-default").Get(groupResource, "foo")
+			gottenScale, err := scaleClient.Scales("not-the-default").Get(context.TODO(), groupResource, "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/client-go/scale/BUILD
+++ b/staging/src/k8s.io/client-go/scale/BUILD
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/serializer:go_default_library",

--- a/staging/src/k8s.io/client-go/scale/client.go
+++ b/staging/src/k8s.io/client-go/scale/client.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	autoscaling "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
@@ -31,6 +32,14 @@ import (
 
 var scaleConverter = NewScaleConverter()
 var codecs = serializer.NewCodecFactory(scaleConverter.Scheme())
+var parameterScheme = runtime.NewScheme()
+var dynamicParameterCodec = runtime.NewParameterCodec(parameterScheme)
+
+var versionV1 = schema.GroupVersion{Version: "v1"}
+
+func init() {
+	metav1.AddToGroupVersion(parameterScheme, versionV1)
+}
 
 // scaleClient is an implementation of ScalesGetter
 // which makes use of a RESTMapper and a generic REST
@@ -138,7 +147,7 @@ func (c *scaleClient) Scales(namespace string) ScaleInterface {
 	}
 }
 
-func (c *namespacedScaleClient) Get(resource schema.GroupResource, name string) (*autoscaling.Scale, error) {
+func (c *namespacedScaleClient) Get(ctx context.Context, resource schema.GroupResource, name string, opts metav1.GetOptions) (*autoscaling.Scale, error) {
 	// Currently, a /scale endpoint can return different scale types.
 	// Until we have support for the alternative API representations proposal,
 	// we need to deal with accepting different API versions.
@@ -155,7 +164,8 @@ func (c *namespacedScaleClient) Get(resource schema.GroupResource, name string) 
 		Resource(gvr.Resource).
 		Name(name).
 		SubResource("scale").
-		Do(context.TODO())
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
+		Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -163,7 +173,7 @@ func (c *namespacedScaleClient) Get(resource schema.GroupResource, name string) 
 	return convertToScale(&result)
 }
 
-func (c *namespacedScaleClient) Update(resource schema.GroupResource, scale *autoscaling.Scale) (*autoscaling.Scale, error) {
+func (c *namespacedScaleClient) Update(ctx context.Context, resource schema.GroupResource, scale *autoscaling.Scale, opts metav1.UpdateOptions) (*autoscaling.Scale, error) {
 	path, gvr, err := c.client.pathAndVersionFor(resource)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get client for %s: %v", resource.String(), err)
@@ -196,8 +206,9 @@ func (c *namespacedScaleClient) Update(resource schema.GroupResource, scale *aut
 		Resource(gvr.Resource).
 		Name(scale.Name).
 		SubResource("scale").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
 		Body(scaleUpdateBytes).
-		Do(context.TODO())
+		Do(ctx)
 	if err := result.Error(); err != nil {
 		// propagate "raw" error from the API
 		// this allows callers to interpret underlying Reason field
@@ -208,7 +219,7 @@ func (c *namespacedScaleClient) Update(resource schema.GroupResource, scale *aut
 	return convertToScale(&result)
 }
 
-func (c *namespacedScaleClient) Patch(gvr schema.GroupVersionResource, name string, pt types.PatchType, data []byte) (*autoscaling.Scale, error) {
+func (c *namespacedScaleClient) Patch(ctx context.Context, gvr schema.GroupVersionResource, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*autoscaling.Scale, error) {
 	groupVersion := gvr.GroupVersion()
 	result := c.client.clientBase.Patch(pt).
 		AbsPath(c.client.apiPathFor(groupVersion)).
@@ -216,8 +227,9 @@ func (c *namespacedScaleClient) Patch(gvr schema.GroupVersionResource, name stri
 		Resource(gvr.Resource).
 		Name(name).
 		SubResource("scale").
+		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
 		Body(data).
-		Do(context.TODO())
+		Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/scale/client_test.go
+++ b/staging/src/k8s.io/client-go/scale/client_test.go
@@ -18,6 +18,7 @@ package scale
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -273,7 +274,7 @@ func TestGetScale(t *testing.T) {
 	}
 
 	for _, groupResource := range groupResources {
-		scale, err := scaleClient.Scales("default").Get(groupResource, "foo")
+		scale, err := scaleClient.Scales("default").Get(context.TODO(), groupResource, "foo", metav1.GetOptions{})
 		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
 			continue
 		}
@@ -301,7 +302,7 @@ func TestUpdateScale(t *testing.T) {
 	}
 
 	for _, groupResource := range groupResources {
-		scale, err := scaleClient.Scales("default").Update(groupResource, expectedScale)
+		scale, err := scaleClient.Scales("default").Update(context.TODO(), groupResource, expectedScale, metav1.UpdateOptions{})
 		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", groupResource.String()) {
 			continue
 		}
@@ -344,7 +345,7 @@ func TestPatchScale(t *testing.T) {
 
 	patch := []byte(`{"spec":{"replicas":5}}`)
 	for _, gvr := range gvrs {
-		scale, err := scaleClient.Scales("default").Patch(gvr, "foo", types.MergePatchType, patch)
+		scale, err := scaleClient.Scales("default").Patch(context.TODO(), gvr, "foo", types.MergePatchType, patch, metav1.PatchOptions{})
 		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
 			continue
 		}
@@ -354,7 +355,7 @@ func TestPatchScale(t *testing.T) {
 
 	patch = []byte(`[{"op":"replace","path":"/spec/replicas","value":5}]`)
 	for _, gvr := range gvrs {
-		scale, err := scaleClient.Scales("default").Patch(gvr, "foo", types.JSONPatchType, patch)
+		scale, err := scaleClient.Scales("default").Patch(context.TODO(), gvr, "foo", types.JSONPatchType, patch, metav1.PatchOptions{})
 		if !assert.NoError(t, err, "should have been able to fetch a scale for %s", gvr.String()) {
 			continue
 		}

--- a/staging/src/k8s.io/client-go/scale/fake/BUILD
+++ b/staging/src/k8s.io/client-go/scale/fake/BUILD
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/client-go/scale:go_default_library",

--- a/staging/src/k8s.io/client-go/scale/fake/client.go
+++ b/staging/src/k8s.io/client-go/scale/fake/client.go
@@ -20,7 +20,10 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	autoscalingapi "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/scale"
@@ -44,7 +47,7 @@ type fakeNamespacedScaleClient struct {
 	fake      *testing.Fake
 }
 
-func (f *fakeNamespacedScaleClient) Get(resource schema.GroupResource, name string) (*autoscalingapi.Scale, error) {
+func (f *fakeNamespacedScaleClient) Get(ctx context.Context, resource schema.GroupResource, name string, opts metav1.GetOptions) (*autoscalingapi.Scale, error) {
 	obj, err := f.fake.
 		Invokes(testing.NewGetSubresourceAction(resource.WithVersion(""), f.namespace, "scale", name), &autoscalingapi.Scale{})
 
@@ -55,7 +58,7 @@ func (f *fakeNamespacedScaleClient) Get(resource schema.GroupResource, name stri
 	return obj.(*autoscalingapi.Scale), err
 }
 
-func (f *fakeNamespacedScaleClient) Update(resource schema.GroupResource, scale *autoscalingapi.Scale) (*autoscalingapi.Scale, error) {
+func (f *fakeNamespacedScaleClient) Update(ctx context.Context, resource schema.GroupResource, scale *autoscalingapi.Scale, opts metav1.UpdateOptions) (*autoscalingapi.Scale, error) {
 	obj, err := f.fake.
 		Invokes(testing.NewUpdateSubresourceAction(resource.WithVersion(""), f.namespace, "scale", scale), &autoscalingapi.Scale{})
 
@@ -66,7 +69,7 @@ func (f *fakeNamespacedScaleClient) Update(resource schema.GroupResource, scale 
 	return obj.(*autoscalingapi.Scale), err
 }
 
-func (f *fakeNamespacedScaleClient) Patch(gvr schema.GroupVersionResource, name string, pt types.PatchType, patch []byte) (*autoscalingapi.Scale, error) {
+func (f *fakeNamespacedScaleClient) Patch(ctx context.Context, gvr schema.GroupVersionResource, name string, pt types.PatchType, patch []byte, opts metav1.PatchOptions) (*autoscalingapi.Scale, error) {
 	obj, err := f.fake.
 		Invokes(testing.NewPatchSubresourceAction(gvr, f.namespace, name, pt, patch, "scale"), &autoscalingapi.Scale{})
 

--- a/staging/src/k8s.io/client-go/scale/interfaces.go
+++ b/staging/src/k8s.io/client-go/scale/interfaces.go
@@ -17,7 +17,10 @@ limitations under the License.
 package scale
 
 import (
+	"context"
+
 	autoscalingapi "k8s.io/api/autoscaling/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -34,11 +37,11 @@ type ScalesGetter interface {
 // the scale subresource.
 type ScaleInterface interface {
 	// Get fetches the scale of the given scalable resource.
-	Get(resource schema.GroupResource, name string) (*autoscalingapi.Scale, error)
+	Get(ctx context.Context, resource schema.GroupResource, name string, opts metav1.GetOptions) (*autoscalingapi.Scale, error)
 
 	// Update updates the scale of the given scalable resource.
-	Update(resource schema.GroupResource, scale *autoscalingapi.Scale) (*autoscalingapi.Scale, error)
+	Update(ctx context.Context, resource schema.GroupResource, scale *autoscalingapi.Scale, opts metav1.UpdateOptions) (*autoscalingapi.Scale, error)
 
 	// Patch patches the scale of the given scalable resource.
-	Patch(gvr schema.GroupVersionResource, name string, pt types.PatchType, data []byte) (*autoscalingapi.Scale, error)
+	Patch(ctx context.Context, gvr schema.GroupVersionResource, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*autoscalingapi.Scale, error)
 }

--- a/staging/src/k8s.io/kubectl/pkg/scale/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/scale/BUILD
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This change adds context and options to the client-go scale client. It's not generated.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md

https://github.com/kubernetes/kubernetes/issues/88274

**Special notes for your reviewer**:

I think we may want to snapshot this first like for `k8s.io/client-go/kubernetes` => `k8s.io/client-go/deprecated`?

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Signatures on scale client methods have been modified to accept `context.Context` as a first argument. Signatures of Get, Update, and Patch methods have been updated to accept GetOptions, UpdateOptions and PatchOptions respectively.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md
```
