### PR TITLE
Fix data race issue in unit test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher_whitebox_test.go
@@ -793,7 +793,7 @@ func TestDispatchingBookmarkEventsWithConcurrentStop(t *testing.T) {
 		wg := sync.WaitGroup{}
 		wg.Add(2)
 		go func() {
-			cacher.dispatchEvent(bookmark)
+			cacher.processEvent(bookmark)
 			wg.Done()
 		}()
 


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation

/kind failing-test

> /kind feature
> /kind flake

**What this PR does / why we need it**:
`TestDispatchingBookmarkEventsWithConcurrentStop` can use `processEvent` instead of `dispatchEvent` to avoid data race conditions with `Cacher.watchersBuffer`.

**Does this PR introduce a user-facing change?**:
None

```release-note
NONE
```
