### PR TITLE
Switch node ssh tunneler health check to the healthz port

### DIFF
--- a/cmd/kube-apiserver/app/options/options.go
+++ b/cmd/kube-apiserver/app/options/options.go
@@ -108,6 +108,7 @@ func NewServerRunOptions() *ServerRunOptions {
 		KubeletConfig: kubeletclient.KubeletClientConfig{
 			Port:         ports.KubeletPort,
 			ReadOnlyPort: ports.KubeletReadOnlyPort,
+			HealthzPort:  ports.KubeletHealthzPort,
 			PreferredAddressTypes: []string{
 				// --override-hostname
 				string(api.NodeHostName),
@@ -213,6 +214,9 @@ func (s *ServerRunOptions) Flags() (fss cliflag.NamedFlagSets) {
 	fs.UintVar(&s.KubeletConfig.ReadOnlyPort, "kubelet-read-only-port", s.KubeletConfig.ReadOnlyPort,
 		"DEPRECATED: kubelet read only port.")
 	fs.MarkDeprecated("kubelet-read-only-port", "kubelet-read-only-port is deprecated and will be removed.")
+
+	fs.UintVar(&s.KubeletConfig.HealthzPort, "kubelet-healthz-port", s.KubeletConfig.HealthzPort,
+		"kubelet healthz port.")
 
 	fs.DurationVar(&s.KubeletConfig.HTTPTimeout, "kubelet-timeout", s.KubeletConfig.HTTPTimeout,
 		"Timeout for kubelet operations.")

--- a/cmd/kube-apiserver/app/options/options_test.go
+++ b/cmd/kube-apiserver/app/options/options_test.go
@@ -184,6 +184,7 @@ func TestAddFlags(t *testing.T) {
 		KubeletConfig: kubeletclient.KubeletClientConfig{
 			Port:         10250,
 			ReadOnlyPort: 10255,
+			HealthzPort:  10248,
 			PreferredAddressTypes: []string{
 				string(kapi.NodeHostName),
 				string(kapi.NodeInternalDNS),

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -254,13 +254,15 @@ func CreateNodeDialer(s completedServerRunOptions) (tunneler.Tunneler, *http.Tra
 		if s.KubeletConfig.Port == 0 {
 			return nil, nil, fmt.Errorf("must enable kubelet port if proxy ssh-tunneling is specified")
 		}
-		healthzPort := 10248
+		if s.KubeletConfig.HealthzPort == 0 {
+			return nil, nil, fmt.Errorf("must enable kubelet healthz port if proxy ssh-tunneling is specified")
+		}
 		// Set up the nodeTunneler
 		// TODO(cjcullen): If we want this to handle per-kubelet ports or other
 		// kubelet listen-addresses, we need to plumb through options.
 		healthCheckPath := &url.URL{
 			Scheme: "http",
-			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(healthzPort)),
+			Host:   net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(s.KubeletConfig.HealthzPort), 10)),
 			Path:   "healthz",
 		}
 		nodeTunneler = tunneler.New(s.SSHUser, s.SSHKeyfile, healthCheckPath, installSSHKey)

--- a/cmd/kube-apiserver/app/server.go
+++ b/cmd/kube-apiserver/app/server.go
@@ -254,15 +254,13 @@ func CreateNodeDialer(s completedServerRunOptions) (tunneler.Tunneler, *http.Tra
 		if s.KubeletConfig.Port == 0 {
 			return nil, nil, fmt.Errorf("must enable kubelet port if proxy ssh-tunneling is specified")
 		}
-		if s.KubeletConfig.ReadOnlyPort == 0 {
-			return nil, nil, fmt.Errorf("must enable kubelet readonly port if proxy ssh-tunneling is specified")
-		}
+		healthzPort := 10248
 		// Set up the nodeTunneler
 		// TODO(cjcullen): If we want this to handle per-kubelet ports or other
 		// kubelet listen-addresses, we need to plumb through options.
 		healthCheckPath := &url.URL{
 			Scheme: "http",
-			Host:   net.JoinHostPort("127.0.0.1", strconv.FormatUint(uint64(s.KubeletConfig.ReadOnlyPort), 10)),
+			Host:   net.JoinHostPort("127.0.0.1", strconv.Itoa(healthzPort)),
 			Path:   "healthz",
 		}
 		nodeTunneler = tunneler.New(s.SSHUser, s.SSHKeyfile, healthCheckPath, installSSHKey)

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -41,6 +41,12 @@ type KubeletClientConfig struct {
 	// ReadOnlyPort specifies the Port for ReadOnly communications.
 	ReadOnlyPort uint
 
+	// HealthzPort specifies the Port for Healthz communications.
+	HealthzPort uint
+
+	// EnableHTTPs specifies if traffic should be encrypted.
+	EnableHTTPS bool
+
 	// PreferredAddressTypes - used to select an address from Node.NodeStatus.Addresses
 	PreferredAddressTypes []string
 

--- a/pkg/kubelet/client/kubelet_client.go
+++ b/pkg/kubelet/client/kubelet_client.go
@@ -44,9 +44,6 @@ type KubeletClientConfig struct {
 	// HealthzPort specifies the Port for Healthz communications.
 	HealthzPort uint
 
-	// EnableHTTPs specifies if traffic should be encrypted.
-	EnableHTTPS bool
-
 	// PreferredAddressTypes - used to select an address from Node.NodeStatus.Addresses
 	PreferredAddressTypes []string
 

--- a/pkg/master/ports/ports.go
+++ b/pkg/master/ports/ports.go
@@ -21,6 +21,9 @@ import (
 )
 
 const (
+	// KubeletHealthzPort is the default port for the kubelet healthz port.
+	// May be overridden by a flag at startup.
+	KubeletHealthzPort = 10248
 	// ProxyStatusPort is the default port for the proxy metrics server.
 	// May be overridden by a flag at startup.
 	ProxyStatusPort = 10249


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Part of the process to remove the kubelet read only port.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
