### PR TITLE
Automated cherry pick of #89401: fix kubectl port-forward for services with explicit local

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -185,7 +185,10 @@ func translateServicePortToTargetPort(ports []string, svc corev1.Service, pod co
 			return nil, err
 		}
 
-		if int32(portnum) != containerPort || localPort == "" {
+		// should fail when localPort is empty (=> use random local port)
+		localportnum, err := strconv.Atoi(localPort)
+
+		if int32(portnum) != containerPort || localPort == "" || (int32(localportnum) != containerPort && err == nil) {
 			translated = append(translated, fmt.Sprintf("%s:%d", localPort, containerPort))
 		} else {
 			translated = append(translated, fmt.Sprintf("%d", containerPort))

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward.go
@@ -185,13 +185,13 @@ func translateServicePortToTargetPort(ports []string, svc corev1.Service, pod co
 			return nil, err
 		}
 
-		// should fail when localPort is empty (=> use random local port)
-		localportnum, err := strconv.Atoi(localPort)
+		// convert the resolved target port back to a string
+		remotePort = strconv.Itoa(int(containerPort))
 
-		if int32(portnum) != containerPort || localPort == "" || (int32(localportnum) != containerPort && err == nil) {
-			translated = append(translated, fmt.Sprintf("%s:%d", localPort, containerPort))
+		if localPort != remotePort {
+			translated = append(translated, fmt.Sprintf("%s:%s", localPort, remotePort))
 		} else {
-			translated = append(translated, fmt.Sprintf("%d", containerPort))
+			translated = append(translated, remotePort)
 		}
 	}
 	return translated, nil

--- a/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/portforward/portforward_test.go
@@ -210,6 +210,35 @@ func TestTranslateServicePortToTargetPort(t *testing.T) {
 			err:        false,
 		},
 		{
+			name: "test success 1 (int port with explicit local port)",
+			svc: corev1.Service{
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{
+						{
+							Port:       8080,
+							TargetPort: intstr.FromInt(8080),
+						},
+					},
+				},
+			},
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "http",
+									ContainerPort: int32(8080)},
+							},
+						},
+					},
+				},
+			},
+			ports:      []string{"8000:8080"},
+			translated: []string{"8000:8080"},
+			err:        false,
+		},
+		{
 			name: "test success 2 (clusterIP: None)",
 			svc: corev1.Service{
 				Spec: corev1.ServiceSpec{


### PR DESCRIPTION
Cherry pick of #89401 on release-1.18.

#89401: fix kubectl port-forward for services with explicit local

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.