### PR TITLE
client-go/discovery/cache/memory: retry ServerResourcesForGroupVersion errors

### DIFF
--- a/staging/src/k8s.io/client-go/discovery/cached/memory/BUILD
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/BUILD
@@ -23,7 +23,6 @@ go_library(
     importmap = "k8s.io/kubernetes/vendor/k8s.io/client-go/discovery/cached/memory",
     importpath = "k8s.io/client-go/discovery/cached/memory",
     deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/version:go_default_library",

--- a/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
+++ b/staging/src/k8s.io/client-go/discovery/cached/memory/memcache_test.go
@@ -272,10 +272,10 @@ func TestPartialPermanentFailure(t *testing.T) {
 		err: nil,
 	}
 	fake.lock.Unlock()
-	// We don't retry permanent errors, so it should fail.
+	// We do retry permanent errors, so it should succeed.
 	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
-	if err == nil {
-		t.Errorf("Expected error, got nil")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
 	}
 	c.Invalidate()
 


### PR DESCRIPTION
This is the behavior of the disk cache, which memcache should behave the
same as.


**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Currently using the in-memory cache doesn't retry on errors. This is problematic when applying CRDs for example. I've modified it to retry ServerResourcesForGroupVersion, which is the same thing as the disk cache.

```release-note
Discovery memory cache: retry all errors in ServerResourcesForGroupVersion.
```