### PR TITLE
ignore gcloud warning in test framework

### DIFF
--- a/test/e2e/framework/providers/gce/gce.go
+++ b/test/e2e/framework/providers/gce/gce.go
@@ -188,7 +188,7 @@ func (p *Provider) EnsureLoadBalancerResourcesDeleted(ip, portRange string) erro
 
 func getGCEZoneForGroup(group string) (string, error) {
 	output, err := exec.Command("gcloud", "compute", "instance-groups", "managed", "list",
-		"--project="+framework.TestContext.CloudConfig.ProjectID, "--format=value(zone)", "--filter=name="+group).CombinedOutput()
+		"--project="+framework.TestContext.CloudConfig.ProjectID, "--format=value(zone)", "--filter=name="+group).Output()
 	if err != nil {
 		return "", fmt.Errorf("Failed to get zone for node group %s: %s", group, output)
 	}


### PR DESCRIPTION
Autoscaling tests with multiple MIGs fail with:

 Failed to get group size for group ca-minion-group: ERROR: (gcloud.compute.instance-groups.managed.list-instances) Some requests did not succeed:
     - Invalid value for field 'zone': 'WARNING: --filter : operator evaluation is changing for consistency across Google APIs.  name=ca-minion-group currently does not match but will match in the near future.  Run `gcloud topic filters` for details.
    https://www.googleapis.com/compute/v1/projects/k8s-jkns-gci-autoscaling-migs/zones/us-west1-b'. Must be a match of regex '(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)'

https://k8s-testgrid.appspot.com/sig-autoscaling-cluster-autoscaler#gci-gce-autoscaling-migs

/kind failing-test
/priority important-soon
/sig autoscaling

```release-note
none
```