### PR TITLE
fix behaviour of aws-load-balancer-security-groups annotation

### DIFF
--- a/pkg/cloudprovider/providers/aws/aws_test.go
+++ b/pkg/cloudprovider/providers/aws/aws_test.go
@@ -1604,11 +1604,12 @@ func TestLBExtraSecurityGroupsAnnotation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			serviceName := types.NamespacedName{Namespace: "default", Name: "myservice"}
 
-			sgList, err := c.buildELBSecurityGroupList(serviceName, "aid", test.annotations)
+			sgList, setupSg, err := c.buildELBSecurityGroupList(serviceName, "aid", test.annotations)
 			assert.NoError(t, err, "buildELBSecurityGroupList failed")
 			extraSGs := sgList[1:]
 			assert.True(t, sets.NewString(test.expectedSGs...).Equal(sets.NewString(extraSGs...)),
 				"Security Groups expected=%q , returned=%q", test.expectedSGs, extraSGs)
+			assert.True(t, setupSg, "Security Groups Setup Permissions Flag expected=%t , returned=%t", true, setupSg)
 		})
 	}
 }
@@ -1637,10 +1638,11 @@ func TestLBSecurityGroupsAnnotation(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			serviceName := types.NamespacedName{Namespace: "default", Name: "myservice"}
 
-			sgList, err := c.buildELBSecurityGroupList(serviceName, "aid", test.annotations)
+			sgList, setupSg, err := c.buildELBSecurityGroupList(serviceName, "aid", test.annotations)
 			assert.NoError(t, err, "buildELBSecurityGroupList failed")
 			assert.True(t, sets.NewString(test.expectedSGs...).Equal(sets.NewString(sgList...)),
 				"Security Groups expected=%q , returned=%q", test.expectedSGs, sgList)
+			assert.False(t, setupSg, "Security Groups Setup Permissions Flag expected=%t , returned=%t", false, setupSg)
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The intention of users utilizing the specified by aws-load-balancer-security-groups annotation is typically, that they want to assign an externally managed security to the load balancer and do not want Kubernetes to modify the group.
(Also see summary/fixed issues)

**Which issue(s) this PR fixes**:
Ensures that Security Group specified by aws-load-balancer-security-groups is not modified on setup of Load Balancer anymore.
Fixes #79723, kubernetes/cloud-provider-aws/issues/65
Redesign implementation from PR #62774
Also addresses #49445, #79279

**Special notes for your reviewer**:
Backport/Cherry-Pick #83446 for release 1.17
I decided for now to not go back to my pre-merge-conflict-resolve version of that PR but take over the getSGListFromAnnotation function from @bhagwat070919 #84265 without cherry picking that full PR (so only use it within buildELBSecurityGroupList changed with this PR) - if that is not fine for You I can do other way (backport/cherry-pick whoul #84265 or inline the functioanlity of getSGListFromAnnotation)

**Release Note**
```release-note
Fix handling of aws-load-balancer-security-groups annotation. Security-Groups assigned with this annotation are no longer modified by kubernetes which is the expected behaviour of most users. Also no unnecessary Security-Groups are created anymore if this annotation is used.
```