### PR TITLE
Replace ExpectNoError(fmt.Errorf(..)) with funcs

### DIFF
--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -157,9 +157,7 @@ func TestReplicationControllerServeImageOrFail(f *framework.Framework, test stri
 	}
 
 	// Sanity check
-	if running != replicas {
-		framework.ExpectNoError(fmt.Errorf("unexpected number of running pods: %+v", pods.Items))
-	}
+	framework.ExpectEqual(running, replicas, "unexpected number of running pods: %+v", pods.Items)
 
 	// Verify that something is listening.
 	framework.Logf("Trying to dial the pod")

--- a/test/e2e/apps/replica_set.go
+++ b/test/e2e/apps/replica_set.go
@@ -159,9 +159,7 @@ func testReplicaSetServeImageOrFail(f *framework.Framework, test string, image s
 	}
 
 	// Sanity check
-	if running != replicas {
-		framework.ExpectNoError(fmt.Errorf("unexpected number of running pods: %+v", pods.Items))
-	}
+	framework.ExpectEqual(running, replicas, "unexpected number of running pods: %+v", pods.Items)
 
 	// Verify that something is listening.
 	framework.Logf("Trying to dial the pod")

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -182,9 +182,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				}
 				return true, nil
 			})
-			if pollErr != nil {
-				framework.ExpectNoError(fmt.Errorf("timed out waiting for ingress %s to get %s annotation", name, instanceGroupAnnotation))
-			}
+			framework.ExpectNoError(pollErr, "timed out waiting for ingress %s to get %s annotation", name, instanceGroupAnnotation)
 
 			// Verify that the ingress does not get other annotations like url-map, target-proxy, backends, etc.
 			// Note: All resources except the firewall rule have an annotation.

--- a/test/e2e/network/no_snat.go
+++ b/test/e2e/network/no_snat.go
@@ -141,9 +141,8 @@ var _ = SIGDescribe("NoSNAT [Feature:NoSNAT] [Slow]", func() {
 		ginkgo.By("creating a test pod on each Node")
 		nodes, err := nc.List(context.TODO(), metav1.ListOptions{})
 		framework.ExpectNoError(err)
-		if len(nodes.Items) == 0 {
-			framework.ExpectNoError(fmt.Errorf("no Nodes in the cluster"))
-		}
+		framework.ExpectNotEqual(len(nodes.Items), 0, "no Nodes in the cluster")
+
 		for _, node := range nodes.Items {
 			// find the Node's internal ip address to feed to the Pod
 			inIP, err := getIP(v1.NodeInternalIP, &node)

--- a/test/e2e/upgrades/apps/deployments.go
+++ b/test/e2e/upgrades/apps/deployments.go
@@ -79,9 +79,7 @@ func (t *DeploymentUpgradeTest) Setup(f *framework.Framework) {
 	rsList, err := rsClient.List(context.TODO(), metav1.ListOptions{LabelSelector: rsSelector.String()})
 	framework.ExpectNoError(err)
 	rss := rsList.Items
-	if len(rss) != 1 {
-		framework.ExpectNoError(fmt.Errorf("expected one replicaset, got %d", len(rss)))
-	}
+	framework.ExpectEqual(len(rss), 1, "expected one replicaset, got %d", len(rss))
 	t.oldRSUID = rss[0].UID
 
 	ginkgo.By(fmt.Sprintf("Waiting for revision of the deployment %q to become 1", deploymentName))
@@ -101,9 +99,7 @@ func (t *DeploymentUpgradeTest) Setup(f *framework.Framework) {
 	rsList, err = rsClient.List(context.TODO(), metav1.ListOptions{LabelSelector: rsSelector.String()})
 	framework.ExpectNoError(err)
 	rss = rsList.Items
-	if len(rss) != 2 {
-		framework.ExpectNoError(fmt.Errorf("expected 2 replicaset, got %d", len(rss)))
-	}
+	framework.ExpectEqual(len(rss), 2, "expected 2 replicaset, got %d", len(rss))
 
 	ginkgo.By(fmt.Sprintf("Checking replicaset of deployment %q that is created before rollout survives the rollout", deploymentName))
 	switch t.oldRSUID {
@@ -144,9 +140,7 @@ func (t *DeploymentUpgradeTest) Test(f *framework.Framework, done <-chan struct{
 	rsList, err := rsClient.List(context.TODO(), metav1.ListOptions{LabelSelector: rsSelector.String()})
 	framework.ExpectNoError(err)
 	rss := rsList.Items
-	if len(rss) != 2 {
-		framework.ExpectNoError(fmt.Errorf("expected 2 replicaset, got %d", len(rss)))
-	}
+	framework.ExpectEqual(len(rss), 2, "expected 2 replicaset, got %d", len(rss))
 
 	switch t.oldRSUID {
 	case rss[0].UID:


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There were framework.ExpectNoError(fmt.Errorf(..)) calls which just
raise an exception without actual value checks, they just raised the
specified error messages. These usages of framework.ExpectNoError()
seemed a little tricky, so this replaces them with corresponding check
functions for the readability.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
