### PR TITLE
api: PodSpec: Document InitContainers as optional

### DIFF
--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -2852,6 +2852,7 @@ type PodSpec struct {
 	// Init containers cannot currently be added or removed.
 	// Cannot be updated.
 	// More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+	// +optional
 	// +patchMergeKey=name
 	// +patchStrategy=merge
 	InitContainers []Container `json:"initContainers,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,20,rep,name=initContainers"`


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> 
/kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Init containers in PodSpec can actually be omitted.
Make it clear in the "meta description".

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
(None)

**Does this PR introduce a user-facing change?**:
Not really: it adds a tag in the documentation, so that the field can be best processed by automated tools leveraging these tags.

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
