### PR TITLE
cross build debian-base with buildx

### DIFF
--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -93,7 +93,7 @@ endif
 	docker build --pull -t $(BUILD_IMAGE) -f $(TEMP_DIR)/Dockerfile.build $(TEMP_DIR)
 	docker create --name $(BUILD_IMAGE) $(BUILD_IMAGE)
 	docker export $(BUILD_IMAGE) > $(TEMP_DIR)/$(TAR_FILE)
-	docker build -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --load --platform linux/$(ARCH) -t $(IMAGE)-$(ARCH):$(TAG) $(TEMP_DIR)
 	rm -rf $(TEMP_DIR)
 
 push: build


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
Using docker buildx with --platform to build debian-base image can give its correct Architecture
information in metadata. Otherwise, when doing cross compiled debian-base image, the Architecture information in metadata is "amd64" for non-amd64 images.
Consequently, other non-amd64 images(kube-apiserver, kube-controller-manager.....), which is based on debian-base image, would inherit the wrong Architecture info in metadata.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Quoting from #87954
These features are usually relatively stable / useful, just not enabled by default, and this is as it sounds, a toggle for the CLI, the daemon does not need any configuration.

buildx is the experimental buildkit based replacement (and the reason we need the experimental env), it overall seems quite nice, and in this case it's drop in compatible with a functional --platform flag. The same flag "works" without buildx but the image manifest still shows the host arch when building from scratch.

https://docs.docker.com/buildx/working-with-buildx/

Existing usage:
https://cs.k8s.io/?q=DOCKER_CLI_EXPERIMENTAL%3Denabled&i=nope&files=&repos=

**Does this PR introduce a user-facing change?**:
Images based on debian-base image and debian-base itself contains "Architecture" in non-amd64 images 
