### PR TITLE
Add common SSHPort on e2essh

### DIFF
--- a/test/e2e/framework/kubesystem/kubesystem.go
+++ b/test/e2e/framework/kubesystem/kubesystem.go
@@ -26,11 +26,6 @@ import (
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 )
 
-const (
-	// ssh port
-	sshPort = "22"
-)
-
 // RestartControllerManager restarts the kube-controller-manager.
 func RestartControllerManager() error {
 	// TODO: Make it work for all providers and distros.
@@ -42,7 +37,7 @@ func RestartControllerManager() error {
 	}
 	cmd := "pidof kube-controller-manager | xargs sudo kill"
 	framework.Logf("Restarting controller-manager via ssh, running: %v", cmd)
-	result, err := e2essh.SSH(cmd, net.JoinHostPort(framework.GetMasterHost(), sshPort), framework.TestContext.Provider)
+	result, err := e2essh.SSH(cmd, net.JoinHostPort(framework.GetMasterHost(), e2essh.SSHPort), framework.TestContext.Provider)
 	if err != nil || result.Code != 0 {
 		e2essh.LogResult(result)
 		return fmt.Errorf("couldn't restart controller-manager: %v", err)
@@ -54,7 +49,7 @@ func RestartControllerManager() error {
 func WaitForControllerManagerUp() error {
 	cmd := "curl http://localhost:" + strconv.Itoa(framework.InsecureKubeControllerManagerPort) + "/healthz"
 	for start := time.Now(); time.Since(start) < time.Minute; time.Sleep(5 * time.Second) {
-		result, err := e2essh.SSH(cmd, net.JoinHostPort(framework.GetMasterHost(), sshPort), framework.TestContext.Provider)
+		result, err := e2essh.SSH(cmd, net.JoinHostPort(framework.GetMasterHost(), e2essh.SSHPort), framework.TestContext.Provider)
 		if err != nil || result.Code != 0 {
 			e2essh.LogResult(result)
 		}

--- a/test/e2e/framework/ssh/ssh.go
+++ b/test/e2e/framework/ssh/ssh.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	// ssh port
-	sshPort = "22"
+	// SSHPort is tcp port number of SSH
+	SSHPort = "22"
 
 	// pollNodeInterval is how often to Poll pods.
 	pollNodeInterval = 2 * time.Second
@@ -136,7 +136,7 @@ func NodeSSHHosts(c clientset.Interface) ([]string, error) {
 
 	sshHosts := make([]string, 0, len(hosts))
 	for _, h := range hosts {
-		sshHosts = append(sshHosts, net.JoinHostPort(h, sshPort))
+		sshHosts = append(sshHosts, net.JoinHostPort(h, SSHPort))
 	}
 	return sshHosts, nil
 }
@@ -155,7 +155,7 @@ type Result struct {
 // eg: the name returned by framework.GetMasterHost(). This is also not guaranteed to work across
 // cloud providers since it involves ssh.
 func NodeExec(nodeName, cmd, provider string) (Result, error) {
-	return SSH(cmd, net.JoinHostPort(nodeName, sshPort), provider)
+	return SSH(cmd, net.JoinHostPort(nodeName, SSHPort), provider)
 }
 
 // SSH synchronously SSHs to a node running on provider and runs cmd. If there
@@ -330,7 +330,7 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*Result, er
 	host := ""
 	for _, a := range node.Status.Addresses {
 		if a.Type == v1.NodeExternalIP && a.Address != "" {
-			host = net.JoinHostPort(a.Address, sshPort)
+			host = net.JoinHostPort(a.Address, SSHPort)
 			break
 		}
 	}
@@ -339,7 +339,7 @@ func IssueSSHCommandWithResult(cmd, provider string, node *v1.Node) (*Result, er
 		// No external IPs were found, let's try to use internal as plan B
 		for _, a := range node.Status.Addresses {
 			if a.Type == v1.NodeInternalIP && a.Address != "" {
-				host = net.JoinHostPort(a.Address, sshPort)
+				host = net.JoinHostPort(a.Address, SSHPort)
 				break
 			}
 		}

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -87,9 +87,6 @@ const (
 	// AffinityConfirmCount is the number of needed continuous requests to confirm that
 	// affinity is enabled.
 	AffinityConfirmCount = 15
-
-	// ssh port
-	sshPort = "22"
 )
 
 var (
@@ -3587,7 +3584,7 @@ func sshRestartMaster() error {
 		command = "sudo /etc/init.d/kube-apiserver restart"
 	}
 	framework.Logf("Restarting master via ssh, running: %v", command)
-	result, err := e2essh.SSH(command, net.JoinHostPort(framework.GetMasterHost(), sshPort), framework.TestContext.Provider)
+	result, err := e2essh.SSH(command, net.JoinHostPort(framework.GetMasterHost(), e2essh.SSHPort), framework.TestContext.Provider)
 	if err != nil || result.Code != 0 {
 		e2essh.LogResult(result)
 		return fmt.Errorf("couldn't restart apiserver: %v", err)

--- a/test/e2e/storage/flexvolume.go
+++ b/test/e2e/storage/flexvolume.go
@@ -38,7 +38,6 @@ import (
 )
 
 const (
-	sshPort                = "22"
 	driverDir              = "test/e2e/testing-manifests/flexvolume/"
 	defaultVolumePluginDir = "/usr/libexec/kubernetes/kubelet-plugins/volume/exec"
 	// TODO: change this and config-test.sh when default flex volume install path is changed for GCI
@@ -84,7 +83,7 @@ func installFlex(c clientset.Interface, node *v1.Node, vendor, driver, filePath 
 	} else {
 		masterHostWithPort := framework.GetMasterHost()
 		hostName := getHostFromHostPort(masterHostWithPort)
-		host = net.JoinHostPort(hostName, sshPort)
+		host = net.JoinHostPort(hostName, e2essh.SSHPort)
 	}
 
 	framework.ExpectNoError(err)
@@ -113,7 +112,7 @@ func uninstallFlex(c clientset.Interface, node *v1.Node, vendor, driver string) 
 	} else {
 		masterHostWithPort := framework.GetMasterHost()
 		hostName := getHostFromHostPort(masterHostWithPort)
-		host = net.JoinHostPort(hostName, sshPort)
+		host = net.JoinHostPort(hostName, e2essh.SSHPort)
 	}
 
 	if host == "" {

--- a/test/e2e/storage/nfs_persistent_volume-disruptive.go
+++ b/test/e2e/storage/nfs_persistent_volume-disruptive.go
@@ -52,7 +52,7 @@ func checkForControllerManagerHealthy(duration time.Duration) error {
 	var PID string
 	cmd := "pidof kube-controller-manager"
 	for start := time.Now(); time.Since(start) < duration; time.Sleep(5 * time.Second) {
-		result, err := e2essh.SSH(cmd, net.JoinHostPort(framework.GetMasterHost(), sshPort), framework.TestContext.Provider)
+		result, err := e2essh.SSH(cmd, net.JoinHostPort(framework.GetMasterHost(), e2essh.SSHPort), framework.TestContext.Provider)
 		if err != nil {
 			// We don't necessarily know that it crashed, pipe could just be broken
 			e2essh.LogResult(result)


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

There were several sshPort values in e2e test packages because we've migrated code from e2e framework by copying and pastting.
This adds common SSHPort on e2essh package to reduce such duplicated code.

This is for following the comment of https://github.com/kubernetes/kubernetes/pull/89563#discussion_r399026227

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
