### PR TITLE
WIP:Preserve querystring when proxy connection is upgraded

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -265,6 +265,9 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 		location = *req.URL
 		location.Scheme = h.Location.Scheme
 		location.Host = h.Location.Host
+	} else {
+		// Even when not using the request location, we want to preserve the querystring
+		location.RawQuery = req.URL.RawQuery
 	}
 
 	clone := utilnet.CloneRequest(req)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug where, when making a websocket request through kubectl proxy, the querystring parameters are lost.

**Which issue(s) this PR fixes**:
Fixes #89360

**Special notes for your reviewer**:
I verified running locally, with the following commands:
```
kubectl run ws --image=brianpursley/hello-websocket-server --restart=Never --port 8888
kubectl proxy
wscat -c ws://localhost:8001/api/v1/namespaces/default/pods/ws/proxy/test?token=123
kubectl logs -f ws
```

Original output:
```
Server listening on port 8888
New connection with path /test and headers:
...
```

New output with this PR (now it preserves ?token=123 on the request):
```
Server listening on port 8888
New connection with path /test?token=123 and headers:
...
```

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
