### PR TITLE
Use utils.net to parse ports instead of atoi

### DIFF
--- a/cmd/kubeadm/app/util/BUILD
+++ b/cmd/kubeadm/app/util/BUILD
@@ -36,6 +36,7 @@ go_library(
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/exec:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/cmd/kubeadm/app/util/endpoint.go
+++ b/cmd/kubeadm/app/util/endpoint.go
@@ -26,6 +26,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/validation"
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
+	utilsnet "k8s.io/utils/net"
 )
 
 // GetControlPlaneEndpoint returns a properly formatted endpoint for the control plane built according following rules:
@@ -115,7 +116,7 @@ func ParseHostPort(hostport string) (string, string, error) {
 // ParsePort parses a string representing a TCP port.
 // If the string is not a valid representation of a TCP port, ParsePort returns an error.
 func ParsePort(port string) (int, error) {
-	portInt, err := strconv.Atoi(port)
+	portInt, err := utilsnet.ParsePort(port, true)
 	if err == nil && (1 <= portInt && portInt <= 65535) {
 		return portInt, nil
 	}

--- a/pkg/registry/core/rest/BUILD
+++ b/pkg/registry/core/rest/BUILD
@@ -62,6 +62,7 @@ go_library(
         "//staging/src/k8s.io/client-go/kubernetes/typed/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -21,7 +21,6 @@ import (
 	"net"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
@@ -66,6 +65,7 @@ import (
 	serviceaccountstore "k8s.io/kubernetes/pkg/registry/core/serviceaccount/storage"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/serviceaccount"
+	utilsnet "k8s.io/utils/net"
 )
 
 // LegacyRESTStorageProvider provides information needed to build RESTStorage for core, but
@@ -360,7 +360,7 @@ func (s componentStatusStorage) serversToValidate() map[string]*componentstatus.
 				klog.Errorf("Failed to split host/port: %s (%v)", etcdUrl.Host, err)
 				continue
 			}
-			port, _ = strconv.Atoi(portString)
+			port, _ = utilsnet.ParsePort(portString, true)
 		} else {
 			addr = etcdUrl.Host
 			port = 2379

--- a/pkg/util/flag/BUILD
+++ b/pkg/util/flag/BUILD
@@ -14,6 +14,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/util/flag/flags.go
+++ b/pkg/util/flag/flags.go
@@ -19,12 +19,12 @@ package flag
 import (
 	"fmt"
 	"net"
-	"strconv"
 
 	"github.com/spf13/pflag"
 	"k8s.io/klog"
 
 	utilnet "k8s.io/apimachinery/pkg/util/net"
+	utilsnet "k8s.io/utils/net"
 )
 
 // PrintFlags logs the flags in the flagset
@@ -109,7 +109,7 @@ func (v IPPortVar) Set(s string) error {
 	if net.ParseIP(host) == nil {
 		return fmt.Errorf("%q is not a valid IP address", host)
 	}
-	if _, err := strconv.Atoi(port); err != nil {
+	if _, err := utilsnet.ParsePort(port, true); err != nil {
 		return fmt.Errorf("%q is not a valid number", port)
 	}
 	*v.Val = s

--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -66,6 +66,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/klog"
 	openapicommon "k8s.io/kube-openapi/pkg/common"
+	utilsnet "k8s.io/utils/net"
 
 	// install apis
 	_ "k8s.io/apiserver/pkg/apis/apiserver/install"
@@ -731,7 +732,7 @@ func (s *SecureServingInfo) HostPort() (string, int, error) {
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to get port from listener address %q: %v", addr, err)
 	}
-	port, err := strconv.Atoi(portStr)
+	port, err := utilsnet.ParsePort(portStr, true)
 	if err != nil {
 		return "", 0, fmt.Errorf("invalid non-numeric port %q", portStr)
 	}

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/BUILD
@@ -47,6 +47,7 @@ go_library(
         "//staging/src/k8s.io/kubectl/pkg/generate:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/util/hash:go_default_library",
+        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/kubectl/pkg/generate"
+	utilsnet "k8s.io/utils/net"
 )
 
 type ServiceCommonGeneratorV1 struct {
@@ -86,13 +87,9 @@ func (ServiceExternalNameGeneratorV1) ParamNames() []generate.GeneratorParam {
 func parsePorts(portString string) (int32, intstr.IntOrString, error) {
 	portStringSlice := strings.Split(portString, ":")
 
-	port, err := strconv.Atoi(portStringSlice[0])
+	port, err := utilsnet.ParsePort(portStringSlice[0], true)
 	if err != nil {
 		return 0, intstr.FromInt(0), err
-	}
-
-	if errs := validation.IsValidPortNum(port); len(errs) != 0 {
-		return 0, intstr.FromInt(0), fmt.Errorf(strings.Join(errs, ","))
 	}
 
 	if len(portStringSlice) == 1 {

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic_test.go
@@ -175,7 +175,12 @@ func TestParsePorts(t *testing.T) {
 			portString:       "-5:1234",
 			expectPort:       0,
 			expectTargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 0},
-			expectErr:        "must be between 1 and 65535, inclusive",
+			expectErr:        "parsing \"-5\": invalid syntax",
+		},
+		{
+			portString:       "0:1234",
+			expectPort:       0,
+			expectTargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: 1234},
 		},
 		{
 			portString:       "5:65536",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug


**What this PR does / why we need it**:

The strconv.Atoi function parses an int - a machine dependent integer type, which, for 64-bit targets will be int64. There are places throughout the codebase where the result returned from strconv.Atoi is later converted to a smaller type: int16 or int32. This may overflow with a certain input.

Updated files:

```
cmd/kubeadm/app/util/endpoint.go
pkg/registry/core/rest/storage_core.go
pkg/util/flag/flags.go
staging/src/k8s.io/apiserver/pkg/server/config.go
staging/src/k8s.io/kubectl/pkg/generate/versioned/service_basic.go

```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Xref #81121

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
