### PR TITLE
Correctly parse X-Stream-Protocol-Version header

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream.go
@@ -114,6 +114,18 @@ func negotiateProtocol(clientProtocols, serverProtocols []string) string {
 	return ""
 }
 
+func commaSeparatedHeaderValues(header []string) []string {
+	var parsedClientProtocols []string
+	for i := range header {
+		for _, clientProtocol := range strings.Split(header[i], ",") {
+			if proto := strings.Trim(clientProtocol, " "); len(proto) > 0 {
+				parsedClientProtocols = append(parsedClientProtocols, proto)
+			}
+		}
+	}
+	return parsedClientProtocols
+}
+
 // Handshake performs a subprotocol negotiation. If the client did request a
 // subprotocol, Handshake will select the first common value found in
 // serverProtocols. If a match is found, Handshake adds a response header
@@ -121,7 +133,7 @@ func negotiateProtocol(clientProtocols, serverProtocols []string) string {
 // returned, along with a response header containing the list of protocols the
 // server can accept.
 func Handshake(req *http.Request, w http.ResponseWriter, serverProtocols []string) (string, error) {
-	clientProtocols := req.Header[http.CanonicalHeaderKey(HeaderProtocolVersion)]
+	clientProtocols := commaSeparatedHeaderValues(req.Header[http.CanonicalHeaderKey(HeaderProtocolVersion)])
 	if len(clientProtocols) == 0 {
 		return "", fmt.Errorf("unable to upgrade: %s is required", HeaderProtocolVersion)
 	}

--- a/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/httpstream/httpstream_test.go
@@ -58,8 +58,19 @@ func TestHandshake(t *testing.T) {
 			expectedProtocol: "",
 			expectError:      true,
 		},
+		"no common protocol with comma separated list": {
+			clientProtocols:  []string{"c, d"},
+			serverProtocols:  []string{"a", "b"},
+			expectedProtocol: "",
+			expectError:      true,
+		},
 		"common protocol": {
 			clientProtocols:  []string{"b"},
+			serverProtocols:  []string{"a", "b"},
+			expectedProtocol: "b",
+		},
+		"common protocol with comma separated list": {
+			clientProtocols:  []string{"b, c"},
 			serverProtocols:  []string{"a", "b"},
 			expectedProtocol: "b",
 		},


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR iterates the components of X-Stream-Protocol-Version header and splits each by comma.
Non-empty protocol versions take part in negotiation.

**Which issue(s) this PR fixes**:
Fixes #89849

```release-note
kube-apiserver: multiple comma-separated protocols in a single X-Stream-Protocol-Version header are now recognized, in addition to multiple headers, complying with RFC2616
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
