### PR TITLE
Fix nil-dereference in GetReference

### DIFF
--- a/staging/src/k8s.io/client-go/tools/reference/ref.go
+++ b/staging/src/k8s.io/client-go/tools/reference/ref.go
@@ -56,7 +56,11 @@ func GetReference(scheme *runtime.Scheme, obj runtime.Object) (*v1.ObjectReferen
 		listMeta = objectMeta
 	}
 
-	gvk := obj.GetObjectKind().GroupVersionKind()
+	objKind := obj.GetObjectKind()
+	if objKind == nil {
+		return nil, fmt.Errorf("unable to retrieve ObjectKind for %v", obj)
+	}
+	gvk := objKind.GroupVersionKind()
 
 	// If object meta doesn't contain data about kind and/or version,
 	// we are falling back to scheme.


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
We recently saw the following panic 
```
Apr 08 16:05:06.986486 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: panic: runtime error: invalid memory address or nil pointer dereference
Apr 08 16:05:06.986486 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa6cdf5]
Apr 08 16:05:06.986486 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: goroutine 1 [running]:
Apr 08 16:05:06.986486 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: panic(0x122f0a0, 0x20b9a30)
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]:         /usr/lib/golang/src/runtime/panic.go:565 +0x2c5 fp=0xc0000e7330 sp=0xc0000e72a0 pc=0x432105
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: runtime.panicmem(...)
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]:         /usr/lib/golang/src/runtime/panic.go:82
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: runtime.sigpanic()
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]:         /usr/lib/golang/src/runtime/signal_unix.go:390 +0x411 fp=0xc0000e7360 sp=0xc0000e7330 pc=0x446d61
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: github.com/intel/multus-cni/vendor/k8s.io/api/core/v1.(*Pod).GetObjectKind(0x0, 0x4, 0xc00011d400)
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]:         <autogenerated>:1 +0x5 fp=0xc0000e7368 sp=0xc0000e7360 pc=0xa6cdf5
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: github.com/intel/multus-cni/vendor/k8s.io/client-go/tools/reference.GetReference(0xc0001ba0e0, 0x1562aa0, 0x0, 0x4d7468, 0xc0000f0000, 0x11a0ee0)
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]:         /usr/src/multus-cni/gopath/src/github.com/intel/multus-cni/vendor/k8s.io/client-go/tools/reference/ref.go:50 +0x73 fp=0xc0000e74e8 sp=0xc0000e7368 pc=0xf59213
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]: github.com/intel/multus-cni/vendor/k8s.io/client-go/tools/record.(*recorderImpl).generateEvent(0xc0002f8580, 0x1562aa0, 0x0, 0x0, 0xbf9b9b6cbaaa78da, 0x76a14e568, 0x20d0940, 0x138ef96, 0x6, 0x1397216, ...)
Apr 08 16:05:06.986879 ci-op-kf7v5-m-0.c.openshift-gce-devel-ci.internal crio[1396]:         /usr/src/multus-cni/gopath/src/github.com/intel/multus-cni/vendor/k8s.io/client-go/tools/record/event.go:257 +0x5d fp=0xc0000e75d0 sp=0xc0000e74e8 pc=0xfde62d
```
The crash seems to be from this line:
```
	gvk := obj.GetObjectKind().GroupVersionKind()
```
obj should not be nil due to earlier check :
```
	if obj == nil {
		return nil, ErrNilObject
	}
```
This PR adds nil check before calling GroupVersionKind()

**Which issue(s) this PR fixes**:
Fixes #

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
