### PR TITLE
Uncapitalize isIncompatibleServerError Error Message for kubectl apply

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -414,7 +414,7 @@ func (o *ApplyOptions) Run() error {
 			)
 			if err != nil {
 				if isIncompatibleServerError(err) {
-					err = fmt.Errorf("Server-side apply not available on the server: (%v)", err)
+					err = fmt.Errorf("server-side apply not available on the server: (%v)", err)
 				}
 				if errors.IsConflict(err) {
 					err = fmt.Errorf(`%v


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Following error message formatting recommendations for go, [error messages should not be captialized](https://github.com/golang/go/wiki/CodeReviewComments#error-strings):

```
Error strings should not be capitalized (unless beginning with proper nouns or acronyms) 
```

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:

```release-note
Change error message for kubectl apply when server doesn't support server-side apply
```
