### PR TITLE
Add nil nodeinfo check in podFitsOnNode

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -619,6 +619,11 @@ func (g *genericScheduler) podFitsOnNode(
 	var failedPredicates []predicates.PredicateFailureReason
 	var status *framework.Status
 
+	// In the case where a node delete event is received before all pods on the node are deleted, a NodeInfo may have
+	// a nil Node(). This should not be an issue in 1.18 and later, but we need to check it here. See https://github.com/kubernetes/kubernetes/issues/89006
+	if info.Node() == nil {
+		return false, []predicates.PredicateFailureReason{}, framework.NewStatus(framework.UnschedulableAndUnresolvable, "node being deleted"), nil
+	}
 	podsAdded := false
 	// We run predicates twice in some cases. If the node has greater or equal priority
 	// nominated pods, we run them when those pods are added to meta and nodeInfo.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Adds a nil check for the `nodeInfo` in `podFitsOnNode` function in the generic scheduler to prevent panics. Same change as in https://github.com/kubernetes/kubernetes/pull/89224

**Which issue(s) this PR fixes**:
Addresses https://github.com/kubernetes/kubernetes/issues/89006 (for 1.17)

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig scheduling
