### PR TITLE
test images: Adds various fixes and cleanups to the image building process

### DIFF
--- a/test/images/kitten/Dockerfile
+++ b/test/images/kitten/Dockerfile
@@ -16,3 +16,4 @@ ARG BASEIMAGE
 FROM $BASEIMAGE
 COPY html/kitten.jpg kitten.jpg
 COPY html/data.json data.json
+CMD ["test-webserver"]

--- a/test/images/nautilus/Dockerfile
+++ b/test/images/nautilus/Dockerfile
@@ -16,3 +16,4 @@ ARG BASEIMAGE
 FROM $BASEIMAGE
 COPY html/nautilus.jpg nautilus.jpg
 COPY html/data.json data.json
+CMD ["test-webserver"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug
/kind cleanup

/sig windows
/sig testing

**What this PR does / why we need it**:

Adds ``splitOsArch`` function to ``image-util.sh``, which makes the script DRY-er.

When building a Windows test image, if ``REMOTE_DOCKER_URL`` is not set, skip the rest of the building process for that image, which will save some time (no need to build binaries).

If a ``REMOTE_DOCKER_URL`` was not set for a particular OS version, exclude that image from the
manifest list. This fixes an issue where, if ``REMOTE_DOCKER_URL`` was not set for Windows Server 1909, the Windows were completely excluded from the manifest list, including for Windows Server 1809 and 1903 which could have been built and pushed.

Sets ``test-webserver`` as the default CMD for ``kitten`` and ``nautilus``. Since they are now based on ``agnhost``, they should be set to run ``test-webserver`` to maintain previous behaviour.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
