### PR TITLE
Fixes problem where kubectl apply stops after first error

### DIFF
--- a/hack/testdata/multi-resource.yaml
+++ b/hack/testdata/multi-resource.yaml
@@ -1,0 +1,19 @@
+# Tests that initial failures to not block subsequent applies.
+# Pod must be before namespace, so it initially fails. Second
+# apply of pod should succeed, since namespace finally exists.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: multi-resource-ns
+  labels:
+    name: test-pod-label
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multi-resource-ns

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/mergepatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",


### PR DESCRIPTION
* Fixes https://github.com/kubernetes/kubectl/issues/845
* Accumulates errors during apply (this used to happen in the builder `Visit()`), and return the aggregate of errors (if any occur).
* Add integration test with the following steps:
1. Applies pod followed by namespace pod should be created in.
2. Check that pod fails, but namespace is created.
3. Apply the same resources as `1` in the same order.
4. Check that pod succeeds (since namespace now exists).
* Tested manually as well

/kind bug
/sig cli
/area kubectl
/priority important-soon

```release-note
NONE
```
