### PR TITLE
Fix dynamic certificates issues

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/named_certificates.go
@@ -23,7 +23,7 @@ import (
 	"net"
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog"
 )
@@ -52,7 +52,7 @@ func (c *DynamicServingCertificateController) BuildNamedCertificates(sniCerts []
 
 		klog.V(2).Infof("loaded SNI cert [%d/%q]: %s", i, c.sniCerts[i].Name(), GetHumanCertDetail(x509Cert))
 		if c.eventRecorder != nil {
-			c.eventRecorder.Eventf(nil, nil, v1.EventTypeWarning, "TLSConfigChanged", "SNICertificateReload", "loaded SNI cert [%d/%q]: %s with explicit names %v", i, c.sniCerts[i].Name(), GetHumanCertDetail(x509Cert), names)
+			c.eventRecorder.Eventf(&corev1.ObjectReference{Name: c.sniCerts[i].Name()}, nil, corev1.EventTypeWarning, "TLSConfigChanged", "SNICertificateReload", "loaded SNI cert [%d/%q]: %s with explicit names %v", i, c.sniCerts[i].Name(), GetHumanCertDetail(x509Cert), names)
 		}
 
 		if len(names) == 0 {

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/server_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/server_test.go
@@ -79,7 +79,7 @@ func TestServingCert(t *testing.T) {
 	}
 
 	dynamicCertificateController := NewDynamicServingCertificateController(
-		*tlsConfig,
+		tlsConfig,
 		&nullCAContent{name: "client-ca"},
 		defaultCertProvider,
 		sniCerts,

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
@@ -41,7 +41,7 @@ const workItemKey = "key"
 type DynamicServingCertificateController struct {
 	// baseTLSConfig is the static portion of the tlsConfig for serving to clients.  It is copied and the copy is mutated
 	// based on the dynamic cert state.
-	baseTLSConfig tls.Config
+	baseTLSConfig *tls.Config
 
 	// clientCA provides the very latest content of the ca bundle
 	clientCA CAContentProvider
@@ -65,7 +65,7 @@ var _ Listener = &DynamicServingCertificateController{}
 
 // NewDynamicServingCertificateController returns a controller that can be used to keep a TLSConfig up to date.
 func NewDynamicServingCertificateController(
-	baseTLSConfig tls.Config,
+	baseTLSConfig *tls.Config,
 	clientCA CAContentProvider,
 	servingCert CertKeyContentProvider,
 	sniCerts []SNICertKeyContentProvider,

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
@@ -200,7 +200,7 @@ func (c *DynamicServingCertificateController) syncCerts() error {
 
 		klog.V(2).Infof("loaded serving cert [%q]: %s", c.servingCert.Name(), GetHumanCertDetail(x509Cert))
 		if c.eventRecorder != nil {
-			c.eventRecorder.Eventf(nil, nil, v1.EventTypeWarning, "TLSConfigChanged", "ServingCertificateReload", "loaded serving cert [%q]: %s", c.clientCA.Name(), GetHumanCertDetail(x509Cert))
+			c.eventRecorder.Eventf(nil, nil, v1.EventTypeWarning, "TLSConfigChanged", "ServingCertificateReload", "loaded serving cert [%q]: %s", c.servingCert.Name(), GetHumanCertDetail(x509Cert))
 		}
 
 		newTLSConfigCopy.Certificates = []tls.Certificate{cert}

--- a/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/dynamiccertificates/tlsconfig.go
@@ -25,8 +25,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	v1 "k8s.io/api/core/v1"
-
+	corev1 "k8s.io/api/core/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/events"
@@ -178,7 +177,7 @@ func (c *DynamicServingCertificateController) syncCerts() error {
 		for i, cert := range newClientCAs {
 			klog.V(2).Infof("loaded client CA [%d/%q]: %s", i, c.clientCA.Name(), GetHumanCertDetail(cert))
 			if c.eventRecorder != nil {
-				c.eventRecorder.Eventf(nil, nil, v1.EventTypeWarning, "TLSConfigChanged", "CACertificateReload", "loaded client CA [%d/%q]: %s", i, c.clientCA.Name(), GetHumanCertDetail(cert))
+				c.eventRecorder.Eventf(&corev1.ObjectReference{Name: c.clientCA.Name()}, nil, corev1.EventTypeWarning, "TLSConfigChanged", "CACertificateReload", "loaded client CA [%d/%q]: %s", i, c.clientCA.Name(), GetHumanCertDetail(cert))
 			}
 
 			newClientCAPool.AddCert(cert)
@@ -200,7 +199,7 @@ func (c *DynamicServingCertificateController) syncCerts() error {
 
 		klog.V(2).Infof("loaded serving cert [%q]: %s", c.servingCert.Name(), GetHumanCertDetail(x509Cert))
 		if c.eventRecorder != nil {
-			c.eventRecorder.Eventf(nil, nil, v1.EventTypeWarning, "TLSConfigChanged", "ServingCertificateReload", "loaded serving cert [%q]: %s", c.servingCert.Name(), GetHumanCertDetail(x509Cert))
+			c.eventRecorder.Eventf(&corev1.ObjectReference{Name: c.servingCert.Name()}, nil, corev1.EventTypeWarning, "TLSConfigChanged", "ServingCertificateReload", "loaded serving cert [%q]: %s", c.servingCert.Name(), GetHumanCertDetail(x509Cert))
 		}
 
 		newTLSConfigCopy.Certificates = []tls.Certificate{cert}

--- a/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/secure_serving.go
@@ -66,7 +66,7 @@ func (s *SecureServingInfo) tlsConfig(stopCh <-chan struct{}) (*tls.Config, erro
 
 	if s.ClientCA != nil || s.Cert != nil || len(s.SNICerts) > 0 {
 		dynamicCertificateController := dynamiccertificates.NewDynamicServingCertificateController(
-			*tlsConfig,
+			tlsConfig,
 			s.ClientCA,
 			s.Cert,
 			s.SNICerts,


### PR DESCRIPTION
This change addresses three bugs:

1. Accidental mutex copy via TLS config struct copy
2. `nil` pointer exception caused by dereferencing the wrong variable
3. Pass in a valid related object to `Eventf` so that an event is actually created

Extracted out of #88682 to make the other PR easier to review.

/kind bug
/priority important-soon
/assign @deads2k 
/milestone v1.18

```release-note
NONE
```