### PR TITLE
Allow signing controller to return intermediate certs

### DIFF
--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -584,6 +584,7 @@ API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,AttachDetachControllerConfiguration,DisableAttachDetachReconcilerSync
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,AttachDetachControllerConfiguration,ReconcilerSyncLoopPeriod
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningCertFile
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningChainFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningDuration
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningKeyFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CloudProviderConfiguration,CloudConfigFile

--- a/api/api-rules/violation_exceptions.list
+++ b/api/api-rules/violation_exceptions.list
@@ -584,8 +584,8 @@ API rule violation: names_match,k8s.io/apimachinery/pkg/util/intstr,IntOrString,
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,AttachDetachControllerConfiguration,DisableAttachDetachReconcilerSync
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,AttachDetachControllerConfiguration,ReconcilerSyncLoopPeriod
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningCertFile
-API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningChainFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningDuration
+API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningIncludeSigners
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CSRSigningControllerConfiguration,ClusterSigningKeyFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CloudProviderConfiguration,CloudConfigFile
 API rule violation: names_match,k8s.io/kube-controller-manager/config/v1alpha1,CloudProviderConfiguration,Name

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -96,7 +96,7 @@ func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error
 		ctx.ComponentConfig.CSRSigningController.ClusterSigningCertFile,
 		ctx.ComponentConfig.CSRSigningController.ClusterSigningKeyFile,
 		ctx.ComponentConfig.CSRSigningController.ClusterSigningDuration.Duration,
-		ctx.ComponentConfig.CSRSigningController.ClusterSigningChainFile,
+		ctx.ComponentConfig.CSRSigningController.ClusterSigningIncludeSigners,
 	)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to start certificate controller: %v", err)

--- a/cmd/kube-controller-manager/app/certificates.go
+++ b/cmd/kube-controller-manager/app/certificates.go
@@ -96,6 +96,7 @@ func startCSRSigningController(ctx ControllerContext) (http.Handler, bool, error
 		ctx.ComponentConfig.CSRSigningController.ClusterSigningCertFile,
 		ctx.ComponentConfig.CSRSigningController.ClusterSigningKeyFile,
 		ctx.ComponentConfig.CSRSigningController.ClusterSigningDuration.Duration,
+		ctx.ComponentConfig.CSRSigningController.ClusterSigningChainFile,
 	)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to start certificate controller: %v", err)

--- a/cmd/kube-controller-manager/app/options/csrsigningcontroller.go
+++ b/cmd/kube-controller-manager/app/options/csrsigningcontroller.go
@@ -46,6 +46,7 @@ func (o *CSRSigningControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ClusterSigningCertFile, "cluster-signing-cert-file", o.ClusterSigningCertFile, "Filename containing a PEM-encoded X509 CA certificate used to issue cluster-scoped certificates")
 	fs.StringVar(&o.ClusterSigningKeyFile, "cluster-signing-key-file", o.ClusterSigningKeyFile, "Filename containing a PEM-encoded RSA or ECDSA private key used to sign cluster-scoped certificates")
 	fs.DurationVar(&o.ClusterSigningDuration.Duration, "experimental-cluster-signing-duration", o.ClusterSigningDuration.Duration, "The length of duration signed certificates will be given.")
+	fs.StringVar(&o.ClusterSigningChainFile, "cluster-signing-chain-file", o.ClusterSigningChainFile, "Optional filename containing a PEM-encoded X509 certificate chain which will be appended to issued cluster-scoped certificates")
 }
 
 // ApplyTo fills up CSRSigningController config with options.
@@ -57,6 +58,7 @@ func (o *CSRSigningControllerOptions) ApplyTo(cfg *csrsigningconfig.CSRSigningCo
 	cfg.ClusterSigningCertFile = o.ClusterSigningCertFile
 	cfg.ClusterSigningKeyFile = o.ClusterSigningKeyFile
 	cfg.ClusterSigningDuration = o.ClusterSigningDuration
+	cfg.ClusterSigningChainFile = o.ClusterSigningChainFile
 
 	return nil
 }

--- a/cmd/kube-controller-manager/app/options/csrsigningcontroller.go
+++ b/cmd/kube-controller-manager/app/options/csrsigningcontroller.go
@@ -46,7 +46,7 @@ func (o *CSRSigningControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.ClusterSigningCertFile, "cluster-signing-cert-file", o.ClusterSigningCertFile, "Filename containing a PEM-encoded X509 CA certificate used to issue cluster-scoped certificates")
 	fs.StringVar(&o.ClusterSigningKeyFile, "cluster-signing-key-file", o.ClusterSigningKeyFile, "Filename containing a PEM-encoded RSA or ECDSA private key used to sign cluster-scoped certificates")
 	fs.DurationVar(&o.ClusterSigningDuration.Duration, "experimental-cluster-signing-duration", o.ClusterSigningDuration.Duration, "The length of duration signed certificates will be given.")
-	fs.StringVar(&o.ClusterSigningChainFile, "cluster-signing-chain-file", o.ClusterSigningChainFile, "Optional filename containing a PEM-encoded X509 certificate chain which will be appended to issued cluster-scoped certificates")
+	fs.BoolVar(&o.ClusterSigningIncludeSigners, "cluster-signing-include-signers", o.ClusterSigningIncludeSigners, "Whether to include the cluster signing cert file appended to the issued leaf certificate")
 }
 
 // ApplyTo fills up CSRSigningController config with options.
@@ -58,7 +58,7 @@ func (o *CSRSigningControllerOptions) ApplyTo(cfg *csrsigningconfig.CSRSigningCo
 	cfg.ClusterSigningCertFile = o.ClusterSigningCertFile
 	cfg.ClusterSigningKeyFile = o.ClusterSigningKeyFile
 	cfg.ClusterSigningDuration = o.ClusterSigningDuration
-	cfg.ClusterSigningChainFile = o.ClusterSigningChainFile
+	cfg.ClusterSigningIncludeSigners = o.ClusterSigningIncludeSigners
 
 	return nil
 }

--- a/pkg/controller/apis/config/fuzzer/fuzzer.go
+++ b/pkg/controller/apis/config/fuzzer/fuzzer.go
@@ -41,7 +41,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 			obj.CSRSigningController.ClusterSigningCertFile = fmt.Sprintf("/%s", c.RandString())
 			obj.CSRSigningController.ClusterSigningKeyFile = fmt.Sprintf("/%s", c.RandString())
-			obj.CSRSigningController.ClusterSigningChainFile = fmt.Sprintf("/%s", c.RandString())
+			obj.CSRSigningController.ClusterSigningIncludeSigners = c.RandBool()
 			obj.PersistentVolumeBinderController.VolumeConfiguration.FlexVolumePluginDir = fmt.Sprintf("/%s", c.RandString())
 			obj.TTLAfterFinishedController.ConcurrentTTLSyncs = c.Int31()
 		},

--- a/pkg/controller/apis/config/fuzzer/fuzzer.go
+++ b/pkg/controller/apis/config/fuzzer/fuzzer.go
@@ -41,6 +41,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			}
 			obj.CSRSigningController.ClusterSigningCertFile = fmt.Sprintf("/%s", c.RandString())
 			obj.CSRSigningController.ClusterSigningKeyFile = fmt.Sprintf("/%s", c.RandString())
+			obj.CSRSigningController.ClusterSigningChainFile = fmt.Sprintf("/%s", c.RandString())
 			obj.PersistentVolumeBinderController.VolumeConfiguration.FlexVolumePluginDir = fmt.Sprintf("/%s", c.RandString())
 			obj.TTLAfterFinishedController.ConcurrentTTLSyncs = c.Int31()
 		},

--- a/pkg/controller/certificates/signer/BUILD
+++ b/pkg/controller/certificates/signer/BUILD
@@ -24,6 +24,7 @@ go_test(
         "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/client-go/util/cert:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp/cmpopts:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificates/signer/config/types.go
+++ b/pkg/controller/certificates/signer/config/types.go
@@ -31,4 +31,9 @@ type CSRSigningControllerConfiguration struct {
 	// clusterSigningDuration is the length of duration signed certificates
 	// will be given.
 	ClusterSigningDuration metav1.Duration
+	// clusterSigningCertFile is the optional filename containing a chain of
+	// PEM-encoded X509 certificates which will be appended to issued cluster
+	// scoped certificates. This is useful to return intermediates certificates
+	// to clients.
+	ClusterSigningChainFile string
 }

--- a/pkg/controller/certificates/signer/config/types.go
+++ b/pkg/controller/certificates/signer/config/types.go
@@ -31,9 +31,7 @@ type CSRSigningControllerConfiguration struct {
 	// clusterSigningDuration is the length of duration signed certificates
 	// will be given.
 	ClusterSigningDuration metav1.Duration
-	// clusterSigningCertFile is the optional filename containing a chain of
-	// PEM-encoded X509 certificates which will be appended to issued cluster
-	// scoped certificates. This is useful to return intermediates certificates
-	// to clients.
-	ClusterSigningChainFile string
+	// if true, the issued certificate will contain the cluster signing certificate
+	// appended after the leaf
+	ClusterSigningIncludeSigners bool
 }

--- a/pkg/controller/certificates/signer/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/certificates/signer/config/v1alpha1/zz_generated.conversion.go
@@ -62,7 +62,7 @@ func autoConvert_v1alpha1_CSRSigningControllerConfiguration_To_config_CSRSigning
 	out.ClusterSigningCertFile = in.ClusterSigningCertFile
 	out.ClusterSigningKeyFile = in.ClusterSigningKeyFile
 	out.ClusterSigningDuration = in.ClusterSigningDuration
-	out.ClusterSigningChainFile = in.ClusterSigningChainFile
+	out.ClusterSigningIncludeSigners = in.ClusterSigningIncludeSigners
 	return nil
 }
 
@@ -70,7 +70,7 @@ func autoConvert_config_CSRSigningControllerConfiguration_To_v1alpha1_CSRSigning
 	out.ClusterSigningCertFile = in.ClusterSigningCertFile
 	out.ClusterSigningKeyFile = in.ClusterSigningKeyFile
 	out.ClusterSigningDuration = in.ClusterSigningDuration
-	out.ClusterSigningChainFile = in.ClusterSigningChainFile
+	out.ClusterSigningIncludeSigners = in.ClusterSigningIncludeSigners
 	return nil
 }
 

--- a/pkg/controller/certificates/signer/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controller/certificates/signer/config/v1alpha1/zz_generated.conversion.go
@@ -62,6 +62,7 @@ func autoConvert_v1alpha1_CSRSigningControllerConfiguration_To_config_CSRSigning
 	out.ClusterSigningCertFile = in.ClusterSigningCertFile
 	out.ClusterSigningKeyFile = in.ClusterSigningKeyFile
 	out.ClusterSigningDuration = in.ClusterSigningDuration
+	out.ClusterSigningChainFile = in.ClusterSigningChainFile
 	return nil
 }
 
@@ -69,6 +70,7 @@ func autoConvert_config_CSRSigningControllerConfiguration_To_v1alpha1_CSRSigning
 	out.ClusterSigningCertFile = in.ClusterSigningCertFile
 	out.ClusterSigningKeyFile = in.ClusterSigningKeyFile
 	out.ClusterSigningDuration = in.ClusterSigningDuration
+	out.ClusterSigningChainFile = in.ClusterSigningChainFile
 	return nil
 }
 

--- a/pkg/controller/certificates/signer/signer.go
+++ b/pkg/controller/certificates/signer/signer.go
@@ -64,7 +64,9 @@ func NewCSRSigningController(
 		dynamicCertReloader: signer.caProvider.caLoader,
 	}
 	if signer.chainProvider != nil {
-		c.dynamicChainReloader = signer.chainProvider
+		if r, ok := signer.chainProvider.(dynamiccertificates.ControllerRunner); ok {
+			c.dynamicChainReloader = r
+		}
 	}
 
 	return c, nil
@@ -86,7 +88,7 @@ type signer struct {
 	client  clientset.Interface
 	certTTL time.Duration
 
-	chainProvider *dynamiccertificates.DynamicFileCAContent
+	chainProvider dynamiccertificates.CAContentProvider
 }
 
 func newSigner(caFile, caKeyFile string, client clientset.Interface, certificateDuration time.Duration, chainFile string) (*signer, error) {

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -43,7 +43,7 @@ import (
 func TestSigner(t *testing.T) {
 	clock := clock.FakeClock{}
 
-	s, err := newSigner("./testdata/ca.crt", "./testdata/ca.key", nil, 1*time.Hour, "")
+	s, err := newSigner("./testdata/ca.crt", "./testdata/ca.key", nil, 1*time.Hour, false)
 	if err != nil {
 		t.Fatalf("failed to create signer: %v", err)
 	}
@@ -108,7 +108,7 @@ func TestSigner(t *testing.T) {
 func TestIntermediateSigner(t *testing.T) {
 	clock := clock.FakeClock{}
 
-	s, err := newSigner("./testdata/ca.crt", "./testdata/ca.key", nil, 1*time.Hour, "./testdata/ca.crt")
+	s, err := newSigner("./testdata/ca.crt", "./testdata/ca.key", nil, 1*time.Hour, true)
 	if err != nil {
 		t.Fatalf("failed to create signer: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestHandle(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			client := &fake.Clientset{}
-			s, err := newSigner("./testdata/ca.crt", "./testdata/ca.key", client, 1*time.Hour, "")
+			s, err := newSigner("./testdata/ca.crt", "./testdata/ca.key", client, 1*time.Hour, false)
 			if err != nil {
 				t.Fatalf("failed to create signer: %v", err)
 			}

--- a/pkg/controller/certificates/signer/signer_test.go
+++ b/pkg/controller/certificates/signer/signer_test.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"io/ioutil"
 	"math/rand"
 	"testing"
@@ -99,8 +100,8 @@ func TestSigner(t *testing.T) {
 		MaxPathLen:            -1,
 	}
 
-	if !cmp.Equal(*certs[0], want, diff.IgnoreUnset()) {
-		t.Errorf("unexpected diff: %v", cmp.Diff(certs[0], want, diff.IgnoreUnset()))
+	if d := cmp.Diff(*certs[0], want, diff.IgnoreUnset()); d != "" {
+		t.Errorf("Unexpected diff in certificate (-got +want): %v", d)
 	}
 }
 
@@ -164,15 +165,14 @@ func TestIntermediateSigner(t *testing.T) {
 		MaxPathLen:            -1,
 	}
 
-	if !cmp.Equal(*certs[0], want, diff.IgnoreUnset()) {
-		t.Errorf("unexpected diff: %v", cmp.Diff(certs[0], want, diff.IgnoreUnset()))
+	if d := cmp.Diff(*certs[0], want, diff.IgnoreUnset()); d != "" {
+		t.Errorf("Unexpected diff in certificate (-got +want): %v", d)
 	}
 
-	wantCA := *currCA.Certificate
-	wantCA.PublicKey = nil
-	wantCA.SerialNumber = nil
-	if !cmp.Equal(*certs[1], wantCA, diff.IgnoreUnset()) {
-		t.Errorf("unexpected diff: %v", cmp.Diff(certs[0], want, diff.IgnoreUnset()))
+	if d := cmp.Diff(*certs[1], *currCA.Certificate, diff.IgnoreUnset(),
+		cmpopts.IgnoreFields(x509.Certificate{}, "PublicKey", "SerialNumber"),
+	); d != "" {
+		t.Errorf("Unexpected diff in certificate (-got +want): %v", d)
 	}
 }
 

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -118,10 +118,8 @@ message CertificateSigningRequestStatus {
   // +optional
   repeated CertificateSigningRequestCondition conditions = 1;
 
-  // If request was approved, the controller will place the issued certificate here.
-  // If more than one PEM block is present, and the definition of the requested spec.signerName
-  // does not indicate otherwise, the first block is the issued certificate,
-  // and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.
+  // This is a sequence (chain) of X.509v3 certificates. The issued certificate comes first in the list. Each following
+  // certificate, if any, directly certifies the one preceding it, and should be presented in TLS handshakes.
   // +optional
   optional bytes certificate = 2;
 }

--- a/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/certificates/v1beta1/generated.proto
@@ -119,6 +119,9 @@ message CertificateSigningRequestStatus {
   repeated CertificateSigningRequestCondition conditions = 1;
 
   // If request was approved, the controller will place the issued certificate here.
+  // If more than one PEM block is present, and the definition of the requested spec.signerName
+  // does not indicate otherwise, the first block is the issued certificate,
+  // and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.
   // +optional
   optional bytes certificate = 2;
 }

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -122,6 +122,9 @@ type CertificateSigningRequestStatus struct {
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
 	// If request was approved, the controller will place the issued certificate here.
+	// If more than one PEM block is present, and the definition of the requested spec.signerName
+	// does not indicate otherwise, the first block is the issued certificate,
+	// and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.
 	// +optional
 	Certificate []byte `json:"certificate,omitempty" protobuf:"bytes,2,opt,name=certificate"`
 }

--- a/staging/src/k8s.io/api/certificates/v1beta1/types.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types.go
@@ -121,10 +121,8 @@ type CertificateSigningRequestStatus struct {
 	// +optional
 	Conditions []CertificateSigningRequestCondition `json:"conditions,omitempty" protobuf:"bytes,1,rep,name=conditions"`
 
-	// If request was approved, the controller will place the issued certificate here.
-	// If more than one PEM block is present, and the definition of the requested spec.signerName
-	// does not indicate otherwise, the first block is the issued certificate,
-	// and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.
+	// This is a sequence (chain) of X.509v3 certificates. The issued certificate comes first in the list. Each following
+	// certificate, if any, directly certifies the one preceding it, and should be presented in TLS handshakes.
 	// +optional
 	Certificate []byte `json:"certificate,omitempty" protobuf:"bytes,2,opt,name=certificate"`
 }

--- a/staging/src/k8s.io/api/certificates/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types_swagger_doc_generated.go
@@ -65,7 +65,7 @@ func (CertificateSigningRequestSpec) SwaggerDoc() map[string]string {
 
 var map_CertificateSigningRequestStatus = map[string]string{
 	"conditions":  "Conditions applied to the request, such as approval or denial.",
-	"certificate": "If request was approved, the controller will place the issued certificate here. If more than one PEM block is present, and the definition of the requested spec.signerName does not indicate otherwise, the first block is the issued certificate, and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.",
+	"certificate": "This is a sequence (chain) of X.509v3 certificates. The issued certificate comes first in the list. Each following certificate, if any, directly certifies the one preceding it, and should be presented in TLS handshakes.",
 }
 
 func (CertificateSigningRequestStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/certificates/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/certificates/v1beta1/types_swagger_doc_generated.go
@@ -65,7 +65,7 @@ func (CertificateSigningRequestSpec) SwaggerDoc() map[string]string {
 
 var map_CertificateSigningRequestStatus = map[string]string{
 	"conditions":  "Conditions applied to the request, such as approval or denial.",
-	"certificate": "If request was approved, the controller will place the issued certificate here.",
+	"certificate": "If request was approved, the controller will place the issued certificate here. If more than one PEM block is present, and the definition of the requested spec.signerName does not indicate otherwise, the first block is the issued certificate, and subsequent blocks should be treated as intermediate certificates and presented in TLS handshakes.",
 }
 
 func (CertificateSigningRequestStatus) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -246,11 +246,9 @@ type CSRSigningControllerConfiguration struct {
 	// clusterSigningDuration is the length of duration signed certificates
 	// will be given.
 	ClusterSigningDuration metav1.Duration
-	// clusterSigningCertFile is the optional filename containing a chain of
-	// PEM-encoded X509 certificates which will be appended to issued cluster
-	// scoped certificates. This is useful to return intermediates certificates
-	// to clients.
-	ClusterSigningChainFile string
+	// if true, the issued certificate will contain the cluster signing certificate
+	// appended after the leaf
+	ClusterSigningIncludeSigners bool
 }
 
 // DaemonSetControllerConfiguration contains elements describing DaemonSetController.

--- a/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
+++ b/staging/src/k8s.io/kube-controller-manager/config/v1alpha1/types.go
@@ -246,6 +246,11 @@ type CSRSigningControllerConfiguration struct {
 	// clusterSigningDuration is the length of duration signed certificates
 	// will be given.
 	ClusterSigningDuration metav1.Duration
+	// clusterSigningCertFile is the optional filename containing a chain of
+	// PEM-encoded X509 certificates which will be appended to issued cluster
+	// scoped certificates. This is useful to return intermediates certificates
+	// to clients.
+	ClusterSigningChainFile string
 }
 
 // DaemonSetControllerConfiguration contains elements describing DaemonSetController.


### PR DESCRIPTION
**What type of PR is this?**

> /kind feature

**What this PR does / why we need it**:
Currently the kubelet cert rotation mechanisms don't allow the kubelet to present intermediate certs, which is a problem if your signer cert in the controller isn't a root. With this PR, we can optionally ask the controller to append extra certs to the issued cert, which can then present it to the apiserver. 

**Special notes for your reviewer**:
https://kubernetes.slack.com/archives/C0EN96KUY/p1583173137021000

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --cluster-signing-chain-file to the controller-manager, which if set will mean that certificates signed via the certificate signing API will have the contents of the file appended to the issued certificate.
```