### PR TITLE
Sync csi-hostpath manifests

### DIFF
--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-attacher.yaml
@@ -40,7 +40,7 @@ spec:
       serviceAccountName: csi-attacher
       containers:
         - name: csi-attacher
-          image: quay.io/k8scsi/csi-attacher:v2.1.0
+          image: quay.io/k8scsi/csi-attacher:v2.2.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-driverinfo.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-driverinfo.yaml
@@ -3,8 +3,10 @@ kind: CSIDriver
 metadata:
   name: hostpath.csi.k8s.io
 spec:
-  # Supports both modes, but needs pod info for that to determine the actual mode.
-  podInfoOnMount: true
+  # Supports persistent and ephemeral inline volumes.
   volumeLifecycleModes:
   - Persistent
   - Ephemeral
+  # To determine at runtime which mode a volume uses, pod info and its
+  # "csi.storage.k8s.io/ephemeral" entry are needed.
+  podInfoOnMount: true

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-plugin.yaml
@@ -36,11 +36,7 @@ spec:
     spec:
       containers:
         - name: node-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
-          lifecycle:
-            preStop:
-              exec:
-                command: ["/bin/sh", "-c", "rm -rf /registration/csi-hostpath /registration/csi-hostpath-reg.sock"]
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
@@ -71,6 +67,8 @@ spec:
             - "--v=5"
             - "--endpoint=$(CSI_ENDPOINT)"
             - "--nodeid=$(KUBE_NODE_NAME)"
+            # The only difference to github.com/kubernetes-csi/csi-driver-host-path/deploy
+            # - we have a tests that checks node limits.
             - "--maxvolumespernode=10"
           env:
             - name: CSI_ENDPOINT
@@ -107,7 +105,6 @@ spec:
               name: csi-data-dir
             - mountPath: /dev
               name: dev-dir
-
         - name: liveness-probe
           volumeMounts:
           - mountPath: /csi
@@ -115,7 +112,6 @@ spec:
           image: quay.io/k8scsi/livenessprobe:v1.1.0
           args:
           - --csi-address=/csi/csi.sock
-          - --connection-timeout=3s
           - --health-port=9898
 
       volumes:

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-provisioner.yaml
@@ -40,11 +40,11 @@ spec:
       serviceAccountName: csi-provisioner
       containers:
         - name: csi-provisioner
-          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          image: quay.io/k8scsi/csi-provisioner:v1.6.0
           args:
             - -v=5
             - --csi-address=/csi/csi.sock
-            - --connection-timeout=15s
+            - --feature-gates=Topology=true
           securityContext:
             # This is necessary only for systems with SELinux, where
             # non-privileged sidecar containers cannot access unix domain socket

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-resizer.yaml
@@ -27,16 +27,23 @@ spec:
       labels:
         app: csi-hostpath-resizer
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
       serviceAccountName: csi-resizer
       containers:
         - name: csi-resizer
-          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          image: quay.io/k8scsi/csi-resizer:v0.5.0
           args:
-            - "--v=5"
-            - "--csi-address=$(ADDRESS)"
-          env:
-            - name: ADDRESS
-              value: /csi/csi.sock
+            - -v=5
+            - -csi-address=/csi/csi.sock
           securityContext:
             # This is necessary only for systems with SELinux, where
             # non-privileged sidecar containers cannot access unix domain socket

--- a/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
+++ b/test/e2e/testing-manifests/storage-csi/hostpath/hostpath/csi-hostpath-snapshotter.yaml
@@ -1,52 +1,59 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: csi-snapshotter
+  name: csi-hostpath-snapshotter
   labels:
-    app: csi-snapshotter
+    app: csi-hostpath-snapshotter
 spec:
   selector:
-    app: csi-snapshotter
+    app: csi-hostpath-snapshotter
   ports:
-  - name: dummy
-    port: 12345
+    - name: dummy
+      port: 12345
 
 ---
 kind: StatefulSet
 apiVersion: apps/v1
 metadata:
-  name: csi-snapshotter
+  name: csi-hostpath-snapshotter
 spec:
-  serviceName: "csi-snapshotter"
+  serviceName: "csi-hostpath-snapshotter"
   replicas: 1
   selector:
     matchLabels:
-      app: csi-snapshotter
+      app: csi-hostpath-snapshotter
   template:
     metadata:
       labels:
-        app: csi-snapshotter
+        app: csi-hostpath-snapshotter
     spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - csi-hostpathplugin
+            topologyKey: kubernetes.io/hostname
       serviceAccount: csi-snapshotter
       containers:
-      - name: csi-snapshotter
-        image: quay.io/k8scsi/csi-snapshotter:v2.0.0
-        args:
-        - "--v=5"
-        - "--csi-address=$(ADDRESS)"
-        env:
-        - name: ADDRESS
-          value: /csi/csi.sock
-        securityContext:
-          # This is necessary only for systems with SELinux, where
-          # non-privileged sidecar containers cannot access unix domain socket
-          # created by privileged CSI driver container.
-          privileged: true
-        volumeMounts:
-        - name: socket-dir
-          mountPath: /csi
+        - name: csi-snapshotter
+          image: quay.io/k8scsi/csi-snapshotter:v2.1.0
+          args:
+            - -v=5
+            - --csi-address=/csi/csi.sock
+          securityContext:
+            # This is necessary only for systems with SELinux, where
+            # non-privileged sidecar containers cannot access unix domain socket
+            # created by privileged CSI driver container.
+            privileged: true
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
       volumes:
-      - hostPath:
-          path: /var/lib/kubelet/plugins/csi-hostpath
-          type: DirectoryOrCreate
-        name: socket-dir
+        - hostPath:
+            path: /var/lib/kubelet/plugins/csi-hostpath
+            type: DirectoryOrCreate
+          name: socket-dir


### PR DESCRIPTION
Copy csi-hostpath driver manifests from kubernetes-csi/csi-driver-host-path. It bumps version of all images to the release shipped along Kubernetes 1.18 (+removes PreStop hook).

Initially I wanted just to remove PreStop hook as in https://github.com/kubernetes-csi/csi-driver-host-path/pull/176, but I noticed the yaml files used in kubernetes/kubernetes are quite different.

/kind cleanup

**What this PR does / why we need it**:
See https://github.com/kubernetes-csi/csi-driver-host-path/issues/175, fixing this in kubernetes/kubernetes.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

@msau42 @pohly, PTAL
