### PR TITLE
Fix Node initialization for GCP cloud provider

### DIFF
--- a/pkg/controller/cloud/node_controller.go
+++ b/pkg/controller/cloud/node_controller.go
@@ -239,7 +239,7 @@ func (cnc *CloudNodeController) updateNodeAddress(ctx context.Context, node *v1.
 		return
 	}
 
-	nodeAddresses, err := getNodeAddressesByProviderIDOrName(ctx, instances, node)
+	nodeAddresses, err := getNodeAddressesByProviderIDOrName(ctx, instances, node.Spec.ProviderID, node.Name)
 	if err != nil {
 		klog.Errorf("Error getting node addresses for node %q: %v", node.Name, err)
 		return
@@ -407,10 +407,14 @@ func (cnc *CloudNodeController) initializeNode(ctx context.Context, node *v1.Nod
 // All of the returned functions are idempotent, because they are used in a retry-if-conflict
 // loop, meaning they could get called multiple times.
 func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Context, node *v1.Node, instances cloudprovider.Instances) ([]nodeModifier, error) {
-	var nodeModifiers []nodeModifier
+	var (
+		nodeModifiers []nodeModifier
+		providerID    string
+		err           error
+	)
 
 	if node.Spec.ProviderID == "" {
-		providerID, err := cloudprovider.GetInstanceProviderID(ctx, cnc.cloud, types.NodeName(node.Name))
+		providerID, err = cloudprovider.GetInstanceProviderID(ctx, cnc.cloud, types.NodeName(node.Name))
 		if err == nil {
 			nodeModifiers = append(nodeModifiers, func(n *v1.Node) {
 				if n.Spec.ProviderID == "" {
@@ -428,9 +432,11 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Co
 			// do not, the taint will be removed, and this will not be retried
 			return nil, err
 		}
+	} else {
+		providerID = node.Spec.ProviderID
 	}
 
-	nodeAddresses, err := getNodeAddressesByProviderIDOrName(ctx, instances, node)
+	nodeAddresses, err := getNodeAddressesByProviderIDOrName(ctx, instances, providerID, node.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -443,7 +449,7 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Co
 		}
 	}
 
-	if instanceType, err := getInstanceTypeByProviderIDOrName(ctx, instances, node); err != nil {
+	if instanceType, err := getInstanceTypeByProviderIDOrName(ctx, instances, providerID, node.Name); err != nil {
 		return nil, err
 	} else if instanceType != "" {
 		klog.V(2).Infof("Adding node label from cloud provider: %s=%s", v1.LabelInstanceType, instanceType)
@@ -458,7 +464,7 @@ func (cnc *CloudNodeController) getNodeModifiersFromCloudProvider(ctx context.Co
 	}
 
 	if zones, ok := cnc.cloud.Zones(); ok {
-		zone, err := getZoneByProviderIDOrName(ctx, zones, node)
+		zone, err := getZoneByProviderIDOrName(ctx, zones, providerID, node.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get zone from cloud provider: %v", err)
 		}
@@ -531,11 +537,11 @@ func ensureNodeExistsByProviderID(ctx context.Context, instances cloudprovider.I
 	return instances.InstanceExistsByProviderID(ctx, providerID)
 }
 
-func getNodeAddressesByProviderIDOrName(ctx context.Context, instances cloudprovider.Instances, node *v1.Node) ([]v1.NodeAddress, error) {
-	nodeAddresses, err := instances.NodeAddressesByProviderID(ctx, node.Spec.ProviderID)
+func getNodeAddressesByProviderIDOrName(ctx context.Context, instances cloudprovider.Instances, providerID, nodeName string) ([]v1.NodeAddress, error) {
+	nodeAddresses, err := instances.NodeAddressesByProviderID(ctx, providerID)
 	if err != nil {
 		providerIDErr := err
-		nodeAddresses, err = instances.NodeAddresses(ctx, types.NodeName(node.Name))
+		nodeAddresses, err = instances.NodeAddresses(ctx, types.NodeName(nodeName))
 		if err != nil {
 			return nil, fmt.Errorf("error fetching node by provider ID: %v, and error by node name: %v", providerIDErr, err)
 		}
@@ -576,11 +582,13 @@ func ensureNodeProvidedIPExists(node *v1.Node, nodeAddresses []v1.NodeAddress) (
 	return nodeIP, nodeIPExists
 }
 
-func getInstanceTypeByProviderIDOrName(ctx context.Context, instances cloudprovider.Instances, node *v1.Node) (string, error) {
-	instanceType, err := instances.InstanceTypeByProviderID(ctx, node.Spec.ProviderID)
+// getInstanceTypeByProviderIDOrName will attempt to get the instance type of node using its providerID
+// then it's name. If both attempts fail, an error is returned.
+func getInstanceTypeByProviderIDOrName(ctx context.Context, instances cloudprovider.Instances, providerID, nodeName string) (string, error) {
+	instanceType, err := instances.InstanceTypeByProviderID(ctx, providerID)
 	if err != nil {
 		providerIDErr := err
-		instanceType, err = instances.InstanceType(ctx, types.NodeName(node.Name))
+		instanceType, err = instances.InstanceType(ctx, types.NodeName(nodeName))
 		if err != nil {
 			return "", fmt.Errorf("InstanceType: Error fetching by providerID: %v Error fetching by NodeName: %v", providerIDErr, err)
 		}
@@ -589,12 +597,12 @@ func getInstanceTypeByProviderIDOrName(ctx context.Context, instances cloudprovi
 }
 
 // getZoneByProviderIDorName will attempt to get the zone of node using its providerID
-// then it's name. If both attempts fail, an error is returned
-func getZoneByProviderIDOrName(ctx context.Context, zones cloudprovider.Zones, node *v1.Node) (cloudprovider.Zone, error) {
-	zone, err := zones.GetZoneByProviderID(ctx, node.Spec.ProviderID)
+// then it's name. If both attempts fail, an error is returned.
+func getZoneByProviderIDOrName(ctx context.Context, zones cloudprovider.Zones, providerID, nodeName string) (cloudprovider.Zone, error) {
+	zone, err := zones.GetZoneByProviderID(ctx, providerID)
 	if err != nil {
 		providerIDErr := err
-		zone, err = zones.GetZoneByNodeName(ctx, types.NodeName(node.Name))
+		zone, err = zones.GetZoneByNodeName(ctx, types.NodeName(nodeName))
 		if err != nil {
 			return cloudprovider.Zone{}, fmt.Errorf("Zone: Error fetching by providerID: %v Error fetching by NodeName: %v", providerIDErr, err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The legacy GCP cloud-controller-manager is not able to initialize new Nodes. Logs:
```
I0410 15:48:51.287480       1 node_controller.go:325] Initializing node shoot--foo--bar-cpu-worker-z1-68f57cffcd-dbq47 with cloud provider
E0410 15:48:51.295679       1 gce_instances.go:575] Failed to fetch instanceID via Metadata: metadata: GCE metadata "instance/hostname" not defined
E0410 15:48:51.541680       1 node_controller.go:370] failed to initialize node shoot--foo--bar-cpu-worker-z1-68f57cffcd-dbq47 at cloudprovider: error fetching node by provider ID: error splitting providerID, and error by node name: couldn't get internal IP: metadata: GCE metadata "instance/network-interfaces/0/ip" not defined
I0410 15:48:51.541710       1 node_controller.go:325] Initializing node shoot--foo--bar-cpu-worker-z1-68f57cffcd-dbq47 with cloud provider
E0410 15:48:51.547318       1 gce_instances.go:575] Failed to fetch instanceID via Metadata: metadata: GCE metadata "instance/hostname" not defined
E0410 15:48:51.762648       1 node_controller.go:370] failed to initialize node shoot--foo--bar-cpu-worker-z1-68f57cffcd-dbq47 at cloudprovider: error fetching node by provider ID: error splitting providerID, and error by node name: couldn't get internal IP: metadata: GCE metadata "instance/network-interfaces/0/ip" not defined
```

The `getNodeAddressesByProviderIDOrName` tries to call `NodeAddressesByProviderID` and `NodeAddresses` funcs.
https://github.com/kubernetes/kubernetes/blob/5bfe8fe2b9024f0319c053d5514b491f7c18aad8/pkg/controller/cloud/node_controller.go#L534-L544

`NodeAddressesByProviderID` func will always fail to split empty providerID.
https://github.com/kubernetes/kubernetes/blob/5bfe8fe2b9024f0319c053d5514b491f7c18aad8/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go#L113-L120

`NodeAddresses` func will fail to fetch the gce metadata if the cloud-controller-manager is not running on the Node.
https://github.com/kubernetes/kubernetes/blob/5bfe8fe2b9024f0319c053d5514b491f7c18aad8/staging/src/k8s.io/legacy-cloud-providers/gce/gce_instances.go#L86-L90

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #90056

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
An issue preventing GCP cloud-controller-manager running out-of-cluster to initialize new Nodes is now fixed.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
