### PR TITLE
Deflake TCP Closewait e2e test

### DIFF
--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -44,10 +44,9 @@ var kubeProxyE2eImage = imageutils.GetE2EImage(imageutils.Agnhost)
 
 var _ = SIGDescribe("Network", func() {
 	const (
-		testDaemonHTTPPort     = 11301
-		testDaemonTCPPort      = 11302
-		deadlineTimeoutSeconds = 5
-		postFinTimeoutSeconds  = 15
+		testDaemonHTTPPort    = 11301
+		testDaemonTCPPort     = 11302
+		postFinTimeoutSeconds = 30
 	)
 
 	fr := framework.NewDefaultFramework("network")
@@ -157,7 +156,7 @@ var _ = SIGDescribe("Network", func() {
 							fmt.Sprintf(`{"RemoteAddr":"%v", "PostFinTimeoutSeconds":%v, "TimeoutSeconds":%v, "LeakConnection":true}`,
 								net.JoinHostPort(serverNodeInfo.nodeIP, strconv.Itoa(testDaemonTCPPort)),
 								postFinTimeoutSeconds,
-								deadlineTimeoutSeconds),
+								0),
 						},
 					},
 				},
@@ -232,7 +231,7 @@ var _ = SIGDescribe("Network", func() {
 		cmd := fmt.Sprintf("cat /rootfs/proc/net/nf_conntrack "+
 			"| grep -m 1 'CLOSE_WAIT.*dst=%v.*dport=%v' ",
 			ip, testDaemonTCPPort)
-		if err := wait.PollImmediate(deadlineTimeoutSeconds, postFinTimeoutSeconds, func() (bool, error) {
+		if err := wait.PollImmediate(1*time.Second, postFinTimeoutSeconds, func() (bool, error) {
 			result, err := framework.RunHostCmd(fr.Namespace.Name, "e2e-net-exec", cmd)
 			// retry if we can't obtain the conntrack entry
 			if err != nil {

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -81,8 +81,6 @@ var _ = SIGDescribe("Network", func() {
 			nodeIP: ips[1],
 		}
 
-		zero := int64(0)
-
 		// Create a pod to check the conntrack entries on the host node
 		// It mounts the host /proc/net folder to be able to access
 		// the nf_conntrack file with the host conntrack entries
@@ -125,7 +123,6 @@ var _ = SIGDescribe("Network", func() {
 						},
 					},
 				},
-				TerminationGracePeriodSeconds: &zero,
 			},
 		}
 		fr.PodClient().CreateSync(hostExecPod)
@@ -164,7 +161,6 @@ var _ = SIGDescribe("Network", func() {
 						},
 					},
 				},
-				TerminationGracePeriodSeconds: &zero,
 			},
 		}
 
@@ -198,7 +194,6 @@ var _ = SIGDescribe("Network", func() {
 						},
 					},
 				},
-				TerminationGracePeriodSeconds: &zero,
 			},
 		}
 

--- a/test/e2e/network/kube_proxy.go
+++ b/test/e2e/network/kube_proxy.go
@@ -101,7 +101,7 @@ var _ = SIGDescribe("Network", func() {
 					{
 						Name:            "e2e-net-exec",
 						Image:           kubeProxyE2eImage,
-						ImagePullPolicy: "Always",
+						ImagePullPolicy: v1.PullIfNotPresent,
 						Args:            []string{"pause"},
 						VolumeMounts: []v1.VolumeMount{
 							{
@@ -152,7 +152,7 @@ var _ = SIGDescribe("Network", func() {
 					{
 						Name:            "e2e-net-client",
 						Image:           kubeProxyE2eImage,
-						ImagePullPolicy: "Always",
+						ImagePullPolicy: v1.PullIfNotPresent,
 						Args: []string{
 							"net",
 							"--runner", "nat-closewait-client",
@@ -180,7 +180,7 @@ var _ = SIGDescribe("Network", func() {
 					{
 						Name:            "e2e-net-server",
 						Image:           kubeProxyE2eImage,
-						ImagePullPolicy: "Always",
+						ImagePullPolicy: v1.PullIfNotPresent,
 						Args: []string{
 							"net",
 							"--runner", "nat-closewait-server",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature

/kind flake

**What this PR does / why we need it**:

Several tweaks to this flake test:

* Don't pull the images always
* Increase the termination grace period
* Increase the timeout holding the TCP connection in the close_wait status
* Poll every 1 second instead of 5 seconds
* Don't close the connection if there is no data, we are not sending data and make the test racy

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

It should fix #71565 :-)
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
