### PR TITLE
Print detailed score results on verbose level 10

### DIFF
--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -647,6 +647,12 @@ func (g *genericScheduler) prioritizeNodes(
 		return nil, scoreStatus.AsError()
 	}
 
+	if klog.V(10) {
+		for plugin, nodeScoreList := range scoresMap {
+			klog.Infof("Plugin %s scores on %v/%v => %v", plugin, pod.Namespace, pod.Name, nodeScoreList)
+		}
+	}
+
 	// Summarize all scores.
 	result := make(framework.NodeScoreList, 0, len(nodes))
 

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/BUILD
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/BUILD
@@ -13,7 +13,6 @@ go_library(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
@@ -20,8 +20,6 @@ import (
 	"context"
 	"fmt"
 
-	"k8s.io/klog"
-
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -163,11 +161,6 @@ func (pl *DefaultPodTopologySpread) NormalizeScore(ctx context.Context, state *f
 			}
 		}
 		scores[i].Score = int64(fScore)
-		if klog.V(10) {
-			klog.Infof(
-				"%v -> %v: SelectorSpreadPriority, Score: (%d)", pod.Name, scores[i].Name, int64(fScore),
-			)
-		}
 	}
 	return nil
 }

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -25,7 +25,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/klog"
 	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/internal/parallelize"
@@ -223,13 +222,6 @@ func (pl *PodTopologySpread) NormalizeScore(ctx context.Context, cycleState *fra
 			return framework.NewStatus(framework.Error, err.Error())
 		}
 		node := nodeInfo.Node()
-		// Debugging purpose: print the score for each node.
-		// Score must be a pointer here, otherwise it's always 0.
-		if klog.V(10) {
-			defer func(score *int64, nodeName string) {
-				klog.Infof("%v -> %v: PodTopologySpread NormalizeScore, Score: (%d)", pod.Name, nodeName, *score)
-			}(&scores[i].Score, node.Name)
-		}
 
 		if maxMinDiff == 0 {
 			scores[i].Score = framework.MaxNodeScore


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

Scheduler used to print detailed score results, but that logic was dropped when refactoring to Score plugins.
In a user's perspective, the debugging info is still valuable to figure out the exact reason why a Pod is/isn't scheduler to a node.

```
I0323 13:20:10.715615   10487 generic_scheduler.go:654] Plugin NodeResourcesBalancedAllocation scores on default/pause => [{node2 95} {node1 72}]
I0323 13:20:10.715646   10487 generic_scheduler.go:654] Plugin NodeAffinity scores on default/pause => [{node2 0} {node1 0}]
I0323 13:20:10.715673   10487 generic_scheduler.go:654] Plugin TaintToleration scores on default/pause => [{node2 100} {node1 100}]
I0323 13:20:10.715696   10487 generic_scheduler.go:654] Plugin ImageLocality scores on default/pause => [{node2 0} {node1 0}]
I0323 13:20:10.715707   10487 generic_scheduler.go:654] Plugin InterPodAffinity scores on default/pause => [{node2 0} {node1 0}]
I0323 13:20:10.715714   10487 generic_scheduler.go:654] Plugin NodeResourcesLeastAllocated scores on default/pause => [{node2 92} {node1 77}]
I0323 13:20:10.715722   10487 generic_scheduler.go:654] Plugin NodePreferAvoidPods scores on default/pause => [{node2 1000000} {node1 1000000}]
I0323 13:20:10.715729   10487 generic_scheduler.go:654] Plugin DefaultPodTopologySpread scores on default/pause => [{node2 100} {node1 100}]
I0323 13:20:10.715744   10487 generic_scheduler.go:654] Plugin PodTopologySpread scores on default/pause => [{node2 0} {node1 0}]
```

**Which issue(s) this PR fixes**:

Fixes #88077

**Special notes for your reviewer**:

Along with this PR, we don't need to debug the score info in individual plugins, such as PodTopologySpread and DefaultPodTopologySpread.

**Does this PR introduce a user-facing change?**:

```release-note
Detailed scheduler scoring result can be printed at verbose level 10.
```
