### PR TITLE
Moving CSI Node storage version to v1

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -609,7 +609,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceNodeExclusion:           {Default: false, PreRelease: featuregate.Alpha},
 	NodeDisruptionExclusion:        {Default: false, PreRelease: featuregate.Alpha},
 	CSIDriverRegistry:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
-	CSINodeInfo:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.19
+	CSINodeInfo:                    {Default: true, PreRelease: featuregate.GA},
 	BlockVolume:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
 	StorageObjectInUseProtection:   {Default: true, PreRelease: featuregate.GA},
 	ResourceLimitsPriorityFunction: {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/registry/storage/csinode/strategy_test.go
+++ b/pkg/registry/storage/csinode/strategy_test.go
@@ -71,7 +71,7 @@ func TestPrepareForCreate(t *testing.T) {
 func testPrepareForCreate(t *testing.T, obj, expected *storage.CSINode) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewContext(), &genericapirequest.RequestInfo{
 		APIGroup:   "storage.k8s.io",
-		APIVersion: "v1beta1",
+		APIVersion: "v1",
 		Resource:   "csinodes",
 	})
 	Strategy.PrepareForCreate(ctx, obj)
@@ -148,7 +148,7 @@ func TestPrepareForUpdate(t *testing.T) {
 func testPrepareForUpdate(t *testing.T, obj, old, expected *storage.CSINode) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewContext(), &genericapirequest.RequestInfo{
 		APIGroup:   "storage.k8s.io",
-		APIVersion: "v1beta1",
+		APIVersion: "v1",
 		Resource:   "csinodes",
 	})
 	Strategy.PrepareForUpdate(ctx, obj, old)
@@ -160,7 +160,7 @@ func testPrepareForUpdate(t *testing.T, obj, old, expected *storage.CSINode) {
 func TestCSINodeStrategy(t *testing.T) {
 	ctx := genericapirequest.WithRequestInfo(genericapirequest.NewContext(), &genericapirequest.RequestInfo{
 		APIGroup:   "storage.k8s.io",
-		APIVersion: "v1beta1",
+		APIVersion: "v1",
 		Resource:   "csinodes",
 	})
 	if Strategy.NamespaceScoped() {
@@ -323,18 +323,18 @@ func TestCSINodeValidation(t *testing.T) {
 			testValidation := func(csiNode *storage.CSINode, apiVersion string) field.ErrorList {
 				ctx := genericapirequest.WithRequestInfo(genericapirequest.NewContext(), &genericapirequest.RequestInfo{
 					APIGroup:   "storage.k8s.io",
-					APIVersion: "v1beta1",
+					APIVersion: "v1",
 					Resource:   "csinodes",
 				})
 				return Strategy.Validate(ctx, csiNode)
 			}
 
-			betaErr := testValidation(test.csiNode, "v1beta1")
-			if len(betaErr) > 0 && !test.expectError {
-				t.Errorf("Validation of v1beta1 object failed: %+v", betaErr)
+			err := testValidation(test.csiNode, "v1")
+			if len(err) > 0 && !test.expectError {
+				t.Errorf("Validation of v1 object failed: %+v", err)
 			}
-			if len(betaErr) == 0 && test.expectError {
-				t.Errorf("Validation of v1beta1 object unexpectedly succeeded")
+			if len(err) == 0 && test.expectError {
+				t.Errorf("Validation of v1 object unexpectedly succeeded")
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
When promoting the CSI Driver to GA [Issue 88821](https://github.com/kubernetes/kubernetes/issues/88821) was filed. I believe that this PR addresses it by removing the `LockToDefault` feature gate for CSI Nodes. I've also updated the test that I found which uses the v1beta1 version of the CSINodes.

Please let me know what else is required to address this issue.

**Which issue(s) this PR fixes**:
Fixes #88821

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
