### PR TITLE
Move DescribeIng() into e2eingress

### DIFF
--- a/test/e2e/framework/ingress/ingress_utils.go
+++ b/test/e2e/framework/ingress/ingress_utils.go
@@ -557,6 +557,14 @@ func (j *TestJig) runUpdate(ing *networkingv1beta1.Ingress) (*networkingv1beta1.
 	return ing, err
 }
 
+// DescribeIng describes information of ingress by running kubectl describe ing.
+func DescribeIng(ns string) {
+	framework.Logf("\nOutput of kubectl describe ing:\n")
+	desc, _ := framework.RunKubectl(
+		ns, "describe", "ing", fmt.Sprintf("--namespace=%v", ns))
+	framework.Logf(desc)
+}
+
 // Update retrieves the ingress, performs the passed function, and then updates it.
 func (j *TestJig) Update(update func(ing *networkingv1beta1.Ingress)) {
 	var err error
@@ -569,7 +577,7 @@ func (j *TestJig) Update(update func(ing *networkingv1beta1.Ingress)) {
 		update(j.Ingress)
 		j.Ingress, err = j.runUpdate(j.Ingress)
 		if err == nil {
-			framework.DescribeIng(j.Ingress.Namespace)
+			DescribeIng(j.Ingress.Namespace)
 			return
 		}
 		if !apierrors.IsConflict(err) && !apierrors.IsServerTimeout(err) {

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -1236,14 +1236,6 @@ func GetAllMasterAddresses(c clientset.Interface) []string {
 	return ips.List()
 }
 
-// DescribeIng describes information of ingress by running kubectl describe ing.
-func DescribeIng(ns string) {
-	Logf("\nOutput of kubectl describe ing:\n")
-	desc, _ := RunKubectl(
-		ns, "describe", "ing", fmt.Sprintf("--namespace=%v", ns))
-	Logf(desc)
-}
-
 // CreateEmptyFileOnPod creates empty file at given path on the pod.
 // TODO(alejandrox1): move to subpkg pod once kubectl methods have been refactored.
 func CreateEmptyFileOnPod(namespace string, podName string, filePath string) error {

--- a/test/e2e/network/ingress.go
+++ b/test/e2e/network/ingress.go
@@ -101,7 +101,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 		// Platform specific cleanup
 		ginkgo.AfterEach(func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
-				framework.DescribeIng(ns)
+				e2eingress.DescribeIng(ns)
 			}
 			if jig.Ingress == nil {
 				ginkgo.By("No ingress created, no cleanup necessary")
@@ -257,7 +257,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 		// Platform specific cleanup
 		ginkgo.AfterEach(func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
-				framework.DescribeIng(ns)
+				e2eingress.DescribeIng(ns)
 			}
 			if jig.Ingress == nil {
 				ginkgo.By("No ingress created, no cleanup necessary")
@@ -614,7 +614,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 		// Platform specific cleanup
 		ginkgo.AfterEach(func() {
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
-				framework.DescribeIng(ns)
+				e2eingress.DescribeIng(ns)
 			}
 			if jig.Ingress == nil {
 				ginkgo.By("No ingress created, no cleanup necessary")
@@ -741,7 +741,7 @@ var _ = SIGDescribe("Loadbalancing: L7", func() {
 				framework.ExpectNoError(gce.GcloudComputeResourceDelete("firewall-rules", fmt.Sprintf("ingress-80-443-%v", ns), framework.TestContext.CloudConfig.ProjectID))
 			}
 			if ginkgo.CurrentGinkgoTestDescription().Failed {
-				framework.DescribeIng(ns)
+				e2eingress.DescribeIng(ns)
 			}
 			defer nginxController.TearDown()
 			if jig.Ingress == nil {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

The function is only for e2e ingress test, it is not necessary to keep the function in e2e test core framework.

Ref: https://github.com/kubernetes/kubernetes/issues/77095

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
