### PR TITLE
Add kind/regression label to the pull request template and group them in an HTML comment

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,17 +9,22 @@ https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-k
 -->
 
 **What type of PR is this?**
-> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
->
-> /kind api-change
-> /kind bug
-> /kind cleanup
-> /kind deprecation
-> /kind design
-> /kind documentation
-> /kind failing-test
-> /kind feature
-> /kind flake
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind documentation
+/kind feature
+/kind design
+
+Optionally add one or more of the following kinds if applicable:
+/kind api-change
+/kind deprecation
+/kind failing-test
+/kind flake
+/kind regression
+-->
 
 **What this PR does / why we need it**:
 


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

We now add the kind/regression to the PR template. We also put the kinds
into an HTML comment, because prow is now able to ignore those entries.

**Which issue(s) this PR fixes**:

None

**Special notes for your reviewer**:

cc @justaugustus @liggitt 

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
