### PR TITLE
Use ExpectNotEqual in test/e2e/network/

### DIFF
--- a/hack/verify-test-code.sh
+++ b/hack/verify-test-code.sh
@@ -46,6 +46,15 @@ do
     fi
 done
 
+errors_expect_no_equal=()
+for file in "${all_e2e_files[@]}"
+do
+    if grep -E "Expect\(.*\)\.(NotTo|ToNot)\((gomega\.Equal|Equal)" "${file}" > /dev/null
+    then
+        errors_expect_no_equal+=( "${file}" )
+    fi
+done
+
 errors_expect_equal=()
 for file in "${all_e2e_files[@]}"
 do
@@ -78,6 +87,20 @@ if [ ${#errors_expect_error[@]} -ne 0 ]; then
     echo
     echo 'The above files need to use framework.ExpectError(err) instead of '
     echo 'Expect(err).To(HaveOccurred()) or gomega.Expect(err).To(gomega.HaveOccurred())'
+    echo
+  } >&2
+  exit 1
+fi
+
+if [ ${#errors_expect_no_equal[@]} -ne 0 ]; then
+  {
+    echo "Errors:"
+    for err in "${errors_expect_no_equal[@]}"; do
+      echo "$err"
+    done
+    echo
+    echo 'The above files need to use framework.ExpectNotEqual(foo, bar) instead of '
+    echo 'Expect(foo).NotTo(Equal(bar)) or gomega.Expect(foo).NotTo(gomega.Equal(bar))'
     echo
   } >&2
   exit 1

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -935,7 +935,7 @@ var _ = SIGDescribe("Services", func() {
 		pausePods, err := cs.CoreV1().Pods(ns).List(context.TODO(), metav1.ListOptions{LabelSelector: labelSelector.String()})
 		framework.ExpectNoError(err, "Error in listing pods associated with pause pod deployments")
 
-		gomega.Expect(pausePods.Items[0].Spec.NodeName).ToNot(gomega.Equal(pausePods.Items[1].Spec.NodeName))
+		framework.ExpectNotEqual(pausePods.Items[0].Spec.NodeName, pausePods.Items[1].Spec.NodeName)
 
 		serviceAddress := net.JoinHostPort(serviceIP, strconv.Itoa(servicePort))
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This replaces `gomega.Expect(foo).ToNot(gomega.Equal(bar))` with `ExpectNotEqual` for code readability and adds a detection of the function to verify-test-code.sh

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
