### PR TITLE
Revert "stop defaulting kubeconfig to http://localhost:8080"

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -35,13 +35,22 @@ import (
 var (
 	// ClusterDefaults has the same behavior as the old EnvVar and DefaultCluster fields
 	// DEPRECATED will be replaced
-	ClusterDefaults = clientcmdapi.Cluster{Server: os.Getenv("KUBERNETES_MASTER")}
+	ClusterDefaults = clientcmdapi.Cluster{Server: getDefaultServer()}
 	// DefaultClientConfig represents the legacy behavior of this package for defaulting
 	// DEPRECATED will be replace
 	DefaultClientConfig = DirectClientConfig{*clientcmdapi.NewConfig(), "", &ConfigOverrides{
 		ClusterDefaults: ClusterDefaults,
 	}, nil, NewDefaultClientConfigLoadingRules(), promptedCredentials{}}
 )
+
+// getDefaultServer returns a default setting for DefaultClientConfig
+// DEPRECATED
+func getDefaultServer() string {
+	if server := os.Getenv("KUBERNETES_MASTER"); len(server) > 0 {
+		return server
+	}
+	return "http://localhost:8080"
+}
 
 // ClientConfig is used to make it easy to get an api server client
 type ClientConfig interface {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/BUILD
@@ -27,6 +27,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/cli-runtime/pkg/genericclioptions:go_default_library",
         "//staging/src/k8s.io/kubectl/pkg/cmd/util:go_default_library",
+        "//vendor/github.com/spf13/cobra:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/version/version_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
@@ -27,9 +29,17 @@ import (
 func TestNewCmdVersionWithoutConfigFile(t *testing.T) {
 	tf := cmdutil.NewFactory(&genericclioptions.ConfigFlags{})
 	streams, _, buf, _ := genericclioptions.NewTestIOStreams()
-	cmd := NewCmdVersion(tf, streams)
-	cmd.SetOutput(buf)
-	if err := cmd.Execute(); err != nil {
+	o := NewOptions(streams)
+	if err := o.Complete(tf, &cobra.Command{}); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if err := o.Validate(); err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	// FIXME soltysh:
+	// since we have defaulting to localhost:8080 in staging/src/k8s.io/client-go/tools/clientcmd/client_config.go#getDefaultServer
+	// we need to ignore the localhost:8080 server, when above gets removed this should be dropped too
+	if err := o.Run(); err != nil && !strings.Contains(err.Error(), "localhost:8080") {
 		t.Errorf("Cannot execute version command: %v", err)
 	}
 	if !strings.Contains(buf.String(), "Client Version") {

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -324,7 +324,6 @@ runTests() {
     exit 1
   fi
   kube::log::status "Checking kubectl version"
-  export KUBERNETES_MASTER=http://127.0.0.1:${API_PORT}
   kubectl version
 
   # Generate a random namespace name, based on the current time (to make


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This reverts commit b19ad9e7a78fea0ecdffe7aa53bbe309d9d346ee.

**Which issue(s) this PR fixes**:
Fixes #90074

**Special notes for your reviewer**:
/assign @liggitt 

**Does this PR introduce a user-facing change?**:
```release-note
Fixed a regression running kubectl commands with  --local or --dry-run flags when no kubeconfig file is present
```

/sig cli
/priority critical-urgent 