### PR TITLE
Move TestWatcherStart to integration tests

### DIFF
--- a/pkg/kubelet/oom/oom_watcher_linux_test.go
+++ b/pkg/kubelet/oom/oom_watcher_linux_test.go
@@ -38,17 +38,6 @@ func (fs *fakeStreamer) StreamOoms(outStream chan<- *oomparser.OomInstance) {
 	}
 }
 
-// TestStartingWatcher tests that the watcher, using the actual streamer
-// and not the fake, starts successfully.
-func TestStartingWatcher(t *testing.T) {
-	fakeRecorder := &record.FakeRecorder{}
-	node := &v1.ObjectReference{}
-
-	oomWatcher, err := NewWatcher(fakeRecorder)
-	assert.NoError(t, err)
-	assert.NoError(t, oomWatcher.Start(node))
-}
-
 // TestWatcherRecordsEventsForOomEvents ensures that our OomInstances coming
 // from `StreamOoms` are translated into events in our recorder.
 func TestWatcherRecordsEventsForOomEvents(t *testing.T) {

--- a/test/integration/kubelet/BUILD
+++ b/test/integration/kubelet/BUILD
@@ -4,12 +4,14 @@ go_test(
     name = "go_default_test",
     srcs = [
         "main_test.go",
+        "oom_watcher_test.go",
         "watch_manager_test.go",
     ],
     rundir = ".",
     tags = ["integration"],
     deps = [
         "//cmd/kube-apiserver/app/testing:go_default_library",
+        "//pkg/kubelet/oom:go_default_library",
         "//pkg/kubelet/util/manager:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -18,7 +20,9 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
+        "//staging/src/k8s.io/client-go/tools/record:go_default_library",
         "//test/integration/framework:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )
 

--- a/test/integration/kubelet/oom_watcher_test.go
+++ b/test/integration/kubelet/oom_watcher_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubelet
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/kubernetes/pkg/kubelet/oom"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestStartingWatcher tests that the watcher, using the actual streamer
+// and not the fake, starts successfully.
+func TestStartingWatcher(t *testing.T) {
+	fakeRecorder := &record.FakeRecorder{}
+	node := &v1.ObjectReference{}
+
+	oomWatcher, err := oom.NewWatcher(fakeRecorder)
+	assert.NoError(t, err)
+	assert.NoError(t, oomWatcher.Start(node))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Moves the test `TestStartingWatcher` from unit tests to integration tests. `TestStartingWatcher` depends on the system it runs on having a `/dev/kmsg`, which is not necessarily true — for instance, in an unprivileged container there is no such file. It is the only unit test to make an assumption along those lines

Given the purpose of the test is just to test whether a real watcher (which attempts to interact with the system) can be started, I think this reasonably qualifies as an integration test, rather than a test to be worked around by the environments the test runs in.

See e.g. [this test run](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-kubernetes-cached-make-test/1235664579724316673) for a failing test in an unprivileged container.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig node
/sig testing
/priority important-soon
/assign @mattjmcnaughton 