### PR TITLE
Generalized NonResourcePolicyRule.NonResourceURLs impl

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/rule.go
+++ b/staging/src/k8s.io/apiserver/pkg/util/flowcontrol/rule.go
@@ -153,7 +153,19 @@ func matchPolicyRuleVerb(policyRuleVerbs []string, requestVerb string) bool {
 }
 
 func matchPolicyRuleNonResourceURL(policyRuleRequestURLs []string, requestPath string) bool {
-	return containsString(requestPath, policyRuleRequestURLs, fctypesv1a1.NonResourceAll)
+	for _, rulePath := range policyRuleRequestURLs {
+		if rulePath == fctypesv1a1.NonResourceAll || rulePath == requestPath {
+			return true
+		}
+		rulePrefix := strings.TrimSuffix(rulePath, "*")
+		if !strings.HasSuffix(rulePrefix, "/") {
+			rulePrefix = rulePrefix + "/"
+		}
+		if strings.HasPrefix(requestPath, rulePrefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func matchPolicyRuleAPIGroup(policyRuleAPIGroups []string, requestAPIGroup string) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
This PR generalizes the matching for NonResourceURLs in the API Priority and Fairness feature to match what is documented for that field.  This PR also generalizes the test case generator to exercise the new flexibility.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:
This is an alternative to #88774 --- that PR changes the field comment to match the existing implementation.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20190228-priority-and-fairness.md
```

/sig api-machinery
/priority important-soon
/cc @lavalamp 
/cc @yue9944882 
/cc @deads2k 
