### PR TITLE
Improve kubectl field manager names for clearer conflicts

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/annotate/annotate.go
@@ -55,6 +55,7 @@ type AnnotateOptions struct {
 	local           bool
 	dryRunStrategy  cmdutil.DryRunStrategy
 	dryRunVerifier  *resource.DryRunVerifier
+	fieldManager    string
 	all             bool
 	resourceVersion string
 	selector        string
@@ -150,6 +151,7 @@ func NewCmdAnnotate(parent string, f cmdutil.Factory, ioStreams genericclioption
 	usage := "identifying the resource to update the annotation"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-annotate")
 
 	return cmd
 }
@@ -329,7 +331,8 @@ func (o AnnotateOptions) RunAnnotate() error {
 			}
 			helper := resource.
 				NewHelper(client, mapping).
-				DryRun(o.dryRunStrategy == cmdutil.DryRunServer)
+				DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+				WithFieldManager(o.fieldManager)
 
 			if createdPatch {
 				outputObj, err = helper.Patch(namespace, name, types.MergePatchType, patchBytes, nil)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_edit_last_applied.go
@@ -83,6 +83,7 @@ func NewCmdApplyEditLastApplied(f cmdutil.Factory, ioStreams genericclioptions.I
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
 	cmd.Flags().BoolVar(&o.WindowsLineEndings, "windows-line-endings", o.WindowsLineEndings,
 		"Defaults to the line ending native to your platform.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, FieldManagerClientSideApply)
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -82,7 +82,7 @@ func newPatcher(o *ApplyOptions, info *resource.Info) (*Patcher, error) {
 
 	return &Patcher{
 		Mapping:       info.Mapping,
-		Helper:        resource.NewHelper(info.Client, info.Mapping),
+		Helper:        resource.NewHelper(info.Client, info.Mapping).WithFieldManager(o.FieldManager),
 		DynamicClient: o.DynamicClient,
 		Overwrite:     o.Overwrite,
 		BackOff:       clockwork.NewRealClock(),

--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -79,6 +79,7 @@ type AutoscaleOptions struct {
 	dryRunVerifier   *resource.DryRunVerifier
 	builder          *resource.Builder
 	generatorFunc    func(string, *meta.RESTMapping) (generate.StructuredGenerator, error)
+	fieldManager     string
 
 	HPAClient         autoscalingv1client.HorizontalPodAutoscalersGetter
 	scaleKindResolver scale.ScaleKindResolver
@@ -131,6 +132,7 @@ func NewCmdAutoscale(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddFilenameOptionFlags(cmd, o.FilenameOptions, "identifying the resource to autoscale.")
 	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-autoscale")
 	return cmd
 }
 
@@ -272,6 +274,9 @@ func (o *AutoscaleOptions) Run() error {
 		}
 
 		createOptions := metav1.CreateOptions{}
+		if o.fieldManager != "" {
+			createOptions.FieldManager = o.fieldManager
+		}
 		if o.dryRunStrategy == cmdutil.DryRunServer {
 			if err := o.dryRunVerifier.HasSupport(hpa.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -54,6 +54,8 @@ type CreateOptions struct {
 	DryRunStrategy cmdutil.DryRunStrategy
 	DryRunVerifier *resource.DryRunVerifier
 
+	fieldManager string
+
 	FilenameOptions  resource.FilenameOptions
 	Selector         string
 	EditBeforeCreate bool
@@ -130,6 +132,7 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to POST to the server.  Uses the transport specified by the kubeconfig file.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-create")
 
 	o.PrintFlags.AddFlags(cmd)
 
@@ -233,7 +236,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 	}
 
 	if o.EditBeforeCreate {
-		return RunEditOnCreate(f, o.PrintFlags, o.RecordFlags, o.IOStreams, cmd, &o.FilenameOptions)
+		return RunEditOnCreate(f, o.PrintFlags, o.RecordFlags, o.IOStreams, cmd, &o.FilenameOptions, o.fieldManager)
 	}
 	schema, err := f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 	if err != nil {
@@ -281,6 +284,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 			obj, err := resource.
 				NewHelper(info.Client, info.Mapping).
 				DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+				WithFieldManager(o.fieldManager).
 				Create(info.Namespace, true, info.Object)
 			if err != nil {
 				return cmdutil.AddSourceToErr("creating", info.Source, err)
@@ -302,7 +306,7 @@ func (o *CreateOptions) RunCreate(f cmdutil.Factory, cmd *cobra.Command) error {
 }
 
 // RunEditOnCreate performs edit on creation
-func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags, recordFlags *genericclioptions.RecordFlags, ioStreams genericclioptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions) error {
+func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags, recordFlags *genericclioptions.RecordFlags, ioStreams genericclioptions.IOStreams, cmd *cobra.Command, options *resource.FilenameOptions, fieldManager string) error {
 	editOptions := editor.NewEditOptions(editor.EditBeforeCreateMode, ioStreams)
 	editOptions.FilenameOptions = *options
 	editOptions.ValidateOptions = cmdutil.ValidateOptions{
@@ -311,6 +315,7 @@ func RunEditOnCreate(f cmdutil.Factory, printFlags *genericclioptions.PrintFlags
 	editOptions.PrintFlags = printFlags
 	editOptions.ApplyAnnotation = cmdutil.GetFlagBool(cmd, cmdutil.ApplyAnnotationsFlag)
 	editOptions.RecordFlags = recordFlags
+	editOptions.FieldManager = "kubectl-create"
 
 	err := editOptions.Complete(f, []string{}, cmd)
 	if err != nil {
@@ -343,6 +348,7 @@ type CreateSubcommandOptions struct {
 	DryRunStrategy      cmdutil.DryRunStrategy
 	DryRunVerifier      *resource.DryRunVerifier
 	CreateAnnotation    bool
+	FieldManager        string
 
 	Namespace        string
 	EnforceNamespace bool
@@ -446,6 +452,9 @@ func (o *CreateSubcommandOptions) Run() error {
 			o.Namespace = ""
 		}
 		createOptions := metav1.CreateOptions{}
+		if o.FieldManager != "" {
+			createOptions.FieldManager = o.FieldManager
+		}
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(mapping.GroupVersionKind); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrole.go
@@ -64,6 +64,7 @@ type CreateClusterRoleOptions struct {
 	*CreateRoleOptions
 	NonResourceURLs []string
 	AggregationRule map[string]string
+	FieldManager    string
 }
 
 // NewCmdCreateClusterRole initializes and returns new ClusterRoles command
@@ -95,6 +96,7 @@ func NewCmdCreateClusterRole(f cmdutil.Factory, ioStreams genericclioptions.IOSt
 	cmd.Flags().StringSlice("resource", []string{}, "Resource that the rule applies to")
 	cmd.Flags().StringArrayVar(&c.ResourceNames, "resource-name", c.ResourceNames, "Resource in the white list that the rule applies to, repeat this flag for multiple items")
 	cmd.Flags().Var(cliflag.NewMapStringString(&c.AggregationRule), "aggregation-rule", "An aggregation label selector for combining ClusterRoles.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &c.FieldManager, "kubectl-create")
 
 	return cmd
 }
@@ -202,6 +204,9 @@ func (c *CreateClusterRoleOptions) RunCreateRole() error {
 	// Create ClusterRole.
 	if c.DryRunStrategy != cmdutil.DryRunClient {
 		createOptions := metav1.CreateOptions{}
+		if c.FieldManager != "" {
+			createOptions.FieldManager = c.FieldManager
+		}
 		if c.DryRunStrategy == cmdutil.DryRunServer {
 			if err := c.DryRunVerifier.HasSupport(clusterRole.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_clusterrolebinding.go
@@ -69,6 +69,7 @@ func NewCmdCreateClusterRoleBinding(f cmdutil.Factory, ioStreams genericclioptio
 	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the clusterrole")
 	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the clusterrole")
 	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the clusterrole, in the format <namespace>:<name>")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_configmap.go
@@ -90,6 +90,7 @@ func NewCmdCreateConfigMap(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	cmd.Flags().StringArray("from-literal", []string{}, "Specify a key and literal value to insert in configmap (i.e. mykey=somevalue)")
 	cmd.Flags().String("from-env-file", "", "Specify the path to a file to read lines of key=val pairs to create a configmap (i.e. a Docker .env file).")
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the configmap to its name.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -66,6 +66,7 @@ type CreateCronJobOptions struct {
 	DryRunStrategy cmdutil.DryRunStrategy
 	DryRunVerifier *resource.DryRunVerifier
 	Builder        *resource.Builder
+	FieldManager   string
 
 	genericclioptions.IOStreams
 }
@@ -101,6 +102,7 @@ func NewCmdCreateCronJob(f cmdutil.Factory, ioStreams genericclioptions.IOStream
 	cmd.Flags().StringVar(&o.Image, "image", o.Image, "Image name to run.")
 	cmd.Flags().StringVar(&o.Schedule, "schedule", o.Schedule, "A schedule in the Cron format the job should be run with.")
 	cmd.Flags().StringVar(&o.Restart, "restart", o.Restart, "job's restart policy. supported values: OnFailure, Never")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 
 	return cmd
 }
@@ -174,6 +176,9 @@ func (o *CreateCronJobOptions) Run() error {
 
 	if o.DryRunStrategy != cmdutil.DryRunClient {
 		createOptions := metav1.CreateOptions{}
+		if o.FieldManager != "" {
+			createOptions.FieldManager = o.FieldManager
+		}
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(cronjob.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -69,6 +69,7 @@ func NewCmdCreateDeployment(f cmdutil.Factory, ioStreams genericclioptions.IOStr
 	cmdutil.AddGeneratorFlags(cmd, "")
 	cmd.Flags().StringSlice("image", []string{}, "Image name to run.")
 	cmd.MarkFlagRequired("image")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -67,6 +67,7 @@ type CreateJobOptions struct {
 	DryRunStrategy cmdutil.DryRunStrategy
 	DryRunVerifier *resource.DryRunVerifier
 	Builder        *resource.Builder
+	FieldManager   string
 
 	genericclioptions.IOStreams
 }
@@ -101,7 +102,7 @@ func NewCmdCreateJob(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *
 	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringVar(&o.Image, "image", o.Image, "Image name to run.")
 	cmd.Flags().StringVar(&o.From, "from", o.From, "The name of the resource to create a Job from (only cronjob is supported).")
-
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	return cmd
 }
 
@@ -201,6 +202,9 @@ func (o *CreateJobOptions) Run() error {
 	}
 	if o.DryRunStrategy != cmdutil.DryRunClient {
 		createOptions := metav1.CreateOptions{}
+		if o.FieldManager != "" {
+			createOptions.FieldManager = o.FieldManager
+		}
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(job.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_namespace.go
@@ -65,6 +65,7 @@ func NewCmdCreateNamespace(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.NamespaceV1GeneratorName)
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pdb.go
@@ -74,6 +74,7 @@ func NewCmdCreatePodDisruptionBudget(f cmdutil.Factory, ioStreams genericcliopti
 	cmd.Flags().String("min-available", "", i18n.T("The minimum number or percentage of available pods this budget requires."))
 	cmd.Flags().String("max-unavailable", "", i18n.T("The maximum number or percentage of unavailable pods this budget requires."))
 	cmd.Flags().String("selector", "", i18n.T("A label selector to use for this budget. Only equality-based selector requirements are supported."))
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_priorityclass.go
@@ -77,6 +77,7 @@ func NewCmdCreatePriorityClass(f cmdutil.Factory, ioStreams genericclioptions.IO
 	cmd.Flags().Bool("global-default", false, i18n.T("global-default specifies whether this PriorityClass should be considered as the default priority."))
 	cmd.Flags().String("description", "", i18n.T("description is an arbitrary string that usually provides guidelines on when this priority class should be used."))
 	cmd.Flags().String("preemption-policy", "", i18n.T("preemption-policy is the policy for preempting pods with lower priority."))
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_quota.go
@@ -70,6 +70,7 @@ func NewCmdCreateQuota(f cmdutil.Factory, ioStreams genericclioptions.IOStreams)
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.ResourceQuotaV1GeneratorName)
 	cmd.Flags().String("hard", "", i18n.T("A comma-delimited set of resource=quantity pairs that define a hard limit."))
 	cmd.Flags().String("scopes", "", i18n.T("A comma-delimited set of quota scopes that must all match each object tracked by the quota."))
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -134,6 +134,7 @@ type CreateRoleOptions struct {
 	Client         clientgorbacv1.RbacV1Interface
 	Mapper         meta.RESTMapper
 	PrintObj       func(obj runtime.Object) error
+	FieldManager   string
 
 	genericclioptions.IOStreams
 }
@@ -172,7 +173,7 @@ func NewCmdCreateRole(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) 
 	cmd.Flags().StringSliceVar(&o.Verbs, "verb", o.Verbs, "Verb that applies to the resources contained in the rule")
 	cmd.Flags().StringSlice("resource", []string{}, "Resource that the rule applies to")
 	cmd.Flags().StringArrayVar(&o.ResourceNames, "resource-name", o.ResourceNames, "Resource in the white list that the rule applies to, repeat this flag for multiple items")
-
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-create")
 	return cmd
 }
 
@@ -355,6 +356,9 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 	// Create role.
 	if o.DryRunStrategy != cmdutil.DryRunClient {
 		createOptions := metav1.CreateOptions{}
+		if o.FieldManager != "" {
+			createOptions.FieldManager = o.FieldManager
+		}
 		if o.DryRunStrategy == cmdutil.DryRunServer {
 			if err := o.DryRunVerifier.HasSupport(role.GroupVersionKind()); err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_rolebinding.go
@@ -69,6 +69,7 @@ func NewCmdCreateRoleBinding(f cmdutil.Factory, ioStreams genericclioptions.IOSt
 	cmd.Flags().StringArray("user", []string{}, "Usernames to bind to the role")
 	cmd.Flags().StringArray("group", []string{}, "Groups to bind to the role")
 	cmd.Flags().StringArray("serviceaccount", []string{}, "Service accounts to bind to the role, in the format <namespace>:<name>")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_secret.go
@@ -106,6 +106,7 @@ func NewCmdCreateSecretGeneric(f cmdutil.Factory, ioStreams genericclioptions.IO
 	cmd.Flags().String("from-env-file", "", "Specify the path to a file to read lines of key=val pairs to create a secret (i.e. a Docker .env file).")
 	cmd.Flags().String("type", "", i18n.T("The type of secret to create"))
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 
@@ -196,6 +197,7 @@ func NewCmdCreateSecretDockerRegistry(f cmdutil.Factory, ioStreams genericcliopt
 	cmd.Flags().String("docker-server", "https://index.docker.io/v1/", i18n.T("Server location for Docker registry"))
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
 	cmd.Flags().StringSlice("from-file", []string{}, "Key files can be specified using their file path, in which case a default name will be given to them, or optionally with a name and file path, in which case the given name will be used.  Specifying a directory will iterate each named file in the directory that is a valid secret key.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 
 	return cmd
 }
@@ -284,6 +286,7 @@ func NewCmdCreateSecretTLS(f cmdutil.Factory, ioStreams genericclioptions.IOStre
 	cmd.Flags().String("cert", "", i18n.T("Path to PEM encoded public key certificate."))
 	cmd.Flags().String("key", "", i18n.T("Path to private key associated with given certificate."))
 	cmd.Flags().Bool("append-hash", false, "Append a hash of the secret to its name.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_service.go
@@ -19,7 +19,7 @@ package create
 import (
 	"github.com/spf13/cobra"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/generate"
@@ -91,6 +91,7 @@ func NewCmdCreateServiceClusterIP(f cmdutil.Factory, ioStreams genericclioptions
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceClusterIPGeneratorV1Name)
 	addPortFlags(cmd)
 	cmd.Flags().String("clusterip", "", i18n.T("Assign your own ClusterIP or set to 'None' for a 'headless' service (no loadbalancing)."))
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 
@@ -164,6 +165,7 @@ func NewCmdCreateServiceNodePort(f cmdutil.Factory, ioStreams genericclioptions.
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceNodePortGeneratorV1Name)
 	cmd.Flags().Int("node-port", 0, "Port used to expose the service on each node in a cluster.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	addPortFlags(cmd)
 	return cmd
 }
@@ -234,6 +236,7 @@ func NewCmdCreateServiceLoadBalancer(f cmdutil.Factory, ioStreams genericcliopti
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceLoadBalancerGeneratorV1Name)
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	addPortFlags(cmd)
 	return cmd
 }
@@ -310,6 +313,7 @@ func NewCmdCreateServiceExternalName(f cmdutil.Factory, ioStreams genericcliopti
 	addPortFlags(cmd)
 	cmd.Flags().String("external-name", "", i18n.T("External name of service"))
 	cmd.MarkFlagRequired("external-name")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_serviceaccount.go
@@ -65,6 +65,7 @@ func NewCmdCreateServiceAccount(f cmdutil.Factory, ioStreams genericclioptions.I
 	cmdutil.AddApplyAnnotationFlags(cmd)
 	cmdutil.AddValidateFlags(cmd)
 	cmdutil.AddGeneratorFlags(cmd, generateversioned.ServiceAccountV1GeneratorName)
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.CreateSubcommandOptions.FieldManager, "kubectl-create")
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/edit/edit.go
@@ -96,7 +96,7 @@ func NewCmdEdit(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra
 	cmd.Flags().BoolVarP(&o.OutputPatch, "output-patch", "", o.OutputPatch, "Output the patch if the resource is edited.")
 	cmd.Flags().BoolVar(&o.WindowsLineEndings, "windows-line-endings", o.WindowsLineEndings,
 		"Defaults to the line ending native to your platform.")
-
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.FieldManager, "kubectl-edit")
 	cmdutil.AddApplyAnnotationVarFlags(cmd, &o.ApplyAnnotation)
 	return cmd
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/expose/expose.go
@@ -91,6 +91,8 @@ type ExposeServiceOptions struct {
 	DryRunVerifier   *resource.DryRunVerifier
 	EnforceNamespace bool
 
+	fieldManager string
+
 	Generators                func(string) map[string]generate.Generator
 	CanBeExposed              polymorphichelpers.CanBeExposedFunc
 	MapBasedSelectorForObject func(runtime.Object) (string, error)
@@ -157,6 +159,7 @@ func NewCmdExposeService(f cmdutil.Factory, streams genericclioptions.IOStreams)
 	cmd.Flags().String("name", "", i18n.T("The name for the newly created object."))
 	cmd.Flags().String("session-affinity", "", i18n.T("If non-empty, set the session affinity for the service to this; legal values: 'None', 'ClientIP'"))
 	cmd.Flags().String("cluster-ip", "", i18n.T("ClusterIP to be assigned to the service. Leave empty to auto-allocate, or set to 'None' to create a headless service."))
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-expose")
 
 	usage := "identifying the resource to expose a service"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
@@ -363,6 +366,7 @@ func (o *ExposeServiceOptions) RunExpose(cmd *cobra.Command, args []string) erro
 		actualObject, err := resource.
 			NewHelper(client, objMapping).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Create(o.Namespace, false, asUnstructured)
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/label/label.go
@@ -62,6 +62,7 @@ type LabelOptions struct {
 	selector        string
 	fieldSelector   string
 	outputFormat    string
+	fieldManager    string
 
 	// results of arg parsing
 	resources    []string
@@ -150,6 +151,7 @@ func NewCmdLabel(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	usage := "identifying the resource to update the labels"
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-label")
 
 	return cmd
 }
@@ -334,7 +336,8 @@ func (o *LabelOptions) RunLabel() error {
 				return err
 			}
 			helper := resource.NewHelper(client, mapping).
-				DryRun(o.dryRunStrategy == cmdutil.DryRunServer)
+				DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+				WithFieldManager(o.fieldManager)
 
 			if createdPatch {
 				outputObj, err = helper.Patch(namespace, name, types.MergePatchType, patchBytes, nil)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/patch/patch.go
@@ -66,6 +66,7 @@ type PatchOptions struct {
 	args                         []string
 	builder                      *resource.Builder
 	unstructuredClientForMapping func(mapping *meta.RESTMapping) (resource.RESTClient, error)
+	fieldManager                 string
 
 	genericclioptions.IOStreams
 }
@@ -127,6 +128,7 @@ func NewCmdPatch(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobr
 	cmdutil.AddDryRunFlag(cmd)
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, "identifying the resource to update")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, patch will operate on the content of the file, not the server-side resource.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-patch")
 
 	return cmd
 }
@@ -238,7 +240,8 @@ func (o *PatchOptions) RunPatch() error {
 
 			helper := resource.
 				NewHelper(client, mapping).
-				DryRun(o.dryRunStrategy == cmdutil.DryRunServer)
+				DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+				WithFieldManager(o.fieldManager)
 			patchedObj, err := helper.Patch(namespace, name, patchType, patchBytes, nil)
 			if err != nil {
 				return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/replace/replace.go
@@ -93,6 +93,8 @@ type ReplaceOptions struct {
 	Recorder genericclioptions.Recorder
 
 	genericclioptions.IOStreams
+
+	fieldManager string
 }
 
 func NewReplaceOptions(streams genericclioptions.IOStreams) *ReplaceOptions {
@@ -129,6 +131,7 @@ func NewCmdReplace(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	cmdutil.AddDryRunFlag(cmd)
 
 	cmd.Flags().StringVar(&o.Raw, "raw", o.Raw, "Raw URI to PUT to the server.  Uses the transport specified by the kubeconfig file.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-replace")
 
 	return cmd
 }
@@ -292,6 +295,7 @@ func (o *ReplaceOptions) Run(f cmdutil.Factory) error {
 		obj, err := resource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Replace(info.Namespace, info.Name, true, info.Object)
 		if err != nil {
 			return cmdutil.AddSourceToErr("replacing", info.Source, err)
@@ -382,7 +386,9 @@ func (o *ReplaceOptions) forceReplace() error {
 			klog.V(4).Infof("error recording current command: %v", err)
 		}
 
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Create(info.Namespace, true, info.Object)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.fieldManager).
+			Create(info.Namespace, true, info.Object)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_pause.go
@@ -48,6 +48,8 @@ type PauseOptions struct {
 
 	resource.FilenameOptions
 	genericclioptions.IOStreams
+
+	fieldManager string
 }
 
 var (
@@ -92,6 +94,7 @@ func NewCmdRolloutPause(f cmdutil.Factory, streams genericclioptions.IOStreams) 
 
 	usage := "identifying the resource to get from a server."
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-rollout")
 	return cmd
 }
 
@@ -173,7 +176,9 @@ func (o *PauseOptions) RunPause() error {
 			continue
 		}
 
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.fieldManager).
+			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch: %v", err))
 			continue

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_restart.go
@@ -48,6 +48,8 @@ type RestartOptions struct {
 
 	resource.FilenameOptions
 	genericclioptions.IOStreams
+
+	fieldManager string
 }
 
 var (
@@ -94,6 +96,7 @@ func NewCmdRolloutRestart(f cmdutil.Factory, streams genericclioptions.IOStreams
 
 	usage := "identifying the resource to get from a server."
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-rollout")
 	o.PrintFlags.AddFlags(cmd)
 	return cmd
 }
@@ -169,7 +172,9 @@ func (o RestartOptions) RunRestart() error {
 			allErrs = append(allErrs, fmt.Errorf("failed to create patch for %v: empty patch", info.Name))
 		}
 
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.fieldManager).
+			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch: %v", err))
 			continue

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_resume.go
@@ -49,6 +49,8 @@ type ResumeOptions struct {
 
 	resource.FilenameOptions
 	genericclioptions.IOStreams
+
+	fieldManager string
 }
 
 var (
@@ -94,6 +96,7 @@ func NewCmdRolloutResume(f cmdutil.Factory, streams genericclioptions.IOStreams)
 
 	usage := "identifying the resource to get from a server."
 	cmdutil.AddFilenameOptionFlags(cmd, &o.FilenameOptions, usage)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-rollout")
 	o.PrintFlags.AddFlags(cmd)
 	return cmd
 }
@@ -177,7 +180,9 @@ func (o ResumeOptions) RunResume() error {
 			continue
 		}
 
-		obj, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
+		obj, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.fieldManager).
+			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch: %v", err))
 			continue

--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -123,6 +123,7 @@ type RunOptions struct {
 	Quiet          bool
 	Schedule       string
 	TTY            bool
+	fieldManager   string
 
 	genericclioptions.IOStreams
 }
@@ -198,6 +199,7 @@ func addRunFlags(cmd *cobra.Command, opt *RunOptions) {
 	cmd.Flags().BoolVar(&opt.Quiet, "quiet", opt.Quiet, "If true, suppress prompt messages.")
 	cmd.Flags().StringVar(&opt.Schedule, "schedule", opt.Schedule, i18n.T("A schedule in the Cron format the job should be run with."))
 	cmd.Flags().MarkDeprecated("schedule", "has no effect and will be removed in the future.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &opt.fieldManager, "kubectl-run")
 }
 
 func (o *RunOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
@@ -662,6 +664,7 @@ func (o *RunOptions) createGeneratedObject(f cmdutil.Factory, cmd *cobra.Command
 		actualObj, err = resource.
 			NewHelper(client, mapping).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Create(namespace, false, obj)
 		if err != nil {
 			return nil, err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	meta "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -113,6 +113,7 @@ type EnvOptions struct {
 	From              string
 	Prefix            string
 	Keys              []string
+	fieldManager      string
 
 	PrintObj printers.ResourcePrinterFunc
 
@@ -171,6 +172,7 @@ func NewCmdEnv(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.Co
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, set env will NOT contact api-server but run locally.")
 	cmd.Flags().BoolVar(&o.All, "all", o.All, "If true, select all resources in the namespace of the specified resource types")
 	cmd.Flags().BoolVar(&o.Overwrite, "overwrite", o.Overwrite, "If true, allow environment to be overwritten, otherwise reject updates that overwrite existing environment.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-set")
 
 	o.PrintFlags.AddFlags(cmd)
 
@@ -512,6 +514,7 @@ func (o *EnvOptions) RunEnv() error {
 		actual, err := resource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch env update to pod template: %v", err))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_image.go
@@ -52,6 +52,7 @@ type SetImageOptions struct {
 	Output         string
 	Local          bool
 	ResolveImage   ImageResolver
+	fieldManager   string
 
 	PrintObj printers.ResourcePrinterFunc
 	Recorder genericclioptions.Recorder
@@ -125,6 +126,7 @@ func NewCmdImage(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 	cmd.Flags().StringVarP(&o.Selector, "selector", "l", o.Selector, "Selector (label query) to filter on, not including uninitialized ones, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&o.Local, "local", o.Local, "If true, set image will NOT contact api-server but run locally.")
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-set")
 	return cmd
 }
 
@@ -286,6 +288,7 @@ func (o *SetImageOptions) Run() error {
 		actual, err := resource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch image update to pod template: %v", err))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_resources.go
@@ -73,6 +73,7 @@ type SetResourcesOptions struct {
 	Output            string
 	All               bool
 	Local             bool
+	fieldManager      string
 
 	DryRunStrategy cmdutil.DryRunStrategy
 
@@ -136,6 +137,7 @@ func NewCmdResources(f cmdutil.Factory, streams genericclioptions.IOStreams) *co
 	cmdutil.AddDryRunFlag(cmd)
 	cmd.Flags().StringVar(&o.Limits, "limits", o.Limits, "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges.")
 	cmd.Flags().StringVar(&o.Requests, "requests", o.Requests, "The resource requirement requests for this container.  For example, 'cpu=100m,memory=256Mi'.  Note that server side components may assign requests depending on the server configuration, such as limit ranges.")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-set")
 	return cmd
 }
 
@@ -301,6 +303,7 @@ func (o *SetResourcesOptions) Run() error {
 		actual, err := resource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch resources update to pod template %v", err))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_selector.go
@@ -46,6 +46,7 @@ type SetSelectorOptions struct {
 	RecordFlags          *genericclioptions.RecordFlags
 	dryRunStrategy       cmdutil.DryRunStrategy
 	dryRunVerifier       *resource.DryRunVerifier
+	fieldManager         string
 
 	// set by args
 	resources       []string
@@ -113,6 +114,7 @@ func NewCmdSelector(f cmdutil.Factory, streams genericclioptions.IOStreams) *cob
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
 	o.PrintFlags.AddFlags(cmd)
 	o.RecordFlags.AddFlags(cmd)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-set")
 
 	cmd.Flags().StringVarP(&o.resourceVersion, "resource-version", "", o.resourceVersion, "If non-empty, the selectors update will only succeed if this is the current resource-version for the object. Only valid when specifying a single resource.")
 	cmdutil.AddDryRunFlag(cmd)
@@ -227,6 +229,7 @@ func (o *SetSelectorOptions) RunSelector() error {
 		actual, err := resource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_serviceaccount.go
@@ -71,6 +71,7 @@ type SetServiceAccountOptions struct {
 	updatePodSpecForObject polymorphichelpers.UpdatePodSpecForObjectFunc
 	infos                  []*resource.Info
 	serviceAccountName     string
+	fieldManager           string
 
 	PrintObj printers.ResourcePrinterFunc
 	Recorder genericclioptions.Recorder
@@ -115,6 +116,7 @@ func NewCmdServiceAccount(f cmdutil.Factory, streams genericclioptions.IOStreams
 	cmd.Flags().BoolVar(&o.all, "all", o.all, "Select all resources, including uninitialized ones, in the namespace of the specified resource types")
 	cmd.Flags().BoolVar(&o.local, "local", o.local, "If true, set serviceaccount will NOT contact api-server but run locally.")
 	cmdutil.AddDryRunFlag(cmd)
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-set")
 	return cmd
 }
 
@@ -224,6 +226,7 @@ func (o *SetServiceAccountOptions) Run() error {
 		actual, err := resource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			patchErrs = append(patchErrs, fmt.Errorf("failed to patch ServiceAccountName %v", err))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_subject.go
@@ -68,6 +68,7 @@ type SubjectOptions struct {
 	DryRunStrategy    cmdutil.DryRunStrategy
 	DryRunVerifier    *resource.DryRunVerifier
 	Local             bool
+	fieldManager      string
 
 	Users           []string
 	Groups          []string
@@ -115,6 +116,7 @@ func NewCmdSubject(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobr
 	cmd.Flags().StringArrayVar(&o.Users, "user", o.Users, "Usernames to bind to the role")
 	cmd.Flags().StringArrayVar(&o.Groups, "group", o.Groups, "Groups to bind to the role")
 	cmd.Flags().StringArrayVar(&o.ServiceAccounts, "serviceaccount", o.ServiceAccounts, "Service accounts to bind to the role")
+	cmdutil.AddFieldManagerFlagVar(cmd, &o.fieldManager, "kubectl-set")
 	return cmd
 }
 
@@ -281,6 +283,7 @@ func (o *SubjectOptions) Run(fn updateSubjects) error {
 		actual, err := resource.
 			NewHelper(info.Client, info.Mapping).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
+			WithFieldManager(o.fieldManager).
 			Patch(info.Namespace, info.Name, types.StrategicMergePatchType, patch.Patch, nil)
 		if err != nil {
 			allErrs = append(allErrs, fmt.Errorf("failed to patch subjects to rolebinding: %v", err))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/taint/taint.go
@@ -56,6 +56,7 @@ type TaintOptions struct {
 	selector       string
 	overwrite      bool
 	all            bool
+	fieldManager   string
 
 	ClientForMapping func(*meta.RESTMapping) (resource.RESTClient, error)
 
@@ -122,6 +123,7 @@ func NewCmdTaint(f cmdutil.Factory, streams genericclioptions.IOStreams) *cobra.
 	cmd.Flags().StringVarP(&options.selector, "selector", "l", options.selector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
 	cmd.Flags().BoolVar(&options.overwrite, "overwrite", options.overwrite, "If true, allow taints to be overwritten, otherwise reject taint updates that overwrite existing taints.")
 	cmd.Flags().BoolVar(&options.all, "all", options.all, "Select all nodes in the cluster")
+	cmdutil.AddFieldManagerFlagVar(cmd, &options.fieldManager, "kubectl-taint")
 	return cmd
 }
 
@@ -339,6 +341,7 @@ func (o TaintOptions) RunTaint() error {
 		}
 		helper := resource.
 			NewHelper(client, mapping).
+			WithFieldManager(o.fieldManager).
 			DryRun(o.DryRunStrategy == cmdutil.DryRunServer)
 
 		var outputObj runtime.Object

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/editor/editoptions.go
@@ -28,7 +28,7 @@ import (
 	goruntime "runtime"
 	"strings"
 
-	"github.com/evanphx/json-patch"
+	jsonpatch "github.com/evanphx/json-patch"
 	"github.com/spf13/cobra"
 	"k8s.io/klog"
 
@@ -78,6 +78,8 @@ type EditOptions struct {
 	f                   cmdutil.Factory
 	editPrinterOptions  *editPrinterOptions
 	updatedResultGetter func(data []byte) *resource.Result
+
+	FieldManager string
 }
 
 // NewEditOptions returns an initialized EditOptions instance
@@ -498,7 +500,7 @@ func (o *EditOptions) annotationPatch(update *resource.Info) error {
 	if err != nil {
 		return err
 	}
-	helper := resource.NewHelper(client, mapping)
+	helper := resource.NewHelper(client, mapping).WithFieldManager(o.FieldManager)
 	_, err = helper.Patch(o.CmdNamespace, update.Name, patchType, patch, nil)
 	if err != nil {
 		return err
@@ -628,7 +630,9 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 			fmt.Fprintf(o.Out, "Patch: %s\n", string(patch))
 		}
 
-		patched, err := resource.NewHelper(info.Client, info.Mapping).Patch(info.Namespace, info.Name, patchType, patch, nil)
+		patched, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.FieldManager).
+			Patch(info.Namespace, info.Name, patchType, patch, nil)
 		if err != nil {
 			fmt.Fprintln(o.ErrOut, results.addError(err, info))
 			return nil
@@ -645,9 +649,13 @@ func (o *EditOptions) visitToPatch(originalInfos []*resource.Info, patchVisitor 
 
 func (o *EditOptions) visitToCreate(createVisitor resource.Visitor) error {
 	err := createVisitor.Visit(func(info *resource.Info, incomingErr error) error {
-		if err := resource.CreateAndRefresh(info); err != nil {
+		obj, err := resource.NewHelper(info.Client, info.Mapping).
+			WithFieldManager(o.FieldManager).
+			Create(info.Namespace, true, info.Object)
+		if err != nil {
 			return err
 		}
+		info.Refresh(obj, true)
 		printer, err := o.ToPrinter("created")
 		if err != nil {
 			return err

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -430,10 +430,13 @@ func AddDryRunFlag(cmd *cobra.Command) {
 	cmd.Flags().Lookup("dry-run").NoOptDefVal = "unchanged"
 }
 
+func AddFieldManagerFlagVar(cmd *cobra.Command, p *string, defaultFieldManager string) {
+	cmd.Flags().StringVar(p, "field-manager", defaultFieldManager, "Name of the manager used to track field ownership.")
+}
+
 func AddServerSideApplyFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("server-side", false, "If true, apply runs in the server instead of the client.")
 	cmd.Flags().Bool("force-conflicts", false, "If true, server-side apply will force the changes against conflicts.")
-	cmd.Flags().String("field-manager", "kubectl", "Name of the manager used to track field ownership.")
 }
 
 func AddPodRunningTimeoutFlag(cmd *cobra.Command, defaultTimeout time.Duration) {

--- a/test/cmd/apps.sh
+++ b/test/cmd/apps.sh
@@ -42,6 +42,9 @@ run_daemonset_tests() {
   kube::test::get_object_assert 'daemonsets bind' "{{${generation_field:?}}}" '3'
   kubectl set resources daemonsets/bind "${kube_flags[@]:?}" --limits=cpu=200m,memory=512Mi
   kube::test::get_object_assert 'daemonsets bind' "{{${generation_field:?}}}" '4'
+  # pod has field for kubectl set field manager
+  output_message=$(kubectl get daemonsets bind -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)
+  kube::test::if_has_string "${output_message}" 'kubectl-set'
 
   # Rollout restart should change generation
   kubectl rollout restart daemonset/bind "${kube_flags[@]:?}"
@@ -335,6 +338,10 @@ run_deployment_tests() {
   newrs="$(kubectl describe deployment nginx | grep NewReplicaSet | awk '{print $2}')"
   rs="$(kubectl get rs "${newrs}" -o yaml)"
   kube::test::if_has_string "${rs}" "deployment.kubernetes.io/revision: \"6\""
+  # Deployment has field for kubectl rollout field manager
+  output_message=$(kubectl get deployment nginx -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)
+  kube::test::if_has_string "${output_message}" 'kubectl-rollout'
+  # Create second deployment
   ${SED} "s/name: nginx$/name: nginx2/" hack/testdata/deployment-revision1.yaml | kubectl create -f - "${kube_flags[@]:?}"
   # Deletion of both deployments should not be blocked
   kubectl delete deployment nginx2 "${kube_flags[@]:?}"
@@ -653,6 +660,10 @@ run_rs_tests() {
   kubectl set serviceaccount rs/frontend "${kube_flags[@]:?}" serviceaccount1
   kube::test::get_object_assert 'rs frontend' "{{${generation_field:?}}}" '5'
 
+  # RS has field for kubectl set field manager
+  output_message=$(kubectl get rs frontend -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)
+  kube::test::if_has_string "${output_message}" 'kubectl-set'
+
   ### Delete replica set with id
   # Pre-condition: frontend replica set exists
   kube::test::get_object_assert rs "{{range.items}}{{${id_field:?}}}:{{end}}" 'frontend:'
@@ -692,6 +703,10 @@ run_rs_tests() {
     # autoscale 2~3 pods, no CPU utilization specified, replica set specified by name
     kubectl autoscale rs frontend "${kube_flags[@]:?}" --min=2 --max=3
     kube::test::get_object_assert 'hpa frontend' "{{${hpa_min_field:?}}} {{${hpa_max_field:?}}} {{${hpa_cpu_field:?}}}" '2 3 80'
+    # HorizontalPodAutoscaler has field for kubectl autoscale field manager
+    output_message=$(kubectl get hpa frontend -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)
+    kube::test::if_has_string "${output_message}" 'kubectl-autoscale'
+    # Clean up
     kubectl delete hpa frontend "${kube_flags[@]:?}"
     # autoscale without specifying --max should fail
     ! kubectl autoscale rs frontend "${kube_flags[@]:?}" || exit 1

--- a/test/cmd/diff.sh
+++ b/test/cmd/diff.sh
@@ -54,7 +54,6 @@ run_kubectl_diff_tests() {
     kube::test::if_has_string "${resourceVersion}" "${initialResourceVersion}"
 
     # Test found diff with server-side apply
-    kubectl apply -f hack/testdata/pod.yaml
     output_message=$(kubectl diff -f hack/testdata/pod-changed.yaml --server-side --force-conflicts || test $? -eq 1)
     kube::test::if_has_string "${output_message}" 'k8s.gcr.io/pause:3.0'
 
@@ -65,6 +64,31 @@ run_kubectl_diff_tests() {
     # Test that we have a return code bigger than 1 if there is an error when diffing
     kubectl diff -f hack/testdata/invalid-pod.yaml || test $? -gt 1
 
+    # Cleanup
+    kubectl delete -f hack/testdata/pod.yaml
+
+    kube::log::status "Testing kubectl diff with server-side apply"
+
+    # Test that kubectl diff --server-side works when the live object doesn't exist
+    output_message=$(! kubectl diff --server-side -f hack/testdata/pod.yaml)
+    kube::test::if_has_string "${output_message}" 'test-pod'
+    # Ensure diff --server-side only dry-runs and doesn't persist change
+    kube::test::get_object_assert 'pod' "{{range.items}}{{ if eq ${id_field:?} \\\"test-pod\\\" }}found{{end}}{{end}}:" ':'
+
+    # Server-side apply the Pod
+    kubectl apply --server-side -f hack/testdata/pod.yaml
+    kube::test::get_object_assert 'pod' "{{range.items}}{{ if eq ${id_field:?} \\\"test-pod\\\" }}found{{end}}{{end}}:" 'found:'
+
+    # Make sure that --server-side diffing the resource right after returns nothing (0 exit code).
+    kubectl diff --server-side -f hack/testdata/pod.yaml
+
+    # Make sure that for kubectl diff --server-side:
+    # 1. the exit code for diff is 1 because it found a difference
+    # 2. the difference contains the changed image
+    output_message=$(kubectl diff --server-side -f hack/testdata/pod-changed.yaml || test $? -eq 1)
+    kube::test::if_has_string "${output_message}" 'k8s.gcr.io/pause:3.0'
+
+    # Cleanup
     kubectl delete -f hack/testdata/pod.yaml
 
     set +o nounset

--- a/test/cmd/node-management.sh
+++ b/test/cmd/node-management.sh
@@ -87,6 +87,9 @@ __EOF__
   # taint can add a taint (<key>:<effect>)
   kubectl taint node 127.0.0.1 dedicated:PreferNoSchedule
   kube::test::get_object_assert "nodes 127.0.0.1" '{{range .spec.taints}}{{if eq .key \"dedicated\"}}{{.key}}={{.value}}:{{.effect}}{{end}}{{end}}' "dedicated=<no value>:PreferNoSchedule"
+  # Node has field manager for kubectl taint
+  output_message=$(kubectl get node 127.0.0.1 -o=jsonpath='{.metadata.managedFields[*].manager}' "${kube_flags[@]:?}" 2>&1)
+  kube::test::if_has_string "${output_message}" 'kubectl-taint'
   # Dry-run remove a taint
   kubectl taint node 127.0.0.1 --dry-run=client dedicated-
   kubectl taint node 127.0.0.1 --dry-run=server dedicated-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This change improves the kubectl field manager names for clearer conflicts, instead of the default `.manager=kubectl`.

When an object is managed by server-side apply and has field managers, any `kubectl` commands will use the same field manager: `kubectl`. When there is a conflict, then this is confusing because different operations will have the same field manager name. Instead, we can set kubectl subcommands as the field manager name e.g. the manager for `kubectl annotate` should be `kubectl-annotate`. This provides a better conflict hint.

For kubectl commands, this change sets the field manager accordingly:
- `kubectl apply` has `.manager=kubectl-client-side-apply`
- `kubectl apply --server-side` has `.manager=kubectl` (remains `kubectl` instead of `kubectl-server-side-apply` for backwards compatibility)
- `kubectl annotate` has `.manager=kubectl-annotate`

List of kubectl subcommands updated:

- [x] annotate
- [x] apply
- [x] apply edit-last-applied
- [x] autoscale
- [ ] cordon
- [x] create
- [x] create clusterrole
- [x] create clusterrolebinding
- [x] create configmap
- [x] create cronjob
- [x] create deployment
- [x] create job
- [x] create namespace
- [x] create poddisruptionbudget
- [x] create priorityclass
- [x] create quota
- [x] create role
- [x] create rolebinding
- [x] create secret
- [x] create service
- [x] create serviceaccount
- [ ] debug
- [ ] drain
- [x] edit
- [x] expose
- [x] label
- [x] patch
- [x] replace
- [x] rollout pause
- [ ] rollout undo
- [x] rollout restart
- [x] rollout resume
- [x] run
- [x] set env
- [x] set image
- [x] set resources
- [x] set selector
- [x] set serviceaccount
- [x] set subject
- [x] taint

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Related to https://github.com/kubernetes/kubernetes/issues/80916

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Improve server-side apply conflict errors by setting dedicated kubectl subcommand field managers
```