### PR TITLE
Change the way test gets a number of available nodes

### DIFF
--- a/test/e2e/framework/network/BUILD
+++ b/test/e2e/framework/network/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
-        "//test/e2e/framework/skipper:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],

--- a/test/e2e/framework/network/utils.go
+++ b/test/e2e/framework/network/utils.go
@@ -41,7 +41,6 @@ import (
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
-	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
 
@@ -621,7 +620,10 @@ func (config *NetworkingTestConfig) setup(selector map[string]string) {
 	framework.ExpectNoError(err)
 	config.ExternalAddr = e2enode.FirstAddress(nodeList, v1.NodeExternalIP)
 
-	e2eskipper.SkipUnlessNodeCountIsAtLeast(2)
+	if len(nodeList.Items) < 2 {
+		msg := fmt.Sprintf("Requires at least 2 nodes (not %d)", len(nodeList.Items))
+		ginkgo.Skip(msg)
+	}
 	config.Nodes = nodeList.Items
 
 	ginkgo.By("Creating the service on top of the pods in kubernetes")


### PR DESCRIPTION
Signed-off-by: Serguei Bezverkhi <sbezverk@cisco.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR proposes a more reliable way to detect available nodes for testing, that relying on a cloud config. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
NONE

```release-note
none
```
/sig network