### PR TITLE
Add DNS1123Label validation to IsFullyQualifiedDomainName() func

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation.go
@@ -106,6 +106,11 @@ func IsFullyQualifiedDomainName(fldPath *field.Path, name string) field.ErrorLis
 	if len(strings.Split(name, ".")) < 2 {
 		return append(allErrors, field.Invalid(fldPath, name, "should be a domain with at least two segments separated by dots"))
 	}
+	for _, label := range strings.Split(name, ".") {
+		if errs := IsDNS1123Label(label); len(errs) > 0 {
+			return append(allErrors, field.Invalid(fldPath, label, strings.Join(errs, ",")))
+		}
+	}
 	return allErrors
 }
 

--- a/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/validation/validation_test.go
@@ -557,7 +557,8 @@ func TestIsFullyQualifiedDomainName(t *testing.T) {
 		"bbc.co.uk",
 		"10.0.0.1", // DNS labels can start with numbers and there is no requirement for letters.
 		"hyphens-are-good.k8s.io",
-		strings.Repeat("a", 246) + ".k8s.io",
+		strings.Repeat("a", 63) + ".k8s.io",
+		strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63) + "." + strings.Repeat("d", 54) + ".k8s.io",
 	}
 	for _, val := range goodValues {
 		if err := IsFullyQualifiedDomainName(field.NewPath(""), val).ToAggregate(); err != nil {
@@ -579,7 +580,8 @@ func TestIsFullyQualifiedDomainName(t *testing.T) {
 		"underscores_are_bad.k8s.io",
 		"foo@bar.example.com",
 		"http://foo.example.com",
-		strings.Repeat("a", 247) + ".k8s.io",
+		strings.Repeat("a", 64) + ".k8s.io",
+		strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + "." + strings.Repeat("c", 63) + "." + strings.Repeat("d", 55) + ".k8s.io",
 	}
 	for _, val := range badValues {
 		if err := IsFullyQualifiedDomainName(field.NewPath(""), val).ToAggregate(); err == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This patch adds IsDNS1123Label validation to
`IsFullyQualifiedDomainName()` func.

Even when one label is longer than 64 characters, the current
validation  does not validate it. Hence this patch adds the label
check and do not allow invalid domains.

**Does this PR introduce a user-facing change?**:

```release-note
IsFullyQualifiedDomainName() validates each label based on IsDNS1123Label.
```

/sig network
