### PR TITLE
Avoid kubelet API in Conformance tests

### DIFF
--- a/test/e2e/common/BUILD
+++ b/test/e2e/common/BUILD
@@ -71,7 +71,6 @@ go_library(
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/events:go_default_library",
-        "//test/e2e/framework/kubelet:go_default_library",
         "//test/e2e/framework/network:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",

--- a/test/e2e/scheduling/BUILD
+++ b/test/e2e/scheduling/BUILD
@@ -43,7 +43,6 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/gpu:go_default_library",
         "//test/e2e/framework/job:go_default_library",
-        "//test/e2e/framework/kubelet:go_default_library",
         "//test/e2e/framework/node:go_default_library",
         "//test/e2e/framework/pod:go_default_library",
         "//test/e2e/framework/providers/gce:go_default_library",

--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -31,7 +31,6 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 	"k8s.io/kubernetes/test/e2e/framework"
-	e2ekubelet "k8s.io/kubernetes/test/e2e/framework/kubelet"
 	e2enode "k8s.io/kubernetes/test/e2e/framework/node"
 	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
 	e2erc "k8s.io/kubernetes/test/e2e/framework/rc"
@@ -112,8 +111,8 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 		framework.ExpectNoError(err)
 
 		for _, node := range nodeList.Items {
-			framework.Logf("\nLogging pods the kubelet thinks is on node %v before test", node.Name)
-			printAllKubeletPods(cs, node.Name)
+			framework.Logf("\nLogging pods the apiserver thinks is on node %v before test", node.Name)
+			printAllPodsOnNode(cs, node.Name)
 		}
 
 	})
@@ -796,11 +795,11 @@ var _ = SIGDescribe("SchedulerPredicates [Serial]", func() {
 	})
 })
 
-// printAllKubeletPods outputs status of all kubelet pods into log.
-func printAllKubeletPods(c clientset.Interface, nodeName string) {
-	podList, err := e2ekubelet.GetKubeletPods(c, nodeName)
+// printAllPodsOnNode outputs status of all kubelet pods into log.
+func printAllPodsOnNode(c clientset.Interface, nodeName string) {
+	podList, err := c.CoreV1().Pods(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{FieldSelector: "spec.nodeName=" + nodeName})
 	if err != nil {
-		framework.Logf("Unable to retrieve kubelet pods for node %v: %v", nodeName, err)
+		framework.Logf("Unable to retrieve pods for node %v: %v", nodeName, err)
 		return
 	}
 	for _, p := range podList.Items {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Removes or avoids calls to the kubelet API in Conformance tests as
identified in https://github.com/kubernetes/kubernetes/issues/81052#issuecomment-561353611

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #81052

**Special notes for your reviewer**:
See individual commits for details on why/how the removal

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig architecture
/area conformance