### PR TITLE
Automated cherry pick of #89236: Restore orphaning check in gc test

### DIFF
--- a/test/integration/garbagecollector/garbage_collector_test.go
+++ b/test/integration/garbagecollector/garbage_collector_test.go
@@ -461,6 +461,9 @@ func setupRCsPods(t *testing.T, gc *garbagecollector.GarbageCollector, clientSet
 	}
 	orphan := false
 	switch {
+	case options.OrphanDependents == nil && options.PropagationPolicy == nil && len(initialFinalizers) == 0:
+		// if there are no deletion options, the default policy for replication controllers is orphan
+		orphan = true
 	case options.OrphanDependents != nil:
 		// if the deletion options explicitly specify whether to orphan, that controls
 		orphan = *options.OrphanDependents


### PR DESCRIPTION
Cherry pick of #89236 on release-1.18.

#89236: Restore orphaning check in gc test

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
NONE
```