### PR TITLE
Automated cherry pick of #89365: Add check for volume zone GA labels

### DIFF
--- a/pkg/scheduler/algorithm/predicates/predicates.go
+++ b/pkg/scheduler/algorithm/predicates/predicates.go
@@ -140,6 +140,13 @@ var (
 		CheckServiceAffinityPred, MaxEBSVolumeCountPred, MaxGCEPDVolumeCountPred, MaxCSIVolumeCountPred,
 		MaxAzureDiskVolumeCountPred, MaxCinderVolumeCountPred, CheckVolumeBindingPred, NoVolumeZoneConflictPred,
 		EvenPodsSpreadPred, MatchInterPodAffinityPred}
+
+	volumeZoneLabels = sets.NewString(
+		v1.LabelZoneFailureDomain,
+		v1.LabelZoneRegion,
+		v1.LabelZoneFailureDomainStable,
+		v1.LabelZoneRegionStable,
+	)
 )
 
 // Ordering returns the ordering of predicates.
@@ -650,7 +657,7 @@ func (c *VolumeZoneChecker) predicate(pod *v1.Pod, meta Metadata, nodeInfo *sche
 
 	nodeConstraints := make(map[string]string)
 	for k, v := range node.ObjectMeta.Labels {
-		if k != v1.LabelZoneFailureDomain && k != v1.LabelZoneRegion {
+		if !volumeZoneLabels.Has(k) {
 			continue
 		}
 		nodeConstraints[k] = v
@@ -709,7 +716,7 @@ func (c *VolumeZoneChecker) predicate(pod *v1.Pod, meta Metadata, nodeInfo *sche
 			}
 
 			for k, v := range pv.ObjectMeta.Labels {
-				if k != v1.LabelZoneFailureDomain && k != v1.LabelZoneRegion {
+				if !volumeZoneLabels.Has(k) {
 					continue
 				}
 				nodeV, _ := nodeConstraints[k]

--- a/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
+++ b/pkg/scheduler/framework/plugins/volumezone/volume_zone_test.go
@@ -54,10 +54,16 @@ func TestSingleZone(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_1", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-a"}},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "Vol_2", Labels: map[string]string{v1.LabelZoneRegion: "us-west1-b", "uselessLabel": "none"}},
+			ObjectMeta: metav1.ObjectMeta{Name: "Vol_2", Labels: map[string]string{v1.LabelZoneRegion: "us-west1", "uselessLabel": "none"}},
 		},
 		{
-			ObjectMeta: metav1.ObjectMeta{Name: "Vol_3", Labels: map[string]string{v1.LabelZoneRegion: "us-west1-c"}},
+			ObjectMeta: metav1.ObjectMeta{Name: "Vol_3", Labels: map[string]string{v1.LabelZoneRegion: "us-west1"}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "Vol_Stable_1", Labels: map[string]string{v1.LabelZoneFailureDomainStable: "us-west1-a"}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "Vol_Stable_2", Labels: map[string]string{v1.LabelZoneRegionStable: "us-west1", "uselessLabel": "none"}},
 		},
 	}
 
@@ -77,6 +83,14 @@ func TestSingleZone(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_4", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_not_exist"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "PVC_Stable_1", Namespace: "default"},
+			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_Stable_1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "PVC_Stable_2", Namespace: "default"},
+			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_Stable_2"},
 		},
 	}
 
@@ -108,7 +122,7 @@ func TestSingleZone(t *testing.T) {
 			},
 		},
 		{
-			name: "label zone failure domain matched",
+			name: "beta zone label matched",
 			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -118,33 +132,75 @@ func TestSingleZone(t *testing.T) {
 			},
 		},
 		{
-			name: "label zone region matched",
+			name: "beta region label matched",
 			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_2"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
-					Labels: map[string]string{v1.LabelZoneRegion: "us-west1-b", "uselessLabel": "none"},
+					Labels: map[string]string{v1.LabelZoneRegion: "us-west1", "uselessLabel": "none"},
 				},
 			},
 		},
 		{
-			name: "label zone region failed match",
+			name: "beta region label doesn't match",
 			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_2"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
-					Labels: map[string]string{v1.LabelZoneRegion: "no_us-west1-b", "uselessLabel": "none"},
+					Labels: map[string]string{v1.LabelZoneRegion: "no_us-west1", "uselessLabel": "none"},
 				},
 			},
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, predicates.ErrVolumeZoneConflict.GetReason()),
 		},
 		{
-			name: "label zone failure domain failed match",
+			name: "beta zone label doesn't match",
 			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
 					Labels: map[string]string{v1.LabelZoneFailureDomain: "no_us-west1-a", "uselessLabel": "none"},
+				},
+			},
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, predicates.ErrVolumeZoneConflict.GetReason()),
+		},
+		{
+			name: "zone label matched",
+			Pod:  createPodWithVolume("pod_1", "Vol_Stable_1", "PVC_Stable_1"),
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "host1",
+					Labels: map[string]string{v1.LabelZoneFailureDomainStable: "us-west1-a", "uselessLabel": "none"},
+				},
+			},
+		},
+		{
+			name: "region label matched",
+			Pod:  createPodWithVolume("pod_1", "Vol_Stable_2", "PVC_Stable_2"),
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "host1",
+					Labels: map[string]string{v1.LabelZoneRegionStable: "us-west1", "uselessLabel": "none"},
+				},
+			},
+		},
+		{
+			name: "region label doesn't match",
+			Pod:  createPodWithVolume("pod_1", "Vol_Stable_2", "PVC_Stable_2"),
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "host1",
+					Labels: map[string]string{v1.LabelZoneRegionStable: "no_us-west1", "uselessLabel": "none"},
+				},
+			},
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, predicates.ErrVolumeZoneConflict.GetReason()),
+		},
+		{
+			name: "zone label doesn't match",
+			Pod:  createPodWithVolume("pod_1", "Vol_Stable_1", "PVC_Stable_1"),
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "host1",
+					Labels: map[string]string{v1.LabelZoneFailureDomainStable: "no_us-west1-a", "uselessLabel": "none"},
 				},
 			},
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, predicates.ErrVolumeZoneConflict.GetReason()),
@@ -177,6 +233,12 @@ func TestMultiZone(t *testing.T) {
 		{
 			ObjectMeta: metav1.ObjectMeta{Name: "Vol_3", Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-c__us-west1-a"}},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "Vol_Stable_1", Labels: map[string]string{v1.LabelZoneFailureDomainStable: "us-west1-a"}},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "Vol_Stable_2", Labels: map[string]string{v1.LabelZoneFailureDomainStable: "us-west1-c__us-west1-a"}},
+		},
 	}
 
 	pvcLister := fakelisters.PersistentVolumeClaimLister{
@@ -196,6 +258,14 @@ func TestMultiZone(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Name: "PVC_4", Namespace: "default"},
 			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_not_exist"},
 		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "PVC_Stable_1", Namespace: "default"},
+			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_Stable_1"},
+		},
+		{
+			ObjectMeta: metav1.ObjectMeta{Name: "PVC_Stable_2", Namespace: "default"},
+			Spec:       v1.PersistentVolumeClaimSpec{VolumeName: "Vol_Stable_2"},
+		},
 	}
 
 	tests := []struct {
@@ -214,7 +284,7 @@ func TestMultiZone(t *testing.T) {
 			},
 		},
 		{
-			name: "label zone failure domain matched",
+			name: "beta zone label matched",
 			Pod:  createPodWithVolume("pod_1", "Vol_3", "PVC_3"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -224,12 +294,33 @@ func TestMultiZone(t *testing.T) {
 			},
 		},
 		{
-			name: "label zone failure domain failed match",
+			name: "beta zone label doesn't match",
 			Pod:  createPodWithVolume("pod_1", "vol_1", "PVC_1"),
 			Node: &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   "host1",
 					Labels: map[string]string{v1.LabelZoneFailureDomain: "us-west1-b", "uselessLabel": "none"},
+				},
+			},
+			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, predicates.ErrVolumeZoneConflict.GetReason()),
+		},
+		{
+			name: "zone label matched",
+			Pod:  createPodWithVolume("pod_1", "Vol_Stable_2", "PVC_Stable_2"),
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "host1",
+					Labels: map[string]string{v1.LabelZoneFailureDomainStable: "us-west1-a", "uselessLabel": "none"},
+				},
+			},
+		},
+		{
+			name: "zone label doesn't match",
+			Pod:  createPodWithVolume("pod_1", "Vol_Stable_1", "PVC_Stable_1"),
+			Node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "host1",
+					Labels: map[string]string{v1.LabelZoneFailureDomainStable: "us-west1-b", "uselessLabel": "none"},
 				},
 			},
 			wantStatus: framework.NewStatus(framework.UnschedulableAndUnresolvable, predicates.ErrVolumeZoneConflict.GetReason()),


### PR DESCRIPTION
Cherry pick of #89365 on release-1.17.

#89365: Add check for volume zone GA labels

```release-note
NONE
```

/assign @ahg-g