### PR TITLE
Automated cherry pick of #89539: Fixes problem where kubectl apply stops after first error

### DIFF
--- a/hack/testdata/multi-resource.yaml
+++ b/hack/testdata/multi-resource.yaml
@@ -1,0 +1,19 @@
+# Tests that initial failures to not block subsequent applies.
+# Pod must be before namespace, so it initially fails. Second
+# apply of pod should succeed, since namespace finally exists.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: multi-resource-ns
+  labels:
+    name: test-pod-label
+spec:
+  containers:
+  - name: kubernetes-pause
+    image: k8s.gcr.io/pause:2.0
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multi-resource-ns

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
@@ -22,6 +22,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/jsonmergepatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/mergepatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",


### PR DESCRIPTION
Cherry pick of #89539 on release-1.18.

#89539: Fixes P0 kubectl apply bug.

P0 kubectl apply bug: https://github.com/kubernetes/kubectl/issues/845

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.

```release-note
kubectl: Fixes bug by aggregating 'apply' errors instead of failing after first error
```