### PR TITLE
Add package comments to the kube-scheduler config APIs

### DIFF
--- a/staging/src/k8s.io/kube-scheduler/config/v1/doc.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1/doc.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1 is the v1 version of the kube-scheduler config API
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
 // +groupName=kubescheduler.config.k8s.io
-
 package v1 // import "k8s.io/kube-scheduler/config/v1"

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha2/doc.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha2/doc.go
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha2 is the v1alpha2 version of the kube-scheduler config API
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
 // +groupName=kubescheduler.config.k8s.io
-
 package v1alpha2 // import "k8s.io/kube-scheduler/config/v1alpha2"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

The tool to generate reference docs uses gengo to parse comments. The groupnames are extracted from the package comment.

https://github.com/ahmetb/gen-crd-api-reference-docs/blob/29b580c31232741d46f579a3ed7371dd35244207/main.go#L190

https://github.com/kubernetes/gengo/blob/e0e292d8aa122d458174e1bef5f142b4d0a67a05/parser/parse.go#L526

**Which issue(s) this PR fixes**:

Ref #88919

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
