### PR TITLE
Bump Cluster-Autoscaler to cluster-autoscaler:v1.18.0-beta.1

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.18.0-beta.0",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.18.0-beta.1",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update Cluster Autoscaler version to 1.18.0-gke.1.

New release for 1.18 is necessary since autoscaler relies on implicit compatibility with scheduler (which it imports as a library).

Not including release notes yet as this is a pre-release version (current plans are to release final version without changes in couple days).

/kind bug
/priority critical-urgent
/sig autoscaling
/assign @mwielgus

```release-note
NONE
```
