### PR TITLE
Automated cherry pick of #89537: kubeadm: add missing RBAC for getting nodes on "upgrade

### DIFF
--- a/cmd/kubeadm/app/phases/upgrade/postupgrade.go
+++ b/cmd/kubeadm/app/phases/upgrade/postupgrade.go
@@ -70,6 +70,11 @@ func PerformPostUpgradeTasks(client clientset.Interface, cfg *kubeadmapi.InitCon
 		errs = append(errs, errors.Wrap(err, "error uploading crisocket"))
 	}
 
+	// Create RBAC rules that makes the bootstrap tokens able to get nodes
+	if err := nodebootstraptoken.AllowBoostrapTokensToGetNodes(client); err != nil {
+		errs = append(errs, err)
+	}
+
 	// Create/update RBAC rules that makes the bootstrap tokens able to post CSRs
 	if err := nodebootstraptoken.AllowBootstrapTokensToPostCSRs(client); err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
Cherry pick of #89537 on release-1.18.

#89537: kubeadm: add missing RBAC for getting nodes on "upgrade

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.