### PR TITLE
Relax huge page node validation

### DIFF
--- a/pkg/registry/core/node/strategy.go
+++ b/pkg/registry/core/node/strategy.go
@@ -124,12 +124,7 @@ func nodeConfigSourceInUse(node *api.Node) bool {
 // Validate validates a new node.
 func (nodeStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	node := obj.(*api.Node)
-	opts := validation.NodeValidationOptions{
-		// This ensures new nodes have no more than one hugepages resource
-		// TODO: set to false in 1.19; 1.18 servers tolerate multiple hugepages resources on update
-		ValidateSingleHugePageResource: true,
-	}
-	return validation.ValidateNode(node, opts)
+	return validation.ValidateNode(node)
 }
 
 // Canonicalize normalizes the object after validation.
@@ -138,14 +133,8 @@ func (nodeStrategy) Canonicalize(obj runtime.Object) {
 
 // ValidateUpdate is the default update validation for an end user.
 func (nodeStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	oldPassesSingleHugepagesValidation := len(validation.ValidateNodeSingleHugePageResources(old.(*api.Node))) == 0
-	opts := validation.NodeValidationOptions{
-		// This ensures the new node has no more than one hugepages resource, if the old node did as well.
-		// TODO: set to false in 1.19; 1.18 servers tolerate relaxed validation on update
-		ValidateSingleHugePageResource: oldPassesSingleHugepagesValidation,
-	}
-	errorList := validation.ValidateNode(obj.(*api.Node), opts)
-	return append(errorList, validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node), opts)...)
+	errorList := validation.ValidateNode(obj.(*api.Node))
+	return append(errorList, validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node))...)
 }
 
 func (nodeStrategy) AllowUnconditionalUpdate() bool {
@@ -196,13 +185,7 @@ func nodeStatusConfigInUse(node *api.Node) bool {
 }
 
 func (nodeStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.Object) field.ErrorList {
-	oldPassesSingleHugepagesValidation := len(validation.ValidateNodeSingleHugePageResources(old.(*api.Node))) == 0
-	opts := validation.NodeValidationOptions{
-		// This ensures the new node has no more than one hugepages resource, if the old node did as well.
-		// TODO: set to false in 1.19; 1.18 servers tolerate relaxed validation on update
-		ValidateSingleHugePageResource: oldPassesSingleHugepagesValidation,
-	}
-	return validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node), opts)
+	return validation.ValidateNodeUpdate(obj.(*api.Node), old.(*api.Node))
 }
 
 // Canonicalize normalizes the object after validation.

--- a/pkg/registry/core/node/strategy_test.go
+++ b/pkg/registry/core/node/strategy_test.go
@@ -263,7 +263,7 @@ func TestValidateUpdate(t *testing.T) {
 					api.ResourceName("hugepages-1Gi"): resource.MustParse("2Gi"),
 				},
 			},
-		}, false},
+		}, true},
 		{api.Node{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "hugepage-change-values",
@@ -328,7 +328,7 @@ func TestValidate(t *testing.T) {
 					api.ResourceName("hugepages-1Gi"): resource.MustParse("2Gi"),
 				},
 			},
-		}, false},
+		}, true},
 	}
 	for i, test := range tests {
 		test.node.ObjectMeta.ResourceVersion = "1"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:

A relaxed version was added in 1.18, and this will disable the
validation all together.

Follow up from https://github.com/kubernetes/kubernetes/pull/82820

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

/assign @liggitt @derekwaynecarr 
/sig node
/priority backlog

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add support for pre allocated huge pages with different sizes, on node level
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
