### PR TITLE
Supports opt-out authn for aggregated apiserver

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/options/authentication.go
@@ -196,6 +196,9 @@ func NewDelegatingAuthenticationOptions() *DelegatingAuthenticationOptions {
 }
 
 func (s *DelegatingAuthenticationOptions) Validate() []error {
+	if s == nil {
+		return nil
+	}
 	allErrors := []error{}
 	allErrors = append(allErrors, s.RequestHeader.Validate()...)
 


### PR DESCRIPTION
we used to support setting nil `DelegatingAuthenticationOptions` in the `RecommendedOptions` to opt-out authn for aggregated apiservers. but for now it's failing upon upgrading `k8s.io/apiserver` dependency to v1.18 w/ a nil panic:

```golang
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x25ba4b6]

goroutine 1 [running]:
k8s.io/apiserver/pkg/server/options.(*DelegatingAuthenticationOptions).Validate(...)
	/Users/guest/go/pkg/mod/k8s.io/apiserver@v0.18.1/pkg/server/options/authentication.go:200
k8s.io/apiserver/pkg/server/options.(*RecommendedOptions).Validate(0xc0001d5810, 0x3d05ce0, 0x0, 0x0)
	/Users/guest/go/pkg/mod/k8s.io/apiserver@v0.18.1/pkg/server/options/recommended.go:146 +0x156
```

/cc @kubernetes/sig-api-machinery-misc @deads2k 
/kind sig-apimachinery
/kind bug

```release-note
NONE
```
