### PR TITLE
/pkg/scheduler/framework/plugins/ : remove the repeat test example and add an test example

### DIFF
--- a/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go
+++ b/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go
@@ -578,19 +578,20 @@ func TestZoneSelectorSpreadPriority(t *testing.T) {
 			pods: []*v1.Pod{
 				buildPod(nodeMachine1Zone1, labels1, nil),
 				buildPod(nodeMachine1Zone2, labels1, nil),
-				buildPod(nodeMachine1Zone3, labels1, nil),
+				buildPod(nodeMachine2Zone2, labels1, nil),
 				buildPod(nodeMachine2Zone2, labels2, nil),
+				buildPod(nodeMachine1Zone3, labels1, nil),
 			},
 			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: labels1}}},
 			expectedList: []framework.NodeScore{
-				{Name: nodeMachine1Zone1, Score: 0},  // Pod on node
+				{Name: nodeMachine1Zone1, Score: 33}, // Pod on node
 				{Name: nodeMachine1Zone2, Score: 0},  // Pod on node
-				{Name: nodeMachine2Zone2, Score: 33}, // Pod in zone
-				{Name: nodeMachine1Zone3, Score: 0},  // Pod on node
-				{Name: nodeMachine2Zone3, Score: 33}, // Pod in zone
-				{Name: nodeMachine3Zone3, Score: 33}, // Pod in zone
+				{Name: nodeMachine2Zone2, Score: 0},  // Pod in zone
+				{Name: nodeMachine1Zone3, Score: 33}, // Pod on node
+				{Name: nodeMachine2Zone3, Score: 66}, // Pod in zone
+				{Name: nodeMachine3Zone3, Score: 66}, // Pod in zone
 			},
-			name: "four pods, 3 matching (z1=1, z2=1, z3=1)",
+			name: "five pods, 4 matching (z1=1, z2=2, z3=1)",
 		},
 		{
 			pod: buildPod("", labels1, controllerRef("ReplicationController", "name", "abc123")),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:https://github.com/kubernetes/kubernetes/pull/90040

**Special notes for your reviewer**:


see https://github.com/kubernetes/kubernetes/pull/90040#issuecomment-614389636

I found a duplicate test in pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go  when updating the test case. so removing the repeat test example and add an test example

see https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go#L558

```
{
			pod: buildPod("", labels1, nil),
			pods: []*v1.Pod{
				buildPod(nodeMachine1Zone1, labels1, nil),
				buildPod(nodeMachine1Zone2, labels1, nil),
				buildPod(nodeMachine2Zone2, labels2, nil),
				buildPod(nodeMachine1Zone3, labels1, nil),
			},
			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: labels1}}},
			expectedList: []framework.NodeScore{
				{Name: nodeMachine1Zone1, Score: 0},  // Pod on node
				{Name: nodeMachine1Zone2, Score: 0},  // Pod on node
				{Name: nodeMachine2Zone2, Score: 33}, // Pod in zone
				{Name: nodeMachine1Zone3, Score: 0},  // Pod on node
				{Name: nodeMachine2Zone3, Score: 33}, // Pod in zone
				{Name: nodeMachine3Zone3, Score: 33}, // Pod in zone
			},
			name: "four pods, 3 matching (z1=1, z2=1, z3=1)",
		}
```

see https://github.com/kubernetes/kubernetes/blob/master/pkg/scheduler/framework/plugins/defaultpodtopologyspread/default_pod_topology_spread_test.go#L577

```
{
			pod: buildPod("", labels1, nil),
			pods: []*v1.Pod{
				buildPod(nodeMachine1Zone1, labels1, nil),
				buildPod(nodeMachine1Zone2, labels1, nil),
				buildPod(nodeMachine1Zone3, labels1, nil),
				buildPod(nodeMachine2Zone2, labels2, nil),
			},
			services: []*v1.Service{{Spec: v1.ServiceSpec{Selector: labels1}}},
			expectedList: []framework.NodeScore{
				{Name: nodeMachine1Zone1, Score: 0},  // Pod on node
				{Name: nodeMachine1Zone2, Score: 0},  // Pod on node
				{Name: nodeMachine2Zone2, Score: 33}, // Pod in zone
				{Name: nodeMachine1Zone3, Score: 0},  // Pod on node
				{Name: nodeMachine2Zone3, Score: 33}, // Pod in zone
				{Name: nodeMachine3Zone3, Score: 33}, // Pod in zone
			},
			name: "four pods, 3 matching (z1=1, z2=1, z3=1)",
		}
```


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
