### PR TITLE
Wait for namespace to be deleted before exiting AfterEach

### DIFF
--- a/test/e2e/storage/csi_mock_volume.go
+++ b/test/e2e/storage/csi_mock_volume.go
@@ -108,6 +108,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 	var m mockDriverSetup
 
 	f := framework.NewDefaultFramework("csi-mock-volumes")
+	f.NamespaceDeletionTimeout = framework.DefaultNamespaceDeletionTimeout
 
 	init := func(tp testParameters) {
 		m = mockDriverSetup{
@@ -381,6 +382,7 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 			var err error
 			init(testParameters{attachLimit: 2})
 			defer cleanup()
+
 			nodeName := m.config.ClientNodeSelection.Name
 			driverName := m.config.GetUniqueDriverName()
 
@@ -543,7 +545,6 @@ var _ = utils.SIGDescribe("CSI mock volume", func() {
 				}
 
 				init(params)
-
 				defer cleanup()
 
 				sc, pvc, pod := createPod(false)

--- a/test/e2e/storage/testsuites/volume_expand.go
+++ b/test/e2e/storage/testsuites/volume_expand.go
@@ -106,6 +106,7 @@ func (v *volumeExpandTestSuite) DefineTests(driver TestDriver, pattern testpatte
 	// also registers an AfterEach which renders f unusable. Any code using
 	// f must run inside an It or Context callback.
 	f := framework.NewDefaultFramework("volume-expand")
+	f.NamespaceDeletionTimeout = framework.DefaultNamespaceDeletionTimeout
 
 	init := func() {
 		l = local{}

--- a/test/e2e/storage/utils/create.go
+++ b/test/e2e/storage/utils/create.go
@@ -141,14 +141,7 @@ func PatchItems(f *framework.Framework, items ...interface{}) error {
 // - only the latest stable API version for each item is supported
 func CreateItems(f *framework.Framework, items ...interface{}) (func(), error) {
 	var destructors []func() error
-	var cleanupHandle framework.CleanupActionHandle
 	cleanup := func() {
-		if cleanupHandle == nil {
-			// Already done.
-			return
-		}
-		framework.RemoveCleanupAction(cleanupHandle)
-
 		// TODO (?): use same logic as framework.go for determining
 		// whether we are expected to clean up? This would change the
 		// meaning of the -delete-namespace and -delete-namespace-on-failure
@@ -160,7 +153,6 @@ func CreateItems(f *framework.Framework, items ...interface{}) (func(), error) {
 			}
 		}
 	}
-	cleanupHandle = framework.AddCleanupAction(cleanup)
 
 	var result error
 	for _, item := range items {


### PR DESCRIPTION
Ginkgo has a weird bug that - AfterEach does not get called when
testsuite exits with certain kind of interrupt (Ctrl-C for example).
More info - https://github.com/onsi/ginkgo/issues/222

We workaround this issue in Kubernetes by adding a special hook into
AfterSuite call, but AfterSuite can not be used to peforms certain
kind of cleanup because it can race with AfterEach hook and
framework.AfterEach hook will set framework.ClientSet to nil. 
Also this makes various CleanupActions order dependent. 

This presents a problem in cleaning up CSI driver and testpods. This
PR removes cleanup of driver manifest via CleanupAction because that
is not safe and racy (such as f.ClientSet may disappear!). But if we
wait for Namespace to be deleted in AfterSuite hook (same hook runs
via framework.AfterEach as well) - we can give time to the testsuite
to clean itself cleanly.

/sig storage

cc @jsafrane @smarterclayton 