### PR TITLE
Automated cherry pick of #88610: fix: azure file mount timeout issue

### DIFF
--- a/pkg/volume/azure_file/BUILD
+++ b/pkg/volume/azure_file/BUILD
@@ -25,6 +25,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/cloud-provider:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume/helpers:go_default_library",


### PR DESCRIPTION
Cherry pick of #88610 on release-1.16.

#88610: fix: azure file mount timeout issue

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.