### PR TITLE
Fix flaws in Azure CSI translation

### DIFF
--- a/staging/src/k8s.io/csi-translation-lib/CONTRIBUTING.md
+++ b/staging/src/k8s.io/csi-translation-lib/CONTRIBUTING.md
@@ -2,6 +2,6 @@
 
 Do not open pull requests directly against this repository, they will be ignored. Instead, please open pull requests against [kubernetes/kubernetes](https://git.k8s.io/kubernetes/).  Please follow the same [contributing guide](https://git.k8s.io/kubernetes/CONTRIBUTING.md) you would follow for any other pull request made to kubernetes/kubernetes.
 
-This repository is published from [kubernetes/kubernetes/staging/src/k8s.io/csi-api](https://git.k8s.io/kubernetes/staging/src/k8s.io/csi-api) by the [kubernetes publishing-bot](https://git.k8s.io/publishing-bot).
+This repository is published from [kubernetes/kubernetes/staging/src/k8s.io/csi-translation-lib](https://git.k8s.io/kubernetes/staging/src/k8s.io/csi-translation-lib) by the [kubernetes publishing-bot](https://git.k8s.io/publishing-bot).
 
 Please see [Staging Directory and Publishing](https://git.k8s.io/community/contributors/devel/sig-architecture/staging.md) for more information.

--- a/staging/src/k8s.io/csi-translation-lib/go.mod
+++ b/staging/src/k8s.io/csi-translation-lib/go.mod
@@ -5,9 +5,11 @@ module k8s.io/csi-translation-lib
 go 1.13
 
 require (
+	github.com/stretchr/testify v1.4.0
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/cloud-provider v0.0.0
+	k8s.io/klog v1.0.0
 )
 
 replace (

--- a/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/cloud-provider/volume:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 
@@ -50,5 +51,6 @@ go_test(
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/BUILD
@@ -49,5 +49,6 @@ go_test(
     deps = [
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/api/storage/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk.go
@@ -110,22 +110,23 @@ func (t *azureDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		return nil, fmt.Errorf("pv is nil or Azure Disk source not defined on pv")
 	}
 
-	azureSource := pv.Spec.PersistentVolumeSource.AzureDisk
+	var (
+		azureSource = pv.Spec.PersistentVolumeSource.AzureDisk
 
-	// refer to https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md
-	csiSource := &v1.CSIPersistentVolumeSource{
-		Driver:           AzureDiskDriverName,
-		VolumeHandle:     azureSource.DataDiskURI,
-		ReadOnly:         *azureSource.ReadOnly,
-		FSType:           *azureSource.FSType,
-		VolumeAttributes: map[string]string{azureDiskKind: "Managed"},
-	}
+		// refer to https://github.com/kubernetes-sigs/azuredisk-csi-driver/blob/master/docs/driver-parameters.md
+		csiSource = &v1.CSIPersistentVolumeSource{
+			Driver:           AzureDiskDriverName,
+			VolumeAttributes: map[string]string{azureDiskKind: "Managed"},
+			VolumeHandle:     azureSource.DataDiskURI,
+		}
+	)
 
 	if azureSource.CachingMode != nil {
 		csiSource.VolumeAttributes[azureDiskCachingMode] = string(*azureSource.CachingMode)
 	}
 
 	if azureSource.FSType != nil {
+		csiSource.FSType = *azureSource.FSType
 		csiSource.VolumeAttributes[azureDiskFSType] = *azureSource.FSType
 	}
 
@@ -133,9 +134,12 @@ func (t *azureDiskCSITranslator) TranslateInTreePVToCSI(pv *v1.PersistentVolume)
 		csiSource.VolumeAttributes[azureDiskKind] = string(*azureSource.Kind)
 	}
 
+	if azureSource.ReadOnly != nil {
+		csiSource.ReadOnly = *azureSource.ReadOnly
+	}
+
 	pv.Spec.PersistentVolumeSource.AzureDisk = nil
 	pv.Spec.PersistentVolumeSource.CSI = csiSource
-	pv.Spec.AccessModes = backwardCompatibleAccessModes(pv.Spec.AccessModes)
 
 	return pv, nil
 }

--- a/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
+++ b/staging/src/k8s.io/csi-translation-lib/plugins/azure_disk_test.go
@@ -20,6 +20,9 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIsManagedDisk(t *testing.T) {
@@ -88,6 +91,142 @@ func TestGetDiskName(t *testing.T) {
 		if !reflect.DeepEqual(result1, test.expected1) || !reflect.DeepEqual(result2, test.expected2) {
 			t.Errorf("input: %q, getDiskName result1: %q, expected1: %q, result2: %q, expected2: %q", test.options, result1, test.expected1,
 				result2, test.expected2)
+		}
+	}
+}
+
+func TestTranslateAzureDiskInTreeStorageClassToCSI(t *testing.T) {
+	translator := NewAzureDiskCSITranslator()
+
+	cases := []struct {
+		name   string
+		volume *corev1.Volume
+		expVol *corev1.PersistentVolume
+		expErr bool
+	}{
+		{
+			name:   "empty volume",
+			expErr: true,
+		},
+		{
+			name:   "no azure disk volume",
+			volume: &corev1.Volume{},
+			expErr: true,
+		},
+		{
+			name: "azure disk volume",
+			volume: &corev1.Volume{
+				VolumeSource: corev1.VolumeSource{
+					AzureDisk: &corev1.AzureDiskVolumeSource{
+						DiskName:    "diskname",
+						DataDiskURI: "datadiskuri",
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "disk.csi.azure.com-diskname",
+				},
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:           "disk.csi.azure.com",
+							VolumeHandle:     "datadiskuri",
+							VolumeAttributes: map[string]string{azureDiskKind: "Managed"},
+						},
+					},
+					AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Testing %v", tc.name)
+		got, err := translator.TranslateInTreeInlineVolumeToCSI(tc.volume)
+		if err != nil && !tc.expErr {
+			t.Errorf("Did not expect error but got: %v", err)
+		}
+
+		if err == nil && tc.expErr {
+			t.Errorf("Expected error, but did not get one.")
+		}
+
+		if !reflect.DeepEqual(got, tc.expVol) {
+			t.Errorf("Got parameters: %v, expected :%v", got, tc.expVol)
+		}
+	}
+}
+
+func TestTranslateAzureDiskInTreePVToCSI(t *testing.T) {
+	translator := NewAzureDiskCSITranslator()
+
+	cachingMode := corev1.AzureDataDiskCachingMode("cachingmode")
+	fsType := "fstype"
+	readOnly := true
+
+	cases := []struct {
+		name   string
+		volume *corev1.PersistentVolume
+		expVol *corev1.PersistentVolume
+		expErr bool
+	}{
+		{
+			name:   "empty volume",
+			expErr: true,
+		},
+		{
+			name:   "no azure file volume",
+			volume: &corev1.PersistentVolume{},
+			expErr: true,
+		},
+		{
+			name: "azure file volume",
+			volume: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						AzureDisk: &corev1.AzureDiskVolumeSource{
+							CachingMode: &cachingMode,
+							DataDiskURI: "datadiskuri",
+							FSType:      &fsType,
+							ReadOnly:    &readOnly,
+						},
+					},
+				},
+			},
+			expVol: &corev1.PersistentVolume{
+				Spec: corev1.PersistentVolumeSpec{
+					PersistentVolumeSource: corev1.PersistentVolumeSource{
+						CSI: &corev1.CSIPersistentVolumeSource{
+							Driver:   "disk.csi.azure.com",
+							FSType:   "fstype",
+							ReadOnly: true,
+							VolumeAttributes: map[string]string{
+								azureDiskCachingMode: "cachingmode",
+								azureDiskFSType:      fsType,
+								azureDiskKind:        "Managed",
+							},
+							VolumeHandle: "datadiskuri",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Logf("Testing %v", tc.name)
+		got, err := translator.TranslateInTreePVToCSI(tc.volume)
+		if err != nil && !tc.expErr {
+			t.Errorf("Did not expect error but got: %v", err)
+		}
+
+		if err == nil && tc.expErr {
+			t.Errorf("Expected error, but did not get one.")
+		}
+
+		if !reflect.DeepEqual(got, tc.expVol) {
+			t.Errorf("Got parameters: %v, expected :%v", got, tc.expVol)
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The Azure File CSI translation was not setting the `DriverName` field, eventually causing the attachdetach-controller to fail when CSI migration is enabled:

```
kubernetes.io/csi: attacher.Attach failed: VolumeAttachment.storage.k8s.io \"csi-19e8c8fd3545d41cebf6a51ffebcdd8588df8c5bfb9bd085b1689e7ca6704c59\" is invalid: [spec.attacher: Required value, spec.attacher: Invalid value: \"\": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')]"
```

I implemented some unit tests for Azure along the way.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix flaws in Azure File CSI translation
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
Part of https://github.com/kubernetes/enhancements/issues/1490