### PR TITLE
Improve performance for VMSS LoadBalancerBackendAddressPools updates

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
@@ -530,6 +530,10 @@ func (fVMC *fakeVirtualMachineScaleSetVMsClient) Update(ctx context.Context, res
 	return nil
 }
 
+func (fVMC *fakeVirtualMachineScaleSetVMsClient) UpdateVMs(ctx context.Context, resourceGroupName string, VMScaleSetName string, instances map[string]compute.VirtualMachineScaleSetVM, source string) *retry.Error {
+	return nil
+}
+
 type fakeVirtualMachineScaleSetsClient struct {
 	mutex     *sync.Mutex
 	FakeStore map[string]map[string]compute.VirtualMachineScaleSet

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_utils.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_utils.go
@@ -21,9 +21,6 @@ package azure
 import (
 	"context"
 	"sync"
-	"time"
-
-	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
 // lockMap used to lock on entries
@@ -76,22 +73,4 @@ func (lm *lockMap) unlockEntry(entry string) {
 
 func getContextWithCancel() (context.Context, context.CancelFunc) {
 	return context.WithCancel(context.Background())
-}
-
-// aggregateGoroutinesWithDelay aggregates goroutines and runs them
-// in parallel with delay before starting each goroutine
-func aggregateGoroutinesWithDelay(delay time.Duration, funcs ...func() error) utilerrors.Aggregate {
-	errChan := make(chan error, len(funcs))
-
-	for _, f := range funcs {
-		go func(f func() error) { errChan <- f() }(f)
-		time.Sleep(delay)
-	}
-	errs := make([]error, 0)
-	for i := 0; i < cap(errChan); i++ {
-		if err := <-errChan; err != nil {
-			errs = append(errs, err)
-		}
-	}
-	return utilerrors.NewAggregate(errs)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_utils_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_utils_test.go
@@ -19,7 +19,6 @@ limitations under the License.
 package azure
 
 import (
-	"fmt"
 	"testing"
 	"time"
 )
@@ -82,69 +81,5 @@ func ensureNoCallback(t *testing.T, callbackChan <-chan interface{}) bool {
 		return false
 	case <-time.After(callbackTimeout):
 		return true
-	}
-}
-
-// running same unit tests as https://github.com/kubernetes/apimachinery/blob/master/pkg/util/errors/errors_test.go#L371
-func TestAggregateGoroutinesWithDelay(t *testing.T) {
-	testCases := []struct {
-		errs     []error
-		expected map[string]bool
-	}{
-		{
-			[]error{},
-			nil,
-		},
-		{
-			[]error{nil},
-			nil,
-		},
-		{
-			[]error{nil, nil},
-			nil,
-		},
-		{
-			[]error{fmt.Errorf("1")},
-			map[string]bool{"1": true},
-		},
-		{
-			[]error{fmt.Errorf("1"), nil},
-			map[string]bool{"1": true},
-		},
-		{
-			[]error{fmt.Errorf("1"), fmt.Errorf("267")},
-			map[string]bool{"1": true, "267": true},
-		},
-		{
-			[]error{fmt.Errorf("1"), nil, fmt.Errorf("1234")},
-			map[string]bool{"1": true, "1234": true},
-		},
-		{
-			[]error{nil, fmt.Errorf("1"), nil, fmt.Errorf("1234"), fmt.Errorf("22")},
-			map[string]bool{"1": true, "1234": true, "22": true},
-		},
-	}
-	for i, testCase := range testCases {
-		funcs := make([]func() error, len(testCase.errs))
-		for i := range testCase.errs {
-			err := testCase.errs[i]
-			funcs[i] = func() error { return err }
-		}
-		agg := aggregateGoroutinesWithDelay(100*time.Millisecond, funcs...)
-		if agg == nil {
-			if len(testCase.expected) > 0 {
-				t.Errorf("%d: expected %v, got nil", i, testCase.expected)
-			}
-			continue
-		}
-		if len(agg.Errors()) != len(testCase.expected) {
-			t.Errorf("%d: expected %d errors in aggregate, got %v", i, len(testCase.expected), agg)
-			continue
-		}
-		for _, err := range agg.Errors() {
-			if !testCase.expected[err.Error()] {
-				t.Errorf("%d: expected %v, got aggregate containing %v", i, testCase.expected, err)
-			}
-		}
 	}
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmsets.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmsets.go
@@ -62,7 +62,7 @@ type VMSet interface {
 	EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, backendPoolID string, vmSetName string, isInternal bool) error
 	// EnsureHostInPool ensures the given VM's Primary NIC's Primary IP Configuration is
 	// participating in the specified LoadBalancer Backend Pool.
-	EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID string, vmSetName string, isInternal bool) error
+	EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID string, vmSetName string, isInternal bool) (string, string, string, *compute.VirtualMachineScaleSetVM, error)
 	// EnsureBackendPoolDeleted ensures the loadBalancer backendAddressPools deleted from the specified nodes.
 	EnsureBackendPoolDeleted(service *v1.Service, backendPoolID, vmSetName string, backendAddressPools *[]network.BackendAddressPool) error
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -26,7 +26,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
@@ -54,13 +53,6 @@ var (
 	vmssIPConfigurationRE  = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(.+)/networkInterfaces(?:.*)`)
 	vmssPIPConfigurationRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(.+)/networkInterfaces/(.+)/ipConfigurations/(.+)/publicIPAddresses/(.+)`)
 	vmssVMProviderIDRE     = regexp.MustCompile(`azure:///subscriptions/(?:.*)/resourceGroups/(.+)/providers/Microsoft.Compute/virtualMachineScaleSets/(.+)/virtualMachines/(?:\d+)`)
-)
-
-const (
-	// vmssVMInstanceUpdateDelay is used when updating multiple vm instances in parallel
-	// the optimum value is 3s to prevent any conflicts that result in concurrent vmss vm
-	// instances update
-	vmssVMInstanceUpdateDelay = 3 * time.Second
 )
 
 // vmssMetaInfo contains the metadata for a VMSS.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/interface.go
@@ -27,6 +27,12 @@ import (
 	"k8s.io/legacy-cloud-providers/azure/retry"
 )
 
+// PutResourcesResponse defines the response for PutResources.
+type PutResourcesResponse struct {
+	Response *http.Response
+	Error    *retry.Error
+}
+
 // Interface is the client interface for ARM.
 // Don't forget to run the following command to generate the mock client:
 // mockgen -source=$GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/interface.go -package=mockarmclient Interface > $GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient/interface.go
@@ -60,6 +66,11 @@ type Interface interface {
 
 	// PutResource puts a resource by resource ID
 	PutResource(ctx context.Context, resourceID string, parameters interface{}) (*http.Response, *retry.Error)
+
+	// PutResources puts a list of resources from resources map[resourceID]parameters.
+	// Those resources sync requests are sequential while async requests are concurent. It 's especially
+	// useful when the ARM API doesn't support concurrent requests.
+	PutResources(ctx context.Context, resources map[string]interface{}) map[string]*PutResourcesResponse
 
 	// PutResourceWithDecorators puts a resource with decorators by resource ID
 	PutResourceWithDecorators(ctx context.Context, resourceID string, parameters interface{}, decorators []autorest.PrepareDecorator) (*http.Response, *retry.Error)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/azure/retry:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient/mockarmclient/interface.go
@@ -26,6 +26,7 @@ import (
 	autorest "github.com/Azure/go-autorest/autorest"
 	azure "github.com/Azure/go-autorest/autorest/azure"
 	gomock "github.com/golang/mock/gomock"
+	armclient "k8s.io/legacy-cloud-providers/azure/clients/armclient"
 	retry "k8s.io/legacy-cloud-providers/azure/retry"
 )
 
@@ -225,6 +226,20 @@ func (m *MockInterface) PutResource(ctx context.Context, resourceID string, para
 func (mr *MockInterfaceMockRecorder) PutResource(ctx, resourceID, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResource", reflect.TypeOf((*MockInterface)(nil).PutResource), ctx, resourceID, parameters)
+}
+
+// PutResources mocks base method
+func (m *MockInterface) PutResources(ctx context.Context, resources map[string]interface{}) map[string]*armclient.PutResourcesResponse {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutResources", ctx, resources)
+	ret0, _ := ret[0].(map[string]*armclient.PutResourcesResponse)
+	return ret0
+}
+
+// PutResources indicates an expected call of PutResources
+func (mr *MockInterfaceMockRecorder) PutResources(ctx, resources interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutResources", reflect.TypeOf((*MockInterface)(nil).PutResources), ctx, resources)
 }
 
 // PutResourceWithDecorators mocks base method

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient",
     visibility = ["//visibility:public"],
     deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/azure/clients:go_default_library",
         "//staging/src/k8s.io/legacy-cloud-providers/azure/clients/armclient:go_default_library",

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/interface.go
@@ -42,4 +42,7 @@ type Interface interface {
 
 	// Update updates a VirtualMachineScaleSetVM.
 	Update(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.VirtualMachineScaleSetVM, source string) *retry.Error
+
+	// UpdateVMs updates a list of VirtualMachineScaleSetVM from map[instanceID]compute.VirtualMachineScaleSetVM.
+	UpdateVMs(ctx context.Context, resourceGroupName string, VMScaleSetName string, instances map[string]compute.VirtualMachineScaleSetVM, source string) *retry.Error
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/mockvmssvmclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssvmclient/mockvmssvmclient/interface.go
@@ -93,3 +93,17 @@ func (mr *MockInterfaceMockRecorder) Update(ctx, resourceGroupName, VMScaleSetNa
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockInterface)(nil).Update), ctx, resourceGroupName, VMScaleSetName, instanceID, parameters, source)
 }
+
+// UpdateVMs mocks base method
+func (m *MockInterface) UpdateVMs(ctx context.Context, resourceGroupName, VMScaleSetName string, instances map[string]compute.VirtualMachineScaleSetVM, source string) *retry.Error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateVMs", ctx, resourceGroupName, VMScaleSetName, instances, source)
+	ret0, _ := ret[0].(*retry.Error)
+	return ret0
+}
+
+// UpdateVMs indicates an expected call of UpdateVMs
+func (mr *MockInterfaceMockRecorder) UpdateVMs(ctx, resourceGroupName, VMScaleSetName, instances, source interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateVMs", reflect.TypeOf((*MockInterface)(nil).UpdateVMs), ctx, resourceGroupName, VMScaleSetName, instances, source)
+}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/mockvmsets/azure_mock_vmsets.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/mockvmsets/azure_mock_vmsets.go
@@ -26,7 +26,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"
-	cloudprovider "k8s.io/cloud-provider"
+	cloud_provider "k8s.io/cloud-provider"
 	cache "k8s.io/legacy-cloud-providers/azure/cache"
 )
 
@@ -130,10 +130,10 @@ func (mr *MockVMSetMockRecorder) GetNodeNameByProviderID(providerID interface{})
 }
 
 // GetZoneByNodeName mocks base method
-func (m *MockVMSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
+func (m *MockVMSet) GetZoneByNodeName(name string) (cloud_provider.Zone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetZoneByNodeName", name)
-	ret0, _ := ret[0].(cloudprovider.Zone)
+	ret0, _ := ret[0].(cloud_provider.Zone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -188,11 +188,15 @@ func (mr *MockVMSetMockRecorder) EnsureHostsInPool(service, nodes, backendPoolID
 }
 
 // EnsureHostInPool mocks base method
-func (m *MockVMSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID, vmSetName string, isInternal bool) error {
+func (m *MockVMSet) EnsureHostInPool(service *v1.Service, nodeName types.NodeName, backendPoolID, vmSetName string, isInternal bool) (string, string, string, *compute.VirtualMachineScaleSetVM, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EnsureHostInPool", service, nodeName, backendPoolID, vmSetName, isInternal)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(string)
+	ret3, _ := ret[3].(*compute.VirtualMachineScaleSetVM)
+	ret4, _ := ret[4].(error)
+	return ret0, ret1, ret2, ret3, ret4
 }
 
 // EnsureHostInPool indicates an expected call of EnsureHostInPool

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/mockvmsets/azure_mock_vmsets.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/mockvmsets/azure_mock_vmsets.go
@@ -26,7 +26,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	types "k8s.io/apimachinery/pkg/types"
-	cloud_provider "k8s.io/cloud-provider"
+	cloudprovider "k8s.io/cloud-provider"
 	cache "k8s.io/legacy-cloud-providers/azure/cache"
 )
 
@@ -130,10 +130,10 @@ func (mr *MockVMSetMockRecorder) GetNodeNameByProviderID(providerID interface{})
 }
 
 // GetZoneByNodeName mocks base method
-func (m *MockVMSet) GetZoneByNodeName(name string) (cloud_provider.Zone, error) {
+func (m *MockVMSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetZoneByNodeName", name)
-	ret0, _ := ret[0].(cloud_provider.Zone)
+	ret0, _ := ret[0].(cloudprovider.Zone)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/sig cloud-provider
/kind bug
/area provider/azure
/priority important-soon
/milestone v1.18

**What this PR does / why we need it**:

Improve performance for VMSS LoadBalancerBackendAddressPools updates. Since multiple VMSS instance's LoadBalancerBackendAddressPools doesn't support concurrent updating, this PR changes the updating logic to squential-sync + concurrent-async requests. In this way, the performance of VMSS LoadBalancerBackendAddressPools updates would be improved a lot.

Here is a performance comparison for 31 nodes (1 vmss with 30 nodes + 1 vmss with 1 node) cluster:

| | EnsureHostsInPool (old->new)  |   EnsureBackendPoolDeleted (old->new)|
|---|---|---|
|Standard LB  |11m30s -> 1m43s    |    7m30s -> 3m30s|
|Basic LB   |  27m50s -> 1m9s    |     5m8s  -> 1m3s|


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

This is continue of https://github.com/kubernetes/kubernetes/pull/88094, which would only included in 1.18.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Azure VMSS LoadBalancerBackendAddressPools updating has been improved with squential-sync + concurrent-async requests.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
