### PR TITLE
file mode should be consistent with readonly flag for ephemeral volumes

### DIFF
--- a/pkg/apis/core/v1/defaults_test.go
+++ b/pkg/apis/core/v1/defaults_test.go
@@ -138,13 +138,13 @@ func TestWorkloadDefaults(t *testing.T) {
 		".Spec.Volumes[0].VolumeSource.AzureDisk.FSType":                                              `"ext4"`,
 		".Spec.Volumes[0].VolumeSource.AzureDisk.Kind":                                                `"Shared"`,
 		".Spec.Volumes[0].VolumeSource.AzureDisk.ReadOnly":                                            `false`,
-		".Spec.Volumes[0].VolumeSource.ConfigMap.DefaultMode":                                         `420`,
-		".Spec.Volumes[0].VolumeSource.DownwardAPI.DefaultMode":                                       `420`,
+		".Spec.Volumes[0].VolumeSource.ConfigMap.DefaultMode":                                         `292`,
+		".Spec.Volumes[0].VolumeSource.DownwardAPI.DefaultMode":                                       `292`,
 		".Spec.Volumes[0].VolumeSource.DownwardAPI.Items[0].FieldRef.APIVersion":                      `"v1"`,
 		".Spec.Volumes[0].VolumeSource.EmptyDir":                                                      `{}`,
 		".Spec.Volumes[0].VolumeSource.HostPath.Type":                                                 `""`,
 		".Spec.Volumes[0].VolumeSource.ISCSI.ISCSIInterface":                                          `"default"`,
-		".Spec.Volumes[0].VolumeSource.Projected.DefaultMode":                                         `420`,
+		".Spec.Volumes[0].VolumeSource.Projected.DefaultMode":                                         `292`,
 		".Spec.Volumes[0].VolumeSource.Projected.Sources[0].DownwardAPI.Items[0].FieldRef.APIVersion": `"v1"`,
 		".Spec.Volumes[0].VolumeSource.Projected.Sources[0].ServiceAccountToken.ExpirationSeconds":    `3600`,
 		".Spec.Volumes[0].VolumeSource.RBD.Keyring":                                                   `"/etc/ceph/keyring"`,
@@ -152,7 +152,7 @@ func TestWorkloadDefaults(t *testing.T) {
 		".Spec.Volumes[0].VolumeSource.RBD.RadosUser":                                                 `"admin"`,
 		".Spec.Volumes[0].VolumeSource.ScaleIO.FSType":                                                `"xfs"`,
 		".Spec.Volumes[0].VolumeSource.ScaleIO.StorageMode":                                           `"ThinProvisioned"`,
-		".Spec.Volumes[0].VolumeSource.Secret.DefaultMode":                                            `420`,
+		".Spec.Volumes[0].VolumeSource.Secret.DefaultMode":                                            `292`,
 	}
 	defaults := detectDefaults(t, rc, reflect.ValueOf(template))
 	if !reflect.DeepEqual(expectedDefaults, defaults) {
@@ -261,13 +261,13 @@ func TestPodDefaults(t *testing.T) {
 		".Spec.Volumes[0].VolumeSource.AzureDisk.FSType":                                              `"ext4"`,
 		".Spec.Volumes[0].VolumeSource.AzureDisk.Kind":                                                `"Shared"`,
 		".Spec.Volumes[0].VolumeSource.AzureDisk.ReadOnly":                                            `false`,
-		".Spec.Volumes[0].VolumeSource.ConfigMap.DefaultMode":                                         `420`,
-		".Spec.Volumes[0].VolumeSource.DownwardAPI.DefaultMode":                                       `420`,
+		".Spec.Volumes[0].VolumeSource.ConfigMap.DefaultMode":                                         `292`,
+		".Spec.Volumes[0].VolumeSource.DownwardAPI.DefaultMode":                                       `292`,
 		".Spec.Volumes[0].VolumeSource.DownwardAPI.Items[0].FieldRef.APIVersion":                      `"v1"`,
 		".Spec.Volumes[0].VolumeSource.EmptyDir":                                                      `{}`,
 		".Spec.Volumes[0].VolumeSource.HostPath.Type":                                                 `""`,
 		".Spec.Volumes[0].VolumeSource.ISCSI.ISCSIInterface":                                          `"default"`,
-		".Spec.Volumes[0].VolumeSource.Projected.DefaultMode":                                         `420`,
+		".Spec.Volumes[0].VolumeSource.Projected.DefaultMode":                                         `292`,
 		".Spec.Volumes[0].VolumeSource.Projected.Sources[0].DownwardAPI.Items[0].FieldRef.APIVersion": `"v1"`,
 		".Spec.Volumes[0].VolumeSource.Projected.Sources[0].ServiceAccountToken.ExpirationSeconds":    `3600`,
 		".Spec.Volumes[0].VolumeSource.RBD.Keyring":                                                   `"/etc/ceph/keyring"`,
@@ -275,7 +275,7 @@ func TestPodDefaults(t *testing.T) {
 		".Spec.Volumes[0].VolumeSource.RBD.RadosUser":                                                 `"admin"`,
 		".Spec.Volumes[0].VolumeSource.ScaleIO.FSType":                                                `"xfs"`,
 		".Spec.Volumes[0].VolumeSource.ScaleIO.StorageMode":                                           `"ThinProvisioned"`,
-		".Spec.Volumes[0].VolumeSource.Secret.DefaultMode":                                            `420`,
+		".Spec.Volumes[0].VolumeSource.Secret.DefaultMode":                                            `292`,
 	}
 	defaults := detectDefaults(t, pod, reflect.ValueOf(pod))
 	if !reflect.DeepEqual(expectedDefaults, defaults) {

--- a/pkg/volume/configmap/configmap.go
+++ b/pkg/volume/configmap/configmap.go
@@ -220,6 +220,14 @@ func (b *configMapVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterA
 		return err
 	}
 
+	// clear write bits
+	if b.GetAttributes().ReadOnly {
+		for k, v := range payload {
+			v.Mode &= ^0222
+			payload[k] = v
+		}
+	}
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err

--- a/pkg/volume/configmap/configmap_test.go
+++ b/pkg/volume/configmap/configmap_test.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
@@ -55,10 +55,10 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"foo": {Data: []byte("foo"), Mode: 0644},
-				"bar": {Data: []byte("bar"), Mode: 0644},
+				"foo": {Data: []byte("foo"), Mode: 0444},
+				"bar": {Data: []byte("bar"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -70,10 +70,10 @@ func TestMakePayload(t *testing.T) {
 					"bar": []byte("bar"),
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"foo": {Data: []byte("foo"), Mode: 0644},
-				"bar": {Data: []byte("bar"), Mode: 0644},
+				"foo": {Data: []byte("foo"), Mode: 0444},
+				"bar": {Data: []byte("bar"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -87,10 +87,10 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"foo": {Data: []byte("foo"), Mode: 0644},
-				"bar": {Data: []byte("bar"), Mode: 0644},
+				"foo": {Data: []byte("foo"), Mode: 0444},
+				"bar": {Data: []byte("bar"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -108,9 +108,9 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"path/to/foo.txt": {Data: []byte("foo"), Mode: 0644},
+				"path/to/foo.txt": {Data: []byte("foo"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -128,9 +128,9 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"path/to/1/2/3/foo.txt": {Data: []byte("foo"), Mode: 0644},
+				"path/to/1/2/3/foo.txt": {Data: []byte("foo"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -148,9 +148,9 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"path/to/1/2/3/foo.txt": {Data: []byte("foo"), Mode: 0644},
+				"path/to/1/2/3/foo.txt": {Data: []byte("foo"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -172,10 +172,10 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"path/to/1/2/3/foo.txt":                {Data: []byte("foo"), Mode: 0644},
-				"another/path/to/the/esteemed/bar.bin": {Data: []byte("bar"), Mode: 0644},
+				"path/to/1/2/3/foo.txt":                {Data: []byte("foo"), Mode: 0444},
+				"another/path/to/the/esteemed/bar.bin": {Data: []byte("bar"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -193,7 +193,7 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode:    0644,
+			mode:    0444,
 			success: false,
 		},
 		{
@@ -216,7 +216,7 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
 				"foo.txt": {Data: []byte("foo"), Mode: caseMappingMode},
 				"bar.bin": {Data: []byte("bar"), Mode: caseMappingMode},
@@ -241,10 +241,10 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode: 0644,
+			mode: 0444,
 			payload: map[string]util.FileProjection{
-				"foo.txt": {Data: []byte("foo"), Mode: 0644},
-				"bar.bin": {Data: []byte("bar"), Mode: 0644},
+				"foo.txt": {Data: []byte("foo"), Mode: 0444},
+				"bar.bin": {Data: []byte("bar"), Mode: 0444},
 			},
 			success: true,
 		},
@@ -262,7 +262,7 @@ func TestMakePayload(t *testing.T) {
 					"bar": "bar",
 				},
 			},
-			mode:     0644,
+			mode:     0444,
 			optional: true,
 			payload:  map[string]util.FileProjection{},
 			success:  true,

--- a/pkg/volume/downwardapi/downwardapi.go
+++ b/pkg/volume/downwardapi/downwardapi.go
@@ -189,6 +189,14 @@ func (b *downwardAPIVolumeMounter) SetUpAt(dir string, mounterArgs volume.Mounte
 		return err
 	}
 
+	// clear write bits
+	if b.GetAttributes().ReadOnly {
+		for k, v := range data {
+			v.Mode &= ^0222
+			data[k] = v
+		}
+	}
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		klog.Errorf("Unable to setup downwardAPI volume %v for pod %v/%v: %s", b.volName, b.pod.Namespace, b.pod.Name, err.Error())

--- a/pkg/volume/downwardapi/downwardapi_test.go
+++ b/pkg/volume/downwardapi/downwardapi_test.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	clientset "k8s.io/client-go/kubernetes"
@@ -169,7 +169,7 @@ func TestDownwardAPI(t *testing.T) {
 			name:  "test_default_mode",
 			files: map[string]string{"name_file_name": "metadata.name"},
 			steps: []testStep{
-				verifyMode{stepName{"name_file_name"}, 0644},
+				verifyMode{stepName{"name_file_name"}, 0444},
 			},
 		},
 		{
@@ -202,7 +202,7 @@ type downwardAPITest struct {
 }
 
 func newDownwardAPITest(t *testing.T, name string, volumeFiles, podLabels, podAnnotations map[string]string, modes map[string]int32) *downwardAPITest {
-	defaultMode := int32(0644)
+	defaultMode := int32(0444)
 	var files []v1.DownwardAPIVolumeFile
 	for path, fieldPath := range volumeFiles {
 		file := v1.DownwardAPIVolumeFile{

--- a/pkg/volume/projected/projected.go
+++ b/pkg/volume/projected/projected.go
@@ -354,6 +354,15 @@ func (s *projectedVolumeMounter) collectData() (map[string]volumeutil.FileProjec
 			}
 		}
 	}
+
+	// clear write bits
+	if s.GetAttributes().ReadOnly {
+		for k, v := range payload {
+			v.Mode &= ^0222
+			payload[k] = v
+		}
+	}
+
 	return payload, utilerrors.NewAggregate(errlist)
 }
 

--- a/pkg/volume/projected/projected_test.go
+++ b/pkg/volume/projected/projected_test.go
@@ -26,7 +26,7 @@ import (
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/volume/secret/secret.go
+++ b/pkg/volume/secret/secret.go
@@ -215,6 +215,14 @@ func (b *secretVolumeMounter) SetUpAt(dir string, mounterArgs volume.MounterArgs
 		return err
 	}
 
+	// clear write bits
+	if b.GetAttributes().ReadOnly {
+		for k, v := range payload {
+			v.Mode &= ^0222
+			payload[k] = v
+		}
+	}
+
 	setupSuccess := false
 	if err := wrapped.SetUpAt(dir, mounterArgs); err != nil {
 		return err

--- a/staging/src/k8s.io/api/core/v1/types.go
+++ b/staging/src/k8s.io/api/core/v1/types.go
@@ -1107,7 +1107,7 @@ type SecretVolumeSource struct {
 }
 
 const (
-	SecretVolumeSourceDefaultMode int32 = 0644
+	SecretVolumeSourceDefaultMode int32 = 0444
 )
 
 // Adapts a secret into a projected volume.
@@ -1535,7 +1535,7 @@ type ConfigMapVolumeSource struct {
 }
 
 const (
-	ConfigMapVolumeSourceDefaultMode int32 = 0644
+	ConfigMapVolumeSourceDefaultMode int32 = 0444
 )
 
 // Adapts a ConfigMap into a projected volume.
@@ -1618,7 +1618,7 @@ type VolumeProjection struct {
 }
 
 const (
-	ProjectedVolumeSourceDefaultMode int32 = 0644
+	ProjectedVolumeSourceDefaultMode int32 = 0444
 )
 
 // Maps a string key to a path within a volume.
@@ -5749,7 +5749,7 @@ type DownwardAPIVolumeSource struct {
 }
 
 const (
-	DownwardAPIVolumeSourceDefaultMode int32 = 0644
+	DownwardAPIVolumeSourceDefaultMode int32 = 0444
 )
 
 // DownwardAPIVolumeFile represents information to create the file containing the pod field

--- a/test/e2e/common/projected_configmap.go
+++ b/test/e2e/common/projected_configmap.go
@@ -21,7 +21,7 @@ import (
 	"fmt"
 	"path"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/kubernetes/test/e2e/framework"
@@ -39,10 +39,11 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	/*
 	   Release : v1.9
 	   Testname: Projected Volume, ConfigMap, volume mode default
-	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
+	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -r--r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume [NodeConformance]", func() {
-		doProjectedConfigMapE2EWithoutMappings(f, false, 0, nil)
+		defaultMode := int32(0444)
+		doProjectedConfigMapE2EWithoutMappings(f, false, 0, &defaultMode)
 	})
 
 	/*
@@ -66,25 +67,28 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	/*
 	   Release : v1.9
 	   Testname: Projected Volume, ConfigMap, non-root user
-	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap as non-root user with uid 1000. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -rw-r--r--.
+	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap as non-root user with uid 1000. Pod MUST be able to read the content of the ConfigMap successfully and the mode on the volume MUST be -r--r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume as non-root [NodeConformance]", func() {
-		doProjectedConfigMapE2EWithoutMappings(f, true, 0, nil)
+		defaultMode := int32(0444)
+		doProjectedConfigMapE2EWithoutMappings(f, true, 0, &defaultMode)
 	})
 
 	ginkgo.It("should be consumable from pods in volume as non-root with FSGroup [LinuxOnly] [NodeFeature:FSGroup]", func() {
 		// Windows does not support RunAsUser / FSGroup SecurityContext options.
+		defaultMode := int32(0444)
 		e2eskipper.SkipIfNodeOSDistroIs("windows")
-		doProjectedConfigMapE2EWithoutMappings(f, true, 1001, nil)
+		doProjectedConfigMapE2EWithoutMappings(f, true, 1001, &defaultMode)
 	})
 
 	/*
 	   Release : v1.9
 	   Testname: Projected Volume, ConfigMap, mapped
-	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -rw-r--r--.
+	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap with default permission mode. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r--r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings [NodeConformance]", func() {
-		doProjectedConfigMapE2EWithMappings(f, false, 0, nil)
+		defaultMode := int32(0444)
+		doProjectedConfigMapE2EWithMappings(f, false, 0, &defaultMode)
 	})
 
 	/*
@@ -104,7 +108,8 @@ var _ = ginkgo.Describe("[sig-storage] Projected configMap", func() {
 	   Description: A Pod is created with projected volume source 'ConfigMap' to store a configMap as non-root user with uid 1000. The ConfigMap is also mapped to a custom path. Pod MUST be able to read the content of the ConfigMap from the custom location successfully and the mode on the volume MUST be -r--r--r--.
 	*/
 	framework.ConformanceIt("should be consumable from pods in volume with mappings as non-root [NodeConformance]", func() {
-		doProjectedConfigMapE2EWithMappings(f, true, 0, nil)
+		defaultMode := int32(0444)
+		doProjectedConfigMapE2EWithMappings(f, true, 0, &defaultMode)
 	})
 
 	ginkgo.It("should be consumable from pods in volume with mappings as non-root with FSGroup [LinuxOnly] [NodeFeature:FSGroup]", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
it will unset write and/or exec bits when readonly flag is set true. right now, projected volumes and other ephemeral volumes are readonly but their mode is 0644.

```release-note
NONE
```