### PR TITLE
Add test for ingress/egress combination

### DIFF
--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -104,12 +104,13 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			nsB, err := f.CreateNamespace(nsBName, map[string]string{
 				"ns-name": nsBName,
 			})
+			framework.ExpectNoError(err, "Error occurred while creating namespace-b.")
 
 			ginkgo.By("Creating a simple server in another namespace that serves on port 80 and 81.")
-			_, serviceB := createServerPodAndService(f, nsB, "pod-b", []int{80, 81})
+			podB, serviceB := createServerPodAndService(f, nsB, "pod-b", []int{80, 81})
 
 			ginkgo.By("Waiting for pod ready", func() {
-				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podServer.Name, f.Namespace.Name, framework.PodStartTimeout)
+				err := e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, nsB.Name, framework.PodStartTimeout)
 				framework.ExpectNoError(err)
 			})
 

--- a/test/e2e/network/network_policy.go
+++ b/test/e2e/network/network_policy.go
@@ -78,14 +78,36 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			cleanupServerPodAndService(f, podServer, service)
 		})
 
-		ginkgo.It("should support a 'default-deny' policy [Feature:NetworkPolicy]", func() {
+		ginkgo.It("should support a 'default-deny-ingress' policy [Feature:NetworkPolicy]", func() {
 			policy := &networkingv1.NetworkPolicy{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "deny-all",
+					Name: "deny-ingress",
 				},
 				Spec: networkingv1.NetworkPolicySpec{
 					PodSelector: metav1.LabelSelector{},
 					Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+				},
+			}
+
+			policy, err := f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(context.TODO(), policy, metav1.CreateOptions{})
+			framework.ExpectNoError(err)
+			defer cleanupNetworkPolicy(f, policy)
+
+			// Create a pod with name 'client-cannot-connect', which will attempt to communicate with the server,
+			// but should not be able to now that isolation is on.
+			testCannotConnect(f, f.Namespace, "client-cannot-connect", service, 80)
+		})
+
+		ginkgo.It("should support a 'default-deny-all' policy [Feature:NetworkPolicy]", func() {
+			policy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "default-deny-all",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PodSelector: metav1.LabelSelector{},
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress, networkingv1.PolicyTypeIngress},
+					Ingress:     []networkingv1.NetworkPolicyIngressRule{},
+					Egress:      []networkingv1.NetworkPolicyEgressRule{},
 				},
 			}
 
@@ -904,6 +926,94 @@ var _ = SIGDescribe("NetworkPolicy [LinuxOnly]", func() {
 			ginkgo.By(fmt.Sprintf("Updating server pod %s to be selected by network policy %s.", podServer.Name, policy.Name))
 			updatePodLabel(f, f.Namespace, podServer.Name, "add", "/metadata/labels/isolated", nil)
 			testCannotConnect(f, f.Namespace, "client-a", service, allowedPort)
+		})
+
+		ginkgo.It("should work with Ingress,Egress specified together [Feature:NetworkPolicy]", func() {
+			const allowedPort = 80
+			const notAllowedPort = 81
+			protocolUDP := v1.ProtocolUDP
+
+			nsBName := f.BaseName + "-b"
+			nsB, err := f.CreateNamespace(nsBName, map[string]string{
+				"ns-name": nsBName,
+			})
+			framework.ExpectNoError(err, "Error occurred while creating namespace-b.")
+
+			podB, serviceB := createServerPodAndService(f, nsB, "pod-b", []int{allowedPort, notAllowedPort})
+			defer cleanupServerPodAndService(f, podB, serviceB)
+
+			// Wait for Server with Service in NS-B to be ready
+			framework.Logf("Waiting for servers to be ready.")
+			err = e2epod.WaitTimeoutForPodReadyInNamespace(f.ClientSet, podB.Name, nsB.Name, framework.PodStartTimeout)
+			framework.ExpectNoError(err, "Error occurred while waiting for pod status in namespace: Ready.")
+
+			ginkgo.By("Create a network policy for the server which denies both Ingress and Egress traffic.")
+			policy := &networkingv1.NetworkPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "ingress-egress-rule",
+				},
+				Spec: networkingv1.NetworkPolicySpec{
+					PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeIngress, networkingv1.PolicyTypeEgress},
+					Ingress: []networkingv1.NetworkPolicyIngressRule{{
+						From: []networkingv1.NetworkPolicyPeer{{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"ns-name": nsBName,
+								},
+							},
+						}},
+						Ports: []networkingv1.NetworkPolicyPort{{
+							Port: &intstr.IntOrString{IntVal: allowedPort},
+						}},
+					}},
+					Egress: []networkingv1.NetworkPolicyEgressRule{
+						{
+							Ports: []networkingv1.NetworkPolicyPort{
+								// Allow DNS look-ups
+								{
+									Protocol: &protocolUDP,
+									Port:     &intstr.IntOrString{Type: intstr.Int, IntVal: 53},
+								},
+							},
+						},
+						{
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											"ns-name": nsBName,
+										},
+									},
+								},
+							},
+							Ports: []networkingv1.NetworkPolicyPort{{
+								Port: &intstr.IntOrString{IntVal: allowedPort},
+							}},
+						},
+					},
+				},
+			}
+
+			policy, err = f.ClientSet.NetworkingV1().NetworkPolicies(f.Namespace.Name).Create(context.TODO(), policy, metav1.CreateOptions{})
+			framework.ExpectNoError(err, "Error creating Network Policy %v: %v", policy.ObjectMeta.Name, err)
+			defer cleanupNetworkPolicy(f, policy)
+
+			ginkgo.By("client-a should be able to communicate with server port 80 in namespace-b", func() {
+				testCanConnect(f, f.Namespace, "client-a", serviceB, allowedPort)
+			})
+
+			ginkgo.By("client-b should be able to communicate with server port 80 in namespace-a", func() {
+				testCanConnect(f, nsB, "client-b", service, allowedPort)
+			})
+
+			ginkgo.By("client-a should not be able to communicate with server port 81 in namespace-b", func() {
+				testCannotConnect(f, f.Namespace, "client-a", serviceB, notAllowedPort)
+			})
+
+			ginkgo.By("client-b should not be able to communicate with server port 81 in namespace-a", func() {
+				testCannotConnect(f, nsB, "client-b", service, notAllowedPort)
+			})
+
 		})
 
 		ginkgo.It("should enforce egress policy allowing traffic to a server in a different namespace based on PodSelector and NamespaceSelector [Feature:NetworkPolicy]", func() {


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Add test to cover network policies when both Ingress and Egress are specified

**Which issue(s) this PR fixes**:
Fixes #87893

**Special notes for your reviewer**:
I found that running e2e tests on local computer might be challenging for beginners, I used combination of https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/e2e-tests.md https://github.com/kubernetes-sigs/kind/issues/1181#issuecomment-567001724 and custom CNI plugin (Calico) installed in kind.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```