### PR TITLE
Add SCTP Network Policy tests

### DIFF
--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -10,7 +10,7 @@ dependencies:
 
   # then after merge and successful postsubmit image push / promotion, bump this
   - name: "agnhost: dependents"
-    version: "2.20"
+    version: "2.21"
     refPaths:
     - path: test/utils/image/manifest.go
       match: configs\[Agnhost\] = Config{promoterE2eRegistry, "agnhost", "\d+\.\d+"}

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -47,6 +47,13 @@ connections from one of the clients. The test then asserts that the clients
 failed or successfully connected as expected.
 */
 
+type protocolPort struct {
+	port     int
+	protocol v1.Protocol
+}
+
+var protocolSCTP = v1.ProtocolSCTP
+
 var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 	var service *v1.Service
 	var podServer *v1.Pod
@@ -61,7 +68,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 	ginkgo.Context("NetworkPolicy between server and client", func() {
 		ginkgo.BeforeEach(func() {
 			ginkgo.By("Creating a simple server that serves on port 80 and 81.")
-			podServer, service = createServerPodAndService(f, f.Namespace, "server", []int{80, 81})
+			podServer, service = createServerPodAndService(f, f.Namespace, "server", []protocolPort{{80, v1.ProtocolTCP}, {81, v1.ProtocolTCP}})
 
 			ginkgo.By("Waiting for pod ready", func() {
 				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, f.Namespace.Name, framework.PodStartTimeout)
@@ -110,7 +117,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			framework.ExpectNoError(err, "Error occurred while creating namespace-b.")
 
 			ginkgo.By("Creating a simple server in another namespace that serves on port 80 and 81.")
-			podB, serviceB := createServerPodAndService(f, nsB, "pod-b", []int{80, 81})
+			podB, serviceB := createServerPodAndService(f, nsB, "pod-b", []protocolPort{{80, v1.ProtocolTCP}, {81, v1.ProtocolTCP}})
 
 			ginkgo.By("Waiting for pod ready", func() {
 				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, nsB.Name, framework.PodStartTimeout)
@@ -904,7 +911,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			ginkgo.By(fmt.Sprintf("Creating client pod %s that should not be able to connect to %s.", "client-a", service.Name))
 			// Specify RestartPolicy to OnFailure so we can check the client pod fails in the beginning and succeeds
 			// after updating its label, otherwise it would not restart after the first failure.
-			podClient := createNetworkClientPodWithRestartPolicy(f, f.Namespace, "client-a", service, allowedPort, v1.RestartPolicyOnFailure)
+			podClient := createNetworkClientPodWithRestartPolicy(f, f.Namespace, "client-a", service, allowedPort, v1.ProtocolTCP, v1.RestartPolicyOnFailure)
 			defer func() {
 				ginkgo.By(fmt.Sprintf("Cleaning up the pod %s", podClient.Name))
 				if err := f.ClientSet.CoreV1().Pods(f.Namespace.Name).Delete(context.TODO(), podClient.Name, metav1.DeleteOptions{}); err != nil {
@@ -965,7 +972,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			})
 			framework.ExpectNoError(err, "Error occurred while creating namespace-b.")
 
-			podB, serviceB := createServerPodAndService(f, nsB, "pod-b", []int{allowedPort, notAllowedPort})
+			podB, serviceB := createServerPodAndService(f, nsB, "pod-b", []protocolPort{{allowedPort, v1.ProtocolTCP}, {notAllowedPort, v1.ProtocolTCP}})
 			defer cleanupServerPodAndService(f, podB, serviceB)
 
 			// Wait for Server with Service in NS-B to be ready
@@ -1054,9 +1061,9 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			framework.ExpectNoError(err, "Error occurred while creating namespace-b.")
 
 			// Creating pods and services in namespace-b
-			nsBpodServerA, nsBserviceA = createServerPodAndService(f, nsB, "ns-b-server-a", []int{80})
+			nsBpodServerA, nsBserviceA = createServerPodAndService(f, nsB, "ns-b-server-a", []protocolPort{{80, v1.ProtocolTCP}})
 			defer cleanupServerPodAndService(f, nsBpodServerA, nsBserviceA)
-			nsBpodServerB, nsBserviceB = createServerPodAndService(f, nsB, "ns-b-server-b", []int{80})
+			nsBpodServerB, nsBserviceB = createServerPodAndService(f, nsB, "ns-b-server-b", []protocolPort{{80, v1.ProtocolTCP}})
 			defer cleanupServerPodAndService(f, nsBpodServerB, nsBserviceB)
 
 			// Wait for Server with Service in NS-A to be ready
@@ -1200,7 +1207,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 		})
 
 		ginkgo.It("should enforce multiple egress policies with egress allow-all policy taking precedence [Feature:NetworkPolicy]", func() {
-			podServerB, serviceB := createServerPodAndService(f, f.Namespace, "server-b", []int{80})
+			podServerB, serviceB := createServerPodAndService(f, f.Namespace, "server-b", []protocolPort{{80, v1.ProtocolTCP}})
 			defer cleanupServerPodAndService(f, podServerB, serviceB)
 
 			ginkgo.By("Waiting for pod ready", func() {
@@ -1381,7 +1388,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			podServerCIDR := fmt.Sprintf("%s/%d", podServerStatus.Status.PodIP, hostMask)
 
 			// Creating pod-b and service-b
-			podServerB, serviceB = createServerPodAndService(f, f.Namespace, "pod-b", []int{80})
+			podServerB, serviceB = createServerPodAndService(f, f.Namespace, "pod-b", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-b to be ready", func() {
 				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServerB.Name, f.Namespace.Name, framework.PodStartTimeout)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
@@ -1660,7 +1667,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			protocolUDP := v1.ProtocolUDP
 
 			// Before applying policy, communication should be successful between pod-a and pod-b
-			podA, serviceA = createServerPodAndService(f, f.Namespace, "pod-a", []int{80})
+			podA, serviceA = createServerPodAndService(f, f.Namespace, "pod-a", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-a to be ready", func() {
 				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podA.Name, f.Namespace.Name, framework.PodStartTimeout)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
@@ -1670,7 +1677,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			})
 			cleanupServerPodAndService(f, podA, serviceA)
 
-			podB, serviceB = createServerPodAndService(f, f.Namespace, "pod-b", []int{80})
+			podB, serviceB = createServerPodAndService(f, f.Namespace, "pod-b", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-b to be ready", func() {
 				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, f.Namespace.Name, framework.PodStartTimeout)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
@@ -1752,7 +1759,7 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			cleanupServerPodAndService(f, podB, serviceB)
 
 			// Creating server pod with label "pod-name": "pod-a" to deny traffic from client pod with label "pod-name": "pod-b"
-			podA, serviceA = createServerPodAndService(f, f.Namespace, "pod-a", []int{80})
+			podA, serviceA = createServerPodAndService(f, f.Namespace, "pod-a", []protocolPort{{80, v1.ProtocolTCP}})
 			ginkgo.By("Waiting for pod-a to be ready", func() {
 				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podA.Name, f.Namespace.Name, framework.PodStartTimeout)
 				framework.ExpectNoError(err, "Error occurred while waiting for pod type: Ready.")
@@ -1770,7 +1777,6 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			sctpLoadedAtStart := CheckSCTPModuleLoadedOnNodes(f, nodes)
 
 			ginkgo.By("Creating a network policy for the server which allows traffic only via SCTP on port 80.")
-			protocolSCTP := v1.ProtocolSCTP
 			policy := &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "allow-only-sctp-ingress-on-port-80",
@@ -1807,9 +1813,180 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 	})
 })
 
+var _ = SIGDescribe("NetworkPolicy [Feature:SCTPConnectivity][LinuxOnly][Disruptive]", func() {
+	var service *v1.Service
+	var podServer *v1.Pod
+	var podServerLabelSelector string
+	f := framework.NewDefaultFramework("sctp-network-policy")
+
+	ginkgo.BeforeEach(func() {
+		// Windows does not support network policies.
+		e2eskipper.SkipIfNodeOSDistroIs("windows")
+	})
+
+	ginkgo.Context("NetworkPolicy between server and client using SCTP", func() {
+		ginkgo.BeforeEach(func() {
+			ginkgo.By("Creating a simple server that serves on port 80 and 81.")
+			podServer, service = createServerPodAndService(f, f.Namespace, "server", []protocolPort{{80, v1.ProtocolSCTP}, {81, v1.ProtocolSCTP}})
+
+			ginkgo.By("Waiting for pod ready", func() {
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, f.Namespace.Name, framework.PodStartTimeout)
+				framework.ExpectNoError(err)
+			})
+
+			// podServerLabelSelector holds the value for the podServer's label "pod-name".
+			podServerLabelSelector = podServer.ObjectMeta.Labels["pod-name"]
+
+			// Create pods, which should be able to communicate with the server on port 80 and 81.
+			ginkgo.By("Testing pods can connect to both ports when no policy is present.")
+			testCanConnectProtocol(f, f.Namespace, "client-can-connect-80", service, 80, v1.ProtocolSCTP)
+			testCanConnectProtocol(f, f.Namespace, "client-can-connect-81", service, 81, v1.ProtocolSCTP)
+		})
+
+		ginkgo.AfterEach(func() {
+			cleanupServerPodAndService(f, podServer, service)
+		})
+
+		ginkgo.It("should support a 'default-deny' policy [Feature:NetworkPolicy]", func() {
+			policy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "deny-all",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+				},
+			}
+
+			policy, err := f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(context.TODO(), policy, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer cleanupNetworkPolicy(f, policy)
+
+			// Create a pod with name 'client-cannot-connect', which will attempt to communicate with the server,
+			// but should not be able to now that isolation is on.
+			testCannotConnect(f, f.Namespace, "client-cannot-connect", service, 80)
+		})
+
+		ginkgo.It("should enforce policy based on Ports [Feature:NetworkPolicy]", func() {
+			ginkgo.By("Creating a network policy for the Service which allows traffic only to one port.")
+			policy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "allow-ingress-on-port-81",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					// Apply to server
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pod-name": podServerLabelSelector,
+						},
+					},
+					// Allow traffic only to one port.
+					Ingress: []networkingv1.NetworkPolicyIngressRule{{
+						Ports: []networkingv1.NetworkPolicyPort{{
+							Port:     &intstr.IntOrString{IntVal: 81},
+							Protocol: &protocolSCTP,
+						}},
+					}},
+				},
+			}
+			policy, err := f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(context.TODO(), policy, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer cleanupNetworkPolicy(f, policy)
+
+			ginkgo.By("Testing pods can connect only to the port allowed by the policy.")
+			testCannotConnectProtocol(f, f.Namespace, "client-a", service, 80, v1.ProtocolSCTP)
+			testCanConnectProtocol(f, f.Namespace, "client-b", service, 81, v1.ProtocolSCTP)
+		})
+
+		ginkgo.It("should enforce policy to allow traffic only from a pod in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {
+			nsA := f.Namespace
+			nsBName := f.BaseName + "-b"
+			nsB, err := f.CreateNamespace(nsBName, map[string]string{
+				"ns-name": nsBName,
+			})
+			framework.ExpectNoError(err, "Error occurred while creating namespace-b.")
+
+			// Wait for Server in namespaces-a to be ready
+			framework.Logf("Waiting for server to come up.")
+			err = e2epod.WaitForPodRunningInNamespace(f.ClientSet, podServer)
+			framework.ExpectNoError(err, "Error occurred while waiting for pod status in namespace: Running.")
+
+			// Before application of the policy, all communication should be successful.
+			ginkgo.By("Creating client-a, in server's namespace, which should be able to contact the server.", func() {
+				testCanConnectProtocol(f, nsA, "client-a", service, 80, v1.ProtocolSCTP)
+			})
+			ginkgo.By("Creating client-b, in server's namespace, which should be able to contact the server.", func() {
+				testCanConnectProtocol(f, nsA, "client-b", service, 80, v1.ProtocolSCTP)
+			})
+			ginkgo.By("Creating client-a, not in server's namespace, which should be able to contact the server.", func() {
+				testCanConnectProtocol(f, nsB, "client-a", service, 80, v1.ProtocolSCTP)
+			})
+			ginkgo.By("Creating client-b, not in server's namespace, which should be able to contact the server.", func() {
+				testCanConnectProtocol(f, nsB, "client-b", service, 80, v1.ProtocolSCTP)
+			})
+
+			ginkgo.By("Creating a network policy for the server which allows traffic only from client-a in namespace-b.")
+			policy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: nsA.Name,
+					Name:      "allow-ns-b-client-a-via-namespace-pod-selector",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					// Apply this policy to the Server
+					PodSelector: metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"pod-name": podServerLabelSelector,
+						},
+					},
+					// Allow traffic only from client-a in namespace-b
+					Ingress: []networkingv1.NetworkPolicyIngressRule{{
+						From: []networkingv1.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"ns-name": nsBName,
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"pod-name": "client-a",
+								},
+							},
+						}},
+					}},
+				},
+			}
+
+			policy, err = f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(context.TODO(), policy, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Error occurred while creating policy: policy.")
+			defer cleanupNetworkPolicy(f, policy)
+
+			ginkgo.By("Creating client-a, in server's namespace, which should not be able to contact the server.", func() {
+				testCannotConnectProtocol(f, nsA, "client-a", service, 80, v1.ProtocolSCTP)
+			})
+			ginkgo.By("Creating client-b, in server's namespace, which should not be able to contact the server.", func() {
+				testCannotConnectProtocol(f, nsA, "client-b", service, 80, v1.ProtocolSCTP)
+			})
+			ginkgo.By("Creating client-a, not in server's namespace, which should be able to contact the server.", func() {
+				testCanConnectProtocol(f, nsB, "client-a", service, 80, v1.ProtocolSCTP)
+			})
+			ginkgo.By("Creating client-b, not in server's namespace, which should not be able to contact the server.", func() {
+				testCannotConnectProtocol(f, nsB, "client-b", service, 80, v1.ProtocolSCTP)
+			})
+		})
+	})
+})
+
 func testCanConnect(f *framework.Framework, ns *v1.Namespace, podName string, service *v1.Service, targetPort int) {
+	testCanConnectProtocol(f, ns, podName, service, targetPort, v1.ProtocolTCP)
+}
+
+func testCannotConnect(f *framework.Framework, ns *v1.Namespace, podName string, service *v1.Service, targetPort int) {
+	testCannotConnectProtocol(f, ns, podName, service, targetPort, v1.ProtocolTCP)
+}
+
+func testCanConnectProtocol(f *framework.Framework, ns *v1.Namespace, podName string, service *v1.Service, targetPort int, protocol v1.Protocol) {
 	ginkgo.By(fmt.Sprintf("Creating client pod %s that should successfully connect to %s.", podName, service.Name))
-	podClient := createNetworkClientPod(f, ns, podName, service, targetPort)
+	podClient := createNetworkClientPod(f, ns, podName, service, targetPort, protocol)
 	defer func() {
 		ginkgo.By(fmt.Sprintf("Cleaning up the pod %s", podClient.Name))
 		if err := f.ClientSet.CoreV1().Pods(ns.Name).Delete(context.TODO(), podClient.Name, metav1.DeleteOptions{}); err != nil {
@@ -1819,15 +1996,16 @@ func testCanConnect(f *framework.Framework, ns *v1.Namespace, podName string, se
 	checkConnectivity(f, ns, podClient, service)
 }
 
-func testCannotConnect(f *framework.Framework, ns *v1.Namespace, podName string, service *v1.Service, targetPort int) {
+func testCannotConnectProtocol(f *framework.Framework, ns *v1.Namespace, podName string, service *v1.Service, targetPort int, protocol v1.Protocol) {
 	ginkgo.By(fmt.Sprintf("Creating client pod %s that should not be able to connect to %s.", podName, service.Name))
-	podClient := createNetworkClientPod(f, ns, podName, service, targetPort)
+	podClient := createNetworkClientPod(f, ns, podName, service, targetPort, protocol)
 	defer func() {
 		ginkgo.By(fmt.Sprintf("Cleaning up the pod %s", podClient.Name))
 		if err := f.ClientSet.CoreV1().Pods(ns.Name).Delete(context.TODO(), podClient.Name, metav1.DeleteOptions{}); err != nil {
 			framework.Failf("unable to cleanup pod %v: %v", podClient.Name, err)
 		}
 	}()
+
 	checkNoConnectivity(f, ns, podClient, service)
 }
 
@@ -1915,37 +2093,46 @@ func collectPodsAndNetworkPolicies(f *framework.Framework, podClient *v1.Pod) ([
 // Create a server pod with a listening container for each port in ports[].
 // Will also assign a pod label with key: "pod-name" and label set to the given podName for later use by the network
 // policy.
-func createServerPodAndService(f *framework.Framework, namespace *v1.Namespace, podName string, ports []int) (*v1.Pod, *v1.Service) {
+func createServerPodAndService(f *framework.Framework, namespace *v1.Namespace, podName string, ports []protocolPort) (*v1.Pod, *v1.Service) {
 	// Because we have a variable amount of ports, we'll first loop through and generate our Containers for our pod,
 	// and ServicePorts.for our Service.
 	containers := []v1.Container{}
 	servicePorts := []v1.ServicePort{}
-	for _, port := range ports {
-		// Build the containers for the server pod.
+	for _, portProtocol := range ports {
+		var porterPort string
+		var connectProtocol string
+		switch portProtocol.protocol {
+		case v1.ProtocolTCP:
+			porterPort = fmt.Sprintf("SERVE_PORT_%d", portProtocol.port)
+			connectProtocol = "tcp"
+		case v1.ProtocolSCTP:
+			porterPort = fmt.Sprintf("SERVE_SCTP_PORT_%d", portProtocol.port)
+			connectProtocol = "sctp"
+		default:
+			framework.Failf("createServerPodAndService, unexpected protocol %v", portProtocol.protocol)
+		}
+
 		containers = append(containers, v1.Container{
-			Name:  fmt.Sprintf("%s-container-%d", podName, port),
+			Name:  fmt.Sprintf("%s-container-%d", podName, portProtocol.port),
 			Image: imageutils.GetE2EImage(imageutils.Agnhost),
 			Args:  []string{"porter"},
 			Env: []v1.EnvVar{
 				{
-					Name:  fmt.Sprintf("SERVE_PORT_%d", port),
+					Name:  porterPort,
 					Value: "foo",
 				},
 			},
 			Ports: []v1.ContainerPort{
 				{
-					ContainerPort: int32(port),
-					Name:          fmt.Sprintf("serve-%d", port),
+					ContainerPort: int32(portProtocol.port),
+					Name:          fmt.Sprintf("serve-%d", portProtocol.port),
+					Protocol:      portProtocol.protocol,
 				},
 			},
 			ReadinessProbe: &v1.Probe{
 				Handler: v1.Handler{
-					HTTPGet: &v1.HTTPGetAction{
-						Path: "/",
-						Port: intstr.IntOrString{
-							IntVal: int32(port),
-						},
-						Scheme: v1.URISchemeHTTP,
+					Exec: &v1.ExecAction{
+						Command: []string{"/agnhost", "connect", fmt.Sprintf("--protocol=%s", connectProtocol), "--timeout=1s", fmt.Sprintf("127.0.0.1:%d", portProtocol.port)},
 					},
 				},
 			},
@@ -1953,9 +2140,10 @@ func createServerPodAndService(f *framework.Framework, namespace *v1.Namespace, 
 
 		// Build the Service Ports for the service.
 		servicePorts = append(servicePorts, v1.ServicePort{
-			Name:       fmt.Sprintf("%s-%d", podName, port),
-			Port:       int32(port),
-			TargetPort: intstr.FromInt(port),
+			Name:       fmt.Sprintf("%s-%d", podName, portProtocol.port),
+			Port:       int32(portProtocol.port),
+			TargetPort: intstr.FromInt(portProtocol.port),
+			Protocol:   portProtocol.protocol,
 		})
 	}
 
@@ -2008,13 +2196,23 @@ func cleanupServerPodAndService(f *framework.Framework, pod *v1.Pod, service *v1
 // Create a client pod which will attempt a netcat to the provided service, on the specified port.
 // This client will attempt a one-shot connection, then die, without restarting the pod.
 // Test can then be asserted based on whether the pod quit with an error or not.
-func createNetworkClientPod(f *framework.Framework, namespace *v1.Namespace, podName string, targetService *v1.Service, targetPort int) *v1.Pod {
-	return createNetworkClientPodWithRestartPolicy(f, namespace, podName, targetService, targetPort, v1.RestartPolicyNever)
+func createNetworkClientPod(f *framework.Framework, namespace *v1.Namespace, podName string, targetService *v1.Service, targetPort int, protocol v1.Protocol) *v1.Pod {
+	return createNetworkClientPodWithRestartPolicy(f, namespace, podName, targetService, targetPort, protocol, v1.RestartPolicyNever)
 }
 
 // Create a client pod which will attempt a netcat to the provided service, on the specified port.
 // It is similar to createNetworkClientPod but supports specifying RestartPolicy.
-func createNetworkClientPodWithRestartPolicy(f *framework.Framework, namespace *v1.Namespace, podName string, targetService *v1.Service, targetPort int, restartPolicy v1.RestartPolicy) *v1.Pod {
+func createNetworkClientPodWithRestartPolicy(f *framework.Framework, namespace *v1.Namespace, podName string, targetService *v1.Service, targetPort int, protocol v1.Protocol, restartPolicy v1.RestartPolicy) *v1.Pod {
+	var connectProtocol string
+	switch protocol {
+	case v1.ProtocolTCP:
+		connectProtocol = "tcp"
+	case v1.ProtocolSCTP:
+		connectProtocol = "sctp"
+	default:
+		framework.Failf("createNetworkClientPodWithRestartPolicy, unexpected protocol %v", protocol)
+	}
+
 	pod, err := f.ClientSet.CoreV1().Pods(namespace.Name).Create(context.TODO(), &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: podName + "-",
@@ -2026,20 +2224,18 @@ func createNetworkClientPodWithRestartPolicy(f *framework.Framework, namespace *
 			RestartPolicy: restartPolicy,
 			Containers: []v1.Container{
 				{
-					Name:  "client",
-					Image: imageutils.GetE2EImage(imageutils.BusyBox),
+					Name:    "client",
+					Image:   imageutils.GetE2EImage(imageutils.Agnhost),
+					Command: []string{"/bin/sh"},
 					Args: []string{
-						"/bin/sh",
 						"-c",
-						fmt.Sprintf("for i in $(seq 1 5); do nc -vz -w 8 %s.%s %d && exit 0 || sleep 1; done; exit 1",
-							targetService.Name, targetService.Namespace, targetPort),
+						fmt.Sprintf("for i in $(seq 1 5); do /agnhost connect %s.%s:%d --protocol %s --timeout 8s && exit 0 || sleep 1; done; exit 1", targetService.Name, targetService.Namespace, targetPort, connectProtocol),
 					},
 				},
 			},
 		},
 	}, metav1.CreateOptions{})
 	framework.ExpectNoError(err)
-
 	return pod
 }
 

--- a/test/e2e/network/networking.go
+++ b/test/e2e/network/networking.go
@@ -181,7 +181,7 @@ var _ = SIGDescribe("Networking", func() {
 
 		// Once basic tests checking for the sctp module not to be loaded are implemented, this
 		// needs to be marked as [Disruptive]
-		ginkgo.It("should function for pod-Service: sctp [Feature:SCTPConnectivity]", func() {
+		ginkgo.It("should function for pod-Service: sctp [Feature:SCTPConnectivity][Disruptive]", func() {
 			config := e2enetwork.NewNetworkingTestConfig(f, false, true)
 			ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterSCTPPort))
 			config.DialFromTestContainer("sctp", config.ClusterIP, e2enetwork.ClusterSCTPPort, config.MaxTries, 0, config.EndpointHostnames())
@@ -325,7 +325,7 @@ var _ = SIGDescribe("Networking", func() {
 
 	// Once basic tests checking for the sctp module not to be loaded are implemented, this
 	// needs to be marked as [Disruptive]
-	ginkgo.It("should function for pod-pod: sctp [Feature:SCTPConnectivity]", func() {
+	ginkgo.It("should function for pod-pod: sctp [Feature:SCTPConnectivity][Disruptive]", func() {
 		config := e2enetwork.NewNetworkingTestConfig(f, false, true)
 		ginkgo.By(fmt.Sprintf("dialing(sctp) %v --> %v:%v (config.clusterIP)", config.TestContainerPod.Name, config.ClusterIP, e2enetwork.ClusterSCTPPort))
 		message := "hello"

--- a/test/utils/image/manifest.go
+++ b/test/utils/image/manifest.go
@@ -200,7 +200,7 @@ const (
 
 func initImageConfigs() map[int]Config {
 	configs := map[int]Config{}
-	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.20"}
+	configs[Agnhost] = Config{promoterE2eRegistry, "agnhost", "2.21"}
 	configs[AgnhostPrivate] = Config{PrivateRegistry, "agnhost", "2.6"}
 	configs[AuthenticatedAlpine] = Config{gcAuthenticatedRegistry, "alpine", "3.7"}
 	configs[AuthenticatedWindowsNanoServer] = Config{gcAuthenticatedRegistry, "windows-nanoserver", "v1"}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature

> /kind flake

**What this PR does / why we need it**:

This PR completes the checklist from [https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md#sctp-connectivity-tests](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md#sctp-connectivity-tests), testing network policies with SCTP.

This is achieved by adding SCTP support to both the `agnhost` `connect` command and `porter` command, and to use then in the network policy tests to check if network policies are working.
This is complementary to https://github.com/kubernetes/kubernetes/pull/87926

In order to maintain the ` [Feature:SCTPConnectivity]` and have the sctp tests optional, I started converting the current policy tests in a tabular form. To do that (and to maintain sctp optional), I removed the `BeforeEach` function and converted it to a custom one invoked with the different protocols in each table body.
Not sure if this is the right approach but I could not find a better one that prevents duplication while still allowing us to skip the SCTP tests.


**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

NONE

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->

[KEP] : https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md

```
