### PR TITLE
refactor podIPs conversion

### DIFF
--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -1525,17 +1525,6 @@ func (kl *Kubelet) syncPod(o syncPodOptions) error {
 
 	// Generate final API pod status with pod and status manager status
 	apiPodStatus := kl.generateAPIPodStatus(pod, podStatus)
-	// The pod IP may be changed in generateAPIPodStatus if the pod is using host network. (See #24576)
-	// TODO(random-liu): After writing pod spec into container labels, check whether pod is using host network, and
-	// set pod IP to hostIP directly in runtime.GetPodStatus
-	podStatus.IPs = make([]string, 0, len(apiPodStatus.PodIPs))
-	for _, ipInfo := range apiPodStatus.PodIPs {
-		podStatus.IPs = append(podStatus.IPs, ipInfo.IP)
-	}
-
-	if len(podStatus.IPs) == 0 && len(apiPodStatus.PodIP) > 0 {
-		podStatus.IPs = []string{apiPodStatus.PodIP}
-	}
 
 	// Record the time it takes for the pod to become running.
 	existingStatus, ok := kl.statusManager.GetPodStatus(pod.UID)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind cleanup

**What this PR does / why we need it**:
1. refactor podIPs convert.
2. ~~fix a podIPs conversion minor bug.~~(fixed by later pr now)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
why refactor:
https://github.com/kubernetes/kubernetes/blob/b1c1187cca7f7986b321073760d067994d1d8483/pkg/kubelet/kubelet.go#L1531-L1538
https://github.com/kubernetes/kubernetes/blob/b1c1187cca7f7986b321073760d067994d1d8483/pkg/kubelet/kubelet_pods.go#L1399-L1408
It's confusing that apiPodStatus and podStatus init each other mutually because check [host network pod with no ips](https://github.com/kubernetes/kubernetes/blob/b1c1187cca7f7986b321073760d067994d1d8483/pkg/kubelet/kubelet_pods.go#L1385) after apiPodStatus IP filled. IMO, it should be checked before filling apiPodStatus IP.

~~what fixed:~~
~~in previous code, if a hostnetwork(127.0.0.1) podStatus.IPs is null, apiPodStatus.PodIP is "127.0.0.1", but its PodIPs is [] which seems not correct (plural[0] equals to singular).~~(fixed by later pr now)
s.PodIPs not set in https://github.com/kubernetes/kubernetes/b1c1187cca7f7986b321073760d067994d1d8483/pkg/kubelet/kubelet_pods.go#L1386 

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
