### PR TITLE
Remove the 'DisabledForLargeClusters' tag from ILB correctness test

### DIFF
--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2161,8 +2161,7 @@ var _ = SIGDescribe("Services", func() {
 		checkReachabilityFromPod(true, normalReachabilityTimeout, namespace, dropPod.Name, svcIP)
 	})
 
-	// TODO: Get rid of [DisabledForLargeClusters] tag when issue #56138 is fixed.
-	ginkgo.It("should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]", func() {
+	ginkgo.It("should be able to create an internal type load balancer [Slow]", func() {
 		e2eskipper.SkipUnlessProviderIs("azure", "gke", "gce")
 
 		createTimeout := e2eservice.GetServiceLoadBalancerCreationTimeout(cs)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

The aforementioned test failed for GCE clusters with more than 1000 nodes in a single zone, hence it was turned off using the `[DisabledForLargeClusters]` tag. After fix in #89902 I confirmed it works by running it on a 5k nodes cluster:

```
I0410 08:40:32.745] [32m• [SLOW TEST:1609.451 seconds][0m
I0410 08:40:32.746] [sig-network] Services
I0410 08:40:32.746] [90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/framework.go:23[0m
I0410 08:40:32.746]   should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]
I0410 08:40:32.746]   [90m/go/src/k8s.io/kubernetes/_output/dockerized/go/src/k8s.io/kubernetes/test/e2e/network/service.go:2165[0m
I0410 08:40:32.746] [90m------------------------------[0m
I0410 08:40:32.747] {"msg":"PASSED [sig-network] Services should be able to create an internal type load balancer [Slow] [DisabledForLargeClusters]","total":-1,"completed":1,"skipped":67,"failed":0}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue is opened for that.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

/sig scalability