### PR TITLE
Scheduler NodeInfo cleanup

### DIFF
--- a/pkg/scheduler/core/extender.go
+++ b/pkg/scheduler/core/extender.go
@@ -287,7 +287,7 @@ func (h *HTTPExtender) convertToNodeToVictims(
 func (h *HTTPExtender) convertPodUIDToPod(
 	metaPod *extenderv1.MetaPod,
 	nodeInfo *framework.NodeInfo) (*v1.Pod, error) {
-	for _, p := range nodeInfo.Pods() {
+	for _, p := range nodeInfo.Pods {
 		if string(p.Pod.UID) == metaPod.UID {
 			return p.Pod, nil
 		}

--- a/pkg/scheduler/core/extender_test.go
+++ b/pkg/scheduler/core/extender_test.go
@@ -225,7 +225,7 @@ func (f *FakeExtender) selectVictimsOnNodeByExtender(pod *v1.Pod, node *v1.Node)
 	// As the first step, remove all the lower priority pods from the node and
 	// check if the given pod can be scheduled.
 	podPriority := podutil.GetPodPriority(pod)
-	for _, p := range nodeInfoCopy.Pods() {
+	for _, p := range nodeInfoCopy.Pods {
 		if podutil.GetPodPriority(p.Pod) < podPriority {
 			potentialVictims = append(potentialVictims, p.Pod)
 			removePod(p.Pod)

--- a/pkg/scheduler/core/generic_scheduler.go
+++ b/pkg/scheduler/core/generic_scheduler.go
@@ -970,7 +970,7 @@ func (g *genericScheduler) selectVictimsOnNode(
 	// As the first step, remove all the lower priority pods from the node and
 	// check if the given pod can be scheduled.
 	podPriority := podutil.GetPodPriority(pod)
-	for _, p := range nodeInfo.Pods() {
+	for _, p := range nodeInfo.Pods {
 		if podutil.GetPodPriority(p.Pod) < podPriority {
 			potentialVictims = append(potentialVictims, p.Pod)
 			if err := removePod(p.Pod); err != nil {
@@ -1062,7 +1062,7 @@ func podEligibleToPreemptOthers(pod *v1.Pod, nodeInfos framework.NodeInfoLister,
 	if len(nomNodeName) > 0 {
 		if nodeInfo, _ := nodeInfos.Get(nomNodeName); nodeInfo != nil {
 			podPriority := podutil.GetPodPriority(pod)
-			for _, p := range nodeInfo.Pods() {
+			for _, p := range nodeInfo.Pods {
 				if p.Pod.DeletionTimestamp != nil && podutil.GetPodPriority(p.Pod) < podPriority {
 					// There is a terminating pod on the nominated node.
 					return false

--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -135,7 +135,7 @@ func (pl *noPodsFilterPlugin) Name() string {
 
 // Filter invoked at the filter extension point.
 func (pl *noPodsFilterPlugin) Filter(_ context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
-	if len(nodeInfo.Pods()) == 0 {
+	if len(nodeInfo.Pods) == 0 {
 		return nil
 	}
 	return framework.NewStatus(framework.Unschedulable, ErrReasonFake)

--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread.go
@@ -196,11 +196,11 @@ func New(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plugin
 
 // countMatchingPods counts pods based on namespace and matching all selectors
 func countMatchingPods(namespace string, selector labels.Selector, nodeInfo *framework.NodeInfo) int {
-	if len(nodeInfo.Pods()) == 0 || selector.Empty() {
+	if len(nodeInfo.Pods) == 0 || selector.Empty() {
 		return 0
 	}
 	count := 0
-	for _, p := range nodeInfo.Pods() {
+	for _, p := range nodeInfo.Pods {
 		// Ignore pods being deleted for spreading purposes
 		// Similar to how it is done for SelectorSpreadPriority
 		if namespace == p.Pod.Namespace && p.Pod.DeletionTimestamp == nil {

--- a/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
+++ b/pkg/scheduler/framework/plugins/imagelocality/image_locality.go
@@ -95,14 +95,11 @@ func calculatePriority(sumScores int64) int64 {
 // the final score. Note that the init containers are not considered for it's rare for users to deploy huge init containers.
 func sumImageScores(nodeInfo *framework.NodeInfo, containers []v1.Container, totalNumNodes int) int64 {
 	var sum int64
-	imageStates := nodeInfo.ImageStates()
-
 	for _, container := range containers {
-		if state, ok := imageStates[normalizedImageName(container.Image)]; ok {
+		if state, ok := nodeInfo.ImageStates[normalizedImageName(container.Image)]; ok {
 			sum += scaledImageScore(state, totalNumNodes)
 		}
 	}
-
 	return sum
 }
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/filtering.go
@@ -228,7 +228,7 @@ func getTPMapMatchingExistingAntiAffinity(pod *v1.Pod, allNodes []*framework.Nod
 			klog.Error("node not found")
 			return
 		}
-		for _, existingPod := range nodeInfo.PodsWithAffinity() {
+		for _, existingPod := range nodeInfo.PodsWithAffinity {
 			existingPodTopologyMaps, err := getMatchingAntiAffinityTopologyPairsOfPod(pod, existingPod.Pod, node)
 			if err != nil {
 				errCh.SendErrorWithCancel(err, cancel)
@@ -291,7 +291,7 @@ func getTPMapMatchingIncomingAffinityAntiAffinity(pod *v1.Pod, allNodes []*frame
 		}
 		nodeTopologyPairsAffinityPodsMap := make(topologyToMatchedTermCount)
 		nodeTopologyPairsAntiAffinityPodsMap := make(topologyToMatchedTermCount)
-		for _, existingPod := range nodeInfo.Pods() {
+		for _, existingPod := range nodeInfo.Pods {
 			// Check affinity terms.
 			nodeTopologyPairsAffinityPodsMap.updateWithAffinityTerms(existingPod.Pod, node, affinityTerms, 1)
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -239,10 +239,10 @@ func (pl *InterPodAffinity) PreScore(
 		}
 		// Unless the pod being scheduled has affinity terms, we only
 		// need to process pods with affinity in the node.
-		podsToProcess := nodeInfo.PodsWithAffinity()
+		podsToProcess := nodeInfo.PodsWithAffinity
 		if hasAffinityConstraints || hasAntiAffinityConstraints {
 			// We need to process all the pods.
-			podsToProcess = nodeInfo.Pods()
+			podsToProcess = nodeInfo.Pods
 		}
 
 		topoScore := make(scoreMap)

--- a/pkg/scheduler/framework/plugins/nodeports/node_ports.go
+++ b/pkg/scheduler/framework/plugins/nodeports/node_ports.go
@@ -118,7 +118,7 @@ func Fits(pod *v1.Pod, nodeInfo *framework.NodeInfo) bool {
 
 func fitsPorts(wantPorts []*v1.ContainerPort, nodeInfo *framework.NodeInfo) bool {
 	// try to see whether existingPorts and wantPorts will conflict or not
-	existingPorts := nodeInfo.UsedPorts()
+	existingPorts := nodeInfo.UsedPorts
 	for _, cp := range wantPorts {
 		if existingPorts.CheckConflict(cp.HostIP, string(cp.Protocol), cp.HostPort) {
 			return false

--- a/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/balanced_allocation_test.go
@@ -384,7 +384,7 @@ func TestNodeResourcesBalancedAllocation(t *testing.T) {
 				maxVolumes := 5
 				nodeInfoList, _ := snapshot.NodeInfos().List()
 				for _, info := range nodeInfoList {
-					info.TransientInfo.TransNodeInfo.AllocatableVolumesCount = getExistingVolumeCountForNode(info.Pods(), maxVolumes)
+					info.TransientInfo.TransNodeInfo.AllocatableVolumesCount = getExistingVolumeCountForNode(info.Pods, maxVolumes)
 					info.TransientInfo.TransNodeInfo.RequestedVolumes = len(test.pod.Spec.Volumes)
 				}
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_allocation.go
@@ -90,20 +90,18 @@ func (r *resourceAllocationScorer) score(
 
 // calculateResourceAllocatableRequest returns resources Allocatable and Requested values
 func calculateResourceAllocatableRequest(nodeInfo *framework.NodeInfo, pod *v1.Pod, resource v1.ResourceName) (int64, int64) {
-	allocatable := nodeInfo.AllocatableResource()
-	requested := nodeInfo.RequestedResource()
 	podRequest := calculatePodResourceRequest(pod, resource)
 	switch resource {
 	case v1.ResourceCPU:
-		return allocatable.MilliCPU, (nodeInfo.NonZeroRequest().MilliCPU + podRequest)
+		return nodeInfo.Allocatable.MilliCPU, (nodeInfo.NonZeroRequested.MilliCPU + podRequest)
 	case v1.ResourceMemory:
-		return allocatable.Memory, (nodeInfo.NonZeroRequest().Memory + podRequest)
+		return nodeInfo.Allocatable.Memory, (nodeInfo.NonZeroRequested.Memory + podRequest)
 
 	case v1.ResourceEphemeralStorage:
-		return allocatable.EphemeralStorage, (requested.EphemeralStorage + podRequest)
+		return nodeInfo.Allocatable.EphemeralStorage, (nodeInfo.Requested.EphemeralStorage + podRequest)
 	default:
 		if v1helper.IsScalarResourceName(resource) {
-			return allocatable.ScalarResources[resource], (requested.ScalarResources[resource] + podRequest)
+			return nodeInfo.Allocatable.ScalarResources[resource], (nodeInfo.Requested.ScalarResources[resource] + podRequest)
 		}
 	}
 	if klog.V(10) {

--- a/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
+++ b/pkg/scheduler/framework/plugins/noderesources/resource_limits.go
@@ -106,14 +106,14 @@ func (rl *ResourceLimits) Score(ctx context.Context, state *framework.CycleState
 	if err != nil || nodeInfo.Node() == nil {
 		return 0, framework.NewStatus(framework.Error, fmt.Sprintf("getting node %q from Snapshot: %v, node is nil: %v", nodeName, err, nodeInfo.Node() == nil))
 	}
-	allocatableResources := nodeInfo.AllocatableResource()
+
 	podLimits, err := getPodResource(state)
 	if err != nil {
 		return 0, framework.NewStatus(framework.Error, err.Error())
 	}
 
-	cpuScore := computeScore(podLimits.MilliCPU, allocatableResources.MilliCPU)
-	memScore := computeScore(podLimits.Memory, allocatableResources.Memory)
+	cpuScore := computeScore(podLimits.MilliCPU, nodeInfo.Allocatable.MilliCPU)
+	memScore := computeScore(podLimits.Memory, nodeInfo.Allocatable.Memory)
 
 	score := int64(0)
 	if cpuScore == 1 || memScore == 1 {

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/csi.go
@@ -102,7 +102,7 @@ func (pl *CSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod *v
 	}
 
 	attachedVolumes := make(map[string]string)
-	for _, existingPod := range nodeInfo.Pods() {
+	for _, existingPod := range nodeInfo.Pods {
 		if err := pl.filterAttachableVolumes(csiNode, existingPod.Pod.Spec.Volumes, existingPod.Pod.Namespace, attachedVolumes); err != nil {
 			return framework.NewStatus(framework.Error, err.Error())
 		}
@@ -286,7 +286,7 @@ func NewCSI(_ *runtime.Unknown, handle framework.FrameworkHandle) (framework.Plu
 
 func getVolumeLimits(nodeInfo *framework.NodeInfo, csiNode *storagev1.CSINode) map[v1.ResourceName]int64 {
 	// TODO: stop getting values from Node object in v1.18
-	nodeVolumeLimits := nodeInfo.VolumeLimits()
+	nodeVolumeLimits := volumeLimits(nodeInfo)
 	if csiNode != nil {
 		for i := range csiNode.Spec.Drivers {
 			d := csiNode.Spec.Drivers[i]

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/non_csi.go
@@ -235,7 +235,7 @@ func (pl *nonCSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod
 
 	// count unique volumes
 	existingVolumes := make(map[string]bool)
-	for _, existingPod := range nodeInfo.Pods() {
+	for _, existingPod := range nodeInfo.Pods {
 		if err := pl.filterVolumes(existingPod.Pod.Spec.Volumes, existingPod.Pod.Namespace, existingVolumes); err != nil {
 			return framework.NewStatus(framework.Error, err.Error())
 		}
@@ -251,7 +251,7 @@ func (pl *nonCSILimits) Filter(ctx context.Context, _ *framework.CycleState, pod
 
 	numNewVolumes := len(newVolumes)
 	maxAttachLimit := pl.maxVolumeFunc(node)
-	volumeLimits := nodeInfo.VolumeLimits()
+	volumeLimits := volumeLimits(nodeInfo)
 	if maxAttachLimitFromAllocatable, ok := volumeLimits[pl.volumeLimitKey]; ok {
 		maxAttachLimit = int(maxAttachLimitFromAllocatable)
 	}

--- a/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
+++ b/pkg/scheduler/framework/plugins/nodevolumelimits/utils.go
@@ -19,12 +19,14 @@ package nodevolumelimits
 import (
 	"strings"
 
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	csilibplugins "k8s.io/csi-translation-lib/plugins"
+	v1helper "k8s.io/kubernetes/pkg/apis/core/v1/helper"
 	"k8s.io/kubernetes/pkg/features"
+	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
 // isCSIMigrationOn returns a boolean value indicating whether
@@ -78,4 +80,15 @@ func isCSIMigrationOn(csiNode *storagev1.CSINode, pluginName string) bool {
 	}
 
 	return mpaSet.Has(pluginName)
+}
+
+// volumeLimits returns volume limits associated with the node.
+func volumeLimits(n *framework.NodeInfo) map[v1.ResourceName]int64 {
+	volumeLimits := map[v1.ResourceName]int64{}
+	for k, v := range n.Allocatable.ScalarResources {
+		if v1helper.IsAttachableVolumeResourceName(k) {
+			volumeLimits[k] = v
+		}
+	}
+	return volumeLimits
 }

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering.go
@@ -255,7 +255,7 @@ func (pl *PodTopologySpread) calPreFilterState(pod *v1.Pod) (*preFilterState, er
 			if tpCount == nil {
 				continue
 			}
-			count := countPodsMatchSelector(nodeInfo.Pods(), constraint.Selector, pod.Namespace)
+			count := countPodsMatchSelector(nodeInfo.Pods, constraint.Selector, pod.Namespace)
 			atomic.AddInt32(tpCount, int32(count))
 		}
 	}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -142,7 +142,7 @@ func (pl *PodTopologySpread) PreScore(
 			if tpCount == nil {
 				continue
 			}
-			count := countPodsMatchSelector(nodeInfo.Pods(), c.Selector, pod.Namespace)
+			count := countPodsMatchSelector(nodeInfo.Pods, c.Selector, pod.Namespace)
 			atomic.AddInt64(tpCount, int64(count))
 		}
 	}
@@ -178,7 +178,7 @@ func (pl *PodTopologySpread) Score(ctx context.Context, cycleState *framework.Cy
 	for _, c := range s.Constraints {
 		if tpVal, ok := node.Labels[c.TopologyKey]; ok {
 			if c.TopologyKey == v1.LabelHostname {
-				count := countPodsMatchSelector(nodeInfo.Pods(), c.Selector, pod.Namespace)
+				count := countPodsMatchSelector(nodeInfo.Pods, c.Selector, pod.Namespace)
 				score += int64(count)
 			} else {
 				pair := topologyPair{key: c.TopologyKey, value: tpVal}

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity.go
@@ -278,11 +278,11 @@ func (pl *ServiceAffinity) Score(ctx context.Context, state *framework.CycleStat
 		selector = labels.NewSelector()
 	}
 
-	if len(nodeInfo.Pods()) == 0 || selector.Empty() {
+	if len(nodeInfo.Pods) == 0 || selector.Empty() {
 		return 0, nil
 	}
 	var score int64
-	for _, existingPod := range nodeInfo.Pods() {
+	for _, existingPod := range nodeInfo.Pods {
 		// Ignore pods being deleted for spreading purposes
 		// Similar to how it is done for SelectorSpreadPriority
 		if pod.Namespace == existingPod.Pod.Namespace && existingPod.Pod.DeletionTimestamp == nil {

--- a/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
+++ b/pkg/scheduler/framework/plugins/volumerestrictions/volume_restrictions.go
@@ -119,7 +119,7 @@ func haveOverlap(a1, a2 []string) bool {
 // - ISCSI forbids if any two pods share at least same IQN and ISCSI volume is read-only
 func (pl *VolumeRestrictions) Filter(ctx context.Context, _ *framework.CycleState, pod *v1.Pod, nodeInfo *framework.NodeInfo) *framework.Status {
 	for _, v := range pod.Spec.Volumes {
-		for _, ev := range nodeInfo.Pods() {
+		for _, ev := range nodeInfo.Pods {
 			if isVolumeConflict(v, ev.Pod) {
 				return framework.NewStatus(framework.Unschedulable, ErrReasonDiskConflict)
 			}

--- a/pkg/scheduler/framework/v1alpha1/types_test.go
+++ b/pkg/scheduler/framework/v1alpha1/types_test.go
@@ -285,31 +285,31 @@ func TestNewNodeInfo(t *testing.T) {
 	}
 
 	expected := &NodeInfo{
-		requestedResource: &Resource{
+		Requested: &Resource{
 			MilliCPU:         300,
 			Memory:           1524,
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		nonzeroRequest: &Resource{
+		NonZeroRequested: &Resource{
 			MilliCPU:         300,
 			Memory:           1524,
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		TransientInfo:       NewTransientSchedulerInfo(),
-		allocatableResource: &Resource{},
-		generation:          2,
-		usedPorts: HostPortInfo{
+		TransientInfo: NewTransientSchedulerInfo(),
+		Allocatable:   &Resource{},
+		Generation:    2,
+		UsedPorts: HostPortInfo{
 			"127.0.0.1": map[ProtocolPort]struct{}{
 				{Protocol: "TCP", Port: 80}:   {},
 				{Protocol: "TCP", Port: 8080}: {},
 			},
 		},
-		imageStates: map[string]*ImageStateSummary{},
-		pods: []*PodInfo{
+		ImageStates: map[string]*ImageStateSummary{},
+		Pods: []*PodInfo{
 			{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -373,10 +373,10 @@ func TestNewNodeInfo(t *testing.T) {
 
 	gen := generation
 	ni := NewNodeInfo(pods...)
-	if ni.generation <= gen {
-		t.Errorf("generation is not incremented. previous: %v, current: %v", gen, ni.generation)
+	if ni.Generation <= gen {
+		t.Errorf("Generation is not incremented. previous: %v, current: %v", gen, ni.Generation)
 	}
-	expected.generation = ni.generation
+	expected.Generation = ni.Generation
 	if !reflect.DeepEqual(expected, ni) {
 		t.Errorf("expected: %#v, got: %#v", expected, ni)
 	}
@@ -390,19 +390,19 @@ func TestNodeInfoClone(t *testing.T) {
 	}{
 		{
 			nodeInfo: &NodeInfo{
-				requestedResource:   &Resource{},
-				nonzeroRequest:      &Resource{},
-				TransientInfo:       NewTransientSchedulerInfo(),
-				allocatableResource: &Resource{},
-				generation:          2,
-				usedPorts: HostPortInfo{
+				Requested:        &Resource{},
+				NonZeroRequested: &Resource{},
+				TransientInfo:    NewTransientSchedulerInfo(),
+				Allocatable:      &Resource{},
+				Generation:       2,
+				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 80}:   {},
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				imageStates: map[string]*ImageStateSummary{},
-				pods: []*PodInfo{
+				ImageStates: map[string]*ImageStateSummary{},
+				Pods: []*PodInfo{
 					{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -464,19 +464,19 @@ func TestNodeInfoClone(t *testing.T) {
 				},
 			},
 			expected: &NodeInfo{
-				requestedResource:   &Resource{},
-				nonzeroRequest:      &Resource{},
-				TransientInfo:       NewTransientSchedulerInfo(),
-				allocatableResource: &Resource{},
-				generation:          2,
-				usedPorts: HostPortInfo{
+				Requested:        &Resource{},
+				NonZeroRequested: &Resource{},
+				TransientInfo:    NewTransientSchedulerInfo(),
+				Allocatable:      &Resource{},
+				Generation:       2,
+				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 80}:   {},
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				imageStates: map[string]*ImageStateSummary{},
-				pods: []*PodInfo{
+				ImageStates: map[string]*ImageStateSummary{},
+				Pods: []*PodInfo{
 					{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -543,8 +543,8 @@ func TestNodeInfoClone(t *testing.T) {
 	for _, test := range tests {
 		ni := test.nodeInfo.Clone()
 		// Modify the field to check if the result is a clone of the origin one.
-		test.nodeInfo.generation += 10
-		test.nodeInfo.usedPorts.Remove("127.0.0.1", "TCP", 80)
+		test.nodeInfo.Generation += 10
+		test.nodeInfo.UsedPorts.Remove("127.0.0.1", "TCP", 80)
 		if !reflect.DeepEqual(test.expected, ni) {
 			t.Errorf("expected: %#v, got: %#v", test.expected, ni)
 		}
@@ -621,31 +621,31 @@ func TestNodeInfoAddPod(t *testing.T) {
 				Name: "test-node",
 			},
 		},
-		requestedResource: &Resource{
+		Requested: &Resource{
 			MilliCPU:         1300,
 			Memory:           1000,
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		nonzeroRequest: &Resource{
+		NonZeroRequested: &Resource{
 			MilliCPU:         1300,
 			Memory:           209716200, //200MB + 1000 specified in requests/overhead
 			EphemeralStorage: 0,
 			AllowedPodNumber: 0,
 			ScalarResources:  map[v1.ResourceName]int64(nil),
 		},
-		TransientInfo:       NewTransientSchedulerInfo(),
-		allocatableResource: &Resource{},
-		generation:          2,
-		usedPorts: HostPortInfo{
+		TransientInfo: NewTransientSchedulerInfo(),
+		Allocatable:   &Resource{},
+		Generation:    2,
+		UsedPorts: HostPortInfo{
 			"127.0.0.1": map[ProtocolPort]struct{}{
 				{Protocol: "TCP", Port: 80}:   {},
 				{Protocol: "TCP", Port: 8080}: {},
 			},
 		},
-		imageStates: map[string]*ImageStateSummary{},
-		pods: []*PodInfo{
+		ImageStates: map[string]*ImageStateSummary{},
+		Pods: []*PodInfo{
 			{
 				Pod: &v1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
@@ -714,16 +714,16 @@ func TestNodeInfoAddPod(t *testing.T) {
 	}
 
 	ni := fakeNodeInfo()
-	gen := ni.generation
+	gen := ni.Generation
 	for _, pod := range pods {
 		ni.AddPod(pod)
-		if ni.generation <= gen {
-			t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
+		if ni.Generation <= gen {
+			t.Errorf("Generation is not incremented. Prev: %v, current: %v", gen, ni.Generation)
 		}
-		gen = ni.generation
+		gen = ni.Generation
 	}
 
-	expected.generation = ni.generation
+	expected.Generation = ni.Generation
 	if !reflect.DeepEqual(expected, ni) {
 		t.Errorf("expected: %#v, got: %#v", expected, ni)
 	}
@@ -759,31 +759,31 @@ func TestNodeInfoRemovePod(t *testing.T) {
 						Name: "test-node",
 					},
 				},
-				requestedResource: &Resource{
+				Requested: &Resource{
 					MilliCPU:         1300,
 					Memory:           2524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				nonzeroRequest: &Resource{
+				NonZeroRequested: &Resource{
 					MilliCPU:         1300,
 					Memory:           2524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				TransientInfo:       NewTransientSchedulerInfo(),
-				allocatableResource: &Resource{},
-				generation:          2,
-				usedPorts: HostPortInfo{
+				TransientInfo: NewTransientSchedulerInfo(),
+				Allocatable:   &Resource{},
+				Generation:    2,
+				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 80}:   {},
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				imageStates: map[string]*ImageStateSummary{},
-				pods: []*PodInfo{
+				ImageStates: map[string]*ImageStateSummary{},
+				Pods: []*PodInfo{
 					{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -892,30 +892,30 @@ func TestNodeInfoRemovePod(t *testing.T) {
 						Name: "test-node",
 					},
 				},
-				requestedResource: &Resource{
+				Requested: &Resource{
 					MilliCPU:         700,
 					Memory:           1524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				nonzeroRequest: &Resource{
+				NonZeroRequested: &Resource{
 					MilliCPU:         700,
 					Memory:           1524,
 					EphemeralStorage: 0,
 					AllowedPodNumber: 0,
 					ScalarResources:  map[v1.ResourceName]int64(nil),
 				},
-				TransientInfo:       NewTransientSchedulerInfo(),
-				allocatableResource: &Resource{},
-				generation:          3,
-				usedPorts: HostPortInfo{
+				TransientInfo: NewTransientSchedulerInfo(),
+				Allocatable:   &Resource{},
+				Generation:    3,
+				UsedPorts: HostPortInfo{
 					"127.0.0.1": map[ProtocolPort]struct{}{
 						{Protocol: "TCP", Port: 8080}: {},
 					},
 				},
-				imageStates: map[string]*ImageStateSummary{},
-				pods: []*PodInfo{
+				ImageStates: map[string]*ImageStateSummary{},
+				Pods: []*PodInfo{
 					{
 						Pod: &v1.Pod{
 							ObjectMeta: metav1.ObjectMeta{
@@ -957,7 +957,7 @@ func TestNodeInfoRemovePod(t *testing.T) {
 	for _, test := range tests {
 		ni := fakeNodeInfo(pods...)
 
-		gen := ni.generation
+		gen := ni.Generation
 		err := ni.RemovePod(test.pod)
 		if err != nil {
 			if test.errExpected {
@@ -969,12 +969,12 @@ func TestNodeInfoRemovePod(t *testing.T) {
 				t.Errorf("expected no error, got: %v", err)
 			}
 		} else {
-			if ni.generation <= gen {
-				t.Errorf("generation is not incremented. Prev: %v, current: %v", gen, ni.generation)
+			if ni.Generation <= gen {
+				t.Errorf("Generation is not incremented. Prev: %v, current: %v", gen, ni.Generation)
 			}
 		}
 
-		test.expectedNodeInfo.generation = ni.generation
+		test.expectedNodeInfo.Generation = ni.Generation
 		if !reflect.DeepEqual(test.expectedNodeInfo, ni) {
 			t.Errorf("expected: %#v, got: %#v", test.expectedNodeInfo, ni)
 		}

--- a/pkg/scheduler/internal/cache/cache.go
+++ b/pkg/scheduler/internal/cache/cache.go
@@ -218,7 +218,7 @@ func (cache *schedulerCache) UpdateSnapshot(nodeSnapshot *Snapshot) error {
 	// Start from the head of the NodeInfo doubly linked list and update snapshot
 	// of NodeInfos updated after the last snapshot.
 	for node := cache.headNode; node != nil; node = node.next {
-		if node.info.GetGeneration() <= snapshotGeneration {
+		if node.info.Generation <= snapshotGeneration {
 			// all the nodes are updated before the existing snapshot. We are done.
 			break
 		}
@@ -237,7 +237,7 @@ func (cache *schedulerCache) UpdateSnapshot(nodeSnapshot *Snapshot) error {
 			// We track nodes that have pods with affinity, here we check if this node changed its
 			// status from having pods with affinity to NOT having pods with affinity or the other
 			// way around.
-			if (len(existing.PodsWithAffinity()) > 0) != (len(clone.PodsWithAffinity()) > 0) {
+			if (len(existing.PodsWithAffinity) > 0) != (len(clone.PodsWithAffinity) > 0) {
 				updateNodesHavePodsWithAffinity = true
 			}
 			// We need to preserve the original pointer of the NodeInfo struct since it
@@ -247,7 +247,7 @@ func (cache *schedulerCache) UpdateSnapshot(nodeSnapshot *Snapshot) error {
 	}
 	// Update the snapshot generation with the latest NodeInfo generation.
 	if cache.headNode != nil {
-		nodeSnapshot.generation = cache.headNode.info.GetGeneration()
+		nodeSnapshot.generation = cache.headNode.info.Generation
 	}
 
 	if len(nodeSnapshot.nodeInfoMap) > len(cache.nodes) {
@@ -284,7 +284,7 @@ func (cache *schedulerCache) updateNodeInfoSnapshotList(snapshot *Snapshot, upda
 			nodeName := cache.nodeTree.next()
 			if n := snapshot.nodeInfoMap[nodeName]; n != nil {
 				snapshot.nodeInfoList = append(snapshot.nodeInfoList, n)
-				if len(n.PodsWithAffinity()) > 0 {
+				if len(n.PodsWithAffinity) > 0 {
 					snapshot.havePodsWithAffinityNodeInfoList = append(snapshot.havePodsWithAffinityNodeInfoList, n)
 				}
 			} else {
@@ -293,7 +293,7 @@ func (cache *schedulerCache) updateNodeInfoSnapshotList(snapshot *Snapshot, upda
 		}
 	} else {
 		for _, n := range snapshot.nodeInfoList {
-			if len(n.PodsWithAffinity()) > 0 {
+			if len(n.PodsWithAffinity) > 0 {
 				snapshot.havePodsWithAffinityNodeInfoList = append(snapshot.havePodsWithAffinityNodeInfoList, n)
 			}
 		}
@@ -322,11 +322,11 @@ func (cache *schedulerCache) ListPods(selector labels.Selector) ([]*v1.Pod, erro
 	// pre-allocating capacity.
 	maxSize := 0
 	for _, n := range cache.nodes {
-		maxSize += len(n.info.Pods())
+		maxSize += len(n.info.Pods)
 	}
 	pods := make([]*v1.Pod, 0, maxSize)
 	for _, n := range cache.nodes {
-		for _, p := range n.info.Pods() {
+		for _, p := range n.info.Pods {
 			if selector.Matches(labels.Set(p.Pod.Labels)) {
 				pods = append(pods, p.Pod)
 			}
@@ -664,7 +664,7 @@ func (cache *schedulerCache) addNodeImageStates(node *v1.Node, nodeInfo *framewo
 			}
 		}
 	}
-	nodeInfo.SetImageStates(newSum)
+	nodeInfo.ImageStates = newSum
 }
 
 // removeNodeImageStates removes the given node record from image entries having the node

--- a/pkg/scheduler/internal/cache/debugger/comparer.go
+++ b/pkg/scheduler/internal/cache/debugger/comparer.go
@@ -91,7 +91,7 @@ func (c *CacheComparer) ComparePods(pods, waitingPods []*v1.Pod, nodeinfos map[s
 
 	cached := []string{}
 	for _, nodeinfo := range nodeinfos {
-		for _, p := range nodeinfo.Pods() {
+		for _, p := range nodeinfo.Pods {
 			cached = append(cached, string(p.Pod.UID))
 		}
 	}

--- a/pkg/scheduler/internal/cache/debugger/dumper.go
+++ b/pkg/scheduler/internal/cache/debugger/dumper.go
@@ -64,9 +64,9 @@ func (d *CacheDumper) dumpSchedulingQueue() {
 func (d *CacheDumper) printNodeInfo(n *framework.NodeInfo) string {
 	var nodeData strings.Builder
 	nodeData.WriteString(fmt.Sprintf("\nNode name: %+v\nRequested Resources: %+v\nAllocatable Resources:%+v\nScheduled Pods(number: %v):\n",
-		n.Node().Name, n.RequestedResource(), n.AllocatableResource(), len(n.Pods())))
+		n.Node().Name, n.Requested, n.Allocatable, len(n.Pods)))
 	// Dumping Pod Info
-	for _, p := range n.Pods() {
+	for _, p := range n.Pods {
 		nodeData.WriteString(printPod(p.Pod))
 	}
 	// Dumping nominated pods info on the node

--- a/pkg/scheduler/internal/cache/snapshot.go
+++ b/pkg/scheduler/internal/cache/snapshot.go
@@ -53,7 +53,7 @@ func NewSnapshot(pods []*v1.Pod, nodes []*v1.Node) *Snapshot {
 	havePodsWithAffinityNodeInfoList := make([]*framework.NodeInfo, 0, len(nodeInfoMap))
 	for _, v := range nodeInfoMap {
 		nodeInfoList = append(nodeInfoList, v)
-		if len(v.PodsWithAffinity()) > 0 {
+		if len(v.PodsWithAffinity) > 0 {
 			havePodsWithAffinityNodeInfoList = append(havePodsWithAffinityNodeInfoList, v)
 		}
 	}
@@ -86,7 +86,7 @@ func createNodeInfoMap(pods []*v1.Pod, nodes []*v1.Node) map[string]*framework.N
 		}
 		nodeInfo := nodeNameToInfo[node.Name]
 		nodeInfo.SetNode(node)
-		nodeInfo.SetImageStates(getNodeImageStates(node, imageExistenceMap))
+		nodeInfo.ImageStates = getNodeImageStates(node, imageExistenceMap)
 	}
 	return nodeNameToInfo
 }
@@ -153,11 +153,11 @@ func (p podLister) FilteredList(filter framework.PodFilter, selector labels.Sele
 	// pre-allocating capacity.
 	maxSize := 0
 	for _, n := range p {
-		maxSize += len(n.Pods())
+		maxSize += len(n.Pods)
 	}
 	pods := make([]*v1.Pod, 0, maxSize)
 	for _, n := range p {
-		for _, p := range n.Pods() {
+		for _, p := range n.Pods {
 			if filter(p.Pod) && selector.Matches(labels.Set(p.Pod.Labels)) {
 				pods = append(pods, p.Pod)
 			}


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Removes most accessor methods from NodeInfo (a golang anti-pattern) so that it is consistent with PodInfo. This PR also removes a number of unnecessary NodeInfo public methods and unused member variables.

There is a couple of public methods that kubelet depends on and will be removed in a separate followup PR.

**Which issue(s) this PR fixes**:
Part of #89528

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @alculquicondor 