### PR TITLE
Fix empty namespace handling in informer lister

### DIFF
--- a/staging/src/k8s.io/code-generator/_examples/HyphenGroup/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/HyphenGroup/listers/example/v1/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestT
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/MixedCase/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/MixedCase/listers/example/v1/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestT
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example/internalversion/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*example.
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*example.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example/v1/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestT
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example2/v1/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestT
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example3.io/internalversion/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example3.io/internalversion/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*example3
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*example3io.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example3.io/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/apiserver/listers/example3.io/v1/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestT
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/crd/listers/example/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/listers/example/v1/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestT
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/_examples/crd/listers/example2/v1/testtype.go
+++ b/staging/src/k8s.io/code-generator/_examples/crd/listers/example2/v1/testtype.go
@@ -83,7 +83,11 @@ func (s testTypeNamespaceLister) List(selector labels.Selector) (ret []*v1.TestT
 
 // Get retrieves the TestType from the indexer for a given namespace and name.
 func (s testTypeNamespaceLister) Get(name string) (*v1.TestType, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
+++ b/staging/src/k8s.io/code-generator/cmd/lister-gen/generators/lister.go
@@ -356,7 +356,11 @@ func (s $.type|private$NamespaceLister) List(selector labels.Selector) (ret []*$
 var namespaceLister_Get = `
 // Get retrieves the $.type|public$ from the indexer for a given namespace and name.
 func (s $.type|private$NamespaceLister) Get(name string) (*$.type|raw$, error) {
-	obj, exists, err := s.indexer.GetByKey(s.namespace + "/" + name)
+	key := name
+	if s.namespace != "" {
+		key = s.namespace + "/" + name
+	}
+	obj, exists, err := s.indexer.GetByKey(key)
 	if err != nil {
 		return nil, err
 	}

--- a/staging/src/k8s.io/code-generator/go.sum
+++ b/staging/src/k8s.io/code-generator/go.sum
@@ -33,6 +33,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

A generated informer lister can't get created objects with an empty namespace because the keys are not correct.

I made a minimum test case in gist.
https://gist.github.com/dtaniwaki/3e460579005a1051927b3dba86816ad6

**Which issue(s) this PR fixes**:

N/A

**Special notes for your reviewer**:

I'm not sure if this behavior is expected, if so, please just tell me.

**Does this PR introduce a user-facing change?**:

```release-note
Fixed objects with an empty namespace handling in `Get` method of informer lister generated by code-generator.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

N/A