### PR TITLE
Add error check for marshaling json in e2e/apps/disruption

### DIFF
--- a/test/e2e/apps/disruption.go
+++ b/test/e2e/apps/disruption.go
@@ -132,9 +132,11 @@ var _ = SIGDescribe("DisruptionController", func() {
 
 		ginkgo.By("Patching PodDisruptionBudget status")
 		patched, _ := patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1beta1.PodDisruptionBudget) (bytes []byte, err error) {
-			oldBytes, _ := json.Marshal(old)
+			oldBytes, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for old data")
 			old.Status.DisruptedPods = make(map[string]metav1.Time)
-			newBytes, _ := json.Marshal(old)
+			newBytes, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for new data")
 			return jsonpatch.CreateMergePatch(oldBytes, newBytes)
 		}, "status")
 		framework.ExpectEmpty(patched.Status.DisruptedPods, "Expecting the PodDisruptionBudget's be empty")
@@ -303,10 +305,12 @@ var _ = SIGDescribe("DisruptionController", func() {
 		ginkgo.By("Patching the pdb to disallow a pod to be evicted")
 		patchPDBOrDie(cs, dc, ns, defaultName, func(old *policyv1beta1.PodDisruptionBudget) (bytes []byte, err error) {
 			oldData, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for old data")
 			old.Spec.MinAvailable = nil
 			maxUnavailable := intstr.FromInt(0)
 			old.Spec.MaxUnavailable = &maxUnavailable
-			newData, _ := json.Marshal(old)
+			newData, err := json.Marshal(old)
+			framework.ExpectNoError(err, "failed to marshal JSON for new data")
 			return jsonpatch.CreateMergePatch(oldData, newData)
 		})
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
There are some `json.Marshal` in e2e/apps/disruption.go.
One returns err, but it is not used. The others don't return err.
If all of them return err and we handle the err, we will get more information when the test fails.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
