### PR TITLE
Fix unbound variable error in gce/configure.sh

### DIFF
--- a/cluster/gce/gci/configure.sh
+++ b/cluster/gce/gci/configure.sh
@@ -498,7 +498,7 @@ function ensure-container-runtime {
     docker version
   elif [[ "${container_runtime}" == "containerd" ]]; then
     # Install containerd/runc if requested
-    if [[ ! -z "${UBUNTU_INSTALL_CONTAINERD_VERSION:-}" || ! -z "${UBUNTU_INSTALL_RUNC_VERSION}" ]]; then
+    if [[ ! -z "${UBUNTU_INSTALL_CONTAINERD_VERSION:-}" || ! -z "${UBUNTU_INSTALL_RUNC_VERSION:-}" ]]; then
       install-containerd-ubuntu
     fi
     # Verify presence and print versions of ctr, containerd, runc


### PR DESCRIPTION
Error:

```
kubernetes/bin/configure.sh: line 501: UBUNTU_INSTALL_RUNC_VERSION: unbound variable
```

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix the bug.

```release-note
NONE
```

/priority important-soon
