### PR TITLE
don't quota virtual resources by default

### DIFF
--- a/pkg/quota/v1/install/registry.go
+++ b/pkg/quota/v1/install/registry.go
@@ -37,6 +37,16 @@ func NewQuotaConfigurationForControllers(f quota.ListerForResourceFunc) quota.Co
 
 // ignoredResources are ignored by quota by default
 var ignoredResources = map[schema.GroupResource]struct{}{
+	// virtual resources that aren't stored and shouldn't be quota-ed
+	{Group: "", Resource: "bindings"}:                                      {},
+	{Group: "", Resource: "componentstatuses"}:                             {},
+	{Group: "authentication.k8s.io", Resource: "tokenreviews"}:             {},
+	{Group: "authorization.k8s.io", Resource: "subjectaccessreviews"}:      {},
+	{Group: "authorization.k8s.io", Resource: "selfsubjectaccessreviews"}:  {},
+	{Group: "authorization.k8s.io", Resource: "localsubjectaccessreviews"}: {},
+	{Group: "authorization.k8s.io", Resource: "selfsubjectrulesreviews"}:   {},
+
+	// events haven't been quota-ed before
 	{Group: "", Resource: "events"}: {},
 }
 


### PR DESCRIPTION
There is no need to quota virtual resources because they are not stored and taking space. This updates the default ignore list with virtual resources.

/kind bug
/priority important-soon

```release-note
NONE
```