### PR TITLE
Add --certificate-authority-data flag to kubectl config set-cluster

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/overrides.go
@@ -151,6 +151,7 @@ const (
 	FlagCertFile         = "client-certificate"
 	FlagKeyFile          = "client-key"
 	FlagCAFile           = "certificate-authority"
+	FlagCAData           = "certificate-authority-data"
 	FlagEmbedCerts       = "embed-certs"
 	FlagBearerToken      = "token"
 	FlagImpersonate      = "as"

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -33,13 +34,14 @@ import (
 )
 
 type createClusterOptions struct {
-	configAccess          clientcmd.ConfigAccess
-	name                  string
-	server                cliflag.StringFlag
-	tlsServerName         cliflag.StringFlag
-	insecureSkipTLSVerify cliflag.Tristate
-	certificateAuthority  cliflag.StringFlag
-	embedCAData           cliflag.Tristate
+	configAccess             clientcmd.ConfigAccess
+	name                     string
+	server                   cliflag.StringFlag
+	tlsServerName            cliflag.StringFlag
+	insecureSkipTLSVerify    cliflag.Tristate
+	certificateAuthority     cliflag.StringFlag
+	certificateAuthorityData cliflag.StringFlag
+	embedCAData              cliflag.Tristate
 }
 
 var (
@@ -52,8 +54,14 @@ var (
 		# Set only the server field on the e2e cluster entry without touching other values.
 		kubectl config set-cluster e2e --server=https://1.2.3.4
 
-		# Embed certificate authority data for the e2e cluster entry
+		# Set certificate authority file for the e2e cluster entry
 		kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt
+
+		# Embed certificate authority data from a file for the e2e cluster entry
+		kubectl config set-cluster e2e --certificate-authority=~/.kube/e2e/kubernetes.ca.crt --embed-certs
+
+		# Embed base64 encoded certificate authority data for the e2e cluster entry
+		kubectl config set-cluster e2e --certificate-authority-data="base64_encoded_certificate_authority_data_here"
 
 		# Disable cert checking for the dev cluster entry
 		kubectl config set-cluster e2e --insecure-skip-tls-verify=true
@@ -67,7 +75,7 @@ func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) 
 	options := &createClusterOptions{configAccess: configAccess}
 
 	cmd := &cobra.Command{
-		Use:                   fmt.Sprintf("set-cluster NAME [--%v=server] [--%v=path/to/certificate/authority] [--%v=true] [--%v=example.com]", clientcmd.FlagAPIServer, clientcmd.FlagCAFile, clientcmd.FlagInsecure, clientcmd.FlagTLSServerName),
+		Use:                   fmt.Sprintf("set-cluster NAME [--%v=server] [--%v=path/to/certificate/authority] [--%v=base64_encoded_certificate_authority_data] [--%v=true] [--%v=example.com]", clientcmd.FlagAPIServer, clientcmd.FlagCAFile, clientcmd.FlagCAData, clientcmd.FlagInsecure, clientcmd.FlagTLSServerName),
 		DisableFlagsInUseLine: true,
 		Short:                 i18n.T("Sets a cluster entry in kubeconfig"),
 		Long:                  createClusterLong,
@@ -87,6 +95,7 @@ func NewCmdConfigSetCluster(out io.Writer, configAccess clientcmd.ConfigAccess) 
 	f.NoOptDefVal = "true"
 	cmd.Flags().Var(&options.certificateAuthority, clientcmd.FlagCAFile, "Path to "+clientcmd.FlagCAFile+" file for the cluster entry in kubeconfig")
 	cmd.MarkFlagFilename(clientcmd.FlagCAFile)
+	cmd.Flags().Var(&options.certificateAuthorityData, clientcmd.FlagCAData, "Base64 encoded certificate authority data")
 	f = cmd.Flags().VarPF(&options.embedCAData, clientcmd.FlagEmbedCerts, "", clientcmd.FlagEmbedCerts+" for the cluster entry in kubeconfig")
 	f.NoOptDefVal = "true"
 
@@ -108,8 +117,11 @@ func (o createClusterOptions) run() error {
 	if !exists {
 		startingStanza = clientcmdapi.NewCluster()
 	}
-	cluster := o.modifyCluster(*startingStanza)
-	config.Clusters[o.name] = &cluster
+	cluster, err := o.modifyCluster(*startingStanza)
+	if err != nil {
+		return err
+	}
+	config.Clusters[o.name] = cluster
 
 	if err := clientcmd.ModifyConfig(o.configAccess, *config, true); err != nil {
 		return err
@@ -119,7 +131,7 @@ func (o createClusterOptions) run() error {
 }
 
 // cluster builds a Cluster object from the options
-func (o *createClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluster) clientcmdapi.Cluster {
+func (o *createClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluster) (*clientcmdapi.Cluster, error) {
 	modifiedCluster := existingCluster
 
 	if o.server.Provided() {
@@ -142,7 +154,11 @@ func (o *createClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluste
 	if o.certificateAuthority.Provided() {
 		caPath := o.certificateAuthority.Value()
 		if o.embedCAData.Value() {
-			modifiedCluster.CertificateAuthorityData, _ = ioutil.ReadFile(caPath)
+			caData, err := ioutil.ReadFile(caPath)
+			if err != nil {
+				return nil, fmt.Errorf("could not read certificate authority data from %s: %v", caPath, err)
+			}
+			modifiedCluster.CertificateAuthorityData = caData
 			modifiedCluster.InsecureSkipTLSVerify = false
 			modifiedCluster.CertificateAuthority = ""
 		} else {
@@ -155,8 +171,17 @@ func (o *createClusterOptions) modifyCluster(existingCluster clientcmdapi.Cluste
 			}
 		}
 	}
+	if o.certificateAuthorityData.Provided() {
+		caData, err := base64.StdEncoding.DecodeString(o.certificateAuthorityData.Value())
+		if err != nil {
+			return nil, fmt.Errorf("could not decode certificate authority data: %v", err)
+		}
+		modifiedCluster.CertificateAuthorityData = caData
+		modifiedCluster.InsecureSkipTLSVerify = false
+		modifiedCluster.CertificateAuthority = ""
+	}
 
-	return modifiedCluster
+	return &modifiedCluster, nil
 }
 
 func (o *createClusterOptions) complete(cmd *cobra.Command) error {
@@ -173,18 +198,14 @@ func (o createClusterOptions) validate() error {
 	if len(o.name) == 0 {
 		return errors.New("you must specify a non-empty cluster name")
 	}
-	if o.insecureSkipTLSVerify.Value() && o.certificateAuthority.Value() != "" {
+	if o.insecureSkipTLSVerify.Value() && (o.certificateAuthority.Value() != "" || o.certificateAuthorityData.Value() != "") {
 		return errors.New("you cannot specify a certificate authority and insecure mode at the same time")
 	}
-	if o.embedCAData.Value() {
-		caPath := o.certificateAuthority.Value()
-		if caPath == "" {
-			return fmt.Errorf("you must specify a --%s to embed", clientcmd.FlagCAFile)
-		}
-		if _, err := ioutil.ReadFile(caPath); err != nil {
-			return fmt.Errorf("could not read %s data from %s: %v", clientcmd.FlagCAFile, caPath, err)
-		}
+	if o.certificateAuthority.Value() != "" && o.certificateAuthorityData.Value() != "" {
+		return fmt.Errorf("you cannot specify a certificate authority file and certificate authority data at the same time")
 	}
-
+	if o.embedCAData.Value() && o.certificateAuthority.Value() == "" {
+		return fmt.Errorf("you must specify a --%s to embed", clientcmd.FlagCAFile)
+	}
 	return nil
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/config/create_cluster_test.go
@@ -18,12 +18,16 @@ package config
 
 import (
 	"bytes"
+	"encoding/base64"
 	"io/ioutil"
 	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 type createClusterTest struct {
@@ -32,8 +36,44 @@ type createClusterTest struct {
 	args           []string
 	flags          []string
 	expected       string
+	expectedError  string
 	expectedConfig clientcmdapi.Config
 }
+
+// This is a certificate generated for testing and has no other significance
+const testCertificate string = `
+-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIUenSLpTUWjs+okVvbEx4YRX0rV1MwDQYJKoZIhvcNAQEL
+BQAwRTELMAkGA1UEBhMCQVUxEzARBgNVBAgMClNvbWUtU3RhdGUxITAfBgNVBAoM
+GEludGVybmV0IFdpZGdpdHMgUHR5IEx0ZDAeFw0yMDA0MTAxNjQyMTlaFw0zMDA0
+MDgxNjQyMTlaMEUxCzAJBgNVBAYTAkFVMRMwEQYDVQQIDApTb21lLVN0YXRlMSEw
+HwYDVQQKDBhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQwggIiMA0GCSqGSIb3DQEB
+AQUAA4ICDwAwggIKAoICAQC4qiGIPgOkrDAFVAilBwAGWrcAdcYRvc4fU9/dafwd
+XM4IAlOa8qtMXVw9rdomSlKXaxfaIRt7ycswLrSoVimy55g7DN7lNqDFjE6agARH
+EkzbYQ+WrDR3TgJf8vCqDgBwsCzz3/HWHMWXueN3YIFgKKDBxPsiA6XdqJv215Q6
+PETxcb6h4ay2Xo+MavSA7F5onrEvRGLJfnSOsd8HOZ3vATgKLPGLjew0HF57T/fR
+C8WLlq4TDbQknn4Hsou25tkIVANN7fYyyL7gXWKui+Kjm2+uCMacBN6kmfuCrRTW
+4CTIUrFR8iUIGcRvccND9JujgrzuRHpBNwov8yVXP9xbnEtoGhbyVZpTWPPr9rdz
+HXOJaMcSvffemA95ImSQ3qxnSuVnJc8jJKUiUFZIwga26k6BFfIIKxSvX8sBFLPU
+gTbFoAbf9Z24lHpL4od3e7reuWmhIOEFC7uzQFOor6/yfiIXss6xRDO356Zizfh6
+c7sy/MGLIm9jk7w7X/l+ND75lI2tuGQxD9Gy116f6ZLnqXFmLc7G+QMzzmXREHlm
+M3xDdayrcxR5hpZNPLzISbSF6484JWImvnYqCaLP7VFg9vWKVB0o5NgEdbAb0AXM
+rMKC+6Q9SFGMpwu6HwvQwQUseCqWCUjmiuZCPKzmVf5oqmuI4iQclf4RhNrGHn93
+VQIDAQABo1MwUTAdBgNVHQ4EFgQUkM9FpYk9oMPNEbGHdpn8PNxOWUUwHwYDVR0j
+BBgwFoAUkM9FpYk9oMPNEbGHdpn8PNxOWUUwDwYDVR0TAQH/BAUwAwEB/zANBgkq
+hkiG9w0BAQsFAAOCAgEAagMpJAFzeZ2U1mZkDZkJrIcuWOFP2rTzjnBMELjqzqcs
+8sqboRK9ef2XpHRXtvlDuBcFBwXaB/dVxb7pjVRxCbG7QVN1bhztrtTUmGoRa4aS
+3IOW9WOxOq+Oywj9GPud/dapfuk43y/RLT3m0A32AtborxgoSiLAKKbZ8RqoGqih
+hukwLhgpKjOrp6Ibqv5OfK93WE/RCAWz/H7bPCaLoMK/DFtQiZMK+PRnvyEWvpnt
+pdcKqgSVKvBKwnJaRICl/vR+evsQHXYe0B+N27aMcJ4nU3Dxw2bsuma7c5Gy00FH
+U9ZpR4+XPqdjHtqFkw7m/UPomb2OPfwSiEfE7yoX139Kqk9159otyOzue+C86gJ+
+hos631VEM/WWr6wXEZe7j9sQJneZ9eflvXlbtAWEpxxX/VLOzOzPALFIpPzOFigG
+pJQftZWJY4Hrj93x+tJwxGB61QMjM8OPdvvpj8+8vQ1Ue8YRiD86+b6IqaX0uBM9
+g7vtDs8oizDnwUomr5K5nQRixIJO3CA3Tp8wJxRYmy92e+oKxO3gdGfQ+1vUUAmn
+811Kkf+41cHP99Is9Km6bKTI0ttsh90OAhx4fz1DfiuX8zdXdxGpvcGyyxltDROv
+rSCNAJXLEWEAHZz8UNCqr53mxldt9dOkpkmZYX3KZY3/xibcBcALp5CQHlQcRsY=
+-----END CERTIFICATE-----
+`
 
 func TestCreateCluster(t *testing.T) {
 	conf := clientcmdapi.Config{}
@@ -102,6 +142,161 @@ func TestModifyClusterServerAndTLS(t *testing.T) {
 	test.run(t)
 }
 
+func TestCertificateAuthorityFlags(t *testing.T) {
+
+	// Create a temp file containing the ca for testing
+	d, err := ioutil.TempDir("", "kubectl-test")
+	if err != nil {
+		t.Fatalf("tempdir: %v", err)
+	}
+	defer os.RemoveAll(d)
+	caPath := filepath.Join(d, "test-ca.crt")
+	ioutil.WriteFile(caPath, []byte(testCertificate), 0644)
+
+	conf := clientcmdapi.Config{}
+	tests := []createClusterTest{
+		{
+			description: "CertificateAuthority should contain ca filename",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority=" + caPath,
+			},
+			expected: "Cluster \"my-cluster\" set.\n",
+			expectedConfig: clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"my-cluster": {
+						Server:                   "http://192.168.0.1",
+						TLSServerName:            "my-tls-server-name",
+						CertificateAuthority:     caPath,
+						CertificateAuthorityData: nil,
+					},
+				},
+			},
+		},
+		{
+			description: "CertificateAuthorityData should contain data from ca file if --embed-certs flag is specified",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority=" + caPath,
+				"--embed-certs",
+			},
+			expected: "Cluster \"my-cluster\" set.\n",
+			expectedConfig: clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"my-cluster": {
+						Server:                   "http://192.168.0.1",
+						TLSServerName:            "my-tls-server-name",
+						CertificateAuthority:     "",
+						CertificateAuthorityData: []byte(testCertificate),
+					},
+				},
+			},
+		},
+		{
+			description: "CertificateAuthorityData should contain base64 decoded data --certificate-authority-data flag",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority-data=" + base64.StdEncoding.EncodeToString([]byte(testCertificate)),
+			},
+			expected: "Cluster \"my-cluster\" set.\n",
+			expectedConfig: clientcmdapi.Config{
+				Clusters: map[string]*clientcmdapi.Cluster{
+					"my-cluster": {
+						Server:                   "http://192.168.0.1",
+						TLSServerName:            "my-tls-server-name",
+						CertificateAuthority:     "",
+						CertificateAuthorityData: []byte(testCertificate),
+					},
+				},
+			},
+		},
+		{
+			description: "SetCluster should fail if --embed-certs is specified without --certificate-authority or --certificate-authority-data",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--embed-certs",
+			},
+			expectedError: "error: you must specify a --certificate-authority to embed",
+		},
+		{
+			description: "SetCluster should fail if both --certificate-authority and --certificate-authority-data are specified",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority=" + caPath,
+				"--certificate-authority-data=" + base64.StdEncoding.EncodeToString([]byte(testCertificate)),
+			},
+			expectedError: "error: you cannot specify a certificate authority file and certificate authority data at the same time",
+		},
+		{
+			description: "SetCluster should fail if --certificate-authority and --insecure-skip-tls-verify are specified",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority=" + caPath,
+				"--insecure-skip-tls-verify",
+			},
+			expectedError: "error: you cannot specify a certificate authority and insecure mode at the same time",
+		},
+		{
+			description: "SetCluster should fail if --certificate-authority-data and --insecure-skip-tls-verify are specified",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority-data=" + base64.StdEncoding.EncodeToString([]byte(testCertificate)),
+				"--insecure-skip-tls-verify",
+			},
+			expectedError: "error: you cannot specify a certificate authority and insecure mode at the same time",
+		},
+		{
+			description: "SetCluster should fail if --certificate-authority-data does not contain base64 encoded data",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority-data=foo",
+			},
+			expectedError: "error: could not decode certificate authority data: illegal base64 data at input byte 0",
+		},
+		{
+			description: "SetCluster should fail if --embed-certs is specified and --certificate-authority file does not exist",
+			config:      conf,
+			args:        []string{"my-cluster"},
+			flags: []string{
+				"--server=http://192.168.0.1",
+				"--tls-server-name=my-tls-server-name",
+				"--certificate-authority=/file/does/not/exist",
+				"--embed-certs",
+			},
+			expectedError: "error: could not read certificate authority data from /file/does/not/exist: open /file/does/not/exist: no such file or directory",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			test.run(t)
+		})
+	}
+}
+
 func (test createClusterTest) run(t *testing.T) {
 	fakeKubeFile, err := ioutil.TempFile(os.TempDir(), "")
 	if err != nil {
@@ -119,9 +314,25 @@ func (test createClusterTest) run(t *testing.T) {
 	cmd := NewCmdConfigSetCluster(buf, pathOptions)
 	cmd.SetArgs(test.args)
 	cmd.Flags().Parse(test.flags)
+
+	var actualError string
+	if len(test.expectedError) > 0 {
+		cmdutil.BehaviorOnFatal(func(str string, code int) {
+			actualError = str
+		})
+	}
+
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("unexpected error executing command: %v, args: %v, flags: %v", err, test.args, test.flags)
 	}
+
+	if len(test.expectedError) > 0 {
+		if actualError == test.expectedError {
+			return
+		}
+		t.Fatalf("Expected error %s but got %s", test.expectedError, actualError)
+	}
+
 	config, err := clientcmd.LoadFromFile(fakeKubeFile.Name())
 	if err != nil {
 		t.Fatalf("unexpected error loading kubeconfig file: %v", err)
@@ -137,11 +348,24 @@ func (test createClusterTest) run(t *testing.T) {
 			t.Errorf("expected cluster %v, but got nil", test.args[0])
 			return
 		}
-		if cluster.Server != test.expectedConfig.Clusters[test.args[0]].Server {
-			t.Errorf("Fail in %q\n expected cluster server %v\n but got %v\n ", test.description, test.expectedConfig.Clusters[test.args[0]].Server, cluster.Server)
+		expectedCluster := test.expectedConfig.Clusters[test.args[0]]
+		if cluster.Server != expectedCluster.Server {
+			t.Errorf("Fail in %q\n expectedCluster cluster server %v\n but got %v\n ", test.description, expectedCluster.Server, cluster.Server)
 		}
-		if cluster.TLSServerName != test.expectedConfig.Clusters[test.args[0]].TLSServerName {
-			t.Errorf("Fail in %q\n expected cluster TLS server name %q\n but got %q\n ", test.description, test.expectedConfig.Clusters[test.args[0]].TLSServerName, cluster.TLSServerName)
+		if cluster.TLSServerName != expectedCluster.TLSServerName {
+			t.Errorf("Fail in %q\n expectedCluster cluster TLS server name %q\n but got %q\n ", test.description, expectedCluster.TLSServerName, cluster.TLSServerName)
+		}
+
+		// The actual cluster has a location of origin in the temp folder.
+		// In order to compare the expected and actual paths, we need to also relativize the expected cluster's paths.
+		expectedCluster.LocationOfOrigin = cluster.LocationOfOrigin
+		clientcmd.RelativizeClusterLocalPaths(expectedCluster)
+
+		if cluster.CertificateAuthority != expectedCluster.CertificateAuthority {
+			t.Errorf("Fail in %q\n expectedCluster cluster certificate authority %q\n but got %q\n ", test.description, expectedCluster.CertificateAuthority, cluster.CertificateAuthority)
+		}
+		if !reflect.DeepEqual(cluster.CertificateAuthorityData, expectedCluster.CertificateAuthorityData) {
+			t.Errorf("Fail in %q\n expectedCluster cluster certificate authority data %q\n but got %q\n ", test.description, expectedCluster.CertificateAuthorityData, cluster.CertificateAuthorityData)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds `--certificate-authority-data` flag to `kubectl config set-cluster` to let you set ca using base64 encoded string directly on the command line, without saving it to a file.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/501

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Added --certificate-authority-data flag to kubectl config set-cluster to allow certificate authority data to be set using base64 encoded string
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
