### PR TITLE
Automated cherry pick of #89722: Ensure Azure availability zone is always in lower cases

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -468,8 +468,8 @@ func (as *availabilitySet) GetZoneByNodeName(name string) (cloudprovider.Zone, e
 	}
 
 	zone := cloudprovider.Zone{
-		FailureDomain: failureDomain,
-		Region:        to.String(vm.Location),
+		FailureDomain: strings.ToLower(failureDomain),
+		Region:        strings.ToLower(to.String(vm.Location)),
 	}
 	return zone, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -377,8 +377,8 @@ func (ss *scaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
 	}
 
 	return cloudprovider.Zone{
-		FailureDomain: failureDomain,
-		Region:        to.String(vm.Location),
+		FailureDomain: strings.ToLower(failureDomain),
+		Region:        strings.ToLower(to.String(vm.Location)),
 	}, nil
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss_test.go
@@ -20,6 +20,7 @@ package azure
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2019-07-01/compute"
@@ -241,6 +242,7 @@ func TestGetZoneByNodeName(t *testing.T) {
 		scaleSet    string
 		vmList      []string
 		nodeName    string
+		location    string
 		zone        string
 		faultDomain int32
 		expected    string
@@ -264,6 +266,16 @@ func TestGetZoneByNodeName(t *testing.T) {
 			expected:    "westus-2",
 		},
 		{
+			description: "scaleSet should get availability zone in lower cases",
+			scaleSet:    "ss",
+			vmList:      []string{"vmssee6c2000000", "vmssee6c2000001"},
+			nodeName:    "vmssee6c2000000",
+			location:    "WestUS",
+			zone:        "2",
+			faultDomain: 3,
+			expected:    "westus-2",
+		},
+		{
 			description: "scaleSet should return error for non-exist nodes",
 			scaleSet:    "ss",
 			faultDomain: 3,
@@ -274,8 +286,14 @@ func TestGetZoneByNodeName(t *testing.T) {
 	}
 
 	for _, test := range testCases {
-		ss, err := newTestScaleSet(test.scaleSet, test.zone, test.faultDomain, test.vmList)
+		cloud := getTestCloud()
+		if test.location != "" {
+			cloud.Location = test.location
+		}
+		setTestVirtualMachineCloud(cloud, test.scaleSet, test.zone, test.faultDomain, test.vmList)
+		scaleset, err := newScaleSet(cloud)
 		assert.NoError(t, err, test.description)
+		ss := scaleset.(*scaleSet)
 
 		real, err := ss.GetZoneByNodeName(test.nodeName)
 		if test.expectError {
@@ -285,6 +303,7 @@ func TestGetZoneByNodeName(t *testing.T) {
 
 		assert.NoError(t, err, test.description)
 		assert.Equal(t, test.expected, real.FailureDomain, test.description)
+		assert.Equal(t, strings.ToLower(cloud.Location), real.Region, test.description)
 	}
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones.go
@@ -77,8 +77,8 @@ func (az *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 		}
 
 		return cloudprovider.Zone{
-			FailureDomain: zone,
-			Region:        location,
+			FailureDomain: strings.ToLower(zone),
+			Region:        strings.ToLower(location),
 		}, nil
 	}
 	// if UseInstanceMetadata is false, get Zone name by calling ARM

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones_test.go
@@ -88,24 +88,34 @@ func TestGetZone(t *testing.T) {
 	testcases := []struct {
 		name        string
 		zone        string
+		location    string
 		faultDomain string
 		expected    string
 	}{
 		{
 			name:     "GetZone should get real zone if only node's zone is set",
 			zone:     "1",
+			location: "eastus",
 			expected: "eastus-1",
 		},
 		{
 			name:        "GetZone should get real zone if both node's zone and FD are set",
 			zone:        "1",
+			location:    "eastus",
 			faultDomain: "99",
 			expected:    "eastus-1",
 		},
 		{
 			name:        "GetZone should get faultDomain if node's zone isn't set",
+			location:    "eastus",
 			faultDomain: "99",
 			expected:    "99",
+		},
+		{
+			name:     "GetZone should get availability zone in lower cases",
+			location: "EastUS",
+			zone:     "1",
+			expected: "eastus-1",
 		},
 	}
 
@@ -117,7 +127,7 @@ func TestGetZone(t *testing.T) {
 
 		mux := http.NewServeMux()
 		mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprintf(w, fmt.Sprintf(`{"compute":{"zone":"%s", "platformFaultDomain":"%s", "location":"eastus"}}`, test.zone, test.faultDomain))
+			fmt.Fprint(w, fmt.Sprintf(`{"compute":{"zone":"%s", "platformFaultDomain":"%s", "location":"%s"}}`, test.zone, test.faultDomain, test.location))
 		}))
 		go func() {
 			http.Serve(listener, mux)


### PR DESCRIPTION
Cherry pick of #89722 on release-1.17.

#89722: Ensure Azure availability zone is always in lower cases

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.