### PR TITLE
Fix autoscale create object not ref to the name flag if present

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/autoscale/autoscale.go
@@ -238,10 +238,11 @@ func (o *AutoscaleOptions) Run() error {
 			return fmt.Errorf("cannot autoscale a %v: %v", mapping.GroupVersionKind.Kind, err)
 		}
 
-		if o.Name == "" {
-			o.Name = info.Name
+		name := o.Name
+		if name == "" {
+			name = info.Name
 		}
-		generator, err := o.generatorFunc(o.Name, info.Name, mapping)
+		generator, err := o.generatorFunc(name, info.Name, mapping)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

If the flag `--name` passing to autoscale command, the created object name does not use the name from `--name` flag, but instead from the name of the input resource.

eg: the following command creates HPA name is `php-apache`, not the user specify name `avg-cpu-util`.
```
kubectl autoscale deployment php-apache \
    --name=avg-cpu-util \
    --min=1 \
    --max=10 \
    --cpu-percent=50
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```
NONE
```

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>