### PR TITLE
publishing-bot: Update go references to new versions

### DIFF
--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -20,17 +20,17 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/code-generator
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/code-generator
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
   - source:
       branch: release-1.18
       dir: staging/src/k8s.io/code-generator
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
 
 - destination: apimachinery
   library: true
@@ -48,17 +48,17 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/apimachinery
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/apimachinery
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
   - source:
       branch: release-1.18
       dir: staging/src/k8s.io/apimachinery
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
 
 - destination: api
   library: true
@@ -82,7 +82,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/api
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
       - repository: apimachinery
         branch: release-1.16
@@ -90,7 +90,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/api
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
       - repository: apimachinery
         branch: release-1.17
@@ -98,7 +98,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/api
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
       - repository: apimachinery
         branch: release-1.18
@@ -129,7 +129,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/client-go
     name: release-13.0
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
       - repository: apimachinery
         branch: release-1.16
@@ -139,7 +139,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/client-go
     name: release-14.0
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
       - repository: apimachinery
         branch: release-1.17
@@ -149,7 +149,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/client-go
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
       - repository: apimachinery
         branch: release-1.18
@@ -186,7 +186,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/component-base
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -198,7 +198,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/component-base
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -210,7 +210,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/component-base
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -253,7 +253,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/apiserver
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -267,7 +267,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/apiserver
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -281,7 +281,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/apiserver
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -333,7 +333,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -351,7 +351,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -369,7 +369,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -429,7 +429,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -449,7 +449,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -469,7 +469,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -526,7 +526,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-controller
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -542,7 +542,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/sample-controller
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -558,7 +558,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/sample-controller
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -619,7 +619,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -639,7 +639,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -659,7 +659,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -710,7 +710,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/metrics
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -724,7 +724,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/metrics
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -738,7 +738,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/metrics
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -779,7 +779,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.16
@@ -791,7 +791,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.17
@@ -803,7 +803,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.18
@@ -846,7 +846,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.16
@@ -860,7 +860,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.17
@@ -874,7 +874,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.18
@@ -915,7 +915,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -929,7 +929,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -943,7 +943,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -980,7 +980,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kubelet
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -990,7 +990,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/kubelet
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -1000,7 +1000,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/kubelet
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -1037,7 +1037,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -1051,7 +1051,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -1065,7 +1065,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -1106,7 +1106,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -1120,7 +1120,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -1134,7 +1134,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -1171,7 +1171,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.16
@@ -1181,7 +1181,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.17
@@ -1191,7 +1191,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: apimachinery
       branch: release-1.18
@@ -1228,7 +1228,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1240,7 +1240,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.17
@@ -1252,7 +1252,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.18
@@ -1295,7 +1295,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1309,7 +1309,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.17
@@ -1323,7 +1323,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.18
@@ -1376,7 +1376,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1396,7 +1396,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.17
@@ -1416,7 +1416,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.18
@@ -1454,7 +1454,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/node-api
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1468,7 +1468,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/node-api
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.17
@@ -1495,17 +1495,17 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/cri-api
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
   - source:
       branch: release-1.17
       dir: staging/src/k8s.io/cri-api
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
   - source:
       branch: release-1.18
       dir: staging/src/k8s.io/cri-api
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
 
 - destination: kubectl
   library: true
@@ -1538,7 +1538,7 @@ rules:
       branch: release-1.16
       dir: staging/src/k8s.io/kubectl
     name: release-1.16
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.16
@@ -1558,7 +1558,7 @@ rules:
       branch: release-1.17
       dir: staging/src/k8s.io/kubectl
     name: release-1.17
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.17
@@ -1578,7 +1578,7 @@ rules:
       branch: release-1.18
       dir: staging/src/k8s.io/kubectl
     name: release-1.18
-    go: 1.13.4
+    go: 1.13.9
     dependencies:
     - repository: api
       branch: release-1.18

--- a/staging/publishing/rules.yaml
+++ b/staging/publishing/rules.yaml
@@ -15,7 +15,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/code-generator
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/code-generator
@@ -43,7 +43,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/apimachinery
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/apimachinery
@@ -74,7 +74,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/api
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
       - repository: apimachinery
         branch: release-1.15
@@ -119,7 +119,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/client-go
     name: release-12.0
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
       - repository: apimachinery
         branch: release-1.15
@@ -178,7 +178,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/component-base
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -239,7 +239,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/apiserver
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -315,7 +315,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/kube-aggregator
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -409,7 +409,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/sample-apiserver
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -510,7 +510,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/sample-controller
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -599,7 +599,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/apiextensions-apiserver
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -696,7 +696,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/metrics
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -767,7 +767,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/cli-runtime
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: api
       branch: release-1.15
@@ -832,7 +832,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/sample-cli-plugin
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: api
       branch: release-1.15
@@ -905,7 +905,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/kube-proxy
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -970,7 +970,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/kubelet
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -1027,7 +1027,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/kube-scheduler
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -1096,7 +1096,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/kube-controller-manager
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -1161,7 +1161,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/cluster-bootstrap
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: apimachinery
       branch: release-1.15
@@ -1216,7 +1216,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/cloud-provider
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: api
       branch: release-1.15
@@ -1281,7 +1281,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/csi-translation-lib
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: api
       branch: release-1.15
@@ -1360,7 +1360,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/legacy-cloud-providers
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: api
       branch: release-1.15
@@ -1440,7 +1440,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/node-api
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
     dependencies:
     - repository: api
       branch: release-1.15
@@ -1490,7 +1490,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/cri-api
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/cri-api
@@ -1533,7 +1533,7 @@ rules:
       branch: release-1.15
       dir: staging/src/k8s.io/kubectl
     name: release-1.15
-    go: 1.12.12
+    go: 1.12.17
   - source:
       branch: release-1.16
       dir: staging/src/k8s.io/kubectl


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area dependency
/sig release
/area release-eng

**What this PR does / why we need it**:
(Part of [quarterly go updates](https://github.com/kubernetes/release/issues/1134))

- publishing-bot: Update go 1.13 references to go1.13.9
- publishing-bot: Update go 1.12 references to go1.12.17

/assign @nikhita @dims @liggitt @sttts 
cc: @kubernetes/release-engineering 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
