### PR TITLE
Optimize preferred spreading for hostname topology

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/BUILD
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/BUILD
@@ -27,6 +27,7 @@ go_test(
     deps = [
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
+        "//pkg/scheduler/internal/parallelize:go_default_library",
         "//pkg/scheduler/testing:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/pkg/scheduler/framework/plugins/podtopologyspread/BUILD
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/BUILD
@@ -41,6 +41,7 @@ go_test(
     deps = [
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
+        "//pkg/scheduler/internal/parallelize:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//pkg/scheduler/testing:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",

--- a/pkg/scheduler/framework/plugins/podtopologyspread/common.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/common.go
@@ -82,3 +82,17 @@ func filterTopologySpreadConstraints(constraints []v1.TopologySpreadConstraint, 
 	}
 	return result, nil
 }
+
+func countPodsMatchSelector(pods []*v1.Pod, selector labels.Selector, ns string) int {
+	count := 0
+	for _, p := range pods {
+		// Bypass terminating Pod (see #87621).
+		if p.DeletionTimestamp != nil || p.Namespace != ns {
+			continue
+		}
+		if selector.Matches(labels.Set(p.Labels)) {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -23,7 +23,6 @@ import (
 	"sync/atomic"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/klog"
 	pluginhelper "k8s.io/kubernetes/pkg/scheduler/framework/plugins/helper"
@@ -74,6 +73,10 @@ func (pl *PodTopologySpread) initPreScoreState(s *preScoreState, pod *v1.Pod, fi
 			continue
 		}
 		for _, constraint := range s.Constraints {
+			// per-node counts are calculated during Score.
+			if constraint.TopologyKey == v1.LabelHostname {
+				continue
+			}
 			pair := topologyPair{key: constraint.TopologyKey, value: node.Labels[constraint.TopologyKey]}
 			if s.TopologyPairToPodCounts[pair] == nil {
 				s.TopologyPairToPodCounts[pair] = new(int64)
@@ -104,7 +107,7 @@ func (pl *PodTopologySpread) PreScore(
 	}
 
 	state := &preScoreState{
-		NodeNameSet:             sets.String{},
+		NodeNameSet:             make(sets.String, len(filteredNodes)),
 		TopologyPairToPodCounts: make(map[topologyPair]*int64),
 	}
 	err = pl.initPreScoreState(state, pod, filteredNodes)
@@ -135,22 +138,13 @@ func (pl *PodTopologySpread) PreScore(
 			pair := topologyPair{key: c.TopologyKey, value: node.Labels[c.TopologyKey]}
 			// If current topology pair is not associated with any candidate node,
 			// continue to avoid unnecessary calculation.
-			if state.TopologyPairToPodCounts[pair] == nil {
+			// Per-node counts are also skipped, as they are done during Score.
+			tpCount := state.TopologyPairToPodCounts[pair]
+			if tpCount == nil {
 				continue
 			}
-
-			// <matchSum> indicates how many pods (on current node) match the <constraint>.
-			matchSum := int64(0)
-			for _, existingPod := range nodeInfo.Pods() {
-				// Bypass terminating Pod (see #87621).
-				if existingPod.DeletionTimestamp != nil || existingPod.Namespace != pod.Namespace {
-					continue
-				}
-				if c.Selector.Matches(labels.Set(existingPod.Labels)) {
-					matchSum++
-				}
-			}
-			atomic.AddInt64(state.TopologyPairToPodCounts[pair], matchSum)
+			count := countPodsMatchSelector(nodeInfo.Pods(), c.Selector, pod.Namespace)
+			atomic.AddInt64(tpCount, int64(count))
 		}
 	}
 	parallelize.Until(ctx, len(allNodes), processAllNode)
@@ -184,9 +178,14 @@ func (pl *PodTopologySpread) Score(ctx context.Context, cycleState *framework.Cy
 	var score int64
 	for _, c := range s.Constraints {
 		if tpVal, ok := node.Labels[c.TopologyKey]; ok {
-			pair := topologyPair{key: c.TopologyKey, value: tpVal}
-			matchSum := *s.TopologyPairToPodCounts[pair]
-			score += matchSum
+			if c.TopologyKey == v1.LabelHostname {
+				count := countPodsMatchSelector(nodeInfo.Pods(), c.Selector, pod.Namespace)
+				score += int64(count)
+			} else {
+				pair := topologyPair{key: c.TopologyKey, value: tpVal}
+				matchSum := *s.TopologyPairToPodCounts[pair]
+				score += matchSum
+			}
 		}
 	}
 	return score, nil


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Optimize spreading when using `kubernetes.io/hostname` as a topology key. We avoid calculating per-node counters during PreScore and do it in Score instead. This is faster because there are less map insertions and accesses.

```
default spreading

BenchmarkTestSelectorSpreadPriority/100nodes-56         	    5161	    226371 ns/op
BenchmarkTestSelectorSpreadPriority/1000nodes-56        	     788	   1516032 ns/op

master

BenchmarkTestDefaultEvenPodsSpreadPriority/100nodes-56         	    2168	    489570 ns/op
BenchmarkTestDefaultEvenPodsSpreadPriority/1000nodes-56        	     378	   3022404 ns/op

this PR

BenchmarkTestDefaultEvenPodsSpreadPriority/100nodes-56         	    3805	    329776 ns/op
BenchmarkTestDefaultEvenPodsSpreadPriority/1000nodes-56        	     631	   1858747 ns/op
```

This makes the implementation of default spreading with "topology spreading" closer to the default spreading:
- 0.3ms for 100 nodes, 1,000 pods (1.4x from default spreading)
- 1.8ms for 1,000 nodes, 10,000 pods (1.2x from default spreading)

**Which issue(s) this PR fixes**:

Part of #84936

**Special notes for your reviewer**:

The first commit contains the optimization.
The second commit updates the benchmark to reflect scheduler code, which parallelizes score calculation.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```