### PR TITLE
Move NewAgnhostPod() to e2e/network

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -155,9 +155,6 @@ var (
 	// BusyBoxImage is the image URI of BusyBox.
 	BusyBoxImage = imageutils.GetE2EImage(imageutils.BusyBox)
 
-	// AgnHostImage is the image URI of AgnHost
-	AgnHostImage = imageutils.GetE2EImage(imageutils.Agnhost)
-
 	// ProvidersWithSSH are those providers where each node is accessible with SSH
 	ProvidersWithSSH = []string{"gce", "gke", "aws", "local"}
 
@@ -1581,25 +1578,6 @@ func DescribeIng(ns string) {
 	desc, _ := RunKubectl(
 		ns, "describe", "ing", fmt.Sprintf("--namespace=%v", ns))
 	Logf(desc)
-}
-
-// NewAgnhostPod returns a pod that uses the agnhost image. The image's binary supports various subcommands
-// that behave the same, no matter the underlying OS.
-func (f *Framework) NewAgnhostPod(name string, args ...string) *v1.Pod {
-	return &v1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.PodSpec{
-			Containers: []v1.Container{
-				{
-					Name:  "agnhost",
-					Image: AgnHostImage,
-					Args:  args,
-				},
-			},
-		},
-	}
 }
 
 // CreateEmptyFileOnPod creates empty file at given path on the pod.

--- a/test/e2e/network/dns.go
+++ b/test/e2e/network/dns.go
@@ -409,7 +409,7 @@ var _ = SIGDescribe("DNS", func() {
 		ginkgo.By("Creating a pod with dnsPolicy=None and customized dnsConfig...")
 		testServerIP := "1.1.1.1"
 		testSearchPath := "resolv.conf.local"
-		testAgnhostPod := f.NewAgnhostPod(f.Namespace.Name, "pause")
+		testAgnhostPod := newAgnhostPod(f.Namespace.Name, "pause")
 		testAgnhostPod.Spec.DNSPolicy = v1.DNSNone
 		testAgnhostPod.Spec.DNSConfig = &v1.PodDNSConfig{
 			Nameservers: []string{testServerIP},

--- a/test/e2e/network/firewall.go
+++ b/test/e2e/network/firewall.go
@@ -146,7 +146,7 @@ var _ = SIGDescribe("Firewall rule", func() {
 			podName := fmt.Sprintf("netexec%v", i)
 
 			framework.Logf("Creating netexec pod %q on node %v in namespace %q", podName, nodeName, ns)
-			pod := f.NewAgnhostPod(podName,
+			pod := newAgnhostPod(podName,
 				"netexec",
 				fmt.Sprintf("--http-port=%d", firewallTestHTTPPort),
 				fmt.Sprintf("--udp-port=%d", firewallTestUDPPort))

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -60,7 +60,7 @@ func checkConnectivityToHost(f *framework.Framework, nodeName, podName, host str
 			Containers: []v1.Container{
 				{
 					Name:    contName,
-					Image:   framework.AgnHostImage,
+					Image:   agnHostImage,
 					Command: command,
 				},
 			},

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -902,7 +902,7 @@ var _ = SIGDescribe("Services", func() {
 
 		ginkgo.By("Creating a webserver pod to be part of the TCP service which echoes back source ip")
 		serverPodName := "echo-sourceip"
-		pod := f.NewAgnhostPod(serverPodName, "netexec", "--http-port", strconv.Itoa(servicePort))
+		pod := newAgnhostPod(serverPodName, "netexec", "--http-port", strconv.Itoa(servicePort))
 		pod.Labels = jig.Labels
 		_, err = cs.CoreV1().Pods(ns).Create(context.TODO(), pod, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
@@ -960,7 +960,7 @@ var _ = SIGDescribe("Services", func() {
 
 		ginkgo.By("creating a client/server pod")
 		serverPodName := "hairpin"
-		podTemplate := f.NewAgnhostPod(serverPodName, "netexec", "--http-port", strconv.Itoa(servicePort))
+		podTemplate := newAgnhostPod(serverPodName, "netexec", "--http-port", strconv.Itoa(servicePort))
 		podTemplate.Labels = jig.Labels
 		pod, err := cs.CoreV1().Pods(ns).Create(context.TODO(), podTemplate, metav1.CreateOptions{})
 		framework.ExpectNoError(err)
@@ -3334,7 +3334,7 @@ func proxyMode(f *framework.Framework) (string, error) {
 			Containers: []v1.Container{
 				{
 					Name:  "detector",
-					Image: framework.AgnHostImage,
+					Image: agnHostImage,
 					Args:  []string{"pause"},
 				},
 			},

--- a/test/e2e/network/util.go
+++ b/test/e2e/network/util.go
@@ -21,9 +21,17 @@ import (
 	"fmt"
 	"time"
 
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/kubernetes/test/e2e/framework"
 	e2enetwork "k8s.io/kubernetes/test/e2e/framework/network"
+	imageutils "k8s.io/kubernetes/test/utils/image"
+)
+
+var (
+	// agnHostImage is the image URI of AgnHost
+	agnHostImage = imageutils.GetE2EImage(imageutils.Agnhost)
 )
 
 // GetHTTPContent returns the content of the given url by HTTP.
@@ -48,4 +56,23 @@ func DescribeSvc(ns string) {
 	desc, _ := framework.RunKubectl(
 		ns, "describe", "svc", fmt.Sprintf("--namespace=%v", ns))
 	framework.Logf(desc)
+}
+
+// newAgnhostPod returns a pod that uses the agnhost image. The image's binary supports various subcommands
+// that behave the same, no matter the underlying OS.
+func newAgnhostPod(name string, args ...string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.PodSpec{
+			Containers: []v1.Container{
+				{
+					Name:  "agnhost",
+					Image: agnHostImage,
+					Args:  args,
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

because the function is called in e2e/network tests only and it is nice to move from util.go for reducing the code of util.go file.

Ref: https://github.com/kubernetes/kubernetes/issues/77095

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

