### PR TITLE
Add kubectl apply generate name error message

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -399,6 +399,14 @@ func (o *ApplyOptions) applyOneObject(info *resource.Info) error {
 		klog.V(4).Infof("error recording current command: %v", err)
 	}
 
+	if len(info.Name) == 0 {
+		metadata, _ := meta.Accessor(info.Object)
+		generatedName := metadata.GetGenerateName()
+		if len(generatedName) > 0 {
+			return fmt.Errorf("from %s: cannot use generate name with apply", generatedName)
+		}
+	}
+
 	helper := resource.NewHelper(info.Client, info.Mapping).
 		DryRun(o.DryRunStrategy == cmdutil.DryRunServer).
 		WithFieldManager(o.FieldManager)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -97,6 +97,7 @@ const (
 	filenameRCPatchTest       = "../../../testdata/apply/patch.json"
 	dirName                   = "../../../testdata/apply/testdir"
 	filenameRCJSON            = "../../../testdata/apply/rc.json"
+	filenamePodGeneratedName  = "../../../testdata/apply/pod-generated-name.yaml"
 
 	filenameWidgetClientside    = "../../../testdata/apply/widget-clientside.yaml"
 	filenameWidgetServerside    = "../../../testdata/apply/widget-serverside.yaml"
@@ -1409,4 +1410,23 @@ func TestDontAllowForceApplyWithServerDryRun(t *testing.T) {
 	cmd.Run(cmd, []string{})
 
 	t.Fatalf(`expected error "%s"`, expectedError)
+}
+
+func TestDontAllowApplyWithPodGeneratedName(t *testing.T) {
+	expectedError := "error: from testing-: cannot use generate name with apply"
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		if str != expectedError {
+			t.Fatalf(`expected error "%s", but got "%s"`, expectedError, str)
+		}
+	})
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdApply("kubectl", tf, ioStreams)
+	cmd.Flags().Set("filename", filenamePodGeneratedName)
+	cmd.Flags().Set("dry-run", "client")
+	cmd.Run(cmd, []string{})
 }

--- a/staging/src/k8s.io/kubectl/testdata/apply/pod-generated-name.yaml
+++ b/staging/src/k8s.io/kubectl/testdata/apply/pod-generated-name.yaml
@@ -1,0 +1,8 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  generateName: testing-
+spec:
+  containers:
+  - image: nginx
+    name: nginx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind cleanup
> /kind documentation

**What this PR does / why we need it**:
When using `kubectl apply` to apply a file with `generate name`, the operations fails with very confused information:
```
error: error when retrieving current configuration of:
Resource: "tekton.dev/v1alpha1, Resource=taskruns", GroupVersionKind: "tekton.dev/v1alpha1, Kind=TaskRun"
Name: "", Namespace: "default"
Object: &{...}
from server for: "taskrun.yaml": resource name may not be empty
```
`resource name may not be empty` comes form `client-go` when  building a request. User will be confused because `generate name` is specified, the output doesn't tell the user that `generated name` is not supported in `kubectl apply`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/835


```release-note
None 
```

