### PR TITLE
Make kubectl client-side apply with server-side dry-run safer

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/BUILD
@@ -68,7 +68,6 @@ go_test(
         "//staging/src/k8s.io/client-go/dynamic/fake:go_default_library",
         "//staging/src/k8s.io/client-go/rest:go_default_library",
         "//staging/src/k8s.io/client-go/rest/fake:go_default_library",
-        "//staging/src/k8s.io/client-go/testing:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/testing:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/scheme:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/patcher.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/resource"
-	"k8s.io/client-go/dynamic"
 	oapi "k8s.io/kube-openapi/pkg/util/proto"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/scheme"
@@ -52,18 +51,16 @@ const (
 
 // Patcher defines options to patch OpenAPI objects.
 type Patcher struct {
-	Mapping       *meta.RESTMapping
-	Helper        *resource.Helper
-	DynamicClient dynamic.Interface
+	Mapping *meta.RESTMapping
+	Helper  *resource.Helper
 
 	Overwrite bool
 	BackOff   clockwork.Clock
 
-	Force        bool
-	Cascade      bool
-	Timeout      time.Duration
-	GracePeriod  int
-	ServerDryRun bool
+	Force       bool
+	Cascade     bool
+	Timeout     time.Duration
+	GracePeriod int
 
 	// If set, forces the patch against a specific resourceVersion
 	ResourceVersion *string
@@ -74,7 +71,7 @@ type Patcher struct {
 	OpenapiSchema openapi.Resources
 }
 
-func newPatcher(o *ApplyOptions, info *resource.Info) (*Patcher, error) {
+func newPatcher(o *ApplyOptions, info *resource.Info, helper *resource.Helper) (*Patcher, error) {
 	var openapiSchema openapi.Resources
 	if o.OpenAPIPatch {
 		openapiSchema = o.OpenAPISchema
@@ -82,22 +79,22 @@ func newPatcher(o *ApplyOptions, info *resource.Info) (*Patcher, error) {
 
 	return &Patcher{
 		Mapping:       info.Mapping,
-		Helper:        resource.NewHelper(info.Client, info.Mapping).WithFieldManager(o.FieldManager),
-		DynamicClient: o.DynamicClient,
+		Helper:        helper,
 		Overwrite:     o.Overwrite,
 		BackOff:       clockwork.NewRealClock(),
 		Force:         o.DeleteOptions.ForceDeletion,
 		Cascade:       o.DeleteOptions.Cascade,
 		Timeout:       o.DeleteOptions.Timeout,
 		GracePeriod:   o.DeleteOptions.GracePeriod,
-		ServerDryRun:  o.DryRunStrategy == cmdutil.DryRunServer,
 		OpenapiSchema: openapiSchema,
 		Retries:       maxPatchRetry,
 	}, nil
 }
 
 func (p *Patcher) delete(namespace, name string) error {
-	return runDelete(namespace, name, p.Mapping, p.DynamicClient, p.Cascade, p.GracePeriod, p.ServerDryRun)
+	options := asDeleteOptions(p.Cascade, p.GracePeriod)
+	_, err := p.Helper.DeleteWithOptions(namespace, name, &options)
+	return err
 }
 
 func (p *Patcher) patchSimple(obj runtime.Object, modified []byte, source, namespace, name string, errOut io.Writer) ([]byte, runtime.Object, error) {
@@ -178,7 +175,7 @@ func (p *Patcher) patchSimple(obj runtime.Object, modified []byte, source, names
 		}
 	}
 
-	patchedObj, err := p.Helper.DryRun(p.ServerDryRun).Patch(namespace, name, patchType, patch, nil)
+	patchedObj, err := p.Helper.Patch(namespace, name, patchType, patch, nil)
 	return patch, patchedObj, err
 }
 
@@ -223,11 +220,11 @@ func (p *Patcher) deleteAndCreate(original runtime.Object, modified []byte, name
 	if err != nil {
 		return modified, nil, err
 	}
-	createdObject, err := p.Helper.DryRun(p.ServerDryRun).Create(namespace, true, versionedObject)
+	createdObject, err := p.Helper.Create(namespace, true, versionedObject)
 	if err != nil {
 		// restore the original object if we fail to create the new one
 		// but still propagate and advertise error to user
-		recreated, recreateErr := p.Helper.DryRun(p.ServerDryRun).Create(namespace, true, original)
+		recreated, recreateErr := p.Helper.Create(namespace, true, original)
 		if recreateErr != nil {
 			err = fmt.Errorf("An error occurred force-replacing the existing object with the newly provided one:\n\n%v.\n\nAdditionally, an error occurred attempting to restore the original object:\n\n%v", err, recreateErr)
 		} else {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/diff/diff.go
@@ -367,7 +367,6 @@ func (obj InfoObject) Merged() (runtime.Object, error) {
 		Helper:          helper,
 		Overwrite:       true,
 		BackOff:         clockwork.NewRealClock(),
-		ServerDryRun:    true,
 		OpenapiSchema:   obj.OpenAPI,
 		ResourceVersion: resourceVersion,
 	}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/util/helpers.go
@@ -523,8 +523,23 @@ func GetFieldManagerFlag(cmd *cobra.Command) string {
 type DryRunStrategy int
 
 const (
+	// DryRunNone indicates the client will make all mutating calls
 	DryRunNone DryRunStrategy = iota
+
+	// DryRunClient, or client-side dry-run, indicates the client will prevent
+	// making mutating calls such as CREATE, PATCH, and DELETE
 	DryRunClient
+
+	// DryRunServer, or server-side dry-run, indicates the client will send
+	// mutating calls to the APIServer with the dry-run parameter to prevent
+	// persisting changes.
+	//
+	// Note that clients sending server-side dry-run calls should verify that
+	// the APIServer and the resource supports server-side dry-run, and otherwise
+	// clients should fail early.
+	//
+	// If a client sends a server-side dry-run call to an APIServer that doesn't
+	// support server-side dry-run, then the APIServer will persist changes inadvertently.
 	DryRunServer
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
This change simplifies the kubectl apply.Patcher to make it safer, which is used by `kubectl apply` and `kubectl diff`:

- Remove the ServerDryRun field and delegate setting server-side dry-run entirely to the Patcher's resource.Helper
- Remove the dynamic client and use resource.Helper for deletions (as in `kubectl apply --force`)
instead of using the pruner's method that uses a dynamic client
- Reduce the number of resource.Helpers created and times we check for server-side dry-run in apply

This change should wait for https://github.com/kubernetes/kubernetes/pull/89795 to merge.

**Which issue(s) this PR fixes**:
Follow up to https://github.com/kubernetes/kubernetes/pull/89795, related to https://github.com/kubernetes/kubectl/issues/852.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
