### PR TITLE
Avoid overwriting podStatus ContainerStatuses in convertToAPIContainerStatuses

### DIFF
--- a/pkg/kubelet/kubelet_pods.go
+++ b/pkg/kubelet/kubelet_pods.go
@@ -1837,11 +1837,15 @@ func (kl *Kubelet) convertToAPIContainerStatuses(pod *v1.Pod, podStatus *kubecon
 		statuses[container.Name] = status
 	}
 
+	// Copy the slice before sorting it
+	containerStatusesCopy := make([]*kubecontainer.Status, len(podStatus.ContainerStatuses))
+	copy(containerStatusesCopy, podStatus.ContainerStatuses)
+
 	// Make the latest container status comes first.
-	sort.Sort(sort.Reverse(kubecontainer.SortContainerStatusesByCreationTime(podStatus.ContainerStatuses)))
+	sort.Sort(sort.Reverse(kubecontainer.SortContainerStatusesByCreationTime(containerStatusesCopy)))
 	// Set container statuses according to the statuses seen in pod status
 	containerSeen := map[string]int{}
-	for _, cStatus := range podStatus.ContainerStatuses {
+	for _, cStatus := range containerStatusesCopy {
 		cName := cStatus.Name
 		if _, ok := statuses[cName]; !ok {
 			// This would also ignore the infra container.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

There is a race condition between the kubelet SyncLoop when the PLEG issues a ContainerDied event and the pod worker syncPod call.

This race condition is triggered by :

- In the SyncLoop, the call to cleanUpContainersInPod which in turn calls generateAPIPodStatus on a podStatus pointer fetched from the pod cache https://github.com/kubernetes/kubernetes/blob/7d176851f2c433f4301a64dfeb3b2626ca9c2f60/pkg/kubelet/kubelet.go#L2278-L2289
- In the pod workers, the call to syncPod which in turn also calls generateAPIPodStatus on a podStatus pointer fetched from the pod cache https://github.com/kubernetes/kubernetes/blob/7d176851f2c433f4301a64dfeb3b2626ca9c2f60/pkg/kubelet/kubelet.go#L1545-L1546
generateAPIPodStatus would eventually call convertToAPIContainerStatuses that sorts podStatus.ContainerStatuses in place. This is not a thread-safe operation, and when called concurrently, leads to the resulting podStatus.ContainerStatuses missing some entries and having some entries as duplicates.

At this point, the pod cache is containing a podStatus that is missing some containers statuses, thus computePodActions https://github.com/kubernetes/kubernetes/blob/7d176851f2c433f4301a64dfeb3b2626ca9c2f60/pkg/kubelet/kuberuntime/kuberuntime_manager.go#L516 will try creating the missing containers.

However, as those containers may already be running, this leads the pod to be in CreateContainerError that does not recover until either the kubelet is restarted or another mechanism causes a refresh of the runtime state and a Set to the podCache.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #94557

**Special notes for your reviewer**:

If testing is needed, would be glad to have pointers to add appropriate test cases to catch the issue! 

Also, I'm not very familiar to the codebase as this is my first contribution, so would be glad to modify my PR if there is a better way to fix the underlying issue. The suggested fix is non-invasive as it only avoids the sort in-place in the affected codepath (instead of, for instance adding a locking mechanism around what is fetched from the podCache).

We managed to track down and reproduce the issue as we were seeing `CreateContainerError` on pods containing multiple containers that were happening after Kubelet restarts. On a test cluster, we deployed the same setup, and forced a kubelet restart at least once every 20min until a `CreateContainerError` is encountered. All pods would eventually get stuck in `CreateContainerError` until the kubelet is restarted on the fleet.

We traced this down to duplicate and missing entries in `podStatus.ContainerStatuses`.

With the proposed patch, we didn't encounter `CreateContainerError` on restarting the kubelet anymore.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
