### PR TITLE
Move RestartKubelet() into e2e/storage/vsphere

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1179,53 +1179,6 @@ func AllNodesReady(c clientset.Interface, timeout time.Duration) error {
 	return nil
 }
 
-// RestartKubelet restarts kubelet on the given host.
-func RestartKubelet(host string) error {
-	// TODO: Make it work for all providers and distros.
-	supportedProviders := []string{"gce", "aws", "vsphere"}
-	if !ProviderIs(supportedProviders...) {
-		return fmt.Errorf("unsupported provider for RestartKubelet: %s, supported providers are: %v", TestContext.Provider, supportedProviders)
-	}
-	if ProviderIs("gce") && !NodeOSDistroIs("debian", "gci") {
-		return fmt.Errorf("unsupported node OS distro: %s", TestContext.NodeOSDistro)
-	}
-	var cmd string
-
-	if ProviderIs("gce") && NodeOSDistroIs("debian") {
-		cmd = "sudo /etc/init.d/kubelet restart"
-	} else if ProviderIs("vsphere") {
-		var sudoPresent bool
-		sshResult, err := e2essh.SSH("sudo --version", host, TestContext.Provider)
-		if err != nil {
-			return fmt.Errorf("Unable to ssh to host %s with error %v", host, err)
-		}
-		if !strings.Contains(sshResult.Stderr, "command not found") {
-			sudoPresent = true
-		}
-		sshResult, err = e2essh.SSH("systemctl --version", host, TestContext.Provider)
-		if err != nil {
-			return fmt.Errorf("Failed to execute command 'systemctl' on host %s with error %v", host, err)
-		}
-		if !strings.Contains(sshResult.Stderr, "command not found") {
-			cmd = "systemctl restart kubelet"
-		} else {
-			cmd = "service kubelet restart"
-		}
-		if sudoPresent {
-			cmd = fmt.Sprintf("sudo %s", cmd)
-		}
-	} else {
-		cmd = "sudo systemctl restart kubelet"
-	}
-	Logf("Restarting kubelet via ssh on host %s with command %s", host, cmd)
-	result, err := e2essh.SSH(cmd, host, TestContext.Provider)
-	if err != nil || result.Code != 0 {
-		e2essh.LogResult(result)
-		return fmt.Errorf("couldn't restart kubelet: %v", err)
-	}
-	return nil
-}
-
 // RestartApiserver restarts the kube-apiserver.
 func RestartApiserver(namespace string, cs clientset.Interface) error {
 	// TODO: Make it work for all providers.

--- a/test/e2e/storage/vsphere/vsphere_volume_master_restart.go
+++ b/test/e2e/storage/vsphere/vsphere_volume_master_restart.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/onsi/ginkgo"
@@ -51,6 +52,40 @@ func waitForKubeletUp(host string) error {
 		}
 	}
 	return fmt.Errorf("waiting for kubelet timed out")
+}
+
+// restartKubelet restarts kubelet on the given host.
+func restartKubelet(host string) error {
+	var cmd string
+
+	var sudoPresent bool
+	sshResult, err := e2essh.SSH("sudo --version", host, framework.TestContext.Provider)
+	if err != nil {
+		return fmt.Errorf("Unable to ssh to host %s with error %v", host, err)
+	}
+	if !strings.Contains(sshResult.Stderr, "command not found") {
+		sudoPresent = true
+	}
+	sshResult, err = e2essh.SSH("systemctl --version", host, framework.TestContext.Provider)
+	if err != nil {
+		return fmt.Errorf("Failed to execute command 'systemctl' on host %s with error %v", host, err)
+	}
+	if !strings.Contains(sshResult.Stderr, "command not found") {
+		cmd = "systemctl restart kubelet"
+	} else {
+		cmd = "service kubelet restart"
+	}
+	if sudoPresent {
+		cmd = fmt.Sprintf("sudo %s", cmd)
+	}
+
+	framework.Logf("Restarting kubelet via ssh on host %s with command %s", host, cmd)
+	result, err := e2essh.SSH(cmd, host, framework.TestContext.Provider)
+	if err != nil || result.Code != 0 {
+		e2essh.LogResult(result)
+		return fmt.Errorf("couldn't restart kubelet: %v", err)
+	}
+	return nil
 }
 
 /*
@@ -134,7 +169,7 @@ var _ = utils.SIGDescribe("Volume Attach Verify [Feature:vsphere][Serial][Disrup
 
 		ginkgo.By("Restarting kubelet on master node")
 		masterAddress := framework.GetMasterHost() + ":22"
-		err := framework.RestartKubelet(masterAddress)
+		err := restartKubelet(masterAddress)
 		framework.ExpectNoError(err, "Unable to restart kubelet on master node")
 
 		ginkgo.By("Verifying the kubelet on master node is up")


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Since 4e7c2f638d311a6a939ef7aa146f195bc33d06dc the function has been
called from storage vsphere e2e test only. This moves the function
into the test file for
- Reducing test/e2e/framework/util.go which is one of huge files
- Remove invalid dependency on e2e test framework
- Remove unnecessary TODO

Ref: https://github.com/kubernetes/kubernetes/issues/77095
Ref: https://github.com/kubernetes/kubernetes/issues/81245

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
