### PR TITLE
update map keys api doc with validation requirements

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/generated.proto
@@ -493,6 +493,9 @@ message JSONSchemaProps {
   // extension set to "map". Also, the values specified for this attribute must
   // be a scalar typed field of the child structure (no nesting is supported).
   //
+  // The properties specified must either be required or have a default value,
+  // to ensure those properties are present for all list items.
+  //
   // +optional
   repeated string xKubernetesListMapKeys = 41;
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1/types_jsonschema.go
@@ -126,6 +126,9 @@ type JSONSchemaProps struct {
 	// extension set to "map". Also, the values specified for this attribute must
 	// be a scalar typed field of the child structure (no nesting is supported).
 	//
+	// The properties specified must either be required or have a default value,
+	// to ensure those properties are present for all list items.
+	//
 	// +optional
 	XListMapKeys []string `json:"x-kubernetes-list-map-keys,omitempty" protobuf:"bytes,41,rep,name=xKubernetesListMapKeys"`
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/generated.proto
@@ -545,6 +545,9 @@ message JSONSchemaProps {
   // extension set to "map". Also, the values specified for this attribute must
   // be a scalar typed field of the child structure (no nesting is supported).
   //
+  // The properties specified must either be required or have a default value,
+  // to ensure those properties are present for all list items.
+  //
   // +optional
   repeated string xKubernetesListMapKeys = 41;
 

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types_jsonschema.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1/types_jsonschema.go
@@ -126,6 +126,9 @@ type JSONSchemaProps struct {
 	// extension set to "map". Also, the values specified for this attribute must
 	// be a scalar typed field of the child structure (no nesting is supported).
 	//
+	// The properties specified must either be required or have a default value,
+	// to ensure those properties are present for all list items.
+	//
 	// +optional
 	XListMapKeys []string `json:"x-kubernetes-list-map-keys,omitempty" protobuf:"bytes,41,rep,name=xKubernetesListMapKeys"`
 


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it**:
Update `XListMapKeys` API documentation with requirement that properties either be required or have a default value.

**Special notes for your reviewer**:
Follow up to: https://github.com/kubernetes/kubernetes/pull/88076

```release-note
NONE
```