### PR TITLE
skip statefulset create pod if pvc deleting

### DIFF
--- a/pkg/controller/statefulset/stateful_pod_control.go
+++ b/pkg/controller/statefulset/stateful_pod_control.go
@@ -181,7 +181,7 @@ func (spc *realStatefulPodControl) recordClaimEvent(verb string, set *apps.State
 func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.StatefulSet, pod *v1.Pod) error {
 	var errs []error
 	for _, claim := range getPersistentVolumeClaims(set, pod) {
-		_, err := spc.pvcLister.PersistentVolumeClaims(claim.Namespace).Get(claim.Name)
+		pvc, err := spc.pvcLister.PersistentVolumeClaims(claim.Namespace).Get(claim.Name)
 		switch {
 		case apierrors.IsNotFound(err):
 			_, err := spc.client.CoreV1().PersistentVolumeClaims(claim.Namespace).Create(context.TODO(), &claim, metav1.CreateOptions{})
@@ -194,6 +194,9 @@ func (spc *realStatefulPodControl) createPersistentVolumeClaims(set *apps.Statef
 		case err != nil:
 			errs = append(errs, fmt.Errorf("failed to retrieve PVC %s: %s", claim.Name, err))
 			spc.recordClaimEvent("create", set, pod, &claim, err)
+		case err == nil && pvc.DeletionTimestamp != nil:
+			errs = append(errs, fmt.Errorf("Can't to create deleting PVC %s ", pvc.Name))
+			spc.recordClaimEvent("create", set, pod, &claim, errs[len(errs)-1])
 		}
 		// TODO: Check resource requirements and accessmodes, update if necessary
 	}


### PR DESCRIPTION

**What type of PR is this?**
/kind bug
/kind apps
/kind storage

**What this PR does / why we need it**:
This pr skip create deleting pvc when statefulset try to recreate pvc and pod. Because if return success, pvc wil lost after pod created.
**Which issue(s) this PR fixes**:
fix #89513 #74374

**Special notes for your reviewer**:
NONE
**Does this PR introduce a user-facing change?**:
NONE