### PR TITLE
Automated cherry pick of #89970: Fix priorityClass typo, add numeric priority to static pods

### DIFF
--- a/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
+++ b/cluster/gce/manifests/etcd-empty-dir-cleanup.yaml
@@ -9,6 +9,7 @@ metadata:
     k8s-app: etcd-empty-dir-cleanup
 spec:
   priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   dnsPolicy: Default
   containers:

--- a/cluster/gce/manifests/etcd.manifest
+++ b/cluster/gce/manifests/etcd.manifest
@@ -9,7 +9,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {

--- a/cluster/gce/manifests/glbc.manifest
+++ b/cluster/gce/manifests/glbc.manifest
@@ -10,6 +10,8 @@ metadata:
     k8s-app: gcp-lb-controller
     kubernetes.io/name: "GLBC"
 spec:
+  priorityClassName: system-node-critical
+  priority: 2000001000
   terminationGracePeriodSeconds: 600
   hostNetwork: true
   containers:

--- a/cluster/gce/manifests/konnectivity-server.yaml
+++ b/cluster/gce/manifests/konnectivity-server.yaml
@@ -7,7 +7,8 @@ metadata:
     seccomp.security.alpha.kubernetes.io/pod: 'docker/default'
   component: konnectivity-server
 spec:
-  priorityClassName: system-cluster-critical
+  priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   containers:
   - name: konnectivity-server-container

--- a/cluster/gce/manifests/kube-addon-manager.yaml
+++ b/cluster/gce/manifests/kube-addon-manager.yaml
@@ -9,6 +9,7 @@ metadata:
     component: kube-addon-manager
 spec:
   priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   containers:
   - name: kube-addon-manager

--- a/cluster/gce/manifests/kube-apiserver.manifest
+++ b/cluster/gce/manifests/kube-apiserver.manifest
@@ -13,7 +13,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {

--- a/cluster/gce/manifests/kube-controller-manager.manifest
+++ b/cluster/gce/manifests/kube-controller-manager.manifest
@@ -13,7 +13,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -10,6 +10,7 @@ metadata:
     component: kube-proxy
 spec:
   priorityClassName: system-node-critical
+  priority: 2000001000
   hostNetwork: true
   tolerations:
   - operator: "Exists"

--- a/cluster/gce/manifests/kube-scheduler.manifest
+++ b/cluster/gce/manifests/kube-scheduler.manifest
@@ -13,7 +13,8 @@
   }
 },
 "spec":{
-"priorityClass": "system-node-critical",
+"priorityClassName": "system-node-critical",
+"priority": 2000001000,
 "hostNetwork": true,
 "containers":[
     {


### PR DESCRIPTION
Cherry pick of #89970 on release-1.17.

#89970: Fix priorityClass typo, add numeric priority to static pods

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.