### PR TITLE
Bump GCE Windows pause image version

### DIFF
--- a/cluster/gce/config-common.sh
+++ b/cluster/gce/config-common.sh
@@ -159,4 +159,4 @@ export WINDOWS_BOOTSTRAP_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\kubelet.bootstrap-k
 # Path for kube-proxy kubeconfig file on Windows nodes.
 export WINDOWS_KUBEPROXY_KUBECONFIG_FILE="${WINDOWS_K8S_DIR}\kubeproxy.kubeconfig"
 # Pause container image for Windows container.
-export WINDOWS_INFRA_CONTAINER="gcr.io/gke-release/pause-win:1.2.0"
+export WINDOWS_INFRA_CONTAINER="gcr.io/gke-release/pause-win:1.2.1"


### PR DESCRIPTION
pause-win:1.2.1 is based on the March 2020 Windows container base images for both LTSC 2019 and SAC 1909; 1.2.0 only updated the SAC base image to March.

This is a follow-up to https://github.com/kubernetes/kubernetes/pull/89601.

/kind cleanup

```release-note
NONE
```