### PR TITLE
Use versioned autoscaling API in code-generator examples

### DIFF
--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/apis/example/v1/types.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/apis/example/v1/types.go
@@ -58,8 +58,8 @@ type ClusterTestTypeList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
-// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/kubernetes/pkg/apis/autoscaling.Scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 
 type ClusterTestType struct {
 	metav1.TypeMeta `json:",inline"`

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/BUILD
@@ -13,7 +13,7 @@ go_library(
     importpath = "k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"time"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/HyphenGroup/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/scheme"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 // ClusterTestTypesGetter has a method to return a ClusterTestTypeInterface.
@@ -48,8 +48,8 @@ type ClusterTestTypeInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterTestType, err error)
-	GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscaling.Scale, error)
-	UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts metav1.UpdateOptions) (*autoscaling.Scale, error)
+	GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error)
 
 	ClusterTestTypeExpansion
 }
@@ -187,9 +187,9 @@ func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.Patc
 	return
 }
 
-// GetScale takes name of the clusterTestType, and returns the corresponding autoscaling.Scale object, and an error if there is any.
-func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscaling.Scale, err error) {
-	result = &autoscaling.Scale{}
+// GetScale takes name of the clusterTestType, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
+func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
@@ -201,8 +201,8 @@ func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName str
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts metav1.UpdateOptions) (result *autoscaling.Scale, err error) {
-	result = &autoscaling.Scale{}
+func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/BUILD
@@ -12,7 +12,7 @@ go_library(
     importpath = "k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -21,6 +21,7 @@ package fake
 import (
 	"context"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,7 +29,6 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 	examplev1 "k8s.io/code-generator/_examples/HyphenGroup/apis/example/v1"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 // FakeClusterTestTypes implements ClusterTestTypeInterface
@@ -134,21 +134,21 @@ func (c *FakeClusterTestTypes) Patch(ctx context.Context, name string, pt types.
 }
 
 // GetScale takes name of the clusterTestType, and returns the corresponding scale object, and an error if there is any.
-func (c *FakeClusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options v1.GetOptions) (result *autoscaling.Scale, err error) {
+func (c *FakeClusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetSubresourceAction(clustertesttypesResource, "scale", clusterTestTypeName), &autoscaling.Scale{})
+		Invokes(testing.NewRootGetSubresourceAction(clustertesttypesResource, "scale", clusterTestTypeName), &autoscalingv1.Scale{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*autoscaling.Scale), err
+	return obj.(*autoscalingv1.Scale), err
 }
 
 // UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *FakeClusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts v1.UpdateOptions) (result *autoscaling.Scale, err error) {
+func (c *FakeClusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts v1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(clustertesttypesResource, "scale", scale), &autoscaling.Scale{})
+		Invokes(testing.NewRootUpdateSubresourceAction(clustertesttypesResource, "scale", scale), &autoscalingv1.Scale{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*autoscaling.Scale), err
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/apis/example/v1/types.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/apis/example/v1/types.go
@@ -58,8 +58,8 @@ type ClusterTestTypeList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
-// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/kubernetes/pkg/apis/autoscaling.Scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 
 type ClusterTestType struct {
 	metav1.TypeMeta `json:",inline"`

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/BUILD
@@ -13,7 +13,7 @@ go_library(
     importpath = "k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"time"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/MixedCase/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/MixedCase/clientset/versioned/scheme"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 // ClusterTestTypesGetter has a method to return a ClusterTestTypeInterface.
@@ -48,8 +48,8 @@ type ClusterTestTypeInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterTestType, err error)
-	GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscaling.Scale, error)
-	UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts metav1.UpdateOptions) (*autoscaling.Scale, error)
+	GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error)
 
 	ClusterTestTypeExpansion
 }
@@ -187,9 +187,9 @@ func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.Patc
 	return
 }
 
-// GetScale takes name of the clusterTestType, and returns the corresponding autoscaling.Scale object, and an error if there is any.
-func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscaling.Scale, err error) {
-	result = &autoscaling.Scale{}
+// GetScale takes name of the clusterTestType, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
+func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
@@ -201,8 +201,8 @@ func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName str
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts metav1.UpdateOptions) (result *autoscaling.Scale, err error) {
-	result = &autoscaling.Scale{}
+func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/BUILD
@@ -12,7 +12,7 @@ go_library(
     importpath = "k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -21,6 +21,7 @@ package fake
 import (
 	"context"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,7 +29,6 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 	examplev1 "k8s.io/code-generator/_examples/MixedCase/apis/example/v1"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 // FakeClusterTestTypes implements ClusterTestTypeInterface
@@ -134,21 +134,21 @@ func (c *FakeClusterTestTypes) Patch(ctx context.Context, name string, pt types.
 }
 
 // GetScale takes name of the clusterTestType, and returns the corresponding scale object, and an error if there is any.
-func (c *FakeClusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options v1.GetOptions) (result *autoscaling.Scale, err error) {
+func (c *FakeClusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetSubresourceAction(clustertesttypesResource, "scale", clusterTestTypeName), &autoscaling.Scale{})
+		Invokes(testing.NewRootGetSubresourceAction(clustertesttypesResource, "scale", clusterTestTypeName), &autoscalingv1.Scale{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*autoscaling.Scale), err
+	return obj.(*autoscalingv1.Scale), err
 }
 
 // UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *FakeClusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts v1.UpdateOptions) (result *autoscaling.Scale, err error) {
+func (c *FakeClusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts v1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(clustertesttypesResource, "scale", scale), &autoscaling.Scale{})
+		Invokes(testing.NewRootUpdateSubresourceAction(clustertesttypesResource, "scale", scale), &autoscalingv1.Scale{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*autoscaling.Scale), err
+	return obj.(*autoscalingv1.Scale), err
 }

--- a/staging/src/k8s.io/code-generator/_examples/crd/apis/example/v1/types.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/apis/example/v1/types.go
@@ -58,8 +58,8 @@ type ClusterTestTypeList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
-// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/kubernetes/pkg/apis/autoscaling.Scale,result=k8s.io/kubernetes/pkg/apis/autoscaling.Scale
+// +genclient:method=GetScale,verb=get,subresource=scale,result=k8s.io/api/autoscaling/v1.Scale
+// +genclient:method=UpdateScale,verb=update,subresource=scale,input=k8s.io/api/autoscaling/v1.Scale,result=k8s.io/api/autoscaling/v1.Scale
 
 type ClusterTestType struct {
 	metav1.TypeMeta `json:",inline"`

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/BUILD
@@ -13,7 +13,7 @@ go_library(
     importpath = "k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/clustertesttype.go
@@ -22,13 +22,13 @@ import (
 	"context"
 	"time"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"
 	rest "k8s.io/client-go/rest"
 	v1 "k8s.io/code-generator/_examples/crd/apis/example/v1"
 	scheme "k8s.io/code-generator/_examples/crd/clientset/versioned/scheme"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 // ClusterTestTypesGetter has a method to return a ClusterTestTypeInterface.
@@ -48,8 +48,8 @@ type ClusterTestTypeInterface interface {
 	List(ctx context.Context, opts metav1.ListOptions) (*v1.ClusterTestTypeList, error)
 	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
 	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (result *v1.ClusterTestType, err error)
-	GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscaling.Scale, error)
-	UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts metav1.UpdateOptions) (*autoscaling.Scale, error)
+	GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (*autoscalingv1.Scale, error)
+	UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (*autoscalingv1.Scale, error)
 
 	ClusterTestTypeExpansion
 }
@@ -187,9 +187,9 @@ func (c *clusterTestTypes) Patch(ctx context.Context, name string, pt types.Patc
 	return
 }
 
-// GetScale takes name of the clusterTestType, and returns the corresponding autoscaling.Scale object, and an error if there is any.
-func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscaling.Scale, err error) {
-	result = &autoscaling.Scale{}
+// GetScale takes name of the clusterTestType, and returns the corresponding autoscalingv1.Scale object, and an error if there is any.
+func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options metav1.GetOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
 	err = c.client.Get().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).
@@ -201,8 +201,8 @@ func (c *clusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName str
 }
 
 // UpdateScale takes the top resource name and the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts metav1.UpdateOptions) (result *autoscaling.Scale, err error) {
-	result = &autoscaling.Scale{}
+func (c *clusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts metav1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
+	result = &autoscalingv1.Scale{}
 	err = c.client.Put().
 		Resource("clustertesttypes").
 		Name(clusterTestTypeName).

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/BUILD
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/BUILD
@@ -12,7 +12,7 @@ go_library(
     importpath = "k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/autoscaling:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/clientset/versioned/typed/example/v1/fake/fake_clustertesttype.go
@@ -21,6 +21,7 @@ package fake
 import (
 	"context"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
@@ -28,7 +29,6 @@ import (
 	watch "k8s.io/apimachinery/pkg/watch"
 	testing "k8s.io/client-go/testing"
 	examplev1 "k8s.io/code-generator/_examples/crd/apis/example/v1"
-	autoscaling "k8s.io/kubernetes/pkg/apis/autoscaling"
 )
 
 // FakeClusterTestTypes implements ClusterTestTypeInterface
@@ -134,21 +134,21 @@ func (c *FakeClusterTestTypes) Patch(ctx context.Context, name string, pt types.
 }
 
 // GetScale takes name of the clusterTestType, and returns the corresponding scale object, and an error if there is any.
-func (c *FakeClusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options v1.GetOptions) (result *autoscaling.Scale, err error) {
+func (c *FakeClusterTestTypes) GetScale(ctx context.Context, clusterTestTypeName string, options v1.GetOptions) (result *autoscalingv1.Scale, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootGetSubresourceAction(clustertesttypesResource, "scale", clusterTestTypeName), &autoscaling.Scale{})
+		Invokes(testing.NewRootGetSubresourceAction(clustertesttypesResource, "scale", clusterTestTypeName), &autoscalingv1.Scale{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*autoscaling.Scale), err
+	return obj.(*autoscalingv1.Scale), err
 }
 
 // UpdateScale takes the representation of a scale and updates it. Returns the server's representation of the scale, and an error, if there is any.
-func (c *FakeClusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscaling.Scale, opts v1.UpdateOptions) (result *autoscaling.Scale, err error) {
+func (c *FakeClusterTestTypes) UpdateScale(ctx context.Context, clusterTestTypeName string, scale *autoscalingv1.Scale, opts v1.UpdateOptions) (result *autoscalingv1.Scale, err error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewRootUpdateSubresourceAction(clustertesttypesResource, "scale", scale), &autoscaling.Scale{})
+		Invokes(testing.NewRootUpdateSubresourceAction(clustertesttypesResource, "scale", scale), &autoscalingv1.Scale{})
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*autoscaling.Scale), err
+	return obj.(*autoscalingv1.Scale), err
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Staging repos should not import `k8s.io/kubernetes`, and these types should be referring to versioned APIs instead of internal.

```release-note
NONE
```

/priority important-soon
/sig api-machinery
/assign @liggitt 