### PR TITLE
Changed kubectl config view to redact user token

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers.go
@@ -98,6 +98,9 @@ func ShortenConfig(config *Config) {
 		if len(authInfo.ClientCertificateData) > 0 {
 			authInfo.ClientCertificateData = redactedBytes
 		}
+		if len(authInfo.Token) > 0 {
+			authInfo.Token = "REDACTED"
+		}
 		config.AuthInfos[key] = authInfo
 	}
 	for key, cluster := range config.Clusters {

--- a/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/api/helpers_test.go
@@ -243,7 +243,7 @@ func Example_minifyAndShorten() {
 	//     LocationOfOrigin: ""
 	//     client-certificate-data: REDACTED
 	//     client-key-data: REDACTED
-	//     token: red-token
+	//     token: REDACTED
 }
 
 func TestShortenSuccess(t *testing.T) {
@@ -298,5 +298,8 @@ func TestShortenSuccess(t *testing.T) {
 	}
 	if string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData) != redacted {
 		t.Errorf("expected %v, got %v", redacted, string(mutatingConfig.AuthInfos[changingAuthInfo].ClientKeyData))
+	}
+	if mutatingConfig.AuthInfos[changingAuthInfo].Token != "REDACTED" {
+		t.Errorf("expected REDACTED, got %v", mutatingConfig.AuthInfos[changingAuthInfo].Token)
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/config_test.go
@@ -72,7 +72,7 @@ func Example_view() {
 	// users:
 	// - name: red-user
 	//   user:
-	//     token: red-token
+	//     token: REDACTED
 }
 
 func TestCurrentContext(t *testing.T) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/view_test.go
@@ -48,8 +48,8 @@ func TestViewCluster(t *testing.T) {
 		},
 		CurrentContext: "minikube",
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"minikube":   {Token: "minikube-token"},
-			"mu-cluster": {Token: "minikube-token"},
+			"minikube":   {Token: "REDACTED"},
+			"mu-cluster": {Token: "REDACTED"},
 		},
 	}
 
@@ -79,10 +79,10 @@ preferences: {}
 users:
 - name: minikube
   user:
-    token: minikube-token
+    token: REDACTED
 - name: mu-cluster
   user:
-    token: minikube-token` + "\n",
+    token: REDACTED` + "\n",
 	}
 
 	test.run(t)
@@ -103,8 +103,8 @@ func TestViewClusterMinify(t *testing.T) {
 		},
 		CurrentContext: "minikube",
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"minikube":   {Token: "minikube-token"},
-			"mu-cluster": {Token: "minikube-token"},
+			"minikube":   {Token: "REDACTED"},
+			"mu-cluster": {Token: "REDACTED"},
 		},
 	}
 
@@ -134,7 +134,7 @@ preferences: {}
 users:
 - name: minikube
   user:
-    token: minikube-token` + "\n",
+    token: REDACTED` + "\n",
 		},
 		{
 			description: "Testing for kubectl config view --minify=true --context=my-cluster",
@@ -156,7 +156,7 @@ preferences: {}
 users:
 - name: mu-cluster
   user:
-    token: minikube-token` + "\n",
+    token: REDACTED` + "\n",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When you run `kubectl config view`, the user token is not redacted like client-certificate-data and client-key-data.  This PR redacts the user token.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/kubectl/issues/667

**Special notes for your reviewer**:
None

**Does this PR introduce a user-facing change?**:
```release-note
`kubectl config view` now redacts bearer tokens by default, similar to client certificates. The `--raw` flag can still be used to output full content.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
