### PR TITLE
Automated cherry pick of #89551 upstream release 1.18

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/prune.go
@@ -77,9 +77,6 @@ func (p *pruner) pruneAll(o *ApplyOptions) error {
 	}
 
 	for n := range p.visitedNamespaces {
-		if len(o.Namespace) != 0 && n != o.Namespace {
-			continue
-		}
 		for _, m := range namespacedRESTMappings {
 			if err := p.prune(n, m); err != nil {
 				return fmt.Errorf("error pruning namespaced object %v: %v", m.GroupVersionKind, err)

--- a/test/cmd/apply.sh
+++ b/test/cmd/apply.sh
@@ -240,6 +240,30 @@ __EOF__
   # cleanup
   kubectl delete svc prune-svc 2>&1 "${kube_flags[@]:?}"
 
+  ## kubectl apply --prune can prune resources not in the defaulted namespace
+  # Pre-Condition: namespace nsb exists; no POD exists
+  kubectl create ns nsb
+  kube::test::get_object_assert pods "{{range.items}}{{${id_field:?}}}:{{end}}" ''
+  # apply a into namespace nsb
+  kubectl apply --namespace nsb -f hack/testdata/prune/a.yaml "${kube_flags[@]:?}"
+  kube::test::get_object_assert 'pods a -n nsb' "{{${id_field:?}}}" 'a'
+  # apply b with namespace
+  kubectl apply --namespace nsb -f hack/testdata/prune/b.yaml "${kube_flags[@]:?}"
+  kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
+  # apply --prune must prune a
+  kubectl apply --prune --all -f hack/testdata/prune/b.yaml
+  # check wrong pod doesn't exist
+  output_message=$(! kubectl get pods a -n nsb 2>&1 "${kube_flags[@]:?}")
+  kube::test::if_has_string "${output_message}" 'pods "a" not found'
+  # check right pod exists
+  kube::test::get_object_assert 'pods b -n nsb' "{{${id_field:?}}}" 'b'
+
+  # cleanup
+  kubectl delete ns nsb
+
+  ## kubectl apply -n must fail if input file contains namespace other than the one given in -n
+  output_message=$(! kubectl apply -n foo -f hack/testdata/prune/b.yaml 2>&1 "${kube_flags[@]:?}")
+  kube::test::if_has_string "${output_message}" 'the namespace from the provided object "nsb" does not match the namespace "foo".'
 
   ## kubectl apply -f some.yml --force
   # Pre-condition: no service exists


### PR DESCRIPTION
* Reverts apply/prune namespace change which causes apply/prune to fail in namespace other than default.
* Adds integration test to prove apply/prune in namespace other than default works.

```release-note
Fixes kubectl apply/prune in namespace other than default.
```

/kind bug
/priority critical-urgent
/area kubectl
/sig cli

/assign @apelisse 
/assign @tatsuhiro-t 
/assign @clarketm 
