### PR TITLE
Change kubectl cluster-info dump to not display output location message when output is stdout

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/clusterinfo/clusterinfo_dump.go
@@ -300,10 +300,7 @@ func (o *ClusterInfoDumpOptions) Run() error {
 	}
 
 	dest := o.OutputDir
-	if len(dest) == 0 {
-		dest = "standard output"
-	}
-	if dest != "-" {
+	if len(dest) > 0 && dest != "-" {
 		fmt.Fprintf(o.Out, "Cluster info dumped to %s\n", dest)
 	}
 	return nil


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
`kubectl cluster-info dump` should only output a message telling you where the output was written when the output is not stdout.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/816

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubectl cluster-info dump changed to only display a message telling you the location where the output was written when the output is not standard output.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
