### PR TITLE
Update curl commands to use pem format

### DIFF
--- a/staging/src/k8s.io/sample-apiserver/README.md
+++ b/staging/src/k8s.io/sample-apiserver/README.md
@@ -155,13 +155,7 @@ only this superuser group is authorized.
    openssl x509 -req -days 365 -in client.csr -CA ca.crt -CAkey ca.key -set_serial 01 -out client.crt
    ```
 
-3. As curl requires client certificates in p12 format with password, do the conversion:
-
-   ``` shell
-   openssl pkcs12 -export -in ./client.crt -inkey ./client.key -out client.p12 -passout pass:password
-   ```
-
-4. With these keys and certs in-place, we start the server:
+3. With these keys and certs in-place, we start the server:
 
    ``` shell
    etcd &
@@ -183,10 +177,10 @@ only this superuser group is authorized.
    member. `system:masters` is the superuser group such that delegated
    authorization is skipped.
 
-5. Use curl to access the server using the client certificate in p12 format for authentication:
+4. Use curl to access the server using the client certificate in pem format for authentication:
 
    ``` shell
-   curl -fv -k --cert client.p12:password \
+   curl -k --cert client.crt --key client.key \
       https://localhost:8443/apis/wardle.example.com/v1alpha1/namespaces/default/flunders
    ```
 


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
I tried these instructions on a Ubuntu 18.04 desktop with curl 7.58.0 . This command worked when I tried the pem format.

![Screenshot from 2020-04-16 19-18-45](https://user-images.githubusercontent.com/94814/79525277-55c81300-8017-11ea-866d-ca450a4086c9.png)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
