### PR TITLE
version/verflag: make program name variable

### DIFF
--- a/staging/src/k8s.io/component-base/version/verflag/verflag.go
+++ b/staging/src/k8s.io/component-base/version/verflag/verflag.go
@@ -89,6 +89,7 @@ const versionFlagName = "version"
 
 var (
 	versionFlag = Version(versionFlagName, VersionFalse, "Print version information and quit")
+	programName = "Kubernetes"
 )
 
 // AddFlags registers this package's flags on arbitrary FlagSets, such that they point to the
@@ -104,7 +105,7 @@ func PrintAndExitIfRequested() {
 		fmt.Printf("%#v\n", version.Get())
 		os.Exit(0)
 	} else if *versionFlag == VersionTrue {
-		fmt.Printf("Kubernetes %s\n", version.Get())
+		fmt.Printf("%s %s\n", programName, version.Get())
 		os.Exit(0)
 	}
 }


### PR DESCRIPTION
Instead of hard-coding `Kubernetes` in the output generated when
executing a binary using the `version/verflag` feature using
`--version`, use a variable `programName` which can be overwritten using
the `-X` linker flag, e.g.:

```
go build -ldflags "-X k8s.io/component-base/version/verflag.programName=my-tool" ...
```

This allows to use the package in non-Kubernetes applications.

/kind feature
Fixes: #90138

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```