### PR TITLE
manager#syncPod should cover reconciliation

### DIFF
--- a/pkg/kubelet/status/status_manager_test.go
+++ b/pkg/kubelet/status/status_manager_test.go
@@ -127,7 +127,7 @@ func (m *manager) consumeUpdates() int {
 	for {
 		select {
 		case syncRequest := <-m.podStatusChannel:
-			m.syncPod(syncRequest.podUID, syncRequest.status)
+			m.syncPod(syncRequest.podUID, syncRequest.status, true)
 			updates++
 		default:
 			return updates


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Please see related discussion (around issue #80968): https://github.com/kubernetes/kubernetes/pull/88255#issuecomment-587231603

@yujuhong 's question led me to thinking about whether reconciliation may miss some case.

For the following code in manager#syncBatch :
```
				delete(m.apiStatusVersions, syncedUID)
				updatedStatuses = append(updatedStatuses, podStatusSyncRequest{uid, status})
```
Please note that syncedUID and uid may carry different values.
With this additional log,
```
@@ -517,33 +521,37 @@ func (m *manager) syncBatch() {
                                        continue
                                }
                                syncedUID = mirrorUID
+                               klog.Infof("assigned syncedUID %q uid %q", syncedUID, uid)
                        }
```
Here is one example:
```
I0710 02:47:35.039903    9058 config.go:383] Receiving a new pod "kube-proxy-e2e-9e17d10a0f-a7d53-minion-group-32vz_kube-system(de2df129-bfbd-4c48-90b1-06d49400dad0)"
I0710 02:47:35.040140    9058 kubelet.go:1817] SyncLoop (ADD, "api"): "kube-proxy-e2e-9e17d10a0f-a7d53-minion-group-32vz_kube-system(de2df129-bfbd-4c48-90b1-06d49400dad0)"
...
I0710 02:47:42.007051    9058 status_manager.go:524] assigned syncedUID "de2df129-bfbd-4c48-90b1-06d49400dad0" uid "b31ab15bb4ea18d79cf1cfa40fe53c82"
```

Please note that, in current code, if m.needsUpdate returns false, syncPod() would return early.
However, this may not work with the reconciliation code path (the UID used to check presence in apiStatusVersions in syncPod may be different from the one whose entry is cleared in syncBatch).

This PR allows manager#syncPod to perform reconciliation. Without this change, reconciliation may be skipped (when syncedUID and uid differ).

See https://github.com/kubernetes/kubernetes/pull/88255#issuecomment-599688624 from @byxorna 

Note: another potential fix is to remove uid from apiStatusVersions in manager#syncBatch but this is not as robust as the current fix.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
