### PR TITLE
fix node role <none>

### DIFF
--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -72,10 +72,10 @@ const (
 
 	// labelNodeRolePrefix is a label prefix for node roles
 	// It's copied over to here until it's merged in core: https://github.com/kubernetes/kubernetes/pull/39112
-	labelNodeRolePrefix = "node-role.kubernetes.io/"
+	labelNodeRolePrefix = "role.node.kubernetes.io/"
 
 	// nodeLabelRole specifies the role of a node
-	nodeLabelRole = "kubernetes.io/role"
+	nodeLabelRole = "kubelet.kubernetes.io/role"
 )
 
 // AddHandlers adds print handlers for default Kubernetes types dealing with internal versions.
@@ -1538,8 +1538,8 @@ func getNodeInternalIP(node *api.Node) string {
 
 // findNodeRoles returns the roles of a given node.
 // The roles are determined by looking for:
-// * a node-role.kubernetes.io/<role>="" label
-// * a kubernetes.io/role="<role>" label
+// * a role.node.kubernetes.io/<role>="" label
+// * a kubelet.kubernetes.io/role="<role>" label
 func findNodeRoles(node *api.Node) []string {
 	roles := sets.NewString()
 	for k, v := range node.Labels {

--- a/pkg/printers/internalversion/printers.go
+++ b/pkg/printers/internalversion/printers.go
@@ -76,7 +76,7 @@ const (
 	deprecatedLabelNodeRolePrefix = "node-role.kubernetes.io/"
 
 	// nodeLabelRole specifies the role of a node
-	nodeLabelRole           = "kubelet.kubernetes.io/role"
+	nodeLabelRole           = "role.kubelet.kubernetes.io/role"
 	deprecatedNodeLabelRole = "kubernetes.io/role"
 )
 
@@ -1541,7 +1541,7 @@ func getNodeInternalIP(node *api.Node) string {
 // findNodeRoles returns the roles of a given node.
 // The roles are determined by looking for:
 // * a role.node.kubernetes.io/<role>="" label
-// * a kubelet.kubernetes.io/role="<role>" label
+// * a role.kubelet.kubernetes.io/role="<role>" label
 // Compatible for old kubelet version:
 // * a node-role.kubernetes.io/<role>="" label
 // * a kubernetes.io/role="<role>" label


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> /kind api-change
> /kind bug

**What this PR does / why we need it**:
When upgrade to v1.17.3 from v1.13.2,  node roles show as `<none>`
```
root@xxx-MASTER01 :~  # kubectl get node node1
NAME     STATUS   ROLES    AGE    VERSION
node1    Ready    <none>   3h4m   v1.17.3-trip
```

**Which issue(s) this PR fixes**:
In former k8s version,  the node-label of `node-role.kubernetes.io` is allowed.   And kubectl displays node roles using the the label.

In v1.17.3,  the label prefix `node-role.kubernetes.io` is not allowed, suggesting `node.kubernetes.io` instead. But kubectl displays node roles still based on the former prefix `node-role.kubernetes.io`.  So kubectl displays node roles as `<none>`.

As https://github.com/kubernetes/enhancements/blob/master/keps/sig-auth/0000-20170814-bounding-self-labeling-kubelets.md#proposal, I suggest that `node-role.kubernetes.io` can be changed to `role.node.kubernetes.io`, `kubernetes.io/role` can be changed to `kubelet.kubernetes.io/role`.

Then we can get the following after label the node `role.node.kubernetes.io/master=true` or `kubelet.kubernetes.io/role=master`
```
root@xxx-MASTER01 :~  # kubectl get node node1
NAME     STATUS   ROLES    AGE    VERSION
node1    Ready    master   3h4m   v1.17.3-trip
```

Fixes #

**Special notes for your reviewer**:
```
Environment:
kubernetes v1.17.3
```


