### PR TITLE
add flag check to ensure that flowcontrol API is present

### DIFF
--- a/cmd/kube-apiserver/app/options/BUILD
+++ b/cmd/kube-apiserver/app/options/BUILD
@@ -28,6 +28,7 @@ go_library(
         "//staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/net:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/admission:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/server/options:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/storagebackend:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",


### PR DESCRIPTION
fixes https://github.com/kubernetes/kubernetes/issues/89957

Add a check that makes the kube-apiserver exit if the desired priority and fairness cannot be successfully enabled/created.

/kind bug
/priority important-soon
@kubernetes/sig-api-machinery-bugs 


```release-note
NONE
```