### PR TITLE
Move BlockNetwork() to e2enetwork

### DIFF
--- a/test/e2e/apps/network_partition.go
+++ b/test/e2e/apps/network_partition.go
@@ -211,7 +211,7 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 				defer func() {
 					ginkgo.By(fmt.Sprintf("Unblock traffic from node %s to the master", node.Name))
 					for _, masterAddress := range masterAddresses {
-						framework.UnblockNetwork(host, masterAddress)
+						e2enetwork.UnblockNetwork(host, masterAddress)
 					}
 
 					if ginkgo.CurrentGinkgoTestDescription().Failed {
@@ -226,7 +226,7 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 				}()
 
 				for _, masterAddress := range masterAddresses {
-					framework.BlockNetwork(host, masterAddress)
+					e2enetwork.BlockNetwork(host, masterAddress)
 				}
 
 				ginkgo.By("Expect to observe node and pod status change from Ready to NotReady after network partition")
@@ -599,7 +599,7 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 				defer func() {
 					ginkgo.By(fmt.Sprintf("Unblock traffic from node %s to the master", node.Name))
 					for _, masterAddress := range masterAddresses {
-						framework.UnblockNetwork(host, masterAddress)
+						e2enetwork.UnblockNetwork(host, masterAddress)
 					}
 
 					if ginkgo.CurrentGinkgoTestDescription().Failed {
@@ -611,7 +611,7 @@ var _ = SIGDescribe("Network Partition [Disruptive] [Slow]", func() {
 				}()
 
 				for _, masterAddress := range masterAddresses {
-					framework.BlockNetwork(host, masterAddress)
+					e2enetwork.BlockNetwork(host, masterAddress)
 				}
 
 				ginkgo.By("Expect to observe node and pod status change from Ready to NotReady after network partition")

--- a/test/e2e/framework/network/BUILD
+++ b/test/e2e/framework/network/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/skipper:go_default_library",
+        "//test/e2e/framework/ssh:go_default_library",
         "//test/utils/image:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],


### PR DESCRIPTION

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This moves both BlockNetwork() and UnblockNetwork() for removing invalid dependency from e2e core framework to e2essh subpackage and reducing test/e2e/framework/util.go code which is one of huge files today.

Ref: https://github.com/kubernetes/kubernetes/issues/77095
Ref: https://github.com/kubernetes/kubernetes/issues/81245

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
