### PR TITLE
Promote Event resource lifecycle test  +5 test endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -804,6 +804,14 @@
     definitions MUST be published for custom resource definitions.
   release: v1.16
   file: test/e2e/apimachinery/crd_publish_openapi.go
+- testname: Event resource lifecycle
+  codename: '[sig-api-machinery] Events should ensure that an event can be fetched,
+    patched, deleted, and listed [Conformance]'
+  description: Create an event, the event MUST exist. The event is patched with a
+    new message, the check MUST have the update message. The event is deleted and
+    MUST NOT show up when listing all events.
+  release: v1.19
+  file: test/e2e/framework/events/events.go
 - testname: Garbage Collector, delete deployment,  propagation policy background
   codename: '[sig-api-machinery] Garbage collector should delete RS created by deployment
     when not orphaning [Conformance]'

--- a/test/e2e/framework/events/events.go
+++ b/test/e2e/framework/events/events.go
@@ -40,11 +40,11 @@ var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 	f := framework.NewDefaultFramework("events")
 
 	/*
-		   Release : v1.19
-		   Testname: Event resource lifecycle
-		   Description: Create an event, the event MUST exist.
-	           The event is patched with a new message, the check MUST have the update message.
-	           The event is deleted and MUST NOT show up when listing all events.
+			   Release : v1.19
+			   Testname: Event resource lifecycle
+			   Description: Create an event, the event MUST exist.
+		           The event is patched with a new message, the check MUST have the update message.
+		           The event is deleted and MUST NOT show up when listing all events.
 	*/
 	framework.ConformanceIt("should ensure that an event can be fetched, patched, deleted, and listed", func() {
 		eventTestName := "event-test"

--- a/test/e2e/framework/events/events.go
+++ b/test/e2e/framework/events/events.go
@@ -40,11 +40,11 @@ var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 	f := framework.NewDefaultFramework("events")
 
 	/*
-	   Release : v1.19
-	   Testname: Event resource lifecycle
-	   Description: Create an event, the event MUST exist.
-           The event is patched with a new message, the check MUST have the update message.
-           The event is deleted and MUST NOT show up when listing all events.
+		   Release : v1.19
+		   Testname: Event resource lifecycle
+		   Description: Create an event, the event MUST exist.
+	           The event is patched with a new message, the check MUST have the update message.
+	           The event is deleted and MUST NOT show up when listing all events.
 	*/
 	framework.ConformanceIt("should ensure that an event can be fetched, patched, deleted, and listed", func() {
 		eventTestName := "event-test"

--- a/test/e2e/framework/events/events.go
+++ b/test/e2e/framework/events/events.go
@@ -39,7 +39,14 @@ type Action func() error
 var _ = ginkgo.Describe("[sig-api-machinery] Events", func() {
 	f := framework.NewDefaultFramework("events")
 
-	ginkgo.It("should ensure that an event can be fetched, patched, deleted, and listed", func() {
+	/*
+	   Release : v1.19
+	   Testname: Event resource lifecycle
+	   Description: Create an event, the event MUST exist.
+           The event is patched with a new message, the check MUST have the update message.
+           The event is deleted and MUST NOT show up when listing all events.
+	*/
+	framework.ConformanceIt("should ensure that an event can be fetched, patched, deleted, and listed", func() {
 		eventTestName := "event-test"
 
 		ginkgo.By("creating a test event")


### PR DESCRIPTION
- [x] [mock test ticket](https://github.com/kubernetes/kubernetes/issues/86288)
- [x] [PR](https://github.com/kubernetes/kubernetes/pull/86858)
- [ ] [promotion](#)

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
`test/e2e/framework/events/events.go: "should ensure that an event can be fetched, patched, deleted, and listed"`

**Which issue(s) this PR fixes**:
Fixes #86288

**Special notes for your reviewer**:
Adds +5 conformance endpoint coverage

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/area conformance
/area test
@kubernetes/cncf-conformance-wg