### PR TITLE
Enable import-boss check for integration test

### DIFF
--- a/hack/verify-import-boss.sh
+++ b/hack/verify-import-boss.sh
@@ -30,7 +30,13 @@ kube::golang::setup_env
 
 make -C "${KUBE_ROOT}" WHAT=vendor/k8s.io/code-generator/cmd/import-boss
 
-packages=("k8s.io/kubernetes/pkg/..." "k8s.io/kubernetes/cmd/..." "k8s.io/kubernetes/plugin/..." "k8s.io/kubernetes/test/e2e/framework/...")
+packages=(
+  "k8s.io/kubernetes/pkg/..."
+  "k8s.io/kubernetes/cmd/..."
+  "k8s.io/kubernetes/plugin/..."
+  "k8s.io/kubernetes/test/e2e/framework/..."
+  "k8s.io/kubernetes/test/integration/..."
+)
 for d in staging/src/k8s.io/*/; do
   if [ -d "$d" ]; then
     packages+=("./vendor/${d#"staging/src/"}...")

--- a/test/integration/.import-restrictions
+++ b/test/integration/.import-restrictions
@@ -1,0 +1,8 @@
+{
+	"Rules": [
+		{
+			"SelectorRegexp": "k8s[.]io/kubernetes/test/e2e",
+			"AllowedPrefixes": []
+		}
+	]
+}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Integration tests imported e2e test code and the dependency made two drawbacks:
- Hard to move test/e2e/framework into staging (#74352)
- Need to run integration tests always even if PRs are just changing e2e test code

This enables import-boss check for blocking such dependency.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89185

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```