### PR TITLE
client-go: plumb context to expansions methods

### DIFF
--- a/pkg/controller/certificates/approver/sarapprove.go
+++ b/pkg/controller/certificates/approver/sarapprove.go
@@ -100,7 +100,7 @@ func (a *sarApprover) handle(csr *capi.CertificateSigningRequest) error {
 		}
 		if approved {
 			appendApprovalCondition(csr, r.successMessage)
-			_, err = a.client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
+			_, err = a.client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(context.Background(), csr, metav1.UpdateOptions{})
 			if err != nil {
 				return fmt.Errorf("error updating approval for csr: %v", err)
 			}

--- a/pkg/controller/certificates/certificate_controller_test.go
+++ b/pkg/controller/certificates/certificate_controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certificates
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -47,7 +48,7 @@ func TestCertificateController(t *testing.T) {
 			Reason:  "test reason",
 			Message: "test message",
 		})
-		_, err := client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
+		_, err := client.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(context.TODO(), csr, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
+++ b/pkg/controller/namespace/deletion/namespaced_resources_deleter.go
@@ -292,7 +292,7 @@ func (d *namespacedResourcesDeleter) finalizeNamespace(namespace *v1.Namespace) 
 	for _, value := range finalizerSet.List() {
 		namespaceFinalize.Spec.Finalizers = append(namespaceFinalize.Spec.Finalizers, v1.FinalizerName(value))
 	}
-	namespace, err := d.nsClient.Finalize(&namespaceFinalize)
+	namespace, err := d.nsClient.Finalize(context.Background(), &namespaceFinalize, metav1.UpdateOptions{})
 	if err != nil {
 		// it was removed already, so life is good
 		if errors.IsNotFound(err) {

--- a/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
+++ b/pkg/scheduler/framework/plugins/defaultbinder/default_binder.go
@@ -53,7 +53,7 @@ func (b DefaultBinder) Bind(ctx context.Context, state *framework.CycleState, p 
 		ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID},
 		Target:     v1.ObjectReference{Kind: "Node", Name: nodeName},
 	}
-	err := b.handle.ClientSet().CoreV1().Pods(binding.Namespace).Bind(binding)
+	err := b.handle.ClientSet().CoreV1().Pods(binding.Namespace).Bind(context.TODO(), binding, metav1.CreateOptions{})
 	if err != nil {
 		return framework.NewStatus(framework.Error, err.Error())
 	}

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/certificatesigningrequest_expansion.go
@@ -20,20 +20,23 @@ import (
 	"context"
 
 	certificates "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	scheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 type CertificateSigningRequestExpansion interface {
-	UpdateApproval(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error)
+	UpdateApproval(ctx context.Context, certificateSigningRequest *certificates.CertificateSigningRequest, opts metav1.UpdateOptions) (result *certificates.CertificateSigningRequest, err error)
 }
 
-func (c *certificateSigningRequests) UpdateApproval(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
+func (c *certificateSigningRequests) UpdateApproval(ctx context.Context, certificateSigningRequest *certificates.CertificateSigningRequest, opts metav1.UpdateOptions) (result *certificates.CertificateSigningRequest, err error) {
 	result = &certificates.CertificateSigningRequest{}
 	err = c.client.Put().
 		Resource("certificatesigningrequests").
 		Name(certificateSigningRequest.Name).
+		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(certificateSigningRequest).
 		SubResource("approval").
-		Do(context.TODO()).
+		Do(ctx).
 		Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake/fake_certificatesigningrequest_expansion.go
@@ -17,11 +17,14 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	certificates "k8s.io/api/certificates/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	core "k8s.io/client-go/testing"
 )
 
-func (c *FakeCertificateSigningRequests) UpdateApproval(certificateSigningRequest *certificates.CertificateSigningRequest) (result *certificates.CertificateSigningRequest, err error) {
+func (c *FakeCertificateSigningRequests) UpdateApproval(ctx context.Context, certificateSigningRequest *certificates.CertificateSigningRequest, opts metav1.UpdateOptions) (result *certificates.CertificateSigningRequest, err error) {
 	obj, err := c.Fake.
 		Invokes(core.NewRootUpdateSubresourceAction(certificatesigningrequestsResource, "approval", certificateSigningRequest), &certificates.CertificateSigningRequest{})
 	if obj == nil {

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_namespace_expansion.go
@@ -17,11 +17,14 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	core "k8s.io/client-go/testing"
 )
 
-func (c *FakeNamespaces) Finalize(namespace *v1.Namespace) (*v1.Namespace, error) {
+func (c *FakeNamespaces) Finalize(ctx context.Context, namespace *v1.Namespace, opts metav1.UpdateOptions) (*v1.Namespace, error) {
 	action := core.CreateActionImpl{}
 	action.Verb = "create"
 	action.Resource = namespacesResource

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/fake/fake_pod_expansion.go
@@ -17,13 +17,16 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	"k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	restclient "k8s.io/client-go/rest"
 	core "k8s.io/client-go/testing"
 )
 
-func (c *FakePods) Bind(binding *v1.Binding) error {
+func (c *FakePods) Bind(ctx context.Context, binding *v1.Binding, opts metav1.CreateOptions) error {
 	action := core.CreateActionImpl{}
 	action.Verb = "create"
 	action.Namespace = binding.Namespace
@@ -57,7 +60,7 @@ func (c *FakePods) GetLogs(name string, opts *v1.PodLogOptions) *restclient.Requ
 	return &restclient.Request{}
 }
 
-func (c *FakePods) Evict(eviction *policy.Eviction) error {
+func (c *FakePods) Evict(ctx context.Context, eviction *policy.Eviction) error {
 	action := core.CreateActionImpl{}
 	action.Verb = "create"
 	action.Namespace = c.ns

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/namespace_expansion.go
@@ -20,16 +20,18 @@ import (
 	"context"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	scheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 // The NamespaceExpansion interface allows manually adding extra methods to the NamespaceInterface.
 type NamespaceExpansion interface {
-	Finalize(item *v1.Namespace) (*v1.Namespace, error)
+	Finalize(ctx context.Context, item *v1.Namespace, opts metav1.UpdateOptions) (*v1.Namespace, error)
 }
 
 // Finalize takes the representation of a namespace to update.  Returns the server's representation of the namespace, and an error, if it occurs.
-func (c *namespaces) Finalize(namespace *v1.Namespace) (result *v1.Namespace, err error) {
+func (c *namespaces) Finalize(ctx context.Context, namespace *v1.Namespace, opts metav1.UpdateOptions) (result *v1.Namespace, err error) {
 	result = &v1.Namespace{}
-	err = c.client.Put().Resource("namespaces").Name(namespace.Name).SubResource("finalize").Body(namespace).Do(context.TODO()).Into(result)
+	err = c.client.Put().Resource("namespaces").Name(namespace.Name).VersionedParams(&opts, scheme.ParameterCodec).SubResource("finalize").Body(namespace).Do(ctx).Into(result)
 	return
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/core/v1/pod_expansion.go
@@ -21,24 +21,25 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	restclient "k8s.io/client-go/rest"
 )
 
 // The PodExpansion interface allows manually adding extra methods to the PodInterface.
 type PodExpansion interface {
-	Bind(binding *v1.Binding) error
-	Evict(eviction *policy.Eviction) error
+	Bind(ctx context.Context, binding *v1.Binding, opts metav1.CreateOptions) error
+	Evict(ctx context.Context, eviction *policy.Eviction) error
 	GetLogs(name string, opts *v1.PodLogOptions) *restclient.Request
 }
 
 // Bind applies the provided binding to the named pod in the current namespace (binding.Namespace is ignored).
-func (c *pods) Bind(binding *v1.Binding) error {
-	return c.client.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).SubResource("binding").Body(binding).Do(context.TODO()).Error()
+func (c *pods) Bind(ctx context.Context, binding *v1.Binding, opts metav1.CreateOptions) error {
+	return c.client.Post().Namespace(c.ns).Resource("pods").Name(binding.Name).VersionedParams(&opts, scheme.ParameterCodec).SubResource("binding").Body(binding).Do(ctx).Error()
 }
 
-func (c *pods) Evict(eviction *policy.Eviction) error {
-	return c.client.Post().Namespace(c.ns).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(context.TODO()).Error()
+func (c *pods) Evict(ctx context.Context, eviction *policy.Eviction) error {
+	return c.client.Post().Namespace(c.ns).Resource("pods").Name(eviction.Name).SubResource("eviction").Body(eviction).Do(ctx).Error()
 }
 
 // Get constructs a request for getting the logs for a pod

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/deployment_expansion.go
@@ -20,14 +20,16 @@ import (
 	"context"
 
 	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	scheme "k8s.io/client-go/kubernetes/scheme"
 )
 
 // The DeploymentExpansion interface allows manually adding extra methods to the DeploymentInterface.
 type DeploymentExpansion interface {
-	Rollback(*v1beta1.DeploymentRollback) error
+	Rollback(context.Context, *v1beta1.DeploymentRollback, metav1.CreateOptions) error
 }
 
 // Rollback applied the provided DeploymentRollback to the named deployment in the current namespace.
-func (c *deployments) Rollback(deploymentRollback *v1beta1.DeploymentRollback) error {
-	return c.client.Post().Namespace(c.ns).Resource("deployments").Name(deploymentRollback.Name).SubResource("rollback").Body(deploymentRollback).Do(context.TODO()).Error()
+func (c *deployments) Rollback(ctx context.Context, deploymentRollback *v1beta1.DeploymentRollback, opts metav1.CreateOptions) error {
+	return c.client.Post().Namespace(c.ns).Resource("deployments").Name(deploymentRollback.Name).VersionedParams(&opts, scheme.ParameterCodec).SubResource("rollback").Body(deploymentRollback).Do(ctx).Error()
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake/fake_deployment_expansion.go
@@ -17,11 +17,14 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	core "k8s.io/client-go/testing"
 )
 
-func (c *FakeDeployments) Rollback(deploymentRollback *v1beta1.DeploymentRollback) error {
+func (c *FakeDeployments) Rollback(ctx context.Context, deploymentRollback *v1beta1.DeploymentRollback, opts metav1.CreateOptions) error {
 	action := core.CreateActionImpl{}
 	action.Verb = "create"
 	action.Resource = deploymentsResource

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/eviction_expansion.go
@@ -24,10 +24,10 @@ import (
 
 // The EvictionExpansion interface allows manually adding extra methods to the ScaleInterface.
 type EvictionExpansion interface {
-	Evict(eviction *policy.Eviction) error
+	Evict(ctx context.Context, eviction *policy.Eviction) error
 }
 
-func (c *evictions) Evict(eviction *policy.Eviction) error {
+func (c *evictions) Evict(ctx context.Context, eviction *policy.Eviction) error {
 	return c.client.Post().
 		AbsPath("/api/v1").
 		Namespace(eviction.Namespace).
@@ -35,6 +35,6 @@ func (c *evictions) Evict(eviction *policy.Eviction) error {
 		Name(eviction.Name).
 		SubResource("eviction").
 		Body(eviction).
-		Do(context.TODO()).
+		Do(ctx).
 		Error()
 }

--- a/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_eviction_expansion.go
+++ b/staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake/fake_eviction_expansion.go
@@ -17,12 +17,14 @@ limitations under the License.
 package fake
 
 import (
+	"context"
+
 	policy "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	core "k8s.io/client-go/testing"
 )
 
-func (c *FakeEvictions) Evict(eviction *policy.Eviction) error {
+func (c *FakeEvictions) Evict(ctx context.Context, eviction *policy.Eviction) error {
 	action := core.CreateActionImpl{}
 	action.Verb = "create"
 	action.Namespace = c.ns

--- a/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/certificates/certificates.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certificates
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -234,7 +235,7 @@ func (o *CertificateOptions) modifyCertificateCondition(builder *resource.Builde
 			csr := info.Object.(*certificatesv1beta1.CertificateSigningRequest)
 			csr, hasCondition := modify(csr)
 			if !hasCondition || force {
-				_, err = clientSet.CertificateSigningRequests().UpdateApproval(csr)
+				_, err = clientSet.CertificateSigningRequests().UpdateApproval(context.TODO(), csr, metav1.UpdateOptions{})
 				if errors.IsConflict(err) && i < 10 {
 					if err := info.Get(); err != nil {
 						return err

--- a/staging/src/k8s.io/kubectl/pkg/drain/drain.go
+++ b/staging/src/k8s.io/kubectl/pkg/drain/drain.go
@@ -165,7 +165,7 @@ func (d *Helper) EvictPod(pod corev1.Pod, policyGroupVersion string) error {
 	}
 
 	// Remember to change change the URL manipulation func when Eviction's version change
-	return d.Client.PolicyV1beta1().Evictions(eviction.Namespace).Evict(eviction)
+	return d.Client.PolicyV1beta1().Evictions(eviction.Namespace).Evict(context.TODO(), eviction)
 }
 
 // GetPodsForDeletion receives resource info for a node, and returns those pods as PodDeleteList,

--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -246,7 +246,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 			}
 
 			if c.shouldDeny {
-				err = cs.CoreV1().Pods(ns).Evict(e)
+				err = cs.CoreV1().Pods(ns).Evict(context.TODO(), e)
 				gomega.Expect(err).Should(gomega.MatchError("Cannot evict pod as it would violate the pod's disruption budget."))
 			} else {
 				// Only wait for running pods in the "allow" case
@@ -257,7 +257,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 				// Since disruptionAllowed starts out false, if an eviction is ever allowed,
 				// that means the controller is working.
 				err = wait.PollImmediate(framework.Poll, timeout, func() (bool, error) {
-					err = cs.CoreV1().Pods(ns).Evict(e)
+					err = cs.CoreV1().Pods(ns).Evict(context.TODO(), e)
 					if err != nil {
 						return false, nil
 					}
@@ -284,7 +284,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 				Namespace: ns,
 			},
 		}
-		err = cs.CoreV1().Pods(ns).Evict(e)
+		err = cs.CoreV1().Pods(ns).Evict(context.TODO(), e)
 		gomega.Expect(err).Should(gomega.MatchError("Cannot evict pod as it would violate the pod's disruption budget."))
 
 		ginkgo.By("Updating the pdb to allow a pod to be evicted")
@@ -297,7 +297,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 		ginkgo.By("Trying to evict the same pod we tried earlier which should now be evictable")
 		waitForPodsOrDie(cs, ns, 3)
 		waitForPdbToObserveHealthyPods(cs, ns, 3)
-		err = cs.CoreV1().Pods(ns).Evict(e)
+		err = cs.CoreV1().Pods(ns).Evict(context.TODO(), e)
 		framework.ExpectNoError(err) // the eviction is now allowed
 
 		ginkgo.By("Patching the pdb to disallow a pod to be evicted")
@@ -319,7 +319,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 				Namespace: ns,
 			},
 		}
-		err = cs.CoreV1().Pods(ns).Evict(e)
+		err = cs.CoreV1().Pods(ns).Evict(context.TODO(), e)
 		gomega.Expect(err).Should(gomega.MatchError("Cannot evict pod as it would violate the pod's disruption budget."))
 
 		ginkgo.By("Deleting the pdb to allow a pod to be evicted")
@@ -327,7 +327,7 @@ var _ = SIGDescribe("DisruptionController", func() {
 
 		ginkgo.By("Trying to evict the same pod we tried earlier which should now be evictable")
 		waitForPodsOrDie(cs, ns, 3)
-		err = cs.CoreV1().Pods(ns).Evict(e)
+		err = cs.CoreV1().Pods(ns).Evict(context.TODO(), e)
 		framework.ExpectNoError(err) // the eviction is now allowed
 	})
 

--- a/test/e2e/auth/certificates.go
+++ b/test/e2e/auth/certificates.go
@@ -82,7 +82,7 @@ var _ = SIGDescribe("Certificates API", func() {
 					Message: "Set from an e2e test",
 				},
 			}
-			csr, err = csrs.UpdateApproval(csr)
+			csr, err = csrs.UpdateApproval(context.TODO(), csr, metav1.UpdateOptions{})
 			if err != nil {
 				csr, _ = csrs.Get(context.TODO(), csrName, metav1.GetOptions{})
 				framework.Logf("err updating approval: %v", err)

--- a/test/e2e/storage/pd.go
+++ b/test/e2e/storage/pd.go
@@ -430,7 +430,7 @@ var _ = utils.SIGDescribe("Pod Disks", func() {
 					}
 					ginkgo.By("evicting host0Pod")
 					err = wait.PollImmediate(framework.Poll, podEvictTimeout, func() (bool, error) {
-						if err := cs.CoreV1().Pods(ns).Evict(evictTarget); err != nil {
+						if err := cs.CoreV1().Pods(ns).Evict(context.TODO(), evictTarget); err != nil {
 							framework.Logf("Failed to evict host0Pod, ignoring error: %v", err)
 							return false, nil
 						}

--- a/test/integration/auth/node_test.go
+++ b/test/integration/auth/node_test.go
@@ -295,7 +295,7 @@ func TestNodeAuthorizer(t *testing.T) {
 	createNode2NormalPodEviction := func(client clientset.Interface) func() error {
 		return func() error {
 			zero := int64(0)
-			return client.PolicyV1beta1().Evictions("ns").Evict(&policy.Eviction{
+			return client.PolicyV1beta1().Evictions("ns").Evict(context.TODO(), &policy.Eviction{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "policy/v1beta1",
 					Kind:       "Eviction",
@@ -311,7 +311,7 @@ func TestNodeAuthorizer(t *testing.T) {
 	createNode2MirrorPodEviction := func(client clientset.Interface) func() error {
 		return func() error {
 			zero := int64(0)
-			return client.PolicyV1beta1().Evictions("ns").Evict(&policy.Eviction{
+			return client.PolicyV1beta1().Evictions("ns").Evict(context.TODO(), &policy.Eviction{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: "policy/v1beta1",
 					Kind:       "Eviction",

--- a/test/integration/certificates/admission_approval_test.go
+++ b/test/integration/certificates/admission_approval_test.go
@@ -77,7 +77,7 @@ func TestCSRSignerNameApprovalPlugin(t *testing.T) {
 				Reason:  "AutoApproved",
 				Message: "Approved during integration test",
 			})
-			_, err := testuserClient.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(csr)
+			_, err := testuserClient.CertificatesV1beta1().CertificateSigningRequests().UpdateApproval(context.TODO(), csr, metav1.UpdateOptions{})
 			if err != nil && test.error != err.Error() {
 				t.Errorf("expected error %q but got: %v", test.error, err)
 			}

--- a/test/integration/evictions/evictions_test.go
+++ b/test/integration/evictions/evictions_test.go
@@ -27,7 +27,7 @@ import (
 	"testing"
 	"time"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/policy/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -113,7 +113,7 @@ func TestConcurrentEvictionRequests(t *testing.T) {
 			eviction := newEviction(ns.Name, podName, deleteOption)
 
 			err := wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
-				e := clientSet.PolicyV1beta1().Evictions(ns.Name).Evict(eviction)
+				e := clientSet.PolicyV1beta1().Evictions(ns.Name).Evict(context.TODO(), eviction)
 				switch {
 				case apierrors.IsTooManyRequests(e):
 					return false, nil
@@ -221,7 +221,7 @@ func TestTerminalPodEviction(t *testing.T) {
 	oldPdb := pdbList.Items[0]
 	eviction := newEviction(ns.Name, pod.Name, deleteOption)
 	err = wait.PollImmediate(5*time.Second, 60*time.Second, func() (bool, error) {
-		e := clientSet.PolicyV1beta1().Evictions(ns.Name).Evict(eviction)
+		e := clientSet.PolicyV1beta1().Evictions(ns.Name).Evict(context.TODO(), eviction)
 		switch {
 		case apierrors.IsTooManyRequests(e):
 			return false, nil

--- a/test/integration/scheduler/extender_test.go
+++ b/test/integration/scheduler/extender_test.go
@@ -232,7 +232,7 @@ func (e *Extender) Bind(binding *extenderv1.ExtenderBindingArgs) error {
 		},
 	}
 
-	return e.Client.CoreV1().Pods(b.Namespace).Bind(b)
+	return e.Client.CoreV1().Pods(b.Namespace).Bind(context.TODO(), b, metav1.CreateOptions{})
 }
 
 func machine1_2_3Predicate(pod *v1.Pod, node *v1.Node) (bool, error) {

--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -301,13 +301,13 @@ func (bp *BindPlugin) Bind(ctx context.Context, state *framework.CycleState, p *
 		bp.pluginInvokeEventChan <- pluginInvokeEvent{pluginName: bp.Name(), val: bp.numBindCalled}
 	}
 	if bp.bindStatus.IsSuccess() {
-		if err := bp.client.CoreV1().Pods(p.Namespace).Bind(&v1.Binding{
+		if err := bp.client.CoreV1().Pods(p.Namespace).Bind(context.TODO(), &v1.Binding{
 			ObjectMeta: metav1.ObjectMeta{Namespace: p.Namespace, Name: p.Name, UID: p.UID, Annotations: map[string]string{bindPluginAnnotation: bp.Name()}},
 			Target: v1.ObjectReference{
 				Kind: "Node",
 				Name: nodeName,
 			},
-		}); err != nil {
+		}, metav1.CreateOptions{}); err != nil {
 			return framework.NewStatus(framework.Error, fmt.Sprintf("bind failed: %v", err))
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Last plumbing PR for https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/20200123-client-go-ctx.md

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

release note already noted client-go typed context signature changes in https://github.com/kubernetes/kubernetes/pull/87299

/sig api-machinery
/cc @mikedanese 