### PR TITLE
WIP: Reproduce flake issue 86678 easily

### DIFF
--- a/test/e2e/kubectl/portforward.go
+++ b/test/e2e/kubectl/portforward.go
@@ -293,7 +293,7 @@ func doTestMustConnectSendNothing(bindAddress string, f *framework.Framework) {
 
 func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework) {
 	ginkgo.By("Creating the target pod")
-	pod := pfPod("abc", "10", "10", "100", fmt.Sprintf("%s", bindAddress))
+	pod := pfPod("abc", "1000", "10", "100", fmt.Sprintf("%s", bindAddress))
 	if _, err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Create(context.TODO(), pod, metav1.CreateOptions{}); err != nil {
 		framework.Failf("Couldn't create pod: %v", err)
 	}
@@ -333,7 +333,7 @@ func doTestMustConnectSendDisconnect(bindAddress string, f *framework.Framework)
 		framework.Failf("Unexpected error reading data from the server: %v", err)
 	}
 
-	if e, a := strings.Repeat("x", 100), string(fromServer); e != a {
+	if e, a := strings.Repeat("x", 10000), string(fromServer); e != a {
 		podlogs, err := e2epod.GetPodLogs(f.ClientSet, f.Namespace.Name, pod.Name, "portforwardtester")
 		if err != nil {
 			framework.Logf("Failed to get logs of portforwardtester pod: %v", err)


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:

This is just a try to reproduce the issue 86678.
I guess the issue happens if CloseWrite() happens on the e2e test side before agnhost pod sends data.
This adds a sleep() to check the above guessing.

Ref: https://github.com/kubernetes/kubernetes/issues/86678

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

