### PR TITLE
Fix cpu resource metric type by changing to counter

### DIFF
--- a/pkg/kubelet/metrics/collectors/resource_metrics.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics.go
@@ -26,7 +26,7 @@ import (
 )
 
 var (
-	nodeCPUUsageDesc = metrics.NewDesc("node_cpu_usage_seconds",
+	nodeCPUUsageDesc = metrics.NewDesc("node_cpu_usage_seconds_total",
 		"Cumulative cpu time consumed by the node in core-seconds",
 		nil,
 		nil,
@@ -40,7 +40,7 @@ var (
 		metrics.ALPHA,
 		"")
 
-	containerCPUUsageDesc = metrics.NewDesc("container_cpu_usage_seconds",
+	containerCPUUsageDesc = metrics.NewDesc("container_cpu_usage_seconds_total",
 		"Cumulative cpu time consumed by the container in core-seconds",
 		[]string{"container", "pod", "namespace"},
 		nil,
@@ -120,7 +120,7 @@ func (rc *resourceMetricsCollector) collectNodeCPUMetrics(ch chan<- metrics.Metr
 	}
 
 	ch <- metrics.NewLazyMetricWithTimestamp(s.CPU.Time.Time,
-		metrics.NewLazyConstMetric(nodeCPUUsageDesc, metrics.GaugeValue, float64(*s.CPU.UsageCoreNanoSeconds)/float64(time.Second)))
+		metrics.NewLazyConstMetric(nodeCPUUsageDesc, metrics.CounterValue, float64(*s.CPU.UsageCoreNanoSeconds)/float64(time.Second)))
 }
 
 func (rc *resourceMetricsCollector) collectNodeMemoryMetrics(ch chan<- metrics.Metric, s summary.NodeStats) {
@@ -138,7 +138,7 @@ func (rc *resourceMetricsCollector) collectContainerCPUMetrics(ch chan<- metrics
 	}
 
 	ch <- metrics.NewLazyMetricWithTimestamp(s.CPU.Time.Time,
-		metrics.NewLazyConstMetric(containerCPUUsageDesc, metrics.GaugeValue,
+		metrics.NewLazyConstMetric(containerCPUUsageDesc, metrics.CounterValue,
 			float64(*s.CPU.UsageCoreNanoSeconds)/float64(time.Second), s.Name, pod.PodRef.Name, pod.PodRef.Namespace))
 }
 

--- a/pkg/kubelet/metrics/collectors/resource_metrics_test.go
+++ b/pkg/kubelet/metrics/collectors/resource_metrics_test.go
@@ -47,9 +47,9 @@ func TestCollectResourceMetrics(t *testing.T) {
 	testTime := metav1.NewTime(time.Unix(2, 0)) // a static timestamp: 2000
 	interestedMetrics := []string{
 		"scrape_error",
-		"node_cpu_usage_seconds",
+		"node_cpu_usage_seconds_total",
 		"node_memory_working_set_bytes",
-		"container_cpu_usage_seconds",
+		"container_cpu_usage_seconds_total",
 		"container_memory_working_set_bytes",
 	}
 
@@ -85,9 +85,9 @@ func TestCollectResourceMetrics(t *testing.T) {
 			},
 			summaryErr: nil,
 			expectedMetrics: `
-				# HELP node_cpu_usage_seconds [ALPHA] Cumulative cpu time consumed by the node in core-seconds
-				# TYPE node_cpu_usage_seconds gauge
-				node_cpu_usage_seconds 10 2000
+				# HELP node_cpu_usage_seconds_total [ALPHA] Cumulative cpu time consumed by the node in core-seconds
+				# TYPE node_cpu_usage_seconds_total counter
+				node_cpu_usage_seconds_total 10 2000
 				# HELP node_memory_working_set_bytes [ALPHA] Current working set of the node in bytes
 				# TYPE node_memory_working_set_bytes gauge
 				node_memory_working_set_bytes 1000 2000
@@ -156,11 +156,11 @@ func TestCollectResourceMetrics(t *testing.T) {
 				# HELP scrape_error [ALPHA] 1 if there was an error while getting container metrics, 0 otherwise
 				# TYPE scrape_error gauge
 				scrape_error 0
-				# HELP container_cpu_usage_seconds [ALPHA] Cumulative cpu time consumed by the container in core-seconds
-				# TYPE container_cpu_usage_seconds gauge
-				container_cpu_usage_seconds{container="container_a",namespace="namespace_a",pod="pod_a"} 10 2000
-				container_cpu_usage_seconds{container="container_a",namespace="namespace_b",pod="pod_b"} 10 2000
-				container_cpu_usage_seconds{container="container_b",namespace="namespace_a",pod="pod_a"} 10 2000
+				# HELP container_cpu_usage_seconds_total [ALPHA] Cumulative cpu time consumed by the container in core-seconds
+				# TYPE container_cpu_usage_seconds_total counter
+				container_cpu_usage_seconds_total{container="container_a",namespace="namespace_a",pod="pod_a"} 10 2000
+				container_cpu_usage_seconds_total{container="container_a",namespace="namespace_b",pod="pod_b"} 10 2000
+				container_cpu_usage_seconds_total{container="container_b",namespace="namespace_a",pod="pod_a"} 10 2000
 				# HELP container_memory_working_set_bytes [ALPHA] Current working set of the container in bytes
 				# TYPE container_memory_working_set_bytes gauge
 				container_memory_working_set_bytes{container="container_a",namespace="namespace_a",pod="pod_a"} 1000 2000


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
CPU metrics should be counters, not gauges.  When I initially created the kubelet resource metrics endpoint in https://github.com/kubernetes/kubernetes/pull/73946, I mistakenly made CPU metrics a gauge.  When this was refactored to make use of the metrics stability framework in https://github.com/kubernetes/kubernetes/pull/86282, the cpu metrics were renamed to omit the `_total` suffix, which caught the attention of some sig instrumentation members.

Since the endpoint was newly added in 1.18, we have decided to just fix the metric without a deprecation period, and cherry-pick the fix back to the 1.18 release.  

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
In the kubelet resource metrics endpoint at /metrics/resource, change the names of the following metrics:
- node_cpu_usage_seconds --> node_cpu_usage_seconds_total
- container_cpu_usage_seconds --> container_cpu_usage_seconds_total
This is a partial revert of #86282, which was added in 1.18.0, and initially removed the _total suffix
```

/assign @brancz @logicalhan @serathius @ehashman 
/hold
to make sure we are all in agreement about this change
cc @kubernetes/sig-instrumentation-bugs 