### PR TITLE
go-to-protobuf: fix rewrite of embedded struct fields

### DIFF
--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/BUILD
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/BUILD
@@ -37,6 +37,7 @@ go_test(
     srcs = [
         "cmd_test.go",
         "namer_test.go",
+        "parser_test.go",
     ],
     embed = [":go_default_library"],
 )

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package protobuf
+
+import (
+	"go/ast"
+	"testing"
+)
+
+func TestProtoParser(t *testing.T) {
+	ident := ast.NewIdent("FieldName")
+	tests := []struct {
+		expr ast.Expr
+		err  bool
+	}{
+		{
+			expr: ident,
+			err:  false,
+		},
+		{
+			expr: &ast.SelectorExpr{
+				Sel: ident,
+			},
+			err: false,
+		},
+		{
+			expr: &ast.StarExpr{
+				X: ident,
+			},
+			err: false,
+		},
+		{
+			expr: &ast.StarExpr{
+				X: &ast.StarExpr{
+					X: ident,
+				},
+			},
+			err: false,
+		},
+		{
+			expr: &ast.StarExpr{
+				X: &ast.SelectorExpr{
+					Sel: ident,
+				},
+			},
+			err: false,
+		},
+
+		{
+			expr: &ast.KeyValueExpr{
+				Key:   ident,
+				Colon: 0,
+				Value: ident,
+			},
+			err: true,
+		},
+		{
+			expr: &ast.StarExpr{
+				X: &ast.KeyValueExpr{
+					Key:   ident,
+					Colon: 0,
+					Value: ident,
+				},
+			},
+			err: true,
+		},
+	}
+
+	for _, test := range tests {
+		actual, err := getFieldName(test.expr, "Struct")
+		if !test.err {
+			if err != nil {
+				t.Errorf("%s: unexpected error %s", test.expr, err)
+			} else {
+				if actual != ident.Name {
+					t.Errorf("%s: expected %s, got %s", test.expr, ident.Name, actual)
+				}
+			}
+		} else {
+			if err == nil {
+				t.Errorf("%s: expected error did not occur, got %s instead", test.expr, actual)
+			}
+		}
+	}
+}

--- a/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser_test.go
+++ b/staging/src/k8s.io/code-generator/cmd/go-to-protobuf/protobuf/parser_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright 2020 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,12 +21,33 @@ import (
 	"testing"
 )
 
+/*
+	struct fields in go AST:
+
+     type Struct struct {
+		// fields with a direct field Name as <Ident>
+        A X  // regular fields
+        B *X // pointer fields
+        C    // embedded type field
+
+        // qualified embedded type fields use an <SelExpr> in the AST
+        v1.TypeMeta // X=v1, Sel=TypeMeta
+
+        // fields without a direct name, but
+        // a <StarExpr> in the go-AST
+        *D   // type field embedded as pointer
+        *v1.ListMeta   // qualified type field embedded as pointer
+                       // with <StarExpr> pointing to <SelExpr>
+     }
+*/
+
 func TestProtoParser(t *testing.T) {
 	ident := ast.NewIdent("FieldName")
 	tests := []struct {
 		expr ast.Expr
 		err  bool
 	}{
+		// valid struct field expressions
 		{
 			expr: ident,
 			err:  false,
@@ -60,6 +81,7 @@ func TestProtoParser(t *testing.T) {
 			err: false,
 		},
 
+		// something else should provide an error
 		{
 			expr: &ast.KeyValueExpr{
 				Key:   ident,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change

/kind bug
/priority important-soon

> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

The protobuf generator cannot handle embedded struct fields correctly.
When using an embedded field by pointer it produces the error message

`unable to get name for tag from struct "...", field ...`

The reason is that the name determination evaluating the AST does not
handle pointers if the AST does not already contain a field name.
This seems to be the case for structs embedded by pointers.

Example:

```
type MyStruct struct {
  *OtherStruct `protobuf:"bytes,1,opt,name=otherStruct"`
}
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
