### PR TITLE
Add missing tableconvertors for role and clusterrole

### DIFF
--- a/pkg/registry/rbac/clusterrole/storage/BUILD
+++ b/pkg/registry/rbac/clusterrole/storage/BUILD
@@ -11,6 +11,9 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/registry/rbac/clusterrole/storage",
     deps = [
         "//pkg/apis/rbac:go_default_library",
+        "//pkg/printers:go_default_library",
+        "//pkg/printers/internalversion:go_default_library",
+        "//pkg/printers/storage:go_default_library",
         "//pkg/registry/rbac/clusterrole:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/rbac/clusterrole/storage/storage.go
+++ b/pkg/registry/rbac/clusterrole/storage/storage.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/printers"
+	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/rbac/clusterrole"
 )
 
@@ -39,6 +42,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 		CreateStrategy: clusterrole.Strategy,
 		UpdateStrategy: clusterrole.Strategy,
 		DeleteStrategy: clusterrole.Strategy,
+
+		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter}
 	if err := store.CompleteWithOptions(options); err != nil {

--- a/pkg/registry/rbac/role/storage/BUILD
+++ b/pkg/registry/rbac/role/storage/BUILD
@@ -11,6 +11,9 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/registry/rbac/role/storage",
     deps = [
         "//pkg/apis/rbac:go_default_library",
+        "//pkg/printers:go_default_library",
+        "//pkg/printers/internalversion:go_default_library",
+        "//pkg/printers/storage:go_default_library",
         "//pkg/registry/rbac/role:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",

--- a/pkg/registry/rbac/role/storage/storage.go
+++ b/pkg/registry/rbac/role/storage/storage.go
@@ -21,6 +21,9 @@ import (
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/kubernetes/pkg/apis/rbac"
+	"k8s.io/kubernetes/pkg/printers"
+	printersinternal "k8s.io/kubernetes/pkg/printers/internalversion"
+	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"k8s.io/kubernetes/pkg/registry/rbac/role"
 )
 
@@ -39,6 +42,8 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, error) {
 		CreateStrategy: role.Strategy,
 		UpdateStrategy: role.Strategy,
 		DeleteStrategy: role.Strategy,
+
+		TableConvertor: printerstorage.TableConvertor{TableGenerator: printers.NewTableGenerator().With(printersinternal.AddHandlers)},
 	}
 	options := &generic.StoreOptions{RESTOptions: optsGetter}
 	if err := store.CompleteWithOptions(options); err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Role and ClusterRole printers were not wired into storage layer, thus they did not serve Tabled output which is the required element by all core resources. 

**Which issue(s) this PR fixes**:
Noticed in https://bugzilla.redhat.com/show_bug.cgi?id=1810848

**Special notes for your reviewer**:
/assign @smarterclayton 

/sig cli
/sig api-machinery
/priority critical-urgent

**Does this PR introduce a user-facing change?**:
```release-note
Properly serve tabled output for Role and ClusterRole.
```
