### PR TITLE
/readyz should start returning failure on shutdown initiation

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/genericapiserver.go
@@ -318,7 +318,13 @@ func (s preparedGenericAPIServer) Run(stopCh <-chan struct{}) error {
 
 	go func() {
 		defer close(delayedStopCh)
+
 		<-stopCh
+
+		// As soon as shutdown is initiated, /readyz should start returning failure.
+		// This gives the load balancer a window defined by ShutdownDelayDuration to detect that /readyz is red
+		// and stop sending traffic to this server.
+		close(s.readinessStopCh)
 
 		time.Sleep(s.ShutdownDelayDuration)
 	}()
@@ -379,7 +385,6 @@ func (s preparedGenericAPIServer) NonBlockingRun(stopCh <-chan struct{}) error {
 	// ensure cleanup.
 	go func() {
 		<-stopCh
-		close(s.readinessStopCh)
 		close(internalStopCh)
 		if stoppedCh != nil {
 			<-stoppedCh


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, `/readyz` starts reporting failure after `ShutdownDelayDuration` elapses. The load balancer(s) uses `/readyz` for health check and are not aware of the shutdown initiation until `ShutdownDelayDuration` elapses. This does not give the load balancer(s) enough time to detect and react to it.

We expect `/readyz` to start returning failure as soon as apiserver shutdown is initiated(SIGTERM received). This gives the load balancer a window (defined by `ShutdownDelayDuration`) to detect that `/readyz` is red and stop sending traffic to this server.

**Does this PR introduce a user-facing change?**:
None

```release-note
Fix /readyz to return error immediately after a shutdown is initiated, before the --shutdown-delay-duration has elapsed.
```
