### PR TITLE
Add new label for node ROLES

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -69,13 +69,6 @@ import (
 
 const (
 	loadBalancerWidth = 16
-
-	// labelNodeRolePrefix is a label prefix for node roles
-	// It's copied over to here until it's merged in core: https://github.com/kubernetes/kubernetes/pull/39112
-	labelNodeRolePrefix = "node-role.kubernetes.io/"
-
-	// nodeLabelRole specifies the role of a node
-	nodeLabelRole = "kubernetes.io/role"
 )
 
 // AddHandlers adds print handlers for default Kubernetes types dealing with internal versions.
@@ -1544,12 +1537,12 @@ func findNodeRoles(node *api.Node) []string {
 	roles := sets.NewString()
 	for k, v := range node.Labels {
 		switch {
-		case strings.HasPrefix(k, labelNodeRolePrefix):
-			if role := strings.TrimPrefix(k, labelNodeRolePrefix); len(role) > 0 {
+		case strings.HasPrefix(k, apiv1.LabelNodeRolePrefix):
+			if role := strings.TrimPrefix(k, apiv1.LabelNodeRolePrefix); len(role) > 0 {
 				roles.Insert(role)
 			}
 
-		case k == nodeLabelRole && v != "":
+		case k == apiv1.LabelLegacyNodeLabelRole && v != "":
 			roles.Insert(v)
 		}
 	}

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -1484,7 +1484,7 @@ func printNode(obj *api.Node, options printers.GenerateOptions) ([]metav1.TableR
 		status = append(status, "SchedulingDisabled")
 	}
 
-	roles := strings.Join(findNodeRoles(obj), ",")
+	roles := strings.Join(apiv1.GetNodeRoles(obj.Labels), ",")
 	if len(roles) == 0 {
 		roles = "<none>"
 	}
@@ -1527,26 +1527,6 @@ func getNodeInternalIP(node *api.Node) string {
 	}
 
 	return "<none>"
-}
-
-// findNodeRoles returns the roles of a given node.
-// The roles are determined by looking for:
-// * a node-role.kubernetes.io/<role>="" label
-// * a kubernetes.io/role="<role>" label
-func findNodeRoles(node *api.Node) []string {
-	roles := sets.NewString()
-	for k, v := range node.Labels {
-		switch {
-		case strings.HasPrefix(k, apiv1.LabelNodeRolePrefix):
-			if role := strings.TrimPrefix(k, apiv1.LabelNodeRolePrefix); len(role) > 0 {
-				roles.Insert(role)
-			}
-
-		case k == apiv1.LabelLegacyNodeLabelRole && v != "":
-			roles.Insert(v)
-		}
-	}
-	return roles.List()
 }
 
 func printNodeList(list *api.NodeList, options printers.GenerateOptions) ([]metav1.TableRow, error) {

--- a/staging/src/k8s.io/api/core/v1/label.go
+++ b/staging/src/k8s.io/api/core/v1/label.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func GetNodeRoles(labels map[string]string) []string {
+	roles := sets.NewString()
+	for k, v := range labels {
+		switch {
+		case strings.HasPrefix(k, LabelNodeRolePrefix):
+			if role := strings.TrimPrefix(k, LabelNodeRolePrefix); len(role) > 0 {
+				roles.Insert(role)
+			}
+
+		case k == LabelLegacyNodeLabelRole && v != "":
+			roles.Insert(v)
+		}
+	}
+	return roles.List()
+}

--- a/staging/src/k8s.io/api/core/v1/label.go
+++ b/staging/src/k8s.io/api/core/v1/label.go
@@ -31,6 +31,11 @@ func GetNodeRoles(labels map[string]string) []string {
 				roles.Insert(role)
 			}
 
+		case strings.HasPrefix(k, LabelLegacyNodeRolePrefix):
+			if role := strings.TrimPrefix(k, LabelLegacyNodeRolePrefix); len(role) > 0 {
+				roles.Insert(role)
+			}
+
 		case k == LabelLegacyNodeLabelRole && v != "":
 			roles.Insert(v)
 		}

--- a/staging/src/k8s.io/api/core/v1/label_test.go
+++ b/staging/src/k8s.io/api/core/v1/label_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/sets"
+)
+
+func TestGetNodeRoles(t *testing.T) {
+	testCases := []struct {
+		name   string
+		labels map[string]string
+		expect []string
+	}{
+		{
+			name:   "no label",
+			labels: nil,
+			expect: []string{},
+		},
+		{
+			name: "no role",
+			labels: map[string]string{
+				"foo": "bar",
+			},
+			expect: []string{},
+		},
+		{
+			name: "old role",
+			labels: map[string]string{
+				"foo":                    "bar",
+				LabelLegacyNodeLabelRole: "old-role",
+			},
+			expect: []string{"old-role"},
+		},
+		{
+			name: "new roles - one role",
+			labels: map[string]string{
+				"foo":                         "bar",
+				LabelNodeRolePrefix + "role1": "role1",
+			},
+			expect: []string{"role1"},
+		},
+		{
+			name: "new roles - two roles",
+			labels: map[string]string{
+				"foo":                         "bar",
+				LabelNodeRolePrefix + "role1": "role1",
+				LabelNodeRolePrefix + "role2": "role2",
+			},
+			expect: []string{"role1", "role2"},
+		},
+		{
+			name: "old role and new roles",
+			labels: map[string]string{
+				"foo":                         "bar",
+				LabelLegacyNodeLabelRole:      "old-role",
+				LabelNodeRolePrefix + "role1": "role1",
+				LabelNodeRolePrefix + "role2": "role2",
+			},
+			expect: []string{"old-role", "role1", "role2"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result := GetNodeRoles(testCase.labels)
+			if !sets.NewString(testCase.expect...).Equal(sets.NewString(result...)) {
+				t.Errorf("expected %v, got %v", testCase.expect, result)
+			}
+		})
+	}
+}

--- a/staging/src/k8s.io/api/core/v1/label_test.go
+++ b/staging/src/k8s.io/api/core/v1/label_test.go
@@ -49,6 +49,33 @@ func TestGetNodeRoles(t *testing.T) {
 			expect: []string{"old-role"},
 		},
 		{
+			name: "legacy roles - one role",
+			labels: map[string]string{
+				"foo":                               "bar",
+				LabelLegacyNodeRolePrefix + "role1": "role1",
+			},
+			expect: []string{"role1"},
+		},
+		{
+			name: "legacy roles - two roles",
+			labels: map[string]string{
+				"foo":                               "bar",
+				LabelLegacyNodeRolePrefix + "role1": "role1",
+				LabelLegacyNodeRolePrefix + "role2": "role2",
+			},
+			expect: []string{"role1", "role2"},
+		},
+		{
+			name: "old role and legacy roles",
+			labels: map[string]string{
+				"foo":                               "bar",
+				LabelLegacyNodeLabelRole:            "old-role",
+				LabelLegacyNodeRolePrefix + "role1": "role1",
+				LabelLegacyNodeRolePrefix + "role2": "role2",
+			},
+			expect: []string{"old-role", "role1", "role2"},
+		},
+		{
 			name: "new roles - one role",
 			labels: map[string]string{
 				"foo":                         "bar",
@@ -74,6 +101,27 @@ func TestGetNodeRoles(t *testing.T) {
 				LabelNodeRolePrefix + "role2": "role2",
 			},
 			expect: []string{"old-role", "role1", "role2"},
+		},
+		{
+			name: "new roles - two roles - legacy roles",
+			labels: map[string]string{
+				"foo":                         "bar",
+				LabelNodeRolePrefix + "role1": "role1",
+				LabelNodeRolePrefix + "role2": "role2",
+				LabelLegacyNodeRolePrefix + "legacyrole1": "legacyrole1",
+			},
+			expect: []string{"role1", "role2", "legacyrole1"},
+		},
+		{
+			name: "old role and new roles and legacy nodes",
+			labels: map[string]string{
+				"foo":                                     "bar",
+				LabelLegacyNodeLabelRole:                  "old-role",
+				LabelNodeRolePrefix + "role1":             "role1",
+				LabelNodeRolePrefix + "role2":             "role2",
+				LabelLegacyNodeRolePrefix + "legacyrole1": "legacyrole1",
+			},
+			expect: []string{"legacyrole1", "old-role", "role1", "role2"},
 		},
 	}
 

--- a/staging/src/k8s.io/api/core/v1/well_known_labels.go
+++ b/staging/src/k8s.io/api/core/v1/well_known_labels.go
@@ -31,7 +31,9 @@ const (
 	LabelArchStable = "kubernetes.io/arch"
 
 	// LabelNodeRolePrefix is a label prefix for node roles
-	LabelNodeRolePrefix = "node-role.kubernetes.io/"
+	LabelNodeRolePrefix = "role.node.kubernetes.io/"
+	// LabelLegacyNodeRolePrefix is a label prefix for node roles
+	LabelLegacyNodeRolePrefix = "node-role.kubernetes.io/"
 	// NodeLabelRole specifies the role of a node
 	LabelLegacyNodeLabelRole = "kubernetes.io/role"
 

--- a/staging/src/k8s.io/api/core/v1/well_known_labels.go
+++ b/staging/src/k8s.io/api/core/v1/well_known_labels.go
@@ -30,6 +30,11 @@ const (
 	LabelOSStable   = "kubernetes.io/os"
 	LabelArchStable = "kubernetes.io/arch"
 
+	// LabelNodeRolePrefix is a label prefix for node roles
+	LabelNodeRolePrefix = "node-role.kubernetes.io/"
+	// NodeLabelRole specifies the role of a node
+	LabelLegacyNodeLabelRole = "kubernetes.io/role"
+
 	// LabelWindowsBuild is used on Windows nodes to specify the Windows build number starting with v1.17.0.
 	// It's in the format MajorVersion.MinorVersion.BuildNumber (for ex: 10.0.17763)
 	LabelWindowsBuild = "node.kubernetes.io/windows-build"

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -3078,7 +3078,7 @@ func describeNode(node *corev1.Node, lease *coordinationv1.Lease, nodeNonTermina
 	return tabbedString(func(out io.Writer) error {
 		w := NewPrefixWriter(out)
 		w.Write(LEVEL_0, "Name:\t%s\n", node.Name)
-		if roles := findNodeRoles(node); len(roles) > 0 {
+		if roles := corev1.GetNodeRoles(node.Labels); len(roles) > 0 {
 			w.Write(LEVEL_0, "Roles:\t%s\n", strings.Join(roles, ","))
 		} else {
 			w.Write(LEVEL_0, "Roles:\t%s\n", "<none>")
@@ -4840,26 +4840,6 @@ func backendStringer(backend *networkingv1beta1.IngressBackend) string {
 		return ""
 	}
 	return fmt.Sprintf("%v:%v", backend.ServiceName, backend.ServicePort.String())
-}
-
-// findNodeRoles returns the roles of a given node.
-// The roles are determined by looking for:
-// * a node-role.kubernetes.io/<role>="" label
-// * a kubernetes.io/role="<role>" label
-func findNodeRoles(node *corev1.Node) []string {
-	roles := sets.NewString()
-	for k, v := range node.Labels {
-		switch {
-		case strings.HasPrefix(k, corev1.LabelNodeRolePrefix):
-			if role := strings.TrimPrefix(k, corev1.LabelNodeRolePrefix); len(role) > 0 {
-				roles.Insert(role)
-			}
-
-		case k == corev1.LabelLegacyNodeLabelRole && v != "":
-			roles.Insert(v)
-		}
-	}
-	return roles.List()
 }
 
 // loadBalancerStatusStringer behaves mostly like a string interface and converts the given status to a string.

--- a/staging/src/k8s.io/kubectl/pkg/describe/describe.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/describe.go
@@ -4850,12 +4850,12 @@ func findNodeRoles(node *corev1.Node) []string {
 	roles := sets.NewString()
 	for k, v := range node.Labels {
 		switch {
-		case strings.HasPrefix(k, LabelNodeRolePrefix):
-			if role := strings.TrimPrefix(k, LabelNodeRolePrefix); len(role) > 0 {
+		case strings.HasPrefix(k, corev1.LabelNodeRolePrefix):
+			if role := strings.TrimPrefix(k, corev1.LabelNodeRolePrefix); len(role) > 0 {
 				roles.Insert(role)
 			}
 
-		case k == NodeLabelRole && v != "":
+		case k == corev1.LabelLegacyNodeLabelRole && v != "":
 			roles.Insert(v)
 		}
 	}

--- a/staging/src/k8s.io/kubectl/pkg/describe/interface.go
+++ b/staging/src/k8s.io/kubectl/pkg/describe/interface.go
@@ -18,6 +18,7 @@ package describe
 
 import (
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
@@ -25,13 +26,6 @@ import (
 const (
 	// LoadBalancerWidth is the width how we describe load balancer
 	LoadBalancerWidth = 16
-
-	// LabelNodeRolePrefix is a label prefix for node roles
-	// It's copied over to here until it's merged in core: https://github.com/kubernetes/kubernetes/pull/39112
-	LabelNodeRolePrefix = "node-role.kubernetes.io/"
-
-	// NodeLabelRole specifies the role of a node
-	NodeLabelRole = "kubernetes.io/role"
 )
 
 // DescriberFunc gives a way to display the specified RESTMapping type


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/kind deprecation

**What this PR does / why we need it**:
Add new label for node ROLES
    
`node-role.kubernetes.io` is deprecated as it cannot be used anymore.
This adds a new role compatible with the new proposal:

`role.node.kubernetes.io/<role>`
    
See:
https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/2019-07-16-node-role-label-use.md#use-of-node-rolekubernetesio-labels
https://github.com/kubernetes-sigs/cluster-api/issues/2596

**Which issue(s) this PR fixes**:
https://github.com/kubernetes-sigs/cluster-api/issues/2596


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
[KEP] https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/2019-07-16-node-role-label-use.md#use-of--labels

