### PR TITLE
Fix ownerReferences.apiVersion for "kubectl create job --from=cronjob/*"

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/BUILD
@@ -24,7 +24,6 @@ go_library(
     importpath = "k8s.io/kubectl/pkg/cmd/create",
     visibility = ["//build/visible_to:pkg_kubectl_cmd_create_CONSUMERS"],
     deps = [
-        "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
@@ -80,7 +79,6 @@ go_test(
     data = ["//staging/src/k8s.io/kubectl/testdata"],
     embed = [":go_default_library"],
     deps = [
-        "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -259,7 +258,7 @@ func (o *CreateJobOptions) createJobFromCronJob(cronJob *batchv1beta1.CronJob) *
 			Annotations: annotations,
 			Labels:      cronJob.Spec.JobTemplate.Labels,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cronJob, appsv1.SchemeGroupVersion.WithKind("CronJob")),
+				*metav1.NewControllerRef(cronJob, cronJob.GroupVersionKind()),
 			},
 		},
 		Spec: cronJob.Spec.JobTemplate.Spec,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -165,7 +164,7 @@ func TestCreateJobFromCronJob(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            jobName,
 					Annotations:     map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, apps.SchemeGroupVersion.WithKind("CronJob"))},
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, cronJob.GroupVersionKind())},
 				},
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

`ownerReferences.apiVersion` of Job created by using `kubectl create job --from=cronjob` command will be `apps/v1`.
This apiVersion is wrong.
https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.17/#cronjob-v1beta1-batch

```shell
$ kubectl create job --from=cronjob/test-cronjob test-job --dry-run -o yaml
apiVersion: batch/v1
kind: Job
metadata:
  annotations:
    cronjob.kubernetes.io/instantiate: manual
  creationTimestamp: null
  name: test-job
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: CronJob
    name: test-cronjob
    uid: bb9bb1cb-695c-4eee-b6d6-1970f809e0da
...
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88645

**Special notes for your reviewer**:

None

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

None

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

