### PR TITLE
Added kubectl apply validation to prevent using --dry-run=server with --force

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply.go
@@ -261,6 +261,10 @@ func (o *ApplyOptions) Complete(f cmdutil.Factory, cmd *cobra.Command) error {
 		return err
 	}
 
+	if o.DryRunStrategy == cmdutil.DryRunServer && o.DeleteOptions.ForceDeletion {
+		return fmt.Errorf("--dry-run=server cannot be used with --force")
+	}
+
 	o.OpenAPISchema, _ = f.OpenAPISchema()
 	o.Validator, err = f.Validator(cmdutil.GetFlagBool(cmd, "validate"))
 	if err != nil {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/apply/apply_test.go
@@ -1388,3 +1388,31 @@ func TestForceApply(t *testing.T) {
 		})
 	}
 }
+
+func TestDontAllowForceApplyWithServerDryRun(t *testing.T) {
+	expectedError := "error: --dry-run=server cannot be used with --force"
+
+	cmdutil.BehaviorOnFatal(func(str string, code int) {
+		panic(str)
+	})
+	defer func() {
+		actualError := recover()
+		if expectedError != actualError {
+			t.Fatalf(`expected error "%s", but got "%s"`, expectedError, actualError)
+		}
+	}()
+
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	tf.ClientConfigVal = cmdtesting.DefaultClientConfig()
+
+	ioStreams, _, _, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdApply("kubectl", tf, ioStreams)
+	cmd.Flags().Set("filename", filenameRC)
+	cmd.Flags().Set("dry-run", "server")
+	cmd.Flags().Set("force", "true")
+	cmd.Run(cmd, []string{})
+
+	t.Fatalf(`expected error "%s"`, expectedError)
+}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
If you try to use `kubectl apply` with  `--dry-run=server`  and `--force` flags, it will hang indefinitely because it is waiting for the resource to be deleted but that never actually happens because dry run is being used.

This PR adds a validation check to prevent `--dry-run=server` and `--force` from being used at the same time.

**Which issue(s) this PR fixes**:
This is associated with https://github.com/kubernetes/kubernetes/issues/90017, but I'm not sure I can say this "fixes" it because it just prevents that combination of flags.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

