### PR TITLE
Fix a data race in kubelet image manager

### DIFF
--- a/pkg/kubelet/images/image_gc_manager.go
+++ b/pkg/kubelet/images/image_gc_manager.go
@@ -113,21 +113,26 @@ type imageCache struct {
 	images []container.Image
 }
 
-// set updates image cache.
+// set sorts the input list and updates image cache.
+// 'i' takes ownership of the list, you should not reference the list again
+// after calling this function.
 func (i *imageCache) set(images []container.Image) {
 	i.Lock()
 	defer i.Unlock()
+	// The image list needs to be sorted when it gets read and used in
+	// setNodeStatusImages. We sort the list on write instead of on read,
+	// because the image cache is more often read than written
+	sort.Sort(sliceutils.ByImageSize(images))
 	i.images = images
 }
 
-// get gets a sorted (by image size) image list from image cache.
-// There is a potentical data race in this function. See PR #60448
-// Because there is deepcopy function available currently, move sort
-// function inside this function
+// get gets image list from image cache.
+// NOTE: The caller of get() should not do mutating operations on the
+// returned list that could cause data race against other readers (e.g.
+// in-place sorting the returned list)
 func (i *imageCache) get() []container.Image {
 	i.Lock()
 	defer i.Unlock()
-	sort.Sort(sliceutils.ByImageSize(i.images))
 	return i.images
 }
 

--- a/pkg/kubelet/images/image_gc_manager_test.go
+++ b/pkg/kubelet/images/image_gc_manager_test.go
@@ -548,16 +548,6 @@ func TestValidateImageGCPolicy(t *testing.T) {
 	}
 }
 
-func TestImageCacheReturnCopiedList(t *testing.T) {
-	cache := &imageCache{}
-	testList := []container.Image{{ID: "1"}, {ID: "2"}}
-	cache.set(testList)
-	list := cache.get()
-	assert.Len(t, list, 2)
-	list[0].ID = "3"
-	assert.Equal(t, cache.get(), testList)
-}
-
 func uint64Ptr(i uint64) *uint64 {
 	return &i
 }

--- a/pkg/kubelet/nodestatus/setters.go
+++ b/pkg/kubelet/nodestatus/setters.go
@@ -446,7 +446,9 @@ func Images(nodeStatusMaxImages int32,
 		}
 
 		for _, image := range containerImages {
-			names := append(image.RepoDigests, image.RepoTags...)
+			// make a copy to avoid modifying slice members of the image items in the list
+			names := append([]string{}, image.RepoDigests...)
+			names = append(names, image.RepoTags...)
 			// Report up to MaxNamesPerImageInNodeStatus names per image.
 			if len(names) > MaxNamesPerImageInNodeStatus {
 				names = names[0:MaxNamesPerImageInNodeStatus]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Let image manager return a copy of image list. Today it [sorts and returns](https://github.com/kubernetes/kubernetes/blob/7c7ce47c018415b09e430c62216764b1b952e19f/pkg/kubelet/images/image_gc_manager.go#L130-L131) the internal image list cache to caller directly, which introduces a data race. Due to the sort being in-place, we've observed the race causing static pod workers to panic during [syncPod](https://github.com/kubernetes/kubernetes/blob/7c7ce47c018415b09e430c62216764b1b952e19f/pkg/kubelet/kubelet.go#L1657). However, given the way kubelet [recovers](https://github.com/kubernetes/kubernetes/blob/7c7ce47c018415b09e430c62216764b1b952e19f/pkg/kubelet/pod_workers.go#L220-L223) from goroutine panics, kubelet would keep running and the pod worker silently stopped working-- all future work dispatched for this pod got ignored. 

git log shows the race was introduced in [1.10](https://github.com/kubernetes/kubernetes/pull/60159). We should cherrypick this fix to all the supported minor releases.

Sample panic log from 1.13:
```
runtime.go:73] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 755 [running]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x..., 0x...)
	...k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:69 +0x...
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x..., 0x..., 0x...)
	...k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:51 +0x...
panic(0x..., 0x...)
	/usr/local/go/src/runtime/panic.go:522 +0x...
k8s.io/kubernetes/pkg/kubelet/nodestatus.Images.func1(0x..., 0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/nodestatus/setters.go:413 +0x...
k8s.io/kubernetes/pkg/kubelet.(*Kubelet).setNodeStatus(0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/kubelet_node_status.go:480 +0x...
k8s.io/kubernetes/pkg/kubelet.(*Kubelet).initialNode(0x..., 0x..., 0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/kubelet_node_status.go:348 +0x...
k8s.io/kubernetes/pkg/kubelet.(*Kubelet).GetNode(0x..., 0x..., 0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/kubelet_getters.go:220 +0x...
k8s.io/kubernetes/pkg/kubelet.(*Kubelet).syncPod(0x..., 0x..., 0x..., 0x..., 0x..., 0x..., 0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/kubelet.go:1666 +0x...
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).managePodLoop.func1(0x..., 0x..., 0x..., 0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/pod_workers.go:174 +0x...
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).managePodLoop(0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/pod_workers.go:183 +0x...
k8s.io/kubernetes/pkg/kubelet.(*podWorkers).UpdatePod.func1(0x..., 0x...)
	...k8s.io/kubernetes/pkg/kubelet/pod_workers.go:221 +0x...
created by k8s.io/kubernetes/pkg/kubelet.(*podWorkers).UpdatePod
	...k8s.io/kubernetes/pkg/kubelet/pod_workers.go:219 +0x...
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #60443

**Special notes for your reviewer**:
I'm going to add a proposal to SIG node about catching/mitigating this kind of programming error in future. In this case the issue would have been mitigated if we either 1) actually crashed kubelet and let it restart or 2) created a new goroutine when the old one panicked. Restarting kubelet is preferred IMO because it guards a wide range of programming error, and it's usually safe to restart kubelet as long as it's not too frequent.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fixed a data race in kubelet image manager that can cause static pod workers to silently stop working.
```

/cc @Random-Liu @cheftako 
/priority critical-urgent
/sig node