### PR TITLE
Automated cherry pick of #89248: Support create or update VMSS asynchoronously.

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_fakes.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2019-06-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage"
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 
@@ -564,6 +565,14 @@ func (fVMSSC *fakeVirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Cont
 	fVMSSC.FakeStore[resourceGroupName][VMScaleSetName] = parameters
 
 	return nil
+}
+
+func (fVMSSC *fakeVirtualMachineScaleSetsClient) CreateOrUpdateAsync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (*azure.Future, *retry.Error) {
+	return nil, nil
+}
+
+func (fVMSSC *fakeVirtualMachineScaleSetsClient) WaitForAsyncOperationResult(ctx context.Context, future *azure.Future) (*http.Response, error) {
+	return nil, nil
 }
 
 func (fVMSSC *fakeVirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGroupName string, VMScaleSetName string) (result compute.VirtualMachineScaleSet, err *retry.Error) {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/vmssclient/interface.go
@@ -20,8 +20,11 @@ package vmssclient
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
+	"github.com/Azure/go-autorest/autorest/azure"
+
 	"k8s.io/legacy-cloud-providers/azure/retry"
 )
 
@@ -42,6 +45,12 @@ type Interface interface {
 
 	// CreateOrUpdate creates or updates a VirtualMachineScaleSet.
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) *retry.Error
+
+	// CreateOrUpdateSync sends the request to arm client and DO NOT wait for the response
+	CreateOrUpdateAsync(ctx context.Context, resourceGroupName string, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) (*azure.Future, *retry.Error)
+
+	// WaitForAsyncOperationResult waits for the response of the request
+	WaitForAsyncOperationResult(ctx context.Context, future *azure.Future) (*http.Response, error)
 
 	// DeleteInstances deletes the instances for a VirtualMachineScaleSet.
 	DeleteInstances(ctx context.Context, resourceGroupName string, vmScaleSetName string, vmInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) *retry.Error


### PR DESCRIPTION
Cherry pick of #89248 on release-1.18.

#89248: Support create or update VMSS asynchoronously.

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.