### PR TITLE
[WIP] IPAM range allocator CIDR set based on maps

### DIFF
--- a/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
+++ b/pkg/controller/nodeipam/ipam/cidrset/cidr_set_test.go
@@ -21,8 +21,6 @@ import (
 	"net"
 	"reflect"
 	"testing"
-
-	"k8s.io/klog"
 )
 
 func TestCIDRSetFullyAllocated(t *testing.T) {
@@ -478,17 +476,17 @@ func TestGetBitforCIDR(t *testing.T) {
 
 		got, err := cs.getIndexForCIDR(subnetCIDR)
 		if err == nil && tc.expectErr {
-			klog.Errorf("expected error but got null for %v", tc.description)
+			t.Errorf("expected error but got null for %v", tc.description)
 			continue
 		}
 
 		if err != nil && !tc.expectErr {
-			klog.Errorf("unexpected error: %v for %v", err, tc.description)
+			t.Errorf("unexpected error: %v for %v", err, tc.description)
 			continue
 		}
 
 		if got != tc.expectedBit {
-			klog.Errorf("expected %v, but got %v for %v", tc.expectedBit, got, tc.description)
+			t.Errorf("expected %v, but got %v for %v", tc.expectedBit, got, tc.description)
 		}
 	}
 }
@@ -736,3 +734,752 @@ func TestCIDRSetv6(t *testing.T) {
 		})
 	}
 }
+func TestMapCIDRSetFullyAllocated(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		subNetMaskSize int
+		expectedCIDR   string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.234.0/30",
+			subNetMaskSize: 30,
+			expectedCIDR:   "127.123.234.0/30",
+			description:    "Fully allocated CIDR with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/30",
+			subNetMaskSize: 30,
+			expectedCIDR:   "beef:1234::/30",
+			description:    "Fully allocated CIDR with IPv6",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a, err := NewMapCIDRSet(clusterCIDR, tc.subNetMaskSize)
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+		p, err := a.AllocateNext()
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+		if p.String() != tc.expectedCIDR {
+			t.Fatalf("unexpected allocated cidr: %v, expecting %v for %v",
+				p.String(), tc.expectedCIDR, tc.description)
+		}
+
+		_, err = a.AllocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+
+		a.Release(p)
+
+		p, err = a.AllocateNext()
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+		if p.String() != tc.expectedCIDR {
+			t.Fatalf("unexpected allocated cidr: %v, expecting %v for %v",
+				p.String(), tc.expectedCIDR, tc.description)
+		}
+		_, err = a.AllocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+	}
+}
+
+func TestMapIndexToCIDRBlock(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		subnetMaskSize int
+		index          uint64
+		CIDRBlock      string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.3.0/16",
+			subnetMaskSize: 24,
+			index:          0,
+			CIDRBlock:      "127.123.0.0/24",
+			description:    "1st IP address indexed with IPv4",
+		},
+		{
+			clusterCIDRStr: "127.123.0.0/16",
+			subnetMaskSize: 24,
+			index:          15,
+			CIDRBlock:      "127.123.15.0/24",
+			description:    "16th IP address indexed with IPv4",
+		},
+		{
+			clusterCIDRStr: "192.168.5.219/28",
+			subnetMaskSize: 32,
+			index:          5,
+			CIDRBlock:      "192.168.5.213/32",
+			description:    "5th IP address indexed with IPv4",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:3::/48",
+			subnetMaskSize: 64,
+			index:          0,
+			CIDRBlock:      "2001:db8:1234::/64",
+			description:    "1st IP address indexed with IPv6 /64",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234::/48",
+			subnetMaskSize: 64,
+			index:          15,
+			CIDRBlock:      "2001:db8:1234:f::/64",
+			description:    "16th IP address indexed with IPv6 /64",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:85a3::8a2e:0370:7334/50",
+			subnetMaskSize: 63,
+			index:          6425,
+			CIDRBlock:      "2001:db8:85a3:3232::/63",
+			description:    "6426th IP address indexed with IPv6 /63",
+		},
+		{
+			clusterCIDRStr: "2001:0db8::/32",
+			subnetMaskSize: 48,
+			index:          0,
+			CIDRBlock:      "2001:db8::/48",
+			description:    "1st IP address indexed with IPv6 /48",
+		},
+		{
+			clusterCIDRStr: "2001:0db8::/32",
+			subnetMaskSize: 48,
+			index:          15,
+			CIDRBlock:      "2001:db8:f::/48",
+			description:    "16th IP address indexed with IPv6 /48",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:85a3::8a2e:0370:7334/32",
+			subnetMaskSize: 48,
+			index:          6425,
+			CIDRBlock:      "2001:db8:1919::/48",
+			description:    "6426th IP address indexed with IPv6 /48",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:ff00::/56",
+			subnetMaskSize: 72,
+			index:          0,
+			CIDRBlock:      "2001:db8:1234:ff00::/72",
+			description:    "1st IP address indexed with IPv6 /72",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:ff00::/56",
+			subnetMaskSize: 72,
+			index:          15,
+			CIDRBlock:      "2001:db8:1234:ff00:f00::/72",
+			description:    "16th IP address indexed with IPv6 /72",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:ff00::0370:7334/56",
+			subnetMaskSize: 72,
+			index:          6425,
+			CIDRBlock:      "2001:db8:1234:ff19:1900::/72",
+			description:    "6426th IP address indexed with IPv6 /72",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:0:1234::/80",
+			subnetMaskSize: 96,
+			index:          0,
+			CIDRBlock:      "2001:db8:1234:0:1234::/96",
+			description:    "1st IP address indexed with IPv6 /96",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:0:1234::/80",
+			subnetMaskSize: 96,
+			index:          15,
+			CIDRBlock:      "2001:db8:1234:0:1234:f::/96",
+			description:    "16th IP address indexed with IPv6 /96",
+		},
+		{
+			clusterCIDRStr: "2001:0db8:1234:ff00::0370:7334/80",
+			subnetMaskSize: 96,
+			index:          6425,
+			CIDRBlock:      "2001:db8:1234:ff00:0:1919::/96",
+			description:    "6426th IP address indexed with IPv6 /96",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a, err := NewMapCIDRSet(clusterCIDR, tc.subnetMaskSize)
+		if err != nil {
+			t.Fatalf("error for %v ", tc.description)
+		}
+		ip := a.addIPOffset(tc.index)
+		_, bits := clusterCIDR.Mask.Size()
+
+		cidr := &net.IPNet{IP: ip, Mask: net.CIDRMask(tc.subnetMaskSize, bits)}
+		if cidr.String() != tc.CIDRBlock {
+			t.Fatalf("error for %v index %d %s", tc.description, tc.index, cidr.String())
+		}
+	}
+}
+
+func TestMapCIDRSet_RandomishAllocation(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.234.0/16",
+			description:    "RandomishAllocation with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/16",
+			description:    "RandomishAllocation with IPv6",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a, err := NewMapCIDRSet(clusterCIDR, 24)
+		if err != nil {
+			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
+		}
+		// allocate all the CIDRs
+		var cidrs []*net.IPNet
+
+		for i := 0; i < 256; i++ {
+			if c, err := a.AllocateNext(); err == nil {
+				cidrs = append(cidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %v for %v", err, tc.description)
+			}
+		}
+
+		//var err error
+		_, err = a.AllocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+		// release them all
+		for i := 0; i < len(cidrs); i++ {
+			a.Release(cidrs[i])
+		}
+
+		// allocate the CIDRs again
+		var rcidrs []*net.IPNet
+		for i := 0; i < 256; i++ {
+			if c, err := a.AllocateNext(); err == nil {
+				rcidrs = append(rcidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %d, %v for %v", i, err, tc.description)
+			}
+		}
+		_, err = a.AllocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+
+		if !reflect.DeepEqual(cidrs, rcidrs) {
+			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
+		}
+	}
+}
+
+func TestMapCIDRSet_AllocationOccupied(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.123.234.0/16",
+			description:    "AllocationOccupied with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/16",
+			description:    "AllocationOccupied with IPv6",
+		},
+	}
+	for _, tc := range cases {
+		_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+		a, err := NewMapCIDRSet(clusterCIDR, 24)
+		if err != nil {
+			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
+		}
+		// allocate all the CIDRs
+		var cidrs []*net.IPNet
+		var numCIDRs = 256
+
+		for i := 0; i < numCIDRs; i++ {
+			if c, err := a.AllocateNext(); err == nil {
+				cidrs = append(cidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %v for %v", err, tc.description)
+			}
+		}
+
+		//var err error
+		_, err = a.AllocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+		// release them all
+		for i := 0; i < len(cidrs); i++ {
+			a.Release(cidrs[i])
+		}
+		// occupy the last 128 CIDRs
+		for i := numCIDRs / 2; i < numCIDRs; i++ {
+			a.Occupy(cidrs[i])
+		}
+
+		// allocate the first 128 CIDRs again
+		var rcidrs []*net.IPNet
+		for i := 0; i < numCIDRs/2; i++ {
+			if c, err := a.AllocateNext(); err == nil {
+				rcidrs = append(rcidrs, c)
+			} else {
+				t.Fatalf("unexpected error: %d, %v for %v", i, err, tc.description)
+			}
+		}
+		_, err = a.AllocateNext()
+		if err == nil {
+			t.Fatalf("expected error because of fully-allocated range for %v", tc.description)
+		}
+
+		// check Occupy() work properly
+		for i := numCIDRs / 2; i < numCIDRs; i++ {
+			rcidrs = append(rcidrs, cidrs[i])
+		}
+		if !reflect.DeepEqual(cidrs, rcidrs) {
+			t.Fatalf("expected re-allocated cidrs are the same collection for %v", tc.description)
+		}
+	}
+}
+
+func TestMapGetBitforCIDR(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		subNetMaskSize int
+		subNetCIDRStr  string
+		expectedBit    int
+		expectErr      bool
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.0.0.0/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "127.0.0.0/16",
+			expectedBit:    0,
+			expectErr:      false,
+			description:    "Get 0 Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "be00::/16",
+			expectedBit:    0,
+			expectErr:      false,
+			description:    "Get 0 Bit with IPv6",
+		},
+		{
+			clusterCIDRStr: "127.0.0.0/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "127.123.0.0/16",
+			expectedBit:    123,
+			expectErr:      false,
+			description:    "Get 123rd Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "beef::/16",
+			expectedBit:    0xef,
+			expectErr:      false,
+			description:    "Get xef Bit with IPv6",
+		},
+		{
+			clusterCIDRStr: "127.0.0.0/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "127.168.0.0/16",
+			expectedBit:    168,
+			expectErr:      false,
+			description:    "Get 168th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "be68::/16",
+			expectedBit:    0x68,
+			expectErr:      false,
+			description:    "Get x68th Bit with IPv6",
+		},
+		{
+			clusterCIDRStr: "127.0.0.0/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "127.224.0.0/16",
+			expectedBit:    224,
+			expectErr:      false,
+			description:    "Get 224th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "be00::/8",
+			subNetMaskSize: 16,
+			subNetCIDRStr:  "be24::/16",
+			expectedBit:    0x24,
+			expectErr:      false,
+			description:    "Get x24th Bit with IPv6",
+		},
+		{
+			clusterCIDRStr: "192.168.0.0/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "192.168.12.0/24",
+			expectedBit:    12,
+			expectErr:      false,
+			description:    "Get 12th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef::/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "beef:1200::/24",
+			expectedBit:    0x12,
+			expectErr:      false,
+			description:    "Get x12th Bit with IPv6",
+		},
+		{
+			clusterCIDRStr: "192.168.0.0/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "192.168.151.0/24",
+			expectedBit:    151,
+			expectErr:      false,
+			description:    "Get 151st Bit with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef::/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "beef:9700::/24",
+			expectedBit:    0x97,
+			expectErr:      false,
+			description:    "Get x97st Bit with IPv6",
+		},
+		{
+			clusterCIDRStr: "192.168.0.0/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "127.168.224.0/24",
+			expectErr:      true,
+			description:    "Get error with IPv4",
+		},
+		{
+			clusterCIDRStr: "beef::/16",
+			subNetMaskSize: 24,
+			subNetCIDRStr:  "2001:db00::/24",
+			expectErr:      true,
+			description:    "Get error with IPv6",
+		},
+	}
+
+	for _, tc := range cases {
+		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+
+		cs, err := NewCIDRSet(clusterCIDR, tc.subNetMaskSize)
+		if err != nil {
+			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
+		}
+		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+
+		got, err := cs.getIndexForCIDR(subnetCIDR)
+		if err == nil && tc.expectErr {
+			t.Errorf("expected error but got null for %v", tc.description)
+		}
+
+		if err != nil && !tc.expectErr {
+			t.Errorf("unexpected error: %v for %v", err, tc.description)
+		}
+
+		if got != tc.expectedBit {
+			t.Errorf("expected %v, but got %v for %v", tc.expectedBit, got, tc.description)
+		}
+	}
+}
+
+func TestMapOccupy(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr    string
+		subNetMaskSize    int
+		subNetCIDRStr     string
+		expectedUsedBegin uint64
+		expectedUsedEnd   uint64
+		expectErr         bool
+		description       string
+	}{
+		{
+			clusterCIDRStr:    "127.0.0.8/8",
+			subNetMaskSize:    16,
+			subNetCIDRStr:     "127.0.0.0/2",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   255,
+			expectErr:         false,
+			description:       "Occupy every Bit with IPv4 with a greater subnet",
+		},
+		{
+			clusterCIDRStr:    "127.0.0.0/8",
+			subNetMaskSize:    16,
+			subNetCIDRStr:     "127.0.0.0/8",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   255,
+			expectErr:         false,
+			description:       "Occupy all Bits with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:1200::/40",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:1200::/40",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   255,
+			expectErr:         false,
+			description:       "Occupy all Bits with IPv6",
+		},
+
+		{
+			clusterCIDRStr:    "2001:beef:1200::/40",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:1234::/34",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   255,
+			expectErr:         false,
+			description:       "Occupy every Bit with IPv6 with a greater subnet",
+		},
+		{
+			clusterCIDRStr:    "127.0.0.0/8",
+			subNetMaskSize:    16,
+			subNetCIDRStr:     "127.0.0.0/16",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   0,
+			expectErr:         false,
+			description:       "Occupy 1st Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:1200::/40",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:1200::/48",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   0,
+			expectErr:         false,
+			description:       "Occupy 1st Bit with IPv6",
+		},
+		{
+			clusterCIDRStr:    "127.0.0.0/8",
+			subNetMaskSize:    32,
+			subNetCIDRStr:     "127.0.0.0/16",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   65535,
+			expectErr:         false,
+			description:       "Occupy 65535 Bits with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:1200::/48",
+			subNetMaskSize:    64,
+			subNetCIDRStr:     "2001:beef:1200::/48",
+			expectedUsedBegin: 0,
+			expectedUsedEnd:   65535,
+			expectErr:         false,
+			description:       "Occupy 65535 Bits with IPv6",
+		},
+		{
+			clusterCIDRStr:    "127.0.0.0/7",
+			subNetMaskSize:    16,
+			subNetCIDRStr:     "127.0.0.0/15",
+			expectedUsedBegin: 256,
+			expectedUsedEnd:   257,
+			expectErr:         false,
+			description:       "Occupy 257th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:7f00::/39",
+			subNetMaskSize:    48,
+			subNetCIDRStr:     "2001:beef:7f00::/47",
+			expectedUsedBegin: 256,
+			expectedUsedEnd:   257,
+			expectErr:         false,
+			description:       "Occupy 257th Bit with IPv6",
+		},
+		{
+			clusterCIDRStr:    "127.0.0.0/7",
+			subNetMaskSize:    15,
+			subNetCIDRStr:     "127.0.0.0/15",
+			expectedUsedBegin: 128,
+			expectedUsedEnd:   128,
+			expectErr:         false,
+			description:       "Occupy 128th Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:7f00::/39",
+			subNetMaskSize:    47,
+			subNetCIDRStr:     "2001:beef:7f00::/47",
+			expectedUsedBegin: 128,
+			expectedUsedEnd:   128,
+			expectErr:         false,
+			description:       "Occupy 128th Bit with IPv6",
+		},
+		{
+			clusterCIDRStr:    "127.0.0.0/7",
+			subNetMaskSize:    18,
+			subNetCIDRStr:     "127.0.0.0/15",
+			expectedUsedBegin: 1024,
+			expectedUsedEnd:   1031,
+			expectErr:         false,
+			description:       "Occupy 1031st Bit with IPv4",
+		},
+		{
+			clusterCIDRStr:    "2001:beef:7f00::/39",
+			subNetMaskSize:    50,
+			subNetCIDRStr:     "2001:beef:7f00::/47",
+			expectedUsedBegin: 1024,
+			expectedUsedEnd:   1031,
+			expectErr:         false,
+			description:       "Occupy 1031st Bit with IPv6",
+		},
+	}
+
+	for _, tc := range cases {
+		_, clusterCIDR, err := net.ParseCIDR(tc.clusterCIDRStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+
+		cs, err := NewMapCIDRSet(clusterCIDR, tc.subNetMaskSize)
+		if err != nil {
+			t.Fatalf("Error allocating CIDRSet for %v", tc.description)
+		}
+
+		_, subnetCIDR, err := net.ParseCIDR(tc.subNetCIDRStr)
+		if err != nil {
+			t.Fatalf("unexpected error: %v for %v", err, tc.description)
+		}
+
+		err = cs.Occupy(subnetCIDR)
+		if err == nil && tc.expectErr {
+			t.Errorf("expected error but got none for %v", tc.description)
+		}
+		if err != nil && !tc.expectErr {
+			t.Errorf("unexpected error: %v for %v", err, tc.description)
+		}
+
+		var i uint64
+		for i = tc.expectedUsedBegin; i <= tc.expectedUsedEnd; i++ {
+			if _, ok := cs.used[i]; !ok {
+				t.Errorf("error for %v, expected used %v", tc.description, i)
+			}
+		}
+	}
+}
+
+func TestMapCIDRSetv6(t *testing.T) {
+	cases := []struct {
+		clusterCIDRStr string
+		subNetMaskSize int
+		expectedCIDR   string
+		expectedCIDR2  string
+		expectErr      bool
+		description    string
+	}{
+		{
+			clusterCIDRStr: "127.0.0.0/8",
+			subNetMaskSize: 32,
+			expectErr:      false,
+			expectedCIDR:   "127.0.0.0/32",
+			expectedCIDR2:  "127.0.0.1/32",
+			description:    "Max cluster subnet size with IPv4",
+		},
+		{
+			clusterCIDRStr: "2001:beef:1234:1234::/48",
+			subNetMaskSize: 111,
+			expectedCIDR:   "2001:beef:1234::/111",
+			expectedCIDR2:  "2001:beef:1234::2:0/111",
+			expectErr:      false,
+			description:    "Max cluster subnet size with IPv6",
+		},
+		{
+			clusterCIDRStr: "beef:1234::/32",
+			subNetMaskSize: 112,
+			expectErr:      true,
+			description:    "Out of max cluster subnet size with IPv6",
+		},
+		{
+			clusterCIDRStr: "2001:beef:1234:369b::/60",
+			subNetMaskSize: 64,
+			expectedCIDR:   "2001:beef:1234:3690::/64",
+			expectedCIDR2:  "2001:beef:1234:3691::/64",
+			expectErr:      false,
+			description:    "Allocate a few IPv6",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.description, func(t *testing.T) {
+			_, clusterCIDR, _ := net.ParseCIDR(tc.clusterCIDRStr)
+			a, err := NewMapCIDRSet(clusterCIDR, tc.subNetMaskSize)
+			if gotErr := err != nil; gotErr != tc.expectErr {
+				t.Fatalf("NewCIDRSet(%v, %v) = %v, %v; gotErr = %t, want %t", clusterCIDR, tc.subNetMaskSize, a, err, gotErr, tc.expectErr)
+			}
+			if a == nil {
+				return
+			}
+			p, err := a.AllocateNext()
+			if err == nil && tc.expectErr {
+				t.Errorf("a.AllocateNext() = nil, want error")
+			}
+			if err != nil && !tc.expectErr {
+				t.Errorf("a.AllocateNext() = %+v, want no error", err)
+			}
+			if !tc.expectErr {
+				if p != nil && p.String() != tc.expectedCIDR {
+					t.Fatalf("a.AllocateNext() got %+v, want %+v", p.String(), tc.expectedCIDR)
+				}
+			}
+			p2, err := a.AllocateNext()
+			if err == nil && tc.expectErr {
+				t.Errorf("a.AllocateNext() = nil, want error")
+			}
+			if err != nil && !tc.expectErr {
+				t.Errorf("a.AllocateNext() = %+v, want no error", err)
+			}
+			if !tc.expectErr {
+				if p2 != nil && p2.String() != tc.expectedCIDR2 {
+					t.Fatalf("a.AllocateNext() got %+v, want %+v", p2.String(), tc.expectedCIDR)
+				}
+			}
+		})
+	}
+}
+
+func benchmarkAllocateNextIPv6(subnetMaskSize int, b *testing.B) {
+	_, clusterCIDR, _ := net.ParseCIDR("2001:db8::/48")
+	a, _ := NewCIDRSet(clusterCIDR, subnetMaskSize)
+	for n := 0; n < b.N; n++ {
+		a.AllocateNext()
+	}
+}
+
+func benchmarkAllocateNextMapIPv6(subnetMaskSize int, b *testing.B) {
+	_, clusterCIDR, _ := net.ParseCIDR("2001:db8::/48")
+	a, _ := NewMapCIDRSet(clusterCIDR, subnetMaskSize)
+	for n := 0; n < b.N; n++ {
+		a.AllocateNext()
+	}
+}
+
+func BenchmarkAllocateNext_48_52(b *testing.B) { benchmarkAllocateNextIPv6(52, b) }
+func BenchmarkAllocateNext_48_56(b *testing.B) { benchmarkAllocateNextIPv6(56, b) }
+
+func BenchmarkAllocateNext_48_60(b *testing.B) { benchmarkAllocateNextIPv6(60, b) }
+
+//func BenchmarkAllocateNext_48_64(b *testing.B) { benchmarkAllocateNextIPv6(64, b) }
+
+func BenchmarkAllocateNextMap_48_52(b *testing.B) { benchmarkAllocateNextMapIPv6(52, b) }
+func BenchmarkAllocateNextMap_48_56(b *testing.B) { benchmarkAllocateNextMapIPv6(56, b) }
+
+func BenchmarkAllocateNextMap_48_60(b *testing.B)  { benchmarkAllocateNextMapIPv6(60, b) }
+func BenchmarkAllocateNextMap_48_64(b *testing.B)  { benchmarkAllocateNextMapIPv6(64, b) }
+func BenchmarkAllocateNextMap_48_88(b *testing.B)  { benchmarkAllocateNextMapIPv6(88, b) }
+func BenchmarkAllocateNextMap_48_100(b *testing.B) { benchmarkAllocateNextMapIPv6(100, b) }

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -87,7 +87,7 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 	cidrSets := make([]cidrset.Interface, len(allocatorParams.ClusterCIDRs))
 	for idx, cidr := range allocatorParams.ClusterCIDRs {
 		var cidrSet cidrset.Interface
-		cidrSet, err := cidrset.NewCIDRSet(cidr, allocatorParams.NodeCIDRMaskSizes[idx])
+		cidrSet, err := cidrset.NewMapCIDRSet(cidr, allocatorParams.NodeCIDRMaskSizes[idx])
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/controller/nodeipam/ipam/range_allocator.go
+++ b/pkg/controller/nodeipam/ipam/range_allocator.go
@@ -21,7 +21,7 @@ import (
 	"net"
 	"sync"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -52,7 +52,7 @@ type rangeAllocator struct {
 	// cluster cidrs as passed in during controller creation
 	clusterCIDRs []*net.IPNet
 	// for each entry in clusterCIDRs we maintain a list of what is used and what is not
-	cidrSets []*cidrset.CidrSet
+	cidrSets []cidrset.Interface
 	// nodeLister is able to list/get nodes and is populated by the shared informer passed to controller
 	nodeLister corelisters.NodeLister
 	// nodesSynced returns true if the node shared informer has been synced at least once.
@@ -84,8 +84,9 @@ func NewCIDRRangeAllocator(client clientset.Interface, nodeInformer informers.No
 
 	// create a cidrSet for each cidr we operate on
 	// cidrSet are mapped to clusterCIDR by index
-	cidrSets := make([]*cidrset.CidrSet, len(allocatorParams.ClusterCIDRs))
+	cidrSets := make([]cidrset.Interface, len(allocatorParams.ClusterCIDRs))
 	for idx, cidr := range allocatorParams.ClusterCIDRs {
+		var cidrSet cidrset.Interface
 		cidrSet, err := cidrset.NewCIDRSet(cidr, allocatorParams.NodeCIDRMaskSizes[idx])
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

Current CIDR_set used for the node IPAM range allocator uses
bitmaps, that is limiting the node-cidr-mask because the bitmap
size is 2^(node-mask - cluster-mask) and we don't want it to go
greater than 64kb, so the cluster-mask - node-mask should be
less than 16 in IPV6.

We canlet the bitmap grow, it  shouldn't be a problem if we only allows
 contiguous allocation,but in sparse scenarios will need to allocate the whole
range, that can lead to corner cases, i.e. a IPv6 /64 were the first
and last CIDR address of the range are allocated will use 2^64 bits.

Replacing a bitmap by a map[uint64]bool adds more overhead but allows
to deal with spare scenarios. The overhead shouldn't be a problem
for the current scale limits, with with 1K nodes or 10K clusters.

It also solves the scalability problem of the cidr_set based in
bitmaps as we can see in the following benchmarks that uses
an IPv6 Cluster CIDR with Mask /48, and a node_cidr mask
represented in the name of the test, so `BenchmarkAllocateNext_48_60`
means that we are testing the AllocateNext() function in a range of
2^60-48 addresses.

```
BenchmarkAllocateNext_48_52-4            2153733           658 ns/op           0 B/op          0 allocs/op
BenchmarkAllocateNext_48_56-4             207295          8037 ns/op           0 B/op          0 allocs/op
BenchmarkAllocateNext_48_60-4              19568         70644 ns/op          18 B/op          0 allocs/op
BenchmarkAllocateNextMap_48_52-4        24808773            51.2 ns/op         0 B/op          0 allocs/op
BenchmarkAllocateNextMap_48_56-4        24824025            53.7 ns/op         0 B/op          0 allocs/op
BenchmarkAllocateNextMap_48_60-4        22987214            49.8 ns/op         0 B/op          0 allocs/op
BenchmarkAllocateNextMap_48_64-4        21648500            55.6 ns/op         0 B/op          0 allocs/op
BenchmarkAllocateNextMap_48_88-4         1000000          1024 ns/op         270 B/op          7 allocs/op
BenchmarkAllocateNextMap_48_100-4        1000000          1054 ns/op         270 B/op          7 allocs/op

```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
the node IPAM limitation between the --node-cidr-mask and the cluster-cidr-mask is raised to 64 instead of 16.  
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
