### PR TITLE
Fix non-ascii characters in pkg/volume/emptydir/empty_dir_test.go

### DIFF
--- a/pkg/volume/emptydir/empty_dir_test.go
+++ b/pkg/volume/emptydir/empty_dir_test.go
@@ -259,7 +259,7 @@ func doTestPlugin(t *testing.T, config pluginTestConfig) {
 func TestPluginBackCompat(t *testing.T) {
 	basePath, err := utiltesting.MkTmpdir("emptydirTest")
 	if err != nil {
-		t.Fatalf("can't make a temp dir： %v", err)
+		t.Fatalf("can't make a temp dir: %v", err)
 	}
 	defer os.RemoveAll(basePath)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
fix non-ascii characters which are written accidentally.

**Which issue(s) this PR fixes**:
Ref #87679



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
