### PR TITLE
e2e/framework: implement ssh exec internally

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// WARNING: DO NOT add new use-caes to this package as it is deprecated and slated for deletion.
+
 package ssh
 
 import (

--- a/test/e2e/framework/.import-restrictions
+++ b/test/e2e/framework/.import-restrictions
@@ -198,7 +198,6 @@
 				"k8s.io/kubernetes/pkg/security/podsecuritypolicy/util",
 				"k8s.io/kubernetes/pkg/securitycontext",
 				"k8s.io/kubernetes/pkg/serviceaccount",
-				"k8s.io/kubernetes/pkg/ssh",
 				"k8s.io/kubernetes/pkg/util/async",
 				"k8s.io/kubernetes/pkg/util/bandwidth",
 				"k8s.io/kubernetes/pkg/util/config",

--- a/test/e2e/framework/ssh/BUILD
+++ b/test/e2e/framework/ssh/BUILD
@@ -6,7 +6,6 @@ go_library(
     importpath = "k8s.io/kubernetes/test/e2e/framework/ssh",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/ssh:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",


### PR DESCRIPTION
Signed-off-by: Andrew Sy Kim <kim.andrewsy@gmail.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Implements "run ssh" internally in the framework to remove dependency to `k8s.io/kubernetes/pkg/ssh`. 

**Which issue(s) this PR fixes**:
Part of https://github.com/kubernetes/kubernetes/issues/74352

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
