### PR TITLE
Decouple cmd and ApplyOptions Complete()

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/BUILD
@@ -59,6 +59,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -56,6 +56,14 @@ type debugError interface {
 	DebugError() (msg string, args []interface{})
 }
 
+type ApplyFlags struct {
+	ServerSideApply bool
+	Validate        bool
+	DryRunStrategy  DryRunStrategy
+	FieldManager    string
+	ForceConflicts  bool
+}
+
 // AddSourceToErr adds handleResourcePrefix and source string to error message.
 // verb is the string like "creating", "deleting" etc.
 // source is the filename or URL to the template file(*.json or *.yaml), or stdin to use to handle the resource.
@@ -390,6 +398,22 @@ func GetPodRunningTimeoutFlag(cmd *cobra.Command) (time.Duration, error) {
 		return timeout, fmt.Errorf("--pod-running-timeout must be higher than zero")
 	}
 	return timeout, nil
+}
+
+// GetApplyFlags extracts the additional flags needed for ApplyOptions.Complete()
+// in order to decouple it from cobra
+func GetApplyFlags(cmd *cobra.Command) (*ApplyFlags, error) {
+	drs, err := GetDryRunStrategy(cmd)
+	if err != nil {
+		return nil, err
+	}
+	af := ApplyFlags{
+		Validate:        GetFlagBool(cmd, "validate"),
+		DryRunStrategy:  drs,
+		ServerSideApply: GetServerSideApplyFlag(cmd),
+		ForceConflicts:  GetForceConflictsFlag(cmd),
+	}
+	return &af, nil
 }
 
 func AddValidateFlags(cmd *cobra.Command) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers_test.go
@@ -25,6 +25,7 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -319,5 +320,30 @@ func TestDumpReaderToFile(t *testing.T) {
 	stringData := string(data)
 	if stringData != testString {
 		t.Fatalf("Wrong file content %s != %s", testString, stringData)
+	}
+}
+
+func TestGetApplyFlags(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().String("dry-run", "client", "")
+	cmd.Flags().Bool("validate", true, "")
+	cmd.Flags().Bool("server-side", true, "")
+	cmd.Flags().Bool("force-conflicts", true, "")
+	af, err := GetApplyFlags(cmd)
+	if err != nil {
+		t.Errorf("unexpected error fetching ApplyFlags %v", err)
+	}
+
+	if !af.Validate {
+		t.Fatalf("Got: %t, expected: %t", af.Validate, true)
+	}
+	if !af.ServerSideApply {
+		t.Fatalf("Got: %t, expected: %t", af.ServerSideApply, true)
+	}
+	if !af.ForceConflicts {
+		t.Fatalf("Got: %t, expected: %t", af.ForceConflicts, true)
+	}
+	if af.DryRunStrategy != DryRunClient {
+		t.Fatalf("Got: %d, expected: %d", af.DryRunStrategy, DryRunClient)
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**: This PR is to cleanup the way cobra cmd is used in ApplyOptions. The aim is to make Complete() method in ApplyOptions to not take cobra cmd as an input argument. By this change, we can decouple Complete() method in ApplyOptions from cobra command so that the ApplyOptions api is more reusable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
