### PR TITLE
Promote service exclusion and legacy node role to beta

### DIFF
--- a/pkg/controller/service/controller.go
+++ b/pkg/controller/service/controller.go
@@ -70,11 +70,6 @@ const (
 	// in 1.16 when the ServiceNodeExclusion gate is on.
 	labelNodeRoleExcludeBalancer = "node.kubernetes.io/exclude-from-external-load-balancers"
 
-	// labelAlphaNodeRoleExcludeBalancer specifies that the node should be
-	// exclude from load balancers created by a cloud provider. This label is deprecated and will
-	// be removed in 1.18.
-	labelAlphaNodeRoleExcludeBalancer = "alpha.service-controller.kubernetes.io/exclude-balancer"
-
 	// serviceNodeExclusionFeature is the feature gate name that
 	// enables nodes to exclude themselves from service load balancers
 	// originated from: https://github.com/kubernetes/kubernetes/blob/28e800245e/pkg/features/kube_features.go#L178
@@ -618,10 +613,6 @@ func getNodeConditionPredicate() NodeConditionPredicate {
 			}
 		}
 		if utilfeature.DefaultFeatureGate.Enabled(serviceNodeExclusionFeature) {
-			// Will be removed in 1.18
-			if _, hasExcludeBalancerLabel := node.Labels[labelAlphaNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
-				return false
-			}
 			if _, hasExcludeBalancerLabel := node.Labels[labelNodeRoleExcludeBalancer]; hasExcludeBalancerLabel {
 				return false
 			}

--- a/pkg/controller/service/controller_test.go
+++ b/pkg/controller/service/controller_test.go
@@ -1404,13 +1404,11 @@ func Test_getNodeConditionPredicate(t *testing.T) {
 		{want: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}}},
 		{want: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleMaster: ""}}}},
 		{want: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleExcludeBalancer: ""}}}},
-		{want: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelAlphaNodeRoleExcludeBalancer: ""}}}},
 
 		{want: true, enableExclusion: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleMaster: ""}}}},
 		{want: true, enableLegacy: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleExcludeBalancer: ""}}}},
 
 		{want: false, enableLegacy: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleMaster: ""}}}},
-		{want: false, enableExclusion: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelAlphaNodeRoleExcludeBalancer: ""}}}},
 		{want: false, enableExclusion: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleExcludeBalancer: ""}}}},
 	}
 	for _, tt := range tests {

--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -146,18 +146,21 @@ const (
 
 	// owner @smarterclayton
 	// alpha: v1.16
+	// beta:  v1.19
 	//
 	// Enable legacy behavior to vary cluster functionality on the node-role.kubernetes.io labels. On by default (legacy), will be turned off in 1.18.
 	LegacyNodeRoleBehavior featuregate.Feature = "LegacyNodeRoleBehavior"
 
 	// owner @brendandburns
 	// alpha: v1.9
+	// beta:  v1.19
 	//
 	// Enable nodes to exclude themselves from service load balancers
 	ServiceNodeExclusion featuregate.Feature = "ServiceNodeExclusion"
 
 	// owner @smarterclayton
 	// alpha: v1.16
+	// beta:  v1.19
 	//
 	// Enable nodes to exclude themselves from network disruption checks
 	NodeDisruptionExclusion featuregate.Feature = "NodeDisruptionExclusion"
@@ -597,8 +600,8 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	CPUManager:                     {Default: true, PreRelease: featuregate.Beta},
 	CPUCFSQuotaPeriod:              {Default: false, PreRelease: featuregate.Alpha},
 	TopologyManager:                {Default: true, PreRelease: featuregate.Beta},
-	ServiceNodeExclusion:           {Default: false, PreRelease: featuregate.Alpha},
-	NodeDisruptionExclusion:        {Default: false, PreRelease: featuregate.Alpha},
+	ServiceNodeExclusion:           {Default: true, PreRelease: featuregate.Beta},
+	NodeDisruptionExclusion:        {Default: true, PreRelease: featuregate.Beta},
 	CSIDriverRegistry:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
 	CSINodeInfo:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.19
 	BlockVolume:                    {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
@@ -674,5 +677,5 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	// features that enable backwards compatibility but are scheduled to be removed
 	// ...
 	HPAScaleToZero:         {Default: false, PreRelease: featuregate.Alpha},
-	LegacyNodeRoleBehavior: {Default: true, PreRelease: featuregate.Alpha},
+	LegacyNodeRoleBehavior: {Default: true, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
We did not promote these to beta in 1.18 but will do so in 1.19.
As per the KEP we do not set disable LegacyNodeRoleBehavior to false
until 1.20.

/kind api-change

```release-note
The ServiceNodeExclusion and NodeDisruptionExclusion feature gates are now on by default. Clusters will recognize those labels to indicate specific behavior is disabled. The LegacyNodeRoleBehavior gate is now beta and will be turned off by default in 1.20. Clusters that rely on the 'node-role.kubernetes.io/master' label to exclude nodes from service load balancers should set the `node.kubernetes.io/exclude-from-external-load-balancers` label on their master nodes if they still wish masters to not be included in service load balancing. The feature gate may be manually enabled in 1.20 but will be removed in 1.21.
```

```docs
```

/assign @liggitt

I'll modify the KEP for dates.