### PR TITLE
kubeadm: honor etcd image tag during upgrades

### DIFF
--- a/cmd/kubeadm/app/cmd/upgrade/common.go
+++ b/cmd/kubeadm/app/cmd/upgrade/common.go
@@ -95,6 +95,9 @@ func enforceRequirements(flags *applyPlanFlags, dryRun bool, newK8sVersion strin
 		cfg, err = configutil.LoadInitConfigurationFromFile(flags.cfgPath)
 	} else {
 		cfg, err = configutil.FetchInitConfigurationFromCluster(client, os.Stdout, "upgrade/config", false)
+		if err := configutil.EnforceEtcdSupportedVersion(client, newK8sVersion, cfg); err != nil {
+			return nil, nil, nil, err
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
During upgrades, kubeadm will override the user provided etcd image
tag in the configuration.

This patch changes the logic, so the desired etcd version is retrieved
from the static map only if we are fetching the configuration from the
cluster. Otherwise, honor the etcd image tag provided in the
configuration.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm: `kubeadm upgrade apply --config` will honor the etcd image tag in the provided configuration, instead of inferring it based on the provided Kubernetes version
```

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews