### PR TITLE
Fix priorityClassName typo, add numeric priority to static pods

### DIFF
--- a/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
+++ b/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
@@ -9,6 +9,7 @@ metadata:
     k8s-app: etcd-empty-dir-cleanup
 spec:
   priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   dnsPolicy: Default
   containers:

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -9,7 +9,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {

--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -10,6 +10,8 @@ metadata:
     k8s-app: gcp-lb-controller
     kubernetes.io/name: "GLBC"
 spec:
+  priorityClassName: system-node-critical
+  priority: 2000001000
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:

--- a/cluster/gce/manifests/konnectivity-server.yaml
+++ b/cluster/gce/manifests/konnectivity-server.yaml
@@ -7,7 +7,8 @@ metadata:
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
   component: konnectivity-server
 spec:
-  priorityClassName: system-cluster-critical
+  priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   containers:
   - name: konnectivity-server-container

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -9,6 +9,7 @@ metadata:
     component: kube-addon-manager
 spec:
   priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   containers:
   - name: kube-addon-manager

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -13,7 +13,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -13,7 +13,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -10,6 +10,7 @@ metadata:
     component: kube-proxy
 spec:
   priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   tolerations:
   - operator: "Exists"

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -13,7 +13,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes typo in static pod manifests, adds numeric priority to ensure relative preemption works properly.

**Which issue(s) this PR fixes**:
xref #89966

**Special notes for your reviewer**:
Fixes regression [introduced in 1.16](https://github.com/kubernetes/kubernetes/pull/80491) when all static pods were made critical

**Does this PR introduce a user-facing change?**:
```release-note
Restores priority of static control plane pods in the cluster/gce/manifests control-plane manifests
```

/sig cluster-lifecycle
/sig node