### PR TITLE
Automated cherry pick of #88487: Use compute v1 api to specify network tier

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_external_test.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	computealpha "google.golang.org/api/compute/v0.alpha"
 	compute "google.golang.org/api/compute/v1"
 
 	"github.com/GoogleCloudPlatform/k8s-cloud-provider/pkg/cloud"
@@ -92,9 +91,9 @@ func TestEnsureStaticIPWithTier(t *testing.T) {
 			assert.NotEqual(t, ip, "")
 			// Get the Address from the fake address service and verify that the tier
 			// is set correctly.
-			alphaAddr, err := s.GetAlphaRegionAddress(tc.name, s.region)
+			Addr, err := s.GetRegionAddress(tc.name, s.region)
 			require.NoError(t, err)
-			assert.Equal(t, tc.expected, alphaAddr.NetworkTier)
+			assert.Equal(t, tc.expected, Addr.NetworkTier)
 		})
 	}
 }
@@ -108,14 +107,14 @@ func TestVerifyRequestedIP(t *testing.T) {
 		requestedIP     string
 		fwdRuleIP       string
 		netTier         cloud.NetworkTier
-		addrList        []*computealpha.Address
+		addrList        []*compute.Address
 		expectErr       bool
 		expectUserOwned bool
 	}{
 		"requested IP exists": {
 			requestedIP:     "1.1.1.1",
 			netTier:         cloud.NetworkTierPremium,
-			addrList:        []*computealpha.Address{{Name: "foo", Address: "1.1.1.1", NetworkTier: "PREMIUM"}},
+			addrList:        []*compute.Address{{Name: "foo", Address: "1.1.1.1", NetworkTier: "PREMIUM"}},
 			expectErr:       false,
 			expectUserOwned: true,
 		},
@@ -138,7 +137,7 @@ func TestVerifyRequestedIP(t *testing.T) {
 		"requested IP exists, but network tier does not match": {
 			requestedIP: "1.1.1.1",
 			netTier:     cloud.NetworkTierStandard,
-			addrList:    []*computealpha.Address{{Name: "foo", Address: "1.1.1.1", NetworkTier: "PREMIUM"}},
+			addrList:    []*compute.Address{{Name: "foo", Address: "1.1.1.1", NetworkTier: "PREMIUM"}},
 			expectErr:   true,
 		},
 	} {
@@ -147,7 +146,7 @@ func TestVerifyRequestedIP(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, addr := range tc.addrList {
-				s.ReserveAlphaRegionAddress(addr, s.region)
+				s.ReserveRegionAddress(addr, s.region)
 			}
 			isUserOwnedIP, err := verifyUserRequestedIP(s, s.region, tc.requestedIP, tc.fwdRuleIP, lbRef, tc.netTier)
 			assert.Equal(t, tc.expectErr, err != nil, fmt.Sprintf("err: %v", err))
@@ -169,11 +168,11 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 
 	for desc, tc := range map[string]struct {
 		netTier      cloud.NetworkTier
-		expectedRule *computealpha.ForwardingRule
+		expectedRule *compute.ForwardingRule
 	}{
 		"Premium tier": {
 			netTier: cloud.NetworkTierPremium,
-			expectedRule: &computealpha.ForwardingRule{
+			expectedRule: &compute.ForwardingRule{
 				Name:        "lb-1",
 				Description: `{"kubernetes.io/service-name":"foo-svc"}`,
 				IPAddress:   "1.1.1.1",
@@ -186,7 +185,7 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 		},
 		"Standard tier": {
 			netTier: cloud.NetworkTierStandard,
-			expectedRule: &computealpha.ForwardingRule{
+			expectedRule: &compute.ForwardingRule{
 				Name:        "lb-2",
 				Description: `{"kubernetes.io/service-name":"foo-svc"}`,
 				IPAddress:   "2.2.2.2",
@@ -194,7 +193,7 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 				PortRange:   "123-123",
 				Target:      target,
 				NetworkTier: "STANDARD",
-				SelfLink:    fmt.Sprintf(baseLinkURL, "alpha", vals.ProjectID, vals.Region, "lb-2"),
+				SelfLink:    fmt.Sprintf(baseLinkURL, "v1", vals.ProjectID, vals.Region, "lb-2"),
 			},
 		},
 	} {
@@ -208,9 +207,9 @@ func TestCreateForwardingRuleWithTier(t *testing.T) {
 			err = createForwardingRule(s, lbName, serviceName, s.region, ipAddr, target, ports, tc.netTier)
 			assert.NoError(t, err)
 
-			alphaRule, err := s.GetAlphaRegionForwardingRule(lbName, s.region)
+			Rule, err := s.GetRegionForwardingRule(lbName, s.region)
 			assert.NoError(t, err)
-			assert.Equal(t, tc.expectedRule, alphaRule)
+			assert.Equal(t, tc.expectedRule, Rule)
 		})
 	}
 }
@@ -229,35 +228,35 @@ func TestDeleteAddressWithWrongTier(t *testing.T) {
 	for desc, tc := range map[string]struct {
 		addrName     string
 		netTier      cloud.NetworkTier
-		addrList     []*computealpha.Address
+		addrList     []*compute.Address
 		expectDelete bool
 	}{
 		"Network tiers (premium) match; do nothing": {
 			addrName: "foo1",
 			netTier:  cloud.NetworkTierPremium,
-			addrList: []*computealpha.Address{{Name: "foo1", Address: "1.1.1.1", NetworkTier: "PREMIUM"}},
+			addrList: []*compute.Address{{Name: "foo1", Address: "1.1.1.1", NetworkTier: "PREMIUM"}},
 		},
 		"Network tiers (standard) match; do nothing": {
 			addrName: "foo2",
 			netTier:  cloud.NetworkTierStandard,
-			addrList: []*computealpha.Address{{Name: "foo2", Address: "1.1.1.2", NetworkTier: "STANDARD"}},
+			addrList: []*compute.Address{{Name: "foo2", Address: "1.1.1.2", NetworkTier: "STANDARD"}},
 		},
 		"Wrong network tier (standard); delete address": {
 			addrName:     "foo3",
 			netTier:      cloud.NetworkTierPremium,
-			addrList:     []*computealpha.Address{{Name: "foo3", Address: "1.1.1.3", NetworkTier: "STANDARD"}},
+			addrList:     []*compute.Address{{Name: "foo3", Address: "1.1.1.3", NetworkTier: "STANDARD"}},
 			expectDelete: true,
 		},
 		"Wrong network tier (premium); delete address": {
 			addrName:     "foo4",
 			netTier:      cloud.NetworkTierStandard,
-			addrList:     []*computealpha.Address{{Name: "foo4", Address: "1.1.1.4", NetworkTier: "PREMIUM"}},
+			addrList:     []*compute.Address{{Name: "foo4", Address: "1.1.1.4", NetworkTier: "PREMIUM"}},
 			expectDelete: true,
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
 			for _, addr := range tc.addrList {
-				s.ReserveAlphaRegionAddress(addr, s.region)
+				s.ReserveRegionAddress(addr, s.region)
 			}
 
 			// Sanity check to ensure we inject the right address.
@@ -417,13 +416,13 @@ func TestLoadBalancerWrongTierResourceDeletion(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	addressObj := &computealpha.Address{
+	addressObj := &compute.Address{
 		Name:        lbName,
 		Description: serviceName.String(),
 		NetworkTier: cloud.NetworkTierStandard.ToGCEValue(),
 	}
 
-	err = gce.ReserveAlphaRegionAddress(addressObj, gce.region)
+	err = gce.ReserveRegionAddress(addressObj, gce.region)
 	require.NoError(t, err)
 
 	_, err = createExternalLoadBalancer(gce, svc, []string{"test-node-1"}, vals.ClusterName, vals.ClusterID, vals.ZoneName)


### PR DESCRIPTION
Cherry pick of #88487 on release-1.16.

#88487: Use compute v1 api to specify network tier

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.