### PR TITLE
test: Remove final user of startup-script image

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -229,7 +229,7 @@ var _ = SIGDescribe("Network", func() {
 	// a problem where spurious retransmits in a long-running TCP connection to a service
 	// IP could result in the connection being closed with the error "Connection reset by
 	// peer"
-	ginkgo.It("should resolve connrection reset issue #74839 [Slow]", func() {
+	ginkgo.It("should resolve connection reset issue #74839 [Slow]", func() {
 		serverLabel := map[string]string{
 			"app": "boom-server",
 		}
@@ -304,7 +304,7 @@ var _ = SIGDescribe("Network", func() {
 				Containers: []v1.Container{
 					{
 						Name:  "startup-script",
-						Image: imageutils.GetE2EImage(imageutils.StartupScript),
+						Image: imageutils.GetE2EImage(imageutils.BusyBox),
 						Command: []string{
 							"bash", "-c", "while true; do sleep 2; nc boom-server 9000& done",
 						},

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -35,6 +35,7 @@ type RegistryList struct {
 	InvalidRegistry         string `yaml:"invalidRegistry"`
 	GcRegistry              string `yaml:"gcRegistry"`
 	GcrReleaseRegistry      string `yaml:"gcrReleaseRegistry"`
+	// TODO: The last consumer of this has been removed and it should be deprecated
 	GoogleContainerRegistry string `yaml:"googleContainerRegistry"`
 	PrivateRegistry         string `yaml:"privateRegistry"`
 	SampleRegistry          string `yaml:"sampleRegistry"`
@@ -71,10 +72,11 @@ func initReg() RegistryList {
 		DockerGluster:           "docker.io/gluster",
 		E2eRegistry:             "gcr.io/kubernetes-e2e-test-images",
 		// TODO: After the domain flip, this should instead be k8s.gcr.io/k8s-artifacts-prod/e2e-test-images
-		PromoterE2eRegistry:     "us.gcr.io/k8s-artifacts-prod/e2e-test-images",
-		InvalidRegistry:         "invalid.com/invalid",
-		GcRegistry:              "k8s.gcr.io",
-		GcrReleaseRegistry:      "gcr.io/gke-release",
+		PromoterE2eRegistry: "us.gcr.io/k8s-artifacts-prod/e2e-test-images",
+		InvalidRegistry:     "invalid.com/invalid",
+		GcRegistry:          "k8s.gcr.io",
+		GcrReleaseRegistry:  "gcr.io/gke-release",
+		// TODO: The last consumer of this has been removed and it should be deleted
 		GoogleContainerRegistry: "gcr.io/google-containers",
 		PrivateRegistry:         "gcr.io/k8s-authenticated-test",
 		SampleRegistry:          "gcr.io/google-samples",
@@ -107,7 +109,6 @@ var (
 	gcAuthenticatedRegistry = registry.GcAuthenticatedRegistry
 	gcRegistry              = registry.GcRegistry
 	gcrReleaseRegistry      = registry.GcrReleaseRegistry
-	googleContainerRegistry = registry.GoogleContainerRegistry
 	invalidRegistry         = registry.InvalidRegistry
 	quayK8sCSI              = registry.QuayK8sCSI
 	quayIncubator           = registry.QuayIncubator
@@ -191,8 +192,6 @@ const (
 	ResourceConsumer
 	// SdDummyExporter image
 	SdDummyExporter
-	// StartupScript image
-	StartupScript
 	// VolumeNFSServer image
 	VolumeNFSServer
 	// VolumeISCSIServer image
@@ -241,7 +240,6 @@ func initImageConfigs() map[int]Config {
 	configs[RegressionIssue74839] = Config{e2eRegistry, "regression-issue-74839-amd64", "1.0"}
 	configs[ResourceConsumer] = Config{e2eRegistry, "resource-consumer", "1.5"}
 	configs[SdDummyExporter] = Config{gcRegistry, "sd-dummy-exporter", "v0.2.0"}
-	configs[StartupScript] = Config{googleContainerRegistry, "startup-script", "v1"}
 	configs[VolumeNFSServer] = Config{e2eRegistry, "volume/nfs", "1.0"}
 	configs[VolumeISCSIServer] = Config{e2eRegistry, "volume/iscsi", "2.0"}
 	configs[VolumeGlusterServer] = Config{e2eRegistry, "volume/gluster", "1.0"}


### PR DESCRIPTION
It can be replaced with nc in busybox like other tests. This image has not been
pushed to gcr since 2016 and is not in the container registry schema v2.2 format
either (so modern tools may sometimes fail to work with it).

/kind cleanup
/sig network
/sig testing

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```