### PR TITLE
fix(kubectl): remove trailing space when completing file path

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/completion/completion.go
@@ -223,49 +223,9 @@ __kubectl_get_comp_words_by_ref() {
 }
 
 __kubectl_filedir() {
-	local RET OLD_IFS w qw
-
-	__kubectl_debug "_filedir $@ cur=$cur"
-	if [[ "$1" = \~* ]]; then
-		# somehow does not work. Maybe, zsh does not call this at all
-		eval echo "$1"
-		return 0
-	fi
-
-	OLD_IFS="$IFS"
-	IFS=$'\n'
-	if [ "$1" = "-d" ]; then
-		shift
-		RET=( $(compgen -d) )
-	else
-		RET=( $(compgen -f) )
-	fi
-	IFS="$OLD_IFS"
-
-	IFS="," __kubectl_debug "RET=${RET[@]} len=${#RET[@]}"
-
-	for w in ${RET[@]}; do
-		if [[ ! "${w}" = "${cur}"* ]]; then
-			continue
-		fi
-		if eval "[[ \"\${w}\" = *.$1 || -d \"\${w}\" ]]"; then
-			qw="$(__kubectl_quote "${w}")"
-			if [ -d "${w}" ]; then
-				COMPREPLY+=("${qw}/")
-			else
-				COMPREPLY+=("${qw}")
-			fi
-		fi
-	done
-}
-
-__kubectl_quote() {
-    if [[ $1 == \'* || $1 == \"* ]]; then
-        # Leave out first character
-        printf %q "${1:1}"
-    else
-	printf %q "$1"
-    fi
+	# Don't need to do anything here.
+	# Otherwise we will get trailing space without "compopt -o nospace"
+	true
 }
 
 autoload -U +X bashcompinit && bashcompinit


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

As desribed in https://github.com/kubernetes/kubectl/issues/407, currently there is always a trailing space after directory path when completing in zsh, which is a bit annoying if a file is deep.

This PR removes the trailing space.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubectl/issues/407

**Special notes for your reviewer**:

https://github.com/kubernetes/kubectl/blob/4a903e621c5a2210ef9480aa64e976a9df153c06/pkg/cmd/completion/completion.go#L171-L174

Since we are using `bashcompinit` now, and `bashcompinit` does not support `compopt`, so we cannot remove the extra space by `compopt -o nospace`. It seems we'd better remove our handwritten `_filedir` function and leave it to zsh.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
