### PR TITLE
EndpointSlice and Endpoints behavior for terminating pods should be the same

### DIFF
--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -86,29 +86,31 @@ func (r *reconciler) reconcile(service *corev1.Service, pods []*corev1.Pod, exis
 	numDesiredEndpoints := 0
 
 	for _, pod := range pods {
-		if endpointutil.ShouldPodBeInEndpoints(pod) {
-			endpointPorts := getEndpointPorts(service, pod)
-			epHash := endpointutil.NewPortMapKey(endpointPorts)
-			if _, ok := desiredEndpointsByPortMap[epHash]; !ok {
-				desiredEndpointsByPortMap[epHash] = endpointSet{}
-			}
+		if !endpointutil.ShouldPodBeInEndpoints(pod, service.Spec.PublishNotReadyAddresses) {
+			continue
+		}
 
-			if _, ok := desiredMetaByPortMap[epHash]; !ok {
-				desiredMetaByPortMap[epHash] = &endpointMeta{
-					AddressType: addressType,
-					Ports:       endpointPorts,
-				}
-			}
+		endpointPorts := getEndpointPorts(service, pod)
+		epHash := endpointutil.NewPortMapKey(endpointPorts)
+		if _, ok := desiredEndpointsByPortMap[epHash]; !ok {
+			desiredEndpointsByPortMap[epHash] = endpointSet{}
+		}
 
-			node, err := r.nodeLister.Get(pod.Spec.NodeName)
-			if err != nil {
-				return err
+		if _, ok := desiredMetaByPortMap[epHash]; !ok {
+			desiredMetaByPortMap[epHash] = &endpointMeta{
+				AddressType: addressType,
+				Ports:       endpointPorts,
 			}
-			endpoint := podToEndpoint(pod, node, service)
-			if len(endpoint.Addresses) > 0 {
-				desiredEndpointsByPortMap[epHash].Insert(&endpoint)
-				numDesiredEndpoints++
-			}
+		}
+
+		node, err := r.nodeLister.Get(pod.Spec.NodeName)
+		if err != nil {
+			return err
+		}
+		endpoint := podToEndpoint(pod, node, service)
+		if len(endpoint.Addresses) > 0 {
+			desiredEndpointsByPortMap[epHash].Insert(&endpoint)
+			numDesiredEndpoints++
 		}
 	}
 

--- a/pkg/controller/util/endpoint/controller_utils.go
+++ b/pkg/controller/util/endpoint/controller_utils.go
@@ -126,9 +126,13 @@ func DeepHashObjectToString(objectToWrite interface{}) string {
 }
 
 // ShouldPodBeInEndpoints returns true if a specified pod should be in an
-// endpoints object.
-func ShouldPodBeInEndpoints(pod *v1.Pod) bool {
+// endpoints object. Terminating pods are only included if publishNotReady is true.
+func ShouldPodBeInEndpoints(pod *v1.Pod, publishNotReady bool) bool {
 	if len(pod.Status.PodIP) == 0 && len(pod.Status.PodIPs) == 0 {
+		return false
+	}
+
+	if !publishNotReady && pod.DeletionTimestamp != nil {
 		return false
 	}
 

--- a/pkg/controller/util/endpoint/controller_utils_test.go
+++ b/pkg/controller/util/endpoint/controller_utils_test.go
@@ -102,9 +102,10 @@ func TestDetermineNeededServiceUpdates(t *testing.T) {
 // 12 true cases.
 func TestShouldPodBeInEndpoints(t *testing.T) {
 	testCases := []struct {
-		name     string
-		pod      *v1.Pod
-		expected bool
+		name            string
+		pod             *v1.Pod
+		publishNotReady bool
+		expected        bool
 	}{
 		// Pod should not be in endpoints:
 		{
@@ -159,6 +160,23 @@ func TestShouldPodBeInEndpoints(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name: "Terminating Pod",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					PodIP: "1.2.3.4",
+				},
+			},
+			publishNotReady: false,
+			expected:        false,
 		},
 		// Pod should be in endpoints:
 		{
@@ -226,11 +244,28 @@ func TestShouldPodBeInEndpoints(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "Terminating Pod with publish not ready",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					PodIP: "1.2.3.4",
+				},
+			},
+			publishNotReady: true,
+			expected:        true,
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			result := ShouldPodBeInEndpoints(test.pod)
+			result := ShouldPodBeInEndpoints(test.pod, test.publishNotReady)
 			if result != test.expected {
 				t.Errorf("expected: %t, got: %t", test.expected, result)
 			}


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Updates endpointslice controller to treat terminating pods for EndpointSlice the same as Endpoints. The expected behavior for terminating pods based on Endpoints is that a terminating Pod is only included if `service.Spec.PublishNotReadyAddresses` is true  

**Which issue(s) this PR fixes**:
Based on a discussion with @robscott @lbernail  and @thockin https://github.com/kubernetes/kubernetes/pull/88590#discussion_r390379302 

**Special notes for your reviewer**:
There's some ongoing discussion on how we should treat terminating pods in Endpoints and EndpointSlice in https://github.com/kubernetes/enhancements/pull/1607. Until we also change the behavior in Endpoints, we should keep the two consistent. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
EndpointSlice should not contain endpoints for terminating pods
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
