### PR TITLE
add nodelost status when TaintBasedEvictions is enabled

### DIFF
--- a/pkg/controller/nodelifecycle/scheduler/BUILD
+++ b/pkg/controller/nodelifecycle/scheduler/BUILD
@@ -12,6 +12,8 @@ go_library(
     deps = [
         "//pkg/apis/core/helper:go_default_library",
         "//pkg/apis/core/v1/helper:go_default_library",
+        "//pkg/controller/util/node:go_default_library",
+        "//pkg/kubelet/util/format:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
@@ -38,6 +40,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/controller/testutil:go_default_library",
+        "//pkg/util/node:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/fields:go_default_library",


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
Add NodeLost status which is missed after TaintBasedEvictions is enabled 

Which issue(s) this PR fixes:
Fixes #89212

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
add nodelost status when TaintBasedEvictions is enabled
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
