### PR TITLE
specify in the flag help text that --enable-cadvisor-json-endpoints d…

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -415,7 +415,7 @@ func (f *KubeletFlags) AddFlags(mainfs *pflag.FlagSet) {
 	fs.MarkDeprecated("non-masquerade-cidr", "will be removed in a future version")
 	fs.BoolVar(&f.KeepTerminatedPodVolumes, "keep-terminated-pod-volumes", f.KeepTerminatedPodVolumes, "Keep terminated pod volumes mounted to the node after the pod terminates.  Can be useful for debugging volume related issues.")
 	fs.MarkDeprecated("keep-terminated-pod-volumes", "will be removed in a future version")
-	fs.BoolVar(&f.EnableCAdvisorJSONEndpoints, "enable-cadvisor-json-endpoints", f.EnableCAdvisorJSONEndpoints, "Enable cAdvisor json /spec and /stats/* endpoints.")
+	fs.BoolVar(&f.EnableCAdvisorJSONEndpoints, "enable-cadvisor-json-endpoints", f.EnableCAdvisorJSONEndpoints, "Enable cAdvisor json /spec and /stats/* endpoints.  [default=false]")
 	// TODO: Remove this flag in 1.20+.  https://github.com/kubernetes/kubernetes/issues/68522
 	fs.MarkDeprecated("enable-cadvisor-json-endpoints", "will be removed in a future version")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/sig node
/priority backlog

**What this PR does / why we need it**:

Specify in flag help text that the --enable-cadvisor-json-endpoints flag defaults to false.  No behavior change.

**Which issue(s) this PR fixes**:

Follow-up to https://github.com/kubernetes/kubernetes/pull/87440.  Addresses https://github.com/kubernetes/kubernetes/pull/87440#issuecomment-606095688
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

cc @Simwar