### PR TITLE
Image Promoter fixes

### DIFF
--- a/test/images/Makefile
+++ b/test/images/Makefile
@@ -37,4 +37,7 @@ all-container:
 all-push: all-container
 	./image-util.sh push $(WHAT)
 
-.PHONY: all all-push all-container
+all-build-and-push:
+	./image-util.sh build_and_push ${WHAT}
+
+.PHONY: all all-build-and-push all-push all-container

--- a/test/images/cloudbuild.yaml
+++ b/test/images/cloudbuild.yaml
@@ -19,7 +19,7 @@ steps:
     - REGISTRY=gcr.io/k8s-staging-e2e-test-images
     # TODO(claudiub): Readd the REMOTE_DOCKER_URL_${os_version} to reenable the Windows test image building process.
     args:
-    - all-push
+    - all-build-and-push
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form vYYYYMMDD-hash, and
   # can be used as a substitution

--- a/test/images/image-util.sh
+++ b/test/images/image-util.sh
@@ -237,6 +237,14 @@ push() {
   docker manifest push --purge "${REGISTRY}/${image}:${TAG}"
 }
 
+# This function is for building AND pushing images. Useful if ${WHAT} is "all-conformance".
+# This will allow images to be pushed immediately after they've been pushed.
+build_and_push() {
+  image=$1
+  build "${image}"
+  push "${image}"
+}
+
 # This function is for building the go code
 bin() {
   local arch_prefix=""

--- a/test/images/kitten/BASEIMAGE
+++ b/test/images/kitten/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=REGISTRY/agnhost:2.11-linux-amd64
-linux/arm=REGISTRY/agnhost:2.11-linux-arm
-linux/arm64=REGISTRY/agnhost:2.11-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.11-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.11-linux-s390x
+linux/amd64=REGISTRY/agnhost:2.12-linux-amd64
+linux/arm=REGISTRY/agnhost:2.12-linux-arm
+linux/arm64=REGISTRY/agnhost:2.12-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.12-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.12-linux-s390x

--- a/test/images/nautilus/BASEIMAGE
+++ b/test/images/nautilus/BASEIMAGE
@@ -1,5 +1,5 @@
-linux/amd64=REGISTRY/agnhost:2.11-linux-amd64
-linux/arm=REGISTRY/agnhost:2.11-linux-arm
-linux/arm64=REGISTRY/agnhost:2.11-linux-arm64
-linux/ppc64le=REGISTRY/agnhost:2.11-linux-ppc64le
-linux/s390x=REGISTRY/agnhost:2.11-linux-s390x
+linux/amd64=REGISTRY/agnhost:2.12-linux-amd64
+linux/arm=REGISTRY/agnhost:2.12-linux-arm
+linux/arm64=REGISTRY/agnhost:2.12-linux-arm64
+linux/ppc64le=REGISTRY/agnhost:2.12-linux-ppc64le
+linux/s390x=REGISTRY/agnhost:2.12-linux-s390x


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Image Promoter: Allows images to be pushed immediately after being built

In the current version, due to how make works, when building all the conformance images (``make all-push WHAT=all-conformance``), ALL the images are being built first before being pushed.

This PR will allow images to be built and pushed immediately afterwards, so the first images that have been succesfully built are already pushed and promotable, even if the the task failed on the last image, or it timed out.

test images: Rebases nautilus and kitten images

The current agnhost version is 2.12, 2.11 was not previously built as the ``VERSION`` bumps merged one after the other, and the Image Promoter did not get to build the 2.11 image.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
