### PR TITLE
kubectl: add app label for run cmd

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -597,7 +597,7 @@ func (o *RunOptions) generateService(f cmdutil.Factory, cmd *cobra.Command, serv
 	}
 	selector, found := params["labels"]
 	if !found || len(selector.(string)) == 0 {
-		selector = fmt.Sprintf("run=%s", name.(string))
+		selector = fmt.Sprintf("run=%s,app=%s", name.(string), name.(string))
 	}
 	params["selector"] = selector
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Add default label `app=%s` for kubectl run command.
Now, `kubectl run` create a deployment/pod with a label `run=%s`, but `kubectl create service` with a selector label `app=%s`, as follow:
```
> kubectl run --image=nginx demo
deployment.apps/demo create
>  kubectl get po --show-labels | grep demo
demo-5c8d4c495b-4wlmf             1/1     Running            0          17m    pod-template-hash=5c8d4c495b,run=demo

> kubectl create service clusterip --tcp=80 demo
service/demo created
> kubectl get service demo -oyaml
spec:
  selector:
    app: demo
```
The default service selector should match the pod created by `run`, and `app=%s` label to fix it. 

Does this PR introduce a user-facing change?:
```release-note
NONE
```