### PR TITLE
feat: support Azure shared disk

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -136,7 +136,7 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 			return -1, rerr.Error()
 		}
 
-		if disk.ManagedBy != nil {
+		if disk.ManagedBy != nil && (disk.MaxShares == nil || *disk.MaxShares <= 1) {
 			attachErr := fmt.Sprintf(
 				"disk(%s) already attached to node(%s), could not be attached to node(%s)",
 				diskURI, *disk.ManagedBy, nodeName)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -75,6 +75,8 @@ type ManagedDiskOptions struct {
 	SourceType string
 	// ResourceId of the disk encryption set to use for enabling encryption at rest.
 	DiskEncryptionSetID string
+	// The maximum number of VMs that can attach to the disk at the same time. Value greater than one indicates a disk that can be mounted on multiple VMs at the same time.
+	MaxShares int32
 }
 
 //CreateManagedDisk : create managed disk
@@ -150,6 +152,10 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 			DiskEncryptionSetID: &options.DiskEncryptionSetID,
 			Type:                compute.EncryptionAtRestWithCustomerKey,
 		}
+	}
+
+	if options.MaxShares > 1 {
+		diskProperties.MaxShares = &options.MaxShares
 	}
 
 	model := compute.Disk{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
feat: support [Azure shared disk](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-shared-enable), added a new field(`maxShares`) in azure disk storage class:
```
kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: shared-disk
provisioner: kubernetes.io/azure-disk
parameters:
  skuname: Premium_LRS  # Currently only available with premium SSDs.
  cachingMode: None  # ReadOnly host caching is not available for premium SSDs with maxShares>1
  maxShares: "2"
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: pvc-azuredisk
spec:
  accessModes:
    - ReadWriteMany
  resources:
    requests:
      storage: 100Gi
  storageClassName: shared-disk
```

Due to the [shared disk feature limitation](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-shared-enable#limitations), will add e2e test when it's in public preview

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
feat: support [Azure shared disk](https://docs.microsoft.com/en-us/azure/virtual-machines/windows/disks-shared-enable), added a new field(`maxShares`) in azure disk storage class:

kind: StorageClass
apiVersion: storage.k8s.io/v1
metadata:
  name: shared-disk
provisioner: kubernetes.io/azure-disk
parameters:
  skuname: Premium_LRS  # Currently only available with premium SSDs.
  cachingMode: None  # ReadOnly host caching is not available for premium SSDs with maxShares>1
  maxShares: 2

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
/assign @feiskyer 
/priority important-soon
/sig cloud-provider