### PR TITLE
Fix for kubectl issue #842 "kubectl create job --from=cronjob/foo foo-job" failing with error: failed to create job: jobs.batch "foo" is forbidden: cannot set blockOwnerDeletion

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -259,7 +258,7 @@ func (o *CreateJobOptions) createJobFromCronJob(cronJob *batchv1beta1.CronJob) *
 			Annotations: annotations,
 			Labels:      cronJob.Spec.JobTemplate.Labels,
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(cronJob, appsv1.SchemeGroupVersion.WithKind("CronJob")),
+				*metav1.NewControllerRef(cronJob, batchv1beta1.SchemeGroupVersion.WithKind("CronJob")),
 			},
 		},
 		Spec: cronJob.Spec.JobTemplate.Spec,

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_job_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	apps "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -165,7 +164,7 @@ func TestCreateJobFromCronJob(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:            jobName,
 					Annotations:     map[string]string{"cronjob.kubernetes.io/instantiate": "manual"},
-					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, apps.SchemeGroupVersion.WithKind("CronJob"))},
+					OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(cronJob, batchv1beta1.SchemeGroupVersion.WithKind("CronJob"))},
 				},
 				Spec: batchv1.JobSpec{
 					Template: corev1.PodTemplateSpec{


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a bug

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/842

**Does this PR introduce a user-facing change?**:
```release-note
"kubectl create job --from=cronjob/foo foo-job" no longer fails with the following error
error: failed to create job: jobs.batch "foo-job" is forbidden: cannot set blockOwnerDeletion in this case because cannot find RESTMapping for APIVersion apps/v1 Kind CronJob: no matches for kind "CronJob" in version "apps/v1"
when the OwnerReferencesPermissionEnforcement admission plugin is enabled.
```