### PR TITLE
Automated cherry pick of #88348: Check that ImageInspect pointer is not nil

### DIFF
--- a/pkg/kubelet/dockershim/docker_container.go
+++ b/pkg/kubelet/dockershim/docker_container.go
@@ -415,7 +415,7 @@ func (ds *dockerService) ContainerStatus(_ context.Context, req *runtimeapi.Cont
 
 	labels, annotations := extractLabels(r.Config.Labels)
 	imageName := r.Config.Image
-	if len(ir.RepoTags) > 0 {
+	if ir != nil && len(ir.RepoTags) > 0 {
 		imageName = ir.RepoTags[0]
 	}
 	status := &runtimeapi.ContainerStatus{


### PR DESCRIPTION
Cherry pick of #88348 on release-1.18.

#88348: Check that ImageInspect pointer is not nil

Fixes #89529

```release-note
NONE
```
