### PR TITLE
Fixes a flaky test, by adding kubectl wait for delete deployment in apply.sh

### DIFF
--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -79,7 +79,7 @@ run_kubectl_apply_tests() {
   ! grep -q emptyDir <<< "$(kubectl get deployments test-deployment-retainkeys -o yaml "${kube_flags[@]:?}")" || exit 1
   # Clean up
   kubectl delete deployments test-deployment-retainkeys "${kube_flags[@]:?}"
-
+  kubectl wait deployment --for=delete test-deployment-retainkeys || true
 
   ## kubectl apply -f with label selector should only apply matching objects
   # Pre-Condition: no POD exists

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -79,7 +79,7 @@ run_kubectl_apply_tests() {
   ! grep -q emptyDir <<< "$(kubectl get deployments test-deployment-retainkeys -o yaml "${kube_flags[@]:?}")" || exit 1
   # Clean up
   kubectl delete deployments test-deployment-retainkeys "${kube_flags[@]:?}"
-  kubectl wait deployment --for=delete test-deployment-retainkeys || true
+  kubectl wait pod --for=delete --all --timeout=15s || true
 
   ## kubectl apply -f with label selector should only apply matching objects
   # Pre-Condition: no POD exists

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -79,11 +79,10 @@ run_kubectl_apply_tests() {
   ! grep -q emptyDir <<< "$(kubectl get deployments test-deployment-retainkeys -o yaml "${kube_flags[@]:?}")" || exit 1
   # Clean up
   kubectl delete deployments test-deployment-retainkeys "${kube_flags[@]:?}"
-  kubectl wait pod --for=delete --all --timeout=15s || true
 
   ## kubectl apply -f with label selector should only apply matching objects
   # Pre-Condition: no POD exists
-  kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+  kube::test::wait_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
   # apply
   kubectl apply -l unique-label=bingbang -f hack/testdata/filter "${kube_flags[@]:?}"
   # check right pod exists


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:
Fixes a flaky test by adding a wait.

**Which issue(s) this PR fixes**:
#89719
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:
This is one of the failed instance of this flaky test.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/88364/pull-kubernetes-integration/1245223371679993859