### PR TITLE
Bump Cluster-Autoscaler to 1.18.0

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.18.0-beta.1",
+                "image": "k8s.gcr.io/cluster-autoscaler:v1.18.0",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update version of Cluster Autoscaler to final 1.18.0.

/kind bug
/priority critical-urgent
/sig autoscaling
/assign @mwielgus

```release-note
Update Cluster Autoscaler to 1.18.0; changelog: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.18.0
```
