### PR TITLE
Allow list-resources.sh to continue if a resource fails to list

### DIFF
--- a/cluster/gce/list-resources.sh
+++ b/cluster/gce/list-resources.sh
@@ -75,6 +75,9 @@ echo "Provider: ${KUBERNETES_PROVIDER:-}"
 
 # List resources related to instances, filtering by the instance prefix if
 # provided.
+
+set +e # do not stop on error
+
 gcloud-list compute instance-templates "name ~ '${INSTANCE_PREFIX}.*'"
 gcloud-list compute instance-groups "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
 gcloud-list compute instances "${ZONE:+"zone:(${ZONE}) AND "}name ~ '${INSTANCE_PREFIX}.*'"
@@ -95,3 +98,5 @@ gcloud-list compute forwarding-rules ${REGION:+"region=(${REGION})"}
 gcloud-list compute target-pools ${REGION:+"region=(${REGION})"}
 
 gcloud-list logging sinks
+
+set -e


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The `cluster/gce/list-resources.sh` script is used solely by our CI, specifically any job using `kubetest` with the `--check-leaked-resources` flag. Currently if a single resource fails to list, we fail the entire job.

I think this is too brittle. A review of previous issues on kubernetes/kubernetes that relate to failure of this script shows that the issues usually resolve themselves, or would be caught by the diff of before/after.

Let's instead allow the script to continue listing all resources, and let `kubetest`'s resource diff fail the job.

**Special notes for your reviewer**:
This will require cherrypick back to previous release branches to be of benefit to them. I tried looking at fixing this centrally in `kubetest`, but that wouldn't allow us to fail gracefully and list other resources if one fails to list.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/priority important-soon

/sig testing
/cc @ixdy @BenTheElder 

/sig scalability
/cc @mm4tt 
This would be relevant to scalability jobs, eg: would have prevented https://github.com/kubernetes/kubernetes/issues/89573

/sig release
/cc @droslean 
This would be relevant to many of the release-blocking jobs, eg: would have prevented https://github.com/kubernetes/kubernetes/issues/89572
