### PR TITLE
Fix the Images newName field example in the Kubectl Book

### DIFF
--- a/staging/src/k8s.io/kubectl/docs/book/pages/app_customization/customizing_pod_templates.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/app_customization/customizing_pod_templates.md
@@ -38,7 +38,7 @@ in a base by specifying the `images` field in the `kustomization.yaml`.
 |-----------|--------------------------------------------------------------------------|----------| --- |
 | `name`    | Match images with this image name| `name: nginx`| |
 | `newTag`  | Override the image **tag** or **digest** for images whose image name matches `name`    | `newTag: new` | `nginx:old` -> `nginx:new` |
-| `newName` | Override the image **name** for images whose image name matches `name`   | `newImage: nginx-special` | `nginx:old` -> `nginx-special:old` |
+| `newName` | Override the image **name** for images whose image name matches `name`   | `newName: nginx-special` | `nginx:old` -> `nginx-special:old` |
 
 {% sample lang="yaml" %}
 **Input:** The `kustomization.yaml` file
@@ -111,7 +111,7 @@ spec:
 
 
 {% panel style="info", title="Replacing Images" %}
-`newImage` allows an image name to be replaced with another arbitrary image name.  e.g. you could
+`newName` allows an image name to be replaced with another arbitrary image name.  e.g. you could
 call your image `webserver` or `database` and replace it with `nginx` or `mysql`.
 
 For more information on customizing images, see [Container Images](../app_management/container_images.md).

--- a/staging/src/k8s.io/kubectl/docs/book/pages/app_management/container_images.md
+++ b/staging/src/k8s.io/kubectl/docs/book/pages/app_management/container_images.md
@@ -40,7 +40,7 @@ tag.
 |-----------|--------------------------------------------------------------------------|----------| --- |
 | `name`    | Match images with this image name| `name: nginx`| |
 | `newTag`  | Override the image **tag** or **digest** for images whose image name matches `name`    | `newTag: new` | `nginx:old` -> `nginx:new` |
-| `newName` | Override the image **name** for images whose image name matches `name`   | `newImage: nginx-special` | `nginx:old` -> `nginx-special:old` |
+| `newName` | Override the image **name** for images whose image name matches `name`   | `newName: nginx-special` | `nginx:old` -> `nginx-special:old` |
 
 {% method %}
 


### PR DESCRIPTION
**What type of PR is this?**

/area kubectl
/kind documentation
/priority important-soon
/sig cli
/size XS

**What this PR does / why we need it**:

This replace the wrong Image field name `newImage` with the right name `newName` in the pages of the Kubectl Book.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubectl/issues/849

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: