### PR TITLE
Add cheftako as an owner of cluster/

### DIFF
--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -5,12 +5,14 @@ reviewers:
   - justaugustus
   - Katharine
   - mikedanese
+  - cheftako
   - dims
 approvers:
   - bentheelder
   - mikedanese
   - spiffxp
   - dims
+  - cheftako
 emeritus_approvers:
   - eparis
   - roberthbailey   # 2019-03-08


### PR DESCRIPTION
Because Walter (@cheftako) is the co-leader of the cloud-provider and is leading the effort of cloud provider extraction.

/assign @BenTheElder 