### PR TITLE
Add behavior <-> conformance test linkage example for pods 

### DIFF
--- a/test/conformance/behaviors/behaviors_test.go
+++ b/test/conformance/behaviors/behaviors_test.go
@@ -56,7 +56,7 @@ func validateSuite(path string, t *testing.T) {
 	if err != nil {
 		t.Errorf("%q", err.Error())
 	}
-	err = yaml.UnmarshalStrict(yamlFile, &suite)
+	err = yaml.Unmarshal(yamlFile, &suite)
 
 	if err != nil {
 		t.Errorf("%q", err.Error())

--- a/test/conformance/behaviors/sig-node/pod-spec.yaml
+++ b/test/conformance/behaviors/sig-node/pod-spec.yaml
@@ -1,43 +1,49 @@
 suite: pod/spec
 description: Base suite for pods
 behaviors:
-- id: pod/basic-create
+- id: pod/spec/basic-create
   description: When a Pod resource is created with a single container and sufficient resources, a Pod MUST be created on a node with the specified container image.
-- id: pod/basic-delete
+- id: pod/spec/basic-delete
   description: When a Pod resource is delete, the Pod containers must receive a TERM signal and the Pod MUST be deleted.
-- id: pod/hostname
+- id: pod/spec/hostname
   description: When the hostname field is set, a container running in the Pod MUST report the hostname as the specified value.
-- id: pod/subdomain
+- id: pod/spec/subdomain
   description: If specified, the fully qualified Pod hostname will be "<hostname>.<subdomain>.<pod
     namespace>.svc.<cluster domain>". If not specified, the pod will not have a
     domainname at all.
-- id: pod/terminationGracePeriodSeconds/in-spec
+- id: pod/spec/terminationGracePeriodSeconds/in-spec
   description: When the terminationGracePeriodSeconds is specified in the spec,
     processes running in the Pod MUST NOT receive a hard termination signal for at
     least that number of seconds after a delete request.
-- id: pod/terminationGracePeriodSeconds/in-delete
+- id: pod/spec/terminationGracePeriodSeconds/in-delete
   description: When the terminationGracePeriodSeconds is specified in a delete request,
     processes running in the Pod MUST NOT receive a hard termination signal for at
     least that number of seconds after the delete request.
-- id: pod/activeDeadlineSeconds
+- id: pod/spec/activeDeadlineSeconds
   description: Optional duration in seconds the pod may be active on the node relative
     to StartTime before the system will actively try to mark it failed and kill
     associated containers. Value must be a positive integer.
-- id: pod/hostNetwork/true
+- id: pod/spec/hostNetwork/true
   description: When hostNetwork is set to true, the Pod MUST use the host's network
     namespace.
-- id: pod/hostNetwork/false
+- id: pod/spec/hostNetwork/false
   description: When hostNetwork is set to false, the Pod MUST NOT use the host's network
     namespace.
-- id: pod/hostPID/true
+- id: pod/spec/hostPID/true
   description: When hostPID is set to true, the Pod MUST use the host's process
     namespace.
-- id: pod/hostPID/false
+- id: pod/spec/hostPID/false
   description: When hostPID is set to false, the Pod MUST NOT use the host's process
     namespace.
-- id: pod/hostIPC/true
+- id: pod/spec/hostIPC/true
   description: When hostIPC is set to true, the Pod MUST use the host's inter-process
     communication namespace.
-- id: pod/hostIPC/false
+- id: pod/spec/hostIPC/false
   description: When hostIPC is set to false, the Pod MUST NOT use the host's inter-process
     communication namespace.
+- id: pod/spec/label/create
+  decription: Create a Pod with a unique label. Query for the Pod with the label as selector MUST be successful.
+- id: pod/spec/label/patch
+  decription: A patch request must be able to update the pod to change the value of an existing Label. Query for the Pod with the new value for the label MUST be successful.
+- id: pod/spec/container/resources
+  description: Create a Pod with CPU and Memory request and limits. Pod status MUST have QOSClass set to PodQOSGuaranteed.

--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -244,6 +244,9 @@
     Query for the Pod with the new value for the label MUST be successful.
   release: v1.9
   file: test/e2e/common/pods.go
+  behaviors:
+  - pod/spec/label/create
+  - pod/spec/label/patch
 - testname: Pods, service environment variables
   codename: '[k8s.io] Pods should contain environment variables for services [NodeConformance]
     [Conformance]'
@@ -482,6 +485,8 @@
     have QOSClass set to PodQOSGuaranteed.
   release: v1.9
   file: test/e2e/node/pods.go
+  behaviors:
+  - pod/spec/container/resources
 - testname: Pods, prestop hook
   codename: '[k8s.io] [sig-node] PreStop should call prestop when killing a pod  [Conformance]'
   description: Create a server pod with a rest endpoint '/write' that changes state.Received

--- a/test/e2e/common/pods.go
+++ b/test/e2e/common/pods.go
@@ -337,6 +337,9 @@ var _ = framework.KubeDescribe("Pods", func() {
 		Release : v1.9
 		Testname: Pods, update
 		Description: Create a Pod with a unique label. Query for the Pod with the label as selector MUST be successful. Update the pod to change the value of the Label. Query for the Pod with the new value for the label MUST be successful.
+		Behaviors:
+		- pod/spec/label/create
+		- pod/spec/label/patch
 	*/
 	framework.ConformanceIt("should be updated [NodeConformance]", func() {
 		ginkgo.By("creating the pod")

--- a/test/e2e/node/pods.go
+++ b/test/e2e/node/pods.go
@@ -166,6 +166,8 @@ var _ = SIGDescribe("Pods Extended", func() {
 			Release : v1.9
 			Testname: Pods, QOS
 			Description:  Create a Pod with CPU and Memory request and limits. Pod status MUST have QOSClass set to PodQOSGuaranteed.
+			Behaviors:
+			- pod/spec/container/resources
 		*/
 		framework.ConformanceIt("should be set on Pods with matching resource requests and limits for memory and cpu", func() {
 			ginkgo.By("creating the pod")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Link two conformance tests to corresponding pod spec behaviors.

There are more conformance tests in the `e2e/common/pods.go` file, but I don't think they belong in the pod spec section.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

