### PR TITLE
Fix Bazel build

### DIFF
--- a/build/BUILD
+++ b/build/BUILD
@@ -52,6 +52,7 @@ DOCKERIZED_BINARIES = {
     srcs = select({"@io_bazel_rules_go//go/platform:" + arch: ["//cmd/" + binary]}),
     mode = "0755",
     package_dir = "/usr/bin",
+    tags = ["manual"],
     visibility = ["//visibility:private"],
 ) for binary in DOCKERIZED_BINARIES.keys() for arch in SERVER_PLATFORMS["linux"]]
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the Bazel build on `master`, which currently fails with the following error:

```
~/g/s/k/kubernetes> make bazel-build
ERROR: /home/mark/go/src/k8s.io/kubernetes/build/BUILD:50:2: Configurable attribute "srcs" doesn't match this configuration (would a default condition help?).
Conditions checked:
 @io_bazel_rules_go//go/platform:s390x
ERROR: Analysis of target '//build:kube-scheduler-data-s390x.tar' failed; build aborted:
/home/mark/go/src/k8s.io/kubernetes/build/BUILD:50:2: Configurable attribute "srcs" doesn't match this configuration (would a default condition help?).
Conditions checked:
 @io_bazel_rules_go//go/platform:s390x
INFO: Elapsed time: 10.073s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded, 0 targets configured)
make: *** [Makefile:577: bazel-build] Error 1
```

This was due to a change in https://github.com/kubernetes/kubernetes/pull/87585/commits/2a5bce8c8202d778ecd19c3b47353209e5184c0d.

All credits go to @ixdy for figuring this out and coming up with the fix!

**Special notes for your reviewer**:

The `release-1.18` branch is also broken.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```