### PR TITLE
Automated cherry pick of #88496: test: don't use hardcoded pod count for memory limit test

### DIFF
--- a/test/e2e/windows/memory_limits.go
+++ b/test/e2e/windows/memory_limits.go
@@ -59,7 +59,7 @@ var _ = SIGDescribe("[Feature:Windows] Memory Limits [Serial] [Slow]", func() {
 
 	ginkgo.Context("attempt to deploy past allocatable memory limits", func() {
 		ginkgo.It("should fail deployments of pods once there isn't enough memory", func() {
-			overrideAllocatableMemoryTest(f, 4)
+			overrideAllocatableMemoryTest(f, framework.TestContext.CloudConfig.NumNodes)
 		})
 	})
 


### PR DESCRIPTION
Cherry pick of #88496 on release-1.16.

#88496: test: don't use hardcoded pod count for memory limit test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
None
```