### PR TITLE
Implement logging format flag at component-base

### DIFF
--- a/staging/src/k8s.io/component-base/go.mod
+++ b/staging/src/k8s.io/component-base/go.mod
@@ -6,6 +6,7 @@ go 1.13
 
 require (
 	github.com/blang/semver v3.5.0+incompatible
+	github.com/go-logr/logr v0.1.0
 	github.com/google/go-cmp v0.4.0
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect

--- a/staging/src/k8s.io/component-base/logs/BUILD
+++ b/staging/src/k8s.io/component-base/logs/BUILD
@@ -7,11 +7,16 @@ load(
 
 go_library(
     name = "go_default_library",
-    srcs = ["logs.go"],
+    srcs = [
+        "logs.go",
+        "options.go",
+        "registry.go",
+    ],
     importmap = "k8s.io/kubernetes/vendor/k8s.io/component-base/logs",
     importpath = "k8s.io/component-base/logs",
     deps = [
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
     ],

--- a/staging/src/k8s.io/component-base/logs/options.go
+++ b/staging/src/k8s.io/component-base/logs/options.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"fmt"
+	"github.com/go-logr/logr"
+	"github.com/spf13/pflag"
+	"k8s.io/klog/v2"
+)
+
+const (
+	logFormatFlagName = "logging-format"
+	defaultLogFormat  = "text"
+)
+
+// Options has klog format parameters
+type Options struct {
+	LogFormat string
+}
+
+// NewOptions return new klog options
+func NewOptions() *Options {
+	return &Options{
+		LogFormat: defaultLogFormat,
+	}
+}
+
+// Validate check LogFormat in registry or not
+func (o *Options) Validate() []error {
+	if _, err := o.Get(); err != nil {
+		return []error{fmt.Errorf("unsupported log format: %s", o.LogFormat)}
+	}
+	return nil
+}
+
+// AddFlags add logging-format flag
+func (o *Options) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.LogFormat, logFormatFlagName, defaultLogFormat, "Set log format")
+}
+
+// Apply set klog logger from LogFormat type
+func (o *Options) Apply() {
+	// if log format not exists, use nil loggr
+	loggr, _ := o.Get()
+
+	klog.SetLogger(loggr)
+}
+
+// Get logger with LogFormat field
+func (o *Options) Get() (logr.Logger, error) {
+	return logRegistry.Get(o.LogFormat)
+}

--- a/staging/src/k8s.io/component-base/logs/registry.go
+++ b/staging/src/k8s.io/component-base/logs/registry.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-logr/logr"
+)
+
+var logRegistry = NewLogFormatRegistry()
+
+// LogFormatRegistry store klog format registry
+type LogFormatRegistry struct {
+	registry map[string]logr.Logger
+	mu       sync.Mutex
+}
+
+// NewLogFormatRegistry return new init LogFormatRegistry struct
+func NewLogFormatRegistry() *LogFormatRegistry {
+	return &LogFormatRegistry{
+		registry: make(map[string]logr.Logger),
+		mu:       sync.Mutex{},
+	}
+}
+
+// Register new log format registry to global logRegistry
+func (lfr *LogFormatRegistry) Register(name string, logger logr.Logger) error {
+	lfr.mu.Lock()
+	defer lfr.mu.Unlock()
+	if _, ok := lfr.registry[name]; ok {
+		return fmt.Errorf("log format: %s already exists", name)
+	}
+	lfr.registry[name] = logger
+	return nil
+}
+
+// Get specified log format logger
+func (lfr *LogFormatRegistry) Get(name string) (logr.Logger, error) {
+	lfr.mu.Lock()
+	defer lfr.mu.Unlock()
+	re, ok := lfr.registry[name]
+	if !ok {
+		return nil, fmt.Errorf("log format: %s does not exists", name)
+	}
+	return re, nil
+}
+
+// Set specified log format logger
+func (lfr *LogFormatRegistry) Set(name string, logger logr.Logger) {
+	lfr.mu.Lock()
+	defer lfr.mu.Unlock()
+	lfr.registry[name] = logger
+}
+
+// Delete specified log format logger
+func (lfr *LogFormatRegistry) Delete(name string) {
+	lfr.mu.Lock()
+	defer lfr.mu.Unlock()
+	delete(lfr.registry, name)
+}
+
+func init() {
+	// Text format is default klog format
+	logRegistry.Register("text", nil)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

[feature] implement logging format flag at component-base

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89190

**Special notes for your reviewer**:



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Add --logging-format flag for component-base. Defaults to "text" using unchanged klog.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
