### PR TITLE
Replace raw usages of tar in build/lib/release.sh

### DIFF
--- a/build/lib/release.sh
+++ b/build/lib/release.sh
@@ -462,7 +462,7 @@ function kube::release::package_kube_manifests_tarball() {
   cp "${KUBE_ROOT}/cluster/gce/gci/health-monitor.sh" "${dst_dir}/health-monitor.sh"
   # Merge GCE-specific addons with general purpose addons.
   for d in cluster/addons cluster/gce/addons; do
-    find "${KUBE_ROOT}/${d}" \( \( -name \*.yaml -o -name \*.yaml.in -o -name \*.json \) -a ! \( -name \*demo\* \) \) -print0 | tar c --transform "s|${KUBE_ROOT#/*}/${d}||" --null -T - | "${TAR}" x -C "${dst_dir}"
+    find "${KUBE_ROOT}/${d}" \( \( -name \*.yaml -o -name \*.yaml.in -o -name \*.json \) -a ! \( -name \*demo\* \) \) -print0 | "${TAR}" c --transform "s|${KUBE_ROOT#/*}/${d}||" --null -T - | "${TAR}" x -C "${dst_dir}"
   done
 
   kube::release::clean_cruft
@@ -528,7 +528,7 @@ function kube::release::package_test_tarballs() {
   # the portable test tarball.
   mkdir -p "${release_stage}/test/images"
   cp -fR "${KUBE_ROOT}/test/images" "${release_stage}/test/"
-  tar c "${KUBE_TEST_PORTABLE[@]}" | tar x -C "${release_stage}"
+  "${TAR}" c "${KUBE_TEST_PORTABLE[@]}" | "${TAR}" x -C "${release_stage}"
 
   kube::release::clean_cruft
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The use of 'raw' `tar` invocations on breaks the ability to run `make quick-release` on darwin

Use `${TAR}` instead so that `gtar` can be used if available.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Looks like this regression was introduced in https://github.com/kubernetes/kubernetes/pull/87285

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```