### PR TITLE
Automated cherry pick of #88444: fix: add remediation in azure disk attach/detach

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/BUILD
@@ -122,6 +122,7 @@ go_test(
         "//vendor/github.com/Azure/go-autorest/autorest:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -21,7 +21,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"net/http"
 	"path"
 	"strings"
 	"sync"
@@ -48,7 +47,7 @@ const (
 	errLeaseFailed       = "AcquireDiskLeaseFailed"
 	errLeaseIDMissing    = "LeaseIdMissing"
 	errContainerNotFound = "ContainerNotFound"
-	errDiskBlobNotFound  = "DiskBlobNotFound"
+	errDiskNotFound      = "is not found"
 )
 
 var defaultBackOff = kwait.Backoff{
@@ -342,11 +341,11 @@ func (c *controllerCommon) checkDiskExists(ctx context.Context, diskURI string) 
 		return false, err
 	}
 
-	if _, rerr := c.cloud.DisksClient.Get(ctx, resourceGroup, diskName); rerr != nil {
-		if rerr.HTTPStatusCode == http.StatusNotFound {
+	if _, err := c.cloud.DisksClient.Get(ctx, resourceGroup, diskName); err != nil {
+		if strings.Contains(err.Error(), errDiskNotFound) {
 			return false, nil
 		}
-		return false, rerr.Error()
+		return false, err
 	}
 
 	return true, nil

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -21,6 +21,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"path"
 	"strings"
 	"sync"
@@ -293,4 +294,60 @@ func (c *controllerCommon) DisksAreAttached(diskNames []string, nodeName types.N
 	}
 
 	return attached, nil
+}
+
+func filterDetachingDisks(unfilteredDisks []compute.DataDisk) []compute.DataDisk {
+	filteredDisks := []compute.DataDisk{}
+	for _, disk := range unfilteredDisks {
+		if disk.ToBeDetached != nil && *disk.ToBeDetached {
+			if disk.Name != nil {
+				klog.V(2).Infof("Filtering disk: %s with ToBeDetached flag set.", *disk.Name)
+			}
+		} else {
+			filteredDisks = append(filteredDisks, disk)
+		}
+	}
+	return filteredDisks
+}
+
+func (c *controllerCommon) filterNonExistingDisks(ctx context.Context, unfilteredDisks []compute.DataDisk) []compute.DataDisk {
+	filteredDisks := []compute.DataDisk{}
+	for _, disk := range unfilteredDisks {
+		filter := false
+		if disk.ManagedDisk != nil && disk.ManagedDisk.ID != nil {
+			diskURI := *disk.ManagedDisk.ID
+			exist, err := c.cloud.checkDiskExists(ctx, diskURI)
+			if err != nil {
+				klog.Errorf("checkDiskExists(%s) failed with error: %v", diskURI, err)
+			} else {
+				// only filter disk when checkDiskExists returns <false, nil>
+				filter = !exist
+				if filter {
+					klog.Errorf("disk(%s) does not exist, removed from data disk list", diskURI)
+				}
+			}
+		}
+
+		if !filter {
+			filteredDisks = append(filteredDisks, disk)
+		}
+	}
+	return filteredDisks
+}
+
+func (c *controllerCommon) checkDiskExists(ctx context.Context, diskURI string) (bool, error) {
+	diskName := path.Base(diskURI)
+	resourceGroup, err := getResourceGroupFromDiskURI(diskURI)
+	if err != nil {
+		return false, err
+	}
+
+	if _, rerr := c.cloud.DisksClient.Get(ctx, resourceGroup, diskName); rerr != nil {
+		if rerr.HTTPStatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, rerr.Error()
+	}
+
+	return true, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -248,3 +248,113 @@ func TestDisksAreAttached(t *testing.T) {
 		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d]: %s", i, test.desc)
 	}
 }
+
+func TestCheckDiskExists(t *testing.T) {
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
+	testCloud := GetTestCloud()
+	common := &controllerCommon{
+		location:              testCloud.Location,
+		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
+		resourceGroup:         testCloud.ResourceGroup,
+		subscriptionID:        testCloud.SubscriptionID,
+		cloud:                 testCloud,
+		vmLockMap:             newLockMap(),
+	}
+	// create a new disk before running test
+	newDiskName := "newdisk"
+	newDiskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
+		testCloud.SubscriptionID, testCloud.ResourceGroup, newDiskName)
+	fDC := newFakeDisksClient()
+	rerr := fDC.CreateOrUpdate(ctx, testCloud.ResourceGroup, newDiskName, compute.Disk{})
+	assert.Equal(t, rerr == nil, true, "return error: %v", rerr)
+	testCloud.DisksClient = fDC
+
+	testCases := []struct {
+		diskURI        string
+		expectedResult bool
+		expectedErr    bool
+	}{
+		{
+			diskURI:        "incorrect disk URI format",
+			expectedResult: false,
+			expectedErr:    true,
+		},
+		{
+			diskURI:        "/subscriptions/xxx/resourceGroups/xxx/providers/Microsoft.Compute/disks/non-existing-disk",
+			expectedResult: false,
+			expectedErr:    false,
+		},
+		{
+			diskURI:        newDiskURI,
+			expectedResult: true,
+			expectedErr:    false,
+		},
+	}
+
+	for i, test := range testCases {
+		exist, err := common.checkDiskExists(ctx, test.diskURI)
+		assert.Equal(t, test.expectedResult, exist, "TestCase[%d]", i, exist)
+		assert.Equal(t, test.expectedErr, err != nil, "TestCase[%d], return error: %v", i, err)
+	}
+}
+
+func TestFilterNonExistingDisks(t *testing.T) {
+	ctx, cancel := getContextWithCancel()
+	defer cancel()
+
+	testCloud := GetTestCloud()
+	common := &controllerCommon{
+		location:              testCloud.Location,
+		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
+		resourceGroup:         testCloud.ResourceGroup,
+		subscriptionID:        testCloud.SubscriptionID,
+		cloud:                 testCloud,
+		vmLockMap:             newLockMap(),
+	}
+	// create a new disk before running test
+	diskURIPrefix := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/",
+		testCloud.SubscriptionID, testCloud.ResourceGroup)
+	newDiskName := "newdisk"
+	newDiskURI := diskURIPrefix + newDiskName
+	fDC := newFakeDisksClient()
+	rerr := fDC.CreateOrUpdate(ctx, testCloud.ResourceGroup, newDiskName, compute.Disk{})
+	assert.Equal(t, rerr == nil, true, "return error: %v", rerr)
+	testCloud.DisksClient = fDC
+
+	disks := []compute.DataDisk{
+		{
+			Name: &newDiskName,
+			ManagedDisk: &compute.ManagedDiskParameters{
+				ID: &newDiskURI,
+			},
+		},
+		{
+			Name: pointer.StringPtr("DiskName2"),
+			ManagedDisk: &compute.ManagedDiskParameters{
+				ID: pointer.StringPtr(diskURIPrefix + "DiskName2"),
+			},
+		},
+		{
+			Name: pointer.StringPtr("DiskName3"),
+			ManagedDisk: &compute.ManagedDiskParameters{
+				ID: pointer.StringPtr(diskURIPrefix + "DiskName3"),
+			},
+		},
+		{
+			Name: pointer.StringPtr("DiskName4"),
+			ManagedDisk: &compute.ManagedDiskParameters{
+				ID: pointer.StringPtr(diskURIPrefix + "DiskName4"),
+			},
+		},
+	}
+
+	filteredDisks := common.filterNonExistingDisks(ctx, disks)
+	assert.Equal(t, 1, len(filteredDisks))
+	assert.Equal(t, newDiskName, *filteredDisks[0].Name)
+
+	disks = []compute.DataDisk{}
+	filteredDisks = filterDetachingDisks(disks)
+	assert.Equal(t, 0, len(filteredDisks))
+}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 )
 
 func TestCommonAttachDisk(t *testing.T) {
@@ -250,13 +251,10 @@ func TestDisksAreAttached(t *testing.T) {
 }
 
 func TestCheckDiskExists(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	testCloud := GetTestCloud(ctrl)
+	testCloud := getTestCloud()
 	common := &controllerCommon{
 		location:              testCloud.Location,
 		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
@@ -270,7 +268,7 @@ func TestCheckDiskExists(t *testing.T) {
 	newDiskURI := fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/disks/%s",
 		testCloud.SubscriptionID, testCloud.ResourceGroup, newDiskName)
 	fDC := newFakeDisksClient()
-	rerr := fDC.CreateOrUpdate(ctx, testCloud.ResourceGroup, newDiskName, compute.Disk{})
+	_, rerr := fDC.CreateOrUpdate(ctx, testCloud.ResourceGroup, newDiskName, compute.Disk{})
 	assert.Equal(t, rerr == nil, true, "return error: %v", rerr)
 	testCloud.DisksClient = fDC
 
@@ -304,13 +302,10 @@ func TestCheckDiskExists(t *testing.T) {
 }
 
 func TestFilterNonExistingDisks(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	testCloud := GetTestCloud(ctrl)
+	testCloud := getTestCloud()
 	common := &controllerCommon{
 		location:              testCloud.Location,
 		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
@@ -325,7 +320,7 @@ func TestFilterNonExistingDisks(t *testing.T) {
 	newDiskName := "newdisk"
 	newDiskURI := diskURIPrefix + newDiskName
 	fDC := newFakeDisksClient()
-	rerr := fDC.CreateOrUpdate(ctx, testCloud.ResourceGroup, newDiskName, compute.Disk{})
+	_, rerr := fDC.CreateOrUpdate(ctx, testCloud.ResourceGroup, newDiskName, compute.Disk{})
 	assert.Equal(t, rerr == nil, true, "return error: %v", rerr)
 	testCloud.DisksClient = fDC
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common_test.go
@@ -250,10 +250,13 @@ func TestDisksAreAttached(t *testing.T) {
 }
 
 func TestCheckDiskExists(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	testCloud := GetTestCloud()
+	testCloud := GetTestCloud(ctrl)
 	common := &controllerCommon{
 		location:              testCloud.Location,
 		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,
@@ -301,10 +304,13 @@ func TestCheckDiskExists(t *testing.T) {
 }
 
 func TestFilterNonExistingDisks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
 	ctx, cancel := getContextWithCancel()
 	defer cancel()
 
-	testCloud := GetTestCloud()
+	testCloud := GetTestCloud(ctrl)
 	common := &controllerCommon{
 		location:              testCloud.Location,
 		storageEndpointSuffix: testCloud.Environment.StorageEndpointSuffix,

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_standard.go
@@ -86,16 +86,16 @@ func (as *availabilitySet) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 
 	_, err = as.VirtualMachinesClient.Update(ctx, nodeResourceGroup, vmName, newVM, "attach_disk")
 	if err != nil {
-		klog.Errorf("azureDisk - attach disk(%s, %s) failed, err: %v", diskName, diskURI, err)
-		detail := err.Error()
-		if strings.Contains(detail, errLeaseFailed) || strings.Contains(detail, errDiskBlobNotFound) {
-			// if lease cannot be acquired or disk not found, immediately detach the disk and return the original error
-			klog.V(2).Infof("azureDisk - err %v, try detach disk(%s, %s)", err, diskName, diskURI)
-			as.DetachDisk(diskName, diskURI, nodeName)
+		klog.Errorf("azureDisk - attach disk(%s, %s) on rg(%s) vm(%s) failed, err: %v", diskName, diskURI, nodeResourceGroup, vmName, err)
+		if strings.Contains(err.Error(), errDiskNotFound) {
+			klog.Errorf("azureDisk - begin to filterNonExistingDisks(%s, %s) on rg(%s) vm(%s)", diskName, diskURI, nodeResourceGroup, vmName)
+			disks := as.filterNonExistingDisks(ctx, *newVM.VirtualMachineProperties.StorageProfile.DataDisks)
+			newVM.VirtualMachineProperties.StorageProfile.DataDisks = &disks
+			_, err = as.VirtualMachinesClient.Update(ctx, nodeResourceGroup, vmName, newVM, "attach_disk")
 		}
-	} else {
-		klog.V(2).Infof("azureDisk - attach disk(%s, %s) succeeded", diskName, diskURI)
 	}
+
+	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk(%s, %s) returned with %v", nodeResourceGroup, vmName, diskName, diskURI, err)
 	return err
 }
 
@@ -151,7 +151,19 @@ func (as *availabilitySet) DetachDisk(diskName, diskURI string, nodeName types.N
 	// Invalidate the cache right after updating
 	defer as.cloud.vmCache.Delete(vmName)
 
-	return as.VirtualMachinesClient.Update(ctx, nodeResourceGroup, vmName, newVM, "detach_disk")
+	httpResponse, err := as.VirtualMachinesClient.Update(ctx, nodeResourceGroup, vmName, newVM, "detach_disk")
+	if err != nil {
+		klog.Errorf("azureDisk - detach disk(%s, %s) on rg(%s) vm(%s) failed, err: %v", diskName, diskURI, nodeResourceGroup, vmName, err)
+		if strings.Contains(err.Error(), errDiskNotFound) {
+			klog.Errorf("azureDisk - begin to filterNonExistingDisks(%s, %s) on rg(%s) vm(%s)", diskName, diskURI, nodeResourceGroup, vmName)
+			disks := as.filterNonExistingDisks(ctx, *vm.StorageProfile.DataDisks)
+			newVM.VirtualMachineProperties.StorageProfile.DataDisks = &disks
+			httpResponse, err = as.VirtualMachinesClient.Update(ctx, nodeResourceGroup, vmName, newVM, "detach_disk")
+		}
+	}
+
+	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%s, %s) returned with %v", nodeResourceGroup, vmName, diskName, diskURI, err)
+	return httpResponse, err
 }
 
 // GetDataDisks gets a list of data disks attached to the node.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_vmss.go
@@ -91,15 +91,15 @@ func (ss *scaleSet) AttachDisk(isManagedDisk bool, diskName, diskURI string, nod
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk(%s, %s)", nodeResourceGroup, nodeName, diskName, diskURI)
 	_, err = ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "attach_disk")
 	if err != nil {
-		detail := err.Error()
-		if strings.Contains(detail, errLeaseFailed) || strings.Contains(detail, errDiskBlobNotFound) {
-			// if lease cannot be acquired or disk not found, immediately detach the disk and return the original error
-			klog.Infof("azureDisk - err %s, try detach disk(%s, %s)", detail, diskName, diskURI)
-			ss.DetachDisk(diskName, diskURI, nodeName)
+		klog.Errorf("azureDisk - attach disk(%s, %s) on rg(%s) vm(%s) failed, err: %v", diskName, diskURI, nodeResourceGroup, nodeName, err)
+		if strings.Contains(err.Error(), errDiskNotFound) {
+			klog.Errorf("azureDisk - begin to filterNonExistingDisks(%s, %s) on rg(%s) vm(%s)", diskName, diskURI, nodeResourceGroup, nodeName)
+			disks := ss.filterNonExistingDisks(ctx, *newVM.VirtualMachineScaleSetVMProperties.StorageProfile.DataDisks)
+			newVM.VirtualMachineScaleSetVMProperties.StorageProfile.DataDisks = &disks
+			_, err = ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "attach_disk")
 		}
-	} else {
-		klog.V(2).Infof("azureDisk - attach disk(%s, %s) succeeded", diskName, diskURI)
 	}
+	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - attach disk(%s, %s) returned with %v", nodeResourceGroup, nodeName, diskName, diskURI, err)
 	return err
 }
 
@@ -159,7 +159,19 @@ func (ss *scaleSet) DetachDisk(diskName, diskURI string, nodeName types.NodeName
 	defer ss.deleteCacheForNode(vmName)
 
 	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%s, %s)", nodeResourceGroup, nodeName, diskName, diskURI)
-	return ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "detach_disk")
+	httpResponse, err := ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "detach_disk")
+	if err != nil {
+		klog.Errorf("azureDisk - detach disk(%s, %s) on rg(%s) vm(%s) failed, err: %v", diskName, diskURI, nodeResourceGroup, nodeName, err)
+		if strings.Contains(err.Error(), errDiskNotFound) {
+			klog.Errorf("azureDisk - begin to filterNonExistingDisks(%s, %s) on rg(%s) vm(%s)", diskName, diskURI, nodeResourceGroup, nodeName)
+			ss.filterNonExistingDisks(ctx, *newVM.VirtualMachineScaleSetVMProperties.StorageProfile.DataDisks)
+			newVM.VirtualMachineScaleSetVMProperties.StorageProfile.DataDisks = &disks
+			httpResponse, err = ss.VirtualMachineScaleSetVMsClient.Update(ctx, nodeResourceGroup, ssName, instanceID, newVM, "detach_disk")
+		}
+	}
+
+	klog.V(2).Infof("azureDisk - update(%s): vm(%s) - detach disk(%s, %s) returned with %v", nodeResourceGroup, nodeName, diskName, diskURI, err)
+	return httpResponse, err
 }
 
 // GetDataDisks gets a list of data disks attached to the node.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
@@ -889,7 +889,7 @@ func (fDC *fakeDisksClient) Get(ctx context.Context, resourceGroupName string, d
 
 	return result, autorest.DetailedError{
 		StatusCode: http.StatusNotFound,
-		Message:    "Not such Disk",
+		Message:    fmt.Sprintf("Disk %s is not found.", diskName),
 	}
 }
 


### PR DESCRIPTION
Cherry pick of #88444 on release-1.16.

#88444: fix: add remediation in azure disk attach/detach

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.