### PR TITLE
Change SCTPSupport default value to true

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -625,7 +625,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CSIInlineVolume:                {Default: true, PreRelease: featuregate.Beta},
 	RuntimeClass:                   {Default: true, PreRelease: featuregate.Beta},
 	NodeLease:                      {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	SCTPSupport:                    {Default: false, PreRelease: featuregate.Alpha},
+	SCTPSupport:                    {Default: true, PreRelease: featuregate.Beta},
 	VolumeSnapshotDataSource:       {Default: true, PreRelease: featuregate.Beta},
 	ProcMountType:                  {Default: false, PreRelease: featuregate.Alpha},
 	TTLAfterFinished:               {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**What type of PR is this?**
 /kind feature

**What this PR does / why we need it**:
This PR changes the default value of the feature flag `SCTPSupport` from false to true as the feature moves form alpha to beta.
Tracking PR: https://github.com/kubernetes/enhancements/issues/614
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
The SCTPSupport feature flag becomes true by default, i.e. there is no need to activate the feature in a cluster.
```release-note
The SCTPSupport feature is now active by default.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md
- [Other doc]: https://github.com/kubernetes/website/pull/21672
```
