### PR TITLE
Update Cluster Autoscaler version to 1.18.0-gke.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.17.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.18.0-beta.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.18.0-gke.0.

New release for 1.18 is necessary since autoscaler relies on implicit compatibility with scheduler (which it imports as a library). 

Not including release notes yet as this is a pre-release version.

/kind bug
/priority important-soon
/sig autoscaling

```release-note
none
```