### PR TITLE
Remove taintsErr prop for NodeInfo struct

### DIFF
--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -1202,11 +1202,7 @@ func (dsc *DaemonSetsController) nodeShouldRunDaemonPod(node *v1.Node, ds *apps.
 
 	nodeInfo := schedulernodeinfo.NewNodeInfo()
 	nodeInfo.SetNode(node)
-	taints, err := nodeInfo.Taints()
-	if err != nil {
-		klog.Warningf("failed to get node %q taints: %v", node.Name, err)
-		return false, false, err
-	}
+	taints := nodeInfo.Taints()
 
 	fitsNodeName, fitsNodeAffinity, fitsTaints := Predicates(pod, node, taints)
 	if !fitsNodeName || !fitsNodeAffinity {

--- a/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
+++ b/pkg/scheduler/framework/plugins/tainttoleration/taint_toleration.go
@@ -56,10 +56,7 @@ func (pl *TaintToleration) Filter(ctx context.Context, state *framework.CycleSta
 		return framework.NewStatus(framework.Error, "invalid nodeInfo")
 	}
 
-	taints, err := nodeInfo.Taints()
-	if err != nil {
-		return framework.NewStatus(framework.Error, err.Error())
-	}
+	taints := nodeInfo.Taints()
 
 	filterPredicate := func(t *v1.Taint) bool {
 		// PodToleratesNodeTaints is only interested in NoSchedule and NoExecute taints.

--- a/pkg/scheduler/framework/v1alpha1/types.go
+++ b/pkg/scheduler/framework/v1alpha1/types.go
@@ -321,11 +321,11 @@ func (n *NodeInfo) Node() *v1.Node {
 
 // Taints returns the taints list on this node.
 // TODO(#89528): Exists only because of kubelet dependency, remove.
-func (n *NodeInfo) Taints() ([]v1.Taint, error) {
+func (n *NodeInfo) Taints() []v1.Taint {
 	if n == nil || n.node.Spec.Taints == nil {
-		return nil, nil
+		return nil
 	}
-	return n.node.Spec.Taints, nil
+	return n.node.Spec.Taints
 }
 
 // AllocatableResource returns allocatable resources on a given node.

--- a/test/e2e/apps/daemon_set.go
+++ b/test/e2e/apps/daemon_set.go
@@ -690,11 +690,7 @@ func canScheduleOnNode(node v1.Node, ds *appsv1.DaemonSet) bool {
 	newPod := daemon.NewPod(ds, node.Name)
 	nodeInfo := schedfwk.NewNodeInfo()
 	nodeInfo.SetNode(&node)
-	taints, err := nodeInfo.Taints()
-	if err != nil {
-		framework.Failf("Can't test DaemonSet predicates for node %s: %v", node.Name, err)
-		return false
-	}
+	taints := nodeInfo.Taints()
 	fitsNodeName, fitsNodeAffinity, fitsTaints := daemon.Predicates(newPod, &node, taints)
 	return fitsNodeName && fitsNodeAffinity && fitsTaints
 }

--- a/test/e2e/framework/node/resource.go
+++ b/test/e2e/framework/node/resource.go
@@ -416,11 +416,7 @@ func isNodeUntaintedWithNonblocking(node *v1.Node, nonblockingTaints string) boo
 		nodeInfo.SetNode(node)
 	}
 
-	taints, err := nodeInfo.Taints()
-	if err != nil {
-		e2elog.Failf("Can't test predicates for node %s: %v", node.Name, err)
-		return false
-	}
+	taints := nodeInfo.Taints()
 
 	return toleratesTaintsWithNoScheduleNoExecuteEffects(taints, fakePod.Spec.Tolerations)
 }

--- a/test/integration/framework/util.go
+++ b/test/integration/framework/util.go
@@ -273,11 +273,7 @@ func isNodeUntainted(node *v1.Node) bool {
 		nodeInfo.SetNode(node)
 	}
 
-	taints, err := nodeInfo.Taints()
-	if err != nil {
-		klog.Fatalf("Can't test predicates for node %s: %v", node.Name, err)
-		return false
-	}
+	taints := nodeInfo.Taints()
 
 	return v1helper.TolerationsTolerateTaintsWithFilter(fakePod.Spec.Tolerations, taints, func(t *v1.Taint) bool {
 		return t.Effect == v1.TaintEffectNoExecute || t.Effect == v1.TaintEffectNoSchedule


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The `taintsErr` property  was introduced in #35275. Now we check the taints error in validation: https://github.com/kubernetes/kubernetes/blob/60df45fa55746fa2e9c9c116d09c5280cba9059f/pkg/apis/core/validation/validation.go#L4422-L4429

The `taintsErr` is no more used in the codebase. Let us clean it.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
