### PR TITLE
test images: ARG instructions should be first

### DIFF
--- a/test/images/node-perf/npb-ep/Dockerfile
+++ b/test/images/node-perf/npb-ep/Dockerfile
@@ -34,7 +34,6 @@ RUN make EP CLASS=D
 # main container in the second build stage.
 RUN mkdir -p /lib-copy && find /usr/lib -name "*.so.*" -exec cp {} /lib-copy \;
 
-ARG BASEIMAGE
 FROM $BASEIMAGE
 
 COPY --from=build_node_perf_npb_ep /NPB3.3.1/NPB3.3-OMP/bin/ep.D.x /

--- a/test/images/node-perf/npb-is/Dockerfile
+++ b/test/images/node-perf/npb-is/Dockerfile
@@ -36,7 +36,6 @@ RUN make IS CLASS=D
 # main container in the second build stage.
 RUN mkdir -p /lib-copy && find /usr/lib -name "*.so.*" -exec cp {} /lib-copy \;
 
-ARG BASEIMAGE
 FROM $BASEIMAGE
 
 COPY --from=build_node_perf_npb_is /NPB3.3.1/NPB3.3-OMP/bin/is.D.x /

--- a/test/images/sample-apiserver/Dockerfile
+++ b/test/images/sample-apiserver/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ARG BASEIMAGE
 FROM us.gcr.io/k8s-artifacts-prod/build-image/kube-cross:v1.13.8-1 as build_k8s_1_17_sample_apiserver
 
 ENV GOPATH /go
@@ -32,7 +33,6 @@ RUN GO111MODULE=on CGO_ENABLED=0 GOOS=linux GOARCH=BASEARCH go get k8s.io/sample
 # we can copy it out from this throw away container image from a standard location
 RUN find /go/bin -name sample-apiserver -exec cp {} / \;
 
-ARG BASEIMAGE
 FROM $BASEIMAGE
 COPY --from=build_k8s_1_17_sample_apiserver /sample-apiserver /sample-apiserver
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

/sig testing
/priority important-soon

**What this PR does / why we need it**:

A few other Dockerfiles had the ARG duplicated as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

Needed in order to build the ``sample-apiserver`` image.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
