### PR TITLE
kubeadm: fix misleading warning for authz modes

### DIFF
--- a/cmd/kubeadm/app/phases/controlplane/manifests.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests.go
@@ -222,14 +222,29 @@ func getAuthzModes(authzModeExtraArgs string) string {
 
 		// only return the user provided mode if at least one was valid
 		if len(mode) > 0 {
-			klog.Warningf("the default kube-apiserver authorization-mode is %q; using %q",
-				strings.Join(defaultMode, ","),
-				strings.Join(mode, ","),
-			)
+			if !compareAuthzModes(defaultMode, mode) {
+				klog.Warningf("the default kube-apiserver authorization-mode is %q; using %q",
+					strings.Join(defaultMode, ","),
+					strings.Join(mode, ","),
+				)
+			}
 			return strings.Join(mode, ",")
 		}
 	}
 	return strings.Join(defaultMode, ",")
+}
+
+// compareAuthzModes compares two given authz modes and returns false if they do not match
+func compareAuthzModes(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, m := range a {
+		if m != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func isValidAuthzMode(authzMode string) bool {

--- a/cmd/kubeadm/app/phases/controlplane/manifests_test.go
+++ b/cmd/kubeadm/app/phases/controlplane/manifests_test.go
@@ -1144,3 +1144,43 @@ func TestIsValidAuthzMode(t *testing.T) {
 		})
 	}
 }
+
+func TestCompareAuthzModes(t *testing.T) {
+	var tests = []struct {
+		name   string
+		modesA []string
+		modesB []string
+		equal  bool
+	}{
+		{
+			name:   "modes match",
+			modesA: []string{"a", "b", "c"},
+			modesB: []string{"a", "b", "c"},
+			equal:  true,
+		},
+		{
+			name:   "modes order does not match",
+			modesA: []string{"a", "c", "b"},
+			modesB: []string{"a", "b", "c"},
+		},
+		{
+			name:   "modes do not match; A has less modes",
+			modesA: []string{"a", "b"},
+			modesB: []string{"a", "b", "c"},
+		},
+		{
+			name:   "modes do not match; B has less modes",
+			modesA: []string{"a", "b", "c"},
+			modesB: []string{"a", "b"},
+		},
+	}
+
+	for _, rt := range tests {
+		t.Run(rt.name, func(t *testing.T) {
+			equal := compareAuthzModes(rt.modesA, rt.modesB)
+			if equal != rt.equal {
+				t.Errorf("failed compareAuthzModes:\nexpected:\n%v\nsaw:\n%v", rt.equal, equal)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Followup from this PR which got abandoned:
https://github.com/kubernetes/kubernetes/pull/88608

kubeadm init prints:
  W0410 23:02:10.119723   13040 manifests.go:225] the default kube-apiserver
  authorization-mode is "Node,RBAC"; using "Node,RBAC"

Add a new function compareAuthzModes() and a unit test for it.
Make sure the warning is printed only if the user modes don't match
the defaults.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #88606

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
