### PR TITLE
bugfix: initcontainer is also taken into account when calculating resource requests

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/types.go
+++ b/pkg/scheduler/framework/v1alpha1/types.go
@@ -200,7 +200,10 @@ func (r *Resource) Add(rl v1.ResourceList) {
 		case v1.ResourcePods:
 			r.AllowedPodNumber += int(rQuant.Value())
 		case v1.ResourceEphemeralStorage:
-			r.EphemeralStorage += rQuant.Value()
+			if utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+				// if the local storage capacity isolation feature gate is disabled, pods request 0 disk.
+				r.EphemeralStorage += rQuant.Value()
+			}
 		default:
 			if v1helper.IsScalarResourceName(rName) {
 				r.AddScalar(rName, rQuant.Value())
@@ -451,21 +454,32 @@ func (n *NodeInfo) resetSlicesIfEmpty() {
 	}
 }
 
+// resourceRequest = max(sum(podSpec.Containers), podSpec.InitContainers) + overHead
 func calculateResource(pod *v1.Pod) (res Resource, non0CPU int64, non0Mem int64) {
 	resPtr := &res
 	for _, c := range pod.Spec.Containers {
 		resPtr.Add(c.Resources.Requests)
-
 		non0CPUReq, non0MemReq := schedutil.GetNonzeroRequests(&c.Resources.Requests)
 		non0CPU += non0CPUReq
 		non0Mem += non0MemReq
 		// No non-zero resources for GPUs or opaque resources.
 	}
 
+	for _, ic := range pod.Spec.InitContainers {
+		resPtr.SetMaxResource(ic.Resources.Requests)
+		non0CPUReq, non0MemReq := schedutil.GetNonzeroRequests(&ic.Resources.Requests)
+		if non0CPU < non0CPUReq {
+			non0CPU = non0CPUReq
+		}
+
+		if non0Mem < non0MemReq {
+			non0Mem = non0MemReq
+		}
+	}
+
 	// If Overhead is being utilized, add to the total requests for the pod
 	if pod.Spec.Overhead != nil && utilfeature.DefaultFeatureGate.Enabled(features.PodOverhead) {
 		resPtr.Add(pod.Spec.Overhead)
-
 		if _, found := pod.Spec.Overhead[v1.ResourceCPU]; found {
 			non0CPU += pod.Spec.Overhead.Cpu().MilliValue()
 		}

--- a/pkg/scheduler/framework/v1alpha1/types_test.go
+++ b/pkg/scheduler/framework/v1alpha1/types_test.go
@@ -614,6 +614,46 @@ func TestNodeInfoAddPod(t *testing.T) {
 				},
 			},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "node_info_cache_test",
+				Name:      "test-3",
+				UID:       types.UID("test-3"),
+			},
+			Spec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU: resource.MustParse("200m"),
+							},
+						},
+						Ports: []v1.ContainerPort{
+							{
+								HostIP:   "127.0.0.1",
+								HostPort: 8080,
+								Protocol: "TCP",
+							},
+						},
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								v1.ResourceCPU:    resource.MustParse("500m"),
+								v1.ResourceMemory: resource.MustParse("200Mi"),
+							},
+						},
+					},
+				},
+				NodeName: nodeName,
+				Overhead: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("500m"),
+					v1.ResourceMemory: resource.MustParse("500"),
+				},
+			},
+		},
 	}
 	expected := &NodeInfo{
 		node: &v1.Node{
@@ -622,15 +662,15 @@ func TestNodeInfoAddPod(t *testing.T) {
 			},
 		},
 		Requested: &Resource{
-			MilliCPU:         1300,
-			Memory:           1000,
+			MilliCPU:         2300,
+			Memory:           209716700, //1500 + 200MB in initContainers
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
 		NonZeroRequested: &Resource{
-			MilliCPU:         1300,
-			Memory:           209716200, //200MB + 1000 specified in requests/overhead
+			MilliCPU:         2300,
+			Memory:           419431900, //200MB(initContainers) + 200MB(default memory value) + 1500 specified in requests/overhead
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
@@ -698,6 +738,48 @@ func TestNodeInfoAddPod(t *testing.T) {
 										HostIP:   "127.0.0.1",
 										HostPort: 8080,
 										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						NodeName: nodeName,
+						Overhead: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("500m"),
+							v1.ResourceMemory: resource.MustParse("500"),
+						},
+					},
+				},
+			},
+			{
+				Pod: &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "node_info_cache_test",
+						Name:      "test-3",
+						UID:       types.UID("test-3"),
+					},
+					Spec: v1.PodSpec{
+						Containers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU: resource.MustParse("200m"),
+									},
+								},
+								Ports: []v1.ContainerPort{
+									{
+										HostIP:   "127.0.0.1",
+										HostPort: 8080,
+										Protocol: "TCP",
+									},
+								},
+							},
+						},
+						InitContainers: []v1.Container{
+							{
+								Resources: v1.ResourceRequirements{
+									Requests: v1.ResourceList{
+										v1.ResourceCPU:    resource.MustParse("500m"),
+										v1.ResourceMemory: resource.MustParse("200Mi"),
 									},
 								},
 							},

--- a/pkg/scheduler/util/BUILD
+++ b/pkg/scheduler/util/BUILD
@@ -38,10 +38,12 @@ go_library(
     deps = [
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
+        "//pkg/features:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/extender/v1:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/scheduler/util/non_zero.go
+++ b/pkg/scheduler/util/non_zero.go
@@ -18,7 +18,9 @@ package util
 
 import (
 	v1 "k8s.io/api/core/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
+	"k8s.io/kubernetes/pkg/features"
 )
 
 // For each of these resources, a pod that doesn't request the resource explicitly
@@ -60,6 +62,11 @@ func GetNonzeroRequestForResource(resource v1.ResourceName, requests *v1.Resourc
 		}
 		return requests.Memory().Value()
 	case v1.ResourceEphemeralStorage:
+		// if the local storage capacity isolation feature gate is disabled, pods request 0 disk.
+		if !utilfeature.DefaultFeatureGate.Enabled(features.LocalStorageCapacityIsolation) {
+			return 0
+		}
+
 		quantity, found := (*requests)[v1.ResourceEphemeralStorage]
 		if !found {
 			return 0


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

 /kind bug

**What this PR does / why we need it**:

use GetResourceRequest util function to calculate the resource request of pod

**Which issue(s) this PR fixes**:

Fixes #89092

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
