### PR TITLE
Add test to NewNotFound func for improving coverage

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/admission/errors_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/admission/errors_test.go
@@ -48,6 +48,46 @@ func TestNewForbidden(t *testing.T) {
 	}
 }
 
+func TestNewNotFound(t *testing.T) {
+	attributes := NewAttributesRecord(
+		&fakeObj{},
+		nil,
+		schema.GroupVersionKind{Group: "foo", Version: "bar", Kind: "Baz"},
+		"",
+		"",
+		schema.GroupVersionResource{Group: "foo", Version: "bar", Resource: "baz"},
+		"",
+		Create,
+		nil,
+		false,
+		nil)
+	expectedErr := `baz.foo "Unknown/errorGettingName" not found`
+
+	actualErr := NewNotFound(attributes)
+	if actualErr.Error() != expectedErr {
+		t.Errorf("expected %v, got %v", expectedErr, actualErr)
+	}
+
+	attributes = NewAttributesRecord(
+		&fakeObj{},
+		nil,
+		schema.GroupVersionKind{Group: "foo", Version: "bar", Kind: "Baz"},
+		"",
+		"Bob",
+		schema.GroupVersionResource{Group: "foo", Version: "bar", Resource: "baz"},
+		"",
+		Create,
+		nil,
+		false,
+		nil)
+	expectedErr = `baz.foo "Bob" not found`
+
+	actualErr = NewNotFound(attributes)
+	if actualErr.Error() != expectedErr {
+		t.Errorf("expected %v, got %v", expectedErr, actualErr)
+	}
+}
+
 type fakeObj struct{}
 type fakeObjKind struct{}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Add test set to improve test coverage in `staging/src/k8s.io/apiserver/pkg/admission/errors.go`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None
```
