### PR TITLE
Add stable metric validation as standard verify

### DIFF
--- a/hack/update-stable-metrics.sh
+++ b/hack/update-stable-metrics.sh
@@ -18,17 +18,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 BAZEL_OUT_DIR="$KUBE_ROOT/bazel-bin"
-BAZEL_GEN_DIR="$KUBE_ROOT/bazel-genfiles"
 METRICS_LIST_PATH="test/instrumentation/stable-metrics-list.yaml"
 
 bazel build //test/instrumentation:list_stable_metrics
-if [ -d "$BAZEL_OUT_DIR" ]; then
-  cp "$BAZEL_OUT_DIR/$METRICS_LIST_PATH" "$KUBE_ROOT/test/instrumentation/testdata/stable-metrics-list.yaml"
-else
-  # Handle bazel < 0.25
-  # https://github.com/bazelbuild/bazel/issues/6761
-  echo "$BAZEL_OUT_DIR not found trying $BAZEL_GEN_DIR"
-  cp "$BAZEL_GEN_DIR/$METRICS_LIST_PATH" "$KUBE_ROOT/test/instrumentation/testdata/stable-metrics-list.yaml"
-fi
+cp "$BAZEL_OUT_DIR/$METRICS_LIST_PATH" "$KUBE_ROOT/test/instrumentation/testdata/stable-metrics-list.yaml"

--- a/hack/verify-stable-metrics.sh
+++ b/hack/verify-stable-metrics.sh
@@ -15,31 +15,16 @@
 
 
 set -o errexit
+set -o nounset
 set -o pipefail
 
-KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/../..
+KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 BAZEL_OUT_DIR="$KUBE_ROOT/bazel-bin"
-BAZEL_GEN_DIR="$KUBE_ROOT/bazel-genfiles"
 METRICS_LIST_PATH="test/instrumentation/stable-metrics-list.yaml"
+OUTPUT_FILE="$BAZEL_OUT_DIR/$METRICS_LIST_PATH"
 
-# detect if run from bazel
-if [ -z "${TEST_BINARY}" ]; then
-  bazel build //test/instrumentation:list_stable_metrics
-
-  if [ -d "$BAZEL_OUT_DIR" ]; then
-    OUTPUT_FILE="$BAZEL_OUT_DIR/$METRICS_LIST_PATH"
-  else
-    # Handle bazel < 0.25
-    # https://github.com/bazelbuild/bazel/issues/6761
-    OUTPUT_FILE="$BAZEL_GEN_DIR/$METRICS_LIST_PATH"
-  fi
-else
-  OUTPUT_FILE="$KUBE_ROOT/$METRICS_LIST_PATH"
+bazel build //test/instrumentation:list_stable_metrics
+if ! diff -u "$KUBE_ROOT/test/instrumentation/testdata/stable-metrics-list.yaml" "$OUTPUT_FILE"; then
+  echo 'Run ./hack/update-stable-metrics.sh'
+  exit 1
 fi
-
-if diff -u "$KUBE_ROOT/test/instrumentation/testdata/stable-metrics-list.yaml" "$OUTPUT_FILE"; then
-  echo PASS
-  exit 0
-fi
-echo 'Diffs in stable metrics detected, please run "test/instrumentation/update-stable-metrics.sh"'
-exit 1

--- a/test/instrumentation/BUILD
+++ b/test/instrumentation/BUILD
@@ -48,15 +48,6 @@ genrule(
     tools = [":instrumentation"],
 )
 
-sh_test(
-    name = "verify_stable_metric",
-    srcs = ["verify-stable-metrics.sh"],
-    data = [
-        "testdata/stable-metrics-list.yaml",
-        ":list_stable_metrics",
-    ],
-)
-
 go_test(
     name = "go_default_test",
     srcs = ["main_test.go"],

--- a/test/instrumentation/README.md
+++ b/test/instrumentation/README.md
@@ -7,7 +7,7 @@ require review by sig-instrumentation.
 To update the list, run
 
 ```console
-./update-stable-metrics.sh
+./hack/update-stable-metrics.sh
 ```
 
 Add the changed file to your PR, then send for review.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
PR proposes to move validation that was implemented in [Metrics Verification and Validation](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-validation-and-verification.md) as standard verify.

This validation was already running for half a year as a test without any problems.

/cc @logicalhan 

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/20190605-metrics-validation-and-verification.md
```
/sig instrumentation