### PR TITLE
Remove unnecessary sorting step in removeTerminatedPods

### DIFF
--- a/pkg/kubelet/stats/cri_stats_provider_test.go
+++ b/pkg/kubelet/stats/cri_stats_provider_test.go
@@ -174,12 +174,24 @@ func TestCRIListPodStats(t *testing.T) {
 		On("RootFsInfo").Return(rootFsInfo, nil).
 		On("GetDirFsInfo", imageFsMountpoint).Return(imageFsInfo, nil).
 		On("GetDirFsInfo", unknownMountpoint).Return(cadvisorapiv2.FsInfo{}, cadvisorfs.ErrNoSuchDevice)
-	fakeRuntimeService.SetFakeSandboxes([]*critest.FakePodSandbox{
+	rand.Seed(time.Now().UnixNano())
+	// the order of the sandboxes can be arbitrary
+	sandboxes := []*critest.FakePodSandbox{
 		sandbox0, sandbox1, sandbox2, sandbox3, sandbox4, sandbox5,
+	}
+	rand.Shuffle(len(sandboxes), func(i, j int) {
+		sandboxes[i], sandboxes[j] = sandboxes[j], sandboxes[i]
 	})
-	fakeRuntimeService.SetFakeContainers([]*critest.FakeContainer{
+	fakeRuntimeService.SetFakeSandboxes(sandboxes)
+
+	// the order of the containers can be arbitrary
+	containers := []*critest.FakeContainer{
 		container0, container1, container2, container3, container4, container5, container6, container7, container8,
+	}
+	rand.Shuffle(len(containers), func(i, j int) {
+		containers[i], containers[j] = containers[j], containers[i]
 	})
+	fakeRuntimeService.SetFakeContainers(containers)
 	fakeRuntimeService.SetFakeContainerStats([]*runtimeapi.ContainerStats{
 		containerStats0, containerStats1, containerStats2, containerStats3, containerStats4, containerStats5, containerStats6, containerStats7, containerStats8,
 	})


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

*Background*:

Making metrics collection / reporting more efficient is important to smoothly operating large clusters.
By large scale, we are looking at 500 pods per node.

metrics reporting is not only used by devops, but also serves as feedback to kubelet for better decision making (e.g. facilitating smart pod eviction).

I have been experimenting with criStatsProvider for the past week.
My goal is to evaluate, from various angles, how to make cri stats provider more efficient.

*About this PR:*

Currently removeTerminatedPods (called by criStatsProvider#listPodStats) performs sorting followed by iteration over the sorted slice.
It also uses podMap to find the running instance given namespace and pod name.
However, the sorting step is not needed since we are only concerned with one PodSandbox which has the largest CreatedAt timestamp. We are not concerned with the relative order of PodSandboxes which are not the latest (under the same namespace and pod name).

Further, the return value from removeTerminatedPods is organized into another map, podSandboxMap, further illustrating that relative order of PodSandboxes is not of importance (there is no guarantee of order across traversals of the same map in golang).

In this PR, removeTerminatedPods traverses the input PodSandbox slice once (without sorting).

Similar optimization is applied to removeTerminatedContainers

TestCRIListPodStats is modified where the order of sandboxes / containers is shuffled to simulate different sequences which can occur in cluster.

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
