### PR TITLE
update statefulset pod when it is not running and has ErrImagePullBackOff error

### DIFF
--- a/pkg/controller/statefulset/BUILD
+++ b/pkg/controller/statefulset/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//pkg/api/v1/pod:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/history:go_default_library",
+        "//pkg/kubelet/images:go_default_library",
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/controller/statefulset/stateful_set_control.go
+++ b/pkg/controller/statefulset/stateful_set_control.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller/history"
+	"k8s.io/kubernetes/pkg/kubelet/images"
 )
 
 // StatefulSetControl implements the control logic for updating StatefulSets and their children Pods. It is implemented
@@ -444,6 +445,33 @@ func (ssc *defaultStatefulSetControl) updateStatefulSet(
 		// We must ensure that all for each Pod, when we create it, all of its predecessors, with respect to its
 		// ordinal, are Running and Ready.
 		if !isRunningAndReady(replicas[i]) && monotonic {
+			for _, cs := range replicas[i].Status.ContainerStatuses {
+				if cs.State.Waiting != nil {
+					if cs.State.Waiting.Reason == images.ErrImagePullBackOff.Error() {
+						ssc.recorder.Eventf(set, v1.EventTypeWarning, "PodErrImagePullBackOff",
+							"StatefulSet %s/%s Pod %s ErrImagePullBackOff",
+							set.Namespace,
+							set.Name,
+							replicas[i].Name)
+						if err := ssc.podControl.DeleteStatefulPod(set, replicas[i]); err != nil {
+							return &status, err
+						}
+						if getPodRevision(replicas[i]) == currentRevision.Name {
+							status.CurrentReplicas--
+						}
+						if getPodRevision(replicas[i]) == updateRevision.Name {
+							status.UpdatedReplicas--
+						}
+						status.Replicas--
+						replicas[i] = newVersionedStatefulSetPod(
+							currentSet,
+							updateSet,
+							currentRevision.Name,
+							updateRevision.Name,
+							i)
+					}
+				}
+			}
 			klog.V(4).Infof(
 				"StatefulSet %s/%s is waiting for Pod %s to be Running and Ready",
 				set.Namespace,


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
update statefulset pod when it is not running and has ErrImagePullBackOff error

**Which issue(s) this PR fixes**:
Fixes #88896

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
update statefulset pod when it is not running and has ErrImagePullBackOff error
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
