### PR TITLE
Fix isCurrentInstance for Windows by removing the dependency of hostname

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances.go
@@ -21,7 +21,7 @@ package azure
 import (
 	"context"
 	"fmt"
-	"os"
+	"strconv"
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
@@ -231,18 +231,22 @@ func (az *Cloud) InstanceShutdownByProviderID(ctx context.Context, providerID st
 }
 
 func (az *Cloud) isCurrentInstance(name types.NodeName, metadataVMName string) (bool, error) {
-	var err error
 	nodeName := mapNodeNameToVMName(name)
+
 	if az.VMType == vmTypeVMSS {
-		// VMSS vmName is not same with hostname, use hostname instead.
-		metadataVMName, err = os.Hostname()
-		if err != nil {
-			return false, err
+		// VMSS vmName is not same with hostname, construct the node name "{computer-name-prefix}{base-36-instance-id}".
+		// Refer https://docs.microsoft.com/en-us/azure/virtual-machine-scale-sets/virtual-machine-scale-sets-instance-ids#scale-set-vm-computer-name.
+		if ssName, instanceID, err := extractVmssVMName(metadataVMName); err == nil {
+			instance, err := strconv.ParseInt(instanceID, 10, 64)
+			if err != nil {
+				return false, fmt.Errorf("failed to parse VMSS instanceID %q: %v", instanceID, err)
+			}
+			metadataVMName = fmt.Sprintf("%s%06s", ssName, strconv.FormatInt(instance, 36))
 		}
 	}
 
 	metadataVMName = strings.ToLower(metadataVMName)
-	return (metadataVMName == nodeName), err
+	return (metadataVMName == nodeName), nil
 }
 
 // InstanceID returns the cloud provider ID of the specified instance.

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_instances_test.go
@@ -361,3 +361,56 @@ func TestNodeAddresses(t *testing.T) {
 		}
 	}
 }
+
+func TestIsCurrentInstance(t *testing.T) {
+	cloud := &Cloud{
+		Config: Config{
+			VMType: vmTypeVMSS,
+		},
+	}
+	testcases := []struct {
+		nodeName       string
+		metadataVMName string
+		expected       bool
+		expectError    bool
+	}{
+		{
+			nodeName:       "node1",
+			metadataVMName: "node1",
+			expected:       true,
+		},
+		{
+			nodeName:       "node1",
+			metadataVMName: "node2",
+			expected:       false,
+		},
+		{
+			nodeName:       "vmss000001",
+			metadataVMName: "vmss_1",
+			expected:       true,
+		},
+		{
+			nodeName:       "vmss_2",
+			metadataVMName: "vmss000000",
+			expected:       false,
+		},
+		{
+			nodeName:       "vmss123456",
+			metadataVMName: "vmss_$123",
+			expected:       false,
+			expectError:    true,
+		},
+	}
+
+	for i, test := range testcases {
+		real, err := cloud.isCurrentInstance(types.NodeName(test.nodeName), test.metadataVMName)
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Test[%d] unexpected nil err", i)
+			}
+		}
+		if real != test.expected {
+			t.Errorf("Test[%d] unexpected isCurrentInstance result %v != %v", i, real, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug 

**What this PR does / why we need it**:

Azure cloud provider Instances interfaces don't work expected on Windows containers. This is because Windows containers don't support HostNetwork mode, while Azure cloud provider depends on "os.Hostname()" to check whether the VMName from IMDS is same with NodeName.

This PR fixes `isCurrentInstance` for Windows by removing the dependency of hostname.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89137

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix isCurrentInstance for Windows by removing the dependency of hostname.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig cloud-provider
/priority critical-urgent
/area provider/azure
/assign @andyzhangx 