### PR TITLE
Decouple yaml based integration test from legacy test

### DIFF
--- a/test/integration/scheduler_perf/BUILD
+++ b/test/integration/scheduler_perf/BUILD
@@ -15,6 +15,7 @@ go_library(
     importpath = "k8s.io/kubernetes/test/integration/scheduler_perf",
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/client-go/informers/core/v1:go_default_library",
@@ -23,6 +24,7 @@ go_library(
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
         "//test/integration/util:go_default_library",
+        "//test/utils:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -32,7 +34,7 @@ go_test(
     size = "large",
     srcs = [
         "main_test.go",
-        "scheduler_bench_test.go",
+        "scheduler_perf_legacy_test.go",
         "scheduler_perf_test.go",
         "scheduler_test.go",
     ],

--- a/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
+++ b/test/integration/scheduler_perf/scheduler_perf_legacy_test.go
@@ -50,8 +50,6 @@ var (
 		{nodes: 600, existingPods: 10000, minPods: 1000},
 		{nodes: 5000, existingPods: 5000, minPods: 1000},
 	}
-	testNamespace  = "sched-test"
-	setupNamespace = "sched-setup"
 )
 
 // BenchmarkScheduling benchmarks the scheduling rate when the cluster has
@@ -521,17 +519,6 @@ func makeBasePodWithSecret() *v1.Pod {
 		},
 	}
 	basePod.Spec.Volumes = volumes
-	return basePod
-}
-
-// makeBasePod creates a Pod object to be used as a template.
-func makeBasePod() *v1.Pod {
-	basePod := &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "pod-",
-		},
-		Spec: testutils.MakePodSpec(),
-	}
 	return basePod
 }
 

--- a/test/integration/scheduler_perf/util.go
+++ b/test/integration/scheduler_perf/util.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	coreinformers "k8s.io/client-go/informers/core/v1"
@@ -36,10 +37,13 @@ import (
 	"k8s.io/component-base/metrics/testutil"
 	"k8s.io/klog"
 	"k8s.io/kubernetes/test/integration/util"
+	testutils "k8s.io/kubernetes/test/utils"
 )
 
 const (
 	dateFormat                = "2006-01-02T15:04:05Z"
+	testNamespace             = "sched-test"
+	setupNamespace            = "sched-setup"
 	throughputSampleFrequency = time.Second
 )
 
@@ -104,6 +108,17 @@ type DataItem struct {
 type DataItems struct {
 	Version   string     `json:"version"`
 	DataItems []DataItem `json:"dataItems"`
+}
+
+// makeBasePod creates a Pod object to be used as a template.
+func makeBasePod() *v1.Pod {
+	basePod := &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "pod-",
+		},
+		Spec: testutils.MakePodSpec(),
+	}
+	return basePod
 }
 
 func dataItems2JSONFile(dataItems DataItems, namePrefix string) error {


### PR DESCRIPTION
- Move utilities and constants out so that both of them should be able
to run independently.
- Rename the legacy test so that it can eventually be deleted when the
perf dash changes is done



There are two approaches to run `scheduler_perf` testcases with different ways to define the test spec, both of them could be able to run independently.

- test spec is defined in the yaml
```performance-config.yaml
- template:
    desc: SchedulingPodAntiAffinity
    nodes:
      uniqueNodeLabelStrategy:
        labelKey: kubernetes.io/hostname
    initPods:
      podTemplatePath: config/pod-with-pod-anti-affinity.yaml
    podsToSchedule:
      podTemplatePath: config/pod-with-pod-anti-affinity.yaml
  params:
    - numNodes: 500
      numInitPods: 100
      numPodsToSchedule: 400
    - numNodes: 5000
      numInitPods: 1000
      numPodsToSchedule: 1000
```
- test spec is defined in the golang source.

```scheduler_bench_test.go
func BenchmarkSchedulingPodAntiAffinity(b *testing.B) {
	// Since the pods has anti affinity to each other, the number of pods to schedule
	// can't exceed the number of nodes (the topology used in the test)
	tests := []struct{ nodes, existingPods, minPods int }{
		{nodes: 500, existingPods: 100, minPods: 400},
		{nodes: 5000, existingPods: 1000, minPods: 1000},
	}
       ...
}
```
The second one becomes duplicated along with the merge of defining the test spec in the yaml file. There is no need to maintain both of them in the code base, this change refactor the code to decouple one from the other and drop the support of the legacy way to run the  `scheduler_perf`.



<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind cleanup


**What this PR does / why we need it**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
