### PR TITLE
Asyncronously pull images while init container is running

### DIFF
--- a/pkg/kubelet/images/image_manager.go
+++ b/pkg/kubelet/images/image_manager.go
@@ -18,6 +18,7 @@ package images
 
 import (
 	"fmt"
+	"sync"
 
 	dockerref "github.com/docker/distribution/reference"
 	v1 "k8s.io/api/core/v1"
@@ -37,7 +38,8 @@ type imageManager struct {
 	imageService kubecontainer.ImageService
 	backOff      *flowcontrol.Backoff
 	// It will check the presence of the image, and report the 'image pulling', image pulled' events correspondingly.
-	puller imagePuller
+	puller     imagePuller
+	asyncPulls sync.Map
 }
 
 var _ ImageManager = &imageManager{}
@@ -84,6 +86,91 @@ func (m *imageManager) logIt(ref *v1.ObjectReference, eventtype, event, prefix, 
 	}
 }
 
+// getAsyncPullKey generates a key used to track async image pulls
+func getAsyncPullKey(pod *v1.Pod, container *v1.Container) string {
+	return fmt.Sprintf("%s_%s_%s", pod.UID, container.Name, container.Image)
+}
+
+// RemoveAsyncPullsForPod removes any tracked async pulls for a given pod
+func (m *imageManager) RemoveAsyncPullsForPod(pod *v1.Pod) {
+	for _, container := range pod.Spec.InitContainers {
+		asyncKey := getAsyncPullKey(pod, &container)
+		if _, exists := m.asyncPulls.Load(asyncKey); exists {
+			m.asyncPulls.Delete(asyncKey)
+		}
+	}
+
+	for _, container := range pod.Spec.Containers {
+		asyncKey := getAsyncPullKey(pod, &container)
+		if _, exists := m.asyncPulls.Load(asyncKey); exists {
+			m.asyncPulls.Delete(asyncKey)
+		}
+	}
+}
+
+func (m *imageManager) ensureImageExistsInternal(ref *v1.ObjectReference, pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error, kubecontainer.ImageSpec) {
+	logPrefix := fmt.Sprintf("%s/%s", pod.Name, container.Image)
+
+	// If the image contains no tag or digest, a default tag should be applied.
+	image, err := applyDefaultImageTag(container.Image)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to apply default image tag %q: %v", container.Image, err)
+		m.logIt(ref, v1.EventTypeWarning, events.FailedToInspectImage, logPrefix, msg, klog.Warning)
+		return "", msg, ErrInvalidImageName, kubecontainer.ImageSpec{}
+	}
+
+	spec := kubecontainer.ImageSpec{Image: image}
+	imageRef, err := m.imageService.GetImageRef(spec)
+	if err != nil {
+		msg := fmt.Sprintf("Failed to inspect image %q: %v", container.Image, err)
+		m.logIt(ref, v1.EventTypeWarning, events.FailedToInspectImage, logPrefix, msg, klog.Warning)
+		return "", msg, ErrImageInspect, spec
+	}
+
+	present := imageRef != ""
+	if !shouldPullImage(container, present) {
+		if present {
+			msg := fmt.Sprintf("Container image %q already present on machine", container.Image)
+			m.logIt(ref, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
+			return imageRef, "", nil, spec
+		}
+		msg := fmt.Sprintf("Container image %q is not present with pull policy of Never", container.Image)
+		m.logIt(ref, v1.EventTypeWarning, events.ErrImageNeverPullPolicy, logPrefix, msg, klog.Warning)
+		return "", msg, ErrImageNeverPull, spec
+	}
+
+	return "", "", nil, spec
+}
+
+// EnsureImageExistsAsync pulls the image for the specified pod and container, and returns
+// (imageRef, error message, error).
+func (m *imageManager) EnsureImageExistsAsync(pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error) {
+	logPrefix := fmt.Sprintf("%s/%s", pod.Name, container.Image)
+	ref, err := kubecontainer.GenerateContainerRef(pod, container)
+	if err != nil {
+		klog.Errorf("Couldn't make a ref to pod %v, container %v: '%v'", pod.Name, container.Name, err)
+	}
+
+	backOffKey := fmt.Sprintf("%s_%s", pod.UID, container.Image)
+	if m.backOff.IsInBackOffSinceUpdate(backOffKey, m.backOff.Clock.Now()) {
+		msg := fmt.Sprintf("Back-off pulling image %q", container.Image)
+		m.logIt(ref, v1.EventTypeNormal, events.BackOffPullImage, logPrefix, msg, klog.Info)
+		return "", msg, ErrImagePullBackOff
+	}
+
+	imageRef, errorMessage, err, imageSpec := m.ensureImageExistsInternal(ref, pod, container, pullSecrets, podSandboxConfig)
+	if err != nil {
+		return imageRef, errorMessage, err
+	}
+
+	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Async pulling image %q", container.Image), klog.Info)
+	pullChan := make(chan pullResult, 1)
+	m.puller.pullImage(imageSpec, pullSecrets, pullChan, podSandboxConfig)
+	m.asyncPulls.Store(getAsyncPullKey(pod, container), pullChan)
+
+	return "", "", nil
+}
+
 // EnsureImageExists pulls the image for the specified pod and container, and returns
 // (imageRef, error message, error).
 func (m *imageManager) EnsureImageExists(pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error) {
@@ -93,43 +180,31 @@ func (m *imageManager) EnsureImageExists(pod *v1.Pod, container *v1.Container, p
 		klog.Errorf("Couldn't make a ref to pod %v, container %v: '%v'", pod.Name, container.Name, err)
 	}
 
-	// If the image contains no tag or digest, a default tag should be applied.
-	image, err := applyDefaultImageTag(container.Image)
-	if err != nil {
-		msg := fmt.Sprintf("Failed to apply default image tag %q: %v", container.Image, err)
-		m.logIt(ref, v1.EventTypeWarning, events.FailedToInspectImage, logPrefix, msg, klog.Warning)
-		return "", msg, ErrInvalidImageName
-	}
-
-	spec := kubecontainer.ImageSpec{Image: image}
-	imageRef, err := m.imageService.GetImageRef(spec)
-	if err != nil {
-		msg := fmt.Sprintf("Failed to inspect image %q: %v", container.Image, err)
-		m.logIt(ref, v1.EventTypeWarning, events.FailedToInspectImage, logPrefix, msg, klog.Warning)
-		return "", msg, ErrImageInspect
-	}
-
-	present := imageRef != ""
-	if !shouldPullImage(container, present) {
-		if present {
-			msg := fmt.Sprintf("Container image %q already present on machine", container.Image)
-			m.logIt(ref, v1.EventTypeNormal, events.PulledImage, logPrefix, msg, klog.Info)
-			return imageRef, "", nil
-		}
-		msg := fmt.Sprintf("Container image %q is not present with pull policy of Never", container.Image)
-		m.logIt(ref, v1.EventTypeWarning, events.ErrImageNeverPullPolicy, logPrefix, msg, klog.Warning)
-		return "", msg, ErrImageNeverPull
-	}
-
 	backOffKey := fmt.Sprintf("%s_%s", pod.UID, container.Image)
 	if m.backOff.IsInBackOffSinceUpdate(backOffKey, m.backOff.Clock.Now()) {
 		msg := fmt.Sprintf("Back-off pulling image %q", container.Image)
 		m.logIt(ref, v1.EventTypeNormal, events.BackOffPullImage, logPrefix, msg, klog.Info)
 		return "", msg, ErrImagePullBackOff
 	}
-	m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
-	pullChan := make(chan pullResult)
-	m.puller.pullImage(spec, pullSecrets, pullChan, podSandboxConfig)
+
+	var pullChan chan pullResult
+
+	// If there is already an async pull started wait on it and return it's result.
+	asyncKey := getAsyncPullKey(pod, container)
+	if pullChanInt, asyncPullExists := m.asyncPulls.Load(asyncKey); asyncPullExists {
+		pullChan = pullChanInt.(chan pullResult)
+		m.asyncPulls.Delete(asyncKey)
+	} else {
+		imageRef, errorMessage, err, imageSpec := m.ensureImageExistsInternal(ref, pod, container, pullSecrets, podSandboxConfig)
+		if err != nil {
+			return imageRef, errorMessage, err
+		}
+
+		m.logIt(ref, v1.EventTypeNormal, events.PullingImage, logPrefix, fmt.Sprintf("Pulling image %q", container.Image), klog.Info)
+		pullChan = make(chan pullResult)
+		m.puller.pullImage(imageSpec, pullSecrets, pullChan, podSandboxConfig)
+	}
+
 	imagePullResult := <-pullChan
 	if imagePullResult.err != nil {
 		m.logIt(ref, v1.EventTypeWarning, events.FailedToPullImage, logPrefix, fmt.Sprintf("Failed to pull image %q: %v", container.Image, imagePullResult.err), klog.Warning)

--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -51,7 +51,7 @@ var (
 type ImageManager interface {
 	// EnsureImageExists ensures that image specified in `container` exists.
 	EnsureImageExists(pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error)
-	EnsureImageExistsAsync(pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error)
+	EnsureImageExistsAsync(pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, error)
 	RemoveAsyncPullsForPod(pod *v1.Pod)
 
 	// TODO(ronl): consolidating image managing and deleting operation in this interface

--- a/pkg/kubelet/images/types.go
+++ b/pkg/kubelet/images/types.go
@@ -19,7 +19,7 @@ package images
 import (
 	"errors"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	runtimeapi "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
 )
 
@@ -51,6 +51,8 @@ var (
 type ImageManager interface {
 	// EnsureImageExists ensures that image specified in `container` exists.
 	EnsureImageExists(pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error)
+	EnsureImageExistsAsync(pod *v1.Pod, container *v1.Container, pullSecrets []v1.Secret, podSandboxConfig *runtimeapi.PodSandboxConfig) (string, string, error)
+	RemoveAsyncPullsForPod(pod *v1.Pod)
 
 	// TODO(ronl): consolidating image managing and deleting operation in this interface
 }

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -828,7 +828,7 @@ func (m *kubeGenericRuntimeManager) SyncPod(pod *v1.Pod, podStatus *kubecontaine
 	// Async pull containers
 	if len(podContainerChanges.ContainersToPrepull) > 0 {
 		for _, container := range podContainerChanges.ContainersToPrepull {
-			_, _, err := m.imagePuller.EnsureImageExistsAsync(pod, &container, pullSecrets, podSandboxConfig)
+			_, err := m.imagePuller.EnsureImageExistsAsync(pod, &container, pullSecrets, podSandboxConfig)
 			if err != nil {
 				klog.V(3).Infof("On image: %s pre-pull failed: %v", container.Image, err)
 				continue


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

The aim here is to optimize the startup process for a pod with an initContainer (or multiple) followed by a set of normal containers as discussed in #88265.

Currently the initContainer pulls it's image, runs for a while, then after exiting the normal containers images are pulled (if not present) and the containers started. Note if you have multiple initContainers this flow is repeated with init1 pull-> run then init 2 pull -> run then main workload.

This PR moves to pulling all the required images asynchronously while the first init container is running. 

With this change in place startup times for pods with images not already on the nodes are significantly improved. Here are tests run with this change tracking timings: https://github.com/lawrencegripper/hack-testingasyncpull#results-with-ordered-async

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88265

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Images will be pulled asynchronously during initContainer execution to improve startup time
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
