### PR TITLE
Fix golint failures in pkg/credentialprovider

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -96,7 +96,6 @@ pkg/controller/volume/events
 pkg/controller/volume/expand
 pkg/controller/volume/persistentvolume
 pkg/controller/volume/persistentvolume/config/v1alpha1
-pkg/credentialprovider
 pkg/features
 pkg/kubeapiserver
 pkg/kubeapiserver/options

--- a/pkg/credentialprovider/config.go
+++ b/pkg/credentialprovider/config.go
@@ -36,12 +36,12 @@ const (
 	maxReadLength = 10 * 1 << 20 // 10MB
 )
 
-// DockerConfigJson represents ~/.docker/config.json file info
+// DockerConfigJSON represents ~/.docker/config.json file info
 // see https://github.com/docker/docker/pull/12009
-type DockerConfigJson struct {
+type DockerConfigJSON struct {
 	Auths DockerConfig `json:"auths"`
 	// +optional
-	HttpHeaders map[string]string `json:"HttpHeaders,omitempty"`
+	HTTPHeaders map[string]string `json:"HttpHeaders,omitempty"`
 }
 
 // DockerConfig represents the config file used by the docker CLI.
@@ -49,6 +49,7 @@ type DockerConfigJson struct {
 // when pulling images from specific image repositories.
 type DockerConfig map[string]DockerConfigEntry
 
+// DockerConfigEntry wraps a docker config as a entry
 type DockerConfigEntry struct {
 	Username string
 	Password string
@@ -62,19 +63,21 @@ var (
 	workingDirPath    = ""
 	homeDirPath, _    = os.UserHomeDir()
 	rootDirPath       = "/"
-	homeJsonDirPath   = filepath.Join(homeDirPath, ".docker")
-	rootJsonDirPath   = filepath.Join(rootDirPath, ".docker")
+	homeJSONDirPath   = filepath.Join(homeDirPath, ".docker")
+	rootJSONDirPath   = filepath.Join(rootDirPath, ".docker")
 
 	configFileName     = ".dockercfg"
-	configJsonFileName = "config.json"
+	configJSONFileName = "config.json"
 )
 
+// SetPreferredDockercfgPath set preferred docker config path
 func SetPreferredDockercfgPath(path string) {
 	preferredPathLock.Lock()
 	defer preferredPathLock.Unlock()
 	preferredPath = path
 }
 
+// GetPreferredDockercfgPath get preferred docker config path
 func GetPreferredDockercfgPath() string {
 	preferredPathLock.Lock()
 	defer preferredPathLock.Unlock()
@@ -88,7 +91,7 @@ func DefaultDockercfgPaths() []string {
 
 //DefaultDockerConfigJSONPaths returns default search paths of .docker/config.json
 func DefaultDockerConfigJSONPaths() []string {
-	return []string{GetPreferredDockercfgPath(), workingDirPath, homeJsonDirPath, rootJsonDirPath}
+	return []string{GetPreferredDockercfgPath(), workingDirPath, homeJSONDirPath, rootJSONDirPath}
 }
 
 // ReadDockercfgFile attempts to read a legacy dockercfg file from the given paths.
@@ -129,36 +132,37 @@ func ReadDockerConfigJSONFile(searchPaths []string) (cfg DockerConfig, err error
 		searchPaths = DefaultDockerConfigJSONPaths()
 	}
 	for _, configPath := range searchPaths {
-		absDockerConfigFileLocation, err := filepath.Abs(filepath.Join(configPath, configJsonFileName))
+		absDockerConfigFileLocation, err := filepath.Abs(filepath.Join(configPath, configJSONFileName))
 		if err != nil {
 			klog.Errorf("while trying to canonicalize %s: %v", configPath, err)
 			continue
 		}
-		klog.V(4).Infof("looking for %s at %s", configJsonFileName, absDockerConfigFileLocation)
-		cfg, err = ReadSpecificDockerConfigJsonFile(absDockerConfigFileLocation)
+		klog.V(4).Infof("looking for %s at %s", configJSONFileName, absDockerConfigFileLocation)
+		cfg, err = ReadSpecificDockerConfigJSONFile(absDockerConfigFileLocation)
 		if err != nil {
 			if !os.IsNotExist(err) {
 				klog.V(4).Infof("while trying to read %s: %v", absDockerConfigFileLocation, err)
 			}
 			continue
 		}
-		klog.V(4).Infof("found valid %s at %s", configJsonFileName, absDockerConfigFileLocation)
+		klog.V(4).Infof("found valid %s at %s", configJSONFileName, absDockerConfigFileLocation)
 		return cfg, nil
 	}
-	return nil, fmt.Errorf("couldn't find valid %s after checking in %v", configJsonFileName, searchPaths)
+	return nil, fmt.Errorf("couldn't find valid %s after checking in %v", configJSONFileName, searchPaths)
 
 }
 
-//ReadSpecificDockerConfigJsonFile attempts to read docker configJSON from a given file path.
-func ReadSpecificDockerConfigJsonFile(filePath string) (cfg DockerConfig, err error) {
+//ReadSpecificDockerConfigJSONFile attempts to read docker configJSON from a given file path.
+func ReadSpecificDockerConfigJSONFile(filePath string) (cfg DockerConfig, err error) {
 	var contents []byte
 
 	if contents, err = ioutil.ReadFile(filePath); err != nil {
 		return nil, err
 	}
-	return readDockerConfigJsonFileFromBytes(contents)
+	return readDockerConfigJSONFileFromBytes(contents)
 }
 
+// ReadDockerConfigFile read a docker config file from default path
 func ReadDockerConfigFile() (cfg DockerConfig, err error) {
 	if cfg, err := ReadDockerConfigJSONFile(nil); err == nil {
 		return cfg, nil
@@ -167,19 +171,20 @@ func ReadDockerConfigFile() (cfg DockerConfig, err error) {
 	return ReadDockercfgFile(nil)
 }
 
-// HttpError wraps a non-StatusOK error code as an error.
-type HttpError struct {
+// HTTPError wraps a non-StatusOK error code as an error.
+type HTTPError struct {
 	StatusCode int
-	Url        string
+	URL        string
 }
 
 // Error implements error
-func (he *HttpError) Error() string {
+func (he *HTTPError) Error() string {
 	return fmt.Sprintf("http status code: %d while fetching url %s",
-		he.StatusCode, he.Url)
+		he.StatusCode, he.URL)
 }
 
-func ReadUrl(url string, client *http.Client, header *http.Header) (body []byte, err error) {
+// ReadURL read contents from given url
+func ReadURL(url string, client *http.Client, header *http.Header) (body []byte, err error) {
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -195,9 +200,9 @@ func ReadUrl(url string, client *http.Client, header *http.Header) (body []byte,
 
 	if resp.StatusCode != http.StatusOK {
 		klog.V(2).Infof("body of failing http response: %v", resp.Body)
-		return nil, &HttpError{
+		return nil, &HTTPError{
 			StatusCode: resp.StatusCode,
-			Url:        url,
+			URL:        url,
 		}
 	}
 
@@ -214,12 +219,13 @@ func ReadUrl(url string, client *http.Client, header *http.Header) (body []byte,
 	return contents, nil
 }
 
-func ReadDockerConfigFileFromUrl(url string, client *http.Client, header *http.Header) (cfg DockerConfig, err error) {
-	if contents, err := ReadUrl(url, client, header); err != nil {
-		return nil, err
-	} else {
+// ReadDockerConfigFileFromURL read a docker config file from the given url
+func ReadDockerConfigFileFromURL(url string, client *http.Client, header *http.Header) (cfg DockerConfig, err error) {
+	if contents, err := ReadURL(url, client, header); err == nil {
 		return readDockerConfigFileFromBytes(contents)
 	}
+
+	return nil, err
 }
 
 func readDockerConfigFileFromBytes(contents []byte) (cfg DockerConfig, err error) {
@@ -230,13 +236,13 @@ func readDockerConfigFileFromBytes(contents []byte) (cfg DockerConfig, err error
 	return
 }
 
-func readDockerConfigJsonFileFromBytes(contents []byte) (cfg DockerConfig, err error) {
-	var cfgJson DockerConfigJson
-	if err = json.Unmarshal(contents, &cfgJson); err != nil {
+func readDockerConfigJSONFileFromBytes(contents []byte) (cfg DockerConfig, err error) {
+	var cfgJSON DockerConfigJSON
+	if err = json.Unmarshal(contents, &cfgJSON); err != nil {
 		klog.Errorf("while trying to parse blob %q: %v", contents, err)
 		return nil, err
 	}
-	cfg = cfgJson.Auths
+	cfg = cfgJSON.Auths
 	return
 }
 
@@ -253,6 +259,7 @@ type dockerConfigEntryWithAuth struct {
 	Auth string `json:"auth,omitempty"`
 }
 
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (ident *DockerConfigEntry) UnmarshalJSON(data []byte) error {
 	var tmp dockerConfigEntryWithAuth
 	err := json.Unmarshal(data, &tmp)
@@ -272,6 +279,7 @@ func (ident *DockerConfigEntry) UnmarshalJSON(data []byte) error {
 	return err
 }
 
+// MarshalJSON implements the json.Marshaler interface.
 func (ident DockerConfigEntry) MarshalJSON() ([]byte, error) {
 	toEncode := dockerConfigEntryWithAuth{ident.Username, ident.Password, ident.Email, ""}
 	toEncode.Auth = encodeDockerConfigFieldAuth(ident.Username, ident.Password)

--- a/pkg/credentialprovider/config_test.go
+++ b/pkg/credentialprovider/config_test.go
@@ -27,11 +27,11 @@ import (
 )
 
 func TestReadDockerConfigFile(t *testing.T) {
-	configJsonFileName := "config.json"
+	configJSONFileName := "config.json"
 	var fileInfo *os.File
 
 	//test dockerconfig json
-	inputDockerconfigJsonFile := "{ \"auths\": { \"http://foo.example.com\":{\"auth\":\"Zm9vOmJhcgo=\",\"email\":\"foo@example.com\"}}}"
+	inputDockerconfigJSONFile := "{ \"auths\": { \"http://foo.example.com\":{\"auth\":\"Zm9vOmJhcgo=\",\"email\":\"foo@example.com\"}}}"
 
 	preferredPath, err := ioutil.TempDir("", "test_foo_bar_dockerconfigjson_")
 	if err != nil {
@@ -39,7 +39,7 @@ func TestReadDockerConfigFile(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(preferredPath)
-	absDockerConfigFileLocation, err := filepath.Abs(filepath.Join(preferredPath, configJsonFileName))
+	absDockerConfigFileLocation, err := filepath.Abs(filepath.Join(preferredPath, configJSONFileName))
 	if err != nil {
 		t.Fatalf("While trying to canonicalize %s: %v", preferredPath, err)
 	}
@@ -53,7 +53,7 @@ func TestReadDockerConfigFile(t *testing.T) {
 		defer fileInfo.Close()
 	}
 
-	fileInfo.WriteString(inputDockerconfigJsonFile)
+	fileInfo.WriteString(inputDockerconfigJSONFile)
 
 	orgPreferredPath := GetPreferredDockercfgPath()
 	SetPreferredDockercfgPath(preferredPath)
@@ -66,7 +66,7 @@ func TestDockerConfigJsonJSONDecode(t *testing.T) {
 	// Fake values for testing.
 	input := []byte(`{"auths": {"http://foo.example.com":{"username": "foo", "password": "bar", "email": "foo@example.com"}, "http://bar.example.com":{"username": "bar", "password": "baz", "email": "bar@example.com"}}}`)
 
-	expect := DockerConfigJson{
+	expect := DockerConfigJSON{
 		Auths: DockerConfig(map[string]DockerConfigEntry{
 			"http://foo.example.com": {
 				Username: "foo",
@@ -81,7 +81,7 @@ func TestDockerConfigJsonJSONDecode(t *testing.T) {
 		}),
 	}
 
-	var output DockerConfigJson
+	var output DockerConfigJSON
 	err := json.Unmarshal(input, &output)
 	if err != nil {
 		t.Errorf("Received unexpected error: %v", err)

--- a/pkg/credentialprovider/gcp/metadata.go
+++ b/pkg/credentialprovider/gcp/metadata.go
@@ -150,7 +150,7 @@ func (g *metadataProvider) Enabled() bool {
 func (g *dockerConfigKeyProvider) Provide(image string) credentialprovider.DockerConfig {
 	// Read the contents of the google-dockercfg metadata key and
 	// parse them as an alternate .dockercfg
-	if cfg, err := credentialprovider.ReadDockerConfigFileFromUrl(dockerConfigKey, g.Client, metadataHeader); err != nil {
+	if cfg, err := credentialprovider.ReadDockerConfigFileFromURL(dockerConfigKey, g.Client, metadataHeader); err != nil {
 		klog.Errorf("while reading 'google-dockercfg' metadata: %v", err)
 	} else {
 		return cfg
@@ -162,11 +162,11 @@ func (g *dockerConfigKeyProvider) Provide(image string) credentialprovider.Docke
 // Provide implements DockerConfigProvider
 func (g *dockerConfigURLKeyProvider) Provide(image string) credentialprovider.DockerConfig {
 	// Read the contents of the google-dockercfg-url key and load a .dockercfg from there
-	if url, err := credentialprovider.ReadUrl(dockerConfigURLKey, g.Client, metadataHeader); err != nil {
+	if url, err := credentialprovider.ReadURL(dockerConfigURLKey, g.Client, metadataHeader); err != nil {
 		klog.Errorf("while reading 'google-dockercfg-url' metadata: %v", err)
 	} else {
 		if strings.HasPrefix(string(url), "http") {
-			if cfg, err := credentialprovider.ReadDockerConfigFileFromUrl(string(url), g.Client, nil); err != nil {
+			if cfg, err := credentialprovider.ReadDockerConfigFileFromURL(string(url), g.Client, nil); err != nil {
 				klog.Errorf("while reading 'google-dockercfg-url'-specified url: %s, %v", string(url), err)
 			} else {
 				return cfg
@@ -214,7 +214,7 @@ func (g *containerRegistryProvider) Enabled() bool {
 	}
 	// Given that we are on GCE, we should keep retrying until the metadata server responds.
 	value := runWithBackoff(func() ([]byte, error) {
-		value, err := credentialprovider.ReadUrl(serviceAccounts, g.Client, metadataHeader)
+		value, err := credentialprovider.ReadURL(serviceAccounts, g.Client, metadataHeader)
 		if err != nil {
 			klog.V(2).Infof("Failed to Get service accounts from gce metadata server: %v", err)
 		}
@@ -237,7 +237,7 @@ func (g *containerRegistryProvider) Enabled() bool {
 	}
 	url := metadataScopes + "?alt=json"
 	value = runWithBackoff(func() ([]byte, error) {
-		value, err := credentialprovider.ReadUrl(url, g.Client, metadataHeader)
+		value, err := credentialprovider.ReadURL(url, g.Client, metadataHeader)
 		if err != nil {
 			klog.V(2).Infof("Failed to Get scopes in default service account from gce metadata server: %v", err)
 		}
@@ -268,13 +268,13 @@ type tokenBlob struct {
 func (g *containerRegistryProvider) Provide(image string) credentialprovider.DockerConfig {
 	cfg := credentialprovider.DockerConfig{}
 
-	tokenJSONBlob, err := credentialprovider.ReadUrl(metadataToken, g.Client, metadataHeader)
+	tokenJSONBlob, err := credentialprovider.ReadURL(metadataToken, g.Client, metadataHeader)
 	if err != nil {
 		klog.Errorf("while reading access token endpoint: %v", err)
 		return cfg
 	}
 
-	email, err := credentialprovider.ReadUrl(metadataEmail, g.Client, metadataHeader)
+	email, err := credentialprovider.ReadURL(metadataEmail, g.Client, metadataHeader)
 	if err != nil {
 		klog.Errorf("while reading email endpoint: %v", err)
 		return cfg

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -73,6 +73,7 @@ type AuthConfig struct {
 	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
+// Add .
 func (dk *BasicDockerKeyring) Add(cfg DockerConfig) {
 	if dk.index == nil {
 		dk.index = make([]string, 0)
@@ -159,8 +160,8 @@ func isDefaultRegistryMatch(image string) bool {
 
 // url.Parse require a scheme, but ours don't have schemes.  Adding a
 // scheme to make url.Parse happy, then clear out the resulting scheme.
-func parseSchemelessUrl(schemelessUrl string) (*url.URL, error) {
-	parsed, err := url.Parse("https://" + schemelessUrl)
+func parseSchemelessURL(schemelessURL string) (*url.URL, error) {
+	parsed, err := url.Parse("https://" + schemelessURL)
 	if err != nil {
 		return nil, err
 	}
@@ -170,7 +171,7 @@ func parseSchemelessUrl(schemelessUrl string) (*url.URL, error) {
 }
 
 // split the host name into parts, as well as the port
-func splitUrl(url *url.URL) (parts []string, port string) {
+func splitURL(url *url.URL) (parts []string, port string) {
 	host, port, err := net.SplitHostPort(url.Host)
 	if err != nil {
 		// could not parse port
@@ -181,43 +182,43 @@ func splitUrl(url *url.URL) (parts []string, port string) {
 
 // overloaded version of urlsMatch, operating on strings instead of URLs.
 func urlsMatchStr(glob string, target string) (bool, error) {
-	globUrl, err := parseSchemelessUrl(glob)
+	globURL, err := parseSchemelessURL(glob)
 	if err != nil {
 		return false, err
 	}
-	targetUrl, err := parseSchemelessUrl(target)
+	targetURL, err := parseSchemelessURL(target)
 	if err != nil {
 		return false, err
 	}
-	return urlsMatch(globUrl, targetUrl)
+	return urlsMatch(globURL, targetURL)
 }
 
 // check whether the given target url matches the glob url, which may have
 // glob wild cards in the host name.
 //
 // Examples:
-//    globUrl=*.docker.io, targetUrl=blah.docker.io => match
-//    globUrl=*.docker.io, targetUrl=not.right.io   => no match
+//    globURL=*.docker.io, targetURL=blah.docker.io => match
+//    globURL=*.docker.io, targetURL=not.right.io   => no match
 //
 // Note that we don't support wildcards in ports and paths yet.
-func urlsMatch(globUrl *url.URL, targetUrl *url.URL) (bool, error) {
-	globUrlParts, globPort := splitUrl(globUrl)
-	targetUrlParts, targetPort := splitUrl(targetUrl)
+func urlsMatch(globURL *url.URL, targetURL *url.URL) (bool, error) {
+	globURLParts, globPort := splitURL(globURL)
+	targetURLParts, targetPort := splitURL(targetURL)
 	if globPort != targetPort {
 		// port doesn't match
 		return false, nil
 	}
-	if len(globUrlParts) != len(targetUrlParts) {
+	if len(globURLParts) != len(targetURLParts) {
 		// host name does not have the same number of parts
 		return false, nil
 	}
-	if !strings.HasPrefix(targetUrl.Path, globUrl.Path) {
+	if !strings.HasPrefix(targetURL.Path, globURL.Path) {
 		// the path of the credential must be a prefix
 		return false, nil
 	}
-	for k, globUrlPart := range globUrlParts {
-		targetUrlPart := targetUrlParts[k]
-		matched, err := filepath.Match(globUrlPart, targetUrlPart)
+	for k, globURLPart := range globURLParts {
+		targetURLPart := targetURLParts[k]
+		matched, err := filepath.Match(globURLPart, targetURLPart)
 		if err != nil {
 			return false, err
 		}
@@ -270,18 +271,11 @@ func (dk *providersDockerKeyring) Lookup(image string) ([]AuthConfig, bool) {
 	return keyring.Lookup(image)
 }
 
-type FakeKeyring struct {
-	auth []AuthConfig
-	ok   bool
-}
-
-func (f *FakeKeyring) Lookup(image string) ([]AuthConfig, bool) {
-	return f.auth, f.ok
-}
-
 // UnionDockerKeyring delegates to a set of keyrings.
 type UnionDockerKeyring []DockerKeyring
 
+// Lookup implements the DockerKeyring method for fetching credentials based on image name.
+// return each credentials
 func (k UnionDockerKeyring) Lookup(image string) ([]AuthConfig, bool) {
 	authConfigs := []AuthConfig{}
 	for _, subKeyring := range k {

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -271,6 +271,18 @@ func (dk *providersDockerKeyring) Lookup(image string) ([]AuthConfig, bool) {
 	return keyring.Lookup(image)
 }
 
+// FakeKeyring a fake config credentials
+type FakeKeyring struct {
+	auth []AuthConfig
+	ok   bool
+}
+
+// Lookup implements the DockerKeyring method for fetching credentials based on image name
+// return fake auth and ok
+func (f *FakeKeyring) Lookup(image string) ([]AuthConfig, bool) {
+	return f.auth, f.ok
+}
+
 // UnionDockerKeyring delegates to a set of keyrings.
 type UnionDockerKeyring []DockerKeyring
 

--- a/pkg/credentialprovider/keyring.go
+++ b/pkg/credentialprovider/keyring.go
@@ -73,7 +73,7 @@ type AuthConfig struct {
 	RegistryToken string `json:"registrytoken,omitempty"`
 }
 
-// Add .
+// Add add some docker config in basic docker keyring
 func (dk *BasicDockerKeyring) Add(cfg DockerConfig) {
 	if dk.index == nil {
 		dk.index = make([]string, 0)

--- a/pkg/credentialprovider/keyring_test.go
+++ b/pkg/credentialprovider/keyring_test.go
@@ -25,169 +25,169 @@ import (
 
 func TestUrlsMatch(t *testing.T) {
 	tests := []struct {
-		globUrl       string
-		targetUrl     string
+		globURL       string
+		targetURL     string
 		matchExpected bool
 	}{
 		// match when there is no path component
 		{
-			globUrl:       "*.kubernetes.io",
-			targetUrl:     "prefix.kubernetes.io",
+			globURL:       "*.kubernetes.io",
+			targetURL:     "prefix.kubernetes.io",
 			matchExpected: true,
 		},
 		{
-			globUrl:       "prefix.*.io",
-			targetUrl:     "prefix.kubernetes.io",
+			globURL:       "prefix.*.io",
+			targetURL:     "prefix.kubernetes.io",
 			matchExpected: true,
 		},
 		{
-			globUrl:       "prefix.kubernetes.*",
-			targetUrl:     "prefix.kubernetes.io",
+			globURL:       "prefix.kubernetes.*",
+			targetURL:     "prefix.kubernetes.io",
 			matchExpected: true,
 		},
 		{
-			globUrl:       "*-good.kubernetes.io",
-			targetUrl:     "prefix-good.kubernetes.io",
+			globURL:       "*-good.kubernetes.io",
+			targetURL:     "prefix-good.kubernetes.io",
 			matchExpected: true,
 		},
 		// match with path components
 		{
-			globUrl:       "*.kubernetes.io/blah",
-			targetUrl:     "prefix.kubernetes.io/blah",
+			globURL:       "*.kubernetes.io/blah",
+			targetURL:     "prefix.kubernetes.io/blah",
 			matchExpected: true,
 		},
 		{
-			globUrl:       "prefix.*.io/foo",
-			targetUrl:     "prefix.kubernetes.io/foo/bar",
+			globURL:       "prefix.*.io/foo",
+			targetURL:     "prefix.kubernetes.io/foo/bar",
 			matchExpected: true,
 		},
 		// match with path components and ports
 		{
-			globUrl:       "*.kubernetes.io:1111/blah",
-			targetUrl:     "prefix.kubernetes.io:1111/blah",
+			globURL:       "*.kubernetes.io:1111/blah",
+			targetURL:     "prefix.kubernetes.io:1111/blah",
 			matchExpected: true,
 		},
 		{
-			globUrl:       "prefix.*.io:1111/foo",
-			targetUrl:     "prefix.kubernetes.io:1111/foo/bar",
+			globURL:       "prefix.*.io:1111/foo",
+			targetURL:     "prefix.kubernetes.io:1111/foo/bar",
 			matchExpected: true,
 		},
 		// no match when number of parts mismatch
 		{
-			globUrl:       "*.kubernetes.io",
-			targetUrl:     "kubernetes.io",
+			globURL:       "*.kubernetes.io",
+			targetURL:     "kubernetes.io",
 			matchExpected: false,
 		},
 		{
-			globUrl:       "*.*.kubernetes.io",
-			targetUrl:     "prefix.kubernetes.io",
+			globURL:       "*.*.kubernetes.io",
+			targetURL:     "prefix.kubernetes.io",
 			matchExpected: false,
 		},
 		{
-			globUrl:       "*.*.kubernetes.io",
-			targetUrl:     "kubernetes.io",
+			globURL:       "*.*.kubernetes.io",
+			targetURL:     "kubernetes.io",
 			matchExpected: false,
 		},
 		// no match when some parts mismatch
 		{
-			globUrl:       "kubernetes.io",
-			targetUrl:     "kubernetes.com",
+			globURL:       "kubernetes.io",
+			targetURL:     "kubernetes.com",
 			matchExpected: false,
 		},
 		{
-			globUrl:       "k*.io",
-			targetUrl:     "quay.io",
+			globURL:       "k*.io",
+			targetURL:     "quay.io",
 			matchExpected: false,
 		},
 		// no match when ports mismatch
 		{
-			globUrl:       "*.kubernetes.io:1234/blah",
-			targetUrl:     "prefix.kubernetes.io:1111/blah",
+			globURL:       "*.kubernetes.io:1234/blah",
+			targetURL:     "prefix.kubernetes.io:1111/blah",
 			matchExpected: false,
 		},
 		{
-			globUrl:       "prefix.*.io/foo",
-			targetUrl:     "prefix.kubernetes.io:1111/foo/bar",
+			globURL:       "prefix.*.io/foo",
+			targetURL:     "prefix.kubernetes.io:1111/foo/bar",
 			matchExpected: false,
 		},
 	}
 	for _, test := range tests {
-		matched, _ := urlsMatchStr(test.globUrl, test.targetUrl)
+		matched, _ := urlsMatchStr(test.globURL, test.targetURL)
 		if matched != test.matchExpected {
 			t.Errorf("Expected match result of %s and %s to be %t, but was %t",
-				test.globUrl, test.targetUrl, test.matchExpected, matched)
+				test.globURL, test.targetURL, test.matchExpected, matched)
 		}
 	}
 }
 
 func TestDockerKeyringForGlob(t *testing.T) {
 	tests := []struct {
-		globUrl   string
-		targetUrl string
+		globURL   string
+		targetURL string
 	}{
 		{
-			globUrl:   "https://hello.kubernetes.io",
-			targetUrl: "hello.kubernetes.io",
+			globURL:   "https://hello.kubernetes.io",
+			targetURL: "hello.kubernetes.io",
 		},
 		{
-			globUrl:   "https://*.docker.io",
-			targetUrl: "prefix.docker.io",
+			globURL:   "https://*.docker.io",
+			targetURL: "prefix.docker.io",
 		},
 		{
-			globUrl:   "https://prefix.*.io",
-			targetUrl: "prefix.docker.io",
+			globURL:   "https://prefix.*.io",
+			targetURL: "prefix.docker.io",
 		},
 		{
-			globUrl:   "https://prefix.docker.*",
-			targetUrl: "prefix.docker.io",
+			globURL:   "https://prefix.docker.*",
+			targetURL: "prefix.docker.io",
 		},
 		{
-			globUrl:   "https://*.docker.io/path",
-			targetUrl: "prefix.docker.io/path",
+			globURL:   "https://*.docker.io/path",
+			targetURL: "prefix.docker.io/path",
 		},
 		{
-			globUrl:   "https://prefix.*.io/path",
-			targetUrl: "prefix.docker.io/path/subpath",
+			globURL:   "https://prefix.*.io/path",
+			targetURL: "prefix.docker.io/path/subpath",
 		},
 		{
-			globUrl:   "https://prefix.docker.*/path",
-			targetUrl: "prefix.docker.io/path",
+			globURL:   "https://prefix.docker.*/path",
+			targetURL: "prefix.docker.io/path",
 		},
 		{
-			globUrl:   "https://*.docker.io:8888",
-			targetUrl: "prefix.docker.io:8888",
+			globURL:   "https://*.docker.io:8888",
+			targetURL: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "https://prefix.*.io:8888",
-			targetUrl: "prefix.docker.io:8888",
+			globURL:   "https://prefix.*.io:8888",
+			targetURL: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "https://prefix.docker.*:8888",
-			targetUrl: "prefix.docker.io:8888",
+			globURL:   "https://prefix.docker.*:8888",
+			targetURL: "prefix.docker.io:8888",
 		},
 		{
-			globUrl:   "https://*.docker.io/path:1111",
-			targetUrl: "prefix.docker.io/path:1111",
+			globURL:   "https://*.docker.io/path:1111",
+			targetURL: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "https://*.docker.io/v1/",
-			targetUrl: "prefix.docker.io/path:1111",
+			globURL:   "https://*.docker.io/v1/",
+			targetURL: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "https://*.docker.io/v2/",
-			targetUrl: "prefix.docker.io/path:1111",
+			globURL:   "https://*.docker.io/v2/",
+			targetURL: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "https://prefix.docker.*/path:1111",
-			targetUrl: "prefix.docker.io/path:1111",
+			globURL:   "https://prefix.docker.*/path:1111",
+			targetURL: "prefix.docker.io/path:1111",
 		},
 		{
-			globUrl:   "prefix.docker.io:1111",
-			targetUrl: "prefix.docker.io:1111/path",
+			globURL:   "prefix.docker.io:1111",
+			targetURL: "prefix.docker.io:1111/path",
 		},
 		{
-			globUrl:   "*.docker.io:1111",
-			targetUrl: "prefix.docker.io:1111/path",
+			globURL:   "*.docker.io:1111",
+			targetURL: "prefix.docker.io:1111/path",
 		},
 	}
 	for i, test := range tests {
@@ -200,7 +200,7 @@ func TestDockerKeyringForGlob(t *testing.T) {
      "email": %q,
      "auth": %q
    }
-}`, test.globUrl, email, auth)
+}`, test.globURL, email, auth)
 
 		keyring := &BasicDockerKeyring{}
 		if cfg, err := readDockerConfigFileFromBytes([]byte(sampleDockerConfig)); err != nil {
@@ -209,9 +209,9 @@ func TestDockerKeyringForGlob(t *testing.T) {
 			keyring.Add(cfg)
 		}
 
-		creds, ok := keyring.Lookup(test.targetUrl + "/foo/bar")
+		creds, ok := keyring.Lookup(test.targetURL + "/foo/bar")
 		if !ok {
-			t.Errorf("%d: Didn't find expected URL: %s", i, test.targetUrl)
+			t.Errorf("%d: Didn't find expected URL: %s", i, test.targetURL)
 			continue
 		}
 		val := creds[0]
@@ -230,32 +230,32 @@ func TestDockerKeyringForGlob(t *testing.T) {
 
 func TestKeyringMiss(t *testing.T) {
 	tests := []struct {
-		globUrl   string
-		lookupUrl string
+		globURL   string
+		lookupURL string
 	}{
 		{
-			globUrl:   "https://hello.kubernetes.io",
-			lookupUrl: "world.mesos.org/foo/bar",
+			globURL:   "https://hello.kubernetes.io",
+			lookupURL: "world.mesos.org/foo/bar",
 		},
 		{
-			globUrl:   "https://*.docker.com",
-			lookupUrl: "prefix.docker.io",
+			globURL:   "https://*.docker.com",
+			lookupURL: "prefix.docker.io",
 		},
 		{
-			globUrl:   "https://suffix.*.io",
-			lookupUrl: "prefix.docker.io",
+			globURL:   "https://suffix.*.io",
+			lookupURL: "prefix.docker.io",
 		},
 		{
-			globUrl:   "https://prefix.docker.c*",
-			lookupUrl: "prefix.docker.io",
+			globURL:   "https://prefix.docker.c*",
+			lookupURL: "prefix.docker.io",
 		},
 		{
-			globUrl:   "https://prefix.*.io/path:1111",
-			lookupUrl: "prefix.docker.io/path/subpath:1111",
+			globURL:   "https://prefix.*.io/path:1111",
+			lookupURL: "prefix.docker.io/path/subpath:1111",
 		},
 		{
-			globUrl:   "suffix.*.io",
-			lookupUrl: "prefix.docker.io",
+			globURL:   "suffix.*.io",
+			lookupURL: "prefix.docker.io",
 		},
 	}
 	for _, test := range tests {
@@ -268,7 +268,7 @@ func TestKeyringMiss(t *testing.T) {
      "email": %q,
      "auth": %q
    }
-}`, test.globUrl, email, auth)
+}`, test.globURL, email, auth)
 
 		keyring := &BasicDockerKeyring{}
 		if cfg, err := readDockerConfigFileFromBytes([]byte(sampleDockerConfig)); err != nil {
@@ -277,9 +277,9 @@ func TestKeyringMiss(t *testing.T) {
 			keyring.Add(cfg)
 		}
 
-		_, ok := keyring.Lookup(test.lookupUrl + "/foo/bar")
+		_, ok := keyring.Lookup(test.lookupURL + "/foo/bar")
 		if ok {
-			t.Errorf("Expected not to find URL %s, but found", test.lookupUrl)
+			t.Errorf("Expected not to find URL %s, but found", test.lookupURL)
 		}
 	}
 

--- a/pkg/credentialprovider/secrets/secrets.go
+++ b/pkg/credentialprovider/secrets/secrets.go
@@ -30,7 +30,7 @@ func MakeDockerKeyring(passedSecrets []v1.Secret, defaultKeyring credentialprovi
 	passedCredentials := []credentialprovider.DockerConfig{}
 	for _, passedSecret := range passedSecrets {
 		if dockerConfigJSONBytes, dockerConfigJSONExists := passedSecret.Data[v1.DockerConfigJsonKey]; (passedSecret.Type == v1.SecretTypeDockerConfigJson) && dockerConfigJSONExists && (len(dockerConfigJSONBytes) > 0) {
-			dockerConfigJSON := credentialprovider.DockerConfigJson{}
+			dockerConfigJSON := credentialprovider.DockerConfigJSON{}
 			if err := json.Unmarshal(dockerConfigJSONBytes, &dockerConfigJSON); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This fixes golint errors in the following file:

```
Errors from golint:
pkg/credentialprovider/config.go:41:6: type DockerConfigJson should be DockerConfigJSON
pkg/credentialprovider/config.go:44:2: struct field HttpHeaders should be HTTPHeaders
pkg/credentialprovider/config.go:52:6: exported type DockerConfigEntry should have comment or be unexported
pkg/credentialprovider/config.go:65:2: var homeJsonDirPath should be homeJSONDirPath
pkg/credentialprovider/config.go:66:2: var rootJsonDirPath should be rootJSONDirPath
pkg/credentialprovider/config.go:69:2: var configJsonFileName should be configJSONFileName
pkg/credentialprovider/config.go:72:1: exported function SetPreferredDockercfgPath should have comment or be unexported
pkg/credentialprovider/config.go:78:1: exported function GetPreferredDockercfgPath should have comment or be unexported
pkg/credentialprovider/config.go:153:6: func ReadSpecificDockerConfigJsonFile should be ReadSpecificDockerConfigJSONFile
pkg/credentialprovider/config.go:162:1: exported function ReadDockerConfigFile should have comment or be unexported
pkg/credentialprovider/config.go:171:6: type HttpError should be HTTPError
pkg/credentialprovider/config.go:173:2: struct field Url should be URL
pkg/credentialprovider/config.go:182:1: exported function ReadUrl should have comment or be unexported
pkg/credentialprovider/config.go:182:6: func ReadUrl should be ReadURL
pkg/credentialprovider/config.go:217:1: exported function ReadDockerConfigFileFromUrl should have comment or be unexported
pkg/credentialprovider/config.go:217:6: func ReadDockerConfigFileFromUrl should be ReadDockerConfigFileFromURL
pkg/credentialprovider/config.go:220:9: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/credentialprovider/config.go:233:6: func readDockerConfigJsonFileFromBytes should be readDockerConfigJSONFileFromBytes
pkg/credentialprovider/config.go:234:6: var cfgJson should be cfgJSON
pkg/credentialprovider/config.go:256:1: exported method DockerConfigEntry.UnmarshalJSON should have comment or be unexported
pkg/credentialprovider/config.go:275:1: exported method DockerConfigEntry.MarshalJSON should have comment or be unexported
pkg/credentialprovider/config_test.go:30:2: var configJsonFileName should be configJSONFileName
pkg/credentialprovider/config_test.go:34:2: var inputDockerconfigJsonFile should be inputDockerconfigJSONFile
pkg/credentialprovider/keyring.go:76:1: exported method BasicDockerKeyring.Add should have comment or be unexported
pkg/credentialprovider/keyring.go:162:6: func parseSchemelessUrl should be parseSchemelessURL
pkg/credentialprovider/keyring.go:162:25: func parameter schemelessUrl should be schemelessURL
pkg/credentialprovider/keyring.go:173:6: func splitUrl should be splitURL
pkg/credentialprovider/keyring.go:184:2: var globUrl should be globURL
pkg/credentialprovider/keyring.go:188:2: var targetUrl should be targetURL
pkg/credentialprovider/keyring.go:203:16: func parameter globUrl should be globURL
pkg/credentialprovider/keyring.go:203:34: func parameter targetUrl should be targetURL
pkg/credentialprovider/keyring.go:204:2: var globUrlParts should be globURLParts
pkg/credentialprovider/keyring.go:205:2: var targetUrlParts should be targetURLParts
pkg/credentialprovider/keyring.go:218:9: range var globUrlPart should be globURLPart
pkg/credentialprovider/keyring.go:219:3: var targetUrlPart should be targetURLPart
pkg/credentialprovider/keyring.go:273:6: exported type FakeKeyring should have comment or be unexported
pkg/credentialprovider/keyring.go:278:1: exported method FakeKeyring.Lookup should have comment or be unexported
pkg/credentialprovider/keyring.go:285:1: exported method UnionDockerKeyring.Lookup should have comment or be unexported
pkg/credentialprovider/keyring_test.go:28:3: struct field globUrl should be globURL
pkg/credentialprovider/keyring_test.go:29:3: struct field targetUrl should be targetURL
pkg/credentialprovider/keyring_test.go:125:3: struct field globUrl should be globURL
pkg/credentialprovider/keyring_test.go:126:3: struct field targetUrl should be targetURL
pkg/credentialprovider/keyring_test.go:233:3: struct field globUrl should be globURL
pkg/credentialprovider/keyring_test.go:234:3: struct field lookupUrl should be lookupURL


```
**Which issue(s) this PR fixes**:

Ref #68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```