### PR TITLE
apiextensions: wait for complete discovery endpoint

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_discovery_controller.go
@@ -201,7 +201,7 @@ func sortGroupDiscoveryByKubeAwareVersion(gd []metav1.GroupVersionForDiscovery) 
 	})
 }
 
-func (c *DiscoveryController) Run(stopCh <-chan struct{}) {
+func (c *DiscoveryController) Run(stopCh <-chan struct{}, synchedCh chan<- struct{}) {
 	defer utilruntime.HandleCrash()
 	defer c.queue.ShutDown()
 	defer klog.Infof("Shutting down DiscoveryController")
@@ -212,6 +212,31 @@ func (c *DiscoveryController) Run(stopCh <-chan struct{}) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for caches to sync"))
 		return
 	}
+
+	// initially sync all group versions to make sure we serve complete discovery
+	if err := wait.PollImmediateUntil(time.Second, func() (bool, error) {
+		crds, err := c.crdLister.List(labels.Everything())
+		if err != nil {
+			utilruntime.HandleError(fmt.Errorf("failed to initially list CRDs: %v", err))
+			return false, nil
+		}
+		for _, crd := range crds {
+			for _, v := range crd.Spec.Versions {
+				gv := schema.GroupVersion{crd.Spec.Group, v.Name}
+				if err := c.sync(gv); err != nil {
+					utilruntime.HandleError(fmt.Errorf("failed to initially sync CRD version %v: %v", gv, err))
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	}, stopCh); err == wait.ErrWaitTimeout {
+		utilruntime.HandleError(fmt.Errorf("timed out waiting for discovery endpoint to initialize"))
+		return
+	} else if err != nil {
+		panic(fmt.Errorf("unexpected error: %v", err))
+	}
+	close(synchedCh)
 
 	// only start one worker thread since its a slow moving API
 	go wait.Until(c.runWorker, time.Second, stopCh)


### PR DESCRIPTION
/kind bug

The discovery endpoint is driven by an informer. During startup it adds CRDs asynchronously (in contrast to the main handler endpoint which is complete as soon as the lister has synched). As a consequence the discovery endpoint might be incomplete for a short period of time when the server starts up. This PR adds an explicit wait until all CRD version have been added to discovery.

```release-note
Wait for all CRDs to show up in discovery endpoint before reporting readiness.
```