### PR TITLE
Remove timeout from query param

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/get.go
@@ -240,7 +240,6 @@ func ListResource(r rest.Lister, rw rest.Watcher, scope *RequestScope, forceWatc
 				scope.err(errors.NewMethodNotSupported(scope.Resource.GroupResource(), "watch"), w, req)
 				return
 			}
-			// TODO: Currently we explicitly ignore ?timeout= and use only ?timeoutSeconds=.
 			timeout := time.Duration(0)
 			if opts.TimeoutSeconds != nil {
 				timeout = time.Duration(*opts.TimeoutSeconds) * time.Second

--- a/staging/src/k8s.io/client-go/kubernetes_test/timeout_test.go
+++ b/staging/src/k8s.io/client-go/kubernetes_test/timeout_test.go
@@ -38,7 +38,7 @@ func TestListTimeout(t *testing.T) {
 		GroupVersion:         appsv1.SchemeGroupVersion,
 		NegotiatedSerializer: scheme.Codecs,
 		Client: manualfake.CreateHTTPClient(func(req *http.Request) (*http.Response, error) {
-			if req.URL.Query().Get("timeout") != "21s" {
+			if req.URL.Query().Get("timeout") != "" {
 				t.Fatal(spew.Sdump(req.URL.Query()))
 			}
 			return &http.Response{StatusCode: http.StatusNotFound, Body: ioutil.NopCloser(&bytes.Buffer{})}, nil

--- a/staging/src/k8s.io/client-go/rest/request.go
+++ b/staging/src/k8s.io/client-go/rest/request.go
@@ -468,7 +468,8 @@ func (r *Request) URL() *url.URL {
 	}
 
 	// timeout is handled specially here.
-	if r.timeout != 0 {
+	// Do not set timeout for GET request as apiserver does not use it.
+	if r.timeout != 0 && r.verb != "GET" {
 		query.Set("timeout", r.timeout.String())
 	}
 	finalURL.RawQuery = query.Encode()

--- a/test/e2e/auth/audit.go
+++ b/test/e2e/auth/audit.go
@@ -141,7 +141,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelRequest,
 				Stage:             auditinternal.StageResponseStarted,
-				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,
@@ -153,7 +153,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelRequest,
 				Stage:             auditinternal.StageResponseComplete,
-				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,
@@ -268,7 +268,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelRequest,
 				Stage:             auditinternal.StageResponseStarted,
-				RequestURI:        fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,
@@ -280,7 +280,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelRequest,
 				Stage:             auditinternal.StageResponseComplete,
-				RequestURI:        fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/apis/apps/v1/namespaces/%s/deployments?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,
@@ -401,7 +401,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelMetadata,
 				Stage:             auditinternal.StageResponseStarted,
-				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,
@@ -413,7 +413,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelMetadata,
 				Stage:             auditinternal.StageResponseComplete,
-				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,
@@ -533,7 +533,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelMetadata,
 				Stage:             auditinternal.StageResponseStarted,
-				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/secrets?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/secrets?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,
@@ -545,7 +545,7 @@ var _ = SIGDescribe("Advanced Audit [DisabledForLargeClusters][Flaky]", func() {
 			}, {
 				Level:             auditinternal.LevelMetadata,
 				Stage:             auditinternal.StageResponseComplete,
-				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/secrets?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+				RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/secrets?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 				Verb:              "watch",
 				Code:              200,
 				User:              auditTestUser,

--- a/test/e2e/auth/audit_dynamic.go
+++ b/test/e2e/auth/audit_dynamic.go
@@ -253,7 +253,7 @@ var _ = SIGDescribe("[Feature:DynamicAudit]", func() {
 					}, {
 						Level:             auditinternal.LevelRequestResponse,
 						Stage:             auditinternal.StageResponseStarted,
-						RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+						RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 						Verb:              "watch",
 						Code:              200,
 						User:              auditTestUser,
@@ -265,7 +265,7 @@ var _ = SIGDescribe("[Feature:DynamicAudit]", func() {
 					}, {
 						Level:             auditinternal.LevelRequestResponse,
 						Stage:             auditinternal.StageResponseComplete,
-						RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+						RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/pods?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 						Verb:              "watch",
 						Code:              200,
 						User:              auditTestUser,

--- a/test/integration/master/audit_test.go
+++ b/test/integration/master/audit_test.go
@@ -114,7 +114,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseStarted,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 			Verb:              "watch",
 			Code:              200,
 			User:              auditTestUser,
@@ -126,7 +126,7 @@ rules:
 		}, {
 			Level:             auditinternal.LevelRequestResponse,
 			Stage:             auditinternal.StageResponseComplete,
-			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeout=%ds&timeoutSeconds=%d&watch=true", namespace, watchTestTimeout, watchTestTimeout),
+			RequestURI:        fmt.Sprintf("/api/v1/namespaces/%s/configmaps?timeoutSeconds=%d&watch=true", namespace, watchTestTimeout),
 			Verb:              "watch",
 			Code:              200,
 			User:              auditTestUser,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Currently timeout is passed, which is useless
`?allowWatchBookmarks=true&resourceVersion=1&timeout=8m26s&timeoutSeconds=506&watch=true'`

```release-note
none
```
