### PR TITLE
Set ip alias route on kubernetes-master during booting

### DIFF
--- a/cluster/gce/gci/kube-master-internal-route.sh
+++ b/cluster/gce/gci/kube-master-internal-route.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+METADATA_ENDPOINT="http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-master-internal-ip"
+METADATA_HEADER="Metadata-Flavor: Google"
+ip=$(curl -s --fail ${METADATA_ENDPOINT} -H "${METADATA_HEADER}")
+if [ -n "$ip" ];
+then
+    # Check if route is already set if not set it
+    if ! sudo ip route show table local | grep -q "$(echo "$ip" | cut -d'/' -f 1)";
+    then
+            sudo ip route add to local "${ip}/32" dev "$(ip route | grep default | awk '{print $5}')"
+    fi
+fi

--- a/cluster/gce/gci/master-helper.sh
+++ b/cluster/gce/gci/master-helper.sh
@@ -157,6 +157,7 @@ function create-master-instance-internal() {
   metadata="${metadata},gci-docker-version=${KUBE_TEMP}/gci-docker-version.txt"
   metadata="${metadata},kube-master-certs=${KUBE_TEMP}/kube-master-certs.yaml"
   metadata="${metadata},cluster-location=${KUBE_TEMP}/cluster-location.txt"
+  metadata="${metadata},kube-master-internal-route=${KUBE_ROOT}/cluster/gce/gci/kube-master-internal-route.sh"
   metadata="${metadata},${MASTER_EXTRA_METADATA}"
 
   local disk="name=${master_name}-pd"

--- a/cluster/gce/gci/master.yaml
+++ b/cluster/gce/gci/master.yaml
@@ -23,6 +23,24 @@ write_files:
       [Install]
       WantedBy=kubernetes.target
 
+  - path: /etc/systemd/system/kube-master-internal-route.service
+    permissions: 0644
+    owner: root
+    content: |
+      [Unit]
+      Description=Configure kube internal route
+      After=kube-master-installation.service
+
+      [Service]
+      Type=oneshot
+      RemainAfterExit=yes
+      ExecStartPre=/usr/bin/curl --fail --retry 5 --retry-delay 3 --silent --show-error -H "X-Google-Metadata-Request: True" -o /home/kubernetes/bin/kube-master-internal-route.sh http://metadata.google.internal/computeMetadata/v1/instance/attributes/kube-master-internal-route
+      ExecStartPre=/bin/chmod 544 /home/kubernetes/bin/kube-master-internal-route.sh
+      ExecStart=/home/kubernetes/bin/kube-master-internal-route.sh
+
+      [Install]
+      WantedBy=kubernetes.target
+
   - path: /etc/systemd/system/kube-master-configuration.service
     permissions: 0644
     owner: root
@@ -119,6 +137,7 @@ write_files:
 runcmd:
  - systemctl daemon-reload
  - systemctl enable kube-master-installation.service
+ - systemctl enable kube-master-internal-route.service
  - systemctl enable kube-master-configuration.service
  - systemctl enable kube-container-runtime-monitor.service
  - systemctl enable kubelet-monitor.service

--- a/cluster/gce/util.sh
+++ b/cluster/gce/util.sh
@@ -2946,7 +2946,8 @@ function attach-internal-master-ip() {
   echo "Setting ${name}'s aliases to '${aliases}' (added ${ip})"
   # Attach ${ip} to ${name}
   gcloud compute instances network-interfaces update "${name}" --project "${PROJECT}" --zone "${zone}" --aliases="${aliases}"
-  run-gcloud-command "${name}" "${zone}" 'sudo ip route add to local '${ip}'/32 dev $(ip route | grep default | awk '\''{print $5}'\'')' || true
+  gcloud compute instances add-metadata "${name}" --zone "${zone}" --metadata=kube-master-internal-ip="${ip}"
+  run-gcloud-command "${name}" "${zone}" 'sudo /bin/bash /home/kubernetes/bin/kube-master-internal-route.sh' || true
   return $?
 }
 
@@ -2964,6 +2965,7 @@ function detach-internal-master-ip() {
   echo "Setting ${name}'s aliases to '${aliases}' (removed ${ip})"
   # Detach ${MASTER_NAME}-internal-ip from ${name}
   gcloud compute instances network-interfaces update "${name}" --project "${PROJECT}" --zone "${zone}" --aliases="${aliases}"
+  gcloud compute instances remove-metadata "${name}" --zone "${zone}" --keys=kube-master-internal-ip
   run-gcloud-command "${name}" "${zone}" 'sudo ip route del to local '${ip}'/32 dev $(ip route | grep default | awk '\''{print $5}'\'')' || true
   return $?
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
There is no posibility to restart master node when you create private cluster via kube-up (provider GCE). After restart nodes are not able to connect to master due to missing route in master route table.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #86547

**Special notes for your reviewer**:
Currently ip alias on kubernetes-master is set during cluster creation via:
```
sudo ip route add to local '${ip}'/32 dev $(ip route | grep default | awk '\''{print $5}'\'')
```
because of that ip alias is not permanent (host reboot will erase it and not set up again).
This PR provide script that will set ip alias during boot. It is set up as systemd service on host which mean that ip alias will be set after reboot.

**Does this PR introduce a user-facing change?**:
```release-note
NONE

```