### PR TITLE
Enable timeout for SSH-ing to non-logexported nodes

### DIFF
--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -420,6 +420,11 @@ function dump_nodes() {
 
   proc=${max_dump_processes}
   start="$(date +%s)"
+  # log_dump_ssh_timeout is the maximal number of seconds the log dumping over
+  # SSH operation can take. Please note that the logic enforcing the timeout
+  # is only a best effort. The actual time of the operation may be longer
+  # due to waiting for all the child processes below.
+  log_dump_ssh_timeout_seconds="${LOG_DUMP_SSH_TIMEOUT_SECONDS:-}"
   for i in "${!all_selected_nodes[@]}"; do
     node_name="${all_selected_nodes[$i]}"
     node_dir="${report_dir}/${node_name}"
@@ -440,7 +445,8 @@ function dump_nodes() {
       proc=${max_dump_processes}
       wait
       now="$(date +%s)"
-      if [[ ! -z "${LOG_DUMP_SSH_TIMEOUT}" && $((now - start)) -gt ${LOG_DUMP_SSH_TIMEOUT} ]]; then
+      if [[ -n "${log_dump_ssh_timeout_seconds}" && $((now - start)) -gt ${log_dump_ssh_timeout_seconds} ]]; then
+        echo "WARNING: Hit timeout after ${log_dump_ssh_timeout_seconds} seconds, finishing log dumping over SSH shortly"
         break
       fi
     fi

--- a/cluster/log-dump/log-dump.sh
+++ b/cluster/log-dump/log-dump.sh
@@ -419,6 +419,7 @@ function dump_nodes() {
   all_selected_nodes+=( "${windows_node_names[@]}" )
 
   proc=${max_dump_processes}
+  start="$(date +%s)"
   for i in "${!all_selected_nodes[@]}"; do
     node_name="${all_selected_nodes[$i]}"
     node_dir="${report_dir}/${node_name}"
@@ -438,6 +439,10 @@ function dump_nodes() {
     if [[ proc -eq 0 ]]; then
       proc=${max_dump_processes}
       wait
+      now="$(date +%s)"
+      if [[ ! -z "${LOG_DUMP_SSH_TIMEOUT}" && $((now - start)) -gt ${LOG_DUMP_SSH_TIMEOUT} ]]; then
+        break
+      fi
     fi
   done
   # Wait for any remaining processes.


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
During log exporting phase of testing, occasionally, some of the nodes in the cluster may not be log exported. Such situation results in a fallback to SSH-ing to all such nodes. In worst case scenarios, it takes many hours for large clusters to do so (and even then the SSH connections may not succeed at all). The PR would introduce a timeout mechanism in such situations using an appropriate environment variable.

**Which issue(s) this PR fixes**:
No issue is opened for that.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig scalability