### PR TITLE
Backward support for old KVM driver disks name

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/openstack/openstack_volumes.go
@@ -491,6 +491,8 @@ func (os *OpenStack) GetDevicePathBySerialID(volumeID string) string {
 		fmt.Sprintf("virtio-%s", volumeID[:20]),
 		// KVM virtio-scsi
 		fmt.Sprintf("scsi-0QEMU_QEMU_HARDDISK_%s", volumeID[:20]),
+		// older KVM virtio-scsi
+		fmt.Sprintf("scsi-0QEMU_QEMU_HARDDISK_%s", volumeID),
 		// ESXi
 		fmt.Sprintf("wwn-0x%s", strings.Replace(volumeID, "-", "", -1)),
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #89723.

The root cause issue has been already reported on [OpenStack Cloud Provider](https://github.com/kubernetes/cloud-provider-openstack/issues/852) and addressed by the following [PR](https://github.com/kubernetes/cloud-provider-openstack/pull/853).

**Special notes for your reviewer**:
We're aware of the deprecation path for the legacy OpenStack Cloud Provider, asking to get it merged in order to provide at least support for legacy clusters anyone could have.

**Does this PR introduce a user-facing change?**:
None

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```release-note
NONE
```