### PR TITLE
Automated cherry pick of #89722: Ensure Azure availability zone is always in lower cases

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard.go
@@ -490,8 +490,8 @@ func (as *availabilitySet) GetZoneByNodeName(name string) (cloudprovider.Zone, e
 	}
 
 	zone := cloudprovider.Zone{
-		FailureDomain: failureDomain,
-		Region:        to.String(vm.Location),
+		FailureDomain: strings.ToLower(failureDomain),
+		Region:        strings.ToLower(to.String(vm.Location)),
 	}
 	return zone, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -380,8 +380,8 @@ func (ss *scaleSet) GetZoneByNodeName(name string) (cloudprovider.Zone, error) {
 	}
 
 	return cloudprovider.Zone{
-		FailureDomain: failureDomain,
-		Region:        to.String(vm.Location),
+		FailureDomain: strings.ToLower(failureDomain),
+		Region:        strings.ToLower(to.String(vm.Location)),
 	}, nil
 }
 

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones.go
@@ -78,8 +78,8 @@ func (az *Cloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 		}
 
 		return cloudprovider.Zone{
-			FailureDomain: zone,
-			Region:        location,
+			FailureDomain: strings.ToLower(zone),
+			Region:        strings.ToLower(location),
 		}, nil
 	}
 	// if UseInstanceMetadata is false, get Zone name by calling ARM

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_zones_test.go
@@ -88,24 +88,34 @@ func TestGetZone(t *testing.T) {
 	testcases := []struct {
 		name        string
 		zone        string
+		location    string
 		faultDomain string
 		expected    string
 	}{
 		{
 			name:     "GetZone should get real zone if only node's zone is set",
 			zone:     "1",
+			location: "eastus",
 			expected: "eastus-1",
 		},
 		{
 			name:        "GetZone should get real zone if both node's zone and FD are set",
 			zone:        "1",
+			location:    "eastus",
 			faultDomain: "99",
 			expected:    "eastus-1",
 		},
 		{
 			name:        "GetZone should get faultDomain if node's zone isn't set",
+			location:    "eastus",
 			faultDomain: "99",
 			expected:    "99",
+		},
+		{
+			name:     "GetZone should get availability zone in lower cases",
+			location: "EastUS",
+			zone:     "1",
+			expected: "eastus-1",
 		},
 	}
 
@@ -117,7 +127,7 @@ func TestGetZone(t *testing.T) {
 
 		mux := http.NewServeMux()
 		mux.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			fmt.Fprint(w, fmt.Sprintf(`{"compute":{"zone":"%s", "platformFaultDomain":"%s", "location":"eastus"}}`, test.zone, test.faultDomain))
+			fmt.Fprint(w, fmt.Sprintf(`{"compute":{"zone":"%s", "platformFaultDomain":"%s", "location":"%s"}}`, test.zone, test.faultDomain, test.location))
 		}))
 		go func() {
 			http.Serve(listener, mux)


### PR DESCRIPTION
Cherry pick of #89722 on release-1.18.

#89722: Ensure Azure availability zone is always in lower cases

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.