### PR TITLE
Dynamic client: plumb context

### DIFF
--- a/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
+++ b/cmd/kubeadm/app/util/apiclient/clientbacked_dryrun.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apiclient
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 
@@ -74,7 +75,7 @@ func NewClientBackedDryRunGetterFromKubeconfig(file string) (*ClientBackedDryRun
 
 // HandleGetAction handles GET actions to the dryrun clientset this interface supports
 func (clg *ClientBackedDryRunGetter) HandleGetAction(action core.GetAction) (bool, runtime.Object, error) {
-	unstructuredObj, err := clg.dynamicClient.Resource(action.GetResource()).Namespace(action.GetNamespace()).Get(action.GetName(), metav1.GetOptions{})
+	unstructuredObj, err := clg.dynamicClient.Resource(action.GetResource()).Namespace(action.GetNamespace()).Get(context.TODO(), action.GetName(), metav1.GetOptions{})
 	// Inform the user that the requested object wasn't found.
 	printIfNotExists(err)
 	if err != nil {
@@ -95,7 +96,7 @@ func (clg *ClientBackedDryRunGetter) HandleListAction(action core.ListAction) (b
 		FieldSelector: action.GetListRestrictions().Fields.String(),
 	}
 
-	unstructuredList, err := clg.dynamicClient.Resource(action.GetResource()).Namespace(action.GetNamespace()).List(listOpts)
+	unstructuredList, err := clg.dynamicClient.Resource(action.GetResource()).Namespace(action.GetNamespace()).List(context.TODO(), listOpts)
 	if err != nil {
 		return true, nil, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/basic_test.go
@@ -265,7 +265,7 @@ func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1beta
 		}
 
 		// Delete test
-		if err := noxuResourceClient.Delete("foo", metav1.NewDeleteOptions(0)); err != nil {
+		if err := noxuResourceClient.Delete("foo", *metav1.NewDeleteOptions(0)); err != nil {
 			t.Fatal(err)
 		}
 
@@ -305,7 +305,7 @@ func testSimpleCRUD(t *testing.T, ns string, noxuDefinition *apiextensionsv1beta
 		}
 
 		// Delete test
-		if err := noxuResourceClient.DeleteCollection(metav1.NewDeleteOptions(0), metav1.ListOptions{}); err != nil {
+		if err := noxuResourceClient.DeleteCollection(*metav1.NewDeleteOptions(0), metav1.ListOptions{}); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -468,10 +468,10 @@ func testFieldSelector(t *testing.T, ns string, noxuDefinition *apiextensionsv1b
 		t.Errorf("expected %v, got %v", e, a)
 	}
 
-	if err := noxuResourceClient.Delete("bar", nil); err != nil {
+	if err := noxuResourceClient.Delete("bar", metav1.DeleteOptions{}); err != nil {
 		t.Fatal(err)
 	}
-	if err := noxuResourceClient.Delete("foo", nil); err != nil {
+	if err := noxuResourceClient.Delete("foo", metav1.DeleteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/change_test.go
@@ -103,7 +103,7 @@ func TestChangeCRD(t *testing.T) {
 		go func(i int) {
 			defer wg.Done()
 			noxuInstanceToCreate := fixtures.NewNoxuInstance(ns, fmt.Sprintf("foo-%d", i))
-			if _, err := noxuNamespacedResourceClient.Create(noxuInstanceToCreate, metav1.CreateOptions{}); err != nil {
+			if _, err := noxuNamespacedResourceClient.Create(context.TODO(), noxuInstanceToCreate, metav1.CreateOptions{}); err != nil {
 				t.Error(err)
 				return
 			}
@@ -113,7 +113,7 @@ func TestChangeCRD(t *testing.T) {
 				case <-stopChan:
 					return
 				default:
-					if _, err := noxuNamespacedResourceClient.Get(noxuInstanceToCreate.GetName(), metav1.GetOptions{}); err != nil {
+					if _, err := noxuNamespacedResourceClient.Get(context.TODO(), noxuInstanceToCreate.GetName(), metav1.GetOptions{}); err != nil {
 						t.Error(err)
 						continue
 					}
@@ -130,7 +130,7 @@ func TestChangeCRD(t *testing.T) {
 				case <-stopChan:
 					return
 				default:
-					w, err := noxuNamespacedResourceClient.Watch(metav1.ListOptions{})
+					w, err := noxuNamespacedResourceClient.Watch(context.TODO(), metav1.ListOptions{})
 					if err != nil {
 						t.Errorf("unexpected error establishing watch: %v", err)
 						continue

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/conversion/conversion_test.go
@@ -197,7 +197,7 @@ func testWebhookConverter(t *testing.T, watchCache bool) {
 	defer ctcTearDown()
 
 	// read only object to read at a different version than stored when we need to force conversion
-	marker, err := ctc.versionedClient("marker", "v1beta1").Create(newConversionMultiVersionFixture("marker", "marker", "v1beta1"), metav1.CreateOptions{})
+	marker, err := ctc.versionedClient("marker", "v1beta1").Create(context.TODO(), newConversionMultiVersionFixture("marker", "marker", "v1beta1"), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -216,7 +216,7 @@ func testWebhookConverter(t *testing.T, watchCache bool) {
 
 			// wait until new webhook is called the first time
 			if err := wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-				_, err := ctc.versionedClient(marker.GetNamespace(), "v1alpha1").Get(marker.GetName(), metav1.GetOptions{})
+				_, err := ctc.versionedClient(marker.GetNamespace(), "v1alpha1").Get(context.TODO(), marker.GetName(), metav1.GetOptions{})
 				select {
 				case <-upCh:
 					return true, nil
@@ -247,13 +247,13 @@ func validateStorageVersion(t *testing.T, ctc *conversionTestContext) {
 		t.Run(version.Name, func(t *testing.T) {
 			name := "storageversion-" + version.Name
 			client := ctc.versionedClient(ns, version.Name)
-			obj, err := client.Create(newConversionMultiVersionFixture(ns, name, version.Name), metav1.CreateOptions{})
+			obj, err := client.Create(context.TODO(), newConversionMultiVersionFixture(ns, name, version.Name), metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
 			ctc.setAndWaitStorageVersion(t, "v1beta2")
 
-			if _, err = client.Get(obj.GetName(), metav1.GetOptions{}); err != nil {
+			if _, err = client.Get(context.TODO(), obj.GetName(), metav1.GetOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -275,7 +275,7 @@ func validateMixedStorageVersions(versions ...string) func(t *testing.T, ctc *co
 			ctc.setAndWaitStorageVersion(t, version)
 
 			name := "mixedstorage-stored-as-" + version
-			obj, err := clients[version].Create(newConversionMultiVersionFixture(ns, name, version), metav1.CreateOptions{})
+			obj, err := clients[version].Create(context.TODO(), newConversionMultiVersionFixture(ns, name, version), metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -285,12 +285,12 @@ func validateMixedStorageVersions(versions ...string) func(t *testing.T, ctc *co
 		// Ensure copies of an object have the same fields and values at each custom resource definition version regardless of storage version
 		for clientVersion, client := range clients {
 			t.Run(clientVersion, func(t *testing.T) {
-				o1, err := client.Get(objNames[0], metav1.GetOptions{})
+				o1, err := client.Get(context.TODO(), objNames[0], metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
 				for _, objName := range objNames[1:] {
-					o2, err := client.Get(objName, metav1.GetOptions{})
+					o2, err := client.Get(context.TODO(), objName, metav1.GetOptions{})
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -314,7 +314,7 @@ func validateServed(t *testing.T, ctc *conversionTestContext) {
 		t.Run(version.Name, func(t *testing.T) {
 			name := "served-" + version.Name
 			client := ctc.versionedClient(ns, version.Name)
-			obj, err := client.Create(newConversionMultiVersionFixture(ns, name, version.Name), metav1.CreateOptions{})
+			obj, err := client.Create(context.TODO(), newConversionMultiVersionFixture(ns, name, version.Name), metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -340,7 +340,7 @@ func validateNonTrivialConverted(t *testing.T, ctc *conversionTestContext) {
 					t.Fatal(err)
 				}
 			}
-			if _, err := client.Create(fixture, metav1.CreateOptions{}); err != nil {
+			if _, err := client.Create(context.TODO(), fixture, metav1.CreateOptions{}); err != nil {
 				t.Fatal(err)
 			}
 
@@ -353,7 +353,7 @@ func validateNonTrivialConverted(t *testing.T, ctc *conversionTestContext) {
 
 			for _, getVersion := range ctc.crd.Spec.Versions {
 				client := ctc.versionedClient(ns, getVersion.Name)
-				obj, err := client.Get(name, metav1.GetOptions{})
+				obj, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -361,7 +361,7 @@ func validateNonTrivialConverted(t *testing.T, ctc *conversionTestContext) {
 			}
 
 			// send a non-trivial patch to the main resource to verify the oldObject is in the right version
-			if _, err := client.Patch(name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"main":"true"}}}`), metav1.PatchOptions{}); err != nil {
+			if _, err := client.Patch(context.TODO(), name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"main":"true"}}}`), metav1.PatchOptions{}); err != nil {
 				t.Fatal(err)
 			}
 			// verify that the right, pruned version is in storage
@@ -372,7 +372,7 @@ func validateNonTrivialConverted(t *testing.T, ctc *conversionTestContext) {
 			verifyMultiVersionObject(t, "v1beta1", obj)
 
 			// send a non-trivial patch to the status subresource to verify the oldObject is in the right version
-			if _, err := client.Patch(name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"status":"true"}}}`), metav1.PatchOptions{}, "status"); err != nil {
+			if _, err := client.Patch(context.TODO(), name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"status":"true"}}}`), metav1.PatchOptions{}, "status"); err != nil {
 				t.Fatal(err)
 			}
 			// verify that the right, pruned version is in storage
@@ -398,7 +398,7 @@ func validateNonTrivialConvertedList(t *testing.T, ctc *conversionTestContext) {
 				t.Fatal(err)
 			}
 		}
-		_, err := client.Create(fixture, metav1.CreateOptions{})
+		_, err := client.Create(context.TODO(), fixture, metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -408,7 +408,7 @@ func validateNonTrivialConvertedList(t *testing.T, ctc *conversionTestContext) {
 	for _, listVersion := range ctc.crd.Spec.Versions {
 		t.Run(fmt.Sprintf("listing objects as %s", listVersion.Name), func(t *testing.T) {
 			client := ctc.versionedClient(ns, listVersion.Name)
-			obj, err := client.List(metav1.ListOptions{})
+			obj, err := client.List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -443,7 +443,7 @@ func validateStoragePruning(t *testing.T, ctc *conversionTestContext) {
 			if err := unstructured.SetNestedField(fixture.Object, "foo", "garbage"); err != nil {
 				t.Fatal(err)
 			}
-			_, err := client.Create(fixture, metav1.CreateOptions{})
+			_, err := client.Create(context.TODO(), fixture, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -471,7 +471,7 @@ func validateStoragePruning(t *testing.T, ctc *conversionTestContext) {
 
 			for _, getVersion := range ctc.crd.Spec.Versions {
 				client := ctc.versionedClient(ns, getVersion.Name)
-				obj, err := client.Get(name, metav1.GetOptions{})
+				obj, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -496,7 +496,7 @@ func validateObjectMetaMutation(t *testing.T, ctc *conversionTestContext) {
 	ctc.setAndWaitStorageVersion(t, storageVersion)
 	name := "objectmeta-mutation-" + storageVersion
 	client := ctc.versionedClient(ns, storageVersion)
-	obj, err := client.Create(newConversionMultiVersionFixture(ns, name, storageVersion), metav1.CreateOptions{})
+	obj, err := client.Create(context.TODO(), newConversionMultiVersionFixture(ns, name, storageVersion), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -504,7 +504,7 @@ func validateObjectMetaMutation(t *testing.T, ctc *conversionTestContext) {
 
 	t.Logf("Getting object in other version v1beta2")
 	client = ctc.versionedClient(ns, "v1beta2")
-	obj, err = client.Get(name, metav1.GetOptions{})
+	obj, err = client.Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -513,7 +513,7 @@ func validateObjectMetaMutation(t *testing.T, ctc *conversionTestContext) {
 	t.Logf("Creating object in non-storage version")
 	name = "objectmeta-mutation-v1beta2"
 	client = ctc.versionedClient(ns, "v1beta2")
-	obj, err = client.Create(newConversionMultiVersionFixture(ns, name, "v1beta2"), metav1.CreateOptions{})
+	obj, err = client.Create(context.TODO(), newConversionMultiVersionFixture(ns, name, "v1beta2"), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -521,7 +521,7 @@ func validateObjectMetaMutation(t *testing.T, ctc *conversionTestContext) {
 
 	t.Logf("Listing objects in non-storage version")
 	client = ctc.versionedClient(ns, "v1beta2")
-	list, err := client.List(metav1.ListOptions{})
+	list, err := client.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -582,7 +582,7 @@ func validateUIDMutation(t *testing.T, ctc *conversionTestContext) {
 	ctc.setAndWaitStorageVersion(t, storageVersion)
 	name := "uid-mutation-" + storageVersion
 	client := ctc.versionedClient(ns, "v1beta2")
-	obj, err := client.Create(newConversionMultiVersionFixture(ns, name, "v1beta2"), metav1.CreateOptions{})
+	obj, err := client.Create(context.TODO(), newConversionMultiVersionFixture(ns, name, "v1beta2"), metav1.CreateOptions{})
 	if err == nil {
 		t.Fatalf("expected creation error, but got: %v", obj)
 	} else if !strings.Contains(err.Error(), "must have the same UID") {
@@ -607,7 +607,7 @@ func validateDefaulting(t *testing.T, ctc *conversionTestContext) {
 			if err := unstructured.SetNestedField(fixture.Object, map[string]interface{}{}, "defaults"); err != nil {
 				t.Fatal(err)
 			}
-			created, err := client.Create(fixture, metav1.CreateOptions{})
+			created, err := client.Create(context.TODO(), fixture, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -654,7 +654,7 @@ func validateDefaulting(t *testing.T, ctc *conversionTestContext) {
 					continue
 				}
 
-				got, err := ctc.versionedClient(ns, v.Name).Get(created.GetName(), metav1.GetOptions{})
+				got, err := ctc.versionedClient(ns, v.Name).Get(context.TODO(), created.GetName(), metav1.GetOptions{})
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -681,7 +681,7 @@ func expectConversionFailureMessage(id, message string) func(t *testing.T, ctc *
 		clients := ctc.versionedClients(ns)
 		var err error
 		// storage version is v1beta1, so this skips conversion
-		obj, err := clients["v1beta1"].Create(newConversionMultiVersionFixture(ns, id, "v1beta1"), metav1.CreateOptions{})
+		obj, err := clients["v1beta1"].Create(context.TODO(), newConversionMultiVersionFixture(ns, id, "v1beta1"), metav1.CreateOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -689,19 +689,19 @@ func expectConversionFailureMessage(id, message string) func(t *testing.T, ctc *
 			t.Run(verb, func(t *testing.T) {
 				switch verb {
 				case "get":
-					_, err = clients["v1beta2"].Get(obj.GetName(), metav1.GetOptions{})
+					_, err = clients["v1beta2"].Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 				case "list":
-					_, err = clients["v1beta2"].List(metav1.ListOptions{})
+					_, err = clients["v1beta2"].List(context.TODO(), metav1.ListOptions{})
 				case "create":
-					_, err = clients["v1beta2"].Create(newConversionMultiVersionFixture(ns, id, "v1beta2"), metav1.CreateOptions{})
+					_, err = clients["v1beta2"].Create(context.TODO(), newConversionMultiVersionFixture(ns, id, "v1beta2"), metav1.CreateOptions{})
 				case "update":
-					_, err = clients["v1beta2"].Update(obj, metav1.UpdateOptions{})
+					_, err = clients["v1beta2"].Update(context.TODO(), obj, metav1.UpdateOptions{})
 				case "patch":
-					_, err = clients["v1beta2"].Patch(obj.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"patch":"true"}}}`), metav1.PatchOptions{})
+					_, err = clients["v1beta2"].Patch(context.TODO(), obj.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"patch":"true"}}}`), metav1.PatchOptions{})
 				case "delete":
-					err = clients["v1beta2"].Delete(obj.GetName(), &metav1.DeleteOptions{})
+					err = clients["v1beta2"].Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{})
 				case "deletecollection":
-					err = clients["v1beta2"].DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{})
+					err = clients["v1beta2"].DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 				}
 
 				if err == nil {
@@ -716,11 +716,11 @@ func expectConversionFailureMessage(id, message string) func(t *testing.T, ctc *
 				t.Run(fmt.Sprintf("%s-%s", subresource, verb), func(t *testing.T) {
 					switch verb {
 					case "create":
-						_, err = clients["v1beta2"].Create(newConversionMultiVersionFixture(ns, id, "v1beta2"), metav1.CreateOptions{}, subresource)
+						_, err = clients["v1beta2"].Create(context.TODO(), newConversionMultiVersionFixture(ns, id, "v1beta2"), metav1.CreateOptions{}, subresource)
 					case "update":
-						_, err = clients["v1beta2"].Update(obj, metav1.UpdateOptions{}, subresource)
+						_, err = clients["v1beta2"].Update(context.TODO(), obj, metav1.UpdateOptions{}, subresource)
 					case "patch":
-						_, err = clients["v1beta2"].Patch(obj.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"patch":"true"}}}`), metav1.PatchOptions{}, subresource)
+						_, err = clients["v1beta2"].Patch(context.TODO(), obj.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"patch":"true"}}}`), metav1.PatchOptions{}, subresource)
 					}
 
 					if err == nil {
@@ -983,7 +983,7 @@ func (c *conversionTestContext) setAndWaitStorageVersion(t *testing.T, version s
 	// create probe object. Version should be the default one to avoid webhook calls during test setup.
 	client := c.versionedClient("probe", "v1beta1")
 	name := fmt.Sprintf("probe-%v", uuid.NewUUID())
-	storageProbe, err := client.Create(newConversionMultiVersionFixture("probe", name, "v1beta1"), metav1.CreateOptions{})
+	storageProbe, err := client.Create(context.TODO(), newConversionMultiVersionFixture("probe", name, "v1beta1"), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -991,7 +991,7 @@ func (c *conversionTestContext) setAndWaitStorageVersion(t *testing.T, version s
 	// update object continuously and wait for etcd to have the target storage version.
 	c.waitForStorageVersion(t, version, c.versionedClient(storageProbe.GetNamespace(), "v1beta1"), storageProbe)
 
-	err = client.Delete(name, &metav1.DeleteOptions{})
+	err = client.Delete(context.TODO(), name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1014,7 +1014,7 @@ func (c *conversionTestContext) setStorageVersion(t *testing.T, version string) 
 
 func (c *conversionTestContext) waitForStorageVersion(t *testing.T, version string, versionedClient dynamic.ResourceInterface, obj *unstructured.Unstructured) *unstructured.Unstructured {
 	if err := c.etcdObjectReader.WaitForStorageVersion(version, obj.GetNamespace(), obj.GetName(), 30*time.Second, func() {
-		if _, err := versionedClient.Patch(obj.GetName(), types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}); err != nil {
+		if _, err := versionedClient.Patch(context.TODO(), obj.GetName(), types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}); err != nil {
 			t.Fatalf("failed to update object: %v", err)
 		}
 	}); err != nil {
@@ -1047,7 +1047,7 @@ func (c *conversionTestContext) waitForServed(t *testing.T, version string, serv
 	timeout := 30 * time.Second
 	waitCh := time.After(timeout)
 	for {
-		obj, err := versionedClient.Get(obj.GetName(), metav1.GetOptions{})
+		obj, err := versionedClient.Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if (err == nil && served) || (errors.IsNotFound(err) && served == false) {
 			return
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/defaulting_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/defaulting_test.go
@@ -265,7 +265,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 	}
 	unstructured.SetNestedField(foo.Object, "a", "spec", "a")
 	unstructured.SetNestedField(foo.Object, "b", "status", "b")
-	foo, err = fooClient.Create(foo, metav1.CreateOptions{})
+	foo, err = fooClient.Create(context.TODO(), foo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}
@@ -279,7 +279,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 
 	t.Logf("Updating status and expecting 'a' and 'b' to show up.")
 	unstructured.SetNestedField(foo.Object, map[string]interface{}{}, "status")
-	if foo, err = fooClient.UpdateStatus(foo, metav1.UpdateOptions{}); err != nil {
+	if foo, err = fooClient.UpdateStatus(context.TODO(), foo, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	mustExist(foo.Object, [][]string{{"spec", "a"}, {"spec", "b"}, {"status", "a"}, {"status", "b"}})
@@ -289,7 +289,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 
 	t.Logf("wait until GET sees 'c' in both status and spec")
 	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		obj, err := fooClient.Get(foo.GetName(), metav1.GetOptions{})
+		obj, err := fooClient.Get(context.TODO(), foo.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -306,7 +306,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 
 	t.Logf("wait until GET sees 'c' in both status and spec of cached get")
 	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		obj, err := fooClient.Get(foo.GetName(), metav1.GetOptions{ResourceVersion: "0"})
+		obj, err := fooClient.Get(context.TODO(), foo.GetName(), metav1.GetOptions{ResourceVersion: "0"})
 		if err != nil {
 			return false, err
 		}
@@ -322,7 +322,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 	mustExist(foo.Object, [][]string{{"spec", "a"}, {"spec", "b"}, {"spec", "c"}, {"status", "a"}, {"status", "b"}, {"status", "c"}})
 
 	t.Logf("verify LIST sees 'c' in both status and spec")
-	foos, err := fooClient.List(metav1.ListOptions{})
+	foos, err := fooClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -331,7 +331,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 	}
 
 	t.Logf("verify LIST from cache sees 'c' in both status and spec")
-	foos, err = fooClient.List(metav1.ListOptions{ResourceVersion: "0"})
+	foos, err = fooClient.List(context.TODO(), metav1.ListOptions{ResourceVersion: "0"})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +344,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 	// The contents of the watch cache are seen by list with rv=0, which is tested by this test.
 	if !watchCache {
 		t.Logf("verify WATCH sees 'c' in both status and spec")
-		w, err := fooClient.Watch(metav1.ListOptions{ResourceVersion: initialResourceVersion})
+		w, err := fooClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: initialResourceVersion})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -369,7 +369,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 	addDefault("v1beta1", "c", "C")
 	removeDefault("v1beta2", "c")
 	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		obj, err := fooClient.Get(foo.GetName(), metav1.GetOptions{})
+		obj, err := fooClient.Get(context.TODO(), foo.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -383,7 +383,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 	mustNotExist(foo.Object, [][]string{{"spec", "c"}, {"status", "c"}})
 
 	t.Logf("Updating status, expecting 'c' to be set in status only")
-	if foo, err = fooClient.UpdateStatus(foo, metav1.UpdateOptions{}); err != nil {
+	if foo, err = fooClient.UpdateStatus(context.TODO(), foo, metav1.UpdateOptions{}); err != nil {
 		t.Fatal(err)
 	}
 	mustExist(foo.Object, [][]string{{"spec", "a"}, {"spec", "b"}, {"status", "a"}, {"status", "b"}, {"status", "c"}})
@@ -394,7 +394,7 @@ func testDefaulting(t *testing.T, watchCache bool) {
 	removeDefault("v1beta1", "b")
 	removeDefault("v1beta1", "c")
 	if err := wait.PollImmediate(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-		obj, err := fooClient.Get(foo.GetName(), metav1.GetOptions{})
+		obj, err := fooClient.Get(context.TODO(), foo.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -623,7 +623,7 @@ func TestCustomResourceDefaultingOfMetaFields(t *testing.T) {
 			}
 		}
 	}
-	returnedFoo, err = fooClient.Create(returnedFoo, metav1.CreateOptions{})
+	returnedFoo, err = fooClient.Create(context.TODO(), returnedFoo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -50,7 +50,7 @@ func TestFinalization(t *testing.T) {
 	require.NoError(t, err)
 
 	uid := createdNoxuInstance.GetUID()
-	err = noxuResourceClient.Delete(name, &metav1.DeleteOptions{
+	err = noxuResourceClient.Delete(name, metav1.DeleteOptions{
 		Preconditions: &metav1.Preconditions{
 			UID: &uid,
 		},
@@ -65,7 +65,7 @@ func TestFinalization(t *testing.T) {
 	require.NotNil(t, gottenNoxuInstance.GetDeletionTimestamp())
 
 	// Trying to delete it again to confirm it will not remove the object because finalizer is still there.
-	err = noxuResourceClient.Delete(name, &metav1.DeleteOptions{
+	err = noxuResourceClient.Delete(name, metav1.DeleteOptions{
 		Preconditions: &metav1.Preconditions{
 			UID: &uid,
 		},
@@ -116,7 +116,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 
 	// Delete a CR. Because there's a finalizer, it will not get deleted now.
 	uid := createdNoxuInstance.GetUID()
-	err = noxuResourceClient.Delete(name, &metav1.DeleteOptions{
+	err = noxuResourceClient.Delete(name, metav1.DeleteOptions{
 		Preconditions: &metav1.Preconditions{
 			UID: &uid,
 		},

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/finalization_test.go
@@ -50,7 +50,7 @@ func TestFinalization(t *testing.T) {
 	require.NoError(t, err)
 
 	uid := createdNoxuInstance.GetUID()
-	err = noxuResourceClient.Delete(name, metav1.DeleteOptions{
+	err = noxuResourceClient.Delete(context.TODO(), name, metav1.DeleteOptions{
 		Preconditions: &metav1.Preconditions{
 			UID: &uid,
 		},
@@ -59,13 +59,13 @@ func TestFinalization(t *testing.T) {
 
 	// Deleting something with a finalizer sets deletion timestamp to a not-nil value but does not
 	// remove the object from the API server. Here we read it to confirm this.
-	gottenNoxuInstance, err := noxuResourceClient.Get(name, metav1.GetOptions{})
+	gottenNoxuInstance, err := noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	require.NotNil(t, gottenNoxuInstance.GetDeletionTimestamp())
 
 	// Trying to delete it again to confirm it will not remove the object because finalizer is still there.
-	err = noxuResourceClient.Delete(name, metav1.DeleteOptions{
+	err = noxuResourceClient.Delete(context.TODO(), name, metav1.DeleteOptions{
 		Preconditions: &metav1.Preconditions{
 			UID: &uid,
 		},
@@ -77,19 +77,19 @@ func TestFinalization(t *testing.T) {
 	// object will be deleted as part of the finalizer update.
 	for {
 		gottenNoxuInstance.SetFinalizers(nil)
-		_, err = noxuResourceClient.Update(gottenNoxuInstance, metav1.UpdateOptions{})
+		_, err = noxuResourceClient.Update(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 		if err == nil {
 			break
 		}
 		if !errors.IsConflict(err) {
 			require.NoError(t, err) // Fail on unexpected error
 		}
-		gottenNoxuInstance, err = noxuResourceClient.Get(name, metav1.GetOptions{})
+		gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 		require.NoError(t, err)
 	}
 
 	// Check that the object is actually gone.
-	_, err = noxuResourceClient.Get(name, metav1.GetOptions{})
+	_, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 	require.Error(t, err)
 	require.True(t, errors.IsNotFound(err), "%#v", err)
 }
@@ -116,7 +116,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 
 	// Delete a CR. Because there's a finalizer, it will not get deleted now.
 	uid := createdNoxuInstance.GetUID()
-	err = noxuResourceClient.Delete(name, metav1.DeleteOptions{
+	err = noxuResourceClient.Delete(context.TODO(), name, metav1.DeleteOptions{
 		Preconditions: &metav1.Preconditions{
 			UID: &uid,
 		},
@@ -124,7 +124,7 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check is the CR scheduled for deletion.
-	gottenNoxuInstance, err := noxuResourceClient.Get(name, metav1.GetOptions{})
+	gottenNoxuInstance, err := noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, gottenNoxuInstance.GetDeletionTimestamp())
 
@@ -132,26 +132,26 @@ func TestFinalizationAndDeletion(t *testing.T) {
 	fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient)
 
 	// Check is CR still there after the CRD deletion.
-	gottenNoxuInstance, err = noxuResourceClient.Get(name, metav1.GetOptions{})
+	gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 	require.NoError(t, err)
 
 	// Update the CR to remove the finalizer.
 	for {
 		gottenNoxuInstance.SetFinalizers(nil)
-		_, err = noxuResourceClient.Update(gottenNoxuInstance, metav1.UpdateOptions{})
+		_, err = noxuResourceClient.Update(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 		if err == nil {
 			break
 		}
 		if !errors.IsConflict(err) {
 			require.NoError(t, err) // Fail on unexpected error
 		}
-		gottenNoxuInstance, err = noxuResourceClient.Get(name, metav1.GetOptions{})
+		gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 		require.NoError(t, err)
 	}
 
 	// Verify the CR is gone.
 	// It should return the NonFound error.
-	_, err = noxuResourceClient.Get(name, metav1.GetOptions{})
+	_, err = noxuResourceClient.Get(context.TODO(), name, metav1.GetOptions{})
 	if !errors.IsNotFound(err) {
 		t.Fatalf("unable to delete cr: %v", err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -462,11 +462,11 @@ func isWatchCachePrimed(crd *apiextensionsv1.CustomResourceDefinition, dynamicCl
 			"spec":    map[string]interface{}{},
 		},
 	}
-	createdInstance, err := resourceClient.Create(instance, metav1.CreateOptions{})
+	createdInstance, err := resourceClient.Create(context.TODO(), instance, metav1.CreateOptions{})
 	if err != nil {
 		return false, err
 	}
-	err = resourceClient.Delete(createdInstance.GetName(), metav1.DeleteOptions{})
+	err = resourceClient.Delete(context.TODO(), createdInstance.GetName(), metav1.DeleteOptions{})
 	if err != nil {
 		return false, err
 	}
@@ -480,6 +480,7 @@ func isWatchCachePrimed(crd *apiextensionsv1.CustomResourceDefinition, dynamicCl
 	// delivered to any future watch with resourceVersion=0.
 	for _, v := range versions {
 		noxuWatch, err := resourceClientForVersion(crd, dynamicClientSet, ns, v).Watch(
+			context.TODO(),
 			metav1.ListOptions{ResourceVersion: createdInstance.GetResourceVersion()})
 		if err != nil {
 			return false, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/fixtures/resources.go
@@ -466,7 +466,7 @@ func isWatchCachePrimed(crd *apiextensionsv1.CustomResourceDefinition, dynamicCl
 	if err != nil {
 		return false, err
 	}
-	err = resourceClient.Delete(createdInstance.GetName(), nil)
+	err = resourceClient.Delete(createdInstance.GetName(), metav1.DeleteOptions{})
 	if err != nil {
 		return false, err
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/helpers.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/helpers.go
@@ -39,7 +39,7 @@ func instantiateCustomResource(t *testing.T, instanceToCreate *unstructured.Unst
 }
 
 func instantiateVersionedCustomResource(t *testing.T, instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1beta1.CustomResourceDefinition, version string) (*unstructured.Unstructured, error) {
-	createdInstance, err := client.Create(instanceToCreate, metav1.CreateOptions{})
+	createdInstance, err := client.Create(context.TODO(), instanceToCreate, metav1.CreateOptions{})
 	if err != nil {
 		t.Logf("%#v", createdInstance)
 		return nil, err

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/listtype_test.go
@@ -143,7 +143,7 @@ func TestListTypes(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(listTypeResourceInstance), &invalidInstance.Object); err != nil {
 		t.Fatal(err)
 	}
-	_, createErr := fooClient.Create(invalidInstance, metav1.CreateOptions{})
+	_, createErr := fooClient.Create(context.TODO(), invalidInstance, metav1.CreateOptions{})
 	if createErr == nil {
 		t.Fatalf("Expected validation errors, but did not get one")
 	}
@@ -170,7 +170,7 @@ func TestListTypes(t *testing.T) {
 	for _, invalid := range invalidListTypeFields {
 		unstructured.RemoveNestedField(validInstance.Object, invalid)
 	}
-	validInstance, err = fooClient.Create(validInstance, metav1.CreateOptions{})
+	validInstance, err = fooClient.Create(context.TODO(), validInstance, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -183,7 +183,7 @@ func TestListTypes(t *testing.T) {
 		l = append(l, l[0])
 		modifiedInstance.Object[valid] = l
 	}
-	_, err = fooClient.Update(modifiedInstance, metav1.UpdateOptions{})
+	_, err = fooClient.Update(context.TODO(), modifiedInstance, metav1.UpdateOptions{})
 	if err == nil {
 		t.Fatalf("Expected validation errors, but did not get one")
 	}
@@ -211,7 +211,7 @@ func TestListTypes(t *testing.T) {
 
 	t.Logf("Updating again with invalid values, eventually successfully due to ratcheting logic")
 	err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-		_, err = fooClient.Update(modifiedInstance, metav1.UpdateOptions{})
+		_, err = fooClient.Update(context.TODO(), modifiedInstance, metav1.UpdateOptions{})
 		if err == nil {
 			return true, err
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -181,7 +181,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 
 	t.Logf("Checking that invalid objects can be deleted")
 	noxuResourceClient := newNamespacedCustomResourceClient("default", dynamicClient, noxuDefinition)
-	if err := noxuResourceClient.Delete("foo", &metav1.DeleteOptions{}); err != nil {
+	if err := noxuResourceClient.Delete("foo", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Unexpected delete error %v", err)
 	}
 	if _, err := etcdclient.Put(ctx, key, string(val)); err != nil {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/objectmeta_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"path"
 	"reflect"
 	"strings"
@@ -181,7 +182,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 
 	t.Logf("Checking that invalid objects can be deleted")
 	noxuResourceClient := newNamespacedCustomResourceClient("default", dynamicClient, noxuDefinition)
-	if err := noxuResourceClient.Delete("foo", metav1.DeleteOptions{}); err != nil {
+	if err := noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Unexpected delete error %v", err)
 	}
 	if _, err := etcdclient.Put(ctx, key, string(val)); err != nil {
@@ -189,7 +190,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 	}
 
 	t.Logf("Checking that ObjectMeta is pruned from unknown fields")
-	obj, err := noxuResourceClient.Get("foo", metav1.GetOptions{})
+	obj, err := noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Unexpected error: %v", err)
 	}
@@ -249,7 +250,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 
 	t.Logf("Trying to fail on updating with invalid labels")
 	unstructured.SetNestedField(obj.Object, "changed", "metadata", "labels", "something")
-	if got, err := noxuResourceClient.Update(obj, metav1.UpdateOptions{}); err == nil {
+	if got, err := noxuResourceClient.Update(context.TODO(), obj, metav1.UpdateOptions{}); err == nil {
 		objJSON, _ := json.Marshal(obj.Object)
 		gotJSON, _ := json.Marshal(got.Object)
 		t.Fatalf("Expected update error, but didn't get one\nin: %s\nresponse: %v", string(objJSON), string(gotJSON))
@@ -257,7 +258,7 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 
 	t.Logf("Trying to fail on updating with invalid embedded label")
 	unstructured.SetNestedField(obj.Object, "fixed", "metadata", "labels", "invalid")
-	if got, err := noxuResourceClient.Update(obj, metav1.UpdateOptions{}); err == nil {
+	if got, err := noxuResourceClient.Update(context.TODO(), obj, metav1.UpdateOptions{}); err == nil {
 		objJSON, _ := json.Marshal(obj.Object)
 		gotJSON, _ := json.Marshal(got.Object)
 		t.Fatalf("Expected update error, but didn't get one\nin: %s\nresponse: %v", string(objJSON), string(gotJSON))
@@ -265,13 +266,13 @@ func TestInvalidObjectMetaInStorage(t *testing.T) {
 
 	t.Logf("Fixed all labels and update should work")
 	unstructured.SetNestedField(obj.Object, "fixed", "embedded", "metadata", "labels", "invalid")
-	if _, err := noxuResourceClient.Update(obj, metav1.UpdateOptions{}); err != nil {
+	if _, err := noxuResourceClient.Update(context.TODO(), obj, metav1.UpdateOptions{}); err != nil {
 		t.Errorf("Unexpected update error with fixed labels: %v", err)
 	}
 
 	t.Logf("Trying to fail on updating with wrongly-typed embedded label")
 	unstructured.SetNestedField(obj.Object, int64(42), "embedded", "metadata", "labels", "invalid")
-	if got, err := noxuResourceClient.Update(obj, metav1.UpdateOptions{}); err == nil {
+	if got, err := noxuResourceClient.Update(context.TODO(), obj, metav1.UpdateOptions{}); err == nil {
 		objJSON, _ := json.Marshal(obj.Object)
 		gotJSON, _ := json.Marshal(got.Object)
 		t.Fatalf("Expected update error, but didn't get one\nin: %s\nresponse: %v", string(objJSON), string(gotJSON))
@@ -452,7 +453,7 @@ func TestEmbeddedResources(t *testing.T) {
 		t.Fatal(err)
 	}
 	unstructured.SetNestedField(foo.Object, "foo", "metadata", "name")
-	foo, err = fooClient.Create(foo, metav1.CreateOptions{})
+	foo, err = fooClient.Create(context.TODO(), foo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}
@@ -474,7 +475,7 @@ func TestEmbeddedResources(t *testing.T) {
 		t.Fatal(err)
 	}
 	unstructured.SetNestedField(wronglyTyped.Object, "invalid", "metadata", "name")
-	_, err = fooClient.Create(wronglyTyped, metav1.CreateOptions{})
+	_, err = fooClient.Create(context.TODO(), wronglyTyped, metav1.CreateOptions{})
 	if err == nil {
 		t.Fatal("Expected creation to fail, but didn't")
 	}
@@ -495,7 +496,7 @@ func TestEmbeddedResources(t *testing.T) {
 	}
 	unstructured.SetNestedField(invalid.Object, "invalid", "metadata", "name")
 	unstructured.SetNestedField(invalid.Object, "x y", "metadata", "labels", "foo")
-	_, err = fooClient.Create(invalid, metav1.CreateOptions{})
+	_, err = fooClient.Create(context.TODO(), invalid, metav1.CreateOptions{})
 	if err == nil {
 		t.Fatal("Expected creation to fail, but didn't")
 	}
@@ -522,7 +523,7 @@ func TestEmbeddedResources(t *testing.T) {
 		t.Fatal(err)
 	}
 	unstructured.SetNestedField(valid.Object, "valid", "metadata", "name")
-	valid, err = fooClient.Create(valid, metav1.CreateOptions{})
+	valid, err = fooClient.Create(context.TODO(), valid, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}
@@ -533,7 +534,7 @@ func TestEmbeddedResources(t *testing.T) {
 		valid.Object[k] = v
 	}
 	unstructured.SetNestedField(valid.Object, "x y", "metadata", "labels", "foo")
-	if _, err = fooClient.Update(valid, metav1.UpdateOptions{}); err == nil {
+	if _, err = fooClient.Update(context.TODO(), valid, metav1.UpdateOptions{}); err == nil {
 		t.Fatal("Expected update error, but got none")
 	}
 	t.Logf("Update failed with: %v", err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/pruning_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"path"
 	"reflect"
 	"strings"
@@ -209,7 +210,7 @@ func TestPruningCreate(t *testing.T) {
 	unstructured.SetNestedField(foo.Object, float64(42.0), "beta")
 	unstructured.SetNestedField(foo.Object, "bar", "metadata", "unspecified")
 	unstructured.SetNestedField(foo.Object, "bar", "metadata", "labels", "foo")
-	foo, err = fooClient.Create(foo, metav1.CreateOptions{})
+	foo, err = fooClient.Create(context.TODO(), foo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}
@@ -256,7 +257,7 @@ func TestPruningStatus(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(pruningFooInstance), &foo.Object); err != nil {
 		t.Fatal(err)
 	}
-	foo, err = fooClient.Create(foo, metav1.CreateOptions{})
+	foo, err = fooClient.Create(context.TODO(), foo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}
@@ -267,7 +268,7 @@ func TestPruningStatus(t *testing.T) {
 	unstructured.SetNestedField(foo.Object, float64(42.0), "status", "beta")
 	unstructured.SetNestedField(foo.Object, "bar", "metadata", "unspecified")
 
-	foo, err = fooClient.UpdateStatus(foo, metav1.UpdateOptions{})
+	foo, err = fooClient.UpdateStatus(context.TODO(), foo, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to update status: %v", err)
 	}
@@ -368,7 +369,7 @@ func TestPruningFromStorage(t *testing.T) {
 
 	t.Logf("Checking that CustomResource is pruned from unknown fields")
 	fooClient := dynamicClient.Resource(schema.GroupVersionResource{crd.Spec.Group, crd.Spec.Version, crd.Spec.Names.Plural})
-	foo, err := fooClient.Get("foo", metav1.GetOptions{})
+	foo, err := fooClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -413,7 +414,7 @@ func TestPruningPatch(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(pruningFooInstance), &foo.Object); err != nil {
 		t.Fatal(err)
 	}
-	foo, err = fooClient.Create(foo, metav1.CreateOptions{})
+	foo, err = fooClient.Create(context.TODO(), foo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}
@@ -421,7 +422,7 @@ func TestPruningPatch(t *testing.T) {
 
 	// a patch with a change
 	patch := []byte(`{"alpha": "abc", "beta": 42.0, "unspecified": "bar", "metadata": {"unspecified": "bar", "labels":{"foo":"bar"}}}`)
-	if foo, err = fooClient.Patch("foo", types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
+	if foo, err = fooClient.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{}); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -484,7 +485,7 @@ func TestPruningCreatePreservingUnknownFields(t *testing.T) {
 		"preserving":        map[string]interface{}{"unspecified": "bar"},
 	}, "preserving")
 
-	foo, err = fooClient.Create(foo, metav1.CreateOptions{})
+	foo, err = fooClient.Create(context.TODO(), foo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}
@@ -551,7 +552,7 @@ func TestPruningEmbeddedResources(t *testing.T) {
 	if err := yaml.Unmarshal([]byte(fooSchemaEmbeddedResourceInstance), &foo.Object); err != nil {
 		t.Fatal(err)
 	}
-	foo, err = fooClient.Create(foo, metav1.CreateOptions{})
+	foo, err = fooClient.Create(context.TODO(), foo, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Unable to create CR: %v", err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -53,7 +53,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 		t.Fatal(err)
 	}
 	noxuNamespacedResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
-	noxuList, err := noxuNamespacedResourceClient.List(metav1.ListOptions{})
+	noxuList, err := noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,7 +63,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	noxuNamespacedWatch, err := noxuNamespacedResourceClient.Watch(metav1.ListOptions{ResourceVersion: noxuListListMeta.GetResourceVersion()})
+	noxuNamespacedWatch, err := noxuNamespacedResourceClient.Watch(context.TODO(), metav1.ListOptions{ResourceVersion: noxuListListMeta.GetResourceVersion()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +107,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 	}
 
 	for key, val := range instances {
-		gottenNoxuInstace, err := noxuNamespacedResourceClient.Get(key, metav1.GetOptions{})
+		gottenNoxuInstace, err := noxuNamespacedResourceClient.Get(context.TODO(), key, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -115,7 +115,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 			t.Errorf("expected %v, got %v", e, a)
 		}
 	}
-	listWithItem, err := noxuNamespacedResourceClient.List(metav1.ListOptions{})
+	listWithItem, err := noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,11 +128,11 @@ func TestMultipleResourceInstances(t *testing.T) {
 		}
 	}
 	for key := range instances {
-		if err := noxuNamespacedResourceClient.Delete(key, metav1.DeleteOptions{}); err != nil {
+		if err := noxuNamespacedResourceClient.Delete(context.TODO(), key, metav1.DeleteOptions{}); err != nil {
 			t.Fatalf("unable to delete %s:%v", key, err)
 		}
 	}
-	listWithoutItem, err := noxuNamespacedResourceClient.List(metav1.ListOptions{})
+	listWithoutItem, err := noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -183,7 +183,7 @@ func TestMultipleRegistration(t *testing.T) {
 		t.Fatalf("unable to create noxu Instance:%v", err)
 	}
 
-	gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
+	gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(context.TODO(), sameInstanceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -201,7 +201,7 @@ func TestMultipleRegistration(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to create noxu Instance:%v", err)
 	}
-	gottenCurletInstance, err := curletNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
+	gottenCurletInstance, err := curletNamespacedResourceClient.Get(context.TODO(), sameInstanceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -210,7 +210,7 @@ func TestMultipleRegistration(t *testing.T) {
 	}
 
 	// now re-GET noxu
-	gottenNoxuInstance2, err := noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
+	gottenNoxuInstance2, err := noxuNamespacedResourceClient.Get(context.TODO(), sameInstanceName, metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,10 +243,10 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if _, err := apiExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get(context.TODO(), noxuDefinition.Name, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
-		if _, err = noxuNamespacedResourceClient.List(metav1.ListOptions{}); err == nil || !errors.IsNotFound(err) {
+		if _, err = noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
-		if _, err = noxuNamespacedResourceClient.Get("foo", metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
+		if _, err = noxuNamespacedResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
 	}()
@@ -260,11 +260,11 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 			t.Fatal(err)
 		}
 		noxuNamespacedResourceClient := newNamespacedCustomResourceClient(ns, dynamicClient, noxuDefinition)
-		initialList, err := noxuNamespacedResourceClient.List(metav1.ListOptions{})
+		initialList, err := noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
-		if _, err = noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
+		if _, err = noxuNamespacedResourceClient.Get(context.TODO(), sameInstanceName, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
 		if e, a := 0, len(initialList.Items); e != a {
@@ -274,14 +274,14 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{})
+		gottenNoxuInstance, err := noxuNamespacedResourceClient.Get(context.TODO(), sameInstanceName, metav1.GetOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
 		if e, a := createdNoxuInstance, gottenNoxuInstance; !reflect.DeepEqual(e, a) {
 			t.Fatalf("expected %v, got %v", e, a)
 		}
-		listWithItem, err := noxuNamespacedResourceClient.List(metav1.ListOptions{})
+		listWithItem, err := noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -292,13 +292,13 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 			t.Fatalf("expected %v, got %v", e, a)
 		}
 
-		if err := noxuNamespacedResourceClient.Delete(sameInstanceName, metav1.DeleteOptions{}); err != nil {
+		if err := noxuNamespacedResourceClient.Delete(context.TODO(), sameInstanceName, metav1.DeleteOptions{}); err != nil {
 			t.Fatal(err)
 		}
-		if _, err = noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
+		if _, err = noxuNamespacedResourceClient.Get(context.TODO(), sameInstanceName, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {
 			t.Fatalf("expected a NotFound error, got:%v", err)
 		}
-		listWithoutItem, err := noxuNamespacedResourceClient.List(metav1.ListOptions{})
+		listWithoutItem, err := noxuNamespacedResourceClient.List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/registration_test.go
@@ -128,7 +128,7 @@ func TestMultipleResourceInstances(t *testing.T) {
 		}
 	}
 	for key := range instances {
-		if err := noxuNamespacedResourceClient.Delete(key, nil); err != nil {
+		if err := noxuNamespacedResourceClient.Delete(key, metav1.DeleteOptions{}); err != nil {
 			t.Fatalf("unable to delete %s:%v", key, err)
 		}
 	}
@@ -292,7 +292,7 @@ func TestDeRegistrationAndReRegistration(t *testing.T) {
 			t.Fatalf("expected %v, got %v", e, a)
 		}
 
-		if err := noxuNamespacedResourceClient.Delete(sameInstanceName, nil); err != nil {
+		if err := noxuNamespacedResourceClient.Delete(sameInstanceName, metav1.DeleteOptions{}); err != nil {
 			t.Fatal(err)
 		}
 		if _, err = noxuNamespacedResourceClient.Get(sameInstanceName, metav1.GetOptions{}); err == nil || !errors.IsNotFound(err) {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -89,68 +90,68 @@ func TestHandlerScope(t *testing.T) {
 				},
 			}
 
-			_, err := otherScopeClient.Create(cr, metav1.CreateOptions{})
+			_, err := otherScopeClient.Create(context.TODO(), cr, metav1.CreateOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Create(cr, metav1.CreateOptions{}, "status")
+			_, err = otherScopeClient.Create(context.TODO(), cr, metav1.CreateOptions{}, "status")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Create(cr, metav1.CreateOptions{}, "scale")
+			_, err = otherScopeClient.Create(context.TODO(), cr, metav1.CreateOptions{}, "scale")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = client.Create(cr, metav1.CreateOptions{})
+			_, err = client.Create(context.TODO(), cr, metav1.CreateOptions{})
 			assert.NoError(t, err)
 
-			_, err = otherScopeClient.Get(name, metav1.GetOptions{})
+			_, err = otherScopeClient.Get(context.TODO(), name, metav1.GetOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Get(name, metav1.GetOptions{}, "status")
+			_, err = otherScopeClient.Get(context.TODO(), name, metav1.GetOptions{}, "status")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Get(name, metav1.GetOptions{}, "scale")
+			_, err = otherScopeClient.Get(context.TODO(), name, metav1.GetOptions{}, "scale")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Update(cr, metav1.UpdateOptions{})
+			_, err = otherScopeClient.Update(context.TODO(), cr, metav1.UpdateOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Update(cr, metav1.UpdateOptions{}, "status")
+			_, err = otherScopeClient.Update(context.TODO(), cr, metav1.UpdateOptions{}, "status")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Update(cr, metav1.UpdateOptions{}, "scale")
+			_, err = otherScopeClient.Update(context.TODO(), cr, metav1.UpdateOptions{}, "scale")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Patch(name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{})
+			_, err = otherScopeClient.Patch(context.TODO(), name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Patch(name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}, "status")
+			_, err = otherScopeClient.Patch(context.TODO(), name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}, "status")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			_, err = otherScopeClient.Patch(name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}, "scale")
+			_, err = otherScopeClient.Patch(context.TODO(), name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}, "scale")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.Delete(name, metav1.DeleteOptions{})
+			err = otherScopeClient.Delete(context.TODO(), name, metav1.DeleteOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.Delete(name, metav1.DeleteOptions{}, "status")
+			err = otherScopeClient.Delete(context.TODO(), name, metav1.DeleteOptions{}, "status")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.Delete(name, metav1.DeleteOptions{}, "scale")
+			err = otherScopeClient.Delete(context.TODO(), name, metav1.DeleteOptions{}, "scale")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.DeleteCollection(metav1.DeleteOptions{}, metav1.ListOptions{})
+			err = otherScopeClient.DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
 			if scope == apiextensionsv1beta1.ClusterScoped {
-				_, err = otherScopeClient.List(metav1.ListOptions{})
+				_, err = otherScopeClient.List(context.TODO(), metav1.ListOptions{})
 				assert.True(t, apierrors.IsNotFound(err))
 
-				_, err = otherScopeClient.Watch(metav1.ListOptions{})
+				_, err = otherScopeClient.Watch(context.TODO(), metav1.ListOptions{})
 				assert.True(t, apierrors.IsNotFound(err))
 			} else {
-				_, err = otherScopeClient.List(metav1.ListOptions{})
+				_, err = otherScopeClient.List(context.TODO(), metav1.ListOptions{})
 				assert.NoError(t, err)
 
-				w, err := otherScopeClient.Watch(metav1.ListOptions{})
+				w, err := otherScopeClient.Watch(context.TODO(), metav1.ListOptions{})
 				assert.NoError(t, err)
 				if w != nil {
 					w.Stop()

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/scope_test.go
@@ -128,16 +128,16 @@ func TestHandlerScope(t *testing.T) {
 			_, err = otherScopeClient.Patch(name, types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}, "scale")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.Delete(name, &metav1.DeleteOptions{})
+			err = otherScopeClient.Delete(name, metav1.DeleteOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.Delete(name, &metav1.DeleteOptions{}, "status")
+			err = otherScopeClient.Delete(name, metav1.DeleteOptions{}, "status")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.Delete(name, &metav1.DeleteOptions{}, "scale")
+			err = otherScopeClient.Delete(name, metav1.DeleteOptions{}, "scale")
 			assert.True(t, apierrors.IsNotFound(err))
 
-			err = otherScopeClient.DeleteCollection(&metav1.DeleteOptions{}, metav1.ListOptions{})
+			err = otherScopeClient.DeleteCollection(metav1.DeleteOptions{}, metav1.ListOptions{})
 			assert.True(t, apierrors.IsNotFound(err))
 
 			if scope == apiextensionsv1beta1.ClusterScoped {

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integration
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"reflect"
@@ -166,7 +167,7 @@ func TestStatusSubresource(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to create noxu instance: %v", err)
 			}
-			gottenNoxuInstance, err := noxuResourceClient.Get("foo", metav1.GetOptions{})
+			gottenNoxuInstance, err := noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -189,7 +190,7 @@ func TestStatusSubresource(t *testing.T) {
 
 			// UpdateStatus should not update spec.
 			// Check that .spec.num = 10 and .status.num = 20
-			updatedStatusInstance, err := noxuResourceClient.UpdateStatus(gottenNoxuInstance, metav1.UpdateOptions{})
+			updatedStatusInstance, err := noxuResourceClient.UpdateStatus(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("unable to update status: %v", err)
 			}
@@ -210,7 +211,7 @@ func TestStatusSubresource(t *testing.T) {
 				t.Fatalf(".status.num: expected: %v, got: %v", int64(20), statusNum)
 			}
 
-			gottenNoxuInstance, err = noxuResourceClient.Get("foo", metav1.GetOptions{})
+			gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -229,7 +230,7 @@ func TestStatusSubresource(t *testing.T) {
 
 			// Update should not update status.
 			// Check that .spec.num = 40 and .status.num = 20
-			updatedInstance, err := noxuResourceClient.Update(gottenNoxuInstance, metav1.UpdateOptions{})
+			updatedInstance, err := noxuResourceClient.Update(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("unable to update instance: %v", err)
 			}
@@ -249,7 +250,7 @@ func TestStatusSubresource(t *testing.T) {
 			if statusNum != int64(20) {
 				t.Fatalf(".status.num: expected: %v, got: %v", int64(20), statusNum)
 			}
-			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -314,7 +315,7 @@ func TestScaleSubresource(t *testing.T) {
 			}
 
 			// set .status.labelSelector = bar
-			gottenNoxuInstance, err := noxuResourceClient.Get("foo", metav1.GetOptions{})
+			gottenNoxuInstance, err := noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -322,7 +323,7 @@ func TestScaleSubresource(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			_, err = noxuResourceClient.UpdateStatus(gottenNoxuInstance, metav1.UpdateOptions{})
+			_, err = noxuResourceClient.UpdateStatus(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("unable to update status: %v", err)
 			}
@@ -361,7 +362,7 @@ func TestScaleSubresource(t *testing.T) {
 			}
 
 			// check that .spec.replicas = 5, but status is not updated
-			updatedNoxuInstance, err := noxuResourceClient.Get("foo", metav1.GetOptions{})
+			updatedNoxuInstance, err := noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -382,7 +383,7 @@ func TestScaleSubresource(t *testing.T) {
 
 			// validate maximum value
 			// set .spec.replicas = math.MaxInt64
-			gottenNoxuInstance, err = noxuResourceClient.Get("foo", metav1.GetOptions{})
+			gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -390,11 +391,11 @@ func TestScaleSubresource(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
-			_, err = noxuResourceClient.Update(gottenNoxuInstance, metav1.UpdateOptions{})
+			_, err = noxuResourceClient.Update(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 			if err == nil {
 				t.Fatalf("unexpected non-error: .spec.replicas should be less than 2147483647")
 			}
-			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 			if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
@@ -526,7 +527,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error setting .spec.num: %v", err)
 			}
-			createdNoxuInstance, err = noxuResourceClient.UpdateStatus(createdNoxuInstance, metav1.UpdateOptions{})
+			createdNoxuInstance, err = noxuResourceClient.UpdateStatus(context.TODO(), createdNoxuInstance, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -536,7 +537,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unexpected error setting .status.num: %v", err)
 			}
-			_, err = noxuResourceClient.UpdateStatus(createdNoxuInstance, metav1.UpdateOptions{})
+			_, err = noxuResourceClient.UpdateStatus(context.TODO(), createdNoxuInstance, metav1.UpdateOptions{})
 			if err == nil {
 				t.Fatal("expected error, but got none")
 			}
@@ -547,7 +548,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			if !strings.Contains(statusError.Error(), "Invalid value") {
 				t.Fatalf("expected 'Invalid value' in error, got: %v", err)
 			}
-			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -669,7 +670,7 @@ func TestGeneration(t *testing.T) {
 			}
 
 			// .metadata.generation = 1
-			gottenNoxuInstance, err := noxuResourceClient.Get("foo", metav1.GetOptions{})
+			gottenNoxuInstance, err := noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -684,7 +685,7 @@ func TestGeneration(t *testing.T) {
 			}
 
 			// UpdateStatus does not increment generation
-			updatedStatusInstance, err := noxuResourceClient.UpdateStatus(gottenNoxuInstance, metav1.UpdateOptions{})
+			updatedStatusInstance, err := noxuResourceClient.UpdateStatus(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("unable to update status: %v", err)
 			}
@@ -692,7 +693,7 @@ func TestGeneration(t *testing.T) {
 				t.Fatalf("updating status should not increment .metadata.generation: expected: %v, got: %v", 1, updatedStatusInstance.GetGeneration())
 			}
 
-			gottenNoxuInstance, err = noxuResourceClient.Get("foo", metav1.GetOptions{})
+			gottenNoxuInstance, err = noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -704,14 +705,14 @@ func TestGeneration(t *testing.T) {
 			}
 
 			// Update increments generation
-			updatedInstance, err := noxuResourceClient.Update(gottenNoxuInstance, metav1.UpdateOptions{})
+			updatedInstance, err := noxuResourceClient.Update(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 			if err != nil {
 				t.Fatalf("unable to update instance: %v", err)
 			}
 			if updatedInstance.GetGeneration() != 2 {
 				t.Fatalf("updating spec should increment .metadata.generation: expected: %v, got: %v", 2, updatedStatusInstance.GetGeneration())
 			}
-			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -764,7 +765,7 @@ func TestSubresourcePatch(t *testing.T) {
 
 			t.Logf("Patching .status.num to 999")
 			patch := []byte(`{"spec": {"num":999}, "status": {"num":999}}`)
-			patchedNoxuInstance, err := noxuResourceClient.Patch("foo", types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+			patchedNoxuInstance, err := noxuResourceClient.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{}, "status")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -785,14 +786,14 @@ func TestSubresourcePatch(t *testing.T) {
 			// and then the updated object shows a conflicting diff, which permanently fails the patch.
 			// This gives expected stability in the patch without retrying on an known number of conflicts below in the test.
 			// See https://issue.k8s.io/42644
-			_, err = noxuResourceClient.Get("foo", metav1.GetOptions{ResourceVersion: patchedNoxuInstance.GetResourceVersion()})
+			_, err = noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{ResourceVersion: patchedNoxuInstance.GetResourceVersion()})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			// no-op patch
 			t.Logf("Patching .status.num again to 999")
-			patchedNoxuInstance, err = noxuResourceClient.Patch("foo", types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+			patchedNoxuInstance, err = noxuResourceClient.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{}, "status")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -803,7 +804,7 @@ func TestSubresourcePatch(t *testing.T) {
 
 			// empty patch
 			t.Logf("Applying empty patch")
-			patchedNoxuInstance, err = noxuResourceClient.Patch("foo", types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}, "status")
+			patchedNoxuInstance, err = noxuResourceClient.Patch(context.TODO(), "foo", types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}, "status")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -815,7 +816,7 @@ func TestSubresourcePatch(t *testing.T) {
 
 			t.Logf("Patching .spec.replicas to 7")
 			patch = []byte(`{"spec": {"replicas":7}, "status": {"replicas":7}}`)
-			patchedNoxuInstance, err = noxuResourceClient.Patch("foo", types.MergePatchType, patch, metav1.PatchOptions{}, "scale")
+			patchedNoxuInstance, err = noxuResourceClient.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{}, "scale")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -836,7 +837,7 @@ func TestSubresourcePatch(t *testing.T) {
 			// and then the updated object shows a conflicting diff, which permanently fails the patch.
 			// This gives expected stability in the patch without retrying on an known number of conflicts below in the test.
 			// See https://issue.k8s.io/42644
-			_, err = noxuResourceClient.Get("foo", metav1.GetOptions{ResourceVersion: patchedNoxuInstance.GetResourceVersion()})
+			_, err = noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{ResourceVersion: patchedNoxuInstance.GetResourceVersion()})
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -855,7 +856,7 @@ func TestSubresourcePatch(t *testing.T) {
 
 			// no-op patch
 			t.Logf("Patching .spec.replicas again to 7")
-			patchedNoxuInstance, err = noxuResourceClient.Patch("foo", types.MergePatchType, patch, metav1.PatchOptions{}, "scale")
+			patchedNoxuInstance, err = noxuResourceClient.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{}, "scale")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -866,7 +867,7 @@ func TestSubresourcePatch(t *testing.T) {
 
 			// empty patch
 			t.Logf("Applying empty patch")
-			patchedNoxuInstance, err = noxuResourceClient.Patch("foo", types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}, "scale")
+			patchedNoxuInstance, err = noxuResourceClient.Patch(context.TODO(), "foo", types.MergePatchType, []byte(`{}`), metav1.PatchOptions{}, "scale")
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -876,16 +877,16 @@ func TestSubresourcePatch(t *testing.T) {
 			expectString(t, patchedNoxuInstance.UnstructuredContent(), rv, "metadata", "resourceVersion")
 
 			// make sure strategic merge patch is not supported for both status and scale
-			_, err = noxuResourceClient.Patch("foo", types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
+			_, err = noxuResourceClient.Patch(context.TODO(), "foo", types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "status")
 			if err == nil {
 				t.Fatalf("unexpected non-error: strategic merge patch is not supported for custom resources")
 			}
 
-			_, err = noxuResourceClient.Patch("foo", types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "scale")
+			_, err = noxuResourceClient.Patch(context.TODO(), "foo", types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "scale")
 			if err == nil {
 				t.Fatalf("unexpected non-error: strategic merge patch is not supported for custom resources")
 			}
-			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/subresources_test.go
@@ -249,7 +249,7 @@ func TestStatusSubresource(t *testing.T) {
 			if statusNum != int64(20) {
 				t.Fatalf(".status.num: expected: %v, got: %v", int64(20), statusNum)
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -394,7 +394,7 @@ func TestScaleSubresource(t *testing.T) {
 			if err == nil {
 				t.Fatalf("unexpected non-error: .spec.replicas should be less than 2147483647")
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
 			if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}
@@ -547,7 +547,7 @@ func TestValidateOnlyStatus(t *testing.T) {
 			if !strings.Contains(statusError.Error(), "Invalid value") {
 				t.Fatalf("expected 'Invalid value' in error, got: %v", err)
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -711,7 +711,7 @@ func TestGeneration(t *testing.T) {
 			if updatedInstance.GetGeneration() != 2 {
 				t.Fatalf("updating spec should increment .metadata.generation: expected: %v, got: %v", 2, updatedStatusInstance.GetGeneration())
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -885,7 +885,7 @@ func TestSubresourcePatch(t *testing.T) {
 			if err == nil {
 				t.Fatalf("unexpected non-error: strategic merge patch is not supported for custom resources")
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", mmetav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/table_test.go
@@ -131,7 +131,7 @@ func TestTableGet(t *testing.T) {
 	t.Logf("table crd created: %#v", crd)
 
 	crClient := newNamespacedCustomResourceVersionedClient("", dynamicClient, crd, "v1")
-	foo, err := crClient.Create(newTableInstance("foo"), metav1.CreateOptions{})
+	foo, err := crClient.Create(context.TODO(), newTableInstance("foo"), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("unable to create noxu instance: %v", err)
 	}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -77,7 +77,7 @@ func TestForProperValidationErrors(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		_, err := noxuResourceClient.Create(tc.instanceFn(), metav1.CreateOptions{})
+		_, err := noxuResourceClient.Create(context.TODO(), tc.instanceFn(), metav1.CreateOptions{})
 		if err == nil {
 			t.Errorf("%v: expected %v", tc.name, tc.expectedError)
 			continue
@@ -246,7 +246,7 @@ func TestCustomResourceValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to create noxu instance: %v", err)
 			}
-			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -326,7 +326,7 @@ func TestCustomResourceItemsValidation(t *testing.T) {
 			},
 		},
 	}}
-	_, err = client.Resource(gvr).Create(&u, metav1.CreateOptions{})
+	_, err = client.Resource(gvr).Create(context.TODO(), &u, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -452,7 +452,7 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 				t.Fatalf("unable to create noxu instance: %v", err)
 			}
 
-			gottenNoxuInstance, err := noxuResourceClient.Get("foo", metav1.GetOptions{})
+			gottenNoxuInstance, err := noxuResourceClient.Get(context.TODO(), "foo", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -469,11 +469,11 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 				"delta": "hello",
 			}
 
-			_, err = noxuResourceClient.Update(gottenNoxuInstance, metav1.UpdateOptions{})
+			_, err = noxuResourceClient.Update(context.TODO(), gottenNoxuInstance, metav1.UpdateOptions{})
 			if err == nil {
 				t.Fatalf("unexpected non-error: alpha and beta should be present while updating %v", gottenNoxuInstance)
 			}
-			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -566,7 +566,7 @@ func TestCustomResourceValidationErrors(t *testing.T) {
 				noxuResourceClient := newNamespacedCustomResourceVersionedClient(ns, dynamicClient, noxuDefinition, v.Name)
 				instanceToCreate := tc.instanceFn()
 				instanceToCreate.Object["apiVersion"] = fmt.Sprintf("%s/%s", noxuDefinition.Spec.Group, v.Name)
-				_, err := noxuResourceClient.Create(instanceToCreate, metav1.CreateOptions{})
+				_, err := noxuResourceClient.Create(context.TODO(), instanceToCreate, metav1.CreateOptions{})
 				if err == nil {
 					t.Errorf("%v: expected %v", tc.name, tc.expectedErrors)
 					continue
@@ -634,7 +634,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 
 			// CR is now accepted
 			err = wait.Poll(500*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {
-				_, err := noxuResourceClient.Create(instanceToCreate, metav1.CreateOptions{})
+				_, err := noxuResourceClient.Create(context.TODO(), instanceToCreate, metav1.CreateOptions{})
 				if _, isStatus := err.(*apierrors.StatusError); isStatus {
 					if apierrors.IsInvalid(err) {
 						return false, nil
@@ -648,7 +648,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
+			noxuResourceClient.Delete(context.TODO(), "foo", metav1.DeleteOptions{})
 			if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/validation_test.go
@@ -246,7 +246,7 @@ func TestCustomResourceValidation(t *testing.T) {
 			if err != nil {
 				t.Fatalf("unable to create noxu instance: %v", err)
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -473,7 +473,7 @@ func TestCustomResourceUpdateValidation(t *testing.T) {
 			if err == nil {
 				t.Fatalf("unexpected non-error: alpha and beta should be present while updating %v", gottenNoxuInstance)
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
 		}
 		if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 			t.Fatal(err)
@@ -648,7 +648,7 @@ func TestCRValidationOnCRDUpdate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			noxuResourceClient.Delete("foo", &metav1.DeleteOptions{})
+			noxuResourceClient.Delete("foo", metav1.DeleteOptions{})
 			if err := fixtures.DeleteCustomResourceDefinition(noxuDefinition, apiExtensionClient); err != nil {
 				t.Fatal(err)
 			}

--- a/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/test/integration/versioning_test.go
@@ -57,7 +57,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 
 	t.Logf("Creating foo")
 	noxuInstanceToCreate := fixtures.NewNoxuInstance(ns, "foo")
-	_, err = noxuNamespacedResourceClientV1beta1.Create(noxuInstanceToCreate, metav1.CreateOptions{})
+	_, err = noxuNamespacedResourceClientV1beta1.Create(context.TODO(), noxuInstanceToCreate, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -88,7 +88,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 
-			_, err := noxuNamespacedResourceClientV1beta1.Patch("foo", types.MergePatchType, patch, metav1.PatchOptions{})
+			_, err := noxuNamespacedResourceClientV1beta1.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{})
 			if err != nil {
 				// work around "grpc: the client connection is closing" error
 				// TODO: fix the grpc error
@@ -111,7 +111,7 @@ func TestInternalVersionIsHandlerVersion(t *testing.T) {
 			patch := []byte(fmt.Sprintf(`{"i": %d}`, i))
 			i++
 
-			_, err := noxuNamespacedResourceClientV1beta2.Patch("foo", types.MergePatchType, patch, metav1.PatchOptions{})
+			_, err := noxuNamespacedResourceClientV1beta2.Patch(context.TODO(), "foo", types.MergePatchType, patch, metav1.PatchOptions{})
 			assert.NotNil(t, err)
 
 			// work around "grpc: the client connection is closing" error

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/watch_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package endpoints
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -781,7 +782,7 @@ func TestWatchHTTPDynamicClientErrors(t *testing.T) {
 		APIPath: "/" + prefix,
 	}).Resource(newGroupVersion.WithResource("simple"))
 
-	_, err := client.Watch(metav1.ListOptions{})
+	_, err := client.Watch(context.TODO(), metav1.ListOptions{})
 	if err == nil {
 		t.Fatal(err)
 	}

--- a/staging/src/k8s.io/cli-runtime/pkg/resource/crd_finder.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/resource/crd_finder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package resource
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -36,7 +37,7 @@ func CRDFromDynamic(client dynamic.Interface) CRDGetter {
 			Group:    "apiextensions.k8s.io",
 			Version:  "v1beta1",
 			Resource: "customresourcedefinitions",
-		}).List(metav1.ListOptions{})
+		}).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return nil, fmt.Errorf("failed to list CRDs: %v", err)
 		}

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -18,6 +18,7 @@ package dynamic
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -134,7 +135,7 @@ func TestList(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource).Namespace(tc.namespace).List(metav1.ListOptions{})
+		got, err := cl.Resource(resource).Namespace(tc.namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when listing %q: %v", tc.name, err)
 			continue
@@ -209,7 +210,7 @@ func TestGet(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource).Namespace(tc.namespace).Get(tc.name, metav1.GetOptions{}, tc.subresource...)
+		got, err := cl.Resource(resource).Namespace(tc.namespace).Get(context.TODO(), tc.name, metav1.GetOptions{}, tc.subresource...)
 		if err != nil {
 			t.Errorf("unexpected error when getting %q: %v", tc.name, err)
 			continue
@@ -283,7 +284,7 @@ func TestDelete(t *testing.T) {
 		}
 		defer srv.Close()
 
-		err = cl.Resource(resource).Namespace(tc.namespace).Delete(tc.name, tc.deleteOptions, tc.subresource...)
+		err = cl.Resource(resource).Namespace(tc.namespace).Delete(context.TODO(), tc.name, tc.deleteOptions, tc.subresource...)
 		if err != nil {
 			t.Errorf("unexpected error when deleting %q: %v", tc.name, err)
 			continue
@@ -331,7 +332,7 @@ func TestDeleteCollection(t *testing.T) {
 		}
 		defer srv.Close()
 
-		err = cl.Resource(resource).Namespace(tc.namespace).DeleteCollection(metav1.DeleteOptions{}, metav1.ListOptions{})
+		err = cl.Resource(resource).Namespace(tc.namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when deleting collection %q: %v", tc.name, err)
 			continue
@@ -404,7 +405,7 @@ func TestCreate(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource).Namespace(tc.namespace).Create(tc.obj, metav1.CreateOptions{}, tc.subresource...)
+		got, err := cl.Resource(resource).Namespace(tc.namespace).Create(context.TODO(), tc.obj, metav1.CreateOptions{}, tc.subresource...)
 		if err != nil {
 			t.Errorf("unexpected error when creating %q: %v", tc.name, err)
 			continue
@@ -481,7 +482,7 @@ func TestUpdate(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource).Namespace(tc.namespace).Update(tc.obj, metav1.UpdateOptions{}, tc.subresource...)
+		got, err := cl.Resource(resource).Namespace(tc.namespace).Update(context.TODO(), tc.obj, metav1.UpdateOptions{}, tc.subresource...)
 		if err != nil {
 			t.Errorf("unexpected error when updating %q: %v", tc.name, err)
 			continue
@@ -550,7 +551,7 @@ func TestWatch(t *testing.T) {
 		}
 		defer srv.Close()
 
-		watcher, err := cl.Resource(resource).Namespace(tc.namespace).Watch(metav1.ListOptions{})
+		watcher, err := cl.Resource(resource).Namespace(tc.namespace).Watch(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when watching %q: %v", tc.name, err)
 			continue
@@ -640,7 +641,7 @@ func TestPatch(t *testing.T) {
 		}
 		defer srv.Close()
 
-		got, err := cl.Resource(resource).Namespace(tc.namespace).Patch(tc.name, types.StrategicMergePatchType, tc.patch, metav1.PatchOptions{}, tc.subresource...)
+		got, err := cl.Resource(resource).Namespace(tc.namespace).Patch(context.TODO(), tc.name, types.StrategicMergePatchType, tc.patch, metav1.PatchOptions{}, tc.subresource...)
 		if err != nil {
 			t.Errorf("unexpected error when patching %q: %v", tc.name, err)
 			continue

--- a/staging/src/k8s.io/client-go/dynamic/client_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/client_test.go
@@ -234,7 +234,7 @@ func TestDelete(t *testing.T) {
 		namespace     string
 		name          string
 		path          string
-		deleteOptions *metav1.DeleteOptions
+		deleteOptions metav1.DeleteOptions
 	}{
 		{
 			name: "normal_delete",
@@ -260,7 +260,7 @@ func TestDelete(t *testing.T) {
 			namespace:     "nstest",
 			name:          "namespaced_delete_with_options",
 			path:          "/apis/gtest/vtest/namespaces/nstest/rtest/namespaced_delete_with_options",
-			deleteOptions: &metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}, PropagationPolicy: &background},
+			deleteOptions: metav1.DeleteOptions{Preconditions: &metav1.Preconditions{UID: &uid}, PropagationPolicy: &background},
 		},
 	}
 	for _, tc := range tcs {
@@ -331,7 +331,7 @@ func TestDeleteCollection(t *testing.T) {
 		}
 		defer srv.Close()
 
-		err = cl.Resource(resource).Namespace(tc.namespace).DeleteCollection(nil, metav1.ListOptions{})
+		err = cl.Resource(resource).Namespace(tc.namespace).DeleteCollection(metav1.DeleteOptions{}, metav1.ListOptions{})
 		if err != nil {
 			t.Errorf("unexpected error when deleting collection %q: %v", tc.name, err)
 			continue

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dynamicinformer
 
 import (
+	"context"
 	"sync"
 	"time"
 
@@ -125,13 +126,13 @@ func NewFilteredDynamicInformer(client dynamic.Interface, gvr schema.GroupVersio
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}
-					return client.Resource(gvr).Namespace(namespace).List(options)
+					return client.Resource(gvr).Namespace(namespace).List(context.TODO(), options)
 				},
 				WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 					if tweakListOptions != nil {
 						tweakListOptions(&options)
 					}
-					return client.Resource(gvr).Namespace(namespace).Watch(options)
+					return client.Resource(gvr).Namespace(namespace).Watch(context.TODO(), options)
 				},
 			},
 			&unstructured.Unstructured{},

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
@@ -93,7 +93,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			gvr:         schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"},
 			existingObj: newUnstructured("extensions/v1beta1", "Deployment", "ns-foo", "name-foo"),
 			trigger: func(gvr schema.GroupVersionResource, ns string, fakeClient *fake.FakeDynamicClient, testObject *unstructured.Unstructured) *unstructured.Unstructured {
-				err := fakeClient.Resource(gvr).Namespace(ns).Delete(testObject.GetName(), &metav1.DeleteOptions{})
+				err := fakeClient.Resource(gvr).Namespace(ns).Delete(testObject.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					t.Error(err)
 				}

--- a/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/dynamicinformer/informer_test.go
@@ -48,7 +48,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			gvr:  schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"},
 			trigger: func(gvr schema.GroupVersionResource, ns string, fakeClient *fake.FakeDynamicClient, _ *unstructured.Unstructured) *unstructured.Unstructured {
 				testObject := newUnstructured("extensions/v1beta1", "Deployment", "ns-foo", "name-foo")
-				createdObj, err := fakeClient.Resource(gvr).Namespace(ns).Create(testObject, metav1.CreateOptions{})
+				createdObj, err := fakeClient.Resource(gvr).Namespace(ns).Create(context.TODO(), testObject, metav1.CreateOptions{})
 				if err != nil {
 					t.Error(err)
 				}
@@ -71,7 +71,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			existingObj: newUnstructured("extensions/v1beta1", "Deployment", "ns-foo", "name-foo"),
 			trigger: func(gvr schema.GroupVersionResource, ns string, fakeClient *fake.FakeDynamicClient, testObject *unstructured.Unstructured) *unstructured.Unstructured {
 				testObject.Object["spec"] = "updatedName"
-				updatedObj, err := fakeClient.Resource(gvr).Namespace(ns).Update(testObject, metav1.UpdateOptions{})
+				updatedObj, err := fakeClient.Resource(gvr).Namespace(ns).Update(context.TODO(), testObject, metav1.UpdateOptions{})
 				if err != nil {
 					t.Error(err)
 				}
@@ -93,7 +93,7 @@ func TestDynamicSharedInformerFactory(t *testing.T) {
 			gvr:         schema.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"},
 			existingObj: newUnstructured("extensions/v1beta1", "Deployment", "ns-foo", "name-foo"),
 			trigger: func(gvr schema.GroupVersionResource, ns string, fakeClient *fake.FakeDynamicClient, testObject *unstructured.Unstructured) *unstructured.Unstructured {
-				err := fakeClient.Resource(gvr).Namespace(ns).Delete(testObject.GetName(), metav1.DeleteOptions{})
+				err := fakeClient.Resource(gvr).Namespace(ns).Delete(context.TODO(), testObject.GetName(), metav1.DeleteOptions{})
 				if err != nil {
 					t.Error(err)
 				}

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -196,7 +196,7 @@ func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opt
 	return ret, err
 }
 
-func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+func (c *dynamicResourceClient) Delete(name string, opts metav1.DeleteOptions, subresources ...string) error {
 	var err error
 	switch {
 	case len(c.namespace) == 0 && len(subresources) == 0:
@@ -219,7 +219,7 @@ func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, 
 	return err
 }
 
-func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (c *dynamicResourceClient) DeleteCollection(opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	var err error
 	switch {
 	case len(c.namespace) == 0:

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fake
 
 import (
+	"context"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -86,7 +87,7 @@ func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
 	return &ret
 }
 
-func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	var uncastRet runtime.Object
 	var err error
 	switch {
@@ -132,7 +133,7 @@ func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts meta
 	return ret, err
 }
 
-func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	var uncastRet runtime.Object
 	var err error
 	switch {
@@ -168,7 +169,7 @@ func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts meta
 	return ret, err
 }
 
-func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
 	var uncastRet runtime.Object
 	var err error
 	switch {
@@ -196,7 +197,7 @@ func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opt
 	return ret, err
 }
 
-func (c *dynamicResourceClient) Delete(name string, opts metav1.DeleteOptions, subresources ...string) error {
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
 	var err error
 	switch {
 	case len(c.namespace) == 0 && len(subresources) == 0:
@@ -219,7 +220,7 @@ func (c *dynamicResourceClient) Delete(name string, opts metav1.DeleteOptions, s
 	return err
 }
 
-func (c *dynamicResourceClient) DeleteCollection(opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	var err error
 	switch {
 	case len(c.namespace) == 0:
@@ -235,7 +236,7 @@ func (c *dynamicResourceClient) DeleteCollection(opts metav1.DeleteOptions, list
 	return err
 }
 
-func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	var uncastRet runtime.Object
 	var err error
 	switch {
@@ -270,7 +271,7 @@ func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subreso
 	return ret, err
 }
 
-func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	var obj runtime.Object
 	var err error
 	switch {
@@ -317,7 +318,7 @@ func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.Uns
 	return list, nil
 }
 
-func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	switch {
 	case len(c.namespace) == 0:
 		return c.client.Fake.
@@ -333,7 +334,7 @@ func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface,
 }
 
 // TODO: opts are currently ignored.
-func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	var uncastRet runtime.Object
 	var err error
 	switch {

--- a/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
+++ b/staging/src/k8s.io/client-go/dynamic/fake/simple_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fake
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -68,7 +69,7 @@ func TestList(t *testing.T) {
 		newUnstructured("group/version", "TheKind", "ns-foo", "name-baz"),
 		newUnstructured("group2/version", "TheKind", "ns-foo", "name2-baz"),
 	)
-	listFirst, err := client.Resource(schema.GroupVersionResource{Group: "group", Version: "version", Resource: "thekinds"}).List(metav1.ListOptions{})
+	listFirst, err := client.Resource(schema.GroupVersionResource{Group: "group", Version: "version", Resource: "thekinds"}).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +97,7 @@ func (tc *patchTestCase) runner(t *testing.T) {
 	client := NewSimpleDynamicClient(runtime.NewScheme(), tc.object)
 	resourceInterface := client.Resource(schema.GroupVersionResource{Group: testGroup, Version: testVersion, Resource: testResource}).Namespace(testNamespace)
 
-	got, recErr := resourceInterface.Patch(testName, tc.patchType, tc.patchBytes, metav1.PatchOptions{})
+	got, recErr := resourceInterface.Patch(context.TODO(), testName, tc.patchType, tc.patchBytes, metav1.PatchOptions{})
 
 	if err := tc.verifyErr(recErr); err != nil {
 		t.Error(err)

--- a/staging/src/k8s.io/client-go/dynamic/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/interface.go
@@ -17,6 +17,8 @@ limitations under the License.
 package dynamic
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -29,15 +31,15 @@ type Interface interface {
 }
 
 type ResourceInterface interface {
-	Create(obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
-	Update(obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
-	UpdateStatus(obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
-	Delete(name string, options metav1.DeleteOptions, subresources ...string) error
-	DeleteCollection(options metav1.DeleteOptions, listOptions metav1.ListOptions) error
-	Get(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
-	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
-	Watch(opts metav1.ListOptions) (watch.Interface, error)
-	Patch(name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Create(ctx context.Context, obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	Update(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
+	UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
+	Delete(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(ctx context.Context, options metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Get(ctx context.Context, name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
+	List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error)
+	Patch(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error)
 }
 
 type NamespaceableResourceInterface interface {

--- a/staging/src/k8s.io/client-go/dynamic/interface.go
+++ b/staging/src/k8s.io/client-go/dynamic/interface.go
@@ -32,8 +32,8 @@ type ResourceInterface interface {
 	Create(obj *unstructured.Unstructured, options metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error)
 	Update(obj *unstructured.Unstructured, options metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error)
 	UpdateStatus(obj *unstructured.Unstructured, options metav1.UpdateOptions) (*unstructured.Unstructured, error)
-	Delete(name string, options *metav1.DeleteOptions, subresources ...string) error
-	DeleteCollection(options *metav1.DeleteOptions, listOptions metav1.ListOptions) error
+	Delete(name string, options metav1.DeleteOptions, subresources ...string) error
+	DeleteCollection(options metav1.DeleteOptions, listOptions metav1.ListOptions) error
 	Get(name string, options metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error)
 	List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error)
 	Watch(opts metav1.ListOptions) (watch.Interface, error)

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -90,7 +90,7 @@ func (c *dynamicResourceClient) Namespace(ns string) ResourceInterface {
 	return &ret
 }
 
-func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Create(ctx context.Context, obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	outBytes, err := runtime.Encode(unstructured.UnstructuredJSONScheme, obj)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts meta
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(outBytes).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do(context.TODO())
+		Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -128,7 +128,7 @@ func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts meta
 	return uncastObj.(*unstructured.Unstructured), nil
 }
 
-func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Update(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts meta
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(outBytes).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do(context.TODO())
+		Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts meta
 	return uncastObj.(*unstructured.Unstructured), nil
 }
 
-func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) UpdateStatus(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
 	accessor, err := meta.Accessor(obj)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opt
 		AbsPath(append(c.makeURLSegments(name), "status")...).
 		Body(outBytes).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do(context.TODO())
+		Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -199,7 +199,7 @@ func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opt
 	return uncastObj.(*unstructured.Unstructured), nil
 }
 
-func (c *dynamicResourceClient) Delete(name string, opts metav1.DeleteOptions, subresources ...string) error {
+func (c *dynamicResourceClient) Delete(ctx context.Context, name string, opts metav1.DeleteOptions, subresources ...string) error {
 	if len(name) == 0 {
 		return fmt.Errorf("name is required")
 	}
@@ -212,11 +212,11 @@ func (c *dynamicResourceClient) Delete(name string, opts metav1.DeleteOptions, s
 		Delete().
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(deleteOptionsByte).
-		Do(context.TODO())
+		Do(ctx)
 	return result.Error()
 }
 
-func (c *dynamicResourceClient) DeleteCollection(opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+func (c *dynamicResourceClient) DeleteCollection(ctx context.Context, opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
 	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
 	if err != nil {
 		return err
@@ -227,15 +227,15 @@ func (c *dynamicResourceClient) DeleteCollection(opts metav1.DeleteOptions, list
 		AbsPath(c.makeURLSegments("")...).
 		Body(deleteOptionsByte).
 		SpecificallyVersionedParams(&listOptions, dynamicParameterCodec, versionV1).
-		Do(context.TODO())
+		Do(ctx)
 	return result.Error()
 }
 
-func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Get(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	if len(name) == 0 {
 		return nil, fmt.Errorf("name is required")
 	}
-	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(context.TODO())
+	result := c.client.client.Get().AbsPath(append(c.makeURLSegments(name), subresources...)...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -250,8 +250,8 @@ func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subreso
 	return uncastObj.(*unstructured.Unstructured), nil
 }
 
-func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(context.TODO())
+func (c *dynamicResourceClient) List(ctx context.Context, opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	result := c.client.client.Get().AbsPath(c.makeURLSegments("")...).SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}
@@ -274,14 +274,14 @@ func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.Uns
 	return list, nil
 }
 
-func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+func (c *dynamicResourceClient) Watch(ctx context.Context, opts metav1.ListOptions) (watch.Interface, error) {
 	opts.Watch = true
 	return c.client.client.Get().AbsPath(c.makeURLSegments("")...).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Watch(context.TODO())
+		Watch(ctx)
 }
 
-func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+func (c *dynamicResourceClient) Patch(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
 	if len(name) == 0 {
 		return nil, fmt.Errorf("name is required")
 	}
@@ -290,7 +290,7 @@ func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []by
 		AbsPath(append(c.makeURLSegments(name), subresources...)...).
 		Body(data).
 		SpecificallyVersionedParams(&opts, dynamicParameterCodec, versionV1).
-		Do(context.TODO())
+		Do(ctx)
 	if err := result.Error(); err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/client-go/dynamic/simple.go
+++ b/staging/src/k8s.io/client-go/dynamic/simple.go
@@ -199,14 +199,11 @@ func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opt
 	return uncastObj.(*unstructured.Unstructured), nil
 }
 
-func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+func (c *dynamicResourceClient) Delete(name string, opts metav1.DeleteOptions, subresources ...string) error {
 	if len(name) == 0 {
 		return fmt.Errorf("name is required")
 	}
-	if opts == nil {
-		opts = &metav1.DeleteOptions{}
-	}
-	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
 	if err != nil {
 		return err
 	}
@@ -219,11 +216,8 @@ func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, 
 	return result.Error()
 }
 
-func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
-	if opts == nil {
-		opts = &metav1.DeleteOptions{}
-	}
-	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), opts)
+func (c *dynamicResourceClient) DeleteCollection(opts metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	deleteOptionsByte, err := runtime.Encode(deleteOptionsCodec.LegacyCodec(schema.GroupVersion{Version: "v1"}), &opts)
 	if err != nil {
 		return err
 	}

--- a/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
@@ -19,6 +19,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"flag"
 	"fmt"
 	"os"
@@ -108,7 +109,7 @@ func main() {
 
 	// Create Deployment
 	fmt.Println("Creating deployment...")
-	result, err := client.Resource(deploymentRes).Namespace(namespace).Create(deployment, metav1.CreateOptions{})
+	result, err := client.Resource(deploymentRes).Namespace(namespace).Create(context.TODO(), deployment, metav1.CreateOptions{})
 	if err != nil {
 		panic(err)
 	}
@@ -133,7 +134,7 @@ func main() {
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		// Retrieve the latest version of Deployment before attempting update
 		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
-		result, getErr := client.Resource(deploymentRes).Namespace(namespace).Get("demo-deployment", metav1.GetOptions{})
+		result, getErr := client.Resource(deploymentRes).Namespace(namespace).Get(context.TODO(), "demo-deployment", metav1.GetOptions{})
 		if getErr != nil {
 			panic(fmt.Errorf("failed to get latest version of Deployment: %v", getErr))
 		}
@@ -157,7 +158,7 @@ func main() {
 			panic(err)
 		}
 
-		_, updateErr := client.Resource(deploymentRes).Namespace(namespace).Update(result, metav1.UpdateOptions{})
+		_, updateErr := client.Resource(deploymentRes).Namespace(namespace).Update(context.TODO(), result, metav1.UpdateOptions{})
 		return updateErr
 	})
 	if retryErr != nil {
@@ -168,7 +169,7 @@ func main() {
 	// List Deployments
 	prompt()
 	fmt.Printf("Listing deployments in namespace %q:\n", apiv1.NamespaceDefault)
-	list, err := client.Resource(deploymentRes).Namespace(namespace).List(metav1.ListOptions{})
+	list, err := client.Resource(deploymentRes).Namespace(namespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		panic(err)
 	}
@@ -188,7 +189,7 @@ func main() {
 	deleteOptions := metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
 	}
-	if err := client.Resource(deploymentRes).Namespace(namespace).Delete("demo-deployment", deleteOptions); err != nil {
+	if err := client.Resource(deploymentRes).Namespace(namespace).Delete(context.TODO(), "demo-deployment", deleteOptions); err != nil {
 		panic(err)
 	}
 

--- a/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
+++ b/staging/src/k8s.io/client-go/examples/dynamic-create-update-delete-deployment/main.go
@@ -185,7 +185,7 @@ func main() {
 	prompt()
 	fmt.Println("Deleting deployment...")
 	deletePolicy := metav1.DeletePropagationForeground
-	deleteOptions := &metav1.DeleteOptions{
+	deleteOptions := metav1.DeleteOptions{
 		PropagationPolicy: &deletePolicy,
 	}
 	if err := client.Resource(deploymentRes).Namespace(namespace).Delete("demo-deployment", deleteOptions); err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -145,9 +145,9 @@ func (p *pruner) delete(namespace, name string, mapping *meta.RESTMapping) error
 }
 
 func runDelete(namespace, name string, mapping *meta.RESTMapping, c dynamic.Interface, cascade bool, gracePeriod int, serverDryRun bool) error {
-	options := &metav1.DeleteOptions{}
+	options := metav1.DeleteOptions{}
 	if gracePeriod >= 0 {
-		options = metav1.NewDeleteOptions(int64(gracePeriod))
+		options = *metav1.NewDeleteOptions(int64(gracePeriod))
 	}
 	if serverDryRun {
 		options.DryRun = []string{metav1.DryRunAll}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apply
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -97,7 +98,7 @@ func (p *pruner) pruneAll(o *ApplyOptions) error {
 func (p *pruner) prune(namespace string, mapping *meta.RESTMapping) error {
 	objList, err := p.dynamicClient.Resource(mapping.Resource).
 		Namespace(namespace).
-		List(metav1.ListOptions{
+		List(context.TODO(), metav1.ListOptions{
 			LabelSelector: p.labelSelector,
 			FieldSelector: p.fieldSelector,
 		})
@@ -157,7 +158,7 @@ func runDelete(namespace, name string, mapping *meta.RESTMapping, c dynamic.Inte
 		policy = metav1.DeletePropagationOrphan
 	}
 	options.PropagationPolicy = &policy
-	return c.Resource(mapping.Resource).Namespace(namespace).Delete(name, options)
+	return c.Resource(mapping.Resource).Namespace(namespace).Delete(context.TODO(), name, options)
 }
 
 type pruneResource struct {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -17,6 +17,7 @@ limitations under the License.
 package create
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/url"
@@ -451,7 +452,7 @@ func (o *CreateSubcommandOptions) Run() error {
 			}
 			createOptions.DryRun = []string{metav1.DryRunAll}
 		}
-		actualObject, err := o.DynamicClient.Resource(mapping.Resource).Namespace(o.Namespace).Create(asUnstructured, createOptions)
+		actualObject, err := o.DynamicClient.Resource(mapping.Resource).Namespace(o.Namespace).Create(context.TODO(), asUnstructured, createOptions)
 		if err != nil {
 			return err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -192,11 +192,11 @@ func (o *RolloutStatusOptions) Run() error {
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
 			options.FieldSelector = fieldSelector
-			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(options)
+			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(context.TODO(), options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
 			options.FieldSelector = fieldSelector
-			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(options)
+			return o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(context.TODO(), options)
 		},
 	}
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -263,7 +263,7 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 		nameSelector := fields.OneTermEqualSelector("metadata.name", info.Name).String()
 
 		// List with a name field selector to get the current resourceVersion to watch from (not the object's resourceVersion)
-		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(metav1.ListOptions{FieldSelector: nameSelector})
+		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: nameSelector})
 		if apierrors.IsNotFound(err) {
 			return info.Object, true, nil
 		}
@@ -289,7 +289,7 @@ func IsDeleted(info *resource.Info, o *WaitOptions) (runtime.Object, bool, error
 		watchOptions := metav1.ListOptions{}
 		watchOptions.FieldSelector = nameSelector
 		watchOptions.ResourceVersion = gottenObjList.GetResourceVersion()
-		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(watchOptions)
+		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(context.TODO(), watchOptions)
 		if err != nil {
 			return gottenObj, false, err
 		}
@@ -361,7 +361,7 @@ func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (ru
 
 		var gottenObj *unstructured.Unstructured
 		// List with a name field selector to get the current resourceVersion to watch from (not the object's resourceVersion)
-		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(metav1.ListOptions{FieldSelector: nameSelector})
+		gottenObjList, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).List(context.TODO(), metav1.ListOptions{FieldSelector: nameSelector})
 
 		resourceVersion := ""
 		switch {
@@ -384,7 +384,7 @@ func (w ConditionalWait) IsConditionMet(info *resource.Info, o *WaitOptions) (ru
 		watchOptions := metav1.ListOptions{}
 		watchOptions.FieldSelector = nameSelector
 		watchOptions.ResourceVersion = resourceVersion
-		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(watchOptions)
+		objWatch, err := o.DynamicClient.Resource(info.Mapping.Resource).Namespace(info.Namespace).Watch(context.TODO(), watchOptions)
 		if err != nil {
 			return gottenObj, false, err
 		}

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -247,7 +247,7 @@ type genericDescriber struct {
 }
 
 func (g *genericDescriber) Describe(namespace, name string, describerSettings DescriberSettings) (output string, err error) {
-	obj, err := g.dynamic.Resource(g.mapping.Resource).Namespace(namespace).Get(name, metav1.GetOptions{})
+	obj, err := g.dynamic.Resource(g.mapping.Resource).Namespace(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -489,7 +489,7 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 	}
 
 	// kubectl delete flunder test-flunder
-	err = dynamicClient.Delete(flunderName, &metav1.DeleteOptions{})
+	err = dynamicClient.Delete(flunderName, metav1.DeleteOptions{})
 	validateErrorWithDebugInfo(f, err, pods, "deleting flunders(%v) using dynamic client", unstructuredList.Items)
 
 	// kubectl get flunders

--- a/test/e2e/apimachinery/aggregator.go
+++ b/test/e2e/apimachinery/aggregator.go
@@ -478,22 +478,22 @@ func TestSampleAPIServer(f *framework.Framework, aggrclient *aggregatorclient.Cl
 	unstruct := &unstructuredv1.Unstructured{}
 	err = unstruct.UnmarshalJSON(jsonFlunder)
 	framework.ExpectNoError(err, "unmarshalling test-flunder as unstructured for create using dynamic client")
-	_, err = dynamicClient.Create(unstruct, metav1.CreateOptions{})
+	_, err = dynamicClient.Create(context.TODO(), unstruct, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "listing flunders using dynamic client")
 
 	// kubectl get flunders
-	unstructuredList, err := dynamicClient.List(metav1.ListOptions{})
+	unstructuredList, err := dynamicClient.List(context.TODO(), metav1.ListOptions{})
 	framework.ExpectNoError(err, "listing flunders using dynamic client")
 	if len(unstructuredList.Items) != 1 {
 		framework.Failf("failed to get back the correct flunders list %v from the dynamic client", unstructuredList)
 	}
 
 	// kubectl delete flunder test-flunder
-	err = dynamicClient.Delete(flunderName, metav1.DeleteOptions{})
+	err = dynamicClient.Delete(context.TODO(), flunderName, metav1.DeleteOptions{})
 	validateErrorWithDebugInfo(f, err, pods, "deleting flunders(%v) using dynamic client", unstructuredList.Items)
 
 	// kubectl get flunders
-	unstructuredList, err = dynamicClient.List(metav1.ListOptions{})
+	unstructuredList, err = dynamicClient.List(context.TODO(), metav1.ListOptions{})
 	framework.ExpectNoError(err, "listing flunders using dynamic client")
 	if len(unstructuredList.Items) != 0 {
 		framework.Failf("failed to get back the correct deleted flunders list %v from the dynamic client", unstructuredList)

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -411,10 +411,10 @@ func testCustomResourceConversionWebhook(f *framework.Framework, crd *apiextensi
 			"hostPort": "localhost:8080",
 		},
 	}
-	_, err := customResourceClients["v1"].Create(crInstance, metav1.CreateOptions{})
+	_, err := customResourceClients["v1"].Create(context.TODO(), crInstance, metav1.CreateOptions{})
 	gomega.Expect(err).To(gomega.BeNil())
 	ginkgo.By("v2 custom resource should be converted")
-	v2crd, err := customResourceClients["v2"].Get(name, metav1.GetOptions{})
+	v2crd, err := customResourceClients["v2"].Get(context.TODO(), name, metav1.GetOptions{})
 	framework.ExpectNoError(err, "Getting v2 of custom resource %s", name)
 	verifyV2Object(crd, v2crd)
 }
@@ -436,7 +436,7 @@ func testCRListConversion(f *framework.Framework, testCrd *crd.TestCrd) {
 			"hostPort": "localhost:8080",
 		},
 	}
-	_, err := customResourceClients["v1"].Create(crInstance, metav1.CreateOptions{})
+	_, err := customResourceClients["v1"].Create(context.TODO(), crInstance, metav1.CreateOptions{})
 	gomega.Expect(err).To(gomega.BeNil())
 
 	// Now cr-instance-1 is stored as v1. lets change storage version
@@ -463,7 +463,7 @@ func testCRListConversion(f *framework.Framework, testCrd *crd.TestCrd) {
 	//
 	// TODO: we have to wait for the storage version to become effective. Storage version changes are not instant.
 	for i := 0; i < 5; i++ {
-		_, err = customResourceClients["v1"].Create(crInstance, metav1.CreateOptions{})
+		_, err = customResourceClients["v1"].Create(context.TODO(), crInstance, metav1.CreateOptions{})
 		if err == nil {
 			break
 		}
@@ -473,7 +473,7 @@ func testCRListConversion(f *framework.Framework, testCrd *crd.TestCrd) {
 	// Now that we have a v1 and v2 object, both list operation in v1 and v2 should work as expected.
 
 	ginkgo.By("List CRs in v1")
-	list, err := customResourceClients["v1"].List(metav1.ListOptions{})
+	list, err := customResourceClients["v1"].List(context.TODO(), metav1.ListOptions{})
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(len(list.Items)).To(gomega.BeIdenticalTo(2))
 	framework.ExpectEqual((list.Items[0].GetName() == name1 && list.Items[1].GetName() == name2) ||
@@ -482,7 +482,7 @@ func testCRListConversion(f *framework.Framework, testCrd *crd.TestCrd) {
 	verifyV1Object(crd, &list.Items[1])
 
 	ginkgo.By("List CRs in v2")
-	list, err = customResourceClients["v2"].List(metav1.ListOptions{})
+	list, err = customResourceClients["v2"].List(context.TODO(), metav1.ListOptions{})
 	gomega.Expect(err).To(gomega.BeNil())
 	gomega.Expect(len(list.Items)).To(gomega.BeIdenticalTo(2))
 	framework.ExpectEqual((list.Items[0].GetName() == name1 && list.Items[1].GetName() == name2) ||
@@ -504,7 +504,7 @@ func waitWebhookConversionReady(f *framework.Framework, crd *apiextensionsv1.Cus
 				},
 			},
 		}
-		_, err := customResourceClients[version].Create(crInstance, metav1.CreateOptions{})
+		_, err := customResourceClients[version].Create(context.TODO(), crInstance, metav1.CreateOptions{})
 		if err != nil {
 			// tolerate clusters that do not set --enable-aggregator-routing and have to wait for kube-proxy
 			// to program the service network, during which conversion requests return errors
@@ -512,7 +512,7 @@ func waitWebhookConversionReady(f *framework.Framework, crd *apiextensionsv1.Cus
 			return false, nil
 		}
 
-		framework.ExpectNoError(customResourceClients[version].Delete(crInstance.GetName(), metav1.DeleteOptions{}), "cleaning up stub object")
+		framework.ExpectNoError(customResourceClients[version].Delete(context.TODO(), crInstance.GetName(), metav1.DeleteOptions{}), "cleaning up stub object")
 		return true, nil
 	}))
 }

--- a/test/e2e/apimachinery/crd_conversion_webhook.go
+++ b/test/e2e/apimachinery/crd_conversion_webhook.go
@@ -512,7 +512,7 @@ func waitWebhookConversionReady(f *framework.Framework, crd *apiextensionsv1.Cus
 			return false, nil
 		}
 
-		framework.ExpectNoError(customResourceClients[version].Delete(crInstance.GetName(), nil), "cleaning up stub object")
+		framework.ExpectNoError(customResourceClients[version].Delete(crInstance.GetName(), metav1.DeleteOptions{}), "cleaning up stub object")
 		return true, nil
 	}))
 }

--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -175,7 +175,7 @@ func patchCustomResource(client dynamic.ResourceInterface, name string) error {
 }
 
 func deleteCustomResource(client dynamic.ResourceInterface, name string) error {
-	return client.Delete(name, &metav1.DeleteOptions{})
+	return client.Delete(name, metav1.DeleteOptions{})
 }
 
 func newNamespacedCustomResourceClient(ns string, client dynamic.Interface, crd *apiextensionsv1.CustomResourceDefinition) (dynamic.ResourceInterface, error) {

--- a/test/e2e/apimachinery/crd_watch.go
+++ b/test/e2e/apimachinery/crd_watch.go
@@ -17,6 +17,7 @@ limitations under the License.
 package apimachinery
 
 import (
+	"context"
 	"fmt"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -129,6 +130,7 @@ var _ = SIGDescribe("CustomResourceDefinition Watch [Privileged:ClusterAdmin]", 
 
 func watchCRWithName(crdResourceClient dynamic.ResourceInterface, name string) (watch.Interface, error) {
 	return crdResourceClient.Watch(
+		context.TODO(),
 		metav1.ListOptions{
 			FieldSelector:  "metadata.name=" + name,
 			TimeoutSeconds: int64ptr(600),
@@ -137,7 +139,7 @@ func watchCRWithName(crdResourceClient dynamic.ResourceInterface, name string) (
 }
 
 func instantiateCustomResource(instanceToCreate *unstructured.Unstructured, client dynamic.ResourceInterface, definition *apiextensionsv1.CustomResourceDefinition) (*unstructured.Unstructured, error) {
-	createdInstance, err := client.Create(instanceToCreate, metav1.CreateOptions{})
+	createdInstance, err := client.Create(context.TODO(), instanceToCreate, metav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -167,6 +169,7 @@ func instantiateCustomResource(instanceToCreate *unstructured.Unstructured, clie
 
 func patchCustomResource(client dynamic.ResourceInterface, name string) error {
 	_, err := client.Patch(
+		context.TODO(),
 		name,
 		types.JSONPatchType,
 		[]byte(`[{ "op": "add", "path": "/dummy", "value": "test" }]`),
@@ -175,7 +178,7 @@ func patchCustomResource(client dynamic.ResourceInterface, name string) error {
 }
 
 func deleteCustomResource(client dynamic.ResourceInterface, name string) error {
-	return client.Delete(name, metav1.DeleteOptions{})
+	return client.Delete(context.TODO(), name, metav1.DeleteOptions{})
 }
 
 func newNamespacedCustomResourceClient(ns string, client dynamic.Interface, crd *apiextensionsv1.CustomResourceDefinition) (dynamic.ResourceInterface, error) {

--- a/test/e2e/apimachinery/custom_resource_definition.go
+++ b/test/e2e/apimachinery/custom_resource_definition.go
@@ -163,7 +163,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			updateCondition := v1.CustomResourceDefinitionCondition{Message: "updated"}
 			err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
 				// Use dynamic client to read the status sub-resource since typed client does not expose it.
-				u, err := resourceClient.Get(crd.GetName(), metav1.GetOptions{}, "status")
+				u, err := resourceClient.Get(context.TODO(), crd.GetName(), metav1.GetOptions{}, "status")
 				framework.ExpectNoError(err, "getting CustomResourceDefinition status")
 				status := unstructuredToCRD(u)
 				if !equality.Semantic.DeepEqual(status.Spec, crd.Spec) {
@@ -294,7 +294,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 			Resource: crd.Spec.Names.Plural,
 		}
 		crClient := dynamicClient.Resource(gvr)
-		_, err = crClient.Create(&unstructured.Unstructured{Object: map[string]interface{}{
+		_, err = crClient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": gvr.Group + "/" + gvr.Version,
 			"kind":       crd.Spec.Names.Kind,
 			"metadata": map[string]interface{}{
@@ -310,7 +310,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		framework.ExpectNoError(err, "setting default for a to \"A\" in schema")
 
 		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-			u1, err := crClient.Get(name1, metav1.GetOptions{})
+			u1, err := crClient.Get(context.TODO(), name1, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}
@@ -330,7 +330,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 
 		// create CR with default in storage
 		name2 := names.SimpleNameGenerator.GenerateName("cr-2")
-		u2, err := crClient.Create(&unstructured.Unstructured{Object: map[string]interface{}{
+		u2, err := crClient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{
 			"apiVersion": gvr.Group + "/" + gvr.Version,
 			"kind":       crd.Spec.Names.Kind,
 			"metadata": map[string]interface{}{
@@ -350,7 +350,7 @@ var _ = SIGDescribe("CustomResourceDefinition resources [Privileged:ClusterAdmin
 		framework.ExpectNoError(err, "setting default for b to \"B\" and remove default for a")
 
 		err = wait.PollImmediate(time.Millisecond*100, wait.ForeverTestTimeout, func() (bool, error) {
-			u2, err := crClient.Get(name2, metav1.GetOptions{})
+			u2, err := crClient.Get(context.TODO(), name2, metav1.GetOptions{})
 			if err != nil {
 				return false, err
 			}

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -935,7 +935,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 				},
 			},
 		}
-		persistedOwner, err := resourceClient.Create(owner, metav1.CreateOptions{})
+		persistedOwner, err := resourceClient.Create(context.TODO(), owner, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("failed to create owner resource %q: %v", ownerName, err)
 		}
@@ -960,7 +960,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 				},
 			},
 		}
-		persistedDependent, err := resourceClient.Create(dependent, metav1.CreateOptions{})
+		persistedDependent, err := resourceClient.Create(context.TODO(), dependent, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("failed to create dependent resource %q: %v", dependentName, err)
 		}
@@ -968,7 +968,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 
 		// Delete the owner.
 		background := metav1.DeletePropagationBackground
-		err = resourceClient.Delete(ownerName, metav1.DeleteOptions{PropagationPolicy: &background})
+		err = resourceClient.Delete(context.TODO(), ownerName, metav1.DeleteOptions{PropagationPolicy: &background})
 		if err != nil {
 			framework.Failf("failed to delete owner resource %q: %v", ownerName, err)
 		}
@@ -982,20 +982,20 @@ var _ = SIGDescribe("Garbage collector", func() {
 				"kind":       definition.Spec.Names.Kind,
 				"metadata":   map[string]interface{}{"name": canaryName}},
 		}
-		_, err = resourceClient.Create(canary, metav1.CreateOptions{})
+		_, err = resourceClient.Create(context.TODO(), canary, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("failed to create canary resource %q: %v", canaryName, err)
 		}
 		framework.Logf("created canary resource %q", canaryName)
 		foreground := metav1.DeletePropagationForeground
-		err = resourceClient.Delete(canaryName, metav1.DeleteOptions{PropagationPolicy: &foreground})
+		err = resourceClient.Delete(context.TODO(), canaryName, metav1.DeleteOptions{PropagationPolicy: &foreground})
 		if err != nil {
 			framework.Failf("failed to delete canary resource %q: %v", canaryName, err)
 		}
 		// Wait for the canary foreground finalization to complete, which means GC is aware of our new custom resource type
 		var lastCanary *unstructured.Unstructured
 		if err := wait.PollImmediate(5*time.Second, 3*time.Minute, func() (bool, error) {
-			lastCanary, err = resourceClient.Get(dependentName, metav1.GetOptions{})
+			lastCanary, err = resourceClient.Get(context.TODO(), dependentName, metav1.GetOptions{})
 			return apierrors.IsNotFound(err), nil
 		}); err != nil {
 			framework.Logf("canary last state: %#v", lastCanary)
@@ -1006,7 +1006,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		var lastDependent *unstructured.Unstructured
 		var err2 error
 		if err := wait.Poll(5*time.Second, 60*time.Second, func() (bool, error) {
-			lastDependent, err2 = resourceClient.Get(dependentName, metav1.GetOptions{})
+			lastDependent, err2 = resourceClient.Get(context.TODO(), dependentName, metav1.GetOptions{})
 			return apierrors.IsNotFound(err2), nil
 		}); err != nil {
 			framework.Logf("owner: %#v", persistedOwner)
@@ -1016,7 +1016,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		}
 
 		// Ensure the owner is deleted.
-		_, err = resourceClient.Get(ownerName, metav1.GetOptions{})
+		_, err = resourceClient.Get(context.TODO(), ownerName, metav1.GetOptions{})
 		if err == nil {
 			framework.Failf("expected owner resource %q to be deleted", ownerName)
 		} else {
@@ -1070,7 +1070,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 				},
 			},
 		}
-		persistedOwner, err := resourceClient.Create(owner, metav1.CreateOptions{})
+		persistedOwner, err := resourceClient.Create(context.TODO(), owner, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("failed to create owner resource %q: %v", ownerName, err)
 		}
@@ -1095,21 +1095,21 @@ var _ = SIGDescribe("Garbage collector", func() {
 				},
 			},
 		}
-		_, err = resourceClient.Create(dependent, metav1.CreateOptions{})
+		_, err = resourceClient.Create(context.TODO(), dependent, metav1.CreateOptions{})
 		if err != nil {
 			framework.Failf("failed to create dependent resource %q: %v", dependentName, err)
 		}
 		framework.Logf("created dependent resource %q", dependentName)
 
 		// Delete the owner and orphan the dependent.
-		err = resourceClient.Delete(ownerName, getOrphanOptions())
+		err = resourceClient.Delete(context.TODO(), ownerName, getOrphanOptions())
 		if err != nil {
 			framework.Failf("failed to delete owner resource %q: %v", ownerName, err)
 		}
 
 		ginkgo.By("wait for the owner to be deleted")
 		if err := wait.Poll(5*time.Second, 120*time.Second, func() (bool, error) {
-			_, err = resourceClient.Get(ownerName, metav1.GetOptions{})
+			_, err = resourceClient.Get(context.TODO(), ownerName, metav1.GetOptions{})
 			if err == nil {
 				return false, nil
 			}
@@ -1124,7 +1124,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		// Wait 30s and ensure the dependent is not deleted.
 		ginkgo.By("wait for 30 seconds to see if the garbage collector mistakenly deletes the dependent crd")
 		if err := wait.Poll(5*time.Second, 30*time.Second, func() (bool, error) {
-			_, err := resourceClient.Get(dependentName, metav1.GetOptions{})
+			_, err := resourceClient.Get(context.TODO(), dependentName, metav1.GetOptions{})
 			return false, err
 		}); err != nil && err != wait.ErrWaitTimeout {
 			framework.Failf("failed to ensure the dependent is not deleted: %v", err)

--- a/test/e2e/apimachinery/garbage_collector.go
+++ b/test/e2e/apimachinery/garbage_collector.go
@@ -968,7 +968,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 
 		// Delete the owner.
 		background := metav1.DeletePropagationBackground
-		err = resourceClient.Delete(ownerName, &metav1.DeleteOptions{PropagationPolicy: &background})
+		err = resourceClient.Delete(ownerName, metav1.DeleteOptions{PropagationPolicy: &background})
 		if err != nil {
 			framework.Failf("failed to delete owner resource %q: %v", ownerName, err)
 		}
@@ -988,7 +988,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		}
 		framework.Logf("created canary resource %q", canaryName)
 		foreground := metav1.DeletePropagationForeground
-		err = resourceClient.Delete(canaryName, &metav1.DeleteOptions{PropagationPolicy: &foreground})
+		err = resourceClient.Delete(canaryName, metav1.DeleteOptions{PropagationPolicy: &foreground})
 		if err != nil {
 			framework.Failf("failed to delete canary resource %q: %v", canaryName, err)
 		}
@@ -1102,8 +1102,7 @@ var _ = SIGDescribe("Garbage collector", func() {
 		framework.Logf("created dependent resource %q", dependentName)
 
 		// Delete the owner and orphan the dependent.
-		delOpts := getOrphanOptions()
-		err = resourceClient.Delete(ownerName, &delOpts)
+		err = resourceClient.Delete(ownerName, getOrphanOptions())
 		if err != nil {
 			framework.Failf("failed to delete owner resource %q: %v", ownerName, err)
 		}

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -1890,7 +1890,7 @@ func testBlockingCustomResourceUpdateDeletion(f *framework.Framework, crd *apiex
 	}
 
 	ginkgo.By("Deleting the custom resource should be denied")
-	err = customResourceClient.Delete(crInstanceName, &metav1.DeleteOptions{})
+	err = customResourceClient.Delete(crInstanceName, metav1.DeleteOptions{})
 	framework.ExpectError(err, "deleting custom resource %s in namespace: %s should be denied", crInstanceName, f.Namespace.Name)
 	expectedErrMsg1 := "the custom resource cannot be deleted because it contains unwanted key and value"
 	if !strings.Contains(err.Error(), expectedErrMsg1) {
@@ -1909,7 +1909,7 @@ func testBlockingCustomResourceUpdateDeletion(f *framework.Framework, crd *apiex
 	framework.ExpectNoError(err, "failed to update custom resource %s in namespace: %s", crInstanceName, f.Namespace.Name)
 
 	ginkgo.By("Deleting the updated custom resource should be successful")
-	err = customResourceClient.Delete(crInstanceName, &metav1.DeleteOptions{})
+	err = customResourceClient.Delete(crInstanceName, metav1.DeleteOptions{})
 	framework.ExpectNoError(err, "failed to delete custom resource %s in namespace: %s", crInstanceName, f.Namespace.Name)
 
 }

--- a/test/e2e/apimachinery/webhook.go
+++ b/test/e2e/apimachinery/webhook.go
@@ -1678,11 +1678,11 @@ func updateCustomResource(c dynamic.ResourceInterface, ns, name string, update u
 	var cr *unstructured.Unstructured
 	pollErr := wait.PollImmediate(2*time.Second, 1*time.Minute, func() (bool, error) {
 		var err error
-		if cr, err = c.Get(name, metav1.GetOptions{}); err != nil {
+		if cr, err = c.Get(context.TODO(), name, metav1.GetOptions{}); err != nil {
 			return false, err
 		}
 		update(cr)
-		if cr, err = c.Update(cr, metav1.UpdateOptions{}); err == nil {
+		if cr, err = c.Update(context.TODO(), cr, metav1.UpdateOptions{}); err == nil {
 			return true, nil
 		}
 		// Only retry update on conflict
@@ -1846,7 +1846,7 @@ func testCustomResourceWebhook(f *framework.Framework, crd *apiextensionsv1.Cust
 			},
 		},
 	}
-	_, err := customResourceClient.Create(crInstance, metav1.CreateOptions{})
+	_, err := customResourceClient.Create(context.TODO(), crInstance, metav1.CreateOptions{})
 	framework.ExpectError(err, "create custom resource %s in namespace %s should be denied by webhook", crInstanceName, f.Namespace.Name)
 	expectedErrMsg := "the custom resource contains unwanted data"
 	if !strings.Contains(err.Error(), expectedErrMsg) {
@@ -1870,7 +1870,7 @@ func testBlockingCustomResourceUpdateDeletion(f *framework.Framework, crd *apiex
 			},
 		},
 	}
-	_, err := customResourceClient.Create(crInstance, metav1.CreateOptions{})
+	_, err := customResourceClient.Create(context.TODO(), crInstance, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "failed to create custom resource %s in namespace: %s", crInstanceName, f.Namespace.Name)
 
 	ginkgo.By("Updating the custom resource with disallowed data should be denied")
@@ -1890,7 +1890,7 @@ func testBlockingCustomResourceUpdateDeletion(f *framework.Framework, crd *apiex
 	}
 
 	ginkgo.By("Deleting the custom resource should be denied")
-	err = customResourceClient.Delete(crInstanceName, metav1.DeleteOptions{})
+	err = customResourceClient.Delete(context.TODO(), crInstanceName, metav1.DeleteOptions{})
 	framework.ExpectError(err, "deleting custom resource %s in namespace: %s should be denied", crInstanceName, f.Namespace.Name)
 	expectedErrMsg1 := "the custom resource cannot be deleted because it contains unwanted key and value"
 	if !strings.Contains(err.Error(), expectedErrMsg1) {
@@ -1909,7 +1909,7 @@ func testBlockingCustomResourceUpdateDeletion(f *framework.Framework, crd *apiex
 	framework.ExpectNoError(err, "failed to update custom resource %s in namespace: %s", crInstanceName, f.Namespace.Name)
 
 	ginkgo.By("Deleting the updated custom resource should be successful")
-	err = customResourceClient.Delete(crInstanceName, metav1.DeleteOptions{})
+	err = customResourceClient.Delete(context.TODO(), crInstanceName, metav1.DeleteOptions{})
 	framework.ExpectNoError(err, "failed to delete custom resource %s in namespace: %s", crInstanceName, f.Namespace.Name)
 
 }
@@ -1930,7 +1930,7 @@ func testMutatingCustomResourceWebhook(f *framework.Framework, crd *apiextension
 			},
 		},
 	}
-	mutatedCR, err := customResourceClient.Create(cr, metav1.CreateOptions{})
+	mutatedCR, err := customResourceClient.Create(context.TODO(), cr, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "failed to create custom resource %s in namespace: %s", crName, f.Namespace.Name)
 	expectedCRData := map[string]interface{}{
 		"mutation-start":   "yes",
@@ -1961,7 +1961,7 @@ func testMultiVersionCustomResourceWebhook(f *framework.Framework, testcrd *crd.
 			},
 		},
 	}
-	_, err := customResourceClient.Create(cr, metav1.CreateOptions{})
+	_, err := customResourceClient.Create(context.TODO(), cr, metav1.CreateOptions{})
 	framework.ExpectNoError(err, "failed to create custom resource %s in namespace: %s", crName, f.Namespace.Name)
 
 	ginkgo.By("Patching Custom Resource Definition to set v2 as storage")
@@ -1992,7 +1992,7 @@ func testMultiVersionCustomResourceWebhook(f *framework.Framework, testcrd *crd.
 
 	ginkgo.By("Patching the custom resource while v2 is storage version")
 	crDummyPatch := fmt.Sprint(`[{ "op": "add", "path": "/dummy", "value": "test" }]`)
-	mutatedCR, err := testcrd.DynamicClients["v2"].Patch(crName, types.JSONPatchType, []byte(crDummyPatch), metav1.PatchOptions{})
+	mutatedCR, err := testcrd.DynamicClients["v2"].Patch(context.TODO(), crName, types.JSONPatchType, []byte(crDummyPatch), metav1.PatchOptions{})
 	framework.ExpectNoError(err, "failed to patch custom resource %s in namespace: %s", crName, f.Namespace.Name)
 	expectedCRData := map[string]interface{}{
 		"mutation-start":   "yes",

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -600,7 +600,7 @@ func waitForPdbToObserveHealthyPods(cs kubernetes.Interface, ns string, healthyC
 
 func getPDBStatusOrDie(dc dynamic.Interface, ns string, name string) *policyv1beta1.PodDisruptionBudget {
 	pdbStatusResource := policyv1beta1.SchemeGroupVersion.WithResource("poddisruptionbudgets")
-	unstruct, err := dc.Resource(pdbStatusResource).Namespace(ns).Get(name, metav1.GetOptions{}, "status")
+	unstruct, err := dc.Resource(pdbStatusResource).Namespace(ns).Get(context.TODO(), name, metav1.GetOptions{}, "status")
 	pdb, err := unstructuredToPDB(unstruct)
 	framework.ExpectNoError(err, "Getting the status of the pdb %s in namespace %s", name, ns)
 	return pdb

--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -19,6 +19,7 @@ package skipper
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"regexp"
 	"runtime"
@@ -137,7 +138,7 @@ func SkipUnlessLocalEphemeralStorageEnabled() {
 // SkipIfMissingResource skips if the gvr resource is missing.
 func SkipIfMissingResource(dynamicClient dynamic.Interface, gvr schema.GroupVersionResource, namespace string) {
 	resourceClient := dynamicClient.Resource(gvr).Namespace(namespace)
-	_, err := resourceClient.List(metav1.ListOptions{})
+	_, err := resourceClient.List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		// not all resources support list, so we ignore those
 		if apierrors.IsMethodNotSupported(err) || apierrors.IsNotFound(err) || apierrors.IsForbidden(err) {

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2238,7 +2238,7 @@ func verbsContain(verbs metav1.Verbs, str string) bool {
 
 // deleteObj deletes an Object with the provided client and name.
 func deleteObj(client dynamic.ResourceInterface, name string) {
-	err := client.Delete(name, &metav1.DeleteOptions{})
+	err := client.Delete(name, metav1.DeleteOptions{})
 	framework.ExpectNoError(err)
 }
 

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -2238,7 +2238,7 @@ func verbsContain(verbs metav1.Verbs, str string) bool {
 
 // deleteObj deletes an Object with the provided client and name.
 func deleteObj(client dynamic.ResourceInterface, name string) {
-	err := client.Delete(name, metav1.DeleteOptions{})
+	err := client.Delete(context.TODO(), name, metav1.DeleteOptions{})
 	framework.ExpectNoError(err)
 }
 
@@ -2246,7 +2246,7 @@ func deleteObj(client dynamic.ResourceInterface, name string) {
 // and then verifies that the kubectl get output provides custom columns. Once
 // the test has completed, it deletes the object.
 func createObjValidateOutputAndCleanup(namespace string, client dynamic.ResourceInterface, obj *unstructured.Unstructured, resource metav1.APIResource) {
-	_, err := client.Create(obj, metav1.CreateOptions{})
+	_, err := client.Create(context.TODO(), obj, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 	defer deleteObj(client, obj.GetName())
 

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -346,7 +346,7 @@ func (d *driverDefinition) GetSnapshotClass(config *testsuites.PerTestConfig) *u
 	case d.SnapshotClass.FromName:
 		// Do nothing (just use empty parameters)
 	case d.SnapshotClass.FromExistingClassName != "":
-		snapshotClass, err := f.DynamicClient.Resource(testsuites.SnapshotClassGVR).Get(d.SnapshotClass.FromExistingClassName, metav1.GetOptions{})
+		snapshotClass, err := f.DynamicClient.Resource(testsuites.SnapshotClassGVR).Get(context.TODO(), d.SnapshotClass.FromExistingClassName, metav1.GetOptions{})
 		framework.ExpectNoError(err, "getting snapshot class %s", d.SnapshotClass.FromExistingClassName)
 
 		if params, ok := snapshotClass.Object["parameters"].(map[string]interface{}); ok {

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -740,12 +740,12 @@ func prepareSnapshotDataSourceForProvisioning(
 	volume.InjectContent(f, config, nil, "", tests)
 
 	ginkgo.By("[Initialize dataSource]creating a SnapshotClass")
-	snapshotClass, err = dynamicClient.Resource(SnapshotClassGVR).Create(snapshotClass, metav1.CreateOptions{})
+	snapshotClass, err = dynamicClient.Resource(SnapshotClassGVR).Create(context.TODO(), snapshotClass, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	ginkgo.By("[Initialize dataSource]creating a snapshot")
 	snapshot := getSnapshot(updatedClaim.Name, updatedClaim.Namespace, snapshotClass.GetName())
-	snapshot, err = dynamicClient.Resource(SnapshotGVR).Namespace(updatedClaim.Namespace).Create(snapshot, metav1.CreateOptions{})
+	snapshot, err = dynamicClient.Resource(SnapshotGVR).Namespace(updatedClaim.Namespace).Create(context.TODO(), snapshot, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
 
 	WaitForSnapshotReady(dynamicClient, snapshot.GetNamespace(), snapshot.GetName(), framework.Poll, framework.SnapshotCreateTimeout)
@@ -753,7 +753,7 @@ func prepareSnapshotDataSourceForProvisioning(
 
 	ginkgo.By("[Initialize dataSource]checking the snapshot")
 	// Get new copy of the snapshot
-	snapshot, err = dynamicClient.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Get(snapshot.GetName(), metav1.GetOptions{})
+	snapshot, err = dynamicClient.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Get(context.TODO(), snapshot.GetName(), metav1.GetOptions{})
 	framework.ExpectNoError(err)
 	group := "snapshot.storage.k8s.io"
 	dataSourceRef := &v1.TypedLocalObjectReference{
@@ -764,7 +764,7 @@ func prepareSnapshotDataSourceForProvisioning(
 
 	cleanupFunc := func() {
 		framework.Logf("deleting snapshot %q/%q", snapshot.GetNamespace(), snapshot.GetName())
-		err = dynamicClient.Resource(SnapshotGVR).Namespace(updatedClaim.Namespace).Delete(snapshot.GetName(), metav1.DeleteOptions{})
+		err = dynamicClient.Resource(SnapshotGVR).Namespace(updatedClaim.Namespace).Delete(context.TODO(), snapshot.GetName(), metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			framework.Failf("Error deleting snapshot %q. Error: %v", snapshot.GetName(), err)
 		}
@@ -776,7 +776,7 @@ func prepareSnapshotDataSourceForProvisioning(
 		}
 
 		framework.Logf("deleting SnapshotClass %s", snapshotClass.GetName())
-		framework.ExpectNoError(dynamicClient.Resource(SnapshotClassGVR).Delete(snapshotClass.GetName(), metav1.DeleteOptions{}))
+		framework.ExpectNoError(dynamicClient.Resource(SnapshotClassGVR).Delete(context.TODO(), snapshotClass.GetName(), metav1.DeleteOptions{}))
 	}
 
 	return dataSourceRef, cleanupFunc

--- a/test/e2e/storage/testsuites/provisioning.go
+++ b/test/e2e/storage/testsuites/provisioning.go
@@ -764,7 +764,7 @@ func prepareSnapshotDataSourceForProvisioning(
 
 	cleanupFunc := func() {
 		framework.Logf("deleting snapshot %q/%q", snapshot.GetNamespace(), snapshot.GetName())
-		err = dynamicClient.Resource(SnapshotGVR).Namespace(updatedClaim.Namespace).Delete(snapshot.GetName(), nil)
+		err = dynamicClient.Resource(SnapshotGVR).Namespace(updatedClaim.Namespace).Delete(snapshot.GetName(), metav1.DeleteOptions{})
 		if err != nil && !apierrors.IsNotFound(err) {
 			framework.Failf("Error deleting snapshot %q. Error: %v", snapshot.GetName(), err)
 		}
@@ -776,7 +776,7 @@ func prepareSnapshotDataSourceForProvisioning(
 		}
 
 		framework.Logf("deleting SnapshotClass %s", snapshotClass.GetName())
-		framework.ExpectNoError(dynamicClient.Resource(SnapshotClassGVR).Delete(snapshotClass.GetName(), nil))
+		framework.ExpectNoError(dynamicClient.Resource(SnapshotClassGVR).Delete(snapshotClass.GetName(), metav1.DeleteOptions{}))
 	}
 
 	return dataSourceRef, cleanupFunc

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -170,22 +170,22 @@ func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatt
 		framework.ExpectNoError(err)
 
 		ginkgo.By("creating a SnapshotClass")
-		vsc, err = dc.Resource(SnapshotClassGVR).Create(vsc, metav1.CreateOptions{})
+		vsc, err = dc.Resource(SnapshotClassGVR).Create(context.TODO(), vsc, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		defer func() {
 			framework.Logf("deleting SnapshotClass %s", vsc.GetName())
-			framework.ExpectNoError(dc.Resource(SnapshotClassGVR).Delete(vsc.GetName(), metav1.DeleteOptions{}))
+			framework.ExpectNoError(dc.Resource(SnapshotClassGVR).Delete(context.TODO(), vsc.GetName(), metav1.DeleteOptions{}))
 		}()
 
 		ginkgo.By("creating a snapshot")
 		snapshot := getSnapshot(pvc.Name, pvc.Namespace, vsc.GetName())
 
-		snapshot, err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Create(snapshot, metav1.CreateOptions{})
+		snapshot, err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Create(context.TODO(), snapshot, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
 		defer func() {
 			framework.Logf("deleting snapshot %q/%q", snapshot.GetNamespace(), snapshot.GetName())
 			// typically this snapshot has already been deleted
-			err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Delete(snapshot.GetName(), metav1.DeleteOptions{})
+			err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Delete(context.TODO(), snapshot.GetName(), metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				framework.Failf("Error deleting snapshot %q. Error: %v", pvc.Name, err)
 			}
@@ -195,13 +195,13 @@ func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatt
 
 		ginkgo.By("checking the snapshot")
 		// Get new copy of the snapshot
-		snapshot, err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Get(snapshot.GetName(), metav1.GetOptions{})
+		snapshot, err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Get(context.TODO(), snapshot.GetName(), metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		// Get the bound snapshotContent
 		snapshotStatus := snapshot.Object["status"].(map[string]interface{})
 		snapshotContentName := snapshotStatus["boundVolumeSnapshotContentName"].(string)
-		snapshotContent, err := dc.Resource(SnapshotContentGVR).Get(snapshotContentName, metav1.GetOptions{})
+		snapshotContent, err := dc.Resource(SnapshotContentGVR).Get(context.TODO(), snapshotContentName, metav1.GetOptions{})
 		framework.ExpectNoError(err)
 
 		snapshotContentSpec := snapshotContent.Object["spec"].(map[string]interface{})
@@ -219,7 +219,7 @@ func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatt
 func WaitForSnapshotReady(c dynamic.Interface, ns string, snapshotName string, Poll, timeout time.Duration) error {
 	framework.Logf("Waiting up to %v for VolumeSnapshot %s to become ready", timeout, snapshotName)
 	for start := time.Now(); time.Since(start) < timeout; time.Sleep(Poll) {
-		snapshot, err := c.Resource(SnapshotGVR).Namespace(ns).Get(snapshotName, metav1.GetOptions{})
+		snapshot, err := c.Resource(SnapshotGVR).Namespace(ns).Get(context.TODO(), snapshotName, metav1.GetOptions{})
 		if err != nil {
 			framework.Logf("Failed to get claim %q, retrying in %v. Error: %v", snapshotName, Poll, err)
 			continue

--- a/test/e2e/storage/testsuites/snapshottable.go
+++ b/test/e2e/storage/testsuites/snapshottable.go
@@ -174,7 +174,7 @@ func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatt
 		framework.ExpectNoError(err)
 		defer func() {
 			framework.Logf("deleting SnapshotClass %s", vsc.GetName())
-			framework.ExpectNoError(dc.Resource(SnapshotClassGVR).Delete(vsc.GetName(), nil))
+			framework.ExpectNoError(dc.Resource(SnapshotClassGVR).Delete(vsc.GetName(), metav1.DeleteOptions{}))
 		}()
 
 		ginkgo.By("creating a snapshot")
@@ -185,7 +185,7 @@ func (s *snapshottableTestSuite) DefineTests(driver TestDriver, pattern testpatt
 		defer func() {
 			framework.Logf("deleting snapshot %q/%q", snapshot.GetNamespace(), snapshot.GetName())
 			// typically this snapshot has already been deleted
-			err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Delete(snapshot.GetName(), nil)
+			err = dc.Resource(SnapshotGVR).Namespace(snapshot.GetNamespace()).Delete(snapshot.GetName(), metav1.DeleteOptions{})
 			if err != nil && !apierrors.IsNotFound(err) {
 				framework.Failf("Error deleting snapshot %q. Error: %v", pvc.Name, err)
 			}

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -669,7 +669,7 @@ func testResourceDelete(c *testContext) {
 	background := metav1.DeletePropagationBackground
 	zero := int64(0)
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, obj.GetName(), obj.GetNamespace(), false, true, true)
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -713,7 +713,7 @@ func testResourceDelete(c *testContext) {
 		return
 	}
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, obj.GetName(), obj.GetNamespace(), false, true, true)
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -793,7 +793,7 @@ func testResourceDeletecollection(c *testContext) {
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, "", obj.GetNamespace(), false, true, true)
 
 	// delete
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).DeleteCollection(&metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background}, metav1.ListOptions{LabelSelector: "webhooktest=true"})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).DeleteCollection(metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background}, metav1.ListOptions{LabelSelector: "webhooktest=true"})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -919,7 +919,7 @@ func testNamespaceDelete(c *testContext) {
 	zero := int64(0)
 
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, obj.GetName(), obj.GetNamespace(), false, true, true)
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), &metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
 	if err != nil {
 		c.t.Error(err)
 		return

--- a/test/integration/apiserver/admissionwebhook/admission_test.go
+++ b/test/integration/apiserver/admissionwebhook/admission_test.go
@@ -618,7 +618,7 @@ func testResourceCreate(c *testContext) {
 		ns = testNamespace
 	}
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkCreateOptions, v1beta1.Create, stubObj.GetName(), ns, true, false, true)
-	_, err = c.client.Resource(c.gvr).Namespace(ns).Create(stubObj, metav1.CreateOptions{})
+	_, err = c.client.Resource(c.gvr).Namespace(ns).Create(context.TODO(), stubObj, metav1.CreateOptions{})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -633,7 +633,7 @@ func testResourceUpdate(c *testContext) {
 		}
 		obj.SetAnnotations(map[string]string{"update": "true"})
 		c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkUpdateOptions, v1beta1.Update, obj.GetName(), obj.GetNamespace(), true, true, true)
-		_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Update(obj, metav1.UpdateOptions{})
+		_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Update(context.TODO(), obj, metav1.UpdateOptions{})
 		return err
 	}); err != nil {
 		c.t.Error(err)
@@ -649,6 +649,7 @@ func testResourcePatch(c *testContext) {
 	}
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkUpdateOptions, v1beta1.Update, obj.GetName(), obj.GetNamespace(), true, true, true)
 	_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Patch(
+		context.TODO(),
 		obj.GetName(),
 		types.MergePatchType,
 		[]byte(`{"metadata":{"annotations":{"patch":"true"}}}`),
@@ -669,7 +670,7 @@ func testResourceDelete(c *testContext) {
 	background := metav1.DeletePropagationBackground
 	zero := int64(0)
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, obj.GetName(), obj.GetNamespace(), false, true, true)
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -678,7 +679,7 @@ func testResourceDelete(c *testContext) {
 
 	// wait for the item to be gone
 	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
+		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -704,6 +705,7 @@ func testResourceDelete(c *testContext) {
 	// because some resource (e.g., events) do not support garbage
 	// collector finalizers.
 	_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Patch(
+		context.TODO(),
 		obj.GetName(),
 		types.MergePatchType,
 		[]byte(`{"metadata":{"finalizers":["test/k8s.io"]}}`),
@@ -713,7 +715,7 @@ func testResourceDelete(c *testContext) {
 		return
 	}
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, obj.GetName(), obj.GetNamespace(), false, true, true)
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -722,7 +724,7 @@ func testResourceDelete(c *testContext) {
 
 	// wait other finalizers (e.g., crd's customresourcecleanup finalizer) to be removed.
 	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
+		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if err != nil {
 			return false, err
 		}
@@ -743,6 +745,7 @@ func testResourceDelete(c *testContext) {
 
 	// remove the finalizer
 	_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Patch(
+		context.TODO(),
 		obj.GetName(),
 		types.MergePatchType,
 		[]byte(`{"metadata":{"finalizers":[]}}`),
@@ -753,7 +756,7 @@ func testResourceDelete(c *testContext) {
 	}
 	// wait for the item to be gone
 	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
+		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -780,6 +783,7 @@ func testResourceDeletecollection(c *testContext) {
 
 	// update the object with a label that matches our selector
 	_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Patch(
+		context.TODO(),
 		obj.GetName(),
 		types.MergePatchType,
 		[]byte(`{"metadata":{"labels":{"webhooktest":"true"}}}`),
@@ -793,7 +797,7 @@ func testResourceDeletecollection(c *testContext) {
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, "", obj.GetNamespace(), false, true, true)
 
 	// delete
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).DeleteCollection(metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background}, metav1.ListOptions{LabelSelector: "webhooktest=true"})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).DeleteCollection(context.TODO(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background}, metav1.ListOptions{LabelSelector: "webhooktest=true"})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -801,7 +805,7 @@ func testResourceDeletecollection(c *testContext) {
 
 	// wait for the item to be gone
 	err = wait.PollImmediate(100*time.Millisecond, 10*time.Second, func() (bool, error) {
-		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
+		obj, err := c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			return true, nil
 		}
@@ -845,7 +849,7 @@ func testSubresourceUpdate(c *testContext) {
 
 		// If the subresource supports get, fetch that as the object to submit (namespaces/finalize, */scale, etc)
 		if sets.NewString(c.resource.Verbs...).Has("get") {
-			submitObj, err = c.client.Resource(gvrWithoutSubresources).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{}, subresources...)
+			submitObj, err = c.client.Resource(gvrWithoutSubresources).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{}, subresources...)
 			if err != nil {
 				return err
 			}
@@ -858,6 +862,7 @@ func testSubresourceUpdate(c *testContext) {
 		c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkUpdateOptions, v1beta1.Update, obj.GetName(), obj.GetNamespace(), true, true, true)
 
 		_, err = c.client.Resource(gvrWithoutSubresources).Namespace(obj.GetNamespace()).Update(
+			context.TODO(),
 			submitObj,
 			metav1.UpdateOptions{},
 			subresources...,
@@ -885,6 +890,7 @@ func testSubresourcePatch(c *testContext) {
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkUpdateOptions, v1beta1.Update, obj.GetName(), obj.GetNamespace(), true, true, true)
 
 	_, err = c.client.Resource(gvrWithoutSubresources).Namespace(obj.GetNamespace()).Patch(
+		context.TODO(),
 		obj.GetName(),
 		types.MergePatchType,
 		[]byte(`{"metadata":{"annotations":{"subresourcepatch":"true"}}}`),
@@ -919,7 +925,7 @@ func testNamespaceDelete(c *testContext) {
 	zero := int64(0)
 
 	c.admissionHolder.expect(c.gvr, gvk(c.resource.Group, c.resource.Version, c.resource.Kind), gvkDeleteOptions, v1beta1.Delete, obj.GetName(), obj.GetNamespace(), false, true, true)
-	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
+	err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{GracePeriodSeconds: &zero, PropagationPolicy: &background})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -927,7 +933,7 @@ func testNamespaceDelete(c *testContext) {
 	c.admissionHolder.verify(c.t)
 
 	// do the finalization so the namespace can be deleted
-	obj, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
+	obj, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -937,13 +943,13 @@ func testNamespaceDelete(c *testContext) {
 		c.t.Error(err)
 		return
 	}
-	_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Update(obj, metav1.UpdateOptions{}, "finalize")
+	_, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Update(context.TODO(), obj, metav1.UpdateOptions{}, "finalize")
 	if err != nil {
 		c.t.Error(err)
 		return
 	}
 	// verify namespace is gone
-	obj, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(obj.GetName(), metav1.GetOptions{})
+	obj, err = c.client.Resource(c.gvr).Namespace(obj.GetNamespace()).Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 	if err == nil || !apierrors.IsNotFound(err) {
 		c.t.Errorf("expected namespace to be gone, got %#v, %v", obj, err)
 	}
@@ -993,7 +999,7 @@ func testDeploymentRollback(c *testContext) {
 	rollbackUnstructuredObj := &unstructured.Unstructured{Object: rollbackUnstructuredBody}
 	rollbackUnstructuredObj.SetName(obj.GetName())
 
-	_, err = c.client.Resource(gvrWithoutSubresources).Namespace(obj.GetNamespace()).Create(rollbackUnstructuredObj, metav1.CreateOptions{}, subresources...)
+	_, err = c.client.Resource(gvrWithoutSubresources).Namespace(obj.GetNamespace()).Create(context.TODO(), rollbackUnstructuredObj, metav1.CreateOptions{}, subresources...)
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -1137,7 +1143,7 @@ func testSubresourceProxy(c *testContext) {
 func testPruningRandomNumbers(c *testContext) {
 	testResourceCreate(c)
 
-	cr2pant, err := c.client.Resource(c.gvr).Get("fortytwo", metav1.GetOptions{})
+	cr2pant, err := c.client.Resource(c.gvr).Get(context.TODO(), "fortytwo", metav1.GetOptions{})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -1156,7 +1162,7 @@ func testPruningRandomNumbers(c *testContext) {
 func testNoPruningCustomFancy(c *testContext) {
 	testResourceCreate(c)
 
-	cr2pant, err := c.client.Resource(c.gvr).Get("cr2pant", metav1.GetOptions{})
+	cr2pant, err := c.client.Resource(c.gvr).Get(context.TODO(), "cr2pant", metav1.GetOptions{})
 	if err != nil {
 		c.t.Error(err)
 		return
@@ -1411,14 +1417,14 @@ func createOrGetResource(client dynamic.Interface, gvr schema.GroupVersionResour
 	if resource.Namespaced {
 		ns = testNamespace
 	}
-	obj, err := client.Resource(gvr).Namespace(ns).Get(stubObj.GetName(), metav1.GetOptions{})
+	obj, err := client.Resource(gvr).Namespace(ns).Get(context.TODO(), stubObj.GetName(), metav1.GetOptions{})
 	if err == nil {
 		return obj, nil
 	}
 	if !apierrors.IsNotFound(err) {
 		return nil, err
 	}
-	return client.Resource(gvr).Namespace(ns).Create(stubObj, metav1.CreateOptions{})
+	return client.Resource(gvr).Namespace(ns).Create(context.TODO(), stubObj, metav1.CreateOptions{})
 }
 
 func gvr(group, version, resource string) schema.GroupVersionResource {

--- a/test/integration/apiserver/apiserver_test.go
+++ b/test/integration/apiserver/apiserver_test.go
@@ -599,7 +599,7 @@ func TestMetadataClient(t *testing.T) {
 			want: func(t *testing.T) {
 				ns := "metadata-crd"
 				crclient := dynamicClient.Resource(crdGVR).Namespace(ns)
-				cr, err := crclient.Create(&unstructured.Unstructured{
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"apiVersion": "cr.bar.com/v1",
 						"kind":       "Foo",
@@ -727,7 +727,7 @@ func TestMetadataClient(t *testing.T) {
 			want: func(t *testing.T) {
 				ns := "metadata-watch-crd"
 				crclient := dynamicClient.Resource(crdGVR).Namespace(ns)
-				cr, err := crclient.Create(&unstructured.Unstructured{
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"apiVersion": "cr.bar.com/v1",
 						"kind":       "Foo",
@@ -858,11 +858,11 @@ func TestAPICRDProtobuf(t *testing.T) {
 			name:   "server returns 406 when asking for protobuf for CRDs, which dynamic client does not support",
 			accept: "application/vnd.kubernetes.protobuf",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-1"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-1"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-1", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-1", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -887,11 +887,11 @@ func TestAPICRDProtobuf(t *testing.T) {
 			name:   "server returns JSON when asking for protobuf and json for CRDs",
 			accept: "application/vnd.kubernetes.protobuf,application/json",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "spec": map[string]interface{}{"field": 1}, "metadata": map[string]interface{}{"name": "test-2"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "spec": map[string]interface{}{"field": 1}, "metadata": map[string]interface{}{"name": "test-2"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-2", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-2", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -916,11 +916,11 @@ func TestAPICRDProtobuf(t *testing.T) {
 			accept:      "application/vnd.kubernetes.protobuf",
 			subresource: "status",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-3"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-3"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-3", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"3"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-3", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"3"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -946,11 +946,11 @@ func TestAPICRDProtobuf(t *testing.T) {
 			accept:      "application/vnd.kubernetes.protobuf,application/json",
 			subresource: "status",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "spec": map[string]interface{}{"field": 1}, "metadata": map[string]interface{}{"name": "test-4"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "spec": map[string]interface{}{"field": 1}, "metadata": map[string]interface{}{"name": "test-4"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-4", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"4"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-4", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"4"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1079,11 +1079,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1beta1 verify columns on CRDs in json",
 			accept: "application/json;as=Table;g=meta.k8s.io;v=v1beta1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-1"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-1"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-1", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-1", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1096,11 +1096,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1beta1 verify columns on CRDs in json;stream=watch",
 			accept: "application/json;stream=watch;as=Table;g=meta.k8s.io;v=v1beta1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-2"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-2"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-2", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-2", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1113,11 +1113,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1beta1 verify columns on CRDs in yaml",
 			accept: "application/yaml;as=Table;g=meta.k8s.io;v=v1beta1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-3"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-3"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-3", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-3", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1230,11 +1230,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1beta1 verify partial metadata object on CRDs in protobuf",
 			accept: "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1beta1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-4", "annotations": map[string]string{"test": "0"}}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-4", "annotations": map[string]string{"test": "0"}}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-4", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-4", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1335,11 +1335,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1 verify columns on CRDs in json",
 			accept: "application/json;as=Table;g=meta.k8s.io;v=v1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-5"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-5"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-5", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-5", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1352,11 +1352,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1 verify columns on CRDs in json;stream=watch",
 			accept: "application/json;stream=watch;as=Table;g=meta.k8s.io;v=v1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-6"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-6"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-6", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-6", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1369,11 +1369,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1 verify columns on CRDs in yaml",
 			accept: "application/yaml;as=Table;g=meta.k8s.io;v=v1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-7"}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-7"}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch("test-7", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), "test-7", types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"
@@ -1486,11 +1486,11 @@ func TestTransform(t *testing.T) {
 			name:   "v1 verify partial metadata object on CRDs in protobuf",
 			accept: "application/vnd.kubernetes.protobuf;as=PartialObjectMetadata;g=meta.k8s.io;v=v1",
 			object: func(t *testing.T) (metav1.Object, string, string) {
-				cr, err := crclient.Create(&unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-8", "annotations": map[string]string{"test": "0"}}}}, metav1.CreateOptions{})
+				cr, err := crclient.Create(context.TODO(), &unstructured.Unstructured{Object: map[string]interface{}{"apiVersion": "cr.bar.com/v1", "kind": "Foo", "metadata": map[string]interface{}{"name": "test-8", "annotations": map[string]string{"test": "0"}}}}, metav1.CreateOptions{})
 				if err != nil {
 					t.Fatalf("unable to create cr: %v", err)
 				}
-				if _, err := crclient.Patch(cr.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
+				if _, err := crclient.Patch(context.TODO(), cr.GetName(), types.MergePatchType, []byte(`{"metadata":{"annotations":{"test":"1"}}}`), metav1.PatchOptions{}); err != nil {
 					t.Fatalf("unable to patch cr: %v", err)
 				}
 				return cr, crdGVR.Group, "foos"

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/fields"
@@ -71,7 +71,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	// check dynamic list
-	unstructuredList, err := dynamicClient.Resource(resource).Namespace("default").List(metav1.ListOptions{})
+	unstructuredList, err := dynamicClient.Resource(resource).Namespace("default").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error when listing pods: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	// check dynamic get
-	unstruct, err := dynamicClient.Resource(resource).Namespace("default").Get(actual.Name, metav1.GetOptions{})
+	unstruct, err := dynamicClient.Resource(resource).Namespace("default").Get(context.TODO(), actual.Name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error when getting pod %q: %v", actual.Name, err)
 	}
@@ -105,7 +105,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	// delete the pod dynamically
-	err = dynamicClient.Resource(resource).Namespace("default").Delete(actual.Name, metav1.DeleteOptions{})
+	err = dynamicClient.Resource(resource).Namespace("default").Delete(context.TODO(), actual.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error when deleting pod: %v", err)
 	}
@@ -163,7 +163,7 @@ func TestDynamicClientWatch(t *testing.T) {
 		t.Logf("Created event %#v", got.ObjectMeta)
 	}
 
-	w, err := dynamicClient.Resource(resource).Namespace("default").Watch(metav1.ListOptions{
+	w, err := dynamicClient.Resource(resource).Namespace("default").Watch(context.TODO(), metav1.ListOptions{
 		ResourceVersion: rv1,
 		Watch:           true,
 		FieldSelector:   fields.OneTermEqualSelector("metadata.name", "event-9").String(),

--- a/test/integration/client/dynamic_client_test.go
+++ b/test/integration/client/dynamic_client_test.go
@@ -105,7 +105,7 @@ func TestDynamicClient(t *testing.T) {
 	}
 
 	// delete the pod dynamically
-	err = dynamicClient.Resource(resource).Namespace("default").Delete(actual.Name, nil)
+	err = dynamicClient.Resource(resource).Namespace("default").Delete(actual.Name, metav1.DeleteOptions{})
 	if err != nil {
 		t.Fatalf("unexpected error when deleting pod: %v", err)
 	}

--- a/test/integration/disruption/disruption_test.go
+++ b/test/integration/disruption/disruption_test.go
@@ -124,7 +124,7 @@ func TestPDBWithScaleSubresource(t *testing.T) {
 			},
 		},
 	}
-	createdResource, err := resourceClient.Create(resource, metav1.CreateOptions{})
+	createdResource, err := resourceClient.Create(context.TODO(), resource, metav1.CreateOptions{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/integration/dryrun/dryrun_test.go
+++ b/test/integration/dryrun/dryrun_test.go
@@ -178,7 +178,7 @@ func DryRunUpdateTest(t *testing.T, rsc dynamic.ResourceInterface, name string) 
 }
 
 func DryRunDeleteCollectionTest(t *testing.T, rsc dynamic.ResourceInterface, name string) {
-	err := rsc.DeleteCollection(&metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}}, metav1.ListOptions{})
+	err := rsc.DeleteCollection(metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}}, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("dry-run delete collection failed: %v", err)
 	}
@@ -193,7 +193,7 @@ func DryRunDeleteCollectionTest(t *testing.T, rsc dynamic.ResourceInterface, nam
 }
 
 func DryRunDeleteTest(t *testing.T, rsc dynamic.ResourceInterface, name string) {
-	err := rsc.Delete(name, &metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}})
+	err := rsc.Delete(name, metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}})
 	if err != nil {
 		t.Fatalf("dry-run delete failed: %v", err)
 	}
@@ -294,7 +294,7 @@ func TestDryRun(t *testing.T) {
 			}
 			DryRunDeleteTest(t, rsc, name)
 
-			if err = rsc.Delete(obj.GetName(), metav1.NewDeleteOptions(0)); err != nil {
+			if err = rsc.Delete(obj.GetName(), *metav1.NewDeleteOptions(0)); err != nil {
 				t.Fatalf("deleting final object failed: %v", err)
 			}
 		})

--- a/test/integration/dryrun/dryrun_test.go
+++ b/test/integration/dryrun/dryrun_test.go
@@ -46,7 +46,7 @@ var kindWhiteList = sets.NewString()
 const testNamespace = "dryrunnamespace"
 
 func DryRunCreateTest(t *testing.T, rsc dynamic.ResourceInterface, obj *unstructured.Unstructured, gvResource schema.GroupVersionResource) {
-	createdObj, err := rsc.Create(obj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
+	createdObj, err := rsc.Create(context.TODO(), obj, metav1.CreateOptions{DryRun: []string{metav1.DryRunAll}})
 	if err != nil {
 		t.Fatalf("failed to dry-run create stub for %s: %#v", gvResource, err)
 	}
@@ -56,21 +56,21 @@ func DryRunCreateTest(t *testing.T, rsc dynamic.ResourceInterface, obj *unstruct
 			obj.GroupVersionKind())
 	}
 
-	if _, err := rsc.Get(obj.GetName(), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
+	if _, err := rsc.Get(context.TODO(), obj.GetName(), metav1.GetOptions{}); !apierrors.IsNotFound(err) {
 		t.Fatalf("object shouldn't exist: %v", err)
 	}
 }
 
 func DryRunPatchTest(t *testing.T, rsc dynamic.ResourceInterface, name string) {
 	patch := []byte(`{"metadata":{"annotations":{"patch": "true"}}}`)
-	obj, err := rsc.Patch(name, types.MergePatchType, patch, metav1.PatchOptions{DryRun: []string{metav1.DryRunAll}})
+	obj, err := rsc.Patch(context.TODO(), name, types.MergePatchType, patch, metav1.PatchOptions{DryRun: []string{metav1.DryRunAll}})
 	if err != nil {
 		t.Fatalf("failed to dry-run patch object: %v", err)
 	}
 	if v := obj.GetAnnotations()["patch"]; v != "true" {
 		t.Fatalf("dry-run patched annotations should be returned, got: %v", obj.GetAnnotations())
 	}
-	obj, err = rsc.Get(obj.GetName(), metav1.GetOptions{})
+	obj, err = rsc.Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get object: %v", err)
 	}
@@ -92,7 +92,7 @@ func getReplicasOrFail(t *testing.T, obj *unstructured.Unstructured) int64 {
 }
 
 func DryRunScalePatchTest(t *testing.T, rsc dynamic.ResourceInterface, name string) {
-	obj, err := rsc.Get(name, metav1.GetOptions{}, "scale")
+	obj, err := rsc.Get(context.TODO(), name, metav1.GetOptions{}, "scale")
 	if apierrors.IsNotFound(err) {
 		return
 	}
@@ -102,14 +102,14 @@ func DryRunScalePatchTest(t *testing.T, rsc dynamic.ResourceInterface, name stri
 
 	replicas := getReplicasOrFail(t, obj)
 	patch := []byte(`{"spec":{"replicas":10}}`)
-	patchedObj, err := rsc.Patch(name, types.MergePatchType, patch, metav1.PatchOptions{DryRun: []string{metav1.DryRunAll}}, "scale")
+	patchedObj, err := rsc.Patch(context.TODO(), name, types.MergePatchType, patch, metav1.PatchOptions{DryRun: []string{metav1.DryRunAll}}, "scale")
 	if err != nil {
 		t.Fatalf("failed to dry-run patch object: %v", err)
 	}
 	if newReplicas := getReplicasOrFail(t, patchedObj); newReplicas != 10 {
 		t.Fatalf("dry-run patch to replicas didn't return new value: %v", newReplicas)
 	}
-	persistedObj, err := rsc.Get(name, metav1.GetOptions{}, "scale")
+	persistedObj, err := rsc.Get(context.TODO(), name, metav1.GetOptions{}, "scale")
 	if err != nil {
 		t.Fatalf("failed to get scale sub-resource")
 	}
@@ -119,7 +119,7 @@ func DryRunScalePatchTest(t *testing.T, rsc dynamic.ResourceInterface, name stri
 }
 
 func DryRunScaleUpdateTest(t *testing.T, rsc dynamic.ResourceInterface, name string) {
-	obj, err := rsc.Get(name, metav1.GetOptions{}, "scale")
+	obj, err := rsc.Get(context.TODO(), name, metav1.GetOptions{}, "scale")
 	if apierrors.IsNotFound(err) {
 		return
 	}
@@ -131,14 +131,14 @@ func DryRunScaleUpdateTest(t *testing.T, rsc dynamic.ResourceInterface, name str
 	if err := unstructured.SetNestedField(obj.Object, int64(10), "spec", "replicas"); err != nil {
 		t.Fatalf("failed to set spec.replicas: %v", err)
 	}
-	updatedObj, err := rsc.Update(obj, metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}}, "scale")
+	updatedObj, err := rsc.Update(context.TODO(), obj, metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}}, "scale")
 	if err != nil {
 		t.Fatalf("failed to dry-run update scale sub-resource: %v", err)
 	}
 	if newReplicas := getReplicasOrFail(t, updatedObj); newReplicas != 10 {
 		t.Fatalf("dry-run update to replicas didn't return new value: %v", newReplicas)
 	}
-	persistedObj, err := rsc.Get(name, metav1.GetOptions{}, "scale")
+	persistedObj, err := rsc.Get(context.TODO(), name, metav1.GetOptions{}, "scale")
 	if err != nil {
 		t.Fatalf("failed to get scale sub-resource")
 	}
@@ -151,12 +151,12 @@ func DryRunUpdateTest(t *testing.T, rsc dynamic.ResourceInterface, name string) 
 	var err error
 	var obj *unstructured.Unstructured
 	for i := 0; i < 3; i++ {
-		obj, err = rsc.Get(name, metav1.GetOptions{})
+		obj, err = rsc.Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
 			t.Fatalf("failed to retrieve object: %v", err)
 		}
 		obj.SetAnnotations(map[string]string{"update": "true"})
-		obj, err = rsc.Update(obj, metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}})
+		obj, err = rsc.Update(context.TODO(), obj, metav1.UpdateOptions{DryRun: []string{metav1.DryRunAll}})
 		if err == nil || !apierrors.IsConflict(err) {
 			break
 		}
@@ -168,7 +168,7 @@ func DryRunUpdateTest(t *testing.T, rsc dynamic.ResourceInterface, name string) 
 		t.Fatalf("dry-run updated annotations should be returned, got: %v", obj.GetAnnotations())
 	}
 
-	obj, err = rsc.Get(obj.GetName(), metav1.GetOptions{})
+	obj, err = rsc.Get(context.TODO(), obj.GetName(), metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get object: %v", err)
 	}
@@ -178,11 +178,11 @@ func DryRunUpdateTest(t *testing.T, rsc dynamic.ResourceInterface, name string) 
 }
 
 func DryRunDeleteCollectionTest(t *testing.T, rsc dynamic.ResourceInterface, name string) {
-	err := rsc.DeleteCollection(metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}}, metav1.ListOptions{})
+	err := rsc.DeleteCollection(context.TODO(), metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}}, metav1.ListOptions{})
 	if err != nil {
 		t.Fatalf("dry-run delete collection failed: %v", err)
 	}
-	obj, err := rsc.Get(name, metav1.GetOptions{})
+	obj, err := rsc.Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get object: %v", err)
 	}
@@ -193,11 +193,11 @@ func DryRunDeleteCollectionTest(t *testing.T, rsc dynamic.ResourceInterface, nam
 }
 
 func DryRunDeleteTest(t *testing.T, rsc dynamic.ResourceInterface, name string) {
-	err := rsc.Delete(name, metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}})
+	err := rsc.Delete(context.TODO(), name, metav1.DeleteOptions{DryRun: []string{metav1.DryRunAll}})
 	if err != nil {
 		t.Fatalf("dry-run delete failed: %v", err)
 	}
-	obj, err := rsc.Get(name, metav1.GetOptions{})
+	obj, err := rsc.Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("failed to get object: %v", err)
 	}
@@ -281,7 +281,7 @@ func TestDryRun(t *testing.T) {
 
 			DryRunCreateTest(t, rsc, obj, gvResource)
 
-			if _, err := rsc.Create(obj, metav1.CreateOptions{}); err != nil {
+			if _, err := rsc.Create(context.TODO(), obj, metav1.CreateOptions{}); err != nil {
 				t.Fatalf("failed to create stub for %s: %#v", gvResource, err)
 			}
 
@@ -294,7 +294,7 @@ func TestDryRun(t *testing.T) {
 			}
 			DryRunDeleteTest(t, rsc, name)
 
-			if err = rsc.Delete(obj.GetName(), *metav1.NewDeleteOptions(0)); err != nil {
+			if err = rsc.Delete(context.TODO(), obj.GetName(), *metav1.NewDeleteOptions(0)); err != nil {
 				t.Fatalf("deleting final object failed: %v", err)
 			}
 		})

--- a/test/integration/etcd/crd_overlap_storage_test.go
+++ b/test/integration/etcd/crd_overlap_storage_test.go
@@ -152,7 +152,7 @@ func TestOverlappingCustomResourceAPIService(t *testing.T) {
 	// Make sure API requests are still handled by the built-in handler (and return built-in kinds)
 
 	// Listing v1 succeeds
-	v1DynamicList, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}).List(metav1.ListOptions{})
+	v1DynamicList, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apiregistration.k8s.io", Version: "v1", Resource: "apiservices"}).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -315,7 +315,7 @@ func TestOverlappingCustomResourceCustomResourceDefinition(t *testing.T) {
 	// Make sure API requests are still handled by the built-in handler (and return built-in kinds)
 
 	// Listing v1 succeeds
-	v1DynamicList, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}).List(metav1.ListOptions{})
+	v1DynamicList, err := dynamicClient.Resource(schema.GroupVersionResource{Group: "apiextensions.k8s.io", Version: "v1", Resource: "customresourcedefinitions"}).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/etcd/etcd_cross_group_test.go
+++ b/test/integration/etcd/etcd_cross_group_test.go
@@ -94,7 +94,7 @@ func TestCrossGroupStorage(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			actual, err := resourceClient.Create(obj, metav1.CreateOptions{})
+			actual, err := resourceClient.Create(context.TODO(), obj, metav1.CreateOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -108,11 +108,11 @@ func TestCrossGroupStorage(t *testing.T) {
 			)
 			for _, resource := range resources {
 				clients[resource.Mapping.Resource] = master.Dynamic.Resource(resource.Mapping.Resource).Namespace(ns)
-				versionedData[resource.Mapping.Resource], err = clients[resource.Mapping.Resource].Get(name, metav1.GetOptions{})
+				versionedData[resource.Mapping.Resource], err = clients[resource.Mapping.Resource].Get(context.TODO(), name, metav1.GetOptions{})
 				if err != nil {
 					t.Fatalf("error finding resource via %s: %v", resource.Mapping.Resource.GroupVersion().String(), err)
 				}
-				watches[resource.Mapping.Resource], err = clients[resource.Mapping.Resource].Watch(metav1.ListOptions{ResourceVersion: actual.GetResourceVersion()})
+				watches[resource.Mapping.Resource], err = clients[resource.Mapping.Resource].Watch(context.TODO(), metav1.ListOptions{ResourceVersion: actual.GetResourceVersion()})
 				if err != nil {
 					t.Fatalf("error opening watch via %s: %v", resource.Mapping.Resource.GroupVersion().String(), err)
 				}
@@ -161,7 +161,7 @@ func TestCrossGroupStorage(t *testing.T) {
 
 				// Ensure everyone can do a direct get and gets the right version
 				for clientResource, client := range clients {
-					obj, err := client.Get(name, metav1.GetOptions{})
+					obj, err := client.Get(context.TODO(), name, metav1.GetOptions{})
 					if err != nil {
 						t.Errorf("error looking up %s after persisting %s", clientResource.GroupVersion().String(), resource.Mapping.Resource.GroupVersion().String())
 						continue

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -291,7 +291,7 @@ func (c *allClient) cleanup(all *[]cleanupData) error {
 		obj := (*all)[i].obj
 		gvr := (*all)[i].resource
 
-		if err := c.dynamicClient.Resource(gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), nil); err != nil {
+		if err := c.dynamicClient.Resource(gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{}); err != nil {
 			return err
 		}
 	}

--- a/test/integration/etcd/etcd_storage_path_test.go
+++ b/test/integration/etcd/etcd_storage_path_test.go
@@ -276,7 +276,7 @@ func (c *allClient) create(stub, ns string, mapping *meta.RESTMapping, all *[]cl
 		return err
 	}
 
-	actual, err := resourceClient.Create(obj, metav1.CreateOptions{})
+	actual, err := resourceClient.Create(context.TODO(), obj, metav1.CreateOptions{})
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func (c *allClient) cleanup(all *[]cleanupData) error {
 		obj := (*all)[i].obj
 		gvr := (*all)[i].resource
 
-		if err := c.dynamicClient.Resource(gvr).Namespace(obj.GetNamespace()).Delete(obj.GetName(), metav1.DeleteOptions{}); err != nil {
+		if err := c.dynamicClient.Resource(gvr).Namespace(obj.GetNamespace()).Delete(context.TODO(), obj.GetName(), metav1.DeleteOptions{}); err != nil {
 			return err
 		}
 	}

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -940,7 +940,7 @@ func TestCustomResourceCascadingDeletion(t *testing.T) {
 
 	// Delete the owner.
 	foreground := metav1.DeletePropagationForeground
-	err = resourceClient.Delete(owner.GetName(), &metav1.DeleteOptions{PropagationPolicy: &foreground})
+	err = resourceClient.Delete(owner.GetName(), metav1.DeleteOptions{PropagationPolicy: &foreground})
 	if err != nil {
 		t.Fatalf("failed to delete owner resource %q: %v", owner.GetName(), err)
 	}
@@ -1018,7 +1018,7 @@ func TestMixedRelationships(t *testing.T) {
 
 	// Delete the custom owner.
 	foreground := metav1.DeletePropagationForeground
-	err = resourceClient.Delete(customOwner.GetName(), &metav1.DeleteOptions{PropagationPolicy: &foreground})
+	err = resourceClient.Delete(customOwner.GetName(), metav1.DeleteOptions{PropagationPolicy: &foreground})
 	if err != nil {
 		t.Fatalf("failed to delete owner resource %q: %v", customOwner.GetName(), err)
 	}

--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -922,7 +922,7 @@ func TestCustomResourceCascadingDeletion(t *testing.T) {
 
 	// Create a custom owner resource.
 	owner := newCRDInstance(definition, ns.Name, names.SimpleNameGenerator.GenerateName("owner"))
-	owner, err := resourceClient.Create(owner, metav1.CreateOptions{})
+	owner, err := resourceClient.Create(context.TODO(), owner, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create owner resource %q: %v", owner.GetName(), err)
 	}
@@ -932,7 +932,7 @@ func TestCustomResourceCascadingDeletion(t *testing.T) {
 	dependent := newCRDInstance(definition, ns.Name, names.SimpleNameGenerator.GenerateName("dependent"))
 	link(t, owner, dependent)
 
-	dependent, err = resourceClient.Create(dependent, metav1.CreateOptions{})
+	dependent, err = resourceClient.Create(context.TODO(), dependent, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create dependent resource %q: %v", dependent.GetName(), err)
 	}
@@ -940,21 +940,21 @@ func TestCustomResourceCascadingDeletion(t *testing.T) {
 
 	// Delete the owner.
 	foreground := metav1.DeletePropagationForeground
-	err = resourceClient.Delete(owner.GetName(), metav1.DeleteOptions{PropagationPolicy: &foreground})
+	err = resourceClient.Delete(context.TODO(), owner.GetName(), metav1.DeleteOptions{PropagationPolicy: &foreground})
 	if err != nil {
 		t.Fatalf("failed to delete owner resource %q: %v", owner.GetName(), err)
 	}
 
 	// Ensure the owner is deleted.
 	if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
-		_, err := resourceClient.Get(owner.GetName(), metav1.GetOptions{})
+		_, err := resourceClient.Get(context.TODO(), owner.GetName(), metav1.GetOptions{})
 		return apierrors.IsNotFound(err), nil
 	}); err != nil {
 		t.Fatalf("failed waiting for owner resource %q to be deleted", owner.GetName())
 	}
 
 	// Ensure the dependent is deleted.
-	_, err = resourceClient.Get(dependent.GetName(), metav1.GetOptions{})
+	_, err = resourceClient.Get(context.TODO(), dependent.GetName(), metav1.GetOptions{})
 	if err == nil {
 		t.Fatalf("expected dependent %q to be deleted", dependent.GetName())
 	} else {
@@ -983,7 +983,7 @@ func TestMixedRelationships(t *testing.T) {
 	definition, resourceClient := createRandomCustomResourceDefinition(t, apiExtensionClient, dynamicClient, ns.Name)
 
 	// Create a custom owner resource.
-	customOwner, err := resourceClient.Create(newCRDInstance(definition, ns.Name, names.SimpleNameGenerator.GenerateName("owner")), metav1.CreateOptions{})
+	customOwner, err := resourceClient.Create(context.TODO(), newCRDInstance(definition, ns.Name, names.SimpleNameGenerator.GenerateName("owner")), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create owner: %v", err)
 	}
@@ -1010,7 +1010,7 @@ func TestMixedRelationships(t *testing.T) {
 	coreOwner.TypeMeta.Kind = "ConfigMap"
 	coreOwner.TypeMeta.APIVersion = "v1"
 	link(t, coreOwner, customDependent)
-	customDependent, err = resourceClient.Create(customDependent, metav1.CreateOptions{})
+	customDependent, err = resourceClient.Create(context.TODO(), customDependent, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create dependent: %v", err)
 	}
@@ -1018,21 +1018,21 @@ func TestMixedRelationships(t *testing.T) {
 
 	// Delete the custom owner.
 	foreground := metav1.DeletePropagationForeground
-	err = resourceClient.Delete(customOwner.GetName(), metav1.DeleteOptions{PropagationPolicy: &foreground})
+	err = resourceClient.Delete(context.TODO(), customOwner.GetName(), metav1.DeleteOptions{PropagationPolicy: &foreground})
 	if err != nil {
 		t.Fatalf("failed to delete owner resource %q: %v", customOwner.GetName(), err)
 	}
 
 	// Ensure the owner is deleted.
 	if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
-		_, err := resourceClient.Get(customOwner.GetName(), metav1.GetOptions{})
+		_, err := resourceClient.Get(context.TODO(), customOwner.GetName(), metav1.GetOptions{})
 		return apierrors.IsNotFound(err), nil
 	}); err != nil {
 		t.Fatalf("failed waiting for owner resource %q to be deleted", customOwner.GetName())
 	}
 
 	// Ensure the dependent is deleted.
-	_, err = resourceClient.Get(coreDependent.GetName(), metav1.GetOptions{})
+	_, err = resourceClient.Get(context.TODO(), coreDependent.GetName(), metav1.GetOptions{})
 	if err == nil {
 		t.Fatalf("expected dependent %q to be deleted", coreDependent.GetName())
 	} else {
@@ -1056,7 +1056,7 @@ func TestMixedRelationships(t *testing.T) {
 	}
 
 	// Ensure the dependent is deleted.
-	_, err = resourceClient.Get(customDependent.GetName(), metav1.GetOptions{})
+	_, err = resourceClient.Get(context.TODO(), customDependent.GetName(), metav1.GetOptions{})
 	if err == nil {
 		t.Fatalf("expected dependent %q to be deleted", customDependent.GetName())
 	} else {
@@ -1096,7 +1096,7 @@ func testCRDDeletion(t *testing.T, ctx *testContext, ns *v1.Namespace, definitio
 	configMapClient := clientSet.CoreV1().ConfigMaps(ns.Name)
 
 	// Create a custom owner resource.
-	owner, err := resourceClient.Create(newCRDInstance(definition, ns.Name, names.SimpleNameGenerator.GenerateName("owner")), metav1.CreateOptions{})
+	owner, err := resourceClient.Create(context.TODO(), newCRDInstance(definition, ns.Name, names.SimpleNameGenerator.GenerateName("owner")), metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("failed to create owner: %v", err)
 	}
@@ -1120,7 +1120,7 @@ func testCRDDeletion(t *testing.T, ctx *testContext, ns *v1.Namespace, definitio
 
 	// Ensure the owner is deleted.
 	if err := wait.Poll(1*time.Second, 60*time.Second, func() (bool, error) {
-		_, err := resourceClient.Get(owner.GetName(), metav1.GetOptions{})
+		_, err := resourceClient.Get(context.TODO(), owner.GetName(), metav1.GetOptions{})
 		return apierrors.IsNotFound(err), nil
 	}); err != nil {
 		t.Fatalf("failed waiting for owner %q to be deleted", owner.GetName())

--- a/test/integration/master/crd_test.go
+++ b/test/integration/master/crd_test.go
@@ -144,7 +144,7 @@ func TestCRD(t *testing.T) {
 		t.Fatalf("Unexpected error: %v", err)
 	}
 	fooResource := schema.GroupVersionResource{Group: "cr.bar.com", Version: "v1", Resource: "foos"}
-	_, err = dynamicClient.Resource(fooResource).Namespace(testNamespace).List(metav1.ListOptions{})
+	_, err = dynamicClient.Resource(fooResource).Namespace(testNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		t.Errorf("Failed to list foos.cr.bar.com instances: %v", err)
 	}

--- a/test/integration/namespace/ns_conditions_test.go
+++ b/test/integration/namespace/ns_conditions_test.go
@@ -63,7 +63,7 @@ func TestNamespaceCondition(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = dynamicClient.Resource(corev1.SchemeGroupVersion.WithResource("pods")).Namespace(nsName).Create(podJSON, metav1.CreateOptions{})
+	_, err = dynamicClient.Resource(corev1.SchemeGroupVersion.WithResource("pods")).Namespace(nsName).Create(context.TODO(), podJSON, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +73,7 @@ func TestNamespaceCondition(t *testing.T) {
 		t.Fatal(err)
 	}
 	deploymentJSON.SetFinalizers([]string{"custom.io/finalizer"})
-	_, err = dynamicClient.Resource(appsv1.SchemeGroupVersion.WithResource("deployments")).Namespace(nsName).Create(deploymentJSON, metav1.CreateOptions{})
+	_, err = dynamicClient.Resource(appsv1.SchemeGroupVersion.WithResource("deployments")).Namespace(nsName).Create(context.TODO(), deploymentJSON, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/statefulset/statefulset_test.go
+++ b/test/integration/statefulset/statefulset_test.go
@@ -88,7 +88,7 @@ func TestVolumeTemplateNoopUpdate(t *testing.T) {
 	stsClient := c.Resource(appsv1.SchemeGroupVersion.WithResource("statefulsets")).Namespace("default")
 
 	// Create the statefulset
-	persistedSTS, err := stsClient.Create(sts, metav1.CreateOptions{})
+	persistedSTS, err := stsClient.Create(context.TODO(), sts, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestVolumeTemplateNoopUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = stsClient.Update(persistedSTS, metav1.UpdateOptions{})
+	_, err = stsClient.Update(context.TODO(), persistedSTS, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Mechanical change to plumb context to the dynamic client.

Part of https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md

Closes #88890

**Does this PR introduce a user-facing change?**:
```release-note
Signatures on the dynamic client methods have been modified to accept `context.Context` as a first argument. Signatures of Delete and DeleteCollection methods now accept DeleteOptions by value instead of by reference.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md
```

/sig api-machinery
/cc @mikedanese 