### PR TITLE
Restore the ability to `kubectl apply --prune` without -n flag

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -77,9 +77,6 @@ func (p *pruner) pruneAll(o *ApplyOptions) error {
 	}
 
 	for n := range p.visitedNamespaces {
-		if len(o.Namespace) != 0 && n != o.Namespace {
-			continue
-		}
 		for _, m := range namespacedRESTMappings {
 			if err := p.prune(n, m); err != nil {
 				return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -223,6 +223,30 @@ __EOF__
   # cleanup
   kubectl delete svc prune-svc 2>&1 "${kube_flags[@]:?}"
 
+  ## kubectl apply --prune can prune resources not in the defaulted namespace
+  # Pre-Condition: namespace nsb exists; no POD exists
+  kubectl create ns nsb
+  kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+  # apply a into namespace nsb
+  kubectl apply --namespace nsb -f hack/testdata/prune/a.yaml "${kube_flags[@]:?}"
+  kube::test::get_object_assert 'pods a -n nsb' "{{${id_field:?}}}" 'a'
+  # apply b with namespace
+  kubectl apply --namespace nsb -f hack/testdata/prune/b.yaml "${kube_flags[@]:?}"
+  kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
+  # apply --prune must prune a
+  kubectl apply --prune --all -f hack/testdata/prune/b.yaml
+  # check wrong pod doesn't exist
+  output_message=$(! kubectl get pods a -n nsb 2>&1 "${kube_flags[@]:?}")
+  kube::test::if_has_string "${output_message}" 'pods "a" not found'
+  # check right pod exists
+  kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
+
+  # cleanup
+  kubectl delete ns nsb
+
+  ## kubectl apply -n must fail if input file contains namespace other than the one given in -n
+  output_message=$(! kubectl apply -n foo -f hack/testdata/prune/b.yaml 2>&1 "${kube_flags[@]:?}")
+  kube::test::if_has_string "${output_message}" 'the namespace from the provided object "nsb" does not match the namespace "foo".'
 
   ## kubectl apply -f some.yml --force
   # Pre-condition: no service exists


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Before https://github.com/kubernetes/kubernetes/pull/83084, `kubectl
apply --prune` can prune resources in all namespaces specified in
config files.  After that PR got merged, only a single namespace is
considered for pruning.  It is OK if namespace is explicitly specified
by --namespace option, but what the PR does is use the default
namespace (or from kubeconfig) if not overridden by command line flag.  That breaks the
existing usage of `kubectl apply --prune` without --namespace option.
If --namespace is not used, there is no error, and no one notices this
issue unless they actually check that pruning happens.  This issue
also prevents resources in multiple namespaces in config file from
being pruned.

kubectl 1.16 does not have this bug.  Let's see the difference between
kubectl 1.16 and kubectl 1.17.  Suppose the following config file:

```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: foo
  namespace: a
  labels:
    pl: foo
data:
  foo: bar
---
apiVersion: v1
kind: ConfigMap
metadata:
  creationTimestamp: null
  name: bar
  namespace: a
  labels:
    pl: foo
data:
  foo: bar
```

Apply it with `kubectl apply -f file`.  Then comment out ConfigMap foo
in this file.  kubectl 1.16 prunes ConfigMap foo with the following
command:

$ kubectl-1.16 apply -f file -l pl=foo --prune
configmap/bar configured
configmap/foo pruned

But kubectl 1.17 does not prune ConfigMap foo with the same command:

$ kubectl-1.17 apply -f file -l pl=foo --prune
configmap/bar configured

With this patch, kubectl once again can prune the resource as before.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #87756

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Restore the ability to `kubectl apply --prune` without --namespace flag.  Since 1.17, `kubectl apply --prune` only prunes resources in the default namespace (or from kubeconfig) or explicitly specified in command line flag.  But this is s breaking change from kubectl 1.16, which can prune resources in all namespace in config file.  This patch restores the kubectl 1.16 behaviour.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
