### PR TITLE
Remove framework.go's dependency on e2e node sub fw

### DIFF
--- a/test/e2e/framework/BUILD
+++ b/test/e2e/framework/BUILD
@@ -43,7 +43,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/uuid:go_default_library",

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -38,7 +38,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/discovery"
 	cacheddiscovery "k8s.io/client-go/discovery/cached/memory"
@@ -48,14 +47,12 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	scaleclient "k8s.io/client-go/scale"
-	testutils "k8s.io/kubernetes/test/utils"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 
 	// TODO: Remove the following imports (ref: https://github.com/kubernetes/kubernetes/issues/81245)
 	e2emetrics "k8s.io/kubernetes/test/e2e/framework/metrics"
-	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 )
 
@@ -566,76 +563,6 @@ func (f *Framework) TestContainerOutput(scenarioName string, pod *v1.Pod, contai
 // the specified container log against the given expected output using a regexp matcher.
 func (f *Framework) TestContainerOutputRegexp(scenarioName string, pod *v1.Pod, containerIndex int, expectedOutput []string) {
 	f.testContainerOutputMatcher(scenarioName, pod, containerIndex, expectedOutput, gomega.MatchRegexp)
-}
-
-// CreateServiceForSimpleAppWithPods is a convenience wrapper to create a service and its matching pods all at once.
-func (f *Framework) CreateServiceForSimpleAppWithPods(contPort int, svcPort int, appName string, podSpec func(n v1.Node) v1.PodSpec, count int, block bool) (*v1.Service, error) {
-	var err error
-	theService := f.CreateServiceForSimpleApp(contPort, svcPort, appName)
-	f.CreatePodsPerNodeForSimpleApp(appName, podSpec, count)
-	if block {
-		err = testutils.WaitForPodsWithLabelRunning(f.ClientSet, f.Namespace.Name, labels.SelectorFromSet(labels.Set(theService.Spec.Selector)))
-	}
-	return theService, err
-}
-
-// CreateServiceForSimpleApp returns a service that selects/exposes pods (send -1 ports if no exposure needed) with an app label.
-func (f *Framework) CreateServiceForSimpleApp(contPort, svcPort int, appName string) *v1.Service {
-	if appName == "" {
-		panic(fmt.Sprintf("no app name provided"))
-	}
-
-	serviceSelector := map[string]string{
-		"app": appName + "-pod",
-	}
-
-	// For convenience, user sending ports are optional.
-	portsFunc := func() []v1.ServicePort {
-		if contPort < 1 || svcPort < 1 {
-			return nil
-		}
-		return []v1.ServicePort{{
-			Protocol:   v1.ProtocolTCP,
-			Port:       int32(svcPort),
-			TargetPort: intstr.FromInt(contPort),
-		}}
-	}
-	Logf("Creating a service-for-%v for selecting app=%v-pod", appName, appName)
-	service, err := f.ClientSet.CoreV1().Services(f.Namespace.Name).Create(context.TODO(), &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "service-for-" + appName,
-			Labels: map[string]string{
-				"app": appName + "-service",
-			},
-		},
-		Spec: v1.ServiceSpec{
-			Ports:    portsFunc(),
-			Selector: serviceSelector,
-		},
-	}, metav1.CreateOptions{})
-	ExpectNoError(err)
-	return service
-}
-
-// CreatePodsPerNodeForSimpleApp creates pods w/ labels.  Useful for tests which make a bunch of pods w/o any networking.
-func (f *Framework) CreatePodsPerNodeForSimpleApp(appName string, podSpec func(n v1.Node) v1.PodSpec, maxCount int) map[string]string {
-	nodes, err := e2enode.GetBoundedReadySchedulableNodes(f.ClientSet, maxCount)
-	ExpectNoError(err)
-	podLabels := map[string]string{
-		"app": appName + "-pod",
-	}
-	for i, node := range nodes.Items {
-		Logf("%v/%v : Creating container with label app=%v-pod", i, maxCount, appName)
-		_, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), &v1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   fmt.Sprintf(appName+"-pod-%v", i),
-				Labels: podLabels,
-			},
-			Spec: podSpec(node),
-		}, metav1.CreateOptions{})
-		ExpectNoError(err)
-	}
-	return podLabels
 }
 
 // KubeUser is a struct for managing kubernetes user info.

--- a/test/e2e/framework/node/BUILD
+++ b/test/e2e/framework/node/BUILD
@@ -23,6 +23,7 @@ go_library(
         "//test/e2e/system:go_default_library",
         "//test/utils:go_default_library",
         "//test/utils/image:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/test/e2e/framework/service/resource.go
+++ b/test/e2e/framework/service/resource.go
@@ -18,15 +18,19 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	clientset "k8s.io/client-go/kubernetes"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	testutils "k8s.io/kubernetes/test/utils"
 )
 
 // GetServicesProxyRequest returns a request for a service proxy.
@@ -103,4 +107,53 @@ func GetServiceLoadBalancerCreationTimeout(cs clientset.Interface) time.Duration
 		return LoadBalancerCreateTimeoutLarge
 	}
 	return LoadBalancerCreateTimeoutDefault
+}
+
+// CreateServiceForSimpleAppWithPods is a convenience wrapper to create a service and its matching pods all at once.
+func CreateServiceForSimpleAppWithPods(c clientset.Interface, contPort int, svcPort int, namespace, appName string, podSpec func(n v1.Node) v1.PodSpec, count int, block bool) (*v1.Service, error) {
+	var err error
+	theService := CreateServiceForSimpleApp(c, contPort, svcPort, namespace, appName)
+	e2enode.CreatePodsPerNodeForSimpleApp(c, namespace, appName, podSpec, count)
+	if block {
+		err = testutils.WaitForPodsWithLabelRunning(c, namespace, labels.SelectorFromSet(labels.Set(theService.Spec.Selector)))
+	}
+	return theService, err
+}
+
+// CreateServiceForSimpleApp returns a service that selects/exposes pods (send -1 ports if no exposure needed) with an app label.
+func CreateServiceForSimpleApp(c clientset.Interface, contPort, svcPort int, namespace, appName string) *v1.Service {
+	if appName == "" {
+		panic(fmt.Sprintf("no app name provided"))
+	}
+
+	serviceSelector := map[string]string{
+		"app": appName + "-pod",
+	}
+
+	// For convenience, user sending ports are optional.
+	portsFunc := func() []v1.ServicePort {
+		if contPort < 1 || svcPort < 1 {
+			return nil
+		}
+		return []v1.ServicePort{{
+			Protocol:   v1.ProtocolTCP,
+			Port:       int32(svcPort),
+			TargetPort: intstr.FromInt(contPort),
+		}}
+	}
+	framework.Logf("Creating a service-for-%v for selecting app=%v-pod", appName, appName)
+	service, err := c.CoreV1().Services(namespace).Create(context.TODO(), &v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "service-for-" + appName,
+			Labels: map[string]string{
+				"app": appName + "-service",
+			},
+		},
+		Spec: v1.ServiceSpec{
+			Ports:    portsFunc(),
+			Selector: serviceSelector,
+		},
+	}, metav1.CreateOptions{})
+	framework.ExpectNoError(err)
+	return service
 }

--- a/test/e2e/instrumentation/logging/generic_soak.go
+++ b/test/e2e/instrumentation/logging/generic_soak.go
@@ -86,7 +86,9 @@ func RunLogPodsWithSleepOf(f *framework.Framework, sleep time.Duration, podname 
 	kilobyte := strings.Repeat("logs-123", 128) // 8*128=1024 = 1KB of text.
 
 	appName := "logging-soak" + podname
-	podlables := f.CreatePodsPerNodeForSimpleApp(
+	podlables := e2enode.CreatePodsPerNodeForSimpleApp(
+		f.ClientSet,
+		f.Namespace.Name,
 		appName,
 		func(n v1.Node) v1.PodSpec {
 			return v1.PodSpec{

--- a/test/e2e/network/networking_perf.go
+++ b/test/e2e/network/networking_perf.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
+	e2eservice "k8s.io/kubernetes/test/e2e/framework/service"
 	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
 	imageutils "k8s.io/kubernetes/test/utils/image"
 )
@@ -60,9 +61,11 @@ func networkingIPerfTest(isIPv6 bool) {
 		// for a single service, we expect to divide bandwidth between the network.  Very crude estimate.
 		expectedBandwidth := int(float64(maxBandwidthBits) / float64(totalPods))
 		appName := "iperf-e2e"
-		_, err = f.CreateServiceForSimpleAppWithPods(
+		_, err = e2eservice.CreateServiceForSimpleAppWithPods(
+			f.ClientSet,
 			8001,
 			8002,
+			f.Namespace.Name,
 			appName,
 			func(n v1.Node) v1.PodSpec {
 				return v1.PodSpec{
@@ -89,7 +92,9 @@ func networkingIPerfTest(isIPv6 bool) {
 			framework.Failf("Fatal error waiting for iperf server endpoint : %v", err)
 		}
 
-		iperfClientPodLabels := f.CreatePodsPerNodeForSimpleApp(
+		iperfClientPodLabels := e2enode.CreatePodsPerNodeForSimpleApp(
+			f.ClientSet,
+			f.Namespace.Name,
 			"iperf-e2e-cli",
 			func(n v1.Node) v1.PodSpec {
 				return v1.PodSpec{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup


**What this PR does / why we need it**:

Refactor framework's methods `CreateServiceForSimpleAppWithPods`, `CreateServiceForSimpleApp` into service e2e fw, `CreatePodsPerNodeForSimpleApp` into node e2e fw. Then it can remove framework.go's dependency on e2e node sub fw.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Xref #81245

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
