### PR TITLE
Deprecate --generator flag from kubectl create commands

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -452,6 +452,7 @@ func AddApplyAnnotationVarFlags(cmd *cobra.Command, applyAnnotation *bool) {
 // TODO: need to take a pass at other generator commands to use this set of flags
 func AddGeneratorFlags(cmd *cobra.Command, defaultGenerator string) {
 	cmd.Flags().String("generator", defaultGenerator, "The name of the API generator to use.")
+	cmd.Flags().MarkDeprecated("generator", "has no effect and will be removed in the future.")
 	AddDryRunFlag(cmd)
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
After we've simplified the `kubectl run` functionality we are ready to remove all of the generators and have each command create the resources it needs to. This PR starts the deprecation clock for `--generator` flag for `kubectl create` commands. 

/assign @pwittrock @seans3 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Deprecate --generator flag from kubectl create commands
```
