### PR TITLE
Made comment on NonResourceURLs match current implementation

### DIFF
--- a/pkg/apis/flowcontrol/types.go
+++ b/pkg/apis/flowcontrol/types.go
@@ -277,13 +277,7 @@ type NonResourcePolicyRule struct {
 	// +listType=set
 	// Required.
 	Verbs []string
-	// `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
-	// For example:
-	//   - "/healthz" is legal
-	//   - "/hea*" is illegal
-	//   - "/hea" is legal but matches nothing
-	//   - "/hea/*" also matches nothing
-	//   - "/healthz/*" matches all per-component health checks.
+	// `nonResourceURLs` is a set of URLs that match and may not be empty.
 	// "*" matches all non-resource urls. if it is present, it must be the only entry.
 	// +listType=set
 	// Required.

--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/generated.proto
@@ -189,13 +189,7 @@ message NonResourcePolicyRule {
   // Required.
   repeated string verbs = 1;
 
-  // `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
-  // For example:
-  //   - "/healthz" is legal
-  //   - "/hea*" is illegal
-  //   - "/hea" is legal but matches nothing
-  //   - "/hea/*" also matches nothing
-  //   - "/healthz/*" matches all per-component health checks.
+  // `nonResourceURLs` is a set of URLs that match and may not be empty.
   // "*" matches all non-resource urls. if it is present, it must be the only entry.
   // +listType=set
   // Required.

--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/types.go
@@ -277,13 +277,7 @@ type NonResourcePolicyRule struct {
 	// +listType=set
 	// Required.
 	Verbs []string `json:"verbs" protobuf:"bytes,1,rep,name=verbs"`
-	// `nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty.
-	// For example:
-	//   - "/healthz" is legal
-	//   - "/hea*" is illegal
-	//   - "/hea" is legal but matches nothing
-	//   - "/hea/*" also matches nothing
-	//   - "/healthz/*" matches all per-component health checks.
+	// `nonResourceURLs` is a set of URLs that match and may not be empty.
 	// "*" matches all non-resource urls. if it is present, it must be the only entry.
 	// +listType=set
 	// Required.

--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/types_swagger_doc_generated.go
@@ -123,7 +123,7 @@ func (LimitedPriorityLevelConfiguration) SwaggerDoc() map[string]string {
 var map_NonResourcePolicyRule = map[string]string{
 	"":                "NonResourcePolicyRule is a predicate that matches non-resource requests according to their verb and the target non-resource URL. A NonResourcePolicyRule matches a request if and only if both (a) at least one member of verbs matches the request and (b) at least one member of nonResourceURLs matches the request.",
 	"verbs":           "`verbs` is a list of matching verbs and may not be empty. \"*\" matches all verbs. If it is present, it must be the only entry. Required.",
-	"nonResourceURLs": "`nonResourceURLs` is a set of url prefixes that a user should have access to and may not be empty. For example:\n  - \"/healthz\" is legal\n  - \"/hea*\" is illegal\n  - \"/hea\" is legal but matches nothing\n  - \"/hea/*\" also matches nothing\n  - \"/healthz/*\" matches all per-component health checks.\n\"*\" matches all non-resource urls. if it is present, it must be the only entry. Required.",
+	"nonResourceURLs": "`nonResourceURLs` is a set of URLs that match and may not be empty. \"*\" matches all non-resource urls. if it is present, it must be the only entry. Required.",
 }
 
 func (NonResourcePolicyRule) SwaggerDoc() map[string]string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR makes the comment on the NonResourceURLs field of a NonResourcePolicyRule match the current implementation.  The comment was originally copied from rbac, but the implementation has not yet lived up to the level of ambition copied from rbac.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190228-priority-and-fairness.md
```
