### PR TITLE
Remove --include-uninitialized flag documentation

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/resource_printing/queries_and_options.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/resource_printing/queries_and_options.md
@@ -150,20 +150,6 @@ kubectl get rc/web service/frontend pods/web-pod-13je7
 ```
 
 {% endmethod %}
-  
-{% method %}
-## Uninitialized
-
-Kubernetes **Resources may be hidden until they have gone through an initialization process**.
-These Resources can be view with the `--include-uninitialized` flag.
-
-{% sample lang="yaml" %}
-
-```bash
-kubectl get deployments --include-uninitialized
-```
-
-{% endmethod %}
 
 {% method %}
 ## Not Found


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
--include-uninitialized flag does not exist anymore.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

Signed-off-by: Tamal Saha <tamal@appscode.com>