### PR TITLE
Add support for listing conformance tests in e2e.test

### DIFF
--- a/hack/generate-bindata.sh
+++ b/hack/generate-bindata.sh
@@ -44,6 +44,7 @@ BINDATA_OUTPUT="test/e2e/generated/bindata.go"
 # test/e2e/generated/BUILD and/or build/bindata.bzl.
 go-bindata -nometadata -o "${BINDATA_OUTPUT}.tmp" -pkg generated \
 	-ignore .jpg -ignore .png -ignore .md -ignore 'BUILD(\.bazel)?' \
+	"test/conformance/testdata/..." \
 	"test/e2e/testing-manifests/..." \
 	"test/e2e_node/testing-manifests/..." \
 	"test/images/..." \

--- a/test/conformance/BUILD
+++ b/test/conformance/BUILD
@@ -34,6 +34,7 @@ filegroup(
         ":package-srcs",
         "//test/conformance/behaviors:all-srcs",
         "//test/conformance/kubeconform:all-srcs",
+        "//test/conformance/testdata:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
@@ -68,8 +69,8 @@ sh_test(
     name = "conformance_test",
     srcs = ["conformance_test.sh"],
     data = [
-        "testdata/conformance.yaml",
         ":list_conformance_tests",
+        ":testdata",
     ],
 )
 

--- a/test/conformance/testdata/BUILD
+++ b/test/conformance/testdata/BUILD
@@ -1,0 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/test/e2e/BUILD
+++ b/test/e2e/BUILD
@@ -43,6 +43,7 @@ go_test(
         "//test/e2e/windows:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/stretchr/testify/require:go_default_library",
+        "//vendor/gopkg.in/yaml.v2:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -83,6 +83,9 @@ type TestContextType struct {
 	// ListImages will list off all images that are used then quit
 	ListImages bool
 
+	// ListConformanceTests will list off all conformance tests that are available then quit
+	ListConformanceTests bool
+
 	// Provider identifies the infrastructure provider (gce, gke, aws)
 	Provider string
 
@@ -301,6 +304,7 @@ func RegisterCommonFlags(flags *flag.FlagSet) {
 	flags.StringVar(&TestContext.NonblockingTaints, "non-blocking-taints", `node-role.kubernetes.io/master`, "Nodes with taints in this comma-delimited list will not block the test framework from starting tests.")
 
 	flags.BoolVar(&TestContext.ListImages, "list-images", false, "If true, will show list of images used for runnning tests.")
+	flags.BoolVar(&TestContext.ListConformanceTests, "list-conformance-tests", false, "If true, will show list of conformance tests.")
 	flags.StringVar(&TestContext.KubectlPath, "kubectl-path", "kubectl", "The kubectl binary to use. For development, you might use 'cluster/kubectl.sh' here.")
 
 	flags.StringVar(&TestContext.ProgressReportURL, "progress-report-url", "", "The URL to POST progress updates to as the suite runs to assist in aiding integrations. If empty, no messages sent.")

--- a/test/e2e/generated/BUILD
+++ b/test/e2e/generated/BUILD
@@ -23,6 +23,7 @@ go_library(
 go_bindata(
     name = "bindata",
     srcs = [
+        "//test/conformance/testdata:all-srcs",
         "//test/e2e/testing-manifests:all-srcs",
         "//test/e2e_node/testing-manifests:all-srcs",
         "//test/fixtures:all-srcs",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Currently resources like https://github.com/cncf/k8s-conformance/tree/master/docs do not get maintained properly. We need an easy way for someone running tests to have access to the list of conformance tests that they need to pass for their cluster to be conformant. 

So since we have the up-to-date conformance.yaml at build time, we should just bundle that into e2e.test binary and have a command line option `--list-conformance-tests` to print them out. Automated scripts can then compare this list with the list of tests that are in say the junit xml to ensure that all tests we run (example when folks report tests results for conformance in https://github.com/cncf/k8s-conformance/pulls)

To try this run:
```
bazel build //test/e2e:e2e.test_binary
bazel-bin/test/e2e/e2e.test --list-conformance-tests
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
e2e.test can print the list of conformance tests that need to pass for the cluster to be conformant.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
