### PR TITLE
Add debug by copy support for kubectl alpha debug command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/BUILD
@@ -32,6 +32,7 @@ go_library(
         "//vendor/github.com/docker/distribution/reference:go_default_library",
         "//vendor/github.com/spf13/cobra:go_default_library",
         "//vendor/k8s.io/klog/v2:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 
@@ -55,7 +56,9 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/debug/debug.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/spf13/cobra"
+	"k8s.io/klog/v2"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -37,7 +38,6 @@ import (
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
 	watchtools "k8s.io/client-go/tools/watch"
-	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/cmd/attach"
 	"k8s.io/kubectl/pkg/cmd/exec"
 	"k8s.io/kubectl/pkg/cmd/logs"
@@ -47,6 +47,7 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/interrupt"
 	"k8s.io/kubectl/pkg/util/templates"
+	"k8s.io/utils/pointer"
 )
 
 var (
@@ -59,26 +60,39 @@ var (
 
 		# Create a debug container named debugger using a custom automated debugging image.
 		# (requires the EphemeralContainers feature to be enabled in the cluster)
-		kubectl alpha debug --image=myproj/debug-tools -c debugger mypod`))
+		kubectl alpha debug --image=myproj/debug-tools -c debugger mypod
+
+		# Create a debug container as a copy of the original Pod and attach to it
+		kubectl alpha debug mypod -it --image=busybox --copy-to=my-debugger
+
+		# Create a copy of mypod named my-debugger with my-container's image changed to busybox
+		kubectl alpha debug mypod --image=busybox --container=my-container --copy-to=my-debugger -- sleep 1d
+`))
 )
 
 var nameSuffixFunc = utilrand.String
 
 // DebugOptions holds the options for an invocation of kubectl debug.
 type DebugOptions struct {
-	Args        []string
-	ArgsOnly    bool
-	Attach      bool
-	Container   string
-	Env         []corev1.EnvVar
-	Image       string
-	Interactive bool
-	Namespace   string
-	TargetNames []string
-	PullPolicy  corev1.PullPolicy
-	Quiet       bool
-	Target      string
-	TTY         bool
+	Args           []string
+	ArgsOnly       bool
+	Attach         bool
+	Container      string
+	CopyTo         string
+	Replace        bool
+	Env            []corev1.EnvVar
+	Image          string
+	Interactive    bool
+	Namespace      string
+	TargetNames    []string
+	PullPolicy     corev1.PullPolicy
+	Quiet          bool
+	SameNode       bool
+	ShareProcesses bool
+	Target         string
+	TTY            bool
+
+	shareProcessedChanged bool
 
 	builder   *resource.Builder
 	podClient corev1client.PodsGetter
@@ -89,9 +103,10 @@ type DebugOptions struct {
 // NewDebugOptions returns a DebugOptions initialized with default values.
 func NewDebugOptions(streams genericclioptions.IOStreams) *DebugOptions {
 	return &DebugOptions{
-		Args:        []string{},
-		IOStreams:   streams,
-		TargetNames: []string{},
+		Args:           []string{},
+		IOStreams:      streams,
+		TargetNames:    []string{},
+		ShareProcesses: true,
 	}
 }
 
@@ -120,12 +135,16 @@ func addDebugFlags(cmd *cobra.Command, opt *DebugOptions) {
 	cmd.Flags().BoolVar(&opt.ArgsOnly, "arguments-only", opt.ArgsOnly, i18n.T("If specified, everything after -- will be passed to the new container as Args instead of Command."))
 	cmd.Flags().BoolVar(&opt.Attach, "attach", opt.Attach, i18n.T("If true, wait for the Pod to start running, and then attach to the Pod as if 'kubectl attach ...' were called.  Default false, unless '-i/--stdin' is set, in which case the default is true."))
 	cmd.Flags().StringVarP(&opt.Container, "container", "c", opt.Container, i18n.T("Container name to use for debug container."))
+	cmd.Flags().StringVar(&opt.CopyTo, "copy-to", opt.CopyTo, i18n.T("Create a copy of the target Pod with this name."))
+	cmd.Flags().BoolVar(&opt.Replace, "replace", opt.Replace, i18n.T("When used with '--copy-to', delete the original Pod"))
 	cmd.Flags().StringToString("env", nil, i18n.T("Environment variables to set in the container."))
 	cmd.Flags().StringVar(&opt.Image, "image", opt.Image, i18n.T("Container image to use for debug container."))
 	cmd.MarkFlagRequired("image")
 	cmd.Flags().String("image-pull-policy", string(corev1.PullIfNotPresent), i18n.T("The image pull policy for the container."))
 	cmd.Flags().BoolVarP(&opt.Interactive, "stdin", "i", opt.Interactive, i18n.T("Keep stdin open on the container(s) in the pod, even if nothing is attached."))
 	cmd.Flags().BoolVar(&opt.Quiet, "quiet", opt.Quiet, i18n.T("If true, suppress prompt messages."))
+	cmd.Flags().BoolVar(&opt.SameNode, "same-node", opt.SameNode, i18n.T("Schedule the copy of target Pod on the same node."))
+	cmd.Flags().BoolVar(&opt.ShareProcesses, "share-processes", opt.ShareProcesses, i18n.T("When used with '--copy-to', enable process namespace sharing in the copy."))
 	cmd.Flags().StringVar(&opt.Target, "target", "", i18n.T("Target processes in this container name."))
 	cmd.Flags().BoolVarP(&opt.TTY, "tty", "t", opt.TTY, i18n.T("Allocated a TTY for each container in the pod."))
 }
@@ -172,6 +191,9 @@ func (o *DebugOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args []st
 		return fmt.Errorf("internal error getting clientset: %v", err)
 	}
 	o.podClient = clientset.CoreV1()
+
+	// Share processes
+	o.shareProcessedChanged = cmd.Flags().Changed("share-processes")
 
 	return nil
 }
@@ -273,9 +295,17 @@ func (o *DebugOptions) Run(f cmdutil.Factory, cmd *cobra.Command) error {
 
 // visitPod handles debugging for pod targets by (depending on options):
 //   1. Creating an ephemeral debug container in an existing pod, OR
-//   2. Making a copy of pod with certain attributes changed (NOT YET IMPLEMENTED)
+//   2. Making a copy of pod with certain attributes changed
 // visitPod returns a pod and debug container name for subsequent attach, if applicable.
 func (o *DebugOptions) visitPod(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, string, error) {
+	if len(o.CopyTo) > 0 {
+		return o.debugByCopy(ctx, pod)
+	}
+	return o.debugByEphemeralContainer(ctx, pod)
+}
+
+// debugByEphemeralContainer runs an EphemeralContainer in the target Pod for use as a debug container
+func (o *DebugOptions) debugByEphemeralContainer(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, string, error) {
 	pods := o.podClient.Pods(pod.Namespace)
 	ec, err := pods.GetEphemeralContainers(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
@@ -298,34 +328,26 @@ func (o *DebugOptions) visitPod(ctx context.Context, pod *corev1.Pod) (*corev1.P
 	return pod, debugContainer.Name, nil
 }
 
-func containerNames(pod *corev1.Pod) map[string]bool {
-	names := map[string]bool{}
-	for _, c := range pod.Spec.Containers {
-		names[c.Name] = true
+// debugByCopy runs a copy of the target Pod with a debug container added or an original container modified
+func (o *DebugOptions) debugByCopy(ctx context.Context, pod *corev1.Pod) (*corev1.Pod, string, error) {
+	copied, dc := o.generatePodCopyWithDebugContainer(pod)
+	copied, err := o.podClient.Pods(copied.Namespace).Create(ctx, copied, metav1.CreateOptions{})
+	if err != nil {
+		return nil, "", err
 	}
-	for _, c := range pod.Spec.InitContainers {
-		names[c.Name] = true
+	if o.Replace {
+		err := o.podClient.Pods(pod.Namespace).Delete(ctx, pod.Name, *metav1.NewDeleteOptions(0))
+		if err != nil {
+			return nil, "", err
+		}
 	}
-	for _, c := range pod.Spec.EphemeralContainers {
-		names[c.Name] = true
-	}
-	return names
+	return copied, dc, nil
 }
 
 // generateDebugContainer returns an EphemeralContainer suitable for use as a debug container
 // in the given pod.
 func (o *DebugOptions) generateDebugContainer(pod *corev1.Pod) *corev1.EphemeralContainer {
-	name := o.Container
-	if len(name) == 0 {
-		cn, existing := "", containerNames(pod)
-		for len(cn) == 0 || existing[cn] {
-			cn = fmt.Sprintf("debugger-%s", nameSuffixFunc(5))
-		}
-		if !o.Quiet {
-			fmt.Fprintf(o.ErrOut, "Defaulting debug container name to %s.\n", cn)
-		}
-		name = cn
-	}
+	name := o.computeDebugContainerName(pod)
 
 	ec := &corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
@@ -349,8 +371,87 @@ func (o *DebugOptions) generateDebugContainer(pod *corev1.Pod) *corev1.Ephemeral
 	return ec
 }
 
-// waitForEphemeralContainer watches the given pod until the ephemeralContainer is running
-func waitForEphemeralContainer(ctx context.Context, podClient corev1client.PodsGetter, ns, podName, ephemeralContainerName string) (*corev1.Pod, error) {
+// generatePodCopy takes a Pod and returns a copy and the debug container name of that copy
+func (o *DebugOptions) generatePodCopyWithDebugContainer(pod *corev1.Pod) (*corev1.Pod, string) {
+	copied := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        o.CopyTo,
+			Namespace:   pod.Namespace,
+			Annotations: pod.Annotations,
+		},
+		Spec: *pod.Spec.DeepCopy(),
+	}
+	// change ShareProcessNamespace configuration only when commanded explicitly
+	if o.shareProcessedChanged {
+		copied.Spec.ShareProcessNamespace = pointer.BoolPtr(o.ShareProcesses)
+	}
+	if !o.SameNode {
+		copied.Spec.NodeName = ""
+	}
+
+	containerByName := containerNameToRef(copied)
+	c, containerExists := containerByName[o.Container]
+	// Add a new container if the specified container does not exist
+	if !containerExists {
+		name := o.computeDebugContainerName(copied)
+		c = &corev1.Container{Name: name}
+		// envs are customizable when adding new container
+		c.Env = o.Env
+	}
+	c.Image = o.Image
+	c.ImagePullPolicy = o.PullPolicy
+	c.Stdin = o.Interactive
+	c.TerminationMessagePolicy = corev1.TerminationMessageReadFile
+	c.TTY = o.TTY
+	if o.ArgsOnly {
+		c.Args = o.Args
+	} else {
+		c.Command = o.Args
+		c.Args = nil
+	}
+	if !containerExists {
+		copied.Spec.Containers = append(copied.Spec.Containers, *c)
+	}
+	return copied, c.Name
+}
+
+func (o *DebugOptions) computeDebugContainerName(pod *corev1.Pod) string {
+	if len(o.Container) > 0 {
+		return o.Container
+	}
+	name := o.Container
+	if len(name) == 0 {
+		cn, containerByName := "", containerNameToRef(pod)
+		for len(cn) == 0 || (containerByName[cn] != nil) {
+			cn = fmt.Sprintf("debugger-%s", nameSuffixFunc(5))
+		}
+		if !o.Quiet {
+			fmt.Fprintf(o.ErrOut, "Defaulting debug container name to %s.\n", cn)
+		}
+		name = cn
+	}
+	return name
+}
+
+func containerNameToRef(pod *corev1.Pod) map[string]*corev1.Container {
+	names := map[string]*corev1.Container{}
+	for i := range pod.Spec.Containers {
+		ref := &pod.Spec.Containers[i]
+		names[ref.Name] = ref
+	}
+	for i := range pod.Spec.InitContainers {
+		ref := &pod.Spec.Containers[i]
+		names[ref.Name] = ref
+	}
+	for i := range pod.Spec.EphemeralContainers {
+		ref := &pod.Spec.Containers[i]
+		names[ref.Name] = ref
+	}
+	return names
+}
+
+// waitForContainer watches the given pod until the container is running
+func waitForContainer(ctx context.Context, podClient corev1client.PodsGetter, ns, podName, containerName string) (*corev1.Pod, error) {
 	// TODO: expose the timeout
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(ctx, 0*time.Second)
 	defer cancel()
@@ -381,17 +482,14 @@ func waitForEphemeralContainer(ctx context.Context, podClient corev1client.PodsG
 				return false, fmt.Errorf("watch did not return a pod: %v", ev.Object)
 			}
 
-			for _, s := range p.Status.EphemeralContainerStatuses {
-				if s.Name != ephemeralContainerName {
-					continue
-				}
-
-				klog.V(2).Infof("debug container status is %v", s)
-				if s.State.Running != nil || s.State.Terminated != nil {
-					return true, nil
-				}
+			s := getContainerStatusByName(p, containerName)
+			if s == nil {
+				return false, nil
 			}
-
+			klog.V(2).Infof("debug container status is %v", s)
+			if s.State.Running != nil || s.State.Terminated != nil {
+				return true, nil
+			}
 			return false, nil
 		})
 		if ev != nil {
@@ -403,9 +501,8 @@ func waitForEphemeralContainer(ctx context.Context, podClient corev1client.PodsG
 	return result, err
 }
 
-// TODO(verb): handle other types of containers
-func handleAttachPod(ctx context.Context, f cmdutil.Factory, podClient corev1client.PodsGetter, ns, podName, ephemeralContainerName string, opts *attach.AttachOptions) error {
-	pod, err := waitForEphemeralContainer(ctx, podClient, ns, podName, ephemeralContainerName)
+func handleAttachPod(ctx context.Context, f cmdutil.Factory, podClient corev1client.PodsGetter, ns, podName, containerName string, opts *attach.AttachOptions) error {
+	pod, err := waitForContainer(ctx, podClient, ns, podName, containerName)
 	if err != nil {
 		return err
 	}
@@ -413,16 +510,15 @@ func handleAttachPod(ctx context.Context, f cmdutil.Factory, podClient corev1cli
 	opts.Namespace = ns
 	opts.Pod = pod
 	opts.PodName = podName
-	opts.ContainerName = ephemeralContainerName
+	opts.ContainerName = containerName
 	if opts.AttachFunc == nil {
 		opts.AttachFunc = attach.DefaultAttachFunc
 	}
 
-	var status *corev1.ContainerStatus
-	for i := range pod.Status.EphemeralContainerStatuses {
-		if pod.Status.EphemeralContainerStatuses[i].Name == ephemeralContainerName {
-			status = &pod.Status.EphemeralContainerStatuses[i]
-		}
+	status := getContainerStatusByName(pod, containerName)
+	if status == nil {
+		// impossible path
+		return fmt.Errorf("Error get container status of %s: %+v", containerName, err)
 	}
 	if status.State.Terminated != nil {
 		klog.V(1).Info("Ephemeral container terminated, falling back to logs")
@@ -432,6 +528,18 @@ func handleAttachPod(ctx context.Context, f cmdutil.Factory, podClient corev1cli
 	if err := opts.Run(); err != nil {
 		fmt.Fprintf(opts.ErrOut, "Error attaching, falling back to logs: %v\n", err)
 		return logOpts(f, pod, opts)
+	}
+	return nil
+}
+
+func getContainerStatusByName(pod *corev1.Pod, containerName string) *corev1.ContainerStatus {
+	allContainerStatus := [][]corev1.ContainerStatus{pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses, pod.Status.EphemeralContainerStatuses}
+	for _, statusSlice := range allContainerStatus {
+		for i := range statusSlice {
+			if statusSlice[i].Name == containerName {
+				return &statusSlice[i]
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Aylei <rayingecho@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add debug by copy support as per [Pod troubleshooting by Copy](https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20190805-kubectl-debug.md#pod-troubleshooting-by-copy) 
ref: https://github.com/kubernetes/enhancements/issues/1441

**Special notes for your reviewer**:
Only UTs were added yet, I did some manual e2e tests though:
```
$ kubectl alpha debug -it  my-pod --copy-to=debugger --image=busybox -- sh
Defaulting debug container name to debugger-cjbqx.
If you don't see a command prompt, try pressing enter.
/ #

$ kubectl alpha debug -it my-pod --copy-to=debugger2 --container=server --image=busybox -- sh
If you don't see a command prompt, try pressing enter.
/ #

$ kubectl alpha debug my-pod --copy-to=debugger3 --container=server --image=busybox -- sleep 1d
$ kubectl get po
$ kubectl get po debugger3
NAME        READY   STATUS    RESTARTS   AGE
debugger3   1/1     Running   0          10s

$ kubectl alpha debug -it mysql-0 --copy-to=debug-mysql --delete-old --image=busybox -- sh
Defaulting debug container name to debugger-tvg57.
If you don't see a command prompt, try pressing enter.
/ #

# The original Pod is stuck in creating because the PVC is attached to the debug pod
$ kubectl get po
NAME                       READY   STATUS              RESTARTS   AGE
debug-mysql                2/2     Running             1          2m24s
mysql-0                    0/1     ContainerCreating   0          2m25s
```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
`kubectl alpha debug` command now supports debugging pods by copy the original one.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: 
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
- [KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20190805-kubectl-debug.md#pod-troubleshooting-by-copy
```
