### PR TITLE
azure: fix concurreny issue in lb creation

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -1101,6 +1101,9 @@ func (ss *scaleSet) EnsureHostsInPool(service *v1.Service, nodes []*v1.Node, bac
 
 	// Update VMs with best effort that have already been added to nodeUpdates.
 	for meta, update := range nodeUpdates {
+		// create new instance of meta and update for passing to anonymous function
+		meta := meta
+		update := update
 		hostUpdates = append(hostUpdates, func() error {
 			ctx, cancel := getContextWithCancel()
 			defer cancel()
@@ -1401,6 +1404,9 @@ func (ss *scaleSet) EnsureBackendPoolDeleted(service *v1.Service, backendPoolID,
 
 	// Update VMs with best effort that have already been added to nodeUpdates.
 	for meta, update := range nodeUpdates {
+		// create new instance of meta and update for passing to anonymous function
+		meta := meta
+		update := update
 		hostUpdates = append(hostUpdates, func() error {
 			ctx, cancel := getContextWithCancel()
 			defer cancel()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind bug

**What this PR does / why we need it**:
Fixes a bug introduced in https://github.com/kubernetes/kubernetes/pull/88699 that causes delay in creating and deleting LB in clusters with multiple scale sets. Same `meta` and `update` variable is used in each iteration (new one is not created). This means the meta and update vars are the same for all anonymous functions generated (for multiple scale sets).

This bug causes updates to happen one scale set at a time and also causes conflicting updates for the same scale set.

```
I0327 20:58:12.771612       1 azure_vmss.go:1107] EnsureHostInPool begins to UpdateVMs for VMSS(c0327, k8s-poollinux-33632080-vmss) with new backendPoolID /subscriptions/c80801f3-5848-4f8f-9c7a-dc0052a3655d/resourceGroups/c0327/providers/Microsoft.Network/loadBalancers/c0327-internal/backendAddressPools/c0327
I0327 20:58:12.771697       1 azure_vmss.go:1107] EnsureHostInPool begins to UpdateVMs for VMSS(c0327, k8s-poollinux-33632080-vmss) with new backendPoolID /subscriptions/c80801f3-5848-4f8f-9c7a-dc0052a3655d/resourceGroups/c0327/providers/Microsoft.Network/loadBalancers/c0327-internal/backendAddressPools/c0327
I0327 20:58:12.772566       1 azure_vmss.go:1107] EnsureHostInPool begins to UpdateVMs for VMSS(c0327, k8s-poollinux-33632080-vmss) with new backendPoolID /subscriptions/c80801f3-5848-4f8f-9c7a-dc0052a3655d/resourceGroups/c0327/providers/Microsoft.Network/loadBalancers/c0327-internal/backendAddressPools/c0327
I0327 20:58:12.771612       1 azure_vmss.go:1107] EnsureHostInPool begins to UpdateVMs for VMSS(c0327, k8s-poollinux-33632080-vmss) with new backendPoolID /subscriptions/c80801f3-5848-4f8f-9c7a-dc0052a3655d/resourceGroups/c0327/providers/Microsoft.Network/loadBalancers/c0327-internal/backendAddressPools/c0327
I0327 20:58:12.771628       1 azure_vmss.go:1107] EnsureHostInPool begins to UpdateVMs for VMSS(c0327, k8s-poollinux-33632080-vmss) with new backendPoolID /subscriptions/c80801f3-5848-4f8f-9c7a-dc0052a3655d/resourceGroups/c0327/providers/Microsoft.Network/loadBalancers/c0327-internal/backendAddressPools/c0327
```

In the above updates need to be for 5 different scale sets, but instead happen for the same scale set.

This PR fixes the issue by creating a new instance of meta and update variables which is used for the anonymous functions instead of the changing loop variable.

Setting `meta := meta` is idiomatic in go (for ref https://golang.org/doc/effective_go.html#channels)

```
but it's legal and idiomatic in Go to do this. You get a fresh version of the variable with the same name, deliberately shadowing the loop variable locally but unique to each goroutine.
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
azure: fix concurreny issue in lb creation
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```