### PR TITLE
Automated cherry pick of #90243: Revert "stop defaulting kubeconfig to http://localhost:8080"

### DIFF
--- a/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -35,13 +35,22 @@ import (
 var (
 	// ClusterDefaults has the same behavior as the old EnvVar and DefaultCluster fields
 	// DEPRECATED will be replaced
-	ClusterDefaults = clientcmdapi.Cluster{Server: os.Getenv("KUBERNETES_MASTER")}
+	ClusterDefaults = clientcmdapi.Cluster{Server: getDefaultServer()}
 	// DefaultClientConfig represents the legacy behavior of this package for defaulting
 	// DEPRECATED will be replace
 	DefaultClientConfig = DirectClientConfig{*clientcmdapi.NewConfig(), "", &ConfigOverrides{
 		ClusterDefaults: ClusterDefaults,
 	}, nil, NewDefaultClientConfigLoadingRules(), promptedCredentials{}}
 )
+
+// getDefaultServer returns a default setting for DefaultClientConfig
+// DEPRECATED
+func getDefaultServer() string {
+	if server := os.Getenv("KUBERNETES_MASTER"); len(server) > 0 {
+		return server
+	}
+	return "http://localhost:8080"
+}
 
 // ClientConfig is used to make it easy to get an api server client
 type ClientConfig interface {

--- a/test/cmd/legacy-script.sh
+++ b/test/cmd/legacy-script.sh
@@ -325,7 +325,6 @@ runTests() {
     exit 1
   fi
   kube::log::status "Checking kubectl version"
-  export KUBERNETES_MASTER=http://127.0.0.1:${API_PORT}
   kubectl version
 
   # Generate a random namespace name, based on the current time (to make


### PR DESCRIPTION
Cherry pick of #90243 on release-1.18.

#90243: Revert "stop defaulting kubeconfig to http://localhost:8080"

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.