### PR TITLE
e2e/framework: remove direct import to pkg/apis/v1/storage/util

### DIFF
--- a/test/e2e/framework/pv/BUILD
+++ b/test/e2e/framework/pv/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/framework/pv",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/storage/v1/util:go_default_library",
         "//pkg/volume/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/test/e2e/framework/pv/pv.go
+++ b/test/e2e/framework/pv/pv.go
@@ -53,13 +53,13 @@ const (
 	// VolumeSelectorKey is the key for volume selector.
 	VolumeSelectorKey = "e2e-pv-pool"
 
-	// IsDefaultStorageClassAnnotation represents a StorageClass annotation that
+	// isDefaultStorageClassAnnotation represents a StorageClass annotation that
 	// marks a class as the default StorageClass
-	IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+	isDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 
-	// BetaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
+	// betaIsDefaultStorageClassAnnotation is the beta version of IsDefaultStorageClassAnnotation.
 	// TODO: remove Beta when no longer used
-	BetaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
+	betaIsDefaultStorageClassAnnotation = "storageclass.beta.kubernetes.io/is-default-class"
 )
 
 var (
@@ -804,10 +804,10 @@ func GetDefaultStorageClassName(c clientset.Interface) (string, error) {
 // annotation is set
 // TODO: remove Beta when no longer needed
 func isDefaultAnnotation(obj metav1.ObjectMeta) bool {
-	if obj.Annotations[IsDefaultStorageClassAnnotation] == "true" {
+	if obj.Annotations[isDefaultStorageClassAnnotation] == "true" {
 		return true
 	}
-	if obj.Annotations[BetaIsDefaultStorageClassAnnotation] == "true" {
+	if obj.Annotations[betaIsDefaultStorageClassAnnotation] == "true" {
 		return true
 	}
 


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes direct imports to pkg/apis/v1/storage/util in test/e2e/framework. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of https://github.com/kubernetes/kubernetes/issues/74352

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
