### PR TITLE
Automated cherry pick of #88987: make filteredZones order predictable

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/in_tree_volume.go
@@ -119,7 +119,7 @@ func addTopology(pv *v1.PersistentVolume, topologyKey string, zones []string) er
 		}
 	}
 
-	zones = filteredZones.UnsortedList()
+	zones = filteredZones.List()
 	if len(zones) < 1 {
 		return errors.New("there are no valid zones to add to pv")
 	}


### PR DESCRIPTION
Cherry pick of #88987 on release-1.18.

#88987: make filteredZones order predictable

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.