### PR TITLE
Make userspace proxy logging quieter

### DIFF
--- a/pkg/proxy/userspace/proxier.go
+++ b/pkg/proxy/userspace/proxier.go
@@ -346,7 +346,7 @@ func (proxier *Proxier) Sync() {
 func (proxier *Proxier) syncProxyRules() {
 	start := time.Now()
 	defer func() {
-		klog.V(2).Infof("userspace syncProxyRules took %v", time.Since(start))
+		klog.V(4).Infof("userspace syncProxyRules took %v", time.Since(start))
 	}()
 
 	// don't sync rules till we've received services and endpoints
@@ -367,7 +367,7 @@ func (proxier *Proxier) syncProxyRules() {
 	proxier.mu.Lock()
 	defer proxier.mu.Unlock()
 
-	klog.V(2).Infof("userspace proxy: processing %d service events", len(changes))
+	klog.V(4).Infof("userspace proxy: processing %d service events", len(changes))
 	for _, change := range changes {
 		existingPorts := proxier.mergeService(change.current)
 		proxier.unmergeService(change.previous, existingPorts)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Moves some spammy userspace proxy logging from `V(2)` to `V(4)`

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig network
/priority backlog
/assign @dcbw 