### PR TITLE
Implement uncertain mount for block volumes

### DIFF
--- a/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
+++ b/pkg/kubelet/volumemanager/reconciler/reconciler_test.go
@@ -1148,7 +1148,6 @@ func Test_Run_Positive_VolumeFSResizeControllerAttachEnabled(t *testing.T) {
 }
 
 func Test_UncertainDeviceGlobalMounts(t *testing.T) {
-	fsMode := v1.PersistentVolumeFilesystem
 	var tests = []struct {
 		name                   string
 		deviceState            operationexecutor.DeviceMountState
@@ -1190,129 +1189,140 @@ func Test_UncertainDeviceGlobalMounts(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
+	for _, mode := range []v1.PersistentVolumeMode{v1.PersistentVolumeBlock, v1.PersistentVolumeFilesystem} {
+		for _, tc := range tests {
+			testName := fmt.Sprintf("%s [%s]", tc.name, mode)
+			t.Run(testName+"[", func(t *testing.T) {
 
-			pv := &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: tc.volumeName,
-					UID:  "pvuid",
-				},
-				Spec: v1.PersistentVolumeSpec{
-					ClaimRef:   &v1.ObjectReference{Name: "pvc"},
-					VolumeMode: &fsMode,
-				},
-			}
-			pvc := &v1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pvc",
-					UID:  "pvcuid",
-				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					VolumeName: tc.volumeName,
-				},
-			}
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pod1",
-					UID:  "pod1uid",
-				},
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
-						{
-							Name: "volume-name",
-							VolumeSource: v1.VolumeSource{
-								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-									ClaimName: pvc.Name,
+				pv := &v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tc.volumeName,
+						UID:  "pvuid",
+					},
+					Spec: v1.PersistentVolumeSpec{
+						ClaimRef:   &v1.ObjectReference{Name: "pvc"},
+						VolumeMode: &mode,
+					},
+				}
+				pvc := &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc",
+						UID:  "pvcuid",
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						VolumeName: tc.volumeName,
+						VolumeMode: &mode,
+					},
+				}
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						UID:  "pod1uid",
+					},
+					Spec: v1.PodSpec{
+						Volumes: []v1.Volume{
+							{
+								Name: "volume-name",
+								VolumeSource: v1.VolumeSource{
+									PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvc.Name,
+									},
 								},
 							},
 						},
 					},
-				},
-			}
+				}
 
-			volumePluginMgr, fakePlugin := volumetesting.GetTestVolumePluginMgr(t)
-			fakePlugin.SupportsRemount = tc.supportRemount
+				volumePluginMgr, fakePlugin := volumetesting.GetTestVolumePluginMgr(t)
+				fakePlugin.SupportsRemount = tc.supportRemount
 
-			dsw := cache.NewDesiredStateOfWorld(volumePluginMgr)
-			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-			kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
-				Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
-				DevicePath: "fake/path",
+				dsw := cache.NewDesiredStateOfWorld(volumePluginMgr)
+				asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
+				kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+					Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
+					DevicePath: "fake/path",
+				})
+				fakeRecorder := &record.FakeRecorder{}
+				fakeHandler := volumetesting.NewBlockVolumePathHandler()
+				oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
+					kubeClient,
+					volumePluginMgr,
+					fakeRecorder,
+					false, /* checkNodeCapabilitiesBeforeMount */
+					fakeHandler))
+
+				reconciler := NewReconciler(
+					kubeClient,
+					true, /* controllerAttachDetachEnabled */
+					reconcilerLoopSleepDuration,
+					waitForAttachTimeout,
+					nodeName,
+					dsw,
+					asw,
+					hasAddedPods,
+					oex,
+					&mount.FakeMounter{},
+					hostutil.NewFakeHostUtil(nil),
+					volumePluginMgr,
+					kubeletPodsDir)
+				volumeSpec := &volume.Spec{PersistentVolume: pv}
+				podName := util.GetUniquePodName(pod)
+				volumeName, err := dsw.AddPodToVolume(
+					podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGidValue */)
+				// Assert
+				if err != nil {
+					t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+				}
+				dsw.MarkVolumesReportedInUse([]v1.UniqueVolumeName{volumeName})
+
+				// Start the reconciler to fill ASW.
+				stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
+				go func() {
+					reconciler.Run(stopChan)
+					close(stoppedChan)
+				}()
+				waitForVolumeToExistInASW(t, volumeName, asw)
+				if tc.volumeName == volumetesting.TimeoutAndFailOnMountDeviceVolumeName {
+					// Wait upto 10s for reconciler to catch up
+					time.Sleep(reconcilerSyncWaitDuration)
+				}
+
+				if tc.volumeName == volumetesting.SuccessAndFailOnMountDeviceName ||
+					tc.volumeName == volumetesting.SuccessAndTimeoutDeviceName {
+					// wait for mount and then break it via remount
+					waitForMount(t, fakePlugin, volumeName, asw)
+					asw.MarkRemountRequired(podName)
+					time.Sleep(reconcilerSyncWaitDuration)
+				}
+
+				if tc.deviceState == operationexecutor.DeviceMountUncertain {
+					waitForUncertainGlobalMount(t, volumeName, asw)
+				}
+
+				if tc.deviceState == operationexecutor.DeviceGloballyMounted {
+					waitForMount(t, fakePlugin, volumeName, asw)
+				}
+
+				dsw.DeletePodFromVolume(podName, volumeName)
+				waitForDetach(t, volumeName, asw)
+				if mode == v1.PersistentVolumeFilesystem {
+					err = volumetesting.VerifyUnmountDeviceCallCount(tc.unmountDeviceCallCount, fakePlugin)
+				} else {
+					if tc.unmountDeviceCallCount == 0 {
+						err = volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin)
+					} else {
+						err = volumetesting.VerifyTearDownDeviceCallCount(tc.unmountDeviceCallCount, fakePlugin)
+					}
+				}
+				if err != nil {
+					t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
+				}
 			})
-			fakeRecorder := &record.FakeRecorder{}
-			fakeHandler := volumetesting.NewBlockVolumePathHandler()
-			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
-				kubeClient,
-				volumePluginMgr,
-				fakeRecorder,
-				false, /* checkNodeCapabilitiesBeforeMount */
-				fakeHandler))
-
-			reconciler := NewReconciler(
-				kubeClient,
-				true, /* controllerAttachDetachEnabled */
-				reconcilerLoopSleepDuration,
-				waitForAttachTimeout,
-				nodeName,
-				dsw,
-				asw,
-				hasAddedPods,
-				oex,
-				&mount.FakeMounter{},
-				hostutil.NewFakeHostUtil(nil),
-				volumePluginMgr,
-				kubeletPodsDir)
-			volumeSpec := &volume.Spec{PersistentVolume: pv}
-			podName := util.GetUniquePodName(pod)
-			volumeName, err := dsw.AddPodToVolume(
-				podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGidValue */)
-			// Assert
-			if err != nil {
-				t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
-			}
-			dsw.MarkVolumesReportedInUse([]v1.UniqueVolumeName{volumeName})
-
-			// Start the reconciler to fill ASW.
-			stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
-			go func() {
-				reconciler.Run(stopChan)
-				close(stoppedChan)
-			}()
-			waitForVolumeToExistInASW(t, volumeName, asw)
-			if tc.volumeName == volumetesting.TimeoutAndFailOnMountDeviceVolumeName {
-				// Wait upto 10s for reconciler to catchup
-				time.Sleep(reconcilerSyncWaitDuration)
-			}
-
-			if tc.volumeName == volumetesting.SuccessAndFailOnMountDeviceName ||
-				tc.volumeName == volumetesting.SuccessAndTimeoutDeviceName {
-				// wait for mount and then break it via remount
-				waitForMount(t, fakePlugin, volumeName, asw)
-				asw.MarkRemountRequired(podName)
-				time.Sleep(reconcilerSyncWaitDuration)
-			}
-
-			if tc.deviceState == operationexecutor.DeviceMountUncertain {
-				waitForUncertainGlobalMount(t, volumeName, asw)
-			}
-
-			if tc.deviceState == operationexecutor.DeviceGloballyMounted {
-				waitForMount(t, fakePlugin, volumeName, asw)
-			}
-
-			dsw.DeletePodFromVolume(podName, volumeName)
-			waitForDetach(t, volumeName, asw)
-			err = volumetesting.VerifyUnmountDeviceCallCount(tc.unmountDeviceCallCount, fakePlugin)
-			if err != nil {
-				t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
-			}
-		})
+		}
 	}
 }
 
 func Test_UncertainVolumeMountState(t *testing.T) {
-	fsMode := v1.PersistentVolumeFilesystem
 	var tests = []struct {
 		name                   string
 		volumeState            operationexecutor.VolumeMountState
@@ -1331,14 +1341,14 @@ func Test_UncertainVolumeMountState(t *testing.T) {
 		{
 			name:                   "failed operation should result in not-mounted volume",
 			volumeState:            operationexecutor.VolumeNotMounted,
-			unmountDeviceCallCount: 0,
+			unmountDeviceCallCount: 1,
 			unmountVolumeCount:     0,
 			volumeName:             volumetesting.FailOnSetupVolumeName,
 		},
 		{
 			name:                   "timeout followed by failed operation should result in non-mounted volume",
 			volumeState:            operationexecutor.VolumeNotMounted,
-			unmountDeviceCallCount: 0,
+			unmountDeviceCallCount: 1,
 			unmountVolumeCount:     0,
 			volumeName:             volumetesting.TimeoutAndFailOnSetupVolumeName,
 		},
@@ -1360,123 +1370,151 @@ func Test_UncertainVolumeMountState(t *testing.T) {
 		},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			pv := &v1.PersistentVolume{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: tc.volumeName,
-					UID:  "pvuid",
-				},
-				Spec: v1.PersistentVolumeSpec{
-					ClaimRef:   &v1.ObjectReference{Name: "pvc"},
-					VolumeMode: &fsMode,
-				},
-			}
-			pvc := &v1.PersistentVolumeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pvc",
-					UID:  "pvcuid",
-				},
-				Spec: v1.PersistentVolumeClaimSpec{
-					VolumeName: tc.volumeName,
-				},
-			}
-			pod := &v1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "pod1",
-					UID:  "pod1uid",
-				},
-				Spec: v1.PodSpec{
-					Volumes: []v1.Volume{
-						{
-							Name: "volume-name",
-							VolumeSource: v1.VolumeSource{
-								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
-									ClaimName: pvc.Name,
+	for _, mode := range []v1.PersistentVolumeMode{v1.PersistentVolumeBlock, v1.PersistentVolumeFilesystem} {
+		for _, tc := range tests {
+			testName := fmt.Sprintf("%s [%s]", tc.name, mode)
+			t.Run(testName, func(t *testing.T) {
+				pv := &v1.PersistentVolume{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: tc.volumeName,
+						UID:  "pvuid",
+					},
+					Spec: v1.PersistentVolumeSpec{
+						ClaimRef:   &v1.ObjectReference{Name: "pvc"},
+						VolumeMode: &mode,
+					},
+				}
+				pvc := &v1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc",
+						UID:  "pvcuid",
+					},
+					Spec: v1.PersistentVolumeClaimSpec{
+						VolumeName: tc.volumeName,
+						VolumeMode: &mode,
+					},
+				}
+				pod := &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+						UID:  "pod1uid",
+					},
+					Spec: v1.PodSpec{
+						Volumes: []v1.Volume{
+							{
+								Name: "volume-name",
+								VolumeSource: v1.VolumeSource{
+									PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+										ClaimName: pvc.Name,
+									},
 								},
 							},
 						},
 					},
-				},
-			}
+				}
 
-			volumePluginMgr, fakePlugin := volumetesting.GetTestVolumePluginMgr(t)
-			fakePlugin.SupportsRemount = tc.supportRemount
-			dsw := cache.NewDesiredStateOfWorld(volumePluginMgr)
-			asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
-			kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
-				Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
-				DevicePath: "fake/path",
+				volumePluginMgr, fakePlugin := volumetesting.GetTestVolumePluginMgr(t)
+				fakePlugin.SupportsRemount = tc.supportRemount
+				dsw := cache.NewDesiredStateOfWorld(volumePluginMgr)
+				asw := cache.NewActualStateOfWorld(nodeName, volumePluginMgr)
+				kubeClient := createtestClientWithPVPVC(pv, pvc, v1.AttachedVolume{
+					Name:       v1.UniqueVolumeName(fmt.Sprintf("fake-plugin/%s", tc.volumeName)),
+					DevicePath: "fake/path",
+				})
+				fakeRecorder := &record.FakeRecorder{}
+				fakeHandler := volumetesting.NewBlockVolumePathHandler()
+				oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
+					kubeClient,
+					volumePluginMgr,
+					fakeRecorder,
+					false, /* checkNodeCapabilitiesBeforeMount */
+					fakeHandler))
+
+				reconciler := NewReconciler(
+					kubeClient,
+					true, /* controllerAttachDetachEnabled */
+					reconcilerLoopSleepDuration,
+					waitForAttachTimeout,
+					nodeName,
+					dsw,
+					asw,
+					hasAddedPods,
+					oex,
+					&mount.FakeMounter{},
+					hostutil.NewFakeHostUtil(nil),
+					volumePluginMgr,
+					kubeletPodsDir)
+				volumeSpec := &volume.Spec{PersistentVolume: pv}
+				podName := util.GetUniquePodName(pod)
+				volumeName, err := dsw.AddPodToVolume(
+					podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGidValue */)
+				// Assert
+				if err != nil {
+					t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
+				}
+				dsw.MarkVolumesReportedInUse([]v1.UniqueVolumeName{volumeName})
+
+				// Start the reconciler to fill ASW.
+				stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
+				go func() {
+					reconciler.Run(stopChan)
+					close(stoppedChan)
+				}()
+				waitForVolumeToExistInASW(t, volumeName, asw)
+				if tc.volumeName == volumetesting.TimeoutAndFailOnSetupVolumeName {
+					// Wait upto 10s for reconciler to catchup
+					time.Sleep(reconcilerSyncWaitDuration)
+				}
+
+				if tc.volumeName == volumetesting.SuccessAndFailOnSetupVolumeName ||
+					tc.volumeName == volumetesting.SuccessAndTimeoutSetupVolumeName {
+					// wait for mount and then break it via remount
+					waitForMount(t, fakePlugin, volumeName, asw)
+					asw.MarkRemountRequired(podName)
+					time.Sleep(reconcilerSyncWaitDuration)
+				}
+
+				if tc.volumeState == operationexecutor.VolumeMountUncertain {
+					waitForUncertainPodMount(t, volumeName, asw)
+				}
+
+				if tc.volumeState == operationexecutor.VolumeMounted {
+					waitForMount(t, fakePlugin, volumeName, asw)
+				}
+
+				dsw.DeletePodFromVolume(podName, volumeName)
+				waitForDetach(t, volumeName, asw)
+
+				if mode == v1.PersistentVolumeFilesystem {
+					if err := volumetesting.VerifyUnmountDeviceCallCount(tc.unmountDeviceCallCount, fakePlugin); err != nil {
+						t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
+					}
+					if err := volumetesting.VerifyTearDownCallCount(tc.unmountVolumeCount, fakePlugin); err != nil {
+						t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
+					}
+				} else {
+					if tc.unmountVolumeCount == 0 {
+						if err := volumetesting.VerifyZeroUnmapPodDeviceCallCount(fakePlugin); err != nil {
+							t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
+						}
+					} else {
+						if err := volumetesting.VerifyUnmapPodDeviceCallCount(tc.unmountVolumeCount, fakePlugin); err != nil {
+							t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
+						}
+					}
+					if tc.unmountDeviceCallCount == 0 {
+						if err := volumetesting.VerifyZeroTearDownDeviceCallCount(fakePlugin); err != nil {
+							t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
+						}
+					} else {
+						if err := volumetesting.VerifyTearDownDeviceCallCount(tc.unmountDeviceCallCount, fakePlugin); err != nil {
+							t.Errorf("Error verifying UnMountDeviceCallCount: %v", err)
+						}
+					}
+				}
 			})
-			fakeRecorder := &record.FakeRecorder{}
-			fakeHandler := volumetesting.NewBlockVolumePathHandler()
-			oex := operationexecutor.NewOperationExecutor(operationexecutor.NewOperationGenerator(
-				kubeClient,
-				volumePluginMgr,
-				fakeRecorder,
-				false, /* checkNodeCapabilitiesBeforeMount */
-				fakeHandler))
-
-			reconciler := NewReconciler(
-				kubeClient,
-				true, /* controllerAttachDetachEnabled */
-				reconcilerLoopSleepDuration,
-				waitForAttachTimeout,
-				nodeName,
-				dsw,
-				asw,
-				hasAddedPods,
-				oex,
-				&mount.FakeMounter{},
-				hostutil.NewFakeHostUtil(nil),
-				volumePluginMgr,
-				kubeletPodsDir)
-			volumeSpec := &volume.Spec{PersistentVolume: pv}
-			podName := util.GetUniquePodName(pod)
-			volumeName, err := dsw.AddPodToVolume(
-				podName, pod, volumeSpec, volumeSpec.Name(), "" /* volumeGidValue */)
-			// Assert
-			if err != nil {
-				t.Fatalf("AddPodToVolume failed. Expected: <no error> Actual: <%v>", err)
-			}
-			dsw.MarkVolumesReportedInUse([]v1.UniqueVolumeName{volumeName})
-
-			// Start the reconciler to fill ASW.
-			stopChan, stoppedChan := make(chan struct{}), make(chan struct{})
-			go func() {
-				reconciler.Run(stopChan)
-				close(stoppedChan)
-			}()
-			waitForVolumeToExistInASW(t, volumeName, asw)
-			if tc.volumeName == volumetesting.TimeoutAndFailOnSetupVolumeName {
-				// Wait upto 10s for reconciler to catchup
-				time.Sleep(reconcilerSyncWaitDuration)
-			}
-
-			if tc.volumeName == volumetesting.SuccessAndFailOnSetupVolumeName ||
-				tc.volumeName == volumetesting.SuccessAndTimeoutSetupVolumeName {
-				// wait for mount and then break it via remount
-				waitForMount(t, fakePlugin, volumeName, asw)
-				asw.MarkRemountRequired(podName)
-				time.Sleep(reconcilerSyncWaitDuration)
-			}
-
-			if tc.volumeState == operationexecutor.VolumeMountUncertain {
-				waitForUncertainPodMount(t, volumeName, asw)
-			}
-
-			if tc.volumeState == operationexecutor.VolumeMounted {
-				waitForMount(t, fakePlugin, volumeName, asw)
-			}
-
-			dsw.DeletePodFromVolume(podName, volumeName)
-			waitForDetach(t, volumeName, asw)
-
-			volumetesting.VerifyUnmountDeviceCallCount(tc.unmountDeviceCallCount, fakePlugin)
-			volumetesting.VerifyTearDownCallCount(tc.unmountVolumeCount, fakePlugin)
-		})
+		}
 	}
-
 }
 
 func waitForUncertainGlobalMount(t *testing.T, volumeName v1.UniqueVolumeName, asw cache.ActualStateOfWorld) {

--- a/pkg/volume/csi/BUILD
+++ b/pkg/volume/csi/BUILD
@@ -88,6 +88,8 @@ go_test(
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
         "//vendor/github.com/container-storage-interface/spec/lib/go/csi:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -189,7 +189,7 @@ func (m *csiBlockMapper) stageVolumeForBlock(
 		nil /* MountOptions */)
 
 	if err != nil {
-		return "", errors.New(log("blockMapper.stageVolumeForBlock failed: %v", err))
+		return "", err
 	}
 
 	klog.V(4).Infof(log("blockMapper.stageVolumeForBlock successfully requested NodeStageVolume [%s]", stagingPath))
@@ -249,7 +249,7 @@ func (m *csiBlockMapper) publishVolumeForBlock(
 	)
 
 	if err != nil {
-		return "", errors.New(log("blockMapper.publishVolumeForBlock failed: %v", err))
+		return "", err
 	}
 
 	return publishPath, nil

--- a/pkg/volume/csi/csi_block.go
+++ b/pkg/volume/csi/csi_block.go
@@ -503,19 +503,8 @@ func (m *csiBlockMapper) UnmapPodDevice() error {
 	ctx, cancel := context.WithTimeout(context.Background(), csiTimeout)
 	defer cancel()
 
-	// Call NodeUnpublishVolume
-	if _, err := os.Stat(publishPath); err != nil {
-		if os.IsNotExist(err) {
-			klog.V(4).Infof(log("blockMapper.UnmapPodDevice publishPath(%s) has already been deleted, skip calling NodeUnpublishVolume", publishPath))
-		} else {
-			return err
-		}
-	} else {
-		err := m.unpublishVolumeForBlock(ctx, csiClient, publishPath)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	// Call NodeUnpublishVolume.
+	// Even if publishPath does not exist - previous NodePublish may have timed out
+	// and Kubernetes makes sure that the operation is finished.
+	return m.unpublishVolumeForBlock(ctx, csiClient, publishPath)
 }

--- a/pkg/volume/csi/csi_block_test.go
+++ b/pkg/volume/csi/csi_block_test.go
@@ -18,11 +18,13 @@ package csi
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	api "k8s.io/api/core/v1"
 	"k8s.io/api/storage/v1beta1"
@@ -299,7 +301,7 @@ func TestBlockMapperSetupDeviceError(t *testing.T) {
 
 	csiMapper.csiClient = setupClient(t, true)
 	fClient := csiMapper.csiClient.(*fakeCsiDriverClient)
-	fClient.nodeClient.SetNextError(errors.New("mock final error"))
+	fClient.nodeClient.SetNextError(status.Error(codes.InvalidArgument, "mock final error"))
 
 	attachID := getAttachmentName(csiMapper.volumeID, string(csiMapper.driverName), string(nodeName))
 	attachment := makeTestAttachment(attachID, nodeName, pvName)

--- a/pkg/volume/util/operationexecutor/operation_generator.go
+++ b/pkg/volume/util/operationexecutor/operation_generator.go
@@ -929,7 +929,7 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 		volumeAttacher, _ = attachableVolumePlugin.NewAttacher()
 	}
 
-	mapVolumeFunc := func() (error, error) {
+	mapVolumeFunc := func() (simpleErr error, detailedErr error) {
 		var devicePath string
 		// Set up global map path under the given plugin directory using symbolic link
 		globalMapPath, err :=
@@ -956,6 +956,7 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 		if customBlockVolumeMapper, ok := blockVolumeMapper.(volume.CustomBlockVolumeMapper); ok {
 			mapErr := customBlockVolumeMapper.SetUpDevice()
 			if mapErr != nil {
+				og.markDeviceErrorState(volumeToMount, devicePath, globalMapPath, mapErr, actualStateOfWorld)
 				// On failure, return error. Caller will log and retry.
 				return volumeToMount.GenerateError("MapVolume.SetUpDevice failed", mapErr)
 			}
@@ -970,14 +971,35 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 			return volumeToMount.GenerateError("MapVolume.MarkDeviceAsMounted failed", markDeviceMappedErr)
 		}
 
+		markVolumeOpts := MarkVolumeOpts{
+			PodName:             volumeToMount.PodName,
+			PodUID:              volumeToMount.Pod.UID,
+			VolumeName:          volumeToMount.VolumeName,
+			BlockVolumeMapper:   blockVolumeMapper,
+			OuterVolumeSpecName: volumeToMount.OuterVolumeSpecName,
+			VolumeGidVolume:     volumeToMount.VolumeGidValue,
+			VolumeSpec:          volumeToMount.VolumeSpec,
+			VolumeMountState:    VolumeMounted,
+		}
+
 		// Call MapPodDevice if blockVolumeMapper implements CustomBlockVolumeMapper
 		if customBlockVolumeMapper, ok := blockVolumeMapper.(volume.CustomBlockVolumeMapper); ok {
 			// Execute driver specific map
 			pluginDevicePath, mapErr := customBlockVolumeMapper.MapPodDevice()
 			if mapErr != nil {
 				// On failure, return error. Caller will log and retry.
+				og.markVolumeErrorState(volumeToMount, markVolumeOpts, mapErr, actualStateOfWorld)
 				return volumeToMount.GenerateError("MapVolume.MapPodDevice failed", mapErr)
 			}
+
+			// From now on, the volume is mapped. Mark it as uncertain on error,
+			// so it is is unmapped when corresponding pod is deleted.
+			defer func() {
+				if simpleErr != nil {
+					errText := simpleErr.Error()
+					og.markVolumeErrorState(volumeToMount, markVolumeOpts, volumetypes.NewUncertainProgressError(errText), actualStateOfWorld)
+				}
+			}()
 
 			// if pluginDevicePath is provided, assume attacher may not provide device
 			// or attachment flow uses SetupDevice to get device path
@@ -1042,17 +1064,6 @@ func (og *operationGenerator) GenerateMapVolumeFunc(
 		if resizeError != nil {
 			klog.Errorf("MapVolume.NodeExpandVolume failed with %v", resizeError)
 			return volumeToMount.GenerateError("MapVolume.MarkVolumeAsMounted failed while expanding volume", resizeError)
-		}
-
-		markVolumeOpts := MarkVolumeOpts{
-			PodName:             volumeToMount.PodName,
-			PodUID:              volumeToMount.Pod.UID,
-			VolumeName:          volumeToMount.VolumeName,
-			BlockVolumeMapper:   blockVolumeMapper,
-			OuterVolumeSpecName: volumeToMount.OuterVolumeSpecName,
-			VolumeGidVolume:     volumeToMount.VolumeGidValue,
-			VolumeSpec:          volumeToMount.VolumeSpec,
-			VolumeMountState:    VolumeMounted,
 		}
 
 		markVolMountedErr := actualStateOfWorld.MarkVolumeAsMounted(markVolumeOpts)

--- a/pkg/volume/util/volumepathhandler/volume_path_handler.go
+++ b/pkg/volume/util/volumepathhandler/volume_path_handler.go
@@ -283,7 +283,7 @@ func (v VolumePathHandler) GetDeviceBindMountRefs(devPath string, mapPath string
 	var refs []string
 	files, err := ioutil.ReadDir(mapPath)
 	if err != nil {
-		return nil, fmt.Errorf("directory cannot read %v", err)
+		return nil, err
 	}
 	for _, file := range files {
 		if file.Mode()&os.ModeDevice != os.ModeDevice {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When NodeStage / NodePublish of a block volume times out, CSI driver may continue publishing/staging the volume in the background. Therefore Kubernetes should ensure NodeUnstage/NodeUnpublish is called when user deletes corresponding pod.

A bit of refactoring was necessary:
* CSI volume plugin must not wrap `UncertainProgressError` / `TransientOperationFailure` with `fmr.Errorf()`, so operationGenerator knows if a block operation is in progress or not.
* NodeUnstage/NodeUnpublish must be called even when the target path does not exists - the driver may not have created it before it timed out, still the operation may be in progress. It's up to the driver to cope with non-existing directories.
* The rest is just marking block device "mounts" as uncertain on errors.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88086

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed block CSI volume cleanup after timeouts.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/20190130-csi-raw-block-support.md
```

cc @gnufied @jingxu97 for operation generator experience.
