### PR TITLE
Ensure NamedCertKeyArray implements flag.Value

### DIFF
--- a/staging/src/k8s.io/component-base/cli/flag/namedcertkey_flag.go
+++ b/staging/src/k8s.io/component-base/cli/flag/namedcertkey_flag.go
@@ -75,7 +75,7 @@ type NamedCertKeyArray struct {
 	changed bool
 }
 
-var _ flag.Value = &NamedCertKey{}
+var _ flag.Value = &NamedCertKeyArray{}
 
 // NewNamedKeyCertArray creates a new NamedCertKeyArray with the internal value
 // pointing to p.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
`var _ flag.Value = &NamedCertKey{}` is declared twice. The second check should be for `NamedCertKeyArray`

https://github.com/kubernetes/kubernetes/blob/e03c7756c76ac8a0a484660515c0344ec8a10569/staging/src/k8s.io/component-base/cli/flag/namedcertkey_flag.go#L31
https://github.com/kubernetes/kubernetes/blob/e03c7756c76ac8a0a484660515c0344ec8a10569/staging/src/k8s.io/component-base/cli/flag/namedcertkey_flag.go#L78

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
