### PR TITLE
Update and improve ReplicationController resource lifecycle test

### DIFF
--- a/test/e2e/apps/BUILD
+++ b/test/e2e/apps/BUILD
@@ -38,6 +38,7 @@ go_library(
         "//pkg/master/ports:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
+        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/apps/BUILD
+++ b/test/e2e/apps/BUILD
@@ -38,7 +38,6 @@ go_library(
         "//pkg/master/ports:go_default_library",
         "//pkg/scheduler/nodeinfo:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
-        "//staging/src/k8s.io/api/autoscaling/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1:go_default_library",
         "//staging/src/k8s.io/api/batch/v1beta1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/apps/rc.go
+++ b/test/e2e/apps/rc.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -210,9 +211,9 @@ var _ = SIGDescribe("ReplicationController", func() {
 		json.Unmarshal(rcStatusUjson, &rcStatus)
 		framework.ExpectEqual(rcStatus.Status.Replicas, testRcInitialReplicaCount, "ReplicationController ReplicaSet cound does not match initial Replica count")
 
-		rcScalePatchPayload, err := json.Marshal(v1.ReplicationController{
-			Spec: v1.ReplicationControllerSpec{
-				Replicas: &testRcMaxReplicaCount,
+		rcScalePatchPayload, err := json.Marshal(autoscalingv1.Scale{
+			Spec: autoscalingv1.ScaleSpec{
+				Replicas: testRcMaxReplicaCount,
 			},
 		})
 		framework.ExpectNoError(err, "Failed to marshal json of replicationcontroller label patch")


### PR DESCRIPTION
- [x] [APISnoop mock ticket](https://github.com/cncf/apisnoop/pull/289)
- [x] [mock template ticket](#)
- [x] [PR](https://github.com/kubernetes/kubernetes/pull/88588)
- [ ] [update and improve](#)

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates the test to rely on responses from `Patch` or `Update` instead of later `Get` or `List`

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/pull/88588#issuecomment-607366847

**Special notes for your reviewer**:
Attempts to fix flakiness.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing