### PR TITLE
Automated cherry pick of #82508: dockershim/network: fix panic for cni plugins in IPv4/IPv6 dual-stack mode

### DIFF
--- a/pkg/kubelet/dockershim/network/cni/cni_others.go
+++ b/pkg/kubelet/dockershim/network/cni/cni_others.go
@@ -74,6 +74,10 @@ func (plugin *cniNetworkPlugin) GetPodNetworkStatus(namespace string, name strin
 		return nil, err
 	}
 
+	if len(ips) == 0 {
+		return nil, fmt.Errorf("cannot find pod IPs in the network namespace, skipping pod network status for container %q", id)
+	}
+
 	return &network.PodNetworkStatus{
 		IP:  ips[0],
 		IPs: ips,

--- a/pkg/kubelet/dockershim/network/plugins.go
+++ b/pkg/kubelet/dockershim/network/plugins.go
@@ -271,18 +271,20 @@ func GetPodIPs(execer utilexec.Interface, nsenterPath, netnsPath, interfaceName 
 		return []net.IP{ip}, nil
 	}
 
-	list := make([]net.IP, 0)
-	var err4, err6 error
-	if ipv4, err4 := getOnePodIP(execer, nsenterPath, netnsPath, interfaceName, "-4"); err4 != nil {
-		list = append(list, ipv4)
-	}
-
-	if ipv6, err6 := getOnePodIP(execer, nsenterPath, netnsPath, interfaceName, "-6"); err6 != nil {
-		list = append(list, ipv6)
+	var (
+		list []net.IP
+		errs []error
+	)
+	for _, addrType := range []string{"-4", "-6"} {
+		if ip, err := getOnePodIP(execer, nsenterPath, netnsPath, interfaceName, addrType); err == nil {
+			list = append(list, ip)
+		} else {
+			errs = append(errs, err)
+		}
 	}
 
 	if len(list) == 0 {
-		return nil, utilerrors.NewAggregate([]error{err4, err6})
+		return nil, utilerrors.NewAggregate(errs)
 	}
 	return list, nil
 


### PR DESCRIPTION
Cherry pick of #82508 on release-1.16.

#82508: dockershim/network: fix panic for cni plugins in IPv4/IPv6 dual-stack mode

```docs
Fix panic in kubelet when running IPv4/IPv6 dual-stack mode with a CNI plugin
```