### PR TITLE
Automated cherry pick of #87980: EndpointSliceTracker should track updated resource version #89056: EndpointSlice and Endpoints should treat terminating pods the

### DIFF
--- a/pkg/controller/endpointslice/reconciler.go
+++ b/pkg/controller/endpointslice/reconciler.go
@@ -205,7 +205,7 @@ func (r *reconciler) finalize(
 
 	for _, endpointSlice := range slicesToCreate {
 		addTriggerTimeAnnotation(endpointSlice, triggerTime)
-		_, err := r.client.DiscoveryV1beta1().EndpointSlices(service.Namespace).Create(endpointSlice)
+		createdSlice, err := r.client.DiscoveryV1beta1().EndpointSlices(service.Namespace).Create(endpointSlice)
 		if err != nil {
 			// If the namespace is terminating, creates will continue to fail. Simply drop the item.
 			if errors.HasStatusCause(err, corev1.NamespaceTerminatingCause) {
@@ -213,18 +213,18 @@ func (r *reconciler) finalize(
 			}
 			errs = append(errs, fmt.Errorf("Error creating EndpointSlice for Service %s/%s: %v", service.Namespace, service.Name, err))
 		} else {
-			r.endpointSliceTracker.Update(endpointSlice)
+			r.endpointSliceTracker.Update(createdSlice)
 			metrics.EndpointSliceChanges.WithLabelValues("create").Inc()
 		}
 	}
 
 	for _, endpointSlice := range slicesToUpdate {
 		addTriggerTimeAnnotation(endpointSlice, triggerTime)
-		_, err := r.client.DiscoveryV1beta1().EndpointSlices(service.Namespace).Update(endpointSlice)
+		updatedSlice, err := r.client.DiscoveryV1beta1().EndpointSlices(service.Namespace).Update(endpointSlice)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("Error updating %s EndpointSlice for Service %s/%s: %v", endpointSlice.Name, service.Namespace, service.Name, err))
 		} else {
-			r.endpointSliceTracker.Update(endpointSlice)
+			r.endpointSliceTracker.Update(updatedSlice)
 			metrics.EndpointSliceChanges.WithLabelValues("update").Inc()
 		}
 	}

--- a/pkg/controller/endpointslice/reconciler_test.go
+++ b/pkg/controller/endpointslice/reconciler_test.go
@@ -61,6 +61,7 @@ func TestReconcileEmpty(t *testing.T) {
 	assert.Equal(t, svc.Name, slices[0].Labels[discovery.LabelServiceName])
 	assert.EqualValues(t, []discovery.EndpointPort{}, slices[0].Ports)
 	assert.EqualValues(t, []discovery.Endpoint{}, slices[0].Endpoints)
+	expectTrackedResourceVersion(t, r.endpointSliceTracker, &slices[0], "100")
 	expectMetrics(t, expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 0, addedPerSync: 0, removedPerSync: 0, numCreated: 1, numUpdated: 0, numDeleted: 0})
 }
 
@@ -189,6 +190,8 @@ func TestReconcile1Pod(t *testing.T) {
 				t.Errorf("Expected endpoint: %+v, got: %+v", testCase.expectedEndpoint, endpoint)
 			}
 
+			expectTrackedResourceVersion(t, r.endpointSliceTracker, &slice, "100")
+
 			expectMetrics(t, expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 1, addedPerSync: 1, removedPerSync: 0, numCreated: 1, numUpdated: 0, numDeleted: 0})
 		})
 	}
@@ -220,6 +223,7 @@ func TestReconcile1EndpointSlice(t *testing.T) {
 	assert.Equal(t, svc.Name, slices[0].Labels[discovery.LabelServiceName])
 	assert.EqualValues(t, []discovery.EndpointPort{}, slices[0].Ports)
 	assert.EqualValues(t, []discovery.Endpoint{}, slices[0].Endpoints)
+	expectTrackedResourceVersion(t, r.endpointSliceTracker, &slices[0], "200")
 	expectMetrics(t, expectedMetrics{desiredSlices: 1, actualSlices: 1, desiredEndpoints: 0, addedPerSync: 0, removedPerSync: 0, numCreated: 0, numUpdated: 1, numDeleted: 0})
 }
 
@@ -817,6 +821,17 @@ func expectActions(t *testing.T, actions []k8stesting.Action, num int, verb, res
 		relativePos := len(actions) - i - 1
 		assert.Equal(t, verb, actions[relativePos].GetVerb(), "Expected action -%d verb to be %s", i, verb)
 		assert.Equal(t, resource, actions[relativePos].GetResource().Resource, "Expected action -%d resource to be %s", i, resource)
+	}
+}
+
+func expectTrackedResourceVersion(t *testing.T, tracker *endpointSliceTracker, slice *discovery.EndpointSlice, expectedRV string) {
+	rrv := tracker.relatedResourceVersions(slice)
+	rv, tracked := rrv[slice.Name]
+	if !tracked {
+		t.Fatalf("Expected EndpointSlice %s to be tracked", slice.Name)
+	}
+	if rv != expectedRV {
+		t.Errorf("Expected ResourceVersion of %s to be %s, got %s", slice.Name, expectedRV, rv)
 	}
 }
 

--- a/pkg/controller/endpointslice/utils_test.go
+++ b/pkg/controller/endpointslice/utils_test.go
@@ -401,7 +401,13 @@ func newClientset() *fake.Clientset {
 			endpointSlice.ObjectMeta.Name = fmt.Sprintf("%s-%s", endpointSlice.ObjectMeta.GenerateName, rand.String(8))
 			endpointSlice.ObjectMeta.GenerateName = ""
 		}
+		endpointSlice.ObjectMeta.ResourceVersion = "100"
 
+		return false, endpointSlice, nil
+	}))
+	client.PrependReactor("update", "endpointslices", k8stesting.ReactionFunc(func(action k8stesting.Action) (bool, runtime.Object, error) {
+		endpointSlice := action.(k8stesting.CreateAction).GetObject().(*discovery.EndpointSlice)
+		endpointSlice.ObjectMeta.ResourceVersion = "200"
 		return false, endpointSlice, nil
 	}))
 

--- a/pkg/controller/util/endpoint/controller_utils.go
+++ b/pkg/controller/util/endpoint/controller_utils.go
@@ -126,9 +126,13 @@ func DeepHashObjectToString(objectToWrite interface{}) string {
 }
 
 // ShouldPodBeInEndpoints returns true if a specified pod should be in an
-// endpoints object.
-func ShouldPodBeInEndpoints(pod *v1.Pod) bool {
+// endpoints object. Terminating pods are only included if publishNotReady is true.
+func ShouldPodBeInEndpoints(pod *v1.Pod, publishNotReady bool) bool {
 	if len(pod.Status.PodIP) == 0 && len(pod.Status.PodIPs) == 0 {
+		return false
+	}
+
+	if !publishNotReady && pod.DeletionTimestamp != nil {
 		return false
 	}
 

--- a/pkg/controller/util/endpoint/controller_utils_test.go
+++ b/pkg/controller/util/endpoint/controller_utils_test.go
@@ -102,9 +102,10 @@ func TestDetermineNeededServiceUpdates(t *testing.T) {
 // 12 true cases.
 func TestShouldPodBeInEndpoints(t *testing.T) {
 	testCases := []struct {
-		name     string
-		pod      *v1.Pod
-		expected bool
+		name            string
+		pod             *v1.Pod
+		publishNotReady bool
+		expected        bool
 	}{
 		// Pod should not be in endpoints:
 		{
@@ -159,6 +160,23 @@ func TestShouldPodBeInEndpoints(t *testing.T) {
 				},
 			},
 			expected: false,
+		},
+		{
+			name: "Terminating Pod",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					PodIP: "1.2.3.4",
+				},
+			},
+			publishNotReady: false,
+			expected:        false,
 		},
 		// Pod should be in endpoints:
 		{
@@ -226,11 +244,28 @@ func TestShouldPodBeInEndpoints(t *testing.T) {
 			},
 			expected: true,
 		},
+		{
+			name: "Terminating Pod with publish not ready",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					DeletionTimestamp: &metav1.Time{
+						Time: time.Now(),
+					},
+				},
+				Spec: v1.PodSpec{},
+				Status: v1.PodStatus{
+					Phase: v1.PodRunning,
+					PodIP: "1.2.3.4",
+				},
+			},
+			publishNotReady: true,
+			expected:        true,
+		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.name, func(t *testing.T) {
-			result := ShouldPodBeInEndpoints(test.pod)
+			result := ShouldPodBeInEndpoints(test.pod, test.publishNotReady)
 			if result != test.expected {
 				t.Errorf("expected: %t, got: %t", test.expected, result)
 			}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Cherry pick of #87980 #89056 on release-1.17.

#87980: EndpointSliceTracker should track updated resource version
#89056: EndpointSlice and Endpoints should treat terminating pods the

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

**Does this PR introduce a user-facing change?**:
```release-note
EndpointSlice controller now handles terminating pods correctly and is better at preventing race conditions.
```

/sig network
/priority important-soon