### PR TITLE
Transform from storage concurrently during List operation.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/types.go
@@ -97,4 +97,10 @@ type KMSConfiguration struct {
 	// timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration
+	// decryptionConcurrencyLevel provides a hint to kube-apiserver on what level on concurrency does
+	// the KMS support.
+	// The default value is 1, implying that decryption of items during List operations will take
+	// place sequentially.
+	// +optional
+	DecryptionConcurrencyLevel int32
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults.go
@@ -24,8 +24,9 @@ import (
 )
 
 var (
-	defaultTimeout         = &metav1.Duration{Duration: 3 * time.Second}
-	defaultCacheSize int32 = 1000
+	defaultTimeout                = &metav1.Duration{Duration: 3 * time.Second}
+	defaultCacheSize        int32 = 1000
+	defaultConcurrencyLevel int32 = 1
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
@@ -40,5 +41,9 @@ func SetDefaults_KMSConfiguration(obj *KMSConfiguration) {
 
 	if obj.CacheSize == nil {
 		obj.CacheSize = &defaultCacheSize
+	}
+
+	if obj.DecryptionConcurrencyLevel == 0 {
+		obj.DecryptionConcurrencyLevel = defaultConcurrencyLevel
 	}
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/defaults_test.go
@@ -34,12 +34,20 @@ func TestKMSProviderTimeoutDefaults(t *testing.T) {
 		{
 			desc: "timeout not supplied",
 			in:   &KMSConfiguration{},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:                    defaultTimeout,
+				CacheSize:                  &defaultCacheSize,
+				DecryptionConcurrencyLevel: defaultConcurrencyLevel,
+			},
 		},
 		{
 			desc: "timeout supplied",
 			in:   &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}},
-			want: &KMSConfiguration{Timeout: &v1.Duration{Duration: 1 * time.Minute}, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:                    &v1.Duration{Duration: 1 * time.Minute},
+				CacheSize:                  &defaultCacheSize,
+				DecryptionConcurrencyLevel: defaultConcurrencyLevel,
+			},
 		},
 	}
 
@@ -67,17 +75,66 @@ func TestKMSProviderCacheDefaults(t *testing.T) {
 		{
 			desc: "cache size not supplied",
 			in:   &KMSConfiguration{},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &defaultCacheSize},
+			want: &KMSConfiguration{
+				Timeout:                    defaultTimeout,
+				CacheSize:                  &defaultCacheSize,
+				DecryptionConcurrencyLevel: defaultConcurrencyLevel,
+			},
 		},
 		{
 			desc: "cache of zero size supplied",
 			in:   &KMSConfiguration{CacheSize: &zero},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &zero},
+			want: &KMSConfiguration{
+				Timeout:                    defaultTimeout,
+				CacheSize:                  &zero,
+				DecryptionConcurrencyLevel: defaultConcurrencyLevel,
+			},
 		},
 		{
 			desc: "positive cache size supplied",
 			in:   &KMSConfiguration{CacheSize: &ten},
-			want: &KMSConfiguration{Timeout: defaultTimeout, CacheSize: &ten},
+			want: &KMSConfiguration{
+				Timeout:                    defaultTimeout,
+				CacheSize:                  &ten,
+				DecryptionConcurrencyLevel: defaultConcurrencyLevel,
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.desc, func(t *testing.T) {
+			SetDefaults_KMSConfiguration(tt.in)
+			if d := cmp.Diff(tt.want, tt.in); d != "" {
+				t.Fatalf("KMS Provider mismatch (-want +got):\n%s", d)
+			}
+		})
+	}
+}
+
+func TestKMSProviderDecryptionConcurrencyLevelDefaults(t *testing.T) {
+
+	testCases := []struct {
+		desc string
+		in   *KMSConfiguration
+		want *KMSConfiguration
+	}{
+		{
+			desc: "decryptionConcurrencyLevel is not supplied",
+			in:   &KMSConfiguration{},
+			want: &KMSConfiguration{
+				Timeout:                    defaultTimeout,
+				CacheSize:                  &defaultCacheSize,
+				DecryptionConcurrencyLevel: defaultConcurrencyLevel,
+			},
+		},
+		{
+			desc: "decryptionConcurrencyLevel is supplied",
+			in:   &KMSConfiguration{DecryptionConcurrencyLevel: int32(4)},
+			want: &KMSConfiguration{
+				Timeout:                    defaultTimeout,
+				CacheSize:                  &defaultCacheSize,
+				DecryptionConcurrencyLevel: int32(4),
+			},
 		},
 	}
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/types.go
@@ -97,4 +97,10 @@ type KMSConfiguration struct {
 	// timeout for gRPC calls to kms-plugin (ex. 5s). The default is 3 seconds.
 	// +optional
 	Timeout *metav1.Duration `json:"timeout,omitempty"`
+	// decryptionConcurrencyLevel provides a hint to kube-apiserver on what level on concurrency does
+	// the KMS support.
+	// The default value is 1, implying that decryption of items during List operations will take
+	// place sequentially.
+	// +optional
+	DecryptionConcurrencyLevel int32 `json:"decryptionConcurrencyLevel,omitempty"`
 }

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.conversion.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/v1/zz_generated.conversion.go
@@ -182,6 +182,7 @@ func autoConvert_v1_KMSConfiguration_To_config_KMSConfiguration(in *KMSConfigura
 	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
 	out.Endpoint = in.Endpoint
 	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	out.DecryptionConcurrencyLevel = in.DecryptionConcurrencyLevel
 	return nil
 }
 
@@ -195,6 +196,7 @@ func autoConvert_config_KMSConfiguration_To_v1_KMSConfiguration(in *config.KMSCo
 	out.CacheSize = (*int32)(unsafe.Pointer(in.CacheSize))
 	out.Endpoint = in.Endpoint
 	out.Timeout = (*metav1.Duration)(unsafe.Pointer(in.Timeout))
+	out.DecryptionConcurrencyLevel = in.DecryptionConcurrencyLevel
 	return nil
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
+++ b/staging/src/k8s.io/apiserver/pkg/apis/config/validation/validation.go
@@ -179,6 +179,16 @@ func validateKMSConfiguration(c *config.KMSConfiguration, fieldPath *field.Path)
 	allErrs = append(allErrs, validateKMSTimeout(c, fieldPath.Child("timeout"))...)
 	allErrs = append(allErrs, validateKMSEndpoint(c, fieldPath.Child("endpoint"))...)
 	allErrs = append(allErrs, validateKMSCacheSize(c, fieldPath.Child("cachesize"))...)
+	allErrs = append(allErrs, validateKMSDecryptionConcurrencyLevel(c, fieldPath.Child("decryptionConcurrencyLevel"))...)
+	return allErrs
+}
+
+func validateKMSDecryptionConcurrencyLevel(c *config.KMSConfiguration, fieldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	if c.DecryptionConcurrencyLevel <= 0 {
+		allErrs = append(allErrs, field.Invalid(fieldPath, c.DecryptionConcurrencyLevel, fmt.Sprintf(zeroOrNegativeErrFmt, "decryptionConcurrencyLevel")))
+	}
+
 	return allErrs
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config.go
@@ -364,7 +364,12 @@ func secretboxPrefixTransformer(config *apiserverconfig.SecretboxConfiguration) 
 }
 
 func envelopePrefixTransformer(config *apiserverconfig.KMSConfiguration, envelopeService envelope.Service, prefix string) (value.PrefixTransformer, error) {
-	envelopeTransformer, err := envelope.NewEnvelopeTransformer(envelopeService, int(*config.CacheSize), aestransformer.NewCBCTransformer)
+	envelopeTransformer, err := envelope.NewEnvelopeTransformer(
+		envelopeService,
+		int(*config.CacheSize),
+		int(config.DecryptionConcurrencyLevel),
+		aestransformer.NewCBCTransformer,
+	)
 	if err != nil {
 		return value.PrefixTransformer{}, err
 	}

--- a/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/encryptionconfig/config_test.go
@@ -94,6 +94,8 @@ func TestLegacyConfig(t *testing.T) {
 	legacyV1Config := "testdata/valid-configs/legacy.yaml"
 	legacyConfigObject, err := loadConfig(mustReadConfig(t, legacyV1Config))
 	cacheSize := int32(10)
+	decryptionConcurrencyLevel := int32(1)
+
 	if err != nil {
 		t.Fatalf("error while parsing configuration file: %s.\nThe file was:\n%s", err, legacyV1Config)
 	}
@@ -111,10 +113,11 @@ func TestLegacyConfig(t *testing.T) {
 						},
 					}},
 					{KMS: &apiserverconfig.KMSConfiguration{
-						Name:      "testprovider",
-						Endpoint:  "unix:///tmp/testprovider.sock",
-						CacheSize: &cacheSize,
-						Timeout:   &metav1.Duration{Duration: 3 * time.Second},
+						Name:                       "testprovider",
+						Endpoint:                   "unix:///tmp/testprovider.sock",
+						CacheSize:                  &cacheSize,
+						Timeout:                    &metav1.Duration{Duration: 3 * time.Second},
+						DecryptionConcurrencyLevel: decryptionConcurrencyLevel,
 					}},
 					{AESCBC: &apiserverconfig.AESConfiguration{
 						Keys: []apiserverconfig.Key{

--- a/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/etcd3/BUILD
@@ -40,6 +40,7 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/coreos/pkg/capnslog:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
         "//vendor/go.etcd.io/etcd/clientv3:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/aes/aes.go
@@ -65,6 +65,13 @@ func (t *gcm) TransformFromStorage(data []byte, context value.Context) ([]byte, 
 	return result, false, err
 }
 
+// TransformFromStorageConcurrencyLevel indication the degree at which a provider (typically KMS)
+// could handle requests concurrently.
+func (t *gcm) TransformFromStorageConcurrencyLevel() int {
+	// TODO(immutableT) Should this be GOMAXPROCS?
+	return 1
+}
+
 func (t *gcm) TransformToStorage(data []byte, context value.Context) ([]byte, error) {
 	aead, err := cipher.NewGCM(t.block)
 	if err != nil {
@@ -131,6 +138,13 @@ func (t *cbc) TransformFromStorage(data []byte, context value.Context) ([]byte, 
 	}
 
 	return result[:size], false, nil
+}
+
+// TransformFromStorageConcurrencyLevel indication the degree at which a provider (typically KMS)
+// could handle requests concurrently.
+func (t *cbc) TransformFromStorageConcurrencyLevel() int {
+	// TODO(immutableT) Should this be GOMAXPROCS?
+	return 1
 }
 
 func (t *cbc) TransformToStorage(data []byte, context value.Context) ([]byte, error) {

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope_test.go
@@ -31,9 +31,10 @@ import (
 )
 
 const (
-	testText              = "abcdefghijklmnopqrstuvwxyz"
-	testContextText       = "0123456789"
-	testEnvelopeCacheSize = 10
+	testText                                 = "abcdefghijklmnopqrstuvwxyz"
+	testContextText                          = "0123456789"
+	testEnvelopeCacheSize                    = 10
+	testTransformFromStorageConcurrencyLevel = 1
 )
 
 // testEnvelopeService is a mock Envelope service which can be used to simulate remote Envelope services
@@ -97,7 +98,7 @@ func TestEnvelopeCaching(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.desc, func(t *testing.T) {
 			envelopeService := newTestEnvelopeService()
-			envelopeTransformer, err := NewEnvelopeTransformer(envelopeService, tt.cacheSize, aestransformer.NewCBCTransformer)
+			envelopeTransformer, err := NewEnvelopeTransformer(envelopeService, tt.cacheSize, testTransformFromStorageConcurrencyLevel, aestransformer.NewCBCTransformer)
 			if err != nil {
 				t.Fatalf("failed to initialize envelope transformer: %v", err)
 			}
@@ -131,7 +132,7 @@ func TestEnvelopeCaching(t *testing.T) {
 
 // Makes Envelope transformer hit cache limit, throws error if it misbehaves.
 func TestEnvelopeCacheLimit(t *testing.T) {
-	envelopeTransformer, err := NewEnvelopeTransformer(newTestEnvelopeService(), testEnvelopeCacheSize, aestransformer.NewCBCTransformer)
+	envelopeTransformer, err := NewEnvelopeTransformer(newTestEnvelopeService(), testEnvelopeCacheSize, testTransformFromStorageConcurrencyLevel, aestransformer.NewCBCTransformer)
 	if err != nil {
 		t.Fatalf("failed to initialize envelope transformer: %v", err)
 	}
@@ -166,7 +167,7 @@ func TestEnvelopeCacheLimit(t *testing.T) {
 }
 
 func BenchmarkEnvelopeCBCRead(b *testing.B) {
-	envelopeTransformer, err := NewEnvelopeTransformer(newTestEnvelopeService(), testEnvelopeCacheSize, aestransformer.NewCBCTransformer)
+	envelopeTransformer, err := NewEnvelopeTransformer(newTestEnvelopeService(), testEnvelopeCacheSize, testTransformFromStorageConcurrencyLevel, aestransformer.NewCBCTransformer)
 	if err != nil {
 		b.Fatalf("failed to initialize envelope transformer: %v", err)
 	}
@@ -184,7 +185,7 @@ func BenchmarkAESCBCRead(b *testing.B) {
 }
 
 func BenchmarkEnvelopeGCMRead(b *testing.B) {
-	envelopeTransformer, err := NewEnvelopeTransformer(newTestEnvelopeService(), testEnvelopeCacheSize, aestransformer.NewGCMTransformer)
+	envelopeTransformer, err := NewEnvelopeTransformer(newTestEnvelopeService(), testEnvelopeCacheSize, testTransformFromStorageConcurrencyLevel, aestransformer.NewGCMTransformer)
 	if err != nil {
 		b.Fatalf("failed to initialize envelope transformer: %v", err)
 	}
@@ -226,7 +227,7 @@ func benchmarkRead(b *testing.B, transformer value.Transformer, valueLength int)
 // remove after 1.13
 func TestBackwardsCompatibility(t *testing.T) {
 	envelopeService := newTestEnvelopeService()
-	envelopeTransformerInst, err := NewEnvelopeTransformer(envelopeService, testEnvelopeCacheSize, aestransformer.NewCBCTransformer)
+	envelopeTransformerInst, err := NewEnvelopeTransformer(envelopeService, testEnvelopeCacheSize, testTransformFromStorageConcurrencyLevel, aestransformer.NewCBCTransformer)
 	if err != nil {
 		t.Fatalf("failed to initialize envelope transformer: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity/identity.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/identity/identity.go
@@ -44,6 +44,12 @@ func (identityTransformer) TransformFromStorage(b []byte, context value.Context)
 	return b, false, nil
 }
 
+// TransformFromStorageConcurrencyLevel indication the degree at which a provider (typically KMS)
+// could handle requests concurrently.
+func (t identityTransformer) TransformFromStorageConcurrencyLevel() int {
+	return 1
+}
+
 // TransformToStorage implements the Transformer interface for identityTransformer
 func (identityTransformer) TransformToStorage(b []byte, context value.Context) ([]byte, error) {
 	return b, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/secretbox/secretbox.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/secretbox/secretbox.go
@@ -56,6 +56,13 @@ func (t *secretboxTransformer) TransformFromStorage(data []byte, context value.C
 	return result, false, nil
 }
 
+// TransformFromStorageConcurrencyLevel indication the degree at which a provider (typically KMS)
+// could handle requests concurrently.
+func (t *secretboxTransformer) TransformFromStorageConcurrencyLevel() int {
+	// TODO(immutableT) Should this be GOMAXPROCS?
+	return 1
+}
+
 func (t *secretboxTransformer) TransformToStorage(data []byte, context value.Context) ([]byte, error) {
 	var nonce [nonceSize]byte
 	n, err := rand.Read(nonce[:])

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/transformer_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/transformer_test.go
@@ -38,6 +38,10 @@ func (t *testTransformer) TransformFromStorage(from []byte, context Context) (da
 	return t.from, t.stale, t.err
 }
 
+func (t *testTransformer) TransformFromStorageConcurrencyLevel() int {
+	return 1
+}
+
 func (t *testTransformer) TransformToStorage(to []byte, context Context) (data []byte, err error) {
 	t.receivedTo = to
 	return t.to, t.err


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature


**What this PR does / why we need it**:
Improve performance of the List operation within kube-apiserver by performing storage transformations (ex. decryption via KMS) concurrently.


**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

