### PR TITLE
Add flag to enable foreground deletion propagation

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete.go
@@ -110,6 +110,7 @@ type DeleteOptions struct {
 	Quiet               bool
 	WarnClusterScope    bool
 	Raw                 string
+	Foreground          bool
 
 	GracePeriod int
 	Timeout     time.Duration
@@ -304,6 +305,9 @@ func (o *DeleteOptions) DeleteResult(r *resource.Result) error {
 		policy := metav1.DeletePropagationBackground
 		if !o.Cascade {
 			policy = metav1.DeletePropagationOrphan
+		}
+		if o.Foreground {
+			policy = metav1.DeletePropagationForeground
 		}
 		options.PropagationPolicy = &policy
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_flags.go
@@ -43,6 +43,7 @@ type DeleteFlags struct {
 	Wait           *bool
 	Output         *string
 	Raw            *string
+	Foreground     *bool
 }
 
 func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams genericclioptions.IOStreams) *DeleteOptions {
@@ -97,6 +98,9 @@ func (f *DeleteFlags) ToOptions(dynamicClient dynamic.Interface, streams generic
 	if f.Raw != nil {
 		options.Raw = *f.Raw
 	}
+	if f.Foreground != nil {
+		options.Foreground = *f.Foreground
+	}
 
 	return options
 }
@@ -142,6 +146,9 @@ func (f *DeleteFlags) AddFlags(cmd *cobra.Command) {
 	if f.Raw != nil {
 		cmd.Flags().StringVar(f.Raw, "raw", *f.Raw, "Raw URI to DELETE to the server.  Uses the transport specified by the kubeconfig file.")
 	}
+	if f.Foreground != nil {
+		cmd.Flags().BoolVar(f.Foreground, "foreground", *f.Foreground, "If true, use foreground deletion propagation. This ensures the object is not deleted before all dependents whose ownerReference.blockOwnerDeletion=true have been garbage collected.")
+	}
 }
 
 // NewDeleteCommandFlags provides default flags and values for use with the "delete" command
@@ -166,6 +173,8 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 	recursive := false
 	kustomize := ""
 
+	foreground := false
+
 	return &DeleteFlags{
 		// Not using helpers.go since it provides function to add '-k' for FileNameOptions, but not FileNameFlags
 		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive},
@@ -184,6 +193,8 @@ func NewDeleteCommandFlags(usage string) *DeleteFlags {
 		Wait:           &wait,
 		Output:         &output,
 		Raw:            &raw,
+
+		Foreground: &foreground,
 	}
 }
 
@@ -200,6 +211,8 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 	kustomize := ""
 	recursive := false
 
+	foreground := false
+
 	return &DeleteFlags{
 		FileNameFlags: &genericclioptions.FileNameFlags{Usage: usage, Filenames: &filenames, Kustomize: &kustomize, Recursive: &recursive},
 
@@ -210,5 +223,7 @@ func NewDeleteFlags(usage string) *DeleteFlags {
 		Force:   &force,
 		Timeout: &timeout,
 		Wait:    &wait,
+
+		Foreground: &foreground,
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/delete/delete_test.go
@@ -161,6 +161,19 @@ func TestOrphanDependentsInDeleteObject(t *testing.T) {
 	if buf.String() != "secret/mysecret\n" {
 		t.Errorf("unexpected output: %s", buf.String())
 	}
+
+	// Test that delete options should be set to foreground when foreground is true.
+	foregroundPolicy := metav1.DeletePropagationForeground
+	policy = &foregroundPolicy
+	streams, _, buf, _ = genericclioptions.NewTestIOStreams()
+	cmd = NewCmdDelete(tf, streams)
+	cmd.Flags().Set("namespace", "test")
+	cmd.Flags().Set("foreground", "true")
+	cmd.Flags().Set("output", "name")
+	cmd.Run(cmd, []string{"secrets/mysecret"})
+	if buf.String() != "secret/mysecret\n" {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
 }
 
 func TestDeleteNamedObject(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
I want to use `kubectl` to ensure that all dependents of a resource have been garbage collected before it gets deleted. Currently the only option to delete objects with foreground propagation from the shell (i.e. not using an API client library) is with a tool like `curl` (as seen in the related issue).

I would expect `kubectl` to be able to do this as well.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubernetes/issues/74609
Other related issues:
https://github.com/kubernetes/kubernetes/issues/59850
https://github.com/kubernetes/kubectl/issues/672

**Special notes for your reviewer**:

I have compiled this on my machine and tested it with a kind cluster (`1.17.0`).

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --foreground flag to delete objects with foreground deletion propagation
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
