### PR TITLE
Clarify cached object type in apiserver log

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/BUILD
@@ -66,6 +66,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/api/validation/path:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/internalversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/storage_factory.go
@@ -17,10 +17,12 @@ limitations under the License.
 package registry
 
 import (
+	"fmt"
 	"sync"
 
 	"k8s.io/klog"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/generic"
 	"k8s.io/apiserver/pkg/storage"
@@ -48,11 +50,11 @@ func StorageWithCacher(capacity int) generic.StorageDecorator {
 			return s, d, err
 		}
 		if capacity <= 0 {
-			klog.V(5).Infof("Storage caching is disabled for %T", newFunc())
+			klog.V(5).Infof("Storage caching is disabled for %s", objectTypeToString(newFunc()))
 			return s, d, nil
 		}
 		if klog.V(5) {
-			klog.Infof("Storage caching is enabled for %T with capacity %v", newFunc(), capacity)
+			klog.Infof("Storage caching is enabled for %s with capacity %v", objectTypeToString(newFunc()), capacity)
 		}
 
 		// TODO: we would change this later to make storage always have cacher and hide low level KV layer inside.
@@ -86,6 +88,17 @@ func StorageWithCacher(capacity int) generic.StorageDecorator {
 
 		return cacher, destroyFunc, nil
 	}
+}
+
+func objectTypeToString(obj runtime.Object) string {
+	// special-case unstructured objects that tell us their apiVersion/kind
+	if u, isUnstructured := obj.(*unstructured.Unstructured); isUnstructured {
+		if apiVersion, kind := u.GetAPIVersion(), u.GetKind(); len(apiVersion) > 0 && len(kind) > 0 {
+			return fmt.Sprintf("apiVersion=%s, kind=%s", apiVersion, kind)
+		}
+	}
+	// otherwise just return the type
+	return fmt.Sprintf("%T", obj)
 }
 
 // TODO : Remove all the code below when PR


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Clarifies the cached object type in the API server log for custom resources.

Before:
```
Storage caching is enabled for *unstructured.Unstructured with capacity 100
```

After:
```
Storage caching is enabled for apiVersion=example.com/v1, kind=Foo with capacity 100
```

```release-note
NONE
```

/cc @MikeSpreitzer 
/sig api-machinery
/priority backlog