### PR TITLE
Remove endpoints RBAC for Cluster Autoscaler

### DIFF
--- a/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
+++ b/cluster/addons/rbac/cluster-autoscaler/cluster-autoscaler-rbac.yaml
@@ -13,14 +13,6 @@ rules:
     resources: ["leases"]
     resourceNames: ["cluster-autoscaler"]
     verbs: ["get", "update", "patch", "delete"]
-  # TODO: remove in 1.18; CA uses lease objects for leader election since 1.17
-  - apiGroups: [""]
-    resources: ["endpoints"]
-    verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["endpoints"]
-    resourceNames: ["cluster-autoscaler"]
-    verbs: ["get", "update", "patch", "delete"]
   # accessing & modifying cluster state (nodes & pods)
   - apiGroups: [""]
     resources: ["nodes"]


### PR DESCRIPTION
Remove endpoints RBAC for Cluster Autoscaler. Those are no longer needed as Cluster Autoscaler uses "lease" objects since 1.17

/kind cleanup
/priority important-soon

```release-note
NONE
```
