### PR TITLE
fix(kubectl): explain crds whose resource name is the same as builtin objects

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/explain/explain.go
@@ -123,19 +123,14 @@ func (o *ExplainOptions) Run(args []string) error {
 	// TODO: After we figured out the new syntax to separate group and resource, allow
 	// the users to use it in explain (kubectl explain <group><syntax><resource>).
 	// Refer to issue #16039 for why we do this. Refer to PR #15808 that used "/" syntax.
-	inModel, fieldsPath, err := explain.SplitAndParseResourceRequest(args[0], o.Mapper)
+	fullySpecifiedGVR, fieldsPath, err := explain.SplitAndParseResourceRequest(args[0], o.Mapper)
 	if err != nil {
 		return err
 	}
 
-	// TODO: We should deduce the group for a resource by discovering the supported resources at server.
-	fullySpecifiedGVR, groupResource := schema.ParseResourceArg(inModel)
-	gvk := schema.GroupVersionKind{}
-	if fullySpecifiedGVR != nil {
-		gvk, _ = o.Mapper.KindFor(*fullySpecifiedGVR)
-	}
+	gvk, _ := o.Mapper.KindFor(fullySpecifiedGVR)
 	if gvk.Empty() {
-		gvk, err = o.Mapper.KindFor(groupResource.WithVersion(""))
+		gvk, err = o.Mapper.KindFor(fullySpecifiedGVR.GroupResource().WithVersion(""))
 		if err != nil {
 			return err
 		}
@@ -151,7 +146,7 @@ func (o *ExplainOptions) Run(args []string) error {
 
 	schema := o.Schema.LookupResource(gvk)
 	if schema == nil {
-		return fmt.Errorf("Couldn't find resource for %q", gvk)
+		return fmt.Errorf("couldn't find resource for %q", gvk)
 	}
 
 	return explain.PrintModelDescription(fieldsPath, o.Out, schema, gvk, recursive)

--- a/staging/src/k8s.io/kubectl/pkg/explain/explain.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/explain.go
@@ -20,9 +20,10 @@ import (
 	"io"
 	"strings"
 
+	"k8s.io/kube-openapi/pkg/util/proto"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/kube-openapi/pkg/util/proto"
 )
 
 type fieldsPrinter interface {
@@ -43,10 +44,13 @@ func splitDotNotation(model string) (string, []string) {
 }
 
 // SplitAndParseResourceRequest separates the users input into a model and fields
-func SplitAndParseResourceRequest(inResource string, mapper meta.RESTMapper) (string, []string, error) {
+func SplitAndParseResourceRequest(inResource string, mapper meta.RESTMapper) (schema.GroupVersionResource, []string, error) {
 	inResource, fieldsPath := splitDotNotation(inResource)
-	inResource, _ = mapper.ResourceSingularizer(inResource)
-	return inResource, fieldsPath, nil
+	gvr, err := mapper.ResourceFor(schema.GroupVersionResource{Resource: inResource})
+	if err != nil {
+		return schema.GroupVersionResource{}, nil, err
+	}
+	return gvr, fieldsPath, nil
 }
 
 // PrintModelDescription prints the description of a specific model or dot path.

--- a/staging/src/k8s.io/kubectl/pkg/explain/explain_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/explain/explain_test.go
@@ -21,37 +21,38 @@ import (
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/meta/testrestmapper"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/kubectl/pkg/scheme"
 )
 
 func TestSplitAndParseResourceRequest(t *testing.T) {
 	tests := []struct {
 		name       string
-		inresource string
+		inResource string
 
-		expectedInResource string
+		expectedGVR        schema.GroupVersionResource
 		expectedFieldsPath []string
 		expectedErr        bool
 	}{
 		{
 			name:       "no trailing period",
-			inresource: "field1.field2.field3",
+			inResource: "pods.field2.field3",
 
-			expectedInResource: "field1",
+			expectedGVR:        schema.GroupVersionResource{Resource: "pods", Version: "v1"},
 			expectedFieldsPath: []string{"field2", "field3"},
 		},
 		{
 			name:       "trailing period with correct fieldsPath",
-			inresource: "field1.field2.field3.",
+			inResource: "service.field2.field3.",
 
-			expectedInResource: "field1",
+			expectedGVR:        schema.GroupVersionResource{Resource: "services", Version: "v1"},
 			expectedFieldsPath: []string{"field2", "field3"},
 		},
 		{
 			name:       "trailing period with incorrect fieldsPath",
-			inresource: "field1.field2.field3.",
+			inResource: "node.field2.field3.",
 
-			expectedInResource: "field1",
+			expectedGVR:        schema.GroupVersionResource{Resource: "nodes", Version: "v1"},
 			expectedFieldsPath: []string{"field2", "field3", ""},
 			expectedErr:        true,
 		},
@@ -60,13 +61,13 @@ func TestSplitAndParseResourceRequest(t *testing.T) {
 	mapper := testrestmapper.TestOnlyStaticRESTMapper(scheme.Scheme, scheme.Scheme.PrioritizedVersionsAllGroups()...)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotInResource, gotFieldsPath, err := SplitAndParseResourceRequest(tt.inresource, mapper)
+			gotGVR, gotFieldsPath, err := SplitAndParseResourceRequest(tt.inResource, mapper)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			if !reflect.DeepEqual(tt.expectedInResource, gotInResource) && !tt.expectedErr {
-				t.Errorf("%s: expected inresource: %s, got: %s", tt.name, tt.expectedInResource, gotInResource)
+			if !reflect.DeepEqual(tt.expectedGVR, gotGVR) && !tt.expectedErr {
+				t.Errorf("%s: expected inResource: %s, got: %s", tt.name, tt.expectedGVR, gotGVR)
 			}
 
 			if !reflect.DeepEqual(tt.expectedFieldsPath, gotFieldsPath) && !tt.expectedErr {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Currently, if the resource name of a custom resource is the same as one of builtin objects(like knative [Service](https://knative.dev/docs/serving/spec/knative-api-specification-1.0/#service) and core Service), `kubectl explain` fails to find the correct resource even a distinguishable short name is given.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubectl/issues/749

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Explain CRDs whose resource name are the same as builtin objects 
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
