### PR TITLE
Fix default regular expressions in conformance tests runner

### DIFF
--- a/cluster/images/conformance/go-runner/cmd_test.go
+++ b/cluster/images/conformance/go-runner/cmd_test.go
@@ -74,7 +74,7 @@ func TestGetCmd(t *testing.T) {
 			},
 			expectArgs: []string{
 				"ginkgobin", "--p",
-				"--focus=", "--skip=[Serial]",
+				"--focus=", "--skip=\\[Serial\\]",
 				"--noColor=true", "testbin", "--",
 				"--disable-log-dump", "--repo-root=/kubernetes",
 				"--provider=", "--report-dir=", "--kubeconfig=",

--- a/cluster/images/conformance/go-runner/const.go
+++ b/cluster/images/conformance/go-runner/const.go
@@ -54,7 +54,7 @@ const (
 	extraArgsSeparaterEnvKey = "E2E_EXTRA_ARGS_SEP"
 
 	defaultSkip         = ""
-	defaultFocus        = "[Conformance]"
+	defaultFocus        = "\\[Conformance\\]"
 	defaultProvider     = "local"
 	defaultParallel     = "1"
 	defaultResultsDir   = "/tmp/results"
@@ -63,5 +63,5 @@ const (
 
 	// serialTestsRegexp is the default skip value if running in parallel. Will not
 	// override an explicit E2E_SKIP value.
-	serialTestsRegexp = "[Serial]"
+	serialTestsRegexp = "\\[Serial\\]"
 )


### PR DESCRIPTION
`[Serial]` should be `\[Serial\]`
`[Conformance]` should be `\[Conformance\]`

Fixes #88640 