### PR TITLE
Prototype of OperationKey refactor for NestedPendingOperations

### DIFF
--- a/pkg/volume/util/types/types_test.go
+++ b/pkg/volume/util/types/types_test.go
@@ -48,3 +48,5 @@ func TestIsFilesystemMismatchError(t *testing.T) {
 		}
 	}
 }
+
+// TODO (verult) operation key tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**: Restructuring how operation keys are passed in and process for `NestedPendingOperations`.

**Special notes for your reviewer**:
This is a prototype for early review. 
/hold

Alternatives considered:
* Each key is a separate type. `Matches()` is messier to implement. Should `Matches()` be a method for each type, or a global function?
* Each key is a separate type, but use struct embedding to preserve the structure of matching keys. `Matches()` is still messy.

/sig storage
/assign @misterikkit 
/cc @gnufied @saad-ali 
