### PR TITLE
test images: Adds OWNERS files for images (part 3)

### DIFF
--- a/test/images/cuda-vector-add/OWNERS
+++ b/test/images/cuda-vector-add/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - jiayingz
+  - mkumatag

--- a/test/images/nonewprivs/OWNERS
+++ b/test/images/nonewprivs/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - jessfraz
+  - mkumatag

--- a/test/images/pets/OWNERS
+++ b/test/images/pets/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - mkumatag
+  - bprashanth

--- a/test/images/redis/OWNERS
+++ b/test/images/redis/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - mkumatag
+  - rmmh

--- a/test/images/volume/OWNERS
+++ b/test/images/volume/OWNERS
@@ -1,0 +1,3 @@
+approvers:
+  - jsafrane
+  - mkumatag


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind documentation

/sig testing

**What this PR does / why we need it**:

Adds reviewers to the OWNERS files in the kubernetes/test/images folder. The reviewers are added automatically, based on their contributions on an image (>= 20% code churn).

Note that the code churn is taken into account for authors, and not committers.

Adds OWNERS files for: cuda-vector-add, nonewprivs, pets, redis, volume.

Script used to generate the OWNERS files: https://paste.ubuntu.com/p/smspRYH7fT/

Script logs: https://paste.ubuntu.com/p/CgT53yKBjf/

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
