### PR TITLE
Timeout flag for ephemeral container waiting

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug_test.go
@@ -18,6 +18,7 @@ package debug
 
 import (
 	"fmt"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -162,5 +163,17 @@ func TestGenerateDebugContainer(t *testing.T) {
 				t.Error("unexpected diff in generated object: (-want +got):\n", diff)
 			}
 		})
+	}
+}
+
+func TestDefaultTimeoutOption(t *testing.T) {
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+
+	stream := genericclioptions.NewTestIOStreamsDiscard()
+	defer tf.Cleanup()
+
+	cmd := NewCmdDebug(tf, stream)
+	if diff := cmp.Diff(cmd.Flag("timeout").DefValue, defaultEphemeralTimeout.String()); diff != "" {
+		t.Error("unexpected diff in default value: (-want +got):\n", diff)
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

Add a timeout in the ephemeral container creation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

In the tests, I'm not sure how to add a stream in the NewTestFactory(), so no tests yet for the waitForEphemeralContainer function

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Adding a timeout wait ephemeral container creation in the debug command.
```