### PR TITLE
kubeadm: deprecate the flag --use-api for cert renewal

### DIFF
--- a/cmd/kubeadm/app/cmd/alpha/certs.go
+++ b/cmd/kubeadm/app/cmd/alpha/certs.go
@@ -43,7 +43,7 @@ var (
 	genericCertRenewLongDesc = cmdutil.LongDesc(`
 	Renew the %s.
 
-	Renewals run unconditionally, regardless of certificate expiration date; extra attributes such as SANs will 
+	Renewals run unconditionally, regardless of certificate expiration date; extra attributes such as SANs will
 	be based on the existing file/certificates, there is no need to resupply them.
 
 	Renewal by default tries to use the certificate authority in the local PKI managed by kubeadm; as alternative
@@ -208,7 +208,12 @@ func addRenewFlags(cmd *cobra.Command, flags *renewFlags) {
 	options.AddKubeConfigFlag(cmd.Flags(), &flags.kubeconfigPath)
 	options.AddCSRFlag(cmd.Flags(), &flags.csrOnly)
 	options.AddCSRDirFlag(cmd.Flags(), &flags.csrPath)
+	// TODO: remove the flag and related logic once legacy signers are removed,
+	// potentially with the release of certificates.k8s.io/v1:
+	//   https://github.com/kubernetes/kubeadm/issues/2047
 	cmd.Flags().BoolVar(&flags.useAPI, "use-api", flags.useAPI, "Use the Kubernetes certificate API to renew certificates")
+	cmd.Flags().MarkDeprecated("use-api", "certificate renewal from kubeadm using the Kubernetes API "+
+		"is deprecated and will be removed when 'certificates.k8s.io/v1' releases.")
 }
 
 func renewCert(flags *renewFlags, kdir string, internalcfg *kubeadmapi.InitConfiguration, handler *renewal.CertificateRenewHandler) error {


### PR DESCRIPTION
**What this PR does / why we need it**:

The KCM is moving to means of only singing apiserver (kubelet) client
and kubelet serving certificates. See:
  https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/20190607-certificates-api.md#signers
Up until now the experimental kubeadm functionality '--use-api'
under "kubeadm alpha certs renew" was using the KCM to sign *any*
certficate as long as the KCM has the root CA cert/key.

Post discussions with the kubeadm maintainers, it was decided that
this functionality should be removed from kubeadm due to the
requirement to have external signers for renewing the common
control-plane certificates that kubeadm manages.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref https://github.com/kubernetes/kubeadm/issues/2047

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: deprecate the usage of the experimental flag '--use-api' under the 'kubeadm alpha certs renew' command.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/assign @fabriziopandini @rosti 
/kind deprecation
/priority important-soon
