### PR TITLE
Fix golint issues for test/utils

### DIFF
--- a/hack/.golint_failures
+++ b/hack/.golint_failures
@@ -502,5 +502,3 @@ staging/src/k8s.io/sample-apiserver/pkg/apis/wardle
 staging/src/k8s.io/sample-apiserver/pkg/apis/wardle/v1alpha1
 staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/fischer
 staging/src/k8s.io/sample-apiserver/pkg/registry/wardle/flunder
-test/e2e/common
-test/utils

--- a/test/e2e/common/container_probe.go
+++ b/test/e2e/common/container_probe.go
@@ -266,6 +266,7 @@ var _ = framework.KubeDescribe("Probing container", func() {
 	})
 })
 
+// GetContainerStartedTime returns the StartedAt time of a Container.
 func GetContainerStartedTime(p *v1.Pod, containerName string) (time.Time, error) {
 	for _, status := range p.Status.ContainerStatuses {
 		if status.Name != containerName {
@@ -279,6 +280,7 @@ func GetContainerStartedTime(p *v1.Pod, containerName string) (time.Time, error)
 	return time.Time{}, fmt.Errorf("cannot find container named %q", containerName)
 }
 
+// GetTransitionTimeForReadyCondition returns the LastTransitionTime of a Pod.
 func GetTransitionTimeForReadyCondition(p *v1.Pod) (time.Time, error) {
 	for _, cond := range p.Status.Conditions {
 		if cond.Type == v1.PodReady {
@@ -407,6 +409,7 @@ func (b webserverProbeBuilder) build() *v1.Probe {
 	return probe
 }
 
+// RunLivenessTest runs a Liveness test on a Pod.
 func RunLivenessTest(f *framework.Framework, pod *v1.Pod, expectNumRestarts int, timeout time.Duration) {
 	podClient := f.PodClient()
 	ns := f.Namespace.Name

--- a/test/e2e/common/kubelet_etc_hosts.go
+++ b/test/e2e/common/kubelet_etc_hosts.go
@@ -38,6 +38,7 @@ const (
 
 var etcHostsImageName = imageutils.GetE2EImage(imageutils.Agnhost)
 
+// KubeletManagedHostConfig holds host managed Pod informations.
 type KubeletManagedHostConfig struct {
 	hostNetworkPod *v1.Pod
 	pod            *v1.Pod

--- a/test/utils/conditions.go
+++ b/test/utils/conditions.go
@@ -23,6 +23,7 @@ import (
 	podutil "k8s.io/kubernetes/pkg/api/v1/pod"
 )
 
+// ContainerFailures holds failure information for a container.
 type ContainerFailures struct {
 	status   *v1.ContainerStateTerminated
 	Restarts int
@@ -44,6 +45,7 @@ func PodRunningReady(p *v1.Pod) (bool, error) {
 	return true, nil
 }
 
+// PodRunningReadyOrSucceeded check if phase is succeeded or running.
 func PodRunningReadyOrSucceeded(p *v1.Pod) (bool, error) {
 	// Check if the phase is succeeded.
 	if p.Status.Phase == v1.PodSucceeded {

--- a/test/utils/create_resources.go
+++ b/test/utils/create_resources.go
@@ -43,7 +43,7 @@ const (
 	retryBackoffSteps           = 6
 )
 
-// Utility for retrying the given function with exponential backoff.
+// RetryWithExponentialBackOff is a utility for retrying the given function with exponential backoff.
 func RetryWithExponentialBackOff(fn wait.ConditionFunc) error {
 	backoff := wait.Backoff{
 		Duration: retryBackoffInitialDuration,
@@ -54,6 +54,7 @@ func RetryWithExponentialBackOff(fn wait.ConditionFunc) error {
 	return wait.ExponentialBackoff(backoff, fn)
 }
 
+// IsRetryableAPIError verifies if the error is liable for retry.
 func IsRetryableAPIError(err error) bool {
 	// These errors may indicate a transient error that we can retry in tests.
 	if apierrors.IsInternalError(err) || apierrors.IsTimeout(err) || apierrors.IsServerTimeout(err) ||
@@ -67,6 +68,7 @@ func IsRetryableAPIError(err error) bool {
 	return false
 }
 
+// CreatePodWithRetries creates a new Pod while retrying on failure.
 func CreatePodWithRetries(c clientset.Interface, namespace string, obj *v1.Pod) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -84,6 +86,7 @@ func CreatePodWithRetries(c clientset.Interface, namespace string, obj *v1.Pod) 
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateRCWithRetries creates a new ReplicationController while retrying on failure.
 func CreateRCWithRetries(c clientset.Interface, namespace string, obj *v1.ReplicationController) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -101,6 +104,7 @@ func CreateRCWithRetries(c clientset.Interface, namespace string, obj *v1.Replic
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateReplicaSetWithRetries creates a new ReplicaSet retrying on failure.
 func CreateReplicaSetWithRetries(c clientset.Interface, namespace string, obj *apps.ReplicaSet) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -118,6 +122,7 @@ func CreateReplicaSetWithRetries(c clientset.Interface, namespace string, obj *a
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateDeploymentWithRetries creates a new Deployment while retrying on failure.
 func CreateDeploymentWithRetries(c clientset.Interface, namespace string, obj *apps.Deployment) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -135,6 +140,7 @@ func CreateDeploymentWithRetries(c clientset.Interface, namespace string, obj *a
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateDaemonSetWithRetries creates a new DaemonSet while retrying on failure.
 func CreateDaemonSetWithRetries(c clientset.Interface, namespace string, obj *apps.DaemonSet) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -152,6 +158,7 @@ func CreateDaemonSetWithRetries(c clientset.Interface, namespace string, obj *ap
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateJobWithRetries creates a new Job while retrying on failure.
 func CreateJobWithRetries(c clientset.Interface, namespace string, obj *batch.Job) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -169,6 +176,7 @@ func CreateJobWithRetries(c clientset.Interface, namespace string, obj *batch.Jo
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateSecretWithRetries creates a new Secret while retrying on failure.
 func CreateSecretWithRetries(c clientset.Interface, namespace string, obj *v1.Secret) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -186,6 +194,7 @@ func CreateSecretWithRetries(c clientset.Interface, namespace string, obj *v1.Se
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateConfigMapWithRetries creates a new ConfigMap while retrying on failure.
 func CreateConfigMapWithRetries(c clientset.Interface, namespace string, obj *v1.ConfigMap) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -203,6 +212,7 @@ func CreateConfigMapWithRetries(c clientset.Interface, namespace string, obj *v1
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateServiceWithRetries creates a new Service while retrying on failure.
 func CreateServiceWithRetries(c clientset.Interface, namespace string, obj *v1.Service) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -220,6 +230,7 @@ func CreateServiceWithRetries(c clientset.Interface, namespace string, obj *v1.S
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateStorageClassWithRetries creates a new StorageClass while retrying on failure.
 func CreateStorageClassWithRetries(c clientset.Interface, obj *storage.StorageClass) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -237,6 +248,7 @@ func CreateStorageClassWithRetries(c clientset.Interface, obj *storage.StorageCl
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreateResourceQuotaWithRetries creates a new ResourceQuota while retrying on failure.
 func CreateResourceQuotaWithRetries(c clientset.Interface, namespace string, obj *v1.ResourceQuota) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -254,6 +266,7 @@ func CreateResourceQuotaWithRetries(c clientset.Interface, namespace string, obj
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreatePersistentVolumeWithRetries create a new PersistentVolume while retrying on failure.
 func CreatePersistentVolumeWithRetries(c clientset.Interface, obj *v1.PersistentVolume) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")
@@ -271,6 +284,7 @@ func CreatePersistentVolumeWithRetries(c clientset.Interface, obj *v1.Persistent
 	return RetryWithExponentialBackOff(createFunc)
 }
 
+// CreatePersistentVolumeClaimWithRetries creates a new PersistentVolumeClaim while retrying on failure.
 func CreatePersistentVolumeClaimWithRetries(c clientset.Interface, namespace string, obj *v1.PersistentVolumeClaim) error {
 	if obj == nil {
 		return fmt.Errorf("Object provided to create is empty")

--- a/test/utils/delete_resources.go
+++ b/test/utils/delete_resources.go
@@ -57,6 +57,7 @@ func deleteResource(c clientset.Interface, kind schema.GroupKind, namespace, nam
 	}
 }
 
+// DeleteResourceWithRetries deletes a resource while retrying on failure.
 func DeleteResourceWithRetries(c clientset.Interface, kind schema.GroupKind, namespace, name string, options metav1.DeleteOptions) error {
 	deleteFunc := func() (bool, error) {
 		err := deleteResource(c, kind, namespace, name, options)

--- a/test/utils/density_utils.go
+++ b/test/utils/density_utils.go
@@ -34,6 +34,7 @@ const (
 	retries = 5
 )
 
+// AddLabelsToNode patches a list of labels in a particular node.
 func AddLabelsToNode(c clientset.Interface, nodeName string, labels map[string]string) error {
 	tokens := make([]string, 0, len(labels))
 	for k, v := range labels {
@@ -79,9 +80,8 @@ func RemoveLabelOffNode(c clientset.Interface, nodeName string, labelKeys []stri
 		if err != nil {
 			if !apierrors.IsConflict(err) {
 				return err
-			} else {
-				klog.V(2).Infof("Conflict when trying to remove a labels %v from %v", labelKeys, nodeName)
 			}
+			klog.V(2).Infof("Conflict when trying to remove a labels %v from %v", labelKeys, nodeName)
 		} else {
 			break
 		}

--- a/test/utils/pod_store.go
+++ b/test/utils/pod_store.go
@@ -31,13 +31,14 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-// Convenient wrapper around cache.Store that returns list of v1.Pod instead of interface{}.
+// PodStore is convenient wrapper around cache.Store that returns list of v1.Pod instead of interface{}.
 type PodStore struct {
 	cache.Store
 	stopCh    chan struct{}
 	Reflector *cache.Reflector
 }
 
+// NewPodStore creates a new PodStore.
 func NewPodStore(c clientset.Interface, namespace string, label labels.Selector, field fields.Selector) (*PodStore, error) {
 	lw := &cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
@@ -68,6 +69,7 @@ func NewPodStore(c clientset.Interface, namespace string, label labels.Selector,
 	return &PodStore{Store: store, stopCh: stopCh, Reflector: reflector}, nil
 }
 
+// List the pods on an existent PodStore.
 func (s *PodStore) List() []*v1.Pod {
 	objects := s.Store.List()
 	pods := make([]*v1.Pod, 0)
@@ -77,6 +79,7 @@ func (s *PodStore) List() []*v1.Pod {
 	return pods
 }
 
+// Stop an existent PodStore.
 func (s *PodStore) Stop() {
 	close(s.stopCh)
 }

--- a/test/utils/replicaset.go
+++ b/test/utils/replicaset.go
@@ -28,8 +28,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
+// UpdateReplicaSetFunc is a type definition for a function that accepts RelicaSet.
 type UpdateReplicaSetFunc func(d *apps.ReplicaSet)
 
+// UpdateReplicaSetWithRetries updates a ReplicaSet retrying of failure.
 func UpdateReplicaSetWithRetries(c clientset.Interface, namespace, name string, applyUpdate UpdateReplicaSetFunc, logf LogfFn, pollInterval, pollTimeout time.Duration) (*apps.ReplicaSet, error) {
 	var rs *apps.ReplicaSet
 	var updateErr error
@@ -53,7 +55,7 @@ func UpdateReplicaSetWithRetries(c clientset.Interface, namespace, name string, 
 	return rs, pollErr
 }
 
-// Verify .Status.Replicas is equal to .Spec.Replicas
+// WaitRSStable verifies if .Status.Replicas is equal to .Spec.Replicas.
 func WaitRSStable(t *testing.T, clientSet clientset.Interface, rs *apps.ReplicaSet, pollInterval, pollTimeout time.Duration) error {
 	desiredGeneration := rs.Generation
 	if err := wait.PollImmediate(pollInterval, pollTimeout, func() (bool, error) {
@@ -68,6 +70,7 @@ func WaitRSStable(t *testing.T, clientSet clientset.Interface, rs *apps.ReplicaS
 	return nil
 }
 
+// UpdateReplicaSetStatusWithRetries update a ReplicaSet status while retrying on failure.
 func UpdateReplicaSetStatusWithRetries(c clientset.Interface, namespace, name string, applyUpdate UpdateReplicaSetFunc, logf LogfFn, pollInterval, pollTimeout time.Duration) (*apps.ReplicaSet, error) {
 	var rs *apps.ReplicaSet
 	var updateErr error

--- a/test/utils/tmpdir.go
+++ b/test/utils/tmpdir.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog"
 )
 
+// MakeTempDirOrDie creates a new temporary directory or die in case of failure.
 func MakeTempDirOrDie(prefix string, baseDir string) string {
 	if baseDir == "" {
 		baseDir = "/tmp"

--- a/test/utils/update_resources.go
+++ b/test/utils/update_resources.go
@@ -35,6 +35,7 @@ const (
 	waitRetryTimeout    = 5 * time.Minute
 )
 
+// RetryErrorCondition is a wrapper for retrying on a condition.
 func RetryErrorCondition(condition wait.ConditionFunc) wait.ConditionFunc {
 	return func() (bool, error) {
 		done, err := condition()
@@ -45,6 +46,7 @@ func RetryErrorCondition(condition wait.ConditionFunc) wait.ConditionFunc {
 	}
 }
 
+// ScaleResourceWithRetries scales a resource while retrying on failure.
 func ScaleResourceWithRetries(scalesGetter scaleclient.ScalesGetter, namespace, name string, size uint, gvr schema.GroupVersionResource) error {
 	scaler := scale.NewScaler(scalesGetter)
 	preconditions := &scale.ScalePrecondition{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

This PR fix golint issues for test/utils:

```test/utils/conditions.go:26:6: exported type ContainerFailures should have comment or be unexported
test/utils/conditions.go:47:1: exported function PodRunningReadyOrSucceeded should have comment or be unexported
test/utils/create_resources.go:46:1: comment on exported function RetryWithExponentialBackOff should be of the form "RetryWithExponentialBackOff ..."
test/utils/create_resources.go:57:1: exported function IsRetryableAPIError should have comment or be unexported
test/utils/create_resources.go:70:1: exported function CreatePodWithRetries should have comment or be unexported
test/utils/create_resources.go:87:1: exported function CreateRCWithRetries should have comment or be unexported
test/utils/create_resources.go:104:1: exported function CreateReplicaSetWithRetries should have comment or be unexported
test/utils/create_resources.go:121:1: exported function CreateDeploymentWithRetries should have comment or be unexported
test/utils/create_resources.go:138:1: exported function CreateDaemonSetWithRetries should have comment or be unexported
test/utils/create_resources.go:155:1: exported function CreateJobWithRetries should have comment or be unexported
test/utils/create_resources.go:172:1: exported function CreateSecretWithRetries should have comment or be unexported
test/utils/create_resources.go:189:1: exported function CreateConfigMapWithRetries should have comment or be unexported
test/utils/create_resources.go:206:1: exported function CreateServiceWithRetries should have comment or be unexported
test/utils/create_resources.go:223:1: exported function CreateStorageClassWithRetries should have comment or be unexported
test/utils/create_resources.go:240:1: exported function CreateResourceQuotaWithRetries should have comment or be unexported
test/utils/create_resources.go:257:1: exported function CreatePersistentVolumeWithRetries should have comment or be unexported
test/utils/create_resources.go:274:1: exported function CreatePersistentVolumeClaimWithRetries should have comment or be unexported
test/utils/delete_resources.go:60:1: exported function DeleteResourceWithRetries should have comment or be unexported
test/utils/density_utils.go:37:1: exported function AddLabelsToNode should have comment or be unexported
test/utils/density_utils.go:82:11: if block ends with a return statement, so drop this else and outdent its block
test/utils/deployment.go:37:6: exported type LogfFn should have comment or be unexported
test/utils/deployment.go:39:1: exported function LogReplicaSetsOfDeployment should have comment or be unexported
test/utils/deployment.go:53:1: exported function LogPodsOfDeployment should have comment or be unexported
test/utils/deployment.go:156:1: comment on exported function WaitForDeploymentCompleteAndCheckRolling should be of the form "WaitForDeploymentCompleteAndCheckRolling ..."
test/utils/deployment.go:163:1: comment on exported function WaitForDeploymentComplete should be of the form "WaitForDeploymentComplete ..."
test/utils/deployment.go:254:21: error strings should not be capitalized or end with punctuation or a newline
test/utils/deployment.go:268:6: exported type UpdateDeploymentFunc should have comment or be unexported
test/utils/deployment.go:270:1: exported function UpdateDeploymentWithRetries should have comment or be unexported
test/utils/deployment.go:293:1: exported function WaitForObservedDeployment should have comment or be unexported
test/utils/deployment.go:335:1: exported function WaitForDeploymentWithCondition should have comment or be unexported
test/utils/pod_store.go:34:1: comment on exported type PodStore should be of the form "PodStore ..." (with optional leading article)
test/utils/pod_store.go:41:1: exported function NewPodStore should have comment or be unexported
test/utils/pod_store.go:71:1: exported method PodStore.List should have comment or be unexported
test/utils/pod_store.go:80:1: exported method PodStore.Stop should have comment or be unexported
test/utils/replicaset.go:31:6: exported type UpdateReplicaSetFunc should have comment or be unexported
test/utils/replicaset.go:33:1: exported function UpdateReplicaSetWithRetries should have comment or be unexported
test/utils/replicaset.go:56:1: comment on exported function WaitRSStable should be of the form "WaitRSStable ..."
test/utils/replicaset.go:71:1: exported function UpdateReplicaSetStatusWithRetries should have comment or be unexported
test/utils/runners.go:68:1: exported function WaitUntilPodIsScheduled should have comment or be unexported
test/utils/runners.go:83:25: error strings should not be capitalized or end with punctuation or a newline
test/utils/runners.go:86:1: exported function RunPodAndGetNodeName should have comment or be unexported
test/utils/runners.go:99:6: exported type RunObjectConfig should have comment or be unexported
test/utils/runners.go:114:6: exported type RCConfig should have comment or be unexported
test/utils/runners.go:126:2: struct field CpuRequest should be CPURequest
test/utils/runners.go:127:2: struct field CpuLimit should be CPULimit
test/utils/runners.go:186:1: exported method RCConfig.RCConfigLog should have comment or be unexported
test/utils/runners.go:193:6: exported type DeploymentConfig should have comment or be unexported
test/utils/runners.go:197:6: exported type ReplicaSetConfig should have comment or be unexported
test/utils/runners.go:201:6: exported type JobConfig should have comment or be unexported
test/utils/runners.go:296:1: exported method DeploymentConfig.Run should have comment or be unexported
test/utils/runners.go:300:1: exported method DeploymentConfig.GetKind should have comment or be unexported
test/utils/runners.go:304:1: exported method DeploymentConfig.GetGroupResource should have comment or be unexported
test/utils/runners.go:308:1: exported method DeploymentConfig.GetGroupVersionResource should have comment or be unexported
test/utils/runners.go:378:1: exported method ReplicaSetConfig.Run should have comment or be unexported
test/utils/runners.go:382:1: exported method ReplicaSetConfig.GetKind should have comment or be unexported
test/utils/runners.go:386:1: exported method ReplicaSetConfig.GetGroupResource should have comment or be unexported
test/utils/runners.go:390:1: exported method ReplicaSetConfig.GetGroupVersionResource should have comment or be unexported
test/utils/runners.go:456:1: exported method JobConfig.Run should have comment or be unexported
test/utils/runners.go:460:1: exported method JobConfig.GetKind should have comment or be unexported
test/utils/runners.go:464:1: exported method JobConfig.GetGroupResource should have comment or be unexported
test/utils/runners.go:468:1: exported method JobConfig.GetGroupVersionResource should have comment or be unexported
test/utils/runners.go:530:1: exported method RCConfig.Run should have comment or be unexported
test/utils/runners.go:530:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:534:1: exported method RCConfig.GetName should have comment or be unexported
test/utils/runners.go:534:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:538:1: exported method RCConfig.GetNamespace should have comment or be unexported
test/utils/runners.go:538:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:542:1: exported method RCConfig.GetKind should have comment or be unexported
test/utils/runners.go:542:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:546:1: exported method RCConfig.GetGroupResource should have comment or be unexported
test/utils/runners.go:546:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:550:1: exported method RCConfig.GetGroupVersionResource should have comment or be unexported
test/utils/runners.go:550:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:554:1: exported method RCConfig.GetClient should have comment or be unexported
test/utils/runners.go:554:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:558:1: exported method RCConfig.GetScalesGetter should have comment or be unexported
test/utils/runners.go:558:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:562:1: exported method RCConfig.SetClient should have comment or be unexported
test/utils/runners.go:562:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:566:1: exported method RCConfig.SetScalesClient should have comment or be unexported
test/utils/runners.go:566:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:570:1: exported method RCConfig.GetReplicas should have comment or be unexported
test/utils/runners.go:570:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:574:1: exported method RCConfig.GetLabelValue should have comment or be unexported
test/utils/runners.go:574:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:579:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:637:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:705:6: exported type RCStartupStatus should have comment or be unexported
test/utils/runners.go:725:1: exported function ComputeRCStartupStatus should have comment or be unexported
test/utils/runners.go:774:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:868:1: comment on exported function StartPods should be of the form "StartPods ..."
test/utils/runners.go:899:1: comment on exported function WaitForPodsWithLabelRunning should be of the form "WaitForPodsWithLabelRunning ..."
test/utils/runners.go:905:1: comment on exported function WaitForEnoughPodsWithLabelRunning should be of the form "WaitForEnoughPodsWithLabelRunning ..."
test/utils/runners.go:938:6: exported type CountToStrategy should have comment or be unexported
test/utils/runners.go:943:6: exported type TestNodePreparer should have comment or be unexported
test/utils/runners.go:948:6: exported type PrepareNodeStrategy should have comment or be unexported
test/utils/runners.go:961:6: exported type TrivialNodePrepareStrategy should have comment or be unexported
test/utils/runners.go:965:1: exported method TrivialNodePrepareStrategy.PreparePatch should have comment or be unexported
test/utils/runners.go:969:1: exported method TrivialNodePrepareStrategy.CleanupNode should have comment or be unexported
test/utils/runners.go:974:1: exported method TrivialNodePrepareStrategy.PrepareDependentObjects should have comment or be unexported
test/utils/runners.go:978:1: exported method TrivialNodePrepareStrategy.CleanupDependentObjects should have comment or be unexported
test/utils/runners.go:982:6: exported type LabelNodePrepareStrategy should have comment or be unexported
test/utils/runners.go:990:1: exported function NewLabelNodePrepareStrategy should have comment or be unexported
test/utils/runners.go:997:1: exported method LabelNodePrepareStrategy.PreparePatch should have comment or be unexported
test/utils/runners.go:1007:1: exported method LabelNodePrepareStrategy.CleanupNode should have comment or be unexported
test/utils/runners.go:1015:1: exported method LabelNodePrepareStrategy.PrepareDependentObjects should have comment or be unexported
test/utils/runners.go:1019:1: exported method LabelNodePrepareStrategy.CleanupDependentObjects should have comment or be unexported
test/utils/runners.go:1037:1: exported function NewNodeAllocatableStrategy should have comment or be unexported
test/utils/runners.go:1045:1: exported method NodeAllocatableStrategy.PreparePatch should have comment or be unexported
test/utils/runners.go:1067:1: exported method NodeAllocatableStrategy.CleanupNode should have comment or be unexported
test/utils/runners.go:1131:1: exported method NodeAllocatableStrategy.PrepareDependentObjects should have comment or be unexported
test/utils/runners.go:1142:1: exported method NodeAllocatableStrategy.CleanupDependentObjects should have comment or be unexported
test/utils/runners.go:1168:1: exported function NewUniqueNodeLabelStrategy should have comment or be unexported
test/utils/runners.go:1174:1: exported method UniqueNodeLabelStrategy.PreparePatch should have comment or be unexported
test/utils/runners.go:1180:1: exported method UniqueNodeLabelStrategy.CleanupNode should have comment or be unexported
test/utils/runners.go:1188:1: exported method UniqueNodeLabelStrategy.PrepareDependentObjects should have comment or be unexported
test/utils/runners.go:1192:1: exported method UniqueNodeLabelStrategy.CleanupDependentObjects should have comment or be unexported
test/utils/runners.go:1196:1: exported function DoPrepareNode should have comment or be unexported
test/utils/runners.go:1230:1: exported function DoCleanupNode should have comment or be unexported
test/utils/runners.go:1269:6: exported type TestPodCreateStrategy should have comment or be unexported
test/utils/runners.go:1271:6: exported type CountToPodStrategy should have comment or be unexported
test/utils/runners.go:1276:6: exported type TestPodCreatorConfig should have comment or be unexported
test/utils/runners.go:1278:1: exported function NewTestPodCreatorConfig should have comment or be unexported
test/utils/runners.go:1283:1: exported method TestPodCreatorConfig.AddStrategy should have comment or be unexported
test/utils/runners.go:1288:6: exported type TestPodCreator should have comment or be unexported
test/utils/runners.go:1294:1: exported function NewTestPodCreator should have comment or be unexported
test/utils/runners.go:1301:1: exported method TestPodCreator.CreatePods should have comment or be unexported
test/utils/runners.go:1312:1: exported function MakePodSpec should have comment or be unexported
test/utils/runners.go:1339:1: exported function CreatePod should have comment or be unexported
test/utils/runners.go:1358:1: exported function CreatePodWithPersistentVolume should have comment or be unexported
test/utils/runners.go:1464:1: exported function NewCustomCreatePodStrategy should have comment or be unexported
test/utils/runners.go:1473:1: exported function NewCreatePodWithPersistentVolumeStrategy should have comment or be unexported
test/utils/runners.go:1493:1: exported function NewCreatePodWithPersistentVolumeWithFirstConsumerStrategy should have comment or be unexported
test/utils/runners.go:1519:1: exported function NewSimpleCreatePodStrategy should have comment or be unexported
test/utils/runners.go:1529:1: exported function NewSimpleWithControllerCreatePodStrategy should have comment or be unexported
test/utils/runners.go:1545:6: exported type SecretConfig should have comment or be unexported
test/utils/runners.go:1554:1: exported method SecretConfig.Run should have comment or be unexported
test/utils/runners.go:1572:1: exported method SecretConfig.Stop should have comment or be unexported
test/utils/runners.go:1603:6: exported type ConfigMapConfig should have comment or be unexported
test/utils/runners.go:1612:1: exported method ConfigMapConfig.Run should have comment or be unexported
test/utils/runners.go:1630:1: exported method ConfigMapConfig.Stop should have comment or be unexported
test/utils/runners.go:1663:1: receiver name config should be consistent with previous receiver name rc for RCConfig
test/utils/runners.go:1721:6: exported type DaemonConfig should have comment or be unexported
test/utils/runners.go:1732:1: exported method DaemonConfig.Run should have comment or be unexported
test/utils/tmpdir.go:25:1: exported function MakeTempDirOrDie should have comment or be unexported
test/utils/update_resources.go:38:1: exported function RetryErrorCondition should have comment or be unexported
test/utils/update_resources.go:48:1: exported function ScaleResourceWithRetries should have comment or be unexported
```

**Which issue(s) this PR fixes**:
https://github.com/kubernetes/kubernetes/issues/68026

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
