### PR TITLE
kubelet: Also set PodIPs when assign a host network PodIP

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1399,6 +1399,7 @@ func (kl *Kubelet) generateAPIPodStatus(pod *v1.Pod, podStatus *kubecontainer.Po
 			s.HostIP = hostIP.String()
 			if kubecontainer.IsHostNetworkPod(pod) && s.PodIP == "" {
 				s.PodIP = hostIP.String()
+				s.PodIPs = []v1.PodIP{{IP: s.PodIP}}
 			}
 		}
 	}


### PR DESCRIPTION
When we clobber PodIP we should also overwrite PodIPs and not rely
on the apiserver to fix it for us - this caused the Kubelet status
manager to report a large string of the following warnings when
it tried to reconcile a host network pod:

```
 I0309 19:41:05.283623    1326 status_manager.go:846] Pod status is inconsistent with cached status for pod "machine-config-daemon-jvwz4_openshift-machine-config-operator(61176279-f752-4e1c-ac8a-b48f0a68d54a)", a reconciliation should be triggered:
   &v1.PodStatus{
           ... // 5 identical fields
           HostIP:                "10.0.32.2",
           PodIP:                 "10.0.32.2",
 -         PodIPs:                []v1.PodIP{{IP: "10.0.32.2"}},
 +         PodIPs:                []v1.PodIP{},
           StartTime:             s"2020-03-09 19:41:05 +0000 UTC",
           InitContainerStatuses: nil,
           ... // 3 identical fields
   }
```

With the changes to the apiserver, this only happens once, but it is
still a bug.

/kind bug

```release-note
NONE
```

/assign @liggitt

as discussed on slack.