### PR TITLE
Implement endpointslice batching

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -597,6 +597,8 @@ API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,D
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointControllerConfiguration,ConcurrentEndpointSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointControllerConfiguration,EndpointUpdatesBatchPeriod
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointSliceControllerConfiguration,ConcurrentServiceEndpointSyncs
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointSliceControllerConfiguration,EndpointUpdatesBurst
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointSliceControllerConfiguration,EndpointUpdatesQPS
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,EndpointSliceControllerConfiguration,MaxEndpointsPerSlice
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,GarbageCollectorControllerConfiguration,ConcurrentGCSyncs
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,GarbageCollectorControllerConfiguration,EnableGarbageCollector

--- a/cmd/kube-controller-manager/app/discovery.go
+++ b/cmd/kube-controller-manager/app/discovery.go
@@ -48,6 +48,8 @@ func startEndpointSliceController(ctx ControllerContext) (http.Handler, bool, er
 		ctx.InformerFactory.Discovery().V1beta1().EndpointSlices(),
 		ctx.ComponentConfig.EndpointSliceController.MaxEndpointsPerSlice,
 		ctx.ClientBuilder.ClientOrDie("endpointslice-controller"),
+		ctx.ComponentConfig.EndpointSliceController.EndpointUpdatesQPS,
+		ctx.ComponentConfig.EndpointSliceController.EndpointUpdatesBurst,
 	).Run(int(ctx.ComponentConfig.EndpointSliceController.ConcurrentServiceEndpointSyncs), ctx.Stop)
 	return nil, true, nil
 }

--- a/cmd/kube-controller-manager/app/options/endpointslicecontroller.go
+++ b/cmd/kube-controller-manager/app/options/endpointslicecontroller.go
@@ -43,6 +43,8 @@ func (o *EndpointSliceControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.Int32Var(&o.ConcurrentServiceEndpointSyncs, "concurrent-service-endpoint-syncs", o.ConcurrentServiceEndpointSyncs, "The number of service endpoint syncing operations that will be done concurrently. Larger number = faster endpoint slice updating, but more CPU (and network) load. Defaults to 5.")
 	fs.Int32Var(&o.MaxEndpointsPerSlice, "max-endpoints-per-slice", o.MaxEndpointsPerSlice, "The maximum number of endpoints that will be added to an EndpointSlice. More endpoints per slice will result in less endpoint slices, but larger resources. Defaults to 100.")
+	fs.Float64Var(&o.EndpointUpdatesQPS, "endpointslice-updates-qps", o.EndpointUpdatesQPS, "Defines a maximum number of pod-triggered endpoint updates per second.")
+	fs.IntVar(&o.EndpointUpdatesBurst, "endpointslice-updates-burst", o.EndpointUpdatesBurst, "Defines a number of first pod-triggered endpoint updates that are passed without delay.")
 }
 
 // ApplyTo fills up EndpointSliceController config with options.
@@ -53,6 +55,8 @@ func (o *EndpointSliceControllerOptions) ApplyTo(cfg *endpointsliceconfig.Endpoi
 
 	cfg.ConcurrentServiceEndpointSyncs = o.ConcurrentServiceEndpointSyncs
 	cfg.MaxEndpointsPerSlice = o.MaxEndpointsPerSlice
+	cfg.EndpointUpdatesQPS = o.EndpointUpdatesQPS
+	cfg.EndpointUpdatesBurst = o.EndpointUpdatesBurst
 
 	return nil
 }

--- a/cmd/kube-controller-manager/app/options/options_test.go
+++ b/cmd/kube-controller-manager/app/options/options_test.go
@@ -247,6 +247,8 @@ func TestAddFlags(t *testing.T) {
 			&endpointsliceconfig.EndpointSliceControllerConfiguration{
 				ConcurrentServiceEndpointSyncs: 10,
 				MaxEndpointsPerSlice:           200,
+				EndpointUpdatesQPS:             50.0,
+				EndpointUpdatesBurst:           1,
 			},
 		},
 		GarbageCollectorController: &GarbageCollectorControllerOptions{

--- a/pkg/controller/endpointslice/config/types.go
+++ b/pkg/controller/endpointslice/config/types.go
@@ -28,4 +28,11 @@ type EndpointSliceControllerConfiguration struct {
 	// added to an EndpointSlice. More endpoints per slice will result in fewer
 	// and larger endpoint slices, but larger resources.
 	MaxEndpointsPerSlice int32
+
+	// EndpointUpdatesQPS defines a max number of pod-triggered endpoints updates per second.
+	EndpointUpdatesQPS float64
+
+	// EndpointUpdatesBurst defines a number of first pod-triggered endpoints updates that can be generated
+	// without additional delay.
+	EndpointUpdatesBurst int
 }

--- a/pkg/controller/endpointslice/config/v1alpha1/defaults.go
+++ b/pkg/controller/endpointslice/config/v1alpha1/defaults.go
@@ -38,4 +38,13 @@ func RecommendedDefaultEndpointSliceControllerConfiguration(obj *kubectrlmgrconf
 	if obj.MaxEndpointsPerSlice == 0 {
 		obj.MaxEndpointsPerSlice = 100
 	}
+
+	if obj.EndpointUpdatesQPS == 0.0 {
+		// Default 50.0 value matches default kube-api-qps limit for endpoint-controller.
+		obj.EndpointUpdatesQPS = 50.0
+	}
+
+	if obj.EndpointUpdatesBurst == 0 {
+		obj.EndpointUpdatesBurst = 1
+	}
 }

--- a/pkg/controller/endpointslice/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/endpointslice/config/v1alpha1/zz_generated.conversion.go
@@ -61,12 +61,16 @@ func RegisterConversions(s *runtime.Scheme) error {
 func autoConvert_v1alpha1_EndpointSliceControllerConfiguration_To_config_EndpointSliceControllerConfiguration(in *v1alpha1.EndpointSliceControllerConfiguration, out *config.EndpointSliceControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentServiceEndpointSyncs = in.ConcurrentServiceEndpointSyncs
 	out.MaxEndpointsPerSlice = in.MaxEndpointsPerSlice
+	out.EndpointUpdatesQPS = in.EndpointUpdatesQPS
+	out.EndpointUpdatesBurst = in.EndpointUpdatesBurst
 	return nil
 }
 
 func autoConvert_config_EndpointSliceControllerConfiguration_To_v1alpha1_EndpointSliceControllerConfiguration(in *config.EndpointSliceControllerConfiguration, out *v1alpha1.EndpointSliceControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentServiceEndpointSyncs = in.ConcurrentServiceEndpointSyncs
 	out.MaxEndpointsPerSlice = in.MaxEndpointsPerSlice
+	out.EndpointUpdatesQPS = in.EndpointUpdatesQPS
+	out.EndpointUpdatesBurst = in.EndpointUpdatesBurst
 	return nil
 }
 

--- a/pkg/controller/endpointslice/endpointslice_controller_test.go
+++ b/pkg/controller/endpointslice/endpointslice_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"testing"
 	"time"
 
@@ -51,7 +52,7 @@ type endpointSliceController struct {
 	serviceStore       cache.Store
 }
 
-func newController(nodeNames []string) (*fake.Clientset, *endpointSliceController) {
+func newController(nodeNames []string, qps float64) (*fake.Clientset, *endpointSliceController) {
 	client := newClientset()
 	informerFactory := informers.NewSharedInformerFactory(client, controller.NoResyncPeriodFunc())
 	nodeInformer := informerFactory.Core().V1().Nodes()
@@ -66,7 +67,9 @@ func newController(nodeNames []string) (*fake.Clientset, *endpointSliceControlle
 		nodeInformer,
 		informerFactory.Discovery().V1beta1().EndpointSlices(),
 		int32(100),
-		client)
+		client,
+		qps,
+		1)
 
 	esController.nodesSynced = alwaysReady
 	esController.podsSynced = alwaysReady
@@ -86,7 +89,7 @@ func newController(nodeNames []string) (*fake.Clientset, *endpointSliceControlle
 func TestSyncServiceNoSelector(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	serviceName := "testing-1"
-	client, esController := newController([]string{"node-1"})
+	client, esController := newController([]string{"node-1"}, 50.0)
 	esController.serviceStore.Add(&v1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: ns},
 		Spec: v1.ServiceSpec{
@@ -103,7 +106,7 @@ func TestSyncServiceNoSelector(t *testing.T) {
 func TestSyncServiceWithSelector(t *testing.T) {
 	ns := metav1.NamespaceDefault
 	serviceName := "testing-1"
-	client, esController := newController([]string{"node-1"})
+	client, esController := newController([]string{"node-1"}, 50.0)
 	standardSyncService(t, esController, ns, serviceName, "true")
 	expectActions(t, client.Actions(), 1, "create", "endpointslices")
 
@@ -123,7 +126,7 @@ func TestSyncServiceWithSelector(t *testing.T) {
 // remove too much.
 func TestSyncServiceMissing(t *testing.T) {
 	namespace := metav1.NamespaceDefault
-	client, esController := newController([]string{"node-1"})
+	client, esController := newController([]string{"node-1"}, 50.0)
 
 	// Build up existing service
 	existingServiceName := "stillthere"
@@ -159,7 +162,7 @@ func TestSyncServiceMissing(t *testing.T) {
 
 // Ensure SyncService correctly selects Pods.
 func TestSyncServicePodSelection(t *testing.T) {
-	client, esController := newController([]string{"node-1"})
+	client, esController := newController([]string{"node-1"}, 50.0)
 	ns := metav1.NamespaceDefault
 
 	pod1 := newPod(1, ns, true, 0)
@@ -186,7 +189,7 @@ func TestSyncServicePodSelection(t *testing.T) {
 
 // Ensure SyncService correctly selects and labels EndpointSlices.
 func TestSyncServiceEndpointSliceLabelSelection(t *testing.T) {
-	client, esController := newController([]string{"node-1"})
+	client, esController := newController([]string{"node-1"}, 50.0)
 	ns := metav1.NamespaceDefault
 	serviceName := "testing-1"
 
@@ -274,7 +277,7 @@ func TestSyncServiceEndpointSliceLabelSelection(t *testing.T) {
 
 // Ensure SyncService handles a variety of protocols and IPs appropriately.
 func TestSyncServiceFull(t *testing.T) {
-	client, esController := newController([]string{"node-1"})
+	client, esController := newController([]string{"node-1"}, 50.0)
 	namespace := metav1.NamespaceDefault
 	serviceName := "all-the-protocols"
 	ipv6Family := v1.IPv6Protocol
@@ -345,7 +348,401 @@ func TestSyncServiceFull(t *testing.T) {
 	}}, slice.Endpoints)
 }
 
+// TestPodAddsBatching verifies that endpoint updates caused by pod addition are batched together.
+// This test uses real time.Sleep, as there is no easy way to mock time in endpoints controller now.
+// TODO(mborsz): Migrate this test to mock clock when possible.
+func TestPodAddsBatching(t *testing.T) {
+	type podAdd struct {
+		delay time.Duration
+	}
+
+	tests := []struct {
+		name             string
+		qps              float64
+		adds             []podAdd
+		finalDelay       time.Duration
+		wantRequestCount int
+	}{
+		{
+			name: "adds with no batching",
+			qps:  50.0,
+			adds: []podAdd{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay: 200 * time.Millisecond,
+				},
+				{
+					delay: 100 * time.Millisecond,
+				},
+				{
+					delay: 100 * time.Millisecond,
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 3,
+		},
+		{
+			name: "adds in two batches",
+			qps:  1.0,
+			adds: []podAdd{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay: 200 * time.Millisecond,
+				},
+				{
+					delay: 100 * time.Millisecond,
+				},
+				{
+					delay: 100 * time.Millisecond,
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 2,
+		},
+		{
+			name: "adds in two batches",
+			qps:  1.0,
+			adds: []podAdd{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay: 200 * time.Millisecond,
+				},
+				{
+					delay: 100 * time.Millisecond,
+				},
+				{
+					delay: 100 * time.Millisecond,
+				},
+				{
+					delay: 100 * time.Millisecond,
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := metav1.NamespaceDefault
+			client, esController := newController([]string{"node-1"}, tc.qps)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go esController.Run(1, stopCh)
+
+			esController.serviceStore.Add(&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{"foo": "bar"},
+					Ports:    []v1.ServicePort{{Port: 80}},
+				},
+			})
+
+			for i, add := range tc.adds {
+				time.Sleep(add.delay)
+
+				p := newPod(i, ns, true, 0)
+				esController.podStore.Add(p)
+				esController.addPod(p)
+			}
+
+			time.Sleep(tc.finalDelay)
+			assert.Len(t, client.Actions(), tc.wantRequestCount)
+			// In case of error, make debugging easier.
+			for _, action := range client.Actions() {
+				t.Logf("action: %v %v", action.GetVerb(), action.GetResource())
+			}
+		})
+	}
+}
+
+// TestPodUpdatesBatching verifies that endpoint updates caused by pod updates are batched together.
+// This test uses real time.Sleep, as there is no easy way to mock time in endpoints controller now.
+// TODO(mborsz): Migrate this test to mock clock when possible.
+func TestPodUpdatesBatching(t *testing.T) {
+	resourceVersion := 1
+	type podUpdate struct {
+		delay   time.Duration
+		podName string
+		podIP   string
+	}
+
+	tests := []struct {
+		name             string
+		qps              float64
+		podsCount        int
+		updates          []podUpdate
+		finalDelay       time.Duration
+		wantRequestCount int
+	}{
+		{
+			name:      "three updates with no batching",
+			qps:       50.0,
+			podsCount: 10,
+			updates: []podUpdate{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay:   200 * time.Millisecond,
+					podName: "pod0",
+					podIP:   "10.0.0.0",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod1",
+					podIP:   "10.0.0.1",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod2",
+					podIP:   "10.0.0.2",
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 3,
+		},
+		{
+			name:      "three updates in two batches",
+			qps:       1.0,
+			podsCount: 10,
+			updates: []podUpdate{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay:   200 * time.Millisecond,
+					podName: "pod0",
+					podIP:   "10.0.0.0",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod1",
+					podIP:   "10.0.0.1",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod2",
+					podIP:   "10.0.0.2",
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 2,
+		},
+		{
+			name:      "four updates in two batches",
+			qps:       1.0,
+			podsCount: 10,
+			updates: []podUpdate{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay:   200 * time.Millisecond,
+					podName: "pod0",
+					podIP:   "10.0.0.0",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod1",
+					podIP:   "10.0.0.1",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod2",
+					podIP:   "10.0.0.2",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod3",
+					podIP:   "10.0.0.2",
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := metav1.NamespaceDefault
+			client, esController := newController([]string{"node-1"}, tc.qps)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go esController.Run(1, stopCh)
+
+			addPods(t, esController, ns, tc.podsCount)
+
+			esController.serviceStore.Add(&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{"foo": "bar"},
+					Ports:    []v1.ServicePort{{Port: 80}},
+				},
+			})
+
+			for _, update := range tc.updates {
+				time.Sleep(update.delay)
+
+				old, exists, err := esController.podStore.GetByKey(fmt.Sprintf("%s/%s", ns, update.podName))
+				if err != nil {
+					t.Fatalf("Error while retrieving old value of %q: %v", update.podName, err)
+				}
+				if !exists {
+					t.Fatalf("Pod %q doesn't exist", update.podName)
+				}
+				oldPod := old.(*v1.Pod)
+				newPod := oldPod.DeepCopy()
+				newPod.Status.PodIPs[0].IP = update.podIP
+				newPod.ResourceVersion = strconv.Itoa(resourceVersion)
+				resourceVersion++
+
+				esController.podStore.Update(newPod)
+				esController.updatePod(oldPod, newPod)
+			}
+
+			time.Sleep(tc.finalDelay)
+			assert.Len(t, client.Actions(), tc.wantRequestCount)
+			// In case of error, make debugging easier.
+			for _, action := range client.Actions() {
+				t.Logf("action: %v %v", action.GetVerb(), action.GetResource())
+			}
+		})
+	}
+}
+
+// TestPodDeleteBatching verifies that endpoint updates caused by pod deletion are batched together.
+// This test uses real time.Sleep, as there is no easy way to mock time in endpoints controller now.
+// TODO(mborsz): Migrate this test to mock clock when possible.
+func TestPodDeleteBatching(t *testing.T) {
+	type podDelete struct {
+		delay   time.Duration
+		podName string
+	}
+
+	tests := []struct {
+		name             string
+		qps              float64
+		podsCount        int
+		deletes          []podDelete
+		finalDelay       time.Duration
+		wantRequestCount int
+	}{
+		{
+			name:      "three deletes with no batching",
+			qps:       50.0,
+			podsCount: 10,
+			deletes: []podDelete{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay:   200 * time.Millisecond,
+					podName: "pod0",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod1",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod2",
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 3,
+		},
+		{
+			name:      "three deletes in two batches",
+			qps:       1.0,
+			podsCount: 10,
+			deletes: []podDelete{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay:   200 * time.Millisecond,
+					podName: "pod0",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod1",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod2",
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 2,
+		},
+		{
+			name:      "four deletes in two batches",
+			qps:       1.0,
+			podsCount: 10,
+			deletes: []podDelete{
+				{
+					// endpoints.Run needs ~100 ms to start processing updates.
+					delay:   200 * time.Millisecond,
+					podName: "pod0",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod1",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod2",
+				},
+				{
+					delay:   100 * time.Millisecond,
+					podName: "pod3",
+				},
+			},
+			finalDelay:       3 * time.Second,
+			wantRequestCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ns := metav1.NamespaceDefault
+			client, esController := newController([]string{"node-1"}, tc.qps)
+			stopCh := make(chan struct{})
+			defer close(stopCh)
+
+			go esController.Run(1, stopCh)
+
+			addPods(t, esController, ns, tc.podsCount)
+
+			esController.serviceStore.Add(&v1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: ns},
+				Spec: v1.ServiceSpec{
+					Selector: map[string]string{"foo": "bar"},
+					Ports:    []v1.ServicePort{{Port: 80}},
+				},
+			})
+
+			for _, update := range tc.deletes {
+				time.Sleep(update.delay)
+
+				old, exists, err := esController.podStore.GetByKey(fmt.Sprintf("%s/%s", ns, update.podName))
+				assert.Nil(t, err, "error while retrieving old value of %q: %v", update.podName, err)
+				assert.Equal(t, true, exists, "pod should exist")
+				esController.podStore.Delete(old)
+				esController.deletePod(old)
+			}
+
+			time.Sleep(tc.finalDelay)
+			assert.Len(t, client.Actions(), tc.wantRequestCount)
+			// In case of error, make debugging easier.
+			for _, action := range client.Actions() {
+				t.Logf("action: %v %v", action.GetVerb(), action.GetResource())
+			}
+		})
+	}
+}
+
 // Test helpers
+func addPods(t *testing.T, esController *endpointSliceController, namespace string, podsCount int) {
+	t.Helper()
+	for i := 0; i < podsCount; i++ {
+		pod := newPod(i, namespace, true, 0)
+		esController.podStore.Add(pod)
+	}
+}
 
 func standardSyncService(t *testing.T, esController *endpointSliceController, namespace, serviceName, managedBySetup string) {
 	t.Helper()

--- a/staging/src/k8s.io/client-go/util/workqueue/BUILD
+++ b/staging/src/k8s.io/client-go/util/workqueue/BUILD
@@ -20,7 +20,6 @@ go_test(
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/clock:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/golang.org/x/time/rate:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -312,6 +312,13 @@ type EndpointSliceControllerConfiguration struct {
 	// added to an EndpointSlice. More endpoints per slice will result in fewer
 	// and larger endpoint slices, but larger resources.
 	MaxEndpointsPerSlice int32
+
+	// EndpointUpdatesQPS defines a max number of pod-triggered endpoints updates.
+	EndpointUpdatesQPS float64
+
+	// EndpointUpdatesBurst defines a number of first pod-triggered endpoints updates that can be generated
+	// without additional delay.
+	EndpointUpdatesBurst int
 }
 
 // GarbageCollectorControllerConfiguration contains elements describing GarbageCollectorController.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

Similarly to https://github.com/kubernetes/kubernetes/pull/88161, it implements qps and burst-based rate limiting in endpoints slice controller.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

The test are still missing. I will add them on Monday.

This depends on https://github.com/kubernetes/kubernetes/pull/88664

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign @lavalamp
/assign @freehan
/cc @mm4tt