### PR TITLE
modify etcd health check so that I don't end up getting confused by it once a year

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -86,8 +86,11 @@ func newETCD3HealthCheck(c storagebackend.Config) (func() error, error) {
 		client := clientValue.Load().(*clientv3.Client)
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
+		// Try and read a key from etcd, if we can retrieve that key, then we can establish:
+		// 		1. that we can talk to our local etcd
+		// 		2. that our etcd instance is able to establish quorum.
 		// See https://github.com/etcd-io/etcd/blob/c57f8b3af865d1b531b979889c602ba14377420e/etcdctl/ctlv3/command/ep_command.go#L118
-		_, err := client.Get(ctx, path.Join("/", c.Prefix, "health"))
+		_, err := client.Get(ctx, path.Join("/", c.Prefix, "fake-key-for-health-check"))
 		if err == nil {
 			return nil
 		}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Once a year, I have to look at this code and every time I look at it I misunderstand what is happening. This is not calling the etcd "/health" endpoint, this code actually just calls the local etcd and tries to retrieve a value for an arbitrary key. If it succeeds, then we know that the member is healthy and is able to establish quorum. 

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/sig api-machinery