### PR TITLE
Detect transitive dependencies on k8s.io/kubernetes

### DIFF
--- a/hack/update-vendor.sh
+++ b/hack/update-vendor.sh
@@ -296,6 +296,14 @@ done
 echo "=== tidying root" >> "${LOG_FILE}"
 go mod tidy >>"${LOG_FILE}" 2>&1
 
+# disallow transitive dependencies on k8s.io/kubernetes
+loopback_deps=()
+kube::util::read-array loopback_deps < <(go mod graph | grep ' k8s.io/kubernetes')
+if [[ -n ${loopback_deps[*]:+"${loopback_deps[*]}"} ]]; then
+  kube::log::error "Disallowed transitive k8s.io/kubernetes dependencies exist via the following imports:"
+  kube::log::error "${loopback_deps[@]}"
+  exit 1
+fi
 
 # Phase 6: add generated comments to go.mod files
 kube::log::status "go.mod: adding generated comments"


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Detects and prevents introduction of dependencies that recursively reference k8s.io/kubernetes

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/area code-organization
/cc @dims