### PR TITLE
Fix regex for label values to allow for slashes

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -147,8 +147,10 @@ func IsDomainPrefixedPath(fldPath *field.Path, dpPath string) field.ErrorList {
 	return allErrs
 }
 
-const labelValueFmt string = "(" + qualifiedNameFmt + ")?"
-const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character"
+const labelValueCharFmt string = "[A-Za-z0-9]"
+const labelValueExtCharFmt string = "[-A-Za-z0-9_./]"
+const labelValueFmt string = "((" + labelValueCharFmt + labelValueExtCharFmt + "*)?" + labelValueCharFmt + ")?"
+const labelValueErrMsg string = "a valid label must be an empty string or consist of alphanumeric characters, '-', '_', '.' or '/', and must start and end with an alphanumeric character"
 
 // LabelValueMaxLength is a label's max length
 const LabelValueMaxLength int = 63
@@ -164,7 +166,7 @@ func IsValidLabelValue(value string) []string {
 		errs = append(errs, MaxLenError(LabelValueMaxLength))
 	}
 	if !labelValueRegexp.MatchString(value) {
-		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345"))
+		errs = append(errs, RegexError(labelValueErrMsg, labelValueFmt, "MyValue", "my_value", "12345", "apps/v1/deployment/nginx"))
 	}
 	return errs
 }

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -293,6 +293,7 @@ func TestIsValidLabelValue(t *testing.T) {
 	successCases := []string{
 		"simple",
 		"now-with-dashes",
+		"now/with/slashes",
 		"1-starts-with-num",
 		"end-with-num-1",
 		"1234",                  // only num
@@ -313,6 +314,8 @@ func TestIsValidLabelValue(t *testing.T) {
 		"ends-with-dash-",
 		".starts.with.dot",
 		"ends.with.dot.",
+		"/starts/with/slash",
+		"ends/with/slash/",
 		strings.Repeat("a", 64), // over the limit
 	}
 	for i := range errorCases {


### PR DESCRIPTION
The regex used to validate labels incorrectly disallowed slashes, which are required by the
recommended approach for `matchLabels`.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The documentation says the recommended approach for `matchLabels` for a controller is:

```
selector:
  matchLabels:
      controller-selector: "apps/v1/deployment/nginx"
template:
  metadata:
    labels:
      controller-selector: "apps/v1/deployment/nginx"
```

However, the current regex doesn't allow for this label.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Slashes '/' are allowed in label values
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

[website documentation]: https://kubernetes.io/docs/tasks/manage-kubernetes-objects/declarative-config/#defining-controller-selectors-and-podtemplate-labels
```
