### PR TITLE
fix mismatch between pod resources verify/update scripts

### DIFF
--- a/hack/verify-generated-pod-resources.sh
+++ b/hack/verify-generated-pod-resources.sh
@@ -24,26 +24,26 @@ set -o nounset
 set -o pipefail
 
 KUBE_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-KUBE_REMOTE_RUNTIME_ROOT="${KUBE_ROOT}/staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+POD_RESOURCES_ALPHA="${KUBE_ROOT}/pkg/kubelet/apis/podresources/v1alpha1/"
 source "${KUBE_ROOT}/hack/lib/init.sh"
 
 kube::golang::setup_env
 
 function cleanup {
-	rm -rf "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
+	rm -rf "${POD_RESOURCES_ALPHA}/_tmp/"
 }
 
 trap cleanup EXIT
 
-mkdir -p "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp"
-cp "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/"
+mkdir -p "${POD_RESOURCES_ALPHA}/_tmp"
+cp "${POD_RESOURCES_ALPHA}/api.pb.go" "${POD_RESOURCES_ALPHA}/_tmp/"
 
 ret=0
 KUBE_VERBOSE=3 "${KUBE_ROOT}/hack/update-generated-pod-resources.sh"
-diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/api.pb.go" || ret=$?
+diff -I "gzipped FileDescriptorProto" -I "0x" -Naupr "${POD_RESOURCES_ALPHA}/_tmp/api.pb.go" "${POD_RESOURCES_ALPHA}/api.pb.go" || ret=$?
 if [[ $ret -eq 0 ]]; then
     echo "Generated pod resources api is up to date."
-    cp "${KUBE_REMOTE_RUNTIME_ROOT}/_tmp/api.pb.go" "${KUBE_REMOTE_RUNTIME_ROOT}/"
+    cp "${POD_RESOURCES_ALPHA}/_tmp/api.pb.go" "${POD_RESOURCES_ALPHA}/"
 else
     echo "Generated pod resources api is out of date. Please run hack/update-generated-pod-resources.sh"
     exit 1


### PR DESCRIPTION
Signed-off-by: Davanum Srinivas <davanum@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
hack/update-generated-pod-resources-dockerized.sh updates `pkg/kubelet/apis/podresources/v1alpha1/`, BUT hack/verify-generated-pod-resources.sh is checking `staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2`:
https://github.com/kubernetes/kubernetes/blob/master/hack/update-generated-pod-resources-dockerized.sh#L26
the verify and update scripts should match.

mea culpa, i had made this change when splitting cri-api into `staging/`:
https://github.com/kubernetes/kubernetes/commit/33081c1f07be128a89441a39c467b7ea2221b23d#diff-1c8fea62e73e7c067d168ad74308ee0cR22

/sig node

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
