### PR TITLE
ipv6 support: addr scope should be global or site

### DIFF
--- a/cluster/addons/dns/coredns_README.md
+++ b/cluster/addons/dns/coredns_README.md
@@ -1,0 +1,30 @@
+## coredns
+
+Users can enable CoreDNS instead of kube-dns for service discovery.
+`coredns` is schedules DNS Pods and Service on the cluster, other pods in cluster
+can use the DNS Service’s IP to resolve DNS names.
+
+* [Administrators guide](https://coredns.io/2018/01/29/deploying-kubernetes-with-coredns-using-kubeadm/)
+* [Code repository](https://github.com/coredns/coredns)
+
+
+### Base Template files
+
+These are the authoritative base templates.
+Run 'make' to generate the Salt and Sed yaml templates from these.
+
+```
+coredns.yaml.base
+```
+
+### Generated Salt files
+
+```
+coredns.yaml.in
+```
+
+### Generated Sed files
+
+```
+coredns.yaml.sed
+```

--- a/pkg/kubelet/network/plugins.go
+++ b/pkg/kubelet/network/plugins.go
@@ -259,27 +259,36 @@ func (plugin *NoopNetworkPlugin) Status() error {
 }
 
 func getOnePodIP(execer utilexec.Interface, nsenterPath, netnsPath, interfaceName, addrType string) (net.IP, error) {
-	// Try to retrieve ip inside container network namespace
-	output, err := execer.Command(nsenterPath, fmt.Sprintf("--net=%s", netnsPath), "-F", "--",
-		"ip", "-o", addrType, "addr", "show", "dev", interfaceName, "scope", "global").CombinedOutput()
-	if err != nil {
-		return nil, fmt.Errorf("Unexpected command output %s with error: %v", output, err)
+	scopes := []string{
+		"global"
 	}
+	if addrType == "-6" {
+		// IPv6 site scope ips will be deprecated later
+		append(scopes, "site")
+	}
+	for _, scope := range scopes {
+		// Try to retrieve ip inside container network namespace
+		output, err := execer.Command(nsenterPath, fmt.Sprintf("--net=%s", netnsPath), "-F", "--",
+			"ip", "-o", addrType, "addr", "show", "dev", interfaceName, "scope", "global").CombinedOutput()
+		if err != nil {
+			return nil, fmt.Errorf("Unexpected command output %s with error: %v", output, err)
+		}
 
-	lines := strings.Split(string(output), "\n")
-	if len(lines) < 1 {
-		return nil, fmt.Errorf("Unexpected command output %s", output)
-	}
-	fields := strings.Fields(lines[0])
-	if len(fields) < 4 {
-		return nil, fmt.Errorf("Unexpected address output %s ", lines[0])
-	}
-	ip, _, err := net.ParseCIDR(fields[3])
-	if err != nil {
-		return nil, fmt.Errorf("CNI failed to parse ip from output %s due to %v", output, err)
-	}
+		lines := strings.Split(string(output), "\n")
+		if len(lines) < 1 {
+			return nil, fmt.Errorf("Unexpected command output %s", output)
+		}
+		fields := strings.Fields(lines[0])
+		if len(fields) < 4 {
+			return nil, fmt.Errorf("Unexpected address output %s ", lines[0])
+		}
+		ip, _, err := net.ParseCIDR(fields[3])
+		if err != nil {
+			return nil, fmt.Errorf("CNI failed to parse ip from output %s due to %v", output, err)
+		}
 
-	return ip, nil
+		return ip, nil
+	}
 }
 
 // GetPodIP gets the IP of the pod by inspecting the network info inside the pod's network namespace.


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it:

When I use fefe:ffff:1::100 as default ipv6 pool with calico， the pod ip cannot be shown in pod spec. These ipv6 addr are with site scope, not global scope. 

However, it seems that site is deprecated but still can used inside cluster. 
Since https://tools.ietf.org/html/rfc3879, deprecating Site Local Addresses, I'm not sure whether we should support site ipv6 ip.



## Additional documentation 
I tried calico dual stack mode with kubernetes and my ipv6 addr cannot be shown in pod spec.

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: tunl0@NONE: <NOARP> mtu 1480 qdisc noop state DOWN group default qlen 1000
    link/ipip 0.0.0.0 brd 0.0.0.0
4: eth0@if27: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1450 qdisc noqueue state UP group default
    link/ether 36:10:b4:f4:03:c0 brd ff:ff:ff:ff:ff:ff link-netnsid 0
    inet 172.29.125.4/32 scope global eth0
       valid_lft forever preferred_lft forever
    inet6 fefe:ffff::ff3b:3eea:d343/128 scope site
       valid_lft forever preferred_lft forever
    inet6 fe80::3410:b4ff:fef4:3c0/64 scope link
       valid_lft forever preferred_lft forever
```

After looking into the code, I find the ipv6 address of calico pod is scope site(in another environement, the scop is global and this one is site in ipv6 dual stack.

According to https://serverfault.com/questions/63014/ip-address-scope-parameter, I think both global and site should be accepted here. Calico
> from http://linux-ip.net/html/tools-ip-address.html :
> 
> Scope | Description
> global | valid everywhere
> site | valid only within this site (IPv6)
> link | valid only on this device
> host | valid only inside this host (machine)

``` release note
fixes of bugs which have not been released
```

Signed-off-by: pacoxu <paco.xu@daocloud.io>
