### PR TITLE
Enable env defined services to dump in logexporter

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -52,6 +52,7 @@ readonly initd_logfiles="docker/log"
 readonly supervisord_logfiles="kubelet.log supervisor/supervisord.log supervisor/kubelet-stdout.log supervisor/kubelet-stderr.log supervisor/docker-stdout.log supervisor/docker-stderr.log"
 readonly systemd_services="kubelet kubelet-monitor kube-container-runtime-monitor ${LOG_DUMP_SYSTEMD_SERVICES:-docker}"
 readonly extra_log_files="${LOG_DUMP_EXTRA_FILES:-}"
+readonly extra_systemd_services="${LOG_DUMP_SAVE_SERVICES:-}"
 readonly dump_systemd_journal="${LOG_DUMP_SYSTEMD_JOURNAL:-false}"
 # Log files found in WINDOWS_LOGS_DIR on Windows nodes:
 readonly windows_node_logfiles="kubelet.log kube-proxy.log docker.log docker_images.log"
@@ -156,7 +157,7 @@ function save-logs() {
           ;;
       esac
     fi
-    local -r services=( ${systemd_services} ${opt_systemd_services} ${LOG_DUMP_SAVE_SERVICES:-} )
+    local -r services=( ${systemd_services} ${opt_systemd_services} ${extra_systemd_services} )
 
     if log-dump-ssh "${node_name}" "command -v journalctl" &> /dev/null; then
         if [[ "${on_master}" == "true" ]]; then
@@ -499,6 +500,7 @@ function dump_nodes_with_logexporter() {
   sed -i'' -e "s@{{.EnableHollowNodeLogs}}@${enable_hollow_node_logs}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
   sed -i'' -e "s@{{.DumpSystemdJournal}}@${dump_systemd_journal}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
   sed -i'' -e "s@{{.ExtraLogFiles}}@${extra_log_files}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
+  sed -i'' -e "s@{{.ExtraSystemdServices}}@${extra_systemd_services}@g" "${KUBE_ROOT}/cluster/log-dump/logexporter-daemonset.yaml"
 
   # Create the logexporter namespace, service-account secret and the logexporter daemonset within that namespace.
   KUBECTL="${KUBE_ROOT}/cluster/kubectl.sh"

--- a/cluster/log-dump/logexporter-daemonset.yaml
+++ b/cluster/log-dump/logexporter-daemonset.yaml
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: logexporter-test
-        image: gcr.io/k8s-testimages/logexporter:v20200327-9ba073aa98
+        image: gcr.io/k8s-testimages/logexporter:v20200401-c3269f485
         env:
         - name: NODE_NAME
           valueFrom:
@@ -51,6 +51,7 @@ spec:
         - --enable-hollow-node-logs={{.EnableHollowNodeLogs}}
         - --dump-systemd-journal={{.DumpSystemdJournal}}
         - --extra-log-files={{.ExtraLogFiles}}
+        - --extra-systemd-services={{.ExtraSystemdServices}}
         - --sleep-duration=24h
         volumeMounts:
         - mountPath: /etc/service-account


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Enable new flag added in Log Exporter in kubernetes/test-infra#17052

**Which issue(s) this PR fixes**:

No issue is opened for that

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig scalability