### PR TITLE
move well-known kubelet cloud provider annotations to k8s.io/cloud-provider

### DIFF
--- a/pkg/controller/cloud/BUILD
+++ b/pkg/controller/cloud/BUILD
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
-        "//pkg/kubelet/apis:go_default_library",
         "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
@@ -43,7 +42,6 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller/testutil:go_default_library",
-        "//pkg/kubelet/apis:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -564,7 +564,7 @@ func nodeAddressesChangeDetected(addressSet1, addressSet2 []v1.NodeAddress) bool
 func ensureNodeProvidedIPExists(node *v1.Node, nodeAddresses []v1.NodeAddress) (*v1.NodeAddress, bool) {
 	var nodeIP *v1.NodeAddress
 	nodeIPExists := false
-	if providedIP, ok := node.ObjectMeta.Annotations[cloudproviderapi.AnnotationProvidedIPAddr]; ok {
+	if providedIP, ok := node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr]; ok {
 		nodeIPExists = true
 		for i := range nodeAddresses {
 			if nodeAddresses[i].Address == providedIP {

--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -39,7 +39,6 @@ import (
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	cloudnodeutil "k8s.io/cloud-provider/node/helpers"
 	"k8s.io/klog"
-	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	nodeutil "k8s.io/kubernetes/pkg/util/node"
 )
 
@@ -565,7 +564,7 @@ func nodeAddressesChangeDetected(addressSet1, addressSet2 []v1.NodeAddress) bool
 func ensureNodeProvidedIPExists(node *v1.Node, nodeAddresses []v1.NodeAddress) (*v1.NodeAddress, bool) {
 	var nodeIP *v1.NodeAddress
 	nodeIPExists := false
-	if providedIP, ok := node.ObjectMeta.Annotations[kubeletapis.AnnotationProvidedIPAddr]; ok {
+	if providedIP, ok := node.ObjectMeta.Annotations[cloudproviderapi.AnnotationProvidedIPAddr]; ok {
 		nodeIPExists = true
 		for i := range nodeAddresses {
 			if nodeAddresses[i].Address == providedIP {

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -461,7 +461,7 @@ func Test_AddCloudNode(t *testing.T) {
 					Name:              "node0",
 					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					Annotations: map[string]string{
-						cloudproviderapi.AnnotationProvidedIPAddr: "10.0.0.1",
+						cloudproviderapi.AnnotationAlphaProvidedIPAddr: "10.0.0.1",
 					},
 				},
 				Spec: v1.NodeSpec{
@@ -501,7 +501,7 @@ func Test_AddCloudNode(t *testing.T) {
 					Name:              "node0",
 					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					Annotations: map[string]string{
-						cloudproviderapi.AnnotationProvidedIPAddr: "10.0.0.1",
+						cloudproviderapi.AnnotationAlphaProvidedIPAddr: "10.0.0.1",
 					},
 				},
 				Spec: v1.NodeSpec{

--- a/pkg/controller/cloud/node_controller_test.go
+++ b/pkg/controller/cloud/node_controller_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/cloud-provider"
 	cloudproviderapi "k8s.io/cloud-provider/api"
 	fakecloud "k8s.io/cloud-provider/fake"
-	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -462,7 +461,7 @@ func Test_AddCloudNode(t *testing.T) {
 					Name:              "node0",
 					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					Annotations: map[string]string{
-						kubeletapis.AnnotationProvidedIPAddr: "10.0.0.1",
+						cloudproviderapi.AnnotationProvidedIPAddr: "10.0.0.1",
 					},
 				},
 				Spec: v1.NodeSpec{
@@ -502,7 +501,7 @@ func Test_AddCloudNode(t *testing.T) {
 					Name:              "node0",
 					CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.UTC),
 					Annotations: map[string]string{
-						kubeletapis.AnnotationProvidedIPAddr: "10.0.0.1",
+						cloudproviderapi.AnnotationProvidedIPAddr: "10.0.0.1",
 					},
 				},
 				Spec: v1.NodeSpec{

--- a/pkg/kubelet/apis/BUILD
+++ b/pkg/kubelet/apis/BUILD
@@ -8,7 +8,6 @@ load(
 go_library(
     name = "go_default_library",
     srcs = [
-        "well_known_annotations.go",
         "well_known_annotations_windows.go",
         "well_known_labels.go",
     ],

--- a/pkg/kubelet/nodestatus/BUILD
+++ b/pkg/kubelet/nodestatus/BUILD
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/features:go_default_library",
-        "//pkg/kubelet/apis:go_default_library",
         "//pkg/kubelet/cadvisor:go_default_library",
         "//pkg/kubelet/cm:go_default_library",
         "//pkg/kubelet/container:go_default_library",
@@ -21,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
+        "//staging/src/k8s.io/cloud-provider/api:go_default_library",
         "//staging/src/k8s.io/component-base/version:go_default_library",
         "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -82,7 +82,7 @@ func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
 				if node.ObjectMeta.Annotations == nil {
 					node.ObjectMeta.Annotations = make(map[string]string)
 				}
-				node.ObjectMeta.Annotations[cloudproviderapi.AnnotationProvidedIPAddr] = nodeIP.String()
+				node.ObjectMeta.Annotations[cloudproviderapi.AnnotationAlphaProvidedIPAddr] = nodeIP.String()
 			}
 
 			// If --cloud-provider=external and node address is already set,

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -33,10 +33,10 @@ import (
 	utilnet "k8s.io/apimachinery/pkg/util/net"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	cloudprovider "k8s.io/cloud-provider"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 	"k8s.io/component-base/version"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
-	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
 	"k8s.io/kubernetes/pkg/kubelet/cadvisor"
 	"k8s.io/kubernetes/pkg/kubelet/cm"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
@@ -82,7 +82,7 @@ func NodeAddress(nodeIP net.IP, // typically Kubelet.nodeIP
 				if node.ObjectMeta.Annotations == nil {
 					node.ObjectMeta.Annotations = make(map[string]string)
 				}
-				node.ObjectMeta.Annotations[kubeletapis.AnnotationProvidedIPAddr] = nodeIP.String()
+				node.ObjectMeta.Annotations[cloudproviderapi.AnnotationProvidedIPAddr] = nodeIP.String()
 			}
 
 			// If --cloud-provider=external and node address is already set,

--- a/staging/src/k8s.io/cloud-provider/api/BUILD
+++ b/staging/src/k8s.io/cloud-provider/api/BUILD
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["well_known_taints.go"],
+    srcs = [
+        "well_known_annotations.go",
+        "well_known_taints.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/cloud-provider/api",
     importpath = "k8s.io/cloud-provider/api",
     visibility = ["//visibility:public"],

--- a/staging/src/k8s.io/cloud-provider/api/well_known_annotations.go
+++ b/staging/src/k8s.io/cloud-provider/api/well_known_annotations.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package apis
+package api
 
 const (
 	// AnnotationProvidedIPAddr is a node IP annotation set by the "external" cloud provider.

--- a/staging/src/k8s.io/cloud-provider/api/well_known_annotations.go
+++ b/staging/src/k8s.io/cloud-provider/api/well_known_annotations.go
@@ -17,10 +17,10 @@ limitations under the License.
 package api
 
 const (
-	// AnnotationProvidedIPAddr is a node IP annotation set by the "external" cloud provider.
+	// AnnotationAlphaProvidedIPAddr is a node IP annotation set by the "external" cloud provider.
 	// When kubelet is started with the "external" cloud provider, then
 	// it sets this annotation on the node to denote an ip address set from the
 	// cmd line flag (--node-ip). This ip is verified with the cloudprovider as valid by
 	// the cloud-controller-manager
-	AnnotationProvidedIPAddr = "alpha.kubernetes.io/provided-node-ip"
+	AnnotationAlphaProvidedIPAddr = "alpha.kubernetes.io/provided-node-ip"
 )


### PR DESCRIPTION
Signed-off-by: andrewsykim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Moves well-known kubelet taints to k8s.io/cloud-provider to remove dependencies to `pkg/kubelet/apis` in the node cloud controller.

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/81172

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
