### PR TITLE
Fix goling issues for pkg/registry/apps

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -128,10 +128,6 @@ pkg/proxy/userspace
 pkg/proxy/winkernel
 pkg/proxy/winuserspace
 pkg/registry/admissionregistration/rest
-pkg/registry/apps/deployment/storage
-pkg/registry/apps/replicaset/storage
-pkg/registry/apps/rest
-pkg/registry/apps/statefulset/storage
 pkg/registry/auditregistration/rest
 pkg/registry/authentication/rest
 pkg/registry/authentication/tokenreview

--- a/pkg/master/master.go
+++ b/pkg/master/master.go
@@ -432,7 +432,7 @@ func (c completedConfig) New(delegationTarget genericapiserver.DelegationTarget)
 		flowcontrolrest.RESTStorageProvider{},
 		// keep apps after extensions so legacy clients resolve the extensions versions of shared resource names.
 		// See https://github.com/kubernetes/kubernetes/issues/42392
-		appsrest.RESTStorageProvider{},
+		appsrest.StorageProvider{},
 		admissionregistrationrest.RESTStorageProvider{},
 		eventsrest.RESTStorageProvider{TTL: c.ExtraConfig.EventTTL},
 	}

--- a/pkg/registry/apps/deployment/storage/storage.go
+++ b/pkg/registry/apps/deployment/storage/storage.go
@@ -53,6 +53,7 @@ type DeploymentStorage struct {
 	Rollback   *RollbackREST
 }
 
+// NewStorage returns new instance of DeploymentStorage.
 func NewStorage(optsGetter generic.RESTOptionsGetter) (DeploymentStorage, error) {
 	deploymentRest, deploymentStatusRest, deploymentRollbackRest, err := NewREST(optsGetter)
 	if err != nil {
@@ -67,6 +68,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (DeploymentStorage, error)
 	}, nil
 }
 
+// REST implements a RESTStorage for Deployments.
 type REST struct {
 	*genericregistry.Store
 	categories []string
@@ -111,6 +113,7 @@ func (r *REST) Categories() []string {
 	return r.categories
 }
 
+// WithCategories sets categories for REST.
 func (r *REST) WithCategories(categories []string) *REST {
 	r.categories = categories
 	return r
@@ -121,6 +124,7 @@ type StatusREST struct {
 	store *genericregistry.Store
 }
 
+// New returns empty Deployment object.
 func (r *StatusREST) New() runtime.Object {
 	return &apps.Deployment{}
 }
@@ -163,6 +167,7 @@ func (r *RollbackREST) New() runtime.Object {
 
 var _ = rest.NamedCreater(&RollbackREST{})
 
+// Create runs rollback for deployment
 func (r *RollbackREST) Create(ctx context.Context, name string, obj runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
 	rollback, ok := obj.(*apps.DeploymentRollback)
 	if !ok {
@@ -230,6 +235,7 @@ func (r *RollbackREST) setDeploymentRollback(ctx context.Context, deploymentID s
 	return finalDeployment, err
 }
 
+// ScaleREST implements a Scale for Deployment.
 type ScaleREST struct {
 	store *genericregistry.Store
 }
@@ -238,6 +244,7 @@ type ScaleREST struct {
 var _ = rest.Patcher(&ScaleREST{})
 var _ = rest.GroupVersionKindProvider(&ScaleREST{})
 
+// GroupVersionKind returns GroupVersionKind for Deployment Scale object
 func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
 	switch containingGV {
 	case extensionsv1beta1.SchemeGroupVersion:
@@ -256,6 +263,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
 }
 
+// Get retrieves object from Scale storage.
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	obj, err := r.store.Get(ctx, name, options)
 	if err != nil {
@@ -269,6 +277,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, nil
 }
 
+// Update alters scale subset of Deployment object.
 func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	obj, err := r.store.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {

--- a/pkg/registry/apps/replicaset/storage/storage.go
+++ b/pkg/registry/apps/replicaset/storage/storage.go
@@ -49,6 +49,7 @@ type ReplicaSetStorage struct {
 	Scale      *ScaleREST
 }
 
+// NewStorage returns new instance of ReplicaSetStorage.
 func NewStorage(optsGetter generic.RESTOptionsGetter) (ReplicaSetStorage, error) {
 	replicaSetRest, replicaSetStatusRest, err := NewREST(optsGetter)
 	if err != nil {
@@ -62,6 +63,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (ReplicaSetStorage, error)
 	}, nil
 }
 
+// REST implements a RESTStorage for ReplicaSet.
 type REST struct {
 	*genericregistry.Store
 	categories []string
@@ -108,6 +110,7 @@ func (r *REST) Categories() []string {
 	return r.categories
 }
 
+// WithCategories sets categories for REST.
 func (r *REST) WithCategories(categories []string) *REST {
 	r.categories = categories
 	return r
@@ -118,6 +121,7 @@ type StatusREST struct {
 	store *genericregistry.Store
 }
 
+// New returns empty ReplicaSet object.
 func (r *StatusREST) New() runtime.Object {
 	return &apps.ReplicaSet{}
 }
@@ -134,6 +138,7 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
 }
 
+// ScaleREST implements a Scale for Deployment.
 type ScaleREST struct {
 	store *genericregistry.Store
 }
@@ -142,6 +147,7 @@ type ScaleREST struct {
 var _ = rest.Patcher(&ScaleREST{})
 var _ = rest.GroupVersionKindProvider(&ScaleREST{})
 
+// GroupVersionKind returns GroupVersionKind for ReplicaSet Scale object
 func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
 	switch containingGV {
 	case extensionsv1beta1.SchemeGroupVersion:
@@ -160,6 +166,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
 }
 
+// Get retrieves object from Scale storage.
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	obj, err := r.store.Get(ctx, name, options)
 	if err != nil {
@@ -173,6 +180,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, err
 }
 
+// Update alters scale subset of ReplicaSet object.
 func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	obj, err := r.store.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {

--- a/pkg/registry/apps/rest/storage_apps.go
+++ b/pkg/registry/apps/rest/storage_apps.go
@@ -31,25 +31,27 @@ import (
 	statefulsetstore "k8s.io/kubernetes/pkg/registry/apps/statefulset/storage"
 )
 
-type RESTStorageProvider struct{}
+// StorageProvider is a struct for apps REST storage.
+type StorageProvider struct{}
 
-func (p RESTStorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool, error) {
+// NewRESTStorage returns APIGroupInfo object.
+func (p StorageProvider) NewRESTStorage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (genericapiserver.APIGroupInfo, bool, error) {
 	apiGroupInfo := genericapiserver.NewDefaultAPIGroupInfo(apps.GroupName, legacyscheme.Scheme, legacyscheme.ParameterCodec, legacyscheme.Codecs)
 	// If you add a version here, be sure to add an entry in `k8s.io/kubernetes/cmd/kube-apiserver/app/aggregator.go with specific priorities.
 	// TODO refactor the plumbing to provide the information in the APIGroupInfo
 
 	if apiResourceConfigSource.VersionEnabled(appsapiv1.SchemeGroupVersion) {
-		if storageMap, err := p.v1Storage(apiResourceConfigSource, restOptionsGetter); err != nil {
+		storageMap, err := p.v1Storage(apiResourceConfigSource, restOptionsGetter)
+		if err != nil {
 			return genericapiserver.APIGroupInfo{}, false, err
-		} else {
-			apiGroupInfo.VersionedResourcesStorageMap[appsapiv1.SchemeGroupVersion.Version] = storageMap
 		}
+		apiGroupInfo.VersionedResourcesStorageMap[appsapiv1.SchemeGroupVersion.Version] = storageMap
 	}
 
 	return apiGroupInfo, true, nil
 }
 
-func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (map[string]rest.Storage, error) {
+func (p StorageProvider) v1Storage(apiResourceConfigSource serverstorage.APIResourceConfigSource, restOptionsGetter generic.RESTOptionsGetter) (map[string]rest.Storage, error) {
 	storage := map[string]rest.Storage{}
 
 	// deployments
@@ -97,6 +99,7 @@ func (p RESTStorageProvider) v1Storage(apiResourceConfigSource serverstorage.API
 	return storage, nil
 }
 
-func (p RESTStorageProvider) GroupName() string {
+// GroupName returns name of the group
+func (p StorageProvider) GroupName() string {
 	return apps.GroupName
 }

--- a/pkg/registry/apps/statefulset/storage/storage.go
+++ b/pkg/registry/apps/statefulset/storage/storage.go
@@ -46,6 +46,7 @@ type StatefulSetStorage struct {
 	Scale       *ScaleREST
 }
 
+// NewStorage returns new instance of StatefulSetStorage.
 func NewStorage(optsGetter generic.RESTOptionsGetter) (StatefulSetStorage, error) {
 	statefulSetRest, statefulSetStatusRest, err := NewREST(optsGetter)
 	if err != nil {
@@ -59,7 +60,7 @@ func NewStorage(optsGetter generic.RESTOptionsGetter) (StatefulSetStorage, error
 	}, nil
 }
 
-// rest implements a RESTStorage for statefulsets against etcd
+// REST implements a RESTStorage for statefulsets against etcd
 type REST struct {
 	*genericregistry.Store
 }
@@ -100,6 +101,7 @@ type StatusREST struct {
 	store *genericregistry.Store
 }
 
+// New returns empty StatefulSet object.
 func (r *StatusREST) New() runtime.Object {
 	return &apps.StatefulSet{}
 }
@@ -124,6 +126,7 @@ func (r *REST) ShortNames() []string {
 	return []string{"sts"}
 }
 
+// ScaleREST implements a Scale for Deployment.
 type ScaleREST struct {
 	store *genericregistry.Store
 }
@@ -132,6 +135,7 @@ type ScaleREST struct {
 var _ = rest.Patcher(&ScaleREST{})
 var _ = rest.GroupVersionKindProvider(&ScaleREST{})
 
+// GroupVersionKind returns GroupVersionKind for StatefulSet Scale object
 func (r *ScaleREST) GroupVersionKind(containingGV schema.GroupVersion) schema.GroupVersionKind {
 	switch containingGV {
 	case appsv1beta1.SchemeGroupVersion:
@@ -148,6 +152,7 @@ func (r *ScaleREST) New() runtime.Object {
 	return &autoscaling.Scale{}
 }
 
+// Get retrieves object from Scale storage.
 func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
 	obj, err := r.store.Get(ctx, name, options)
 	if err != nil {
@@ -161,6 +166,7 @@ func (r *ScaleREST) Get(ctx context.Context, name string, options *metav1.GetOpt
 	return scale, err
 }
 
+// Update alters scale subset of StatefulSet object.
 func (r *ScaleREST) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
 	obj, err := r.store.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR fix golint issues for pkg/registry/apps packages
```
Errors from golint:
pkg/registry/apps/deployment/storage/storage.go:71:6: exported type REST should have comment or be unexported
pkg/registry/apps/deployment/storage/storage.go:115:1: exported method REST.WithCategories should have comment or be unexported
pkg/registry/apps/deployment/storage/storage.go:125:1: exported method StatusREST.New should have comment or be unexported
pkg/registry/apps/deployment/storage/storage.go:167:1: exported method RollbackREST.Create should have comment or be unexported
pkg/registry/apps/deployment/storage/storage.go:234:6: exported type ScaleREST should have comment or be unexported
pkg/registry/apps/deployment/storage/storage.go:242:1: exported method ScaleREST.GroupVersionKind should have comment or be unexported
pkg/registry/apps/deployment/storage/storage.go:260:1: exported method ScaleREST.Get should have comment or be unexported
pkg/registry/apps/deployment/storage/storage.go:273:1: exported method ScaleREST.Update should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:52:1: exported function NewStorage should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:65:6: exported type REST should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:111:1: exported method REST.WithCategories should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:121:1: exported method StatusREST.New should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:137:6: exported type ScaleREST should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:145:1: exported method ScaleREST.GroupVersionKind should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:163:1: exported method ScaleREST.Get should have comment or be unexported
pkg/registry/apps/replicaset/storage/storage.go:176:1: exported method ScaleREST.Update should have comment or be unexported
pkg/registry/apps/rest/storage_apps.go:34:6: exported type RESTStorageProvider should have comment or be unexported
pkg/registry/apps/rest/storage_apps.go:34:6: type name will be used as rest.RESTStorageProvider by other packages, and that stutters; consider calling this StorageProvider
pkg/registry/apps/rest/storage_apps.go:36:1: exported method RESTStorageProvider.NewRESTStorage should have comment or be unexported
pkg/registry/apps/rest/storage_apps.go:44:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
pkg/registry/apps/rest/storage_apps.go:100:1: exported method RESTStorageProvider.GroupName should have comment or be unexported
pkg/registry/apps/statefulset/storage/storage.go:49:1: exported function NewStorage should have comment or be unexported
pkg/registry/apps/statefulset/storage/storage.go:62:1: comment on exported type REST should be of the form "REST ..." (with optional leading article)
pkg/registry/apps/statefulset/storage/storage.go:103:1: exported method StatusREST.New should have comment or be unexported
pkg/registry/apps/statefulset/storage/storage.go:127:6: exported type ScaleREST should have comment or be unexported
pkg/registry/apps/statefulset/storage/storage.go:135:1: exported method ScaleREST.GroupVersionKind should have comment or be unexported
pkg/registry/apps/statefulset/storage/storage.go:151:1: exported method ScaleREST.Get should have comment or be unexported
pkg/registry/apps/statefulset/storage/storage.go:164:1: exported method ScaleREST.Update should have comment or be unexported
```

**Which issue(s) this PR fixes**:
#68026 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
