### PR TITLE
Allow to drain node with pod that has more than one Pod Disruption Budget

### DIFF
--- a/pkg/registry/core/pod/storage/BUILD
+++ b/pkg/registry/core/pod/storage/BUILD
@@ -28,6 +28,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/diff:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/request:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/testing:go_default_library",
@@ -35,7 +36,9 @@ go_test(
         "//staging/src/k8s.io/apiserver/pkg/storage:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/errors:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/storage/etcd3/testing:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
     ],
 )
 
@@ -66,6 +69,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",

--- a/pkg/registry/core/pod/storage/eviction.go
+++ b/pkg/registry/core/pod/storage/eviction.go
@@ -29,9 +29,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/apiserver/pkg/features"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/util/dryrun"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	policyclient "k8s.io/client-go/kubernetes/typed/policy/v1beta1"
 	"k8s.io/client-go/util/retry"
 	api "k8s.io/kubernetes/pkg/apis/core"
@@ -146,38 +148,59 @@ func (r *EvictionREST) Create(ctx context.Context, name string, obj runtime.Obje
 			return err
 		}
 
-		if len(pdbs) > 1 {
-			rtStatus = &metav1.Status{
-				Status:  metav1.StatusFailure,
-				Message: "This pod has more than one PodDisruptionBudget, which the eviction subresource does not support.",
-				Code:    500,
-			}
-			return nil
-		}
 		if len(pdbs) == 0 {
 			return nil
 		}
 
-		pdb := &pdbs[0]
-		pdbName = pdb.Name
-		refresh := false
-		err = retry.RetryOnConflict(EvictionsRetry, func() error {
-			if refresh {
-				pdb, err = r.podDisruptionBudgetClient.PodDisruptionBudgets(pod.Namespace).Get(context.TODO(), pdbName, metav1.GetOptions{})
+		start := metav1.Time{Time: time.Now()}
+		multiPDB := utilfeature.DefaultFeatureGate.Enabled(features.DrainWithMultiPDB)
+		var dryRunRange []bool
+		if multiPDB {
+			dryRunRange = []bool{true, false}
+		} else {
+			if len(pdbs) > 1 {
+				rtStatus = &metav1.Status{
+					Status:  metav1.StatusFailure,
+					Message: "This pod has more than one PodDisruptionBudget, which the eviction subresource does not support.",
+					Code:    500,
+				}
+				return nil
+			}
+			dryRunRange = []bool{dryrun.IsDryRun(deletionOptions.DryRun)}
+		}
+		for _, withDryRun := range dryRunRange {
+			for i := range pdbs {
+				refresh := false
+				err = retry.RetryOnConflict(EvictionsRetry, func() error {
+					pdbName = pdbs[i].Name
+					var pdb *policyv1beta1.PodDisruptionBudget
+					if refresh {
+						pdb, err = r.podDisruptionBudgetClient.PodDisruptionBudgets(pod.Namespace).Get(ctx, pdbName, metav1.GetOptions{})
+						if err != nil {
+							return err
+						}
+					} else {
+						pdb = &pdbs[i]
+					}
+					// Try to verify-and-decrement
+
+					// If it was false already, or if it becomes false during the course of our retries,
+					// raise an error marked as a 429.
+					if err = r.checkAndDecrement(pod.Namespace, pod.Name, *pdb, withDryRun, &start); err != nil {
+						refresh = true
+						return err
+					}
+					return nil
+				})
 				if err != nil {
 					return err
 				}
 			}
-			// Try to verify-and-decrement
-
-			// If it was false already, or if it becomes false during the course of our retries,
-			// raise an error marked as a 429.
-			if err = r.checkAndDecrement(pod.Namespace, pod.Name, *pdb, dryrun.IsDryRun(deletionOptions.DryRun)); err != nil {
-				refresh = true
-				return err
+			// if dry-run is intended, we are done
+			if dryrun.IsDryRun(deletionOptions.DryRun) {
+				return nil
 			}
-			return nil
-		})
+		}
 		return err
 	}()
 	if err == wait.ErrWaitTimeout {
@@ -204,7 +227,7 @@ func (r *EvictionREST) Create(ctx context.Context, name string, obj runtime.Obje
 }
 
 // checkAndDecrement checks if the provided PodDisruptionBudget allows any disruption.
-func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb policyv1beta1.PodDisruptionBudget, dryRun bool) error {
+func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb policyv1beta1.PodDisruptionBudget, dryRun bool, start *metav1.Time) error {
 	if pdb.Status.ObservedGeneration < pdb.Generation {
 		// TODO(mml): Add a Retry-After header.  Once there are time-based
 		// budgets, we can sometimes compute a sensible suggested value.  But
@@ -226,14 +249,16 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 		return err
 	}
 
-	pdb.Status.DisruptionsAllowed--
+	if pdb.Status.DisruptedPods == nil {
+		pdb.Status.DisruptedPods = make(map[string]metav1.Time)
+	}
+	if ts, ok := pdb.Status.DisruptedPods[podName]; !ok || ts.Before(start) {
+		pdb.Status.DisruptionsAllowed--
+	}
+
 	// If this is a dry-run, we don't need to go any further than that.
 	if dryRun == true {
 		return nil
-	}
-
-	if pdb.Status.DisruptedPods == nil {
-		pdb.Status.DisruptedPods = make(map[string]metav1.Time)
 	}
 
 	// Eviction handler needs to inform the PDB controller that it is about to delete a pod
@@ -246,6 +271,14 @@ func (r *EvictionREST) checkAndDecrement(namespace string, podName string, pdb p
 	}
 
 	return nil
+}
+
+func (r *EvictionREST) getDisruptionsAllowed(ctx context.Context, namespace string, pdbName string) (int32, error) {
+	finalPDB, err := r.podDisruptionBudgetClient.PodDisruptionBudgets(namespace).Get(ctx, pdbName, metav1.GetOptions{})
+	if err != nil {
+		return 0, err
+	}
+	return finalPDB.Status.DisruptionsAllowed, nil
 }
 
 // getPodDisruptionBudgets returns any PDBs that match the pod or err if there's an error.

--- a/pkg/registry/core/pod/storage/eviction_test.go
+++ b/pkg/registry/core/pod/storage/eviction_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package storage
 
 import (
+	"context"
+	"k8s.io/apiserver/pkg/features"
 	"testing"
 
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -24,7 +26,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/kubernetes/fake"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 	api "k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/policy"
 )
@@ -61,6 +65,81 @@ func TestEviction(t *testing.T) {
 			expectDeleted: true,
 		},
 		{
+			name: "matching pdbs with two disruptions allowed",
+			pdbs: []runtime.Object{&policyv1beta1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+			},
+				&policyv1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "default"},
+					Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+					Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+				}},
+			eviction:      &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectDeleted: true,
+		},
+		{
+			name: "matching pdbs with one disruption allowed and one non-matching disruption",
+			pdbs: []runtime.Object{&policyv1beta1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+			},
+				&policyv1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "default"},
+					Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"b": "true"}}},
+					Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+				}},
+			eviction:      &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectDeleted: true,
+		},
+		{
+			name: "matching pdbs with one disruption allowed and one disruption disallowed",
+			pdbs: []runtime.Object{&policyv1beta1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+			},
+				&policyv1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "default"},
+					Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+					Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				}},
+			eviction:    &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError: true,
+		},
+		{
+			name: "matching pdbs with one disruption disallowed and one disruption allowed",
+			pdbs: []runtime.Object{&policyv1beta1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+			},
+				&policyv1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "default"},
+					Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+					Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 1},
+				}},
+			eviction:    &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError: true,
+		},
+		{
+			name: "matching pdbs with two disruptions disallowed",
+			pdbs: []runtime.Object{&policyv1beta1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
+				Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+				Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+			},
+				&policyv1beta1.PodDisruptionBudget{
+					ObjectMeta: metav1.ObjectMeta{Name: "bar", Namespace: "default"},
+					Spec:       policyv1beta1.PodDisruptionBudgetSpec{Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"a": "true"}}},
+					Status:     policyv1beta1.PodDisruptionBudgetStatus{DisruptionsAllowed: 0},
+				}},
+			eviction:    &policy.Eviction{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"}, DeleteOptions: metav1.NewDeleteOptions(0)},
+			expectError: true,
+		},
+		{
 			name: "non-matching pdbs",
 			pdbs: []runtime.Object{&policyv1beta1.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "default"},
@@ -82,67 +161,83 @@ func TestEviction(t *testing.T) {
 			expectError:  true,
 		},
 	}
+	for _, enabled := range []bool{true, false} {
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.DrainWithMultiPDB, enabled)()
+				testContext := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceDefault)
+				storage, _, _, server := newStorage(t)
+				defer server.Terminate(t)
+				defer storage.Store.DestroyFunc()
 
-	for _, tc := range testcases {
-		t.Run(tc.name, func(t *testing.T) {
-			testContext := genericapirequest.WithNamespace(genericapirequest.NewContext(), metav1.NamespaceDefault)
-			storage, _, _, server := newStorage(t)
-			defer server.Terminate(t)
-			defer storage.Store.DestroyFunc()
+				pod := validNewPod()
+				pod.Labels = map[string]string{"a": "true"}
+				pod.Spec.NodeName = "foo"
 
-			pod := validNewPod()
-			pod.Labels = map[string]string{"a": "true"}
-			pod.Spec.NodeName = "foo"
+				if _, err := storage.Create(testContext, pod, nil, &metav1.CreateOptions{}); err != nil {
+					t.Error(err)
+				}
 
-			if _, err := storage.Create(testContext, pod, nil, &metav1.CreateOptions{}); err != nil {
-				t.Error(err)
-			}
+				client := fake.NewSimpleClientset(tc.pdbs...)
+				evictionRest := newEvictionStorage(storage.Store, client.PolicyV1beta1())
 
-			client := fake.NewSimpleClientset(tc.pdbs...)
-			evictionRest := newEvictionStorage(storage.Store, client.PolicyV1beta1())
-
-			name := pod.Name
-			if tc.badNameInURL {
-				name += "bad-name"
-			}
-			_, err := evictionRest.Create(testContext, name, tc.eviction, nil, &metav1.CreateOptions{})
-			if (err != nil) != tc.expectError {
-				t.Errorf("expected error=%v, got %v", tc.expectError, err)
-				return
-			}
-			if tc.badNameInURL {
-				if err == nil {
-					t.Error("expected error here, but got nil")
+				name := pod.Name
+				if tc.badNameInURL {
+					name += "bad-name"
+				}
+				_, err := evictionRest.Create(testContext, name, tc.eviction, nil, &metav1.CreateOptions{})
+				if len(tc.pdbs) == 1 && (err != nil) != tc.expectError {
+					t.Errorf("expected error=%v, got %v", tc.expectError, err)
 					return
 				}
-				if err.Error() != "name in URL does not match name in Eviction object" {
-					t.Errorf("got unexpected error: %v", err)
+				if tc.badNameInURL {
+					if err == nil {
+						t.Error("expected error here, but got nil")
+						return
+					}
+					if err.Error() != "name in URL does not match name in Eviction object" {
+						t.Errorf("got unexpected error: %v", err)
+					}
 				}
-			}
-			if tc.expectError {
-				return
-			}
-
-			existingPod, err := storage.Get(testContext, pod.Name, &metav1.GetOptions{})
-			if tc.expectDeleted {
-				if !apierrors.IsNotFound(err) {
-					t.Errorf("expected to be deleted, lookup returned %#v", existingPod)
+				if tc.expectError {
+					return
 				}
-				return
-			} else if apierrors.IsNotFound(err) {
-				t.Errorf("expected graceful deletion, got %v", err)
-				return
-			}
 
-			if err != nil {
-				t.Errorf("%#v", err)
-				return
-			}
+				for _, obj := range tc.pdbs {
+					pdb := obj.(*policyv1beta1.PodDisruptionBudget)
+					disruptionsAllowed, err := evictionRest.getDisruptionsAllowed(context.TODO(), pdb.Namespace, pdb.Name)
+					if err != nil {
+						t.Errorf("%#v", err)
+					}
+					if disruptionsAllowed < 0 {
+						t.Errorf("DisruptionsAllowed becomes negative for %s.%s in %s", pdb.Namespace, pdb.Name, tc.name)
+					}
+					if !tc.expectDeleted && disruptionsAllowed == 0 {
+						t.Errorf("DisruptionsAllowed should not be 0 for %s.%s in %s", pdb.Namespace, pdb.Name, tc.name)
+					}
+				}
+				existingPod, err := storage.Get(testContext, pod.Name, &metav1.GetOptions{})
+				if (len(tc.pdbs) == 1 || enabled) && tc.expectDeleted {
+					if !apierrors.IsNotFound(err) {
+						t.Errorf("expected to be deleted, lookup returned %#v", existingPod)
+					}
+					return
+				}
+				if !tc.expectDeleted && apierrors.IsNotFound(err) {
+					t.Errorf("expected graceful deletion, got %v", err)
+					return
+				}
 
-			if existingPod.(*api.Pod).DeletionTimestamp == nil {
-				t.Errorf("expected gracefully deleted pod with deletionTimestamp set, got %#v", existingPod)
-			}
-		})
+				if err != nil && !apierrors.IsNotFound(err) {
+					t.Errorf("%#v", err)
+					return
+				}
+
+				if (len(tc.pdbs) == 1 || enabled) && existingPod.(*api.Pod).DeletionTimestamp == nil {
+					t.Errorf("expected gracefully deleted pod with deletionTimestamp set, got %#v", existingPod)
+				}
+			})
+		}
 	}
 }
 

--- a/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
+++ b/staging/src/k8s.io/apiserver/pkg/features/kube_features.go
@@ -149,6 +149,10 @@ const (
 	//
 	// Allows label and field based indexes in apiserver watch cache to accelerate list operations.
 	SelectorIndex featuregate.Feature = "SelectorIndex"
+
+	// alpha: v1.19
+	// Allows to drain node with pod that has more than one Pod Disruption Budget
+	DrainWithMultiPDB featuregate.Feature = "DrainWithMultiPDB"
 )
 
 func init() {
@@ -175,4 +179,5 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	APIPriorityAndFairness:  {Default: false, PreRelease: featuregate.Alpha},
 	RemoveSelfLink:          {Default: false, PreRelease: featuregate.Alpha},
 	SelectorIndex:           {Default: false, PreRelease: featuregate.Alpha},
+	DrainWithMultiPDB:       {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
We accommodate draining node with pod with more than one PDB.
In EvictionREST#Create, in the first round, pass dry-run being true to EvictionREST#checkAndDecrement and see if there is any non-nill error returned by any PDB.

If there is no non-nil error, we can go through PDBs again without dry-run (if deletionOptions.DryRun indicates so).
If there is non-nil error, just short circuit and return that error.

**Which issue(s) this PR fixes**:
Fixes #75957

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
