### PR TITLE
Configure AutoSyncInterval when created etcd client config

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/storagebackend/factory/etcd3.go
@@ -44,6 +44,9 @@ import (
 )
 
 const (
+	// autoSyncInterval is the interval for syncing etcd endpoints from the etcd Cluster itself
+	autoSyncInterval = 60 * time.Second
+
 	// The short keepalive timeout and interval have been chosen to aggressively
 	// detect a failed etcd server without introducing much overhead.
 	keepaliveTime    = 30 * time.Second
@@ -141,6 +144,7 @@ func newETCD3Client(c storagebackend.TransportConfig) (*clientv3.Client, error) 
 		dialOptions = append(dialOptions, grpc.WithContextDialer(dialer))
 	}
 	cfg := clientv3.Config{
+		AutoSyncInterval:     autoSyncInterval,
 		DialTimeout:          dialTimeout,
 		DialKeepAliveTime:    keepaliveTime,
 		DialKeepAliveTimeout: keepaliveTimeout,


### PR DESCRIPTION

**What type of PR is this?**
> /kind feature

**What this PR does / why we need it**:
Configure AutoSyncInterval when created etcd client config

This resolves issues when bootstrapping clusters and the full etcd
endpoint list is unknown at the time of bootstrapping, such as when
building an HA cluster using kubeadm.

**Which issue(s) this PR fixes**:
Fixes #64742

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
The etcd client created by the apiserver now configures a 60s autosync interval, which provides improved reliability of HA control planes that are built up iteratively, such as when using kubeadm.
```

/sig api-machinery
/sig cluster-lifecycle