### PR TITLE
Modified subpath configmap mount fails when container restarts

### DIFF
--- a/pkg/volume/util/hostutil/hostutil_linux.go
+++ b/pkg/volume/util/hostutil/hostutil_linux.go
@@ -158,6 +158,11 @@ func (hu *HostUtil) EvalHostSymlinks(pathname string) (string, error) {
 	return filepath.EvalSymlinks(pathname)
 }
 
+// FindMountInfo returns the mount info on the given path.
+func (hu *HostUtil) FindMountInfo(path string) (mount.MountInfo, error) {
+	return findMountInfo(path, procMountInfoPath)
+}
+
 // isShared returns true, if given path is on a mount point that has shared
 // mount propagation.
 func isShared(mount string, mountInfoPath string) (bool, error) {

--- a/pkg/volume/util/subpath/BUILD
+++ b/pkg/volume/util/subpath/BUILD
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = select({
         "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/volume/util/hostutil:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/klog/v2:go_default_library",
             "//vendor/k8s.io/utils/mount:go_default_library",
@@ -33,6 +34,7 @@ go_library(
             "//vendor/k8s.io/utils/nsenter:go_default_library",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/volume/util/hostutil:go_default_library",
             "//vendor/golang.org/x/sys/unix:go_default_library",
             "//vendor/k8s.io/klog/v2:go_default_library",
             "//vendor/k8s.io/utils/mount:go_default_library",

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -431,14 +431,6 @@
     environment variables when backticks are supplied.
   release: v1.19
   file: test/e2e/common/expansion.go
-- testname: VolumeSubpathEnvExpansion, subpath lifecycle
-  codename: '[k8s.io] Variable Expansion should not change the subpath mount on a
-    container restart if the environment variable changes [sig-storage][Slow] [Conformance]'
-  description: "Verify should not change the subpath mount on a container restart
-    if the environment variable changes 1.\tvalid subpathexpr starts a container running
-    2.\ttest for valid subpath writes 3.\tcontainer restarts 4.\tdelete cleanly"
-  release: v1.19
-  file: test/e2e/common/expansion.go
 - testname: VolumeSubpathEnvExpansion, subpath test writes
   codename: '[k8s.io] Variable Expansion should succeed in writing subpaths in container
     [sig-storage][Slow] [Conformance]'

--- a/test/e2e/storage/subpath.go
+++ b/test/e2e/storage/subpath.go
@@ -18,14 +18,14 @@ package storage
 
 import (
 	"context"
-	"k8s.io/api/core/v1"
+
+	"github.com/onsi/ginkgo"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/e2e/storage/testsuites"
 	"k8s.io/kubernetes/test/e2e/storage/utils"
-
-	"github.com/onsi/ginkgo"
 )
 
 var _ = utils.SIGDescribe("Subpath", func() {
@@ -48,7 +48,6 @@ var _ = utils.SIGDescribe("Subpath", func() {
 			if err != nil && !apierrors.IsAlreadyExists(err) {
 				framework.ExpectNoError(err, "while creating configmap")
 			}
-
 		})
 
 		/*
@@ -124,6 +123,15 @@ var _ = utils.SIGDescribe("Subpath", func() {
 				},
 			}, privilegedSecurityContext)
 			testsuites.TestBasicSubpath(f, "configmap-value", pod)
+		})
+
+	})
+
+	ginkgo.Context("Container restart", func() {
+		ginkgo.It("should verify that container can restart successfully after configmaps modified", func() {
+			configmapToModify := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-configmap-to-modify"}, Data: map[string]string{"configmap-key": "configmap-value"}}
+			configmapModified := &v1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "my-configmap-to-modify"}, Data: map[string]string{"configmap-key": "configmap-modified-value"}}
+			testsuites.TestPodContainerRestartWithConfigmapModified(f, configmapToModify, configmapModified)
 		})
 	})
 })

--- a/test/e2e/storage/testsuites/subpath.go
+++ b/test/e2e/storage/testsuites/subpath.go
@@ -28,6 +28,7 @@ import (
 	"github.com/onsi/gomega"
 
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/rand"
@@ -799,25 +800,41 @@ func waitForPodSubpathError(f *framework.Framework, pod *v1.Pod, allowContainerT
 	return nil
 }
 
-// Tests that the existing subpath mount is detected when a container restarts
-func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
+type podContainerRestartHooks struct {
+	AddLivenessProbeFunc  func(pod *v1.Pod, probeFilePath string)
+	FailLivenessProbeFunc func(pod *v1.Pod, probeFilePath string)
+	FixLivenessProbeFunc  func(pod *v1.Pod, probeFilePath string)
+}
+
+func (h *podContainerRestartHooks) AddLivenessProbe(pod *v1.Pod, probeFilePath string) {
+	if h.AddLivenessProbeFunc != nil {
+		h.AddLivenessProbeFunc(pod, probeFilePath)
+	}
+}
+
+func (h *podContainerRestartHooks) FailLivenessProbe(pod *v1.Pod, probeFilePath string) {
+	if h.FailLivenessProbeFunc != nil {
+		h.FailLivenessProbeFunc(pod, probeFilePath)
+	}
+}
+
+func (h *podContainerRestartHooks) FixLivenessProbe(pod *v1.Pod, probeFilePath string) {
+	if h.FixLivenessProbeFunc != nil {
+		h.FixLivenessProbeFunc(pod, probeFilePath)
+	}
+}
+
+// testPodContainerRestartWithHooks tests that container restarts to stabilize.
+// hooks wrap functions between container restarts.
+func testPodContainerRestartWithHooks(f *framework.Framework, pod *v1.Pod, hooks *podContainerRestartHooks) {
 	pod.Spec.RestartPolicy = v1.RestartPolicyOnFailure
 
 	pod.Spec.Containers[0].Image = e2evolume.GetTestImage(imageutils.GetE2EImage(imageutils.BusyBox))
 	pod.Spec.Containers[0].Command = e2evolume.GenerateScriptCmd("sleep 100000")
 	pod.Spec.Containers[1].Image = e2evolume.GetTestImage(imageutils.GetE2EImage(imageutils.BusyBox))
 	pod.Spec.Containers[1].Command = e2evolume.GenerateScriptCmd("sleep 100000")
-	// Add liveness probe to subpath container
-	pod.Spec.Containers[0].LivenessProbe = &v1.Probe{
-		Handler: v1.Handler{
-			Exec: &v1.ExecAction{
-				Command: []string{"cat", probeFilePath},
-			},
-		},
-		InitialDelaySeconds: 1,
-		FailureThreshold:    1,
-		PeriodSeconds:       2,
-	}
+
+	hooks.AddLivenessProbe(pod, probeFilePath)
 
 	// Start pod
 	ginkgo.By(fmt.Sprintf("Creating pod %s", pod.Name))
@@ -831,9 +848,7 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 	framework.ExpectNoError(err, "while waiting for pod to be running")
 
 	ginkgo.By("Failing liveness probe")
-	out, err := podContainerExec(pod, 1, fmt.Sprintf("rm %v", probeFilePath))
-	framework.Logf("Pod exec output: %v", out)
-	framework.ExpectNoError(err, "while failing liveness probe")
+	hooks.FailLivenessProbe(pod, probeFilePath)
 
 	// Check that container has restarted
 	ginkgo.By("Waiting for container to restart")
@@ -858,16 +873,8 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 	framework.ExpectNoError(err, "while waiting for container to restart")
 
 	// Fix liveness probe
-	ginkgo.By("Rewriting the file")
-	var writeCmd string
-	if framework.NodeOSDistroIs("windows") {
-		writeCmd = fmt.Sprintf("echo test-after | Out-File -FilePath %v", probeFilePath)
-	} else {
-		writeCmd = fmt.Sprintf("echo test-after > %v", probeFilePath)
-	}
-	out, err = podContainerExec(pod, 1, writeCmd)
-	framework.Logf("Pod exec output: %v", out)
-	framework.ExpectNoError(err, "while rewriting the probe file")
+	ginkgo.By("Fix liveness probe")
+	hooks.FixLivenessProbe(pod, probeFilePath)
 
 	// Wait for container restarts to stabilize
 	ginkgo.By("Waiting for container to stop restarting")
@@ -897,6 +904,89 @@ func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
 		return false, nil
 	})
 	framework.ExpectNoError(err, "while waiting for container to stabilize")
+}
+
+// testPodContainerRestart tests that the existing subpath mount is detected when a container restarts
+func testPodContainerRestart(f *framework.Framework, pod *v1.Pod) {
+	testPodContainerRestartWithHooks(f, pod, &podContainerRestartHooks{
+		AddLivenessProbeFunc: func(p *v1.Pod, probeFilePath string) {
+			p.Spec.Containers[0].LivenessProbe = &v1.Probe{
+				Handler: v1.Handler{
+					Exec: &v1.ExecAction{
+						Command: []string{"cat", probeFilePath},
+					},
+				},
+				InitialDelaySeconds: 1,
+				FailureThreshold:    1,
+				PeriodSeconds:       2,
+			}
+		},
+		FailLivenessProbeFunc: func(p *v1.Pod, probeFilePath string) {
+			out, err := podContainerExec(p, 1, fmt.Sprintf("rm %v", probeFilePath))
+			framework.Logf("Pod exec output: %v", out)
+			framework.ExpectNoError(err, "while failing liveness probe")
+		},
+		FixLivenessProbeFunc: func(p *v1.Pod, probeFilePath string) {
+			ginkgo.By("Rewriting the file")
+			var writeCmd string
+			if framework.NodeOSDistroIs("windows") {
+				writeCmd = fmt.Sprintf("echo test-after | Out-File -FilePath %v", probeFilePath)
+			} else {
+				writeCmd = fmt.Sprintf("echo test-after > %v", probeFilePath)
+			}
+			out, err := podContainerExec(pod, 1, writeCmd)
+			framework.Logf("Pod exec output: %v", out)
+			framework.ExpectNoError(err, "while rewriting the probe file")
+		},
+	})
+}
+
+// TestPodContainerRestartWithConfigmapModified tests that container can restart to stabilize when configmap has been modified.
+// 1. valid container running
+// 2. update configmap
+// 3. container restarts
+// 4. container becomes stable after configmap mounted file has been modified
+func TestPodContainerRestartWithConfigmapModified(f *framework.Framework, original, modified *v1.ConfigMap) {
+	ginkgo.By("Create configmap")
+	_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Create(context.TODO(), original, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		framework.ExpectNoError(err, "while creating configmap to modify")
+	}
+
+	var subpath string
+	for k := range original.Data {
+		subpath = k
+		break
+	}
+	pod := SubpathTestPod(f, subpath, "configmap", &v1.VolumeSource{ConfigMap: &v1.ConfigMapVolumeSource{LocalObjectReference: v1.LocalObjectReference{Name: original.Name}}}, false)
+	pod.Spec.InitContainers[0].Command = e2evolume.GenerateScriptCmd(fmt.Sprintf("touch %v", probeFilePath))
+
+	modifiedValue := modified.Data[subpath]
+	testPodContainerRestartWithHooks(f, pod, &podContainerRestartHooks{
+		AddLivenessProbeFunc: func(p *v1.Pod, probeFilePath string) {
+			p.Spec.Containers[0].LivenessProbe = &v1.Probe{
+				Handler: v1.Handler{
+					Exec: &v1.ExecAction{
+						// Expect probe file exist or configmap mounted file has been modified.
+						Command: []string{"sh", "-c", fmt.Sprintf("cat %s || test `cat %s` = '%s'", probeFilePath, volumePath, modifiedValue)},
+					},
+				},
+				InitialDelaySeconds: 1,
+				FailureThreshold:    1,
+				PeriodSeconds:       2,
+			}
+		},
+		FailLivenessProbeFunc: func(p *v1.Pod, probeFilePath string) {
+			out, err := podContainerExec(p, 1, fmt.Sprintf("rm %v", probeFilePath))
+			framework.Logf("Pod exec output: %v", out)
+			framework.ExpectNoError(err, "while failing liveness probe")
+		},
+		FixLivenessProbeFunc: func(p *v1.Pod, probeFilePath string) {
+			_, err := f.ClientSet.CoreV1().ConfigMaps(f.Namespace.Name).Update(context.TODO(), modified, metav1.UpdateOptions{})
+			framework.ExpectNoError(err, "while fixing liveness probe")
+		},
+	})
+
 }
 
 func testSubpathReconstruction(f *framework.Framework, hostExec utils.HostExec, pod *v1.Pod, forceDelete bool) {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
When a container uses a configmap which is mounted with the subPath option, the configmap is changed and then the container (but not the pod) restarts the mounting of the configmap fails.

Since #82784 is not active and not rebased, i submit this PR to continue this work or someone can provide another solution?

**Which issue(s) this PR fixes**:
Fixes #68211

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Fix an issue with container restarts using a modified configmap or secret subpath volume mount.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
