### PR TITLE
Apierrors Is<<ErrType>>: Support wrapped errors

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
+++ b/staging/src/k8s.io/apimachinery/pkg/api/errors/errors.go
@@ -18,6 +18,7 @@ package errors
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -483,127 +484,141 @@ func NewGenericServerResponse(code int, verb string, qualifiedResource schema.Gr
 }
 
 // IsNotFound returns true if the specified error was created by NewNotFound.
+// It supports wrapped errors.
 func IsNotFound(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonNotFound
 }
 
 // IsAlreadyExists determines if the err is an error which indicates that a specified resource already exists.
+// It supports wrapped errors.
 func IsAlreadyExists(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonAlreadyExists
 }
 
 // IsConflict determines if the err is an error which indicates the provided update conflicts.
+// It supports wrapped errors.
 func IsConflict(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonConflict
 }
 
 // IsInvalid determines if the err is an error which indicates the provided resource is not valid.
+// It supports wrapped errors.
 func IsInvalid(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonInvalid
 }
 
 // IsGone is true if the error indicates the requested resource is no longer available.
+// It supports wrapped errors.
 func IsGone(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonGone
 }
 
 // IsResourceExpired is true if the error indicates the resource has expired and the current action is
 // no longer possible.
+// It supports wrapped errors.
 func IsResourceExpired(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonExpired
 }
 
 // IsNotAcceptable determines if err is an error which indicates that the request failed due to an invalid Accept header
+// It supports wrapped errors.
 func IsNotAcceptable(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonNotAcceptable
 }
 
 // IsUnsupportedMediaType determines if err is an error which indicates that the request failed due to an invalid Content-Type header
+// It supports wrapped errors.
 func IsUnsupportedMediaType(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonUnsupportedMediaType
 }
 
 // IsMethodNotSupported determines if the err is an error which indicates the provided action could not
 // be performed because it is not supported by the server.
+// It supports wrapped errors.
 func IsMethodNotSupported(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonMethodNotAllowed
 }
 
 // IsServiceUnavailable is true if the error indicates the underlying service is no longer available.
+// It supports wrapped errors.
 func IsServiceUnavailable(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonServiceUnavailable
 }
 
 // IsBadRequest determines if err is an error which indicates that the request is invalid.
+// It supports wrapped errors.
 func IsBadRequest(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonBadRequest
 }
 
 // IsUnauthorized determines if err is an error which indicates that the request is unauthorized and
 // requires authentication by the user.
+// It supports wrapped errors.
 func IsUnauthorized(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonUnauthorized
 }
 
 // IsForbidden determines if err is an error which indicates that the request is forbidden and cannot
 // be completed as requested.
+// It supports wrapped errors.
 func IsForbidden(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonForbidden
 }
 
 // IsTimeout determines if err is an error which indicates that request times out due to long
 // processing.
+// It supports wrapped errors.
 func IsTimeout(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonTimeout
 }
 
 // IsServerTimeout determines if err is an error which indicates that the request needs to be retried
 // by the client.
+// It supports wrapped errors.
 func IsServerTimeout(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonServerTimeout
 }
 
 // IsInternalError determines if err is an error which indicates an internal server error.
+// It supports wrapped errors.
 func IsInternalError(err error) bool {
 	return ReasonForError(err) == metav1.StatusReasonInternalError
 }
 
 // IsTooManyRequests determines if err is an error which indicates that there are too many requests
 // that the server cannot handle.
+// It supports wrapped errors.
 func IsTooManyRequests(err error) bool {
 	if ReasonForError(err) == metav1.StatusReasonTooManyRequests {
 		return true
 	}
-	switch t := err.(type) {
-	case APIStatus:
-		return t.Status().Code == http.StatusTooManyRequests
+	if status := APIStatus(nil); errors.As(err, &status) {
+		return status.Status().Code == http.StatusTooManyRequests
 	}
 	return false
 }
 
 // IsRequestEntityTooLargeError determines if err is an error which indicates
 // the request entity is too large.
+// It supports wrapped errors.
 func IsRequestEntityTooLargeError(err error) bool {
 	if ReasonForError(err) == metav1.StatusReasonRequestEntityTooLarge {
 		return true
 	}
-	switch t := err.(type) {
-	case APIStatus:
-		return t.Status().Code == http.StatusRequestEntityTooLarge
+	if status := APIStatus(nil); errors.As(err, &status) {
+		return status.Status().Code == http.StatusRequestEntityTooLarge
 	}
 	return false
 }
 
 // IsUnexpectedServerError returns true if the server response was not in the expected API format,
 // and may be the result of another HTTP actor.
+// It supports wrapped errors.
 func IsUnexpectedServerError(err error) bool {
-	switch t := err.(type) {
-	case APIStatus:
-		if d := t.Status().Details; d != nil {
-			for _, cause := range d.Causes {
-				if cause.Type == metav1.CauseTypeUnexpectedServerResponse {
-					return true
-				}
+	if status := APIStatus(nil); errors.As(err, &status) && status.Status().Details != nil {
+		for _, cause := range status.Status().Details.Causes {
+			if cause.Type == metav1.CauseTypeUnexpectedServerResponse {
+				return true
 			}
 		}
 	}
@@ -611,38 +626,37 @@ func IsUnexpectedServerError(err error) bool {
 }
 
 // IsUnexpectedObjectError determines if err is due to an unexpected object from the master.
+// It supports wrapped errors.
 func IsUnexpectedObjectError(err error) bool {
-	_, ok := err.(*UnexpectedObjectError)
-	return err != nil && ok
+	uoe := &UnexpectedObjectError{}
+	return err != nil && errors.As(err, &uoe)
 }
 
 // SuggestsClientDelay returns true if this error suggests a client delay as well as the
 // suggested seconds to wait, or false if the error does not imply a wait. It does not
 // address whether the error *should* be retried, since some errors (like a 3xx) may
 // request delay without retry.
+// It supports wrapped errors.
 func SuggestsClientDelay(err error) (int, bool) {
-	switch t := err.(type) {
-	case APIStatus:
-		if t.Status().Details != nil {
-			switch t.Status().Reason {
-			// this StatusReason explicitly requests the caller to delay the action
-			case metav1.StatusReasonServerTimeout:
-				return int(t.Status().Details.RetryAfterSeconds), true
-			}
-			// If the client requests that we retry after a certain number of seconds
-			if t.Status().Details.RetryAfterSeconds > 0 {
-				return int(t.Status().Details.RetryAfterSeconds), true
-			}
+	if t := APIStatus(nil); errors.As(err, &t) && t.Status().Details != nil {
+		switch t.Status().Reason {
+		// this StatusReason explicitly requests the caller to delay the action
+		case metav1.StatusReasonServerTimeout:
+			return int(t.Status().Details.RetryAfterSeconds), true
+		}
+		// If the client requests that we retry after a certain number of seconds
+		if t.Status().Details.RetryAfterSeconds > 0 {
+			return int(t.Status().Details.RetryAfterSeconds), true
 		}
 	}
 	return 0, false
 }
 
 // ReasonForError returns the HTTP status for a particular error.
+// It supports wrapped errors.
 func ReasonForError(err error) metav1.StatusReason {
-	switch t := err.(type) {
-	case APIStatus:
-		return t.Status().Reason
+	if status := APIStatus(nil); errors.As(err, &status) {
+		return status.Status().Reason
 	}
 	return metav1.StatusReasonUnknown
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Testing for specific error types is done via the `apierrors.Is<<Type>>` functions, e.G. `apierrors.IsConflict`. Today, this doesn't work anymore when the error is wrapped and because this is done via a function rather than by comparing to a type, golangs `errors.Is()` can't be used either.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```



**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```

/kind bug
/priority important-longterm
/milestone v1.18
/assign enj