### PR TITLE
Use 'k8s.gcr.io' instead of 'gcr.io/google-containers'

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/egressselector/config_test.go
@@ -164,7 +164,7 @@ spec:
           hostPath:
             path: /etc/srv/kubernetes/pki/konnectivity-agent
       containers:
-        - image: gcr.io/google-containers/proxy-agent:v0.0.3
+        - image: k8s.gcr.io/proxy-agent:v0.0.3
           name: proxy-agent
           command: ["/proxy-agent"]
           args: ["--caCert=/etc/srv/kubernetes/pki/proxy-agent/ca.crt", "--agentCert=/etc/srv/kubernetes/pki/proxy-agent/client.crt", "--agentKey=/etc/srv/kubernetes/pki/proxy-agent/client.key", "--proxyServerHost=127.0.0.1", "--proxyServerPort=8132"]


### PR DESCRIPTION
Related issue: kubernetes/release#270

Use "k8s.gcr.io" for container images rather than "gcr.io/google_containers".  This is just a redirect, for now, so should not impact anyone materially.  

Documentation and tools should all convert to the new name. Users should take note of this in case they see this new name in the system.

Signed-off-by: Nguyen Hai Truong <truongnh@vn.fujitsu.com>

