### PR TITLE
Create Endpoints resource lifecycle test - +5 endpoint coverage

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2709,7 +2709,7 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectNoError(err, "failed to create Endpoint")
 
 		// setup a watch for the Endpoint
-		endpointWatchTimeoutSeconds := int64(60)
+		endpointWatchTimeoutSeconds := int64(180)
 		endpointWatch, err := f.ClientSet.CoreV1().Endpoints(ns).Watch(context.TODO(), metav1.ListOptions{LabelSelector: "testendpoint-static=true", TimeoutSeconds: &endpointWatchTimeoutSeconds})
 		framework.ExpectNoError(err, "failed to setup watch on newly created Endpoint")
 		endpointWatchChan := endpointWatch.ResultChan()

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2784,7 +2784,7 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectEqual(endpointSubsetOnePorts.Port, int32(8080), "failed to patch Endpoint")
 
 		ginkgo.By("deleting the Endpoint by Collection")
-		err = f.ClientSet.CoreV1().Endpoints(ns).DeleteCollection(context.TODO(), &metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "testendpoint-static=true"})
+		err = f.ClientSet.CoreV1().Endpoints(ns).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "testendpoint-static=true"})
 		framework.ExpectNoError(err, "failed to delete Endpoint by Collection")
 
 		ginkgo.By("waiting for Endpoint deletion")


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR adds a test to test the following untested endpoints:
- createCoreV1NamespacedEndpoints
- replaceCoreV1NamespacedEndpoints
- patchCoreV1NamespacedEndpoints
- listCoreV1EndpointsForAllNamespaces
- deleteCoreV1CollectionNamespacedEndpoints

**Which issue(s) this PR fixes**:
Fixes #87762

**Special notes for your reviewer**:
Adds +4 endpoint test coverage (good for conformance)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing