### PR TITLE
Use the same default namespace across event recorders

### DIFF
--- a/staging/src/k8s.io/client-go/tools/events/event_recorder.go
+++ b/staging/src/k8s.io/client-go/tools/events/event_recorder.go
@@ -68,7 +68,7 @@ func (recorder *recorderImpl) makeEvent(refRegarding *v1.ObjectReference, refRel
 	t := metav1.Time{Time: recorder.clock.Now()}
 	namespace := refRegarding.Namespace
 	if namespace == "" {
-		namespace = metav1.NamespaceSystem
+		namespace = metav1.NamespaceDefault
 	}
 	return &v1beta1.Event{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Signed-off-by: Monis Khan <mok@vmware.com>

/kind bug
/priority important-longterm

```release-note
The EventRecorder from k8s.io/client-go/tools/events will now create events in the default namespace (instead of kube-system) when the related object does not have it set.
```

@yastij 