### PR TITLE
Update conformance docs to reference correct bazel location of testdata

### DIFF
--- a/test/conformance/README.md
+++ b/test/conformance/README.md
@@ -9,7 +9,7 @@ To update the list, run
 
 ```console
 bazel build //test/conformance:list_conformance_tests
-cp bazel-genfiles/test/conformance/conformance.yaml test/conformance/testdata
+cp bazel-bin/test/conformance/conformance.yaml test/conformance/testdata
 ```
 
 Add the changed file to your PR, then send for review.


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
https://github.com/kubernetes/kubernetes/pull/89430 updated us from bazel 0.23 to bazel 2.2.0 (ref: https://github.com/kubernetes/kubernetes/issues/89414)

bazel no longer uses/creates the bazel-genfiles directory, so these instructions are out of date

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```