### PR TITLE
Automated cherry pick of #89188: Move PSP tests behind a feature tag

### DIFF
--- a/test/e2e/auth/pod_security_policy.go
+++ b/test/e2e/auth/pod_security_policy.go
@@ -45,7 +45,7 @@ import (
 
 const nobodyUser = int64(65534)
 
-var _ = SIGDescribe("PodSecurityPolicy", func() {
+var _ = SIGDescribe("PodSecurityPolicy [Feature:PodSecurityPolicy]", func() {
 	f := framework.NewDefaultFramework("podsecuritypolicy")
 	f.SkipPrivilegedPSPBinding = true
 
@@ -55,7 +55,8 @@ var _ = SIGDescribe("PodSecurityPolicy", func() {
 	var ns string // Test namespace, for convenience
 	ginkgo.BeforeEach(func() {
 		if !e2epsp.IsPodSecurityPolicyEnabled(f.ClientSet) {
-			framework.Skipf("PodSecurityPolicy not enabled")
+			framework.Failf("PodSecurityPolicy not enabled")
+			return
 		}
 		if !auth.IsRBACEnabled(f.ClientSet.RbacV1()) {
 			framework.Skipf("RBAC not enabled")


### PR DESCRIPTION
Cherry pick of #89188 on release-1.16.

#89188: Move PSP tests behind a feature tag

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.