### PR TITLE
integration test is not stable on Arm platform

### DIFF
--- a/hack/lib/etcd.sh
+++ b/hack/lib/etcd.sh
@@ -77,6 +77,8 @@ kube::etcd::start() {
 
   # Start etcd
   ETCD_DIR=${ETCD_DIR:-$(mktemp -d 2>/dev/null || mktemp -d -t test-etcd.XXXXXX)}
+  kube::log::info "Notice: it is better to use a ramdisk for ${ETCD_DIR} to get better performance, so that the test results will be more stable."
+
   if [[ -d "${ARTIFACTS:-}" ]]; then
     ETCD_LOGFILE="${ARTIFACTS}/etcd.$(uname -n).$(id -un).log.DEBUG.$(date +%Y%m%d-%H%M%S).$$"
   else


### PR DESCRIPTION
The root cause is that the performance of etcd is poor.
So, let's use a ramdisk for etcd to get better performance.
With this patch, the integration test on Arm became stable.
Please see following link as reference:
https://k8s-testgrid.appspot.com/sig-node-arm64#integration-tests

Signed-off-by: Bin Lu <bin.lu@arm.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The integration test on Arm is not stable.
With this patch, the result seems OK on Arm

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None
**Does this PR introduce a user-facing change?**:
No

```release-note

```None.
