### PR TITLE
Make pjh an approver for cluster/gce/ changes.

### DIFF
--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -15,12 +15,13 @@ approvers:
   - bowei
   - cjcullen
   - gmarek
-  - vishh
-  - mwielgus
-  - MaciekPytel
   - jingax10
-  - yujuhong
+  - MaciekPytel
   - mtaufen
+  - mwielgus
+  - pjh
   - sig-scalability-approvers
+  - vishh
+  - yujuhong
 emeritus_approvers:
   - jszczepkowski


### PR DESCRIPTION
I'm already an approver for cluster/gce/windows/, but many Windows-related changes require touching the `config-*.sh`, `util.sh`, etc. files in this directory. Getting approval for those changes is cumbersome so I'd like to get approver status.

Also sorts the list of approvers.

/kind cleanup

```release-note
NONE
```