### PR TITLE
nodelocaldns: have Prometheus collect metrics

### DIFF
--- a/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
+++ b/cluster/addons/dns/nodelocaldns/nodelocaldns.yaml
@@ -121,8 +121,11 @@ spec:
       k8s-app: node-local-dns
   template:
     metadata:
-       labels:
-          k8s-app: node-local-dns
+      labels:
+        k8s-app: node-local-dns
+      annotations:
+        prometheus.io/port: "9253"
+        prometheus.io/scrape: "true"
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns


### PR DESCRIPTION
Add the appropriate annotations to the nodelocaldns podspec so that Prometheus collects metrics from its coredns server, just like it already does for kube-dns.

/kind feature

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
