### PR TITLE
Restore orphaning check in gc test

### DIFF
--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -461,6 +461,9 @@ func setupRCsPods(t *testing.T, gc *garbagecollector.GarbageCollector, clientSet
 	}
 	orphan := false
 	switch {
+	case options.OrphanDependents == nil && options.PropagationPolicy == nil && len(initialFinalizers) == 0:
+		// if there are no deletion options, the default policy for replication controllers is orphan
+		orphan = true
 	case options.OrphanDependents != nil:
 		// if the deletion options explicitly specify whether to orphan, that controls
 		orphan = *options.OrphanDependents


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test
/kind flake

**What this PR does / why we need it**:
Restores orphaning check accidentally removed in https://github.com/kubernetes/kubernetes/pull/88708/files#diff-71e62caa4db77f62b62feb4951fd7ca8L464-L466

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/89021

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/cc @mikedanese 
/sig api-machinery