### PR TITLE
multi-reader stress test for in-tree plugins

### DIFF
--- a/test/e2e/framework/pod/create.go
+++ b/test/e2e/framework/pod/create.go
@@ -46,6 +46,7 @@ type Config struct {
 	SeLinuxLabel        *v1.SELinuxOptions
 	FsGroup             *int64
 	NodeSelection       NodeSelection
+	ReadOnly            bool
 }
 
 // CreateUnschedulablePod with given claims based on node selector
@@ -221,16 +222,16 @@ func MakeSecPod(podConfig *Config) (*v1.Pod, error) {
 		if pvclaim.Spec.VolumeMode != nil && *pvclaim.Spec.VolumeMode == v1.PersistentVolumeBlock {
 			volumeDevices = append(volumeDevices, v1.VolumeDevice{Name: volumename, DevicePath: "/mnt/" + volumename})
 		} else {
-			volumeMounts = append(volumeMounts, v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename})
+			volumeMounts = append(volumeMounts, v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename, ReadOnly: podConfig.ReadOnly})
 		}
 
-		volumes[volumeIndex] = v1.Volume{Name: volumename, VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvclaim.Name, ReadOnly: false}}}
+		volumes[volumeIndex] = v1.Volume{Name: volumename, VolumeSource: v1.VolumeSource{PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{ClaimName: pvclaim.Name, ReadOnly: podConfig.ReadOnly}}}
 		volumeIndex++
 	}
 	for _, src := range podConfig.InlineVolumeSources {
 		volumename := fmt.Sprintf("volume%v", volumeIndex+1)
 		// In-line volumes can be only filesystem, not block.
-		volumeMounts = append(volumeMounts, v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename})
+		volumeMounts = append(volumeMounts, v1.VolumeMount{Name: volumename, MountPath: "/mnt/" + volumename, ReadOnly: podConfig.ReadOnly})
 		volumes[volumeIndex] = v1.Volume{Name: volumename, VolumeSource: *src}
 		volumeIndex++
 	}

--- a/test/e2e/storage/drivers/in_tree.go
+++ b/test/e2e/storage/drivers/in_tree.go
@@ -91,6 +91,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &nfsDriver{}
 var _ testsuites.InlineVolumeTestDriver = &nfsDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &nfsDriver{}
 var _ testsuites.DynamicPVTestDriver = &nfsDriver{}
+var _ testsuites.ReadOnlyPVTestDriver = &nfsDriver{}
 
 // InitNFSDriver returns nfsDriver that implements TestDriver interface
 func InitNFSDriver() testsuites.TestDriver {
@@ -155,6 +156,12 @@ func (n *nfsDriver) GetDynamicProvisionStorageClass(config *testsuites.PerTestCo
 	suffix := fmt.Sprintf("%s-sc", n.driverInfo.Name)
 
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+}
+
+func (n *nfsDriver) UpdateReadOnlyInPVSource(pvSource *v1.PersistentVolumeSource, readOnly bool) {
+	source := pvSource.NFS
+	framework.ExpectNotEqual(source, nil, "Failed to get NFS volume source from the PV")
+	source.ReadOnly = readOnly
 }
 
 func (n *nfsDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
@@ -1051,6 +1058,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &cinderDriver{}
 var _ testsuites.InlineVolumeTestDriver = &cinderDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &cinderDriver{}
 var _ testsuites.DynamicPVTestDriver = &cinderDriver{}
+var _ testsuites.ReadOnlyPVTestDriver = &cinderDriver{}
 
 // InitCinderDriver returns cinderDriver that implements TestDriver interface
 func InitCinderDriver() testsuites.TestDriver {
@@ -1133,6 +1141,12 @@ func (c *cinderDriver) GetDynamicProvisionStorageClass(config *testsuites.PerTes
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
 }
 
+func (c *cinderDriver) UpdateReadOnlyInPVSource(pvSource *v1.PersistentVolumeSource, readOnly bool) {
+	source := pvSource.Cinder
+	framework.ExpectNotEqual(source, nil, "Failed to get Cinder volume source from the PV")
+	source.ReadOnly = readOnly
+}
+
 func (c *cinderDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
 	return &testsuites.PerTestConfig{
 		Driver:    c,
@@ -1213,6 +1227,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &gcePdDriver{}
 var _ testsuites.InlineVolumeTestDriver = &gcePdDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &gcePdDriver{}
 var _ testsuites.DynamicPVTestDriver = &gcePdDriver{}
+var _ testsuites.ReadOnlyPVTestDriver = &gcePdDriver{}
 
 // InitGcePdDriver returns gcePdDriver that implements TestDriver interface
 func InitGcePdDriver() testsuites.TestDriver {
@@ -1308,6 +1323,12 @@ func (g *gcePdDriver) GetDynamicProvisionStorageClass(config *testsuites.PerTest
 	delayedBinding := storagev1.VolumeBindingWaitForFirstConsumer
 
 	return testsuites.GetStorageClass(provisioner, parameters, &delayedBinding, ns, suffix)
+}
+
+func (g *gcePdDriver) UpdateReadOnlyInPVSource(pvSource *v1.PersistentVolumeSource, readOnly bool) {
+	source := pvSource.GCEPersistentDisk
+	framework.ExpectNotEqual(source, nil, "Failed to get GCE PD volume source from the PV")
+	source.ReadOnly = readOnly
 }
 
 func (g *gcePdDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
@@ -1488,6 +1509,7 @@ var _ testsuites.PreprovisionedVolumeTestDriver = &azureDiskDriver{}
 var _ testsuites.InlineVolumeTestDriver = &azureDiskDriver{}
 var _ testsuites.PreprovisionedPVTestDriver = &azureDiskDriver{}
 var _ testsuites.DynamicPVTestDriver = &azureDiskDriver{}
+var _ testsuites.ReadOnlyPVTestDriver = &azureDiskDriver{}
 
 // InitAzureDiskDriver returns azureDiskDriver that implements TestDriver interface
 func InitAzureDiskDriver() testsuites.TestDriver {
@@ -1580,6 +1602,12 @@ func (a *azureDiskDriver) GetDynamicProvisionStorageClass(config *testsuites.Per
 	suffix := fmt.Sprintf("%s-sc", a.driverInfo.Name)
 
 	return testsuites.GetStorageClass(provisioner, parameters, nil, ns, suffix)
+}
+
+func (a *azureDiskDriver) UpdateReadOnlyInPVSource(pvSource *v1.PersistentVolumeSource, readOnly bool) {
+	source := pvSource.AzureDisk
+	framework.ExpectNotEqual(source, nil, "Failed to get AzureDisk volume source from the PV")
+	source.ReadOnly = &readOnly
 }
 
 func (a *azureDiskDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {
@@ -1705,6 +1733,12 @@ func (a *awsDriver) GetDynamicProvisionStorageClass(config *testsuites.PerTestCo
 	delayedBinding := storagev1.VolumeBindingWaitForFirstConsumer
 
 	return testsuites.GetStorageClass(provisioner, parameters, &delayedBinding, ns, suffix)
+}
+
+func (a *awsDriver) UpdateReadOnlyInPVSource(pvSource *v1.PersistentVolumeSource, readOnly bool) {
+	source := pvSource.AWSElasticBlockStore
+	framework.ExpectNotEqual(source, nil, "Failed to get AWS volume source from the PV")
+	source.ReadOnly = readOnly
 }
 
 func (a *awsDriver) PrepareTest(f *framework.Framework) (*testsuites.PerTestConfig, func()) {

--- a/test/e2e/storage/in_tree_volumes.go
+++ b/test/e2e/storage/in_tree_volumes.go
@@ -60,6 +60,7 @@ var testSuites = []func() testsuites.TestSuite{
 	testsuites.InitDisruptiveTestSuite,
 	testsuites.InitVolumeLimitsTestSuite,
 	testsuites.InitTopologyTestSuite,
+	testsuites.InitStressTestSuite,
 }
 
 // This executes testSuites for in-tree volumes.

--- a/test/e2e/storage/testsuites/multireader_stress.go
+++ b/test/e2e/storage/testsuites/multireader_stress.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+/*
+
+A suite of stress tests for volumes in ReadOnlyMany mode.
+
+*/
+
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/onsi/ginkgo"
+	e2evolume "k8s.io/kubernetes/test/e2e/framework/volume"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	errors "k8s.io/apimachinery/pkg/util/errors"
+	clientset "k8s.io/client-go/kubernetes"
+	"k8s.io/kubernetes/test/e2e/framework"
+	e2epod "k8s.io/kubernetes/test/e2e/framework/pod"
+	e2epv "k8s.io/kubernetes/test/e2e/framework/pv"
+	e2eskipper "k8s.io/kubernetes/test/e2e/framework/skipper"
+	"k8s.io/kubernetes/test/e2e/storage/testpatterns"
+)
+
+type multiReaderStressTestSuite struct {
+	tsInfo TestSuiteInfo
+}
+
+type multiReaderStressTest struct {
+	config        *PerTestConfig
+	driverCleanup func()
+
+	intreeOps   opCounts
+	migratedOps opCounts
+
+	writerResource *VolumeResource
+	readerPVC *v1.PersistentVolumeClaim
+	readerPV  *v1.PersistentVolume
+	readerPods     []*v1.Pod
+	// stop and wait for any async routines
+	wg      sync.WaitGroup
+	stopChs []chan struct{}
+}
+
+var _ TestSuite = &multiReaderStressTestSuite{}
+
+// InitStressTestSuite returns multiReaderStressTestSuite that implements TestSuite interface
+func InitStressTestSuite() TestSuite {
+	return &multiReaderStressTestSuite{
+		tsInfo: TestSuiteInfo{
+			Name:       "multireader-stress",
+			FeatureTag: "[Feature: VolumeStress]",
+			TestPatterns: []testpatterns.TestPattern{
+				testpatterns.DefaultFsDynamicPV,
+			},
+		},
+	}
+}
+
+func (t *multiReaderStressTestSuite) GetTestSuiteInfo() TestSuiteInfo {
+	return t.tsInfo
+}
+
+func (t *multiReaderStressTestSuite) SkipRedundantSuite(driver TestDriver, pattern testpatterns.TestPattern) {}
+
+func (t *multiReaderStressTestSuite) DefineTests(driver TestDriver, pattern testpatterns.TestPattern) {
+	var (
+		dInfo = driver.GetDriverInfo()
+		cs    clientset.Interface
+	)
+
+	ginkgo.BeforeEach(func() {
+		// Check preconditions.
+		_, ok := driver.(DynamicPVTestDriver)
+		if !ok {
+			e2eskipper.Skipf("Driver %s doesn't support dynamic PV mode -- skipping", dInfo.Name)
+		}
+
+		_, ok = driver.(ReadOnlyPVTestDriver)
+		if !ok {
+			e2eskipper.Skipf("Driver %s doesn't support readonly PV mode -- skipping", dInfo.Name)
+		}
+	})
+
+	// This intentionally comes after checking the preconditions because it
+	// registers its own BeforeEach which creates the namespace. Beware that it
+	// also registers an AfterEach which renders f unusable. Any code using
+	// f must run inside an It or Context callback.
+	f := framework.NewDefaultFramework("multireader-stress")
+
+	init := func() *multiReaderStressTest {
+		cs = f.ClientSet
+		l := &multiReaderStressTest{}
+
+		// Now do the more expensive test initialization.
+		l.config, l.driverCleanup = driver.PrepareTest(f)
+		l.intreeOps, l.migratedOps = getMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName)
+		l.stopChs = []chan struct{}{}
+
+		return l
+	}
+
+	cleanup := func(l *multiReaderStressTest) {
+		var errs []error
+
+		framework.Logf("Stopping and waiting for all test routines to finish")
+		for _, stopCh := range l.stopChs {
+			close(stopCh)
+		}
+		l.wg.Wait()
+
+		framework.Logf("Deleting reader PV and PVC")
+		readerVolumeCleanupErrs := e2epv.PVPVCCleanup(cs, f.Namespace.Name, l.readerPV, l.readerPVC)
+		errs = append(errs, readerVolumeCleanupErrs...)
+
+		for _, pod := range l.readerPods {
+			framework.Logf("Deleting pod %v", pod.Name)
+			err := e2epod.DeletePodWithWait(cs, pod)
+			errs = append(errs, err)
+		}
+
+		if l.writerResource != nil {
+			framework.Logf("Deleting writer PV and PVC")
+			errs = append(errs, l.writerResource.CleanupResource())
+		}
+
+		errs = append(errs, tryFunc(l.driverCleanup))
+		framework.ExpectNoError(errors.NewAggregate(errs), "while cleaning up resource")
+		validateMigrationVolumeOpCounts(f.ClientSet, dInfo.InTreePluginName, l.intreeOps, l.migratedOps)
+	}
+
+	ginkgo.It("multiple pods should access a single read-only volume repeatedly [Slow] [Serial]", func() {
+		const (
+			numPods = 10
+			// number of times each Pod should start
+			numPodStarts = 10
+		)
+
+		var err error
+
+		l := init()
+		defer func() {
+			cleanup(l)
+		}()
+
+		ginkgo.By("Creating writer volume")
+		l.writerResource = CreateVolumeResource(driver, l.config, pattern, t.GetTestSuiteInfo().SupportedSizeRange)
+
+		ginkgo.By("Running writer pod")
+		writerConfig := e2evolume.TestConfig{
+			Namespace:           f.Namespace.Name,
+			Prefix:              "multireader-stress-writerpod",
+		}
+		tests := []e2evolume.Test{
+			{
+				Volume: *l.writerResource.VolSource,
+				Mode:   pattern.VolMode,
+				File:   "index.html",
+				ExpectedContent: fmt.Sprintf("Hello from %s from namespace %s",
+					dInfo.Name, f.Namespace.Name),
+			},
+		}
+		var fsGroup *int64
+		if framework.NodeOSDistroIs("windows") && dInfo.Capabilities[CapFsGroup] {
+			fsGroupVal := int64(1234)
+			fsGroup = &fsGroupVal
+		}
+		e2evolume.InjectContent(f, writerConfig, fsGroup, pattern.FsType, tests)
+
+		ginkgo.By("Creating read-only PV and PVC")
+		writerPVC, err := cs.CoreV1().PersistentVolumeClaims(f.Namespace.Name).Get(context.TODO(), l.writerResource.Pvc.Name, metav1.GetOptions{})
+		writerPV, err := cs.CoreV1().PersistentVolumes().Get(context.TODO(), writerPVC.Spec.VolumeName, metav1.GetOptions{})
+		framework.ExpectNoError(err)
+		writerPVSource := &writerPV.Spec.PersistentVolumeSource
+		readerPVSource := writerPVSource.DeepCopy()
+		driver.(ReadOnlyPVTestDriver).UpdateReadOnlyInPVSource(
+			readerPVSource,
+			true /* readOnly */)
+
+		emptyStorageClass := ""
+		l.readerPV, l.readerPVC, err = e2epv.CreatePVPVC(cs,
+			e2epv.PersistentVolumeConfig{
+			NamePrefix: "multireader-stress-",
+			PVSource: *readerPVSource,
+			StorageClassName: emptyStorageClass,
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany},
+		}, e2epv.PersistentVolumeClaimConfig{
+			StorageClassName: &emptyStorageClass,
+			AccessModes: []v1.PersistentVolumeAccessMode{v1.ReadOnlyMany},
+		}, f.Namespace.Name, true /* preBind */)
+
+		ginkgo.By("Creating reader pods")
+		for i := 0; i < numPods; i++ {
+			framework.Logf("Creating reader pod %v/%v", i, numPods)
+			pod, err := e2epod.MakeSecPod(&e2epod.Config{
+				NS:                  f.Namespace.Name,
+				PVCs: []*v1.PersistentVolumeClaim{l.readerPVC},
+				SeLinuxLabel:        e2epv.SELinuxLabel,
+				ReadOnly:            true,
+			})
+			framework.ExpectNoError(err)
+			l.readerPods = append(l.readerPods, pod)
+			l.stopChs = append(l.stopChs, make(chan struct{}))
+		}
+
+		ginkgo.By("Restarting pod repeatedly")
+		for i := 0; i < numPods; i++ {
+			podIndex := i
+			l.wg.Add(1)
+			go func() {
+				defer ginkgo.GinkgoRecover()
+				defer l.wg.Done()
+				for j := 0; j < numPodStarts; j++ {
+					select {
+					case <-l.stopChs[podIndex]:
+						return
+					default:
+						pod := l.readerPods[podIndex]
+						framework.Logf("Pod %v, Iteration %v/%v", podIndex, j, numPodStarts)
+						_, err = cs.CoreV1().Pods(pod.Namespace).Create(context.TODO(), pod, metav1.CreateOptions{})
+						framework.ExpectNoError(err, fmt.Sprintf("error creating pod %d on iteration %d", podIndex, j))
+
+						err = e2epod.WaitForPodRunningInNamespace(cs, pod)
+						framework.ExpectNoError(err, fmt.Sprintf("error waiting for pod %d running on iteration %d", podIndex, j))
+
+						// TODO(cxing): read data per pod and validate it everytime
+
+						err = e2epod.DeletePodWithWait(f.ClientSet, pod)
+						framework.ExpectNoError(err, fmt.Sprintf("error deleting pod %d on iteration %d", podIndex, j))
+					}
+				}
+			}()
+		}
+
+		l.wg.Wait()
+	})
+}

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -129,6 +129,14 @@ type SnapshottableTestDriver interface {
 	GetSnapshotClass(config *PerTestConfig) *unstructured.Unstructured
 }
 
+// ReadOnlyPVTestDriver represents an interface for a TestDriver that supports read-only PVs.
+type ReadOnlyPVTestDriver interface {
+	TestDriver
+
+	// Updates the read-only field in the PersistentVolumeSource in place.
+	UpdateReadOnlyInPVSource(pvSource *v1.PersistentVolumeSource, readOnly bool)
+}
+
 // Capability represents a feature that a volume plugin supports
 type Capability string
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Stress test scenario with a single read-only volume accessed by multiple pods repeatedly.

`ReadOnlyPVTestDriver` is currently only implemented for in-tree drivers that implement `DynamicPVTestDriver` because it's required for the stress test. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```

/sig storage
/assign @msau42 @pohly 