### PR TITLE
kubelet prometheus's container_network* metrics's container label in base labels is empty when runtime is containerd

### DIFF
--- a/pkg/kubelet/server/server.go
+++ b/pkg/kubelet/server/server.go
@@ -962,6 +962,8 @@ func containerPrometheusLabelsFunc(s stats.Provider) metrics.ContainerLabelsFunc
 		}
 		if v, ok := c.Spec.Labels[kubelettypes.KubernetesContainerNameLabel]; ok {
 			containerName = v
+		} else if v, ok := c.Spec.Labels[kubelettypes.ContainerdKindLabel]; ok {
+			containerName = v
 		}
 		// Associate pod cgroup with pod so we have an accurate accounting of sandbox
 		if podName == "" && namespace == "" {

--- a/pkg/kubelet/types/labels.go
+++ b/pkg/kubelet/types/labels.go
@@ -21,6 +21,7 @@ const (
 	KubernetesPodNamespaceLabel  = "io.kubernetes.pod.namespace"
 	KubernetesPodUIDLabel        = "io.kubernetes.pod.uid"
 	KubernetesContainerNameLabel = "io.kubernetes.container.name"
+	ContainerdKindLabel          = "io.cri-containerd.kind"
 )
 
 func GetContainerName(labels map[string]string) string {


### PR DESCRIPTION
**What type of PR is this?**
> /kind bug


**What this PR does / why we need it**:
When kubelet works with containerd, if we get kubelet's /metric/cadviosr metrics, we will find that all the network related metrics' container label is empty. Kubelet doesn't handle the situation when container is a pause container and runtime is containerd. Because of that, this empty label may cause users can't get cluster or pod's network related monitor data.

Now the data looks like this, container label is empty.
```
container_network_receive_bytes_total{container="",container_name="",id="/",image="",interface="cbr0",name="",namespace="",pod="",pod_name=""} 1.731303e+06 1587201624447
container_network_receive_bytes_total{container="",container_name="",id="/",image="",interface="eth0",name="",namespace="",pod="",pod_name=""} 5.93193912e+08 1587201624447
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 1.729576e+06 1587201614917
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 5.93160019e+08 1587201614917
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/besteffort/pod1b9dc16e-8141-11ea-b5db-f2f34a2e76a7/ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",namespace="kube-system",pod="tke-cni-agent-jzz5c",pod_name="tke-cni-agent-jzz5c"} 1.73019e+06 1587201619455
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/besteffort/pod1b9dc16e-8141-11ea-b5db-f2f34a2e76a7/ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",namespace="kube-system",pod="tke-cni-agent-jzz5c",pod_name="tke-cni-agent-jzz5c"} 5.93179066e+08 1587201619455
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/besteffort/pod1ba4e3dd-8141-11ea-b5db-f2f34a2e76a7/f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",namespace="kube-system",pod="ip-masq-agent-qhn7v",pod_name="ip-masq-agent-qhn7v"} 1.728869e+06 1587201612711
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/besteffort/pod1ba4e3dd-8141-11ea-b5db-f2f34a2e76a7/f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",namespace="kube-system",pod="ip-masq-agent-qhn7v",pod_name="ip-masq-agent-qhn7v"} 5.93153438e+08 1587201612711
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/besteffort/pod9775b417-8140-11ea-b5db-f2f34a2e76a7/68f62bf4c1715c03fef46f9d651f96b7ca491ad0d32f58813785c95ce5a8fe76",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="68f62bf4c1715c03fef46f9d651f96b7ca491ad0d32f58813785c95ce5a8fe76",namespace="kube-system",pod="l7-lb-controller-587b44947-gnhpk",pod_name="l7-lb-controller-587b44947-gnhpk"} 7.537581e+06 1587201618707
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/burstable/pod9776b177-8140-11ea-b5db-f2f34a2e76a7/46405543d163cef31a71dd2450bb16247252df1ac9d87f2277653be21e29b25b",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="46405543d163cef31a71dd2450bb16247252df1ac9d87f2277653be21e29b25b",namespace="kube-system",pod="coredns-7f47d46d54-stg25",pod_name="coredns-7f47d46d54-stg25"} 5.635208e+06 1587201624955
container_network_receive_bytes_total{container="",container_name="",id="/kubepods/burstable/poda7026e5a-8151-11ea-96be-52f79ad43c22/aa7b3e891372b0e6600841c25ed06aa2863cdf86992ec7ebbbc99ce0e069fd03",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="aa7b3e891372b0e6600841c25ed06aa2863cdf86992ec7ebbbc99ce0e069fd03",namespace="default",pod="test-6f7679dbb6-58lqm",pod_name="test-6f7679dbb6-58lqm"} 1286 1587201617816
# HELP container_network_receive_errors_total Cumulative count of errors encountered while receiving
# TYPE container_network_receive_errors_total counter
container_network_receive_errors_total{container="",container_name="",id="/",image="",interface="cbr0",name="",namespace="",pod="",pod_name=""} 0 1587201624447
container_network_receive_errors_total{container="",container_name="",id="/",image="",interface="eth0",name="",namespace="",pod="",pod_name=""} 0 1587201624447
container_network_receive_errors_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 0 1587201614917
container_network_receive_errors_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 0 1587201614917
container_network_receive_errors_total{container="",container_name="",id="/kubepods/besteffort/pod1b9dc16e-8141-11ea-b5db-f2f34a2e76a7/ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",namespace="kube-system",pod="tke-cni-agent-jzz5c",pod_name="tke-cni-agent-jzz5c"} 0 1587201619455
container_network_receive_errors_total{container="",container_name="",id="/kubepods/besteffort/pod1b9dc16e-8141-11ea-b5db-f2f34a2e76a7/ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",namespace="kube-system",pod="tke-cni-agent-jzz5c",pod_name="tke-cni-agent-jzz5c"} 0 1587201619455
container_network_receive_errors_total{container="",container_name="",id="/kubepods/besteffort/pod1ba4e3dd-8141-11ea-b5db-f2f34a2e76a7/f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",namespace="kube-system",pod="ip-masq-agent-qhn7v",pod_name="ip-masq-agent-qhn7v"} 0 1587201612711
container_network_receive_errors_total{container="",container_name="",id="/kubepods/besteffort/pod1ba4e3dd-8141-11ea-b5db-f2f34a2e76a7/f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",namespace="kube-system",pod="ip-masq-agent-qhn7v",pod_name="ip-masq-agent-qhn7v"} 0 1587201612711
container_network_receive_errors_total{container="",container_name="",id="/kubepods/besteffort/pod9775b417-8140-11ea-b5db-f2f34a2e76a7/68f62bf4c1715c03fef46f9d651f96b7ca491ad0d32f58813785c95ce5a8fe76",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="68f62bf4c1715c03fef46f9d651f96b7ca491ad0d32f58813785c95ce5a8fe76",namespace="kube-system",pod="l7-lb-controller-587b44947-gnhpk",pod_name="l7-lb-controller-587b44947-gnhpk"} 0 1587201618707
container_network_receive_packets_dropped_total{container="",container_name="",id="/",image="",interface="eth0",name="",namespace="",pod="",pod_name=""} 0 1587201624447
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 0 1587201614917
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 0 1587201614917
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/besteffort/pod1b9dc16e-8141-11ea-b5db-f2f34a2e76a7/ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",namespace="kube-system",pod="tke-cni-agent-jzz5c",pod_name="tke-cni-agent-jzz5c"} 0 1587201619455
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/besteffort/pod1b9dc16e-8141-11ea-b5db-f2f34a2e76a7/ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="ffe5efc00ab834bbd9530be3d4c6c7b904a3d9c7e68942eed891a156643aba33",namespace="kube-system",pod="tke-cni-agent-jzz5c",pod_name="tke-cni-agent-jzz5c"} 0 1587201619455
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/besteffort/pod1ba4e3dd-8141-11ea-b5db-f2f34a2e76a7/f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",namespace="kube-system",pod="ip-masq-agent-qhn7v",pod_name="ip-masq-agent-qhn7v"} 0 1587201612711
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/besteffort/pod1ba4e3dd-8141-11ea-b5db-f2f34a2e76a7/f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="f08f0a51d4e6c6c1b44da951e07b02ea20b68c9666688e2d122351bee50279ab",namespace="kube-system",pod="ip-masq-agent-qhn7v",pod_name="ip-masq-agent-qhn7v"} 0 1587201612711
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/besteffort/pod9775b417-8140-11ea-b5db-f2f34a2e76a7/68f62bf4c1715c03fef46f9d651f96b7ca491ad0d32f58813785c95ce5a8fe76",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="68f62bf4c1715c03fef46f9d651f96b7ca491ad0d32f58813785c95ce5a8fe76",namespace="kube-system",pod="l7-lb-controller-587b44947-gnhpk",pod_name="l7-lb-controller-587b44947-gnhpk"} 0 1587201618707
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/burstable/pod9776b177-8140-11ea-b5db-f2f34a2e76a7/46405543d163cef31a71dd2450bb16247252df1ac9d87f2277653be21e29b25b",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="46405543d163cef31a71dd2450bb16247252df1ac9d87f2277653be21e29b25b",namespace="kube-system",pod="coredns-7f47d46d54-stg25",pod_name="coredns-7f47d46d54-stg25"} 0 1587201624955
container_network_receive_packets_dropped_total{container="",container_name="",id="/kubepods/burstable/poda7026e5a-8151-11ea-96be-52f79ad43c22/aa7b3e891372b0e6600841c25ed06aa2863cdf86992ec7ebbbc99ce0e069fd03",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="aa7b3e891372b0e6600841c25ed06aa2863cdf86992ec7ebbbc99ce0e069fd03",namespace="default",pod="test-6f7679dbb6-58lqm",pod_name="test-6f7679dbb6-58lqm"} 0 1587201617816
# HELP container_network_receive_packets_total Cumulative count of packets received
# TYPE container_network_receive_packets_total counter
container_network_receive_packets_total{container="",container_name="",id="/",image="",interface="cbr0",name="",namespace="",pod="",pod_name=""} 25335 1587201624447
container_network_receive_packets_total{container="",container_name="",id="/",image="",interface="eth0",name="",namespace="",pod="",pod_name=""} 489388 1587201624447
container_network_receive_packets_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="cbr0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 25307 1587201614917
container_network_receive_packets_total{container="",container_name="",id="/kubepods/besteffort/pod1b9db6f4-8141-11ea-b5db-f2f34a2e76a7/b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",image="sha256:f9d5de0795395db6c50cb1ac82ebed1bd8eb3eefcebb1aa724e01239594e937b",interface="eth0",name="b873afce6eb437a588a7b4bc3ffcad420d3e1be2e25b9f0d28b78dc9ede81858",namespace="kube-system",pod="tke-bridge-agent-72lxx",pod_name="tke-bridge-agent-72lxx"} 489224 1587201614917
```
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
kubelet prometheus's container_network* metrics's container label in base labels is empty when runtime is containerd
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
