### PR TITLE
Bump Cluster Autoscaler to 1.17.2

### DIFF
--- a/cluster/gce/manifests/cluster-autoscaler.manifest
+++ b/cluster/gce/manifests/cluster-autoscaler.manifest
@@ -17,7 +17,7 @@
         "containers": [
             {
                 "name": "cluster-autoscaler",
-                "image": "k8s.gcr.io/cluster-autoscaler:v1.17.0",
+                "image": "us.gcr.io/k8s-artifacts-prod/autoscaling/cluster-autoscaler:v1.17.2",
                 "livenessProbe": {
                     "httpGet": {
                         "path": "/health-check",


### PR DESCRIPTION
Update the version in Cluster Autoscaler GCE manifest to a new patch release.

/kind bug
/priority important-soon
/sig autoscaling

```release-note
Release notes: https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.17.2
```