### PR TITLE
Fix golint for kubectl logs

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -473,7 +473,6 @@ staging/src/k8s.io/kubectl/pkg/cmd/explain
 staging/src/k8s.io/kubectl/pkg/cmd/expose
 staging/src/k8s.io/kubectl/pkg/cmd/get
 staging/src/k8s.io/kubectl/pkg/cmd/label
-staging/src/k8s.io/kubectl/pkg/cmd/logs
 staging/src/k8s.io/kubectl/pkg/cmd/patch
 staging/src/k8s.io/kubectl/pkg/cmd/plugin
 staging/src/k8s.io/kubectl/pkg/cmd/portforward

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -320,7 +320,7 @@ func (o Options) Validate() error {
 }
 
 // RunLogs retrieves a pod log
-func (o LogsOptions) RunLogs() error {
+func (o Options) RunLogs() error {
 	requests, err := o.LogsForObject(o.RESTClientGetter, o.Object, o.Options, o.GetPodTimeout, o.AllContainers)
 	if err != nil {
 		return err
@@ -340,7 +340,7 @@ func (o LogsOptions) RunLogs() error {
 	return o.sequentialConsumeRequest(requests)
 }
 
-func (o LogsOptions) parallelConsumeRequest(requests map[corev1.ObjectReference]rest.ResponseWrapper) error {
+func (o Options) parallelConsumeRequest(requests map[corev1.ObjectReference]rest.ResponseWrapper) error {
 	reader, writer := io.Pipe()
 	wg := &sync.WaitGroup{}
 	wg.Add(len(requests))
@@ -371,7 +371,7 @@ func (o LogsOptions) parallelConsumeRequest(requests map[corev1.ObjectReference]
 	return err
 }
 
-func (o LogsOptions) sequentialConsumeRequest(requests map[corev1.ObjectReference]rest.ResponseWrapper) error {
+func (o Options) sequentialConsumeRequest(requests map[corev1.ObjectReference]rest.ResponseWrapper) error {
 	for objRef, request := range requests {
 		out := o.addPrefixIfNeeded(objRef, o.Out)
 		if err := o.ConsumeRequestFn(request, out); err != nil {
@@ -382,7 +382,7 @@ func (o LogsOptions) sequentialConsumeRequest(requests map[corev1.ObjectReferenc
 	return nil
 }
 
-func (o LogsOptions) addPrefixIfNeeded(ref corev1.ObjectReference, writer io.Writer) io.Writer {
+func (o Options) addPrefixIfNeeded(ref corev1.ObjectReference, writer io.Writer) io.Writer {
 	if !o.Prefix || ref.FieldPath == "" || ref.Name == "" {
 		return writer
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -128,8 +128,8 @@ type Options struct {
 	containerNameFromRefSpecRegexp *regexp.Regexp
 }
 
-// NewLogsOptions returns a default LogOptions.
-func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *Options {
+// NewOptions returns a default LogOptions.
+func NewOptions(streams genericclioptions.IOStreams, allContainers bool) *Options {
 	return &Options{
 		IOStreams:            streams,
 		AllContainers:        allContainers,
@@ -142,7 +142,7 @@ func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *Op
 
 // NewCmdLogs creates a new pod logs command
 func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewLogsOptions(streams, false)
+	o := NewOptions(streams, false)
 
 	cmd := &cobra.Command{
 		Use:                   logsUsageStr,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs.go
@@ -88,7 +88,8 @@ const (
 	defaultPodLogsTimeout = 20 * time.Second
 )
 
-type LogsOptions struct {
+// Options contains the input to the logs command.
+type Options struct {
 	Namespace     string
 	ResourceArg   string
 	AllContainers bool
@@ -127,8 +128,9 @@ type LogsOptions struct {
 	containerNameFromRefSpecRegexp *regexp.Regexp
 }
 
-func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *LogsOptions {
-	return &LogsOptions{
+// NewLogsOptions returns a default LogOptions.
+func NewLogsOptions(streams genericclioptions.IOStreams, allContainers bool) *Options {
+	return &Options{
 		IOStreams:            streams,
 		AllContainers:        allContainers,
 		Tail:                 -1,
@@ -158,7 +160,9 @@ func NewCmdLogs(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.C
 	return cmd
 }
 
-func (o *LogsOptions) AddFlags(cmd *cobra.Command) {
+// AddFlags receives a *cobra.Command reference and binds
+// flags related to humanreadable and template printing.
+func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.AllContainers, "all-containers", o.AllContainers, "Get all containers' logs in the pod(s).")
 	cmd.Flags().BoolVarP(&o.Follow, "follow", "f", o.Follow, "Specify if the logs should be streamed.")
 	cmd.Flags().BoolVar(&o.Timestamps, "timestamps", o.Timestamps, "Include timestamps on each line in the log output")
@@ -177,7 +181,8 @@ func (o *LogsOptions) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVar(&o.Prefix, "prefix", o.Prefix, "Prefix each log line with the log source (pod name and container name)")
 }
 
-func (o *LogsOptions) ToLogOptions() (*corev1.PodLogOptions, error) {
+// ToLogOptions generates a pod logs options object base on logs options.
+func (o *Options) ToLogOptions() (*corev1.PodLogOptions, error) {
 	logOptions := &corev1.PodLogOptions{
 		Container:                    o.Container,
 		Follow:                       o.Follow,
@@ -214,7 +219,8 @@ func (o *LogsOptions) ToLogOptions() (*corev1.PodLogOptions, error) {
 	return logOptions, nil
 }
 
-func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+// Complete takes the command arguments and factory and infers any remaining options.
+func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	o.ContainerNameSpecified = cmd.Flag("container").Changed
 	o.TailSpecified = cmd.Flag("tail").Changed
 	o.Resources = args
@@ -280,7 +286,8 @@ func (o *LogsOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []str
 	return nil
 }
 
-func (o LogsOptions) Validate() error {
+// Validate checks the set of flags provided by the user.
+func (o Options) Validate() error {
 	if len(o.SinceTime) > 0 && o.SinceSeconds != 0 {
 		return fmt.Errorf("at most one of `sinceTime` or `sinceSeconds` may be specified")
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -57,7 +57,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 
@@ -78,7 +78,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -100,7 +100,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -122,7 +122,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Prefix = true
@@ -154,7 +154,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				return o
@@ -191,7 +191,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Follow = true
@@ -229,7 +229,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.MaxFollowConcurrency = 2
@@ -241,7 +241,7 @@ func TestLog(t *testing.T) {
 		{
 			name: "fail if LogsForObject fails",
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[corev1.ObjectReference]restclient.ResponseWrapper, error) {
 					return nil, errors.New("Error from the LogsForObject")
 				}
@@ -267,7 +267,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = func(req restclient.ResponseWrapper, out io.Writer) error {
 					return errors.New("Error from the ConsumeRequestFn")
@@ -302,7 +302,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = mock.mockConsumeRequest
 				o.Follow = true
@@ -341,7 +341,7 @@ func TestLog(t *testing.T) {
 				}
 				wg.Add(3)
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = func(req restclient.ResponseWrapper, out io.Writer) error {
 					return errors.New("Error from the ConsumeRequestFn")
@@ -364,7 +364,7 @@ func TestLog(t *testing.T) {
 					},
 				}
 
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LogsForObject = mock.mockLogsForObject
 				o.ConsumeRequestFn = func(req restclient.ResponseWrapper, out io.Writer) error {
 					return errors.New("Error from the ConsumeRequestFn")
@@ -437,7 +437,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "since & since-time",
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.SinceSeconds = time.Hour
 				o.SinceTime = "2006-01-02T15:04:05Z"
 
@@ -455,7 +455,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "negative since-time",
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.SinceSeconds = -1 * time.Second
 
 				var err error
@@ -472,7 +472,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "negative limit-bytes",
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.LimitBytes = -100
 
 				var err error
@@ -489,7 +489,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "negative tail",
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.Tail = -100
 
 				var err error
@@ -506,7 +506,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "container name combined with --all-containers",
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, true)
+				o := NewOptions(streams, true)
 				o.Container = "my-container"
 
 				var err error
@@ -523,7 +523,7 @@ func TestValidateLogOptions(t *testing.T) {
 		{
 			name: "container name combined with second argument",
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.Container = "my-container"
 				o.ContainerNameSpecified = true
 
@@ -570,7 +570,7 @@ func TestLogComplete(t *testing.T) {
 			name: "One args case",
 			args: []string{"foo"},
 			opts: func(streams genericclioptions.IOStreams) *Options {
-				o := NewLogsOptions(streams, false)
+				o := NewOptions(streams, false)
 				o.Selector = "foo"
 				return o
 			},

--- a/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/logs/logs_test.go
@@ -40,13 +40,13 @@ import (
 func TestLog(t *testing.T) {
 	tests := []struct {
 		name                  string
-		opts                  func(genericclioptions.IOStreams) *LogsOptions
+		opts                  func(genericclioptions.IOStreams) *Options
 		expectedErr           string
 		expectedOutSubstrings []string
 	}{
 		{
 			name: "v1 - pod log",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -67,7 +67,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "pod logs with prefix",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -89,7 +89,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "pod logs with prefix: init container",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -111,7 +111,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "pod logs with prefix: ephemeral container",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -133,7 +133,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "get logs from multiple requests sequentially",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -167,7 +167,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "follow logs from multiple requests concurrently",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -205,7 +205,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to follow logs from multiple requests when there are more logs sources then MaxFollowConcurrency allows",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -240,7 +240,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail if LogsForObject fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, false)
 				o.LogsForObject = func(restClientGetter genericclioptions.RESTClientGetter, object, options runtime.Object, timeout time.Duration, allContainers bool) (map[corev1.ObjectReference]restclient.ResponseWrapper, error) {
 					return nil, errors.New("Error from the LogsForObject")
@@ -251,7 +251,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to get logs, if ConsumeRequestFn fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -278,7 +278,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "follow logs from multiple requests concurrently with prefix",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -317,7 +317,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to follow logs from multiple requests, if ConsumeRequestFn fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				wg := &sync.WaitGroup{}
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
@@ -353,7 +353,7 @@ func TestLog(t *testing.T) {
 		},
 		{
 			name: "fail to follow logs, if ConsumeRequestFn fails",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				mock := &logTestMock{
 					logsForObjectRequests: map[corev1.ObjectReference]restclient.ResponseWrapper{
 						{
@@ -431,12 +431,12 @@ func TestValidateLogOptions(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     []string
-		opts     func(genericclioptions.IOStreams) *LogsOptions
+		opts     func(genericclioptions.IOStreams) *Options
 		expected string
 	}{
 		{
 			name: "since & since-time",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, false)
 				o.SinceSeconds = time.Hour
 				o.SinceTime = "2006-01-02T15:04:05Z"
@@ -454,7 +454,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "negative since-time",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, false)
 				o.SinceSeconds = -1 * time.Second
 
@@ -471,7 +471,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "negative limit-bytes",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, false)
 				o.LimitBytes = -100
 
@@ -488,7 +488,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "negative tail",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, false)
 				o.Tail = -100
 
@@ -505,7 +505,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "container name combined with --all-containers",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, true)
 				o.Container = "my-container"
 
@@ -522,7 +522,7 @@ func TestValidateLogOptions(t *testing.T) {
 		},
 		{
 			name: "container name combined with second argument",
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, false)
 				o.Container = "my-container"
 				o.ContainerNameSpecified = true
@@ -563,13 +563,13 @@ func TestLogComplete(t *testing.T) {
 	tests := []struct {
 		name     string
 		args     []string
-		opts     func(genericclioptions.IOStreams) *LogsOptions
+		opts     func(genericclioptions.IOStreams) *Options
 		expected string
 	}{
 		{
 			name: "One args case",
 			args: []string{"foo"},
-			opts: func(streams genericclioptions.IOStreams) *LogsOptions {
+			opts: func(streams genericclioptions.IOStreams) *Options {
 				o := NewLogsOptions(streams, false)
 				o.Selector = "foo"
 				return o


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fixes golint issues in staging/src/k8s.io/kubectl/pkg/cmd/top

1. Add comments for exported functions.
2. Remove `Logs` prefix in `LogsOptions`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
