### PR TITLE
Adding a temporary fix for kubectl get output e2e test

### DIFF
--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -434,6 +434,9 @@ var _ = SIGDescribe("Kubectl client", func() {
 				// ignored for being disruptive in an e2e, and getting automatically deleted by a controller
 				"Node": true,
 
+				// ignored due to skew test - fixed in 1.18+ by #88966
+				"IngressClass": true,
+
 				// ignored temporarily while waiting for bug fix.
 				"ComponentStatus":    true,
 				"ClusterRoleBinding": true,


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
When running older e2e tests against a newer Kubernetes release, any new API resources would result in errors due to a lack of test data in the older tests. This temporarily disables the test for the new IngressClass resource until we can find a better approach here. This will only fix the root issue for the skew tests if this fix is also cherry picked into 1.17.

**Which issue(s) this PR fixes**:
Fixes #88335

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cli
/priority critical-urgent
/cc @soltysh 
/assign @alejandrox1 @BenTheElder 