### PR TITLE
Show crio runtime's stats in cadvisor

### DIFF
--- a/cmd/kubelet/app/server.go
+++ b/cmd/kubelet/app/server.go
@@ -617,7 +617,7 @@ func run(s *options.KubeletServer, kubeDeps *kubelet.Dependencies, featureGate f
 		cgroupRoots = append(cgroupRoots, kubeletCgroup)
 	}
 
-	runtimeCgroup, err := cm.GetRuntimeContainer(s.ContainerRuntime, s.RuntimeCgroups)
+	runtimeCgroup, err := cm.GetRuntimeContainer(s.ContainerRuntime, s.RemoteRuntimeEndpoint, s.RuntimeCgroups)
 	if err != nil {
 		klog.Warningf("failed to get the container runtime's cgroup: %v. Runtime system container metrics may be missing.", err)
 	} else if runtimeCgroup != "" {

--- a/pkg/kubelet/cadvisor/BUILD
+++ b/pkg/kubelet/cadvisor/BUILD
@@ -73,16 +73,12 @@ go_test(
         "@io_bazel_rules_go//go/platform:android": [
             "//staging/src/k8s.io/api/core/v1:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-            "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
             "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
-            "//vendor/github.com/stretchr/testify/assert:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "//staging/src/k8s.io/api/core/v1:go_default_library",
             "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-            "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
             "//vendor/github.com/google/cadvisor/info/v1:go_default_library",
-            "//vendor/github.com/stretchr/testify/assert:go_default_library",
         ],
         "//conditions:default": [],
     }),

--- a/pkg/kubelet/cadvisor/helpers_linux.go
+++ b/pkg/kubelet/cadvisor/helpers_linux.go
@@ -42,7 +42,7 @@ func (i *imageFsInfoProvider) ImageFsInfoLabel() (string, error) {
 		// This is a temporary workaround to get stats for cri-o from cadvisor
 		// and should be removed.
 		// Related to https://github.com/kubernetes/kubernetes/issues/51798
-		if i.runtimeEndpoint == CrioSocket || i.runtimeEndpoint == "unix://"+CrioSocket {
+		if i.runtimeEndpoint == types.CrioSocket || i.runtimeEndpoint == "unix://"+types.CrioSocket {
 			return cadvisorfs.LabelCrioImages, nil
 		}
 	}

--- a/pkg/kubelet/cadvisor/util.go
+++ b/pkg/kubelet/cadvisor/util.go
@@ -27,13 +27,6 @@ import (
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
 )
 
-const (
-	// CrioSocket is the path to the CRI-O socket.
-	// Please keep this in sync with the one in:
-	// github.com/google/cadvisor/container/crio/client.go
-	CrioSocket = "/var/run/crio/crio.sock"
-)
-
 // CapacityFromMachineInfo returns the capacity of the resources from the machine info.
 func CapacityFromMachineInfo(info *cadvisorapi.MachineInfo) v1.ResourceList {
 	c := v1.ResourceList{
@@ -75,5 +68,5 @@ func EphemeralStorageCapacityFromFsInfo(info cadvisorapi2.FsInfo) v1.ResourceLis
 // https://github.com/kubernetes/kubernetes/issues/51798
 func UsingLegacyCadvisorStats(runtime, runtimeEndpoint string) bool {
 	return (runtime == kubetypes.DockerContainerRuntime && goruntime.GOOS == "linux") ||
-		runtimeEndpoint == CrioSocket || runtimeEndpoint == "unix://"+CrioSocket
+		runtimeEndpoint == kubetypes.CrioSocket || runtimeEndpoint == "unix://"+kubetypes.CrioSocket
 }

--- a/pkg/kubelet/cadvisor/util_test.go
+++ b/pkg/kubelet/cadvisor/util_test.go
@@ -22,9 +22,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/google/cadvisor/container/crio"
 	info "github.com/google/cadvisor/info/v1"
-	"github.com/stretchr/testify/assert"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 )
@@ -50,8 +48,4 @@ func TestCapacityFromMachineInfoWithHugePagesEnable(t *testing.T) {
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("when set hugepages true, got resource list %v, want %v", actual, expected)
 	}
-}
-
-func TestCrioSocket(t *testing.T) {
-	assert.EqualValues(t, CrioSocket, crio.CrioSocket, "CrioSocket in this package must equal the one in github.com/google/cadvisor/container/crio/client.go")
 }

--- a/pkg/kubelet/cm/container_manager_linux.go
+++ b/pkg/kubelet/cm/container_manager_linux.go
@@ -73,6 +73,8 @@ const (
 	dockerPidFile         = "/var/run/docker.pid"
 	containerdProcessName = "docker-containerd"
 	containerdPidFile     = "/run/docker/libcontainerd/docker-containerd.pid"
+	crioProcessName       = "crio"
+	crioPidFile           = "/var/run/crio/pid"
 	maxPidFileLength      = 1 << 10 // 1KB
 )
 

--- a/pkg/kubelet/cm/helpers_unsupported.go
+++ b/pkg/kubelet/cm/helpers_unsupported.go
@@ -71,6 +71,6 @@ func GetKubeletContainer(kubeletCgroups string) (string, error) {
 }
 
 // GetRuntimeContainer returns the cgroup used by the container runtime
-func GetRuntimeContainer(containerRuntime, runtimeCgroups string) (string, error) {
+func GetRuntimeContainer(containerRuntime, runtimeEndpoint, runtimeCgroups string) (string, error) {
 	return "", nil
 }

--- a/pkg/kubelet/types/BUILD
+++ b/pkg/kubelet/types/BUILD
@@ -28,6 +28,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "constants_test.go",
         "labels_test.go",
         "pod_status_test.go",
         "pod_update_test.go",
@@ -39,7 +40,15 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//vendor/github.com/google/cadvisor/container/crio:go_default_library",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 filegroup(

--- a/pkg/kubelet/types/constants.go
+++ b/pkg/kubelet/types/constants.go
@@ -29,4 +29,9 @@ const (
 	SystemReservedEnforcementKey  = "system-reserved"
 	KubeReservedEnforcementKey    = "kube-reserved"
 	NodeAllocatableNoneKey        = "none"
+
+	// CrioSocket is the path to the CRI-O socket.
+	// Please keep this in sync with the one in:
+	// github.com/google/cadvisor/container/crio/client.go
+	CrioSocket = "/var/run/crio/crio.sock"
 )

--- a/pkg/kubelet/types/constants_test.go
+++ b/pkg/kubelet/types/constants_test.go
@@ -1,0 +1,30 @@
+// +build cgo,linux
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/google/cadvisor/container/crio"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCrioSocket(t *testing.T) {
+	assert.EqualValues(t, CrioSocket, crio.CrioSocket, "CrioSocket in this package must equal the one in github.com/google/cadvisor/container/crio/client.go")
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Per #72787 the kubelet should show statistics for the runtime, but that change seems only to collect statistics if Docker is the runtime. Since crio also uses cadvisor, we should be collecting crio's statistics. This PR adds that functionality back. 

Also, move CrioSocket and its test from pkg/kubelet/cadvisor to pkg/kubelet/types so it can be used in `cm` and `cadvisor` packages without a circular dependency between the two.

**Which issue(s) this PR fixes**:
No issue filed. Fixes an issue apparently introduced in #72787

**Special notes for your reviewer**:

This change takes advantage of (but does not rely upon) work happening in crio to write a PID
file to `/var/run/crio/pid` (see https://github.com/cri-o/cri-o/pull/3362).

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A

/cc @dashpole 
/cc @mrunalp 