### PR TITLE
Fix service account names with a dot

### DIFF
--- a/plugin/pkg/admission/serviceaccount/admission.go
+++ b/plugin/pkg/admission/serviceaccount/admission.go
@@ -467,9 +467,10 @@ func (s *Plugin) mountServiceAccountToken(serviceAccount *corev1.ServiceAccount,
 			tokenVolumeName = s.generateName(ServiceAccountVolumeName + "-")
 		} else {
 			// Try naming the volume the same as the serviceAccountToken, and uniquify if needed
-			tokenVolumeName = serviceAccountToken
+			// Replace dots because volumeMountName can't contain it
+			tokenVolumeName = strings.Replace(serviceAccountToken, ".", "-", -1)
 			if allVolumeNames.Has(tokenVolumeName) {
-				tokenVolumeName = s.generateName(fmt.Sprintf("%s-", serviceAccountToken))
+				tokenVolumeName = s.generateName(fmt.Sprintf("%s-", tokenVolumeName))
 			}
 		}
 	}

--- a/plugin/pkg/admission/serviceaccount/admission_test.go
+++ b/plugin/pkg/admission/serviceaccount/admission_test.go
@@ -1121,6 +1121,85 @@ func TestAutomountIsBackwardsCompatible(t *testing.T) {
 		t.Fatalf("Expected\n\t%#v\ngot\n\t%#v", expectedVolumeMount, pod.Spec.Containers[0].VolumeMounts[0])
 	}
 }
+func TestServiceAccountNameWithDotMount(t *testing.T) {
+	ns := "myns"
+	tokenName := "token.name-123"
+	serviceAccountName := "token.name"
+	serviceAccountUID := "12345"
+
+	expectedVolume := api.Volume{
+		Name: "token-name-123",
+		VolumeSource: api.VolumeSource{
+			Secret: &api.SecretVolumeSource{
+				SecretName: "token.name-123",
+			},
+		},
+	}
+	expectedVolumeMount := api.VolumeMount{
+		Name:      "token-name-123",
+		ReadOnly:  true,
+		MountPath: DefaultAPITokenMountPath,
+	}
+
+	admit := NewServiceAccount()
+	informerFactory := informers.NewSharedInformerFactory(nil, controller.NoResyncPeriodFunc())
+	admit.SetExternalKubeInformerFactory(informerFactory)
+	admit.MountServiceAccountToken = true
+	admit.RequireAPIToken = true
+
+	informerFactory.Core().V1().ServiceAccounts().Informer().GetStore().Add(&corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceAccountName,
+			Namespace: ns,
+			UID:       types.UID(serviceAccountUID),
+		},
+		Secrets: []corev1.ObjectReference{
+			{Name: tokenName},
+		},
+	})
+
+	informerFactory.Core().V1().Secrets().Informer().GetStore().Add(&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tokenName,
+			Namespace: ns,
+			Annotations: map[string]string{
+				corev1.ServiceAccountNameKey: serviceAccountName,
+				corev1.ServiceAccountUIDKey:  serviceAccountUID,
+			},
+		},
+		Type: corev1.SecretTypeServiceAccountToken,
+		Data: map[string][]byte{
+			api.ServiceAccountTokenKey: []byte("token-data"),
+		},
+	})
+
+	pod := &api.Pod{
+		Spec: api.PodSpec{
+			ServiceAccountName: serviceAccountName,
+			Containers: []api.Container{
+				{Name: "container-1"},
+			},
+		},
+	}
+
+	attrs := admission.NewAttributesRecord(pod, nil, api.Kind("Pod").WithVersion("version"), ns, "myname", api.Resource("pods").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+	if err := admissiontesting.WithReinvocationTesting(t, admit).Admit(context.TODO(), attrs, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(pod.Spec.Volumes) != 1 {
+		t.Fatalf("Expected 1 volume, got %d", len(pod.Spec.Volumes))
+	}
+	if !reflect.DeepEqual(expectedVolume, pod.Spec.Volumes[0]) {
+		t.Fatalf("Expected\n\t%#v\ngot\n\t%#v", expectedVolume, pod.Spec.Volumes[0])
+	}
+	if len(pod.Spec.Containers[0].VolumeMounts) != 1 {
+		t.Fatalf("Expected 1 volume mount, got %d", len(pod.Spec.Containers[0].VolumeMounts))
+	}
+	if !reflect.DeepEqual(expectedVolumeMount, pod.Spec.Containers[0].VolumeMounts[0]) {
+		t.Fatalf("Expected\n\t%#v\ngot\n\t%#v", expectedVolumeMount, pod.Spec.Containers[0].VolumeMounts[0])
+	}
+}
 
 func testGenerateName(n string) string {
 	return n + "abc123"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This fix provides the ability to mount service account tokens to pods. The core problem is the volume name option can't contain any dots. 

It leads us to errors like:
```
- lastTransitionTime: "2020-03-31T10:19:40Z"
    lastUpdateTime: "2020-03-31T10:19:40Z"
    message: 'Pod "nginx-deployment-57cff8694-pk965" is invalid: [spec.volumes[0].name:
      Invalid value: "test.sa-token-ncswp": a DNS-1123 label must consist of lower
      case alphanumeric characters or ''-'', and must start and end with an alphanumeric
      character (e.g. ''my-name'',  or ''123-abc'', regex used for validation is ''[a-z0-9]([-a-z0-9]*[a-z0-9])?''),
      spec.containers[0].volumeMounts[0].name: Not found: "test.sa-token-ncswp"]'
```
With this PR admission controller will replace all dots in service account name with "-" while adding volume mounts to the pod.

**Which issue(s) this PR fixes**:
I have not found an issue.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No, because now mounting tokens with dots don't work.

```release-note
Fixed an issue mounting credentials for service accounts whose name contains `.` characters
```