### PR TITLE
Fix kubectl version should print version info without config file

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags.go
@@ -17,7 +17,6 @@ limitations under the License.
 package genericclioptions
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -58,8 +57,7 @@ const (
 
 var (
 	defaultCacheDir = filepath.Join(homedir.HomeDir(), ".kube", "http-cache")
-
-	ErrEmptyConfig = errors.New(`Missing or incomplete configuration info.  Please point to an existing, complete config file:
+	ErrEmptyConfig  = clientcmd.NewEmptyConfigError(`Missing or incomplete configuration info.  Please point to an existing, complete config file:
 
   1. Via the command-line flag --kubeconfig
   2. Via the KUBECONFIG environment variable

--- a/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/validation.go
@@ -30,10 +30,23 @@ import (
 
 var (
 	ErrNoContext   = errors.New("no context chosen")
-	ErrEmptyConfig = errors.New("no configuration has been provided, try setting KUBERNETES_MASTER environment variable")
+	ErrEmptyConfig = NewEmptyConfigError("no configuration has been provided, try setting KUBERNETES_MASTER environment variable")
 	// message is for consistency with old behavior
 	ErrEmptyCluster = errors.New("cluster has no server defined")
 )
+
+// NewEmptyConfigError returns an error wrapping the given message which IsEmptyConfig() will recognize as an empty config error
+func NewEmptyConfigError(message string) error {
+	return &errEmptyConfig{message}
+}
+
+type errEmptyConfig struct {
+	message string
+}
+
+func (e *errEmptyConfig) Error() string {
+	return e.message
+}
 
 type errContextNotFound struct {
 	ContextName string
@@ -60,9 +73,14 @@ func IsContextNotFound(err error) bool {
 func IsEmptyConfig(err error) bool {
 	switch t := err.(type) {
 	case errConfigurationInvalid:
-		return len(t) == 1 && t[0] == ErrEmptyConfig
+		if len(t) != 1 {
+			return false
+		}
+		_, ok := t[0].(*errEmptyConfig)
+		return ok
 	}
-	return err == ErrEmptyConfig
+	_, ok := err.(*errEmptyConfig)
+	return ok
 }
 
 // errConfigurationInvalid is a set of errors indicating the configuration is invalid.

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -17,6 +17,16 @@ go_library(
         "//staging/src/k8s.io/kubectl/pkg/util/templates:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["version_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
+        "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"strings"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+func TestNewCmdVersionWithoutConfigFile(t *testing.T) {
+	tf := cmdutil.NewFactory(&genericclioptions.ConfigFlags{})
+	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdVersion(tf, streams)
+	cmd.SetOutput(buf)
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("Cannot execute version command: %v", err)
+	}
+	if !strings.Contains(buf.String(), "Client Version") {
+		t.Errorf("unexpected output: %s", buf.String())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Now in k8s 1.18, `kubectl version` will not print version if no config file is provided. See https://github.com/kubernetes/kubectl/issues/853.
This problem actually has been fixed by https://github.com/kubernetes/kubernetes/pull/70713.
But after this PR https://github.com/kubernetes/kubernetes/pull/86173 is merged, it breaks the original condition.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/853

**Special notes for your reviewer**:
/cc @soltysh 
/cc @brianpursley
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl version should print version info without config file
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
