### PR TITLE
use OWNERS regex filtering mechanism to auto-label metrics changes

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -38,3 +38,8 @@ filters:
       - kubernetes/dep-approvers
     labels:
       - area/dependency
+  # metrics.go files are sig-instrumentation related, and should be tagged
+  # and reviewed by sig-instrumentation
+  "metrics\\.go$":
+    labels:
+      - sig/instrumentation


### PR DESCRIPTION
We'd like to auto-label SIG-Instrumentation for changes to files which are likely to be instrumentation related. 

Specifically, this change enables auto-labeling for sig-instrumentaion if the file matches `.*metrics[.]go`. 

For ref: [Issue-89788](https://github.com/kubernetes/kubernetes/issues/89788)

```release-note
NONE
```