### PR TITLE
Remove --export flag from kubectl get command.

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/builder.go
@@ -100,8 +100,6 @@ type Builder struct {
 
 	singleItemImplied bool
 
-	export bool
-
 	schema ContentValidator
 
 	// fakeClientFn is used for testing
@@ -458,12 +456,6 @@ func (b *Builder) FieldSelectorParam(s string) *Builder {
 		return b
 	}
 	b.fieldSelector = &s
-	return b
-}
-
-// ExportParam accepts the export boolean for these resources
-func (b *Builder) ExportParam(export bool) *Builder {
-	b.export = export
 	return b
 }
 
@@ -870,7 +862,7 @@ func (b *Builder) visitBySelector() *Result {
 		if mapping.Scope.Name() != meta.RESTScopeNameNamespace {
 			selectorNamespace = ""
 		}
-		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.export, b.limitChunks))
+		visitors = append(visitors, NewSelector(client, mapping, selectorNamespace, labelSelector, fieldSelector, b.limitChunks))
 	}
 	if b.continueOnError {
 		result.visitor = EagerVisitorList(visitors)
@@ -970,7 +962,6 @@ func (b *Builder) visitByResource() *Result {
 			Mapping:   mapping,
 			Namespace: selectorNamespace,
 			Name:      tuple.Name,
-			Export:    b.export,
 		}
 		items = append(items, info)
 	}
@@ -1035,7 +1026,6 @@ func (b *Builder) visitByName() *Result {
 			Mapping:   mapping,
 			Namespace: selectorNamespace,
 			Name:      name,
-			Export:    b.export,
 		}
 		visitors = append(visitors, info)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper.go
@@ -18,7 +18,6 @@ package resource
 
 import (
 	"context"
-	"strconv"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -75,27 +74,19 @@ func (m *Helper) WithFieldManager(fieldManager string) *Helper {
 	return m
 }
 
-func (m *Helper) Get(namespace, name string, export bool) (runtime.Object, error) {
+func (m *Helper) Get(namespace, name string) (runtime.Object, error) {
 	req := m.RESTClient.Get().
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		Name(name)
-	if export {
-		// TODO: I should be part of GetOptions
-		req.Param("export", strconv.FormatBool(export))
-	}
 	return req.Do(context.TODO()).Get()
 }
 
-func (m *Helper) List(namespace, apiVersion string, export bool, options *metav1.ListOptions) (runtime.Object, error) {
+func (m *Helper) List(namespace, apiVersion string, options *metav1.ListOptions) (runtime.Object, error) {
 	req := m.RESTClient.Get().
 		NamespaceIfScoped(namespace, m.NamespaceScoped).
 		Resource(m.Resource).
 		VersionedParams(options, metav1.ParameterCodec)
-	if export {
-		// TODO: I should be part of ListOptions
-		req.Param("export", strconv.FormatBool(export))
-	}
 	return req.Do(context.TODO()).Get()
 }
 

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/helper_test.go
@@ -312,7 +312,7 @@ func TestHelperGet(t *testing.T) {
 				RESTClient:      client,
 				NamespaceScoped: true,
 			}
-			obj, err := modifier.Get("bar", "foo", false)
+			obj, err := modifier.Get("bar", "foo")
 
 			if (err != nil) != tt.Err {
 				t.Errorf("unexpected error: %d %t %v", i, tt.Err, err)
@@ -393,7 +393,7 @@ func TestHelperList(t *testing.T) {
 				RESTClient:      client,
 				NamespaceScoped: true,
 			}
-			obj, err := modifier.List("bar", corev1GV.String(), false, &metav1.ListOptions{LabelSelector: "foo=baz"})
+			obj, err := modifier.List("bar", corev1GV.String(), &metav1.ListOptions{LabelSelector: "foo=baz"})
 			if (err != nil) != tt.Err {
 				t.Errorf("unexpected error: %t %v", tt.Err, err)
 			}
@@ -464,7 +464,6 @@ func TestHelperListSelectorCombination(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			_, err := modifier.List("bar",
 				corev1GV.String(),
-				false,
 				&metav1.ListOptions{LabelSelector: tt.LabelSelector, FieldSelector: tt.FieldSelector})
 			if tt.Err {
 				if err == nil {

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/selector.go
@@ -32,19 +32,17 @@ type Selector struct {
 	Namespace     string
 	LabelSelector string
 	FieldSelector string
-	Export        bool
 	LimitChunks   int64
 }
 
 // NewSelector creates a resource selector which hides details of getting items by their label selector.
-func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelSelector, fieldSelector string, export bool, limitChunks int64) *Selector {
+func NewSelector(client RESTClient, mapping *meta.RESTMapping, namespace, labelSelector, fieldSelector string, limitChunks int64) *Selector {
 	return &Selector{
 		Client:        client,
 		Mapping:       mapping,
 		Namespace:     namespace,
 		LabelSelector: labelSelector,
 		FieldSelector: fieldSelector,
-		Export:        export,
 		LimitChunks:   limitChunks,
 	}
 }
@@ -56,7 +54,6 @@ func (r *Selector) Visit(fn VisitorFunc) error {
 		list, err := NewHelper(r.Client, r.Mapping).List(
 			r.Namespace,
 			r.ResourceMapping().GroupVersionKind.GroupVersion().String(),
-			r.Export,
 			&metav1.ListOptions{
 				LabelSelector: r.LabelSelector,
 				FieldSelector: r.FieldSelector,

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/visitor.go
@@ -88,8 +88,6 @@ type Info struct {
 	// but if set it should be equal to or newer than the resource version of the
 	// object (however the server defines resource version).
 	ResourceVersion string
-	// Optional, should this resource be exported, stripped of cluster-specific and instance specific fields
-	Export bool
 }
 
 // Visit implements Visitor
@@ -99,7 +97,7 @@ func (i *Info) Visit(fn VisitorFunc) error {
 
 // Get retrieves the object from the Namespace and Name fields
 func (i *Info) Get() (err error) {
-	obj, err := NewHelper(i.Client, i.Mapping).Get(i.Namespace, i.Name, i.Export)
+	obj, err := NewHelper(i.Client, i.Mapping).Get(i.Namespace, i.Name)
 	if err != nil {
 		if errors.IsNotFound(err) && len(i.Namespace) > 0 && i.Namespace != metav1.NamespaceDefault && i.Namespace != metav1.NamespaceAll {
 			err2 := i.Client.Get().AbsPath("api", "v1", "namespaces", i.Namespace).Do(context.TODO()).Error()

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -191,7 +191,7 @@ func (p *Patcher) Patch(current runtime.Object, modified []byte, source, namespa
 		if i > triesBeforeBackOff {
 			p.BackOff.Sleep(backOffPeriod)
 		}
-		current, getErr = p.Helper.Get(namespace, name, false)
+		current, getErr = p.Helper.Get(namespace, name)
 		if getErr != nil {
 			return nil, nil, getErr
 		}
@@ -209,7 +209,7 @@ func (p *Patcher) deleteAndCreate(original runtime.Object, modified []byte, name
 	}
 	// TODO: use wait
 	if err := wait.PollImmediate(1*time.Second, p.Timeout, func() (bool, error) {
-		if _, err := p.Helper.Get(namespace, name, false); !errors.IsNotFound(err) {
+		if _, err := p.Helper.Get(namespace, name); !errors.IsNotFound(err) {
 			return false, err
 		}
 		return true, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/get/get.go
@@ -80,7 +80,6 @@ type GetOptions struct {
 	NoHeaders      bool
 	Sort           bool
 	IgnoreNotFound bool
-	Export         bool
 
 	genericclioptions.IOStreams
 }
@@ -183,8 +182,6 @@ func NewCmdGet(parent string, f cmdutil.Factory, streams genericclioptions.IOStr
 	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.")
 	addOpenAPIPrintColumnFlags(cmd, o)
 	addServerPrintColumnFlags(cmd, o)
-	cmd.Flags().BoolVar(&o.Export, "export", o.Export, "If true, use 'export' for the resources.  Exported resources are stripped of cluster-specific information.")
-	cmd.Flags().MarkDeprecated("export", "This flag is deprecated and will be removed in future.")
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to get from a server.")
 	return cmd
 }
@@ -301,7 +298,7 @@ func (o *GetOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []stri
 // Validate checks the set of flags provided by the user.
 func (o *GetOptions) Validate(cmd *cobra.Command) error {
 	if len(o.Raw) > 0 {
-		if o.Watch || o.WatchOnly || len(o.LabelSelector) > 0 || o.Export {
+		if o.Watch || o.WatchOnly || len(o.LabelSelector) > 0 {
 			return fmt.Errorf("--raw may not be specified with other flags that filter the server request or alter the output")
 		}
 		if len(cmdutil.GetFlagString(cmd, "output")) > 0 {
@@ -473,7 +470,6 @@ func (o *GetOptions) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) e
 		FilenameParam(o.ExplicitNamespace, &o.FilenameOptions).
 		LabelSelectorParam(o.LabelSelector).
 		FieldSelectorParam(o.FieldSelector).
-		ExportParam(o.Export).
 		RequestChunksOf(chunkSize).
 		ResourceTypeOrNameArgs(true, args...).
 		ContinueOnError().
@@ -632,7 +628,6 @@ func (o *GetOptions) watch(f cmdutil.Factory, cmd *cobra.Command, args []string)
 		FilenameParam(o.ExplicitNamespace, &o.FilenameOptions).
 		LabelSelectorParam(o.LabelSelector).
 		FieldSelectorParam(o.FieldSelector).
-		ExportParam(o.Export).
 		RequestChunksOf(o.ChunkSize).
 		ResourceTypeOrNameArgs(true, args...).
 		SingleResourceType().

--- a/test/cmd/core.sh
+++ b/test/cmd/core.sh
@@ -105,8 +105,6 @@ run_pod_tests() {
   kube::test::describe_resource_events_assert pods false
   # Describe command should print events information when show-events=true
   kube::test::describe_resource_events_assert pods true
-  ### Validate Export ###
-  kube::test::get_object_assert 'pods/valid-pod' "{{.metadata.namespace}} {{.metadata.name}}" '<no value> valid-pod' "--export=true"
 
   ### Dump current valid-pod POD
   output_pod=$(kubectl get pod valid-pod -o yaml "${kube_flags[@]}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind deprecation

**What this PR does / why we need it**:

This PR removes --export flag from kubectl get command.
This flag is planned to be removed in v1.18.

```
git grep '\-\-export' CHANGELOG
CHANGELOG/CHANGELOG-1.14.md:  - The `--export` flag for the `kubectl get` command is deprecated and will be removed in v1.18. ([#73787](https:
CHANGELOG/CHANGELOG-1.14.md:* Deprecate --export flag from kubectl get command. ([#73787](https://github.com/kubernetes/kubernetes/pull/73787)
CHANGELOG/CHANGELOG-1.15.md:  - The `--export` flag for the `kubectl get` command, deprecated since v1.14, will be removed in v1.18.
CHANGELOG/CHANGELOG-1.16.md:  - The `--export` flag for the `kubectl get` command, deprecated since v1.14, will be removed in v1.18.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Remove --export flag from kubectl get command.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
