### PR TITLE
Fix setting up internal load balancer for GCE

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/gce/gce_loadbalancer_internal_test.go
@@ -148,6 +148,29 @@ func TestEnsureInternalBackendServiceGroups(t *testing.T) {
 	}
 }
 
+func TestEnsureInternalInstanceGroupsLimit(t *testing.T) {
+	t.Parallel()
+
+	vals := DefaultTestClusterValues()
+	nodeNames := []string{}
+	for i := 0; i < maxInstancesPerInstanceGroup+5; i++ {
+		nodeNames = append(nodeNames, fmt.Sprintf("node-%d", i))
+	}
+
+	gce, err := fakeGCECloud(vals)
+	require.NoError(t, err)
+
+	nodes, err := createAndInsertNodes(gce, nodeNames, vals.ZoneName)
+	require.NoError(t, err)
+	igName := makeInstanceGroupName(vals.ClusterID)
+	_, err = gce.ensureInternalInstanceGroups(igName, nodes)
+	require.NoError(t, err)
+
+	instances, err := gce.ListInstancesInInstanceGroup(igName, vals.ZoneName, allInstances)
+	require.NoError(t, err)
+	assert.Equal(t, maxInstancesPerInstanceGroup, len(instances))
+}
+
 func TestEnsureInternalLoadBalancer(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
```release-note
For GCE cluster provider, fix bug of not being able to create internal type load balancer for clusters with more than 1000 nodes in a single zone.
```