### PR TITLE
Automated cherry pick of #87902: gce-addons: Make sure default/limit-range doesn't get

### DIFF
--- a/cluster/gce/addons/limit-range/limit-range.yaml
+++ b/cluster/gce/addons/limit-range/limit-range.yaml
@@ -3,6 +3,8 @@ kind: "LimitRange"
 metadata:
   name: "limits"
   namespace: default
+  labels:
+    addonmanager.kubernetes.io/mode: EnsureExists
 spec:
   limits:
     - type: "Container"


### PR DESCRIPTION
Cherry pick of #87902 on release-1.16.

#87902: gce-addons: Make sure default/limit-range doesn't get

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.