### PR TITLE
Removing ConfigMap as suggestion for IngressClass parameters

### DIFF
--- a/pkg/apis/networking/types.go
+++ b/pkg/apis/networking/types.go
@@ -297,10 +297,9 @@ type IngressClassSpec struct {
 	// "acme.io/ingress-controller". This field is immutable.
 	Controller string
 
-	// Parameters is a link to a resource containing additional configuration
-	// for the controller. This is optional if the controller does not require
-	// extra parameters. Example configuration resources include
-	// `core.ConfigMap` or a controller specific Custom Resource.
+	// Parameters is a link to a custom resource containing additional
+	// configuration for the controller. This is optional if the controller does
+	// not require extra parameters.
 	// +optional
 	Parameters *api.TypedLocalObjectReference
 }

--- a/staging/src/k8s.io/api/networking/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/networking/v1beta1/generated.proto
@@ -148,10 +148,9 @@ message IngressClassSpec {
   // "acme.io/ingress-controller". This field is immutable.
   optional string controller = 1;
 
-  // Parameters is a link to a resource containing additional configuration
-  // for the controller. This is optional if the controller does not require
-  // extra parameters. Example configuration resources include
-  // `core.ConfigMap` or a controller specific Custom Resource.
+  // Parameters is a link to a custom resource containing additional
+  // configuration for the controller. This is optional if the controller does
+  // not require extra parameters.
   // +optional
   optional k8s.io.api.core.v1.TypedLocalObjectReference parameters = 2;
 }

--- a/staging/src/k8s.io/api/networking/v1beta1/types.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types.go
@@ -298,10 +298,9 @@ type IngressClassSpec struct {
 	// "acme.io/ingress-controller". This field is immutable.
 	Controller string `json:"controller,omitempty" protobuf:"bytes,1,opt,name=controller"`
 
-	// Parameters is a link to a resource containing additional configuration
-	// for the controller. This is optional if the controller does not require
-	// extra parameters. Example configuration resources include
-	// `core.ConfigMap` or a controller specific Custom Resource.
+	// Parameters is a link to a custom resource containing additional
+	// configuration for the controller. This is optional if the controller does
+	// not require extra parameters.
 	// +optional
 	Parameters *v1.TypedLocalObjectReference `json:"parameters,omitempty" protobuf:"bytes,2,opt,name=parameters"`
 }

--- a/staging/src/k8s.io/api/networking/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/networking/v1beta1/types_swagger_doc_generated.go
@@ -92,7 +92,7 @@ func (IngressClassList) SwaggerDoc() map[string]string {
 var map_IngressClassSpec = map[string]string{
 	"":           "IngressClassSpec provides information about the class of an Ingress.",
 	"controller": "Controller refers to the name of the controller that should handle this class. This allows for different \"flavors\" that are controlled by the same controller. For example, you may have different Parameters for the same implementing controller. This should be specified as a domain-prefixed path no more than 250 characters in length, e.g. \"acme.io/ingress-controller\". This field is immutable.",
-	"parameters": "Parameters is a link to a resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters. Example configuration resources include `core.ConfigMap` or a controller specific Custom Resource.",
+	"parameters": "Parameters is a link to a custom resource containing additional configuration for the controller. This is optional if the controller does not require extra parameters.",
 }
 
 func (IngressClassSpec) SwaggerDoc() map[string]string {


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
As this is a a local object reference from a global object, referencing a ConfigMap would not be possible. Controller specific custom resources are a much better fit here, allowing for better validation.

**Special notes for your reviewer**:
I'd like to get this into the 1.18 milestone if possible. This is just a docs change, but could help avoid some confusion.

**Does this PR introduce a user-facing change?**:
```release-note
Removes ConfigMap as suggestion for IngressClass parameters
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
* Enhancement Issue: https://github.com/kubernetes/enhancements/issues/1453

/sig network
/cc @cmluciano 
/assign @bowei @liggitt 