### PR TITLE
[WIP] Replace bitmap service IP allocator with a map[int64]

### DIFF
--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -206,7 +206,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 	}
 
 	serviceClusterIPAllocator, err := ipallocator.NewAllocatorCIDRRange(&serviceClusterIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
-		mem := allocator.NewAllocationMap(max, rangeSpec)
+		mem := allocator.NewAllocation(max, rangeSpec)
 		// TODO etcdallocator package to return a storage interface via the storageFactory
 		etcd, err := serviceallocator.NewEtcd(mem, "/ranges/serviceips", api.Resource("serviceipallocations"), serviceStorageConfig)
 		if err != nil {
@@ -225,7 +225,7 @@ func (c LegacyRESTStorageProvider) NewLegacyRESTStorage(restOptionsGetter generi
 	if utilfeature.DefaultFeatureGate.Enabled(features.IPv6DualStack) && c.SecondaryServiceIPRange.IP != nil {
 		var secondaryServiceClusterIPRegistry rangeallocation.RangeRegistry
 		secondaryServiceClusterIPAllocator, err = ipallocator.NewAllocatorCIDRRange(&c.SecondaryServiceIPRange, func(max int, rangeSpec string) (allocator.Interface, error) {
-			mem := allocator.NewAllocationMap(max, rangeSpec)
+			mem := allocator.NewAllocation(max, rangeSpec)
 			// TODO etcdallocator package to return a storage interface via the storageFactory
 			etcd, err := serviceallocator.NewEtcd(mem, "/ranges/secondaryserviceips", api.Resource("serviceipallocations"), serviceStorageConfig)
 			if err != nil {

--- a/pkg/registry/core/service/allocator/BUILD
+++ b/pkg/registry/core/service/allocator/BUILD
@@ -11,6 +11,7 @@ go_library(
     srcs = [
         "bitmap.go",
         "interfaces.go",
+        "map.go",
         "utils.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/registry/core/service/allocator",
@@ -20,6 +21,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "bitmap_test.go",
+        "map_test.go",
         "utils_test.go",
     ],
     embed = [":go_default_library"],

--- a/pkg/registry/core/service/allocator/bitmap_test.go
+++ b/pkg/registry/core/service/allocator/bitmap_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package allocator
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -154,6 +156,43 @@ func TestContiguousAllocation(t *testing.T) {
 	if _, ok, _ := m.AllocateNext(); ok {
 		t.Errorf("unexpected success")
 	}
+}
+
+func TestBitmapSizeSnapshotAndRestore(t *testing.T) {
+	// 1M IPs
+	max := 1000000
+	m := NewAllocationMap(max, "test")
+	// Allocate all
+	start := time.Now()
+	for i := 0; i < max; i++ {
+		_, ok, _ := m.AllocateNext()
+		if !ok {
+			t.Fatalf("unexpected error")
+		}
+
+	}
+	elapsed := time.Since(start)
+	fmt.Printf("Fill the map took %s\n", elapsed)
+
+	start = time.Now()
+	spec, bytes := m.Snapshot()
+	elapsed = time.Since(start)
+	fmt.Printf("Size snapshot: %d bytes in %v\n", len(bytes), elapsed)
+
+	m2 := NewAllocationMap(max, "test")
+	// Check the time to load a snapshot
+	start = time.Now()
+	err := m2.Restore(spec, bytes)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	elapsed = time.Since(start)
+	fmt.Printf("Load the snapshot took %s\n", elapsed)
+
+	if m2.count != max {
+		t.Errorf("expect count to %d, but got %d", 0, m.count)
+	}
+
 }
 
 func benchmarkBitmap(max int, b *testing.B) {

--- a/pkg/registry/core/service/allocator/map.go
+++ b/pkg/registry/core/service/allocator/map.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package allocator
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+// AllocationMap is a map of resources that can be allocated atomically.
+//
+// Each resource has an offset.  The internal structure is a map, with a key for each offset.
+//
+type AllocationMap struct {
+	// strategy carries the details of how to choose the next available item out of the range
+	strategy keyAllocator
+	// max is the maximum size of the usable items in the range
+	max int
+	// rangeSpec is the range specifier, matching RangeAllocation.Range
+	rangeSpec string
+
+	// lock guards the following members
+	lock sync.Mutex
+	// allocated is a map of the allocated items in the range
+	allocated map[uint64]bool
+}
+
+// AllocationMap implements Interface and Snapshottable
+var _ Interface = &AllocationMap{}
+var _ Snapshottable = &AllocationMap{}
+
+// keyAllocator represents a search strategy in the allocation map for a valid item.
+type keyAllocator interface {
+	AllocateKey(allocated map[uint64]bool, max int) (int, bool)
+}
+
+// NewAllocation creates an allocation bitmap using the random scan strategy.
+func NewAllocation(max int, rangeSpec string) *AllocationMap {
+	a := AllocationMap{
+		strategy: randomMapScanStrategy{
+			rand: rand.New(rand.NewSource(time.Now().UnixNano())),
+		},
+		allocated: make(map[uint64]bool),
+		max:       max,
+		rangeSpec: rangeSpec,
+	}
+	return &a
+}
+
+// Allocate attempts to reserve the provided item.
+// Returns true if it was allocated, false if it was already in use
+func (r *AllocationMap) Allocate(offset int) (bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if _, ok := r.allocated[uint64(offset)]; ok {
+		return false, nil
+	}
+	r.allocated[uint64(offset)] = true
+	return true, nil
+}
+
+// AllocateNext reserves one of the items from the pool.
+// (0, false, nil) may be returned if there are no items left.
+func (r *AllocationMap) AllocateNext() (int, bool, error) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	next, ok := r.strategy.AllocateKey(r.allocated, r.max)
+	if !ok {
+		return 0, false, nil
+	}
+	r.allocated[uint64(next)] = true
+	return next, true, nil
+}
+
+// Release releases the item back to the pool. Releasing an
+// unallocated item or an item out of the range is a no-op and
+// returns no error.
+func (r *AllocationMap) Release(offset int) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if _, ok := r.allocated[uint64(offset)]; ok {
+		delete(r.allocated, uint64(offset))
+	}
+	return nil
+}
+
+// ForEach calls the provided function for each allocated bit.  The
+// AllocationMap may not be modified while this loop is running.
+func (r *AllocationMap) ForEach(fn func(int)) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	for k := range r.allocated {
+		fn(int(k))
+	}
+}
+
+// Has returns true if the provided item is already allocated and a call
+// to Allocate(offset) would fail.
+func (r *AllocationMap) Has(offset int) bool {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	_, ok := r.allocated[uint64(offset)]
+	return ok
+}
+
+// Free returns the count of items left in the range.
+func (r *AllocationMap) Free() int {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	return r.max - len(r.allocated)
+}
+
+// Snapshot saves the current state of the pool.
+func (r *AllocationMap) Snapshot() (string, []byte) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	if err := enc.Encode(r.allocated); err != nil {
+		return "", nil
+	}
+	return r.rangeSpec, buf.Bytes()
+}
+
+// Restore restores the pool to the previously captured state.
+func (r *AllocationMap) Restore(rangeSpec string, data []byte) error {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	if r.rangeSpec != rangeSpec {
+		return errors.New("the provided range does not match the current range")
+	}
+
+	buf := bytes.NewBuffer(data)
+	dec := gob.NewDecoder(buf)
+
+	if err := dec.Decode(&r.allocated); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// randomScanStrategy chooses a random address from the provided big.Int, and then
+// scans forward looking for the next available address (it will wrap the range if
+// necessary).
+type randomMapScanStrategy struct {
+	rand *rand.Rand
+}
+
+func (rss randomMapScanStrategy) AllocateKey(allocated map[uint64]bool, max int) (int, bool) {
+	if len(allocated) >= max {
+		return 0, false
+	}
+	offset := rss.rand.Intn(max)
+	for i := 0; i < max; i++ {
+		at := (offset + i) % max
+		if _, ok := allocated[uint64(at)]; !ok {
+			return at, true
+		}
+	}
+	return 0, false
+}
+
+var _ keyAllocator = randomMapScanStrategy{}

--- a/pkg/registry/core/service/allocator/map_test.go
+++ b/pkg/registry/core/service/allocator/map_test.go
@@ -22,24 +22,24 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 )
 
-func TestAllocate(t *testing.T) {
+func TestMapAllocate(t *testing.T) {
 	max := 10
-	m := NewAllocationMap(max, "test")
+	m := NewAllocation(max, "test")
 
 	if _, ok, _ := m.AllocateNext(); !ok {
 		t.Fatalf("unexpected error")
 	}
-	if m.count != 1 {
-		t.Errorf("expect to get %d, but got %d", 1, m.count)
+	if len(m.allocated) != 1 {
+		t.Errorf("expect to get %d, but got %d", 1, len(m.allocated))
 	}
 	if f := m.Free(); f != max-1 {
 		t.Errorf("expect to get %d, but got %d", max-1, f)
 	}
 }
 
-func TestAllocateMax(t *testing.T) {
+func TestMapAllocateMax(t *testing.T) {
 	max := 10
-	m := NewAllocationMap(max, "test")
+	m := NewAllocation(max, "test")
 	for i := 0; i < max; i++ {
 		if _, ok, _ := m.AllocateNext(); !ok {
 			t.Fatalf("unexpected error")
@@ -54,8 +54,8 @@ func TestAllocateMax(t *testing.T) {
 	}
 }
 
-func TestAllocateError(t *testing.T) {
-	m := NewAllocationMap(10, "test")
+func TestMapAllocateError(t *testing.T) {
+	m := NewAllocation(10, "test")
 	if ok, _ := m.Allocate(3); !ok {
 		t.Errorf("error allocate offset %v", 3)
 	}
@@ -64,9 +64,9 @@ func TestAllocateError(t *testing.T) {
 	}
 }
 
-func TestRelease(t *testing.T) {
+func TestMapRelease(t *testing.T) {
 	offset := 3
-	m := NewAllocationMap(10, "test")
+	m := NewAllocation(10, "test")
 	if ok, _ := m.Allocate(offset); !ok {
 		t.Errorf("error allocate offset %v", offset)
 	}
@@ -84,7 +84,7 @@ func TestRelease(t *testing.T) {
 	}
 }
 
-func TestForEach(t *testing.T) {
+func TestMapForEach(t *testing.T) {
 	testCases := []sets.Int{
 		sets.NewInt(),
 		sets.NewInt(0),
@@ -93,7 +93,7 @@ func TestForEach(t *testing.T) {
 	}
 
 	for i, tc := range testCases {
-		m := NewAllocationMap(10, "test")
+		m := NewAllocation(10, "test")
 		for offset := range tc {
 			if ok, _ := m.Allocate(offset); !ok {
 				t.Errorf("[%d] error allocate offset %v", i, offset)
@@ -115,29 +115,29 @@ func TestForEach(t *testing.T) {
 	}
 }
 
-func TestSnapshotAndRestore(t *testing.T) {
+func TestMapSnapshotAndRestore(t *testing.T) {
 	offset := 3
-	m := NewAllocationMap(10, "test")
+	m := NewAllocation(10, "test")
 	if ok, _ := m.Allocate(offset); !ok {
 		t.Errorf("error allocate offset %v", offset)
 	}
 	spec, bytes := m.Snapshot()
 
-	m2 := NewAllocationMap(10, "test")
+	m2 := NewAllocation(10, "test")
 	err := m2.Restore(spec, bytes)
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	if m2.count != 1 {
-		t.Errorf("expect count to %d, but got %d", 0, m.count)
+	if len(m2.allocated) != 1 {
+		t.Errorf("expect count to %d, but got %d", 0, len(m.allocated))
 	}
 	if !m2.Has(offset) {
 		t.Errorf("expect offset %v allocated", offset)
 	}
 }
 
-func TestContiguousAllocation(t *testing.T) {
+func TestMapContiguousAllocation(t *testing.T) {
 	max := 10
 	m := NewContiguousAllocationMap(max, "test")
 
@@ -156,15 +156,15 @@ func TestContiguousAllocation(t *testing.T) {
 	}
 }
 
-func benchmarkBitmap(max int, b *testing.B) {
+func benchmarkMap(max int, b *testing.B) {
 	m := NewAllocationMap(max, "test")
 	for n := 0; n < b.N; n++ {
 		m.AllocateNext()
 	}
 }
 
-func BenchmarkBitmap1000(b *testing.B)     { benchmarkBitmap(1000, b) }
-func BenchmarkBitmap10000(b *testing.B)    { benchmarkBitmap(10000, b) }
-func BenchmarkBitmap100000(b *testing.B)   { benchmarkBitmap(100000, b) }
-func BenchmarkBitmap1000000(b *testing.B)  { benchmarkBitmap(1000000, b) }
-func BenchmarkBitmap10000000(b *testing.B) { benchmarkBitmap(10000000, b) }
+func BenchmarkMap1000(b *testing.B)     { benchmarkMap(1000, b) }
+func BenchmarkMap10000(b *testing.B)    { benchmarkMap(10000, b) }
+func BenchmarkMap100000(b *testing.B)   { benchmarkMap(100000, b) }
+func BenchmarkMap1000000(b *testing.B)  { benchmarkMap(1000000, b) }
+func BenchmarkMap10000000(b *testing.B) { benchmarkMap(10000000, b) }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test

/kind feature
> /kind flake

**What this PR does / why we need it**:

Current service IP allocator limits IPv6 ranges to a /112. However, the most common assignment (and best practice) for a host subnet is a /64.
Replacing the current bitmap implementation for the serviceip allocator with a map allows us to handle spare scenarios so the user can allocate any IP of the range.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
