### PR TITLE
Use internal config types in scheduling plugin args

### DIFF
--- a/cmd/kube-scheduler/app/options/BUILD
+++ b/cmd/kube-scheduler/app/options/BUILD
@@ -19,7 +19,6 @@ go_library(
         "//pkg/scheduler/apis/config/scheme:go_default_library",
         "//pkg/scheduler/apis/config/v1alpha2:go_default_library",
         "//pkg/scheduler/apis/config/validation:go_default_library",
-        "//pkg/scheduler/framework/plugins:go_default_library",
         "//pkg/scheduler/framework/plugins/interpodaffinity:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/cmd/kube-scheduler/app/options/deprecated.go
+++ b/cmd/kube-scheduler/app/options/deprecated.go
@@ -21,10 +21,8 @@ import (
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	kubeschedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
 	kubeschedulerconfig "k8s.io/kubernetes/pkg/scheduler/apis/config"
-	"k8s.io/kubernetes/pkg/scheduler/framework/plugins"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity"
 )
 
@@ -129,10 +127,13 @@ func (o *DeprecatedOptions) ApplyTo(cfg *kubeschedulerconfig.KubeSchedulerConfig
 		profile.SchedulerName = o.SchedulerName
 	}
 	if o.HardPodAffinitySymmetricWeight != interpodaffinity.DefaultHardPodAffinityWeight {
-		args := kubeschedulerv1alpha2.InterPodAffinityArgs{
-			HardPodAffinityWeight: &o.HardPodAffinitySymmetricWeight,
+		plCfg := kubeschedulerconfig.PluginConfig{
+			Name: interpodaffinity.Name,
+			Args: &kubeschedulerconfig.InterPodAffinityArgs{
+				HardPodAffinityWeight: o.HardPodAffinitySymmetricWeight,
+			},
 		}
-		profile.PluginConfig = append(profile.PluginConfig, plugins.NewPluginConfig(interpodaffinity.Name, args))
+		profile.PluginConfig = append(profile.PluginConfig, plCfg)
 	}
 	return nil
 }

--- a/cmd/kube-scheduler/app/options/options_test.go
+++ b/cmd/kube-scheduler/app/options/options_test.go
@@ -203,6 +203,9 @@ profiles:
       disabled:
       - name: baz
   pluginConfig:
+  - name: InterPodAffinity
+    args:
+      hardPodAffinityWeight: 2
   - name: foo
     args:
       bar: baz
@@ -544,6 +547,12 @@ profiles:
 						},
 						PluginConfig: []kubeschedulerconfig.PluginConfig{
 							{
+								Name: "InterPodAffinity",
+								Args: &kubeschedulerconfig.InterPodAffinityArgs{
+									HardPodAffinityWeight: 2,
+								},
+							},
+							{
 								Name: "foo",
 								Args: &runtime.Unknown{
 									Raw:         []byte(`{"bar":"baz"}`),
@@ -670,9 +679,7 @@ profiles:
 						PluginConfig: []kubeschedulerconfig.PluginConfig{
 							{
 								Name: "InterPodAffinity",
-								Args: &runtime.Unknown{
-									Raw: []byte(`{"hardPodAffinityWeight":5}`),
-								},
+								Args: &kubeschedulerconfig.InterPodAffinityArgs{HardPodAffinityWeight: 5},
 							},
 						},
 					},

--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -45,7 +45,6 @@ go_library(
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
         "//staging/src/k8s.io/client-go/listers/policy/v1beta1:go_default_library",
         "//staging/src/k8s.io/client-go/tools/cache:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],

--- a/pkg/scheduler/apis/config/scheme/BUILD
+++ b/pkg/scheduler/apis/config/scheme/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -27,4 +27,20 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["scheme_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
+        "//staging/src/k8s.io/api/core/v1:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
+        "//vendor/k8s.io/utils/pointer:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
 )

--- a/pkg/scheduler/apis/config/scheme/scheme_test.go
+++ b/pkg/scheduler/apis/config/scheme/scheme_test.go
@@ -1,0 +1,450 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheme
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kube-scheduler/config/v1alpha2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/yaml"
+)
+
+func TestCodecsDecodePluginConfig(t *testing.T) {
+	testCases := []struct {
+		name         string
+		data         []byte
+		wantErr      string
+		wantProfiles []config.KubeSchedulerProfile
+	}{
+		{
+			name: "v1alpha2 all plugin args in default profile",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  - name: InterPodAffinity
+    args:
+      hardPodAffinityWeight: 5
+  - name: NodeLabel
+    args:
+      presentLabels: ["foo"]
+  - name: NodeResourcesFit
+    args:
+      ignoredResources: ["foo"]
+  - name: RequestedToCapacityRatio
+    args:
+      shape:
+      - utilization: 1
+  - name: PodTopologySpread
+    args:
+      defaultConstraints:
+      - maxSkew: 1
+        topologyKey: zone
+        whenUnsatisfiable: ScheduleAnyway
+  - name: ServiceAffinity
+    args:
+      affinityLabels: ["bar"]
+`),
+			wantProfiles: []config.KubeSchedulerProfile{
+				{
+					SchedulerName: "default-scheduler",
+					PluginConfig: []config.PluginConfig{
+						{
+							Name: "InterPodAffinity",
+							Args: &config.InterPodAffinityArgs{HardPodAffinityWeight: 5},
+						},
+						{
+							Name: "NodeLabel",
+							Args: &config.NodeLabelArgs{PresentLabels: []string{"foo"}},
+						},
+						{
+							Name: "NodeResourcesFit",
+							Args: &config.NodeResourcesFitArgs{IgnoredResources: []string{"foo"}},
+						},
+						{
+							Name: "RequestedToCapacityRatio",
+							Args: &config.RequestedToCapacityRatioArgs{
+								Shape: []config.UtilizationShapePoint{{Utilization: 1}},
+							},
+						},
+						{
+							Name: "PodTopologySpread",
+							Args: &config.PodTopologySpreadArgs{
+								DefaultConstraints: []v1.TopologySpreadConstraint{
+									{MaxSkew: 1, TopologyKey: "zone", WhenUnsatisfiable: v1.ScheduleAnyway},
+								},
+							},
+						},
+						{
+							Name: "ServiceAffinity",
+							Args: &config.ServiceAffinityArgs{
+								AffinityLabels: []string{"bar"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "v1alpha2 plugins can include version and kind",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  - name: NodeLabel
+    args:
+      apiVersion: kubescheduler.config.k8s.io/v1alpha2
+      kind: NodeLabelArgs
+      presentLabels: ["bars"]
+`),
+			wantProfiles: []config.KubeSchedulerProfile{
+				{
+					SchedulerName: "default-scheduler",
+					PluginConfig: []config.PluginConfig{
+						{
+							Name: "NodeLabel",
+							Args: &config.NodeLabelArgs{PresentLabels: []string{"bars"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "plugin group and kind should match the type",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  - name: NodeLabel
+    args:
+      apiVersion: kubescheduler.config.k8s.io/v1alpha2
+      kind: InterPodAffinityArgs
+`),
+			wantErr: "decoding .profiles[0].pluginConfig[0]: args for plugin NodeLabel were not of type NodeLabelArgs.kubescheduler.config.k8s.io, got InterPodAffinityArgs.kubescheduler.config.k8s.io",
+		},
+		{
+			// TODO: do not replicate this case for v1beta1.
+			name: "v1alpha2 case insensitive RequestedToCapacityRatioArgs",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  - name: RequestedToCapacityRatio
+    args:
+      shape:
+      - utilization: 1
+        score: 2
+      - Utilization: 3
+        Score: 4
+      resources:
+      - name: Upper
+        weight: 1
+      - Name: lower
+        weight: 2
+`),
+			wantProfiles: []config.KubeSchedulerProfile{
+				{
+					SchedulerName: "default-scheduler",
+					PluginConfig: []config.PluginConfig{
+						{
+							Name: "RequestedToCapacityRatio",
+							Args: &config.RequestedToCapacityRatioArgs{
+								Shape: []config.UtilizationShapePoint{
+									{Utilization: 1, Score: 2},
+									{Utilization: 3, Score: 4},
+								},
+								Resources: []config.ResourceSpec{
+									{Name: "Upper", Weight: 1},
+									{Name: "lower", Weight: 2},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "out-of-tree plugin args",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  - name: OutOfTreePlugin
+    args:
+      foo: bar
+`),
+			wantProfiles: []config.KubeSchedulerProfile{
+				{
+					SchedulerName: "default-scheduler",
+					PluginConfig: []config.PluginConfig{
+						{
+							Name: "OutOfTreePlugin",
+							Args: &runtime.Unknown{
+								ContentType: "application/json",
+								Raw:         []byte(`{"foo":"bar"}`),
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "empty and no plugin args",
+			data: []byte(`
+apiVersion: kubescheduler.config.k8s.io/v1alpha2
+kind: KubeSchedulerConfiguration
+profiles:
+- pluginConfig:
+  - name: InterPodAffinity
+    args:
+  - name: NodeResourcesFit
+  - name: OutOfTreePlugin
+    args:
+`),
+			wantProfiles: []config.KubeSchedulerProfile{
+				{
+					SchedulerName: "default-scheduler",
+					PluginConfig: []config.PluginConfig{
+						{
+							Name: "InterPodAffinity",
+							// TODO(acondor): Set default values.
+							Args: &config.InterPodAffinityArgs{},
+						},
+						{
+							Name: "NodeResourcesFit",
+							Args: &config.NodeResourcesFitArgs{},
+						},
+						{Name: "OutOfTreePlugin"},
+					},
+				},
+			},
+		},
+	}
+	decoder := Codecs.UniversalDecoder()
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			obj, gvk, err := decoder.Decode(tt.data, nil, nil)
+			if err != nil {
+				if tt.wantErr != err.Error() {
+					t.Fatalf("got err %w, want %w", err, tt.wantErr)
+				}
+				return
+			}
+			if len(tt.wantErr) != 0 {
+				t.Fatal("no error produced, wanted %w", tt.wantErr)
+			}
+			got, ok := obj.(*config.KubeSchedulerConfiguration)
+			if !ok {
+				t.Fatalf("decoded into %s, want %s", gvk, config.SchemeGroupVersion.WithKind("KubeSchedulerConfiguration"))
+			}
+			if diff := cmp.Diff(tt.wantProfiles, got.Profiles); diff != "" {
+				t.Errorf("unexpected configuration (-want,+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestCodecsEncodePluginConfig(t *testing.T) {
+	testCases := []struct {
+		name    string
+		obj     runtime.Object
+		version schema.GroupVersion
+		want    string
+	}{
+		{
+			name:    "v1alpha2 in-tree and out-of-tree plugins",
+			version: v1alpha2.SchemeGroupVersion,
+			obj: &v1alpha2.KubeSchedulerConfiguration{
+				Profiles: []v1alpha2.KubeSchedulerProfile{
+					{
+						PluginConfig: []v1alpha2.PluginConfig{
+							{
+								Name: "InterPodAffinity",
+								Args: runtime.RawExtension{
+									Object: &v1alpha2.InterPodAffinityArgs{
+										HardPodAffinityWeight: pointer.Int32Ptr(5),
+									},
+								},
+							},
+							{
+								Name: "RequestedToCapacityRatio",
+								Args: runtime.RawExtension{
+									Object: &v1alpha2.RequestedToCapacityRatioArgs{
+										Shape: []v1alpha2.UtilizationShapePoint{
+											{Utilization: 1, Score: 2},
+										},
+										Resources: []v1alpha2.ResourceSpec{
+											{Name: "lower", Weight: 2},
+										},
+									},
+								},
+							},
+							{
+								Name: "OutOfTreePlugin",
+								Args: runtime.RawExtension{
+									Raw: []byte(`{"foo":"bar"}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: `apiVersion: kubescheduler.config.k8s.io/v1alpha2
+clientConnection:
+  acceptContentTypes: ""
+  burst: 0
+  contentType: ""
+  kubeconfig: ""
+  qps: 0
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: null
+  leaseDuration: 0s
+  renewDeadline: 0s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 0s
+profiles:
+- pluginConfig:
+  - args:
+      apiVersion: kubescheduler.config.k8s.io/v1alpha2
+      hardPodAffinityWeight: 5
+      kind: InterPodAffinityArgs
+    name: InterPodAffinity
+  - args:
+      apiVersion: kubescheduler.config.k8s.io/v1alpha2
+      kind: RequestedToCapacityRatioArgs
+      resources:
+      - Name: lower
+        Weight: 2
+      shape:
+      - Score: 2
+        Utilization: 1
+    name: RequestedToCapacityRatio
+  - args:
+      foo: bar
+    name: OutOfTreePlugin
+`,
+		},
+		{
+			name:    "v1alpha2 in-tree and out-of-tree plugins from internal",
+			version: v1alpha2.SchemeGroupVersion,
+			obj: &config.KubeSchedulerConfiguration{
+				Profiles: []config.KubeSchedulerProfile{
+					{
+						PluginConfig: []config.PluginConfig{
+							{
+								Name: "InterPodAffinity",
+								Args: &config.InterPodAffinityArgs{
+									HardPodAffinityWeight: 5,
+								},
+							},
+							{
+								Name: "OutOfTreePlugin",
+								Args: &runtime.Unknown{
+									Raw: []byte(`{"foo":"bar"}`),
+								},
+							},
+						},
+					},
+				},
+			},
+			want: `apiVersion: kubescheduler.config.k8s.io/v1alpha2
+bindTimeoutSeconds: 0
+clientConnection:
+  acceptContentTypes: ""
+  burst: 0
+  contentType: ""
+  kubeconfig: ""
+  qps: 0
+disablePreemption: false
+enableContentionProfiling: false
+enableProfiling: false
+healthzBindAddress: ""
+kind: KubeSchedulerConfiguration
+leaderElection:
+  leaderElect: false
+  leaseDuration: 0s
+  renewDeadline: 0s
+  resourceLock: ""
+  resourceName: ""
+  resourceNamespace: ""
+  retryPeriod: 0s
+metricsBindAddress: ""
+percentageOfNodesToScore: 0
+podInitialBackoffSeconds: 0
+podMaxBackoffSeconds: 0
+profiles:
+- pluginConfig:
+  - args:
+      apiVersion: kubescheduler.config.k8s.io/v1alpha2
+      hardPodAffinityWeight: 5
+      kind: InterPodAffinityArgs
+    name: InterPodAffinity
+  - args:
+      foo: bar
+    name: OutOfTreePlugin
+  schedulerName: ""
+`,
+		},
+	}
+	yamlInfo, ok := runtime.SerializerInfoForMediaType(Codecs.SupportedMediaTypes(), runtime.ContentTypeYAML)
+	if !ok {
+		t.Fatalf("unable to locate encoder -- %q is not a supported media type", runtime.ContentTypeYAML)
+	}
+	jsonInfo, ok := runtime.SerializerInfoForMediaType(Codecs.SupportedMediaTypes(), runtime.ContentTypeJSON)
+	if !ok {
+		t.Fatalf("unable to locate encoder -- %q is not a supported media type", runtime.ContentTypeJSON)
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			encoder := Codecs.EncoderForVersion(yamlInfo.Serializer, tt.version)
+			var buf bytes.Buffer
+			if err := encoder.Encode(tt.obj, &buf); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, buf.String()); diff != "" {
+				t.Errorf("unexpected encoded configuration:\n%s", diff)
+			}
+			encoder = Codecs.EncoderForVersion(jsonInfo.Serializer, tt.version)
+			buf = bytes.Buffer{}
+			if err := encoder.Encode(tt.obj, &buf); err != nil {
+				t.Fatal(err)
+			}
+			out, err := yaml.JSONToYAML(buf.Bytes())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.want, string(out)); diff != "" {
+				t.Errorf("unexpected encoded configuration:\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/scheduler/apis/config/testing/compatibility_test.go
+++ b/pkg/scheduler/apis/config/testing/compatibility_test.go
@@ -25,7 +25,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -1598,90 +1597,58 @@ func TestPluginsConfigurationCompatibility(t *testing.T) {
 			pluginConfig: []config.PluginConfig{
 				{
 					Name: "NodeResourcesFit",
-					Args: &runtime.Unknown{
-						Raw: []byte(`{
-							"ignoredResources": [
-								"foo",
-								"bar"
-							]
-						}`),
+					Args: &config.NodeResourcesFitArgs{
+						IgnoredResources: []string{"foo", "bar"},
 					},
 				},
 				{
 					Name: "PodTopologySpread",
-					Args: &runtime.Unknown{
-						Raw: []byte(`{
-							"defaultConstraints": [
-								{
-									"maxSkew": 1,
-									"topologyKey": "foo",
-									"whenUnsatisfiable": "DoNotSchedule"
-								},
-								{
-									"maxSkew": 10,
-									"topologyKey": "bar",
-									"whenUnsatisfiable": "ScheduleAnyway"
-								}
-							]
-						}`),
+					Args: &config.PodTopologySpreadArgs{
+						DefaultConstraints: []v1.TopologySpreadConstraint{
+							{
+								MaxSkew:           1,
+								TopologyKey:       "foo",
+								WhenUnsatisfiable: v1.DoNotSchedule,
+							},
+							{
+								MaxSkew:           10,
+								TopologyKey:       "bar",
+								WhenUnsatisfiable: v1.ScheduleAnyway,
+							},
+						},
 					},
 				},
 				{
 					Name: "RequestedToCapacityRatio",
-					Args: &runtime.Unknown{
-						Raw: []byte(`{
-							"shape":[
-								"Utilization": 5,
-								"Score": 5
-							],
-							"resources":[
-								"Name": "cpu",
-								"Weight": 10
-							]
-						}`),
+					Args: &config.RequestedToCapacityRatioArgs{
+						Shape: []config.UtilizationShapePoint{
+							{Utilization: 5, Score: 5},
+						},
+						Resources: []config.ResourceSpec{
+							{Name: "cpu", Weight: 10},
+						},
 					},
 				},
 				{
 					Name: "InterPodAffinity",
-					Args: &runtime.Unknown{
-						Raw: []byte(`{
-							"HardPodAffinityWeight": 100
-						}`),
+					Args: &config.InterPodAffinityArgs{
+						HardPodAffinityWeight: 100,
 					},
 				},
 				{
 					Name: "NodeLabel",
-					Args: &runtime.Unknown{
-						Raw: []byte(`{
-							"presentLabels": [
-								"foo",
-								"bar"
-							],
-							"absentLabels": [
-								"apple"
-							],
-							"presentLabelsPreference": [
-								"dog"
-							],
-							"absentLabelsPreference": [
-								"cat"
-							]
-						}`),
+					Args: &config.NodeLabelArgs{
+						PresentLabels:           []string{"foo", "bar"},
+						AbsentLabels:            []string{"apple"},
+						PresentLabelsPreference: []string{"dog"},
+						AbsentLabelsPreference:  []string{"cat"},
 					},
 				},
 				{
 					Name: "ServiceAffinity",
-					Args: &runtime.Unknown{
-						Raw: []byte(`{
-							affinityLabels: [
-								"foo",
-								"bar"
-							],
-							antiAffinityLabelsPreference: [
-								"disk",
-								"flash"
-							]
-						}`),
+					Args: &config.ServiceAffinityArgs{
+						AffinityLabels:               []string{"foo", "bar"},
+						AntiAffinityLabelsPreference: []string{"disk", "flash"},
 					},
 				},
 			},

--- a/pkg/scheduler/apis/config/v1alpha2/BUILD
+++ b/pkg/scheduler/apis/config/v1alpha2/BUILD
@@ -20,6 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/conversion:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/component-base/config/v1alpha1:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/config/v1:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",

--- a/pkg/scheduler/apis/config/v1alpha2/conversion.go
+++ b/pkg/scheduler/apis/config/v1alpha2/conversion.go
@@ -17,20 +17,93 @@ limitations under the License.
 package v1alpha2
 
 import (
-	conversion "k8s.io/apimachinery/pkg/conversion"
-	v1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
+	"fmt"
+	"sync"
+
+	"k8s.io/apimachinery/pkg/conversion"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/kube-scheduler/config/v1alpha2"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/utils/pointer"
 )
+
+var (
+	// pluginArgConversionScheme is a scheme with internal and v1alpha2 registered,
+	// used for defaulting/converting typed PluginConfig Args.
+	// Access via getPluginArgConversionScheme()
+	pluginArgConversionScheme     *runtime.Scheme
+	initPluginArgConversionScheme sync.Once
+)
+
+func getPluginArgConversionScheme() *runtime.Scheme {
+	initPluginArgConversionScheme.Do(func() {
+		// set up the scheme used for plugin arg conversion
+		pluginArgConversionScheme = runtime.NewScheme()
+		utilruntime.Must(AddToScheme(pluginArgConversionScheme))
+		utilruntime.Must(config.AddToScheme(pluginArgConversionScheme))
+	})
+	return pluginArgConversionScheme
+}
 
 func Convert_v1alpha2_KubeSchedulerConfiguration_To_config_KubeSchedulerConfiguration(in *v1alpha2.KubeSchedulerConfiguration, out *config.KubeSchedulerConfiguration, s conversion.Scope) error {
 	if err := autoConvert_v1alpha2_KubeSchedulerConfiguration_To_config_KubeSchedulerConfiguration(in, out, s); err != nil {
 		return err
 	}
 	out.AlgorithmSource.Provider = pointer.StringPtr(v1alpha2.SchedulerDefaultProviderName)
+	return convertToInternalPluginConfigArgs(out)
+}
+
+// convertToInternalPluginConfigArgs converts PluginConfig#Args into internal
+// types using a scheme, after applying defaults.
+func convertToInternalPluginConfigArgs(out *config.KubeSchedulerConfiguration) error {
+	scheme := getPluginArgConversionScheme()
+	for i := range out.Profiles {
+		for j := range out.Profiles[i].PluginConfig {
+			args := out.Profiles[i].PluginConfig[j].Args
+			if args == nil {
+				continue
+			}
+			if _, isUnknown := args.(*runtime.Unknown); isUnknown {
+				continue
+			}
+			scheme.Default(args)
+			internalArgs, err := scheme.ConvertToVersion(args, config.SchemeGroupVersion)
+			if err != nil {
+				return fmt.Errorf("converting .Profiles[%d].PluginConfig[%d].Args into internal type: %w", i, j, err)
+			}
+			out.Profiles[i].PluginConfig[j].Args = internalArgs
+		}
+	}
 	return nil
 }
 
 func Convert_config_KubeSchedulerConfiguration_To_v1alpha2_KubeSchedulerConfiguration(in *config.KubeSchedulerConfiguration, out *v1alpha2.KubeSchedulerConfiguration, s conversion.Scope) error {
-	return autoConvert_config_KubeSchedulerConfiguration_To_v1alpha2_KubeSchedulerConfiguration(in, out, s)
+	if err := autoConvert_config_KubeSchedulerConfiguration_To_v1alpha2_KubeSchedulerConfiguration(in, out, s); err != nil {
+		return err
+	}
+	return convertToExternalPluginConfigArgs(out)
+}
+
+// convertToExternalPluginConfigArgs converts PluginConfig#Args into
+// external (versioned) types using a scheme.
+func convertToExternalPluginConfigArgs(out *v1alpha2.KubeSchedulerConfiguration) error {
+	scheme := getPluginArgConversionScheme()
+	for i := range out.Profiles {
+		for j := range out.Profiles[i].PluginConfig {
+			args := out.Profiles[i].PluginConfig[j].Args
+			if args.Object == nil {
+				continue
+			}
+			if _, isUnknown := args.Object.(*runtime.Unknown); isUnknown {
+				continue
+			}
+			externalArgs, err := scheme.ConvertToVersion(args.Object, SchemeGroupVersion)
+			if err != nil {
+				return err
+			}
+			out.Profiles[i].PluginConfig[j].Args.Object = externalArgs
+		}
+	}
+	return nil
 }

--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -40,7 +40,6 @@ import (
 	policylisters "k8s.io/client-go/listers/policy/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	"k8s.io/kubernetes/pkg/controller/volume/scheduling"
 	kubefeatures "k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/algorithmprovider"
@@ -162,12 +161,13 @@ func (c *Configurator) create() (*Scheduler, error) {
 	if len(ignoredExtendedResources) > 0 {
 		for i := range c.profiles {
 			prof := &c.profiles[i]
-			prof.PluginConfig = append(prof.PluginConfig,
-				frameworkplugins.NewPluginConfig(
-					noderesources.FitName,
-					schedulerv1alpha2.NodeResourcesFitArgs{IgnoredResources: ignoredExtendedResources},
-				),
-			)
+			pc := schedulerapi.PluginConfig{
+				Name: noderesources.FitName,
+				Args: &schedulerapi.NodeResourcesFitArgs{
+					IgnoredResources: ignoredExtendedResources,
+				},
+			}
+			prof.PluginConfig = append(prof.PluginConfig, pc)
 		}
 	}
 
@@ -280,9 +280,8 @@ func (c *Configurator) createFromConfig(policy schedulerapi.Policy) (*Scheduler,
 	// HardPodAffinitySymmetricWeight in the policy config takes precedence over
 	// CLI configuration.
 	if policy.HardPodAffinitySymmetricWeight != 0 {
-		v := policy.HardPodAffinitySymmetricWeight
-		args.InterPodAffinityArgs = &schedulerv1alpha2.InterPodAffinityArgs{
-			HardPodAffinityWeight: &v,
+		args.InterPodAffinityArgs = &schedulerapi.InterPodAffinityArgs{
+			HardPodAffinityWeight: policy.HardPodAffinitySymmetricWeight,
 		}
 	}
 

--- a/pkg/scheduler/framework/plugins/BUILD
+++ b/pkg/scheduler/framework/plugins/BUILD
@@ -31,10 +31,8 @@ go_library(
         "//pkg/scheduler/framework/plugins/volumerestrictions:go_default_library",
         "//pkg/scheduler/framework/plugins/volumezone:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/scheduler/framework/plugins/interpodaffinity/BUILD
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/BUILD
@@ -10,6 +10,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/interpodaffinity",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/parallelize:go_default_library",
         "//pkg/scheduler/util:go_default_library",
@@ -19,9 +20,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 
@@ -33,13 +32,11 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
-        "//vendor/k8s.io/utils/pointer:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring.go
@@ -137,7 +137,7 @@ func (pl *InterPodAffinity) processExistingPod(state *preScoreState, existingPod
 		// For every hard pod affinity term of <existingPod>, if <pod> matches the term,
 		// increment <p.counts> for every node in the cluster with the same <term.TopologyKey>
 		// value as that of <existingPod>'s node by the constant <ipa.hardPodAffinityWeight>
-		if *pl.args.HardPodAffinityWeight > 0 {
+		if pl.args.HardPodAffinityWeight > 0 {
 			terms := existingPodAffinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 			// TODO: Uncomment this block when implement RequiredDuringSchedulingRequiredDuringExecution.
 			//if len(existingPodAffinity.PodAffinity.RequiredDuringSchedulingRequiredDuringExecution) != 0 {
@@ -145,7 +145,7 @@ func (pl *InterPodAffinity) processExistingPod(state *preScoreState, existingPod
 			//}
 			for i := range terms {
 				term := &terms[i]
-				processedTerm, err := newWeightedAffinityTerm(existingPod, term, *pl.args.HardPodAffinityWeight)
+				processedTerm, err := newWeightedAffinityTerm(existingPod, term, pl.args.HardPodAffinityWeight)
 				if err != nil {
 					return err
 				}

--- a/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/interpodaffinity/scoring_test.go
@@ -18,17 +18,14 @@ package interpodaffinity
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
-	"k8s.io/utils/pointer"
 )
 
 func TestPreferredAffinity(t *testing.T) {
@@ -521,8 +518,8 @@ func TestPreferredAffinity(t *testing.T) {
 			state := framework.NewCycleState()
 			snapshot := cache.NewSnapshot(test.pods, test.nodes)
 			p := &InterPodAffinity{
-				args: schedulerv1alpha2.InterPodAffinityArgs{
-					HardPodAffinityWeight: pointer.Int32Ptr(DefaultHardPodAffinityWeight),
+				args: config.InterPodAffinityArgs{
+					HardPodAffinityWeight: DefaultHardPodAffinityWeight,
 				},
 				sharedLister: snapshot,
 			}
@@ -630,7 +627,7 @@ func TestPreferredAffinityWithHardPodAffinitySymmetricWeight(t *testing.T) {
 			snapshot := cache.NewSnapshot(test.pods, test.nodes)
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
 
-			args := &runtime.Unknown{Raw: []byte(fmt.Sprintf(`{"hardPodAffinityWeight":%d}`, test.hardPodAffinityWeight))}
+			args := &config.InterPodAffinityArgs{HardPodAffinityWeight: test.hardPodAffinityWeight}
 			p, err := New(args, fh)
 			if err != nil {
 				t.Fatal(err)

--- a/pkg/scheduler/framework/plugins/legacy_registry.go
+++ b/pkg/scheduler/framework/plugins/legacy_registry.go
@@ -17,13 +17,9 @@ limitations under the License.
 package plugins
 
 import (
-	"encoding/json"
-
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/klog"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	"k8s.io/kubernetes/pkg/features"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	"k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpodtopologyspread"
@@ -165,15 +161,15 @@ type ConfigProducerArgs struct {
 	// Weight used for priority functions.
 	Weight int32
 	// NodeLabelArgs is the args for the NodeLabel plugin.
-	NodeLabelArgs *schedulerv1alpha2.NodeLabelArgs
+	NodeLabelArgs *config.NodeLabelArgs
 	// RequestedToCapacityRatioArgs is the args for the RequestedToCapacityRatio plugin.
-	RequestedToCapacityRatioArgs *schedulerv1alpha2.RequestedToCapacityRatioArgs
+	RequestedToCapacityRatioArgs *config.RequestedToCapacityRatioArgs
 	// ServiceAffinityArgs is the args for the ServiceAffinity plugin.
-	ServiceAffinityArgs *schedulerv1alpha2.ServiceAffinityArgs
+	ServiceAffinityArgs *config.ServiceAffinityArgs
 	// NodeResourcesFitArgs is the args for the NodeResources fit filter.
-	NodeResourcesFitArgs *schedulerv1alpha2.NodeResourcesFitArgs
+	NodeResourcesFitArgs *config.NodeResourcesFitArgs
 	// InterPodAffinityArgs is the args for InterPodAffinity plugin
-	InterPodAffinityArgs *schedulerv1alpha2.InterPodAffinityArgs
+	InterPodAffinityArgs *config.InterPodAffinityArgs
 }
 
 // ConfigProducer returns the set of plugins and their configuration for a
@@ -227,7 +223,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 			plugins.Filter = appendToPluginSet(plugins.Filter, noderesources.FitName, nil)
 			plugins.PreFilter = appendToPluginSet(plugins.PreFilter, noderesources.FitName, nil)
 			if args.NodeResourcesFitArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(noderesources.FitName, args.NodeResourcesFitArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: noderesources.FitName, Args: args.NodeResourcesFitArgs})
 			}
 			plugins.Filter = appendToPluginSet(plugins.Filter, nodename.Name, nil)
 			plugins.Filter = appendToPluginSet(plugins.Filter, nodeports.Name, nil)
@@ -245,7 +242,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 			plugins.Filter = appendToPluginSet(plugins.Filter, noderesources.FitName, nil)
 			plugins.PreFilter = appendToPluginSet(plugins.PreFilter, noderesources.FitName, nil)
 			if args.NodeResourcesFitArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(noderesources.FitName, args.NodeResourcesFitArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: noderesources.FitName, Args: args.NodeResourcesFitArgs})
 			}
 			return
 		})
@@ -320,7 +318,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 		func(args ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
 			plugins.Filter = appendToPluginSet(plugins.Filter, nodelabel.Name, nil)
 			if args.NodeLabelArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(nodelabel.Name, args.NodeLabelArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: nodelabel.Name, Args: args.NodeLabelArgs})
 			}
 			return
 		})
@@ -328,7 +327,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 		func(args ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
 			plugins.Filter = appendToPluginSet(plugins.Filter, serviceaffinity.Name, nil)
 			if args.ServiceAffinityArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(serviceaffinity.Name, args.ServiceAffinityArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: serviceaffinity.Name, Args: args.ServiceAffinityArgs})
 			}
 			plugins.PreFilter = appendToPluginSet(plugins.PreFilter, serviceaffinity.Name, nil)
 			return
@@ -362,7 +362,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 			plugins.PreScore = appendToPluginSet(plugins.PreScore, interpodaffinity.Name, nil)
 			plugins.Score = appendToPluginSet(plugins.Score, interpodaffinity.Name, &args.Weight)
 			if args.InterPodAffinityArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(interpodaffinity.Name, args.InterPodAffinityArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: interpodaffinity.Name, Args: args.InterPodAffinityArgs})
 			}
 			return
 		})
@@ -390,7 +391,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 		func(args ConfigProducerArgs) (plugins config.Plugins, pluginConfig []config.PluginConfig) {
 			plugins.Score = appendToPluginSet(plugins.Score, noderesources.RequestedToCapacityRatioName, &args.Weight)
 			if args.RequestedToCapacityRatioArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(noderesources.RequestedToCapacityRatioName, args.RequestedToCapacityRatioArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: noderesources.RequestedToCapacityRatioName, Args: args.RequestedToCapacityRatioArgs})
 			}
 			return
 		})
@@ -403,7 +405,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 			weight := args.Weight * int32(len(args.NodeLabelArgs.PresentLabelsPreference)+len(args.NodeLabelArgs.AbsentLabelsPreference))
 			plugins.Score = appendToPluginSet(plugins.Score, nodelabel.Name, &weight)
 			if args.NodeLabelArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(nodelabel.Name, args.NodeLabelArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: nodelabel.Name, Args: args.NodeLabelArgs})
 			}
 			return
 		})
@@ -415,7 +418,8 @@ func NewLegacyRegistry() *LegacyRegistry {
 			weight := args.Weight * int32(len(args.ServiceAffinityArgs.AntiAffinityLabelsPreference))
 			plugins.Score = appendToPluginSet(plugins.Score, serviceaffinity.Name, &weight)
 			if args.ServiceAffinityArgs != nil {
-				pluginConfig = append(pluginConfig, NewPluginConfig(serviceaffinity.Name, args.ServiceAffinityArgs))
+				pluginConfig = append(pluginConfig,
+					config.PluginConfig{Name: serviceaffinity.Name, Args: args.ServiceAffinityArgs})
 			}
 			return
 		})
@@ -487,19 +491,6 @@ func appendToPluginSet(set *config.PluginSet, name string, weight *int32) *confi
 	return set
 }
 
-// NewPluginConfig builds a PluginConfig with the struct of args marshaled.
-// It panics if it fails to marshal.
-func NewPluginConfig(pluginName string, args interface{}) config.PluginConfig {
-	encoding, err := json.Marshal(args)
-	if err != nil {
-		klog.Fatalf("failed to marshal %+v: %v", args, err)
-	}
-	return config.PluginConfig{
-		Name: pluginName,
-		Args: &runtime.Unknown{Raw: encoding},
-	}
-}
-
 // ProcessPredicatePolicy given a PredicatePolicy, return the plugin name implementing the predicate and update
 // the ConfigProducerArgs if necessary.
 func (lr *LegacyRegistry) ProcessPredicatePolicy(policy config.PredicatePolicy, pluginArgs *ConfigProducerArgs) string {
@@ -526,7 +517,7 @@ func (lr *LegacyRegistry) ProcessPredicatePolicy(policy config.PredicatePolicy, 
 	if policy.Argument.ServiceAffinity != nil {
 		// map LabelsPresence policy to ConfigProducerArgs that's used to configure the ServiceAffinity plugin.
 		if pluginArgs.ServiceAffinityArgs == nil {
-			pluginArgs.ServiceAffinityArgs = &schedulerv1alpha2.ServiceAffinityArgs{}
+			pluginArgs.ServiceAffinityArgs = &config.ServiceAffinityArgs{}
 		}
 		pluginArgs.ServiceAffinityArgs.AffinityLabels = append(pluginArgs.ServiceAffinityArgs.AffinityLabels, policy.Argument.ServiceAffinity.Labels...)
 
@@ -539,7 +530,7 @@ func (lr *LegacyRegistry) ProcessPredicatePolicy(policy config.PredicatePolicy, 
 	if policy.Argument.LabelsPresence != nil {
 		// Map LabelPresence policy to ConfigProducerArgs that's used to configure the NodeLabel plugin.
 		if pluginArgs.NodeLabelArgs == nil {
-			pluginArgs.NodeLabelArgs = &schedulerv1alpha2.NodeLabelArgs{}
+			pluginArgs.NodeLabelArgs = &config.NodeLabelArgs{}
 		}
 		if policy.Argument.LabelsPresence.Presence {
 			pluginArgs.NodeLabelArgs.PresentLabels = append(pluginArgs.NodeLabelArgs.PresentLabels, policy.Argument.LabelsPresence.Labels...)
@@ -587,7 +578,7 @@ func (lr *LegacyRegistry) ProcessPriorityPolicy(policy config.PriorityPolicy, co
 		// This name is then used to find the registered plugin and run the plugin instead of the priority.
 		priorityName = serviceaffinity.Name
 		if configProducerArgs.ServiceAffinityArgs == nil {
-			configProducerArgs.ServiceAffinityArgs = &schedulerv1alpha2.ServiceAffinityArgs{}
+			configProducerArgs.ServiceAffinityArgs = &config.ServiceAffinityArgs{}
 		}
 		configProducerArgs.ServiceAffinityArgs.AntiAffinityLabelsPreference = append(
 			configProducerArgs.ServiceAffinityArgs.AntiAffinityLabelsPreference,
@@ -601,7 +592,7 @@ func (lr *LegacyRegistry) ProcessPriorityPolicy(policy config.PriorityPolicy, co
 		// This name is then used to find the registered plugin and run the plugin instead of the priority.
 		priorityName = nodelabel.Name
 		if configProducerArgs.NodeLabelArgs == nil {
-			configProducerArgs.NodeLabelArgs = &schedulerv1alpha2.NodeLabelArgs{}
+			configProducerArgs.NodeLabelArgs = &config.NodeLabelArgs{}
 		}
 		if policy.Argument.LabelPreference.Presence {
 			configProducerArgs.NodeLabelArgs.PresentLabelsPreference = append(
@@ -618,19 +609,19 @@ func (lr *LegacyRegistry) ProcessPriorityPolicy(policy config.PriorityPolicy, co
 
 	if policy.Argument.RequestedToCapacityRatioArguments != nil {
 		policyArgs := policy.Argument.RequestedToCapacityRatioArguments
-		args := &schedulerv1alpha2.RequestedToCapacityRatioArgs{}
+		args := &config.RequestedToCapacityRatioArgs{}
 
-		args.Shape = make([]schedulerv1alpha2.UtilizationShapePoint, len(policyArgs.Shape))
+		args.Shape = make([]config.UtilizationShapePoint, len(policyArgs.Shape))
 		for i, s := range policyArgs.Shape {
-			args.Shape[i] = schedulerv1alpha2.UtilizationShapePoint{
+			args.Shape[i] = config.UtilizationShapePoint{
 				Utilization: s.Utilization,
 				Score:       s.Score,
 			}
 		}
 
-		args.Resources = make([]schedulerv1alpha2.ResourceSpec, len(policyArgs.Resources))
+		args.Resources = make([]config.ResourceSpec, len(policyArgs.Resources))
 		for i, r := range policyArgs.Resources {
-			args.Resources[i] = schedulerv1alpha2.ResourceSpec{
+			args.Resources[i] = config.ResourceSpec{
 				Name:   r.Name,
 				Weight: r.Weight,
 			}

--- a/pkg/scheduler/framework/plugins/nodelabel/BUILD
+++ b/pkg/scheduler/framework/plugins/nodelabel/BUILD
@@ -6,11 +6,11 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/nodelabel",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
     ],
 )
 
@@ -19,11 +19,11 @@ go_test(
     srcs = ["node_label_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/nodelabel/node_label_test.go
+++ b/pkg/scheduler/framework/plugins/nodelabel/node_label_test.go
@@ -22,7 +22,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -30,35 +30,54 @@ import (
 func TestValidateNodeLabelArgs(t *testing.T) {
 	tests := []struct {
 		name string
-		args string
+		args config.NodeLabelArgs
 		err  bool
 	}{
 		{
 			name: "happy case",
-			args: `{"presentLabels" : ["foo", "bar"], "absentLabels" : ["baz"], "presentLabelsPreference" : ["foo", "bar"], "absentLabelsPreference" : ["baz"]}`,
+			args: config.NodeLabelArgs{
+				PresentLabels:           []string{"foo", "bar"},
+				AbsentLabels:            []string{"baz"},
+				PresentLabelsPreference: []string{"foo", "bar"},
+				AbsentLabelsPreference:  []string{"baz"},
+			},
 		},
 		{
 			name: "label presence conflict",
 			// "bar" exists in both present and absent labels therefore validation should fail.
-			args: `{"presentLabels" : ["foo", "bar"], "absentLabels" : ["bar", "baz"], "presentLabelsPreference" : ["foo", "bar"], "absentLabelsPreference" : ["baz"]}`,
-			err:  true,
+			args: config.NodeLabelArgs{
+				PresentLabels:           []string{"foo", "bar"},
+				AbsentLabels:            []string{"bar", "baz"},
+				PresentLabelsPreference: []string{"foo", "bar"},
+				AbsentLabelsPreference:  []string{"baz"},
+			},
+			err: true,
 		},
 		{
 			name: "label preference conflict",
 			// "bar" exists in both present and absent labels preferences therefore validation should fail.
-			args: `{"presentLabels" : ["foo", "bar"], "absentLabels" : ["baz"], "presentLabelsPreference" : ["foo", "bar"], "absentLabelsPreference" : ["bar", "baz"]}`,
-			err:  true,
+			args: config.NodeLabelArgs{
+				PresentLabels:           []string{"foo", "bar"},
+				AbsentLabels:            []string{"baz"},
+				PresentLabelsPreference: []string{"foo", "bar"},
+				AbsentLabelsPreference:  []string{"bar", "baz"},
+			},
+			err: true,
 		},
 		{
 			name: "both label presence and preference conflict",
-			args: `{"presentLabels" : ["foo", "bar"], "absentLabels" : ["bar", "baz"], "presentLabelsPreference" : ["foo", "bar"], "absentLabelsPreference" : ["bar", "baz"]}`,
-			err:  true,
+			args: config.NodeLabelArgs{
+				PresentLabels:           []string{"foo", "bar"},
+				AbsentLabels:            []string{"bar", "baz"},
+				PresentLabelsPreference: []string{"foo", "bar"},
+				AbsentLabelsPreference:  []string{"bar", "baz"},
+			},
+			err: true,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			args := &runtime.Unknown{Raw: []byte(test.args)}
-			_, err := New(args, nil)
+			_, err := New(&test.args, nil)
 			if test.err && err == nil {
 				t.Fatal("Plugin initialization should fail.")
 			}
@@ -73,59 +92,83 @@ func TestNodeLabelFilter(t *testing.T) {
 	label := map[string]string{"foo": "any value", "bar": "any value"}
 	var pod *v1.Pod
 	tests := []struct {
-		name    string
-		rawArgs string
-		res     framework.Code
+		name string
+		args config.NodeLabelArgs
+		res  framework.Code
 	}{
 		{
-			name:    "present label does not match",
-			rawArgs: `{"presentLabels" : ["baz"]}`,
-			res:     framework.UnschedulableAndUnresolvable,
+			name: "present label does not match",
+			args: config.NodeLabelArgs{
+				PresentLabels: []string{"baz"},
+			},
+			res: framework.UnschedulableAndUnresolvable,
 		},
 		{
-			name:    "absent label does not match",
-			rawArgs: `{"absentLabels" : ["baz"]}`,
-			res:     framework.Success,
+			name: "absent label does not match",
+			args: config.NodeLabelArgs{
+				AbsentLabels: []string{"baz"},
+			},
+			res: framework.Success,
 		},
 		{
-			name:    "one of two present labels matches",
-			rawArgs: `{"presentLabels" : ["foo", "baz"]}`,
-			res:     framework.UnschedulableAndUnresolvable,
+			name: "one of two present labels matches",
+			args: config.NodeLabelArgs{
+				PresentLabels: []string{"foo", "baz"},
+			},
+			res: framework.UnschedulableAndUnresolvable,
 		},
 		{
-			name:    "one of two absent labels matches",
-			rawArgs: `{"absentLabels" : ["foo", "baz"]}`,
-			res:     framework.UnschedulableAndUnresolvable,
+			name: "one of two absent labels matches",
+			args: config.NodeLabelArgs{
+				AbsentLabels: []string{"foo", "baz"},
+			},
+			res: framework.UnschedulableAndUnresolvable,
 		},
 		{
-			name:    "all present abels match",
-			rawArgs: `{"presentLabels" : ["foo", "bar"]}`,
-			res:     framework.Success,
+			name: "all present labels match",
+			args: config.NodeLabelArgs{
+				PresentLabels: []string{"foo", "bar"},
+			},
+			res: framework.Success,
 		},
 		{
-			name:    "all absent labels match",
-			rawArgs: `{"absentLabels" : ["foo", "bar"]}`,
-			res:     framework.UnschedulableAndUnresolvable,
+			name: "all absent labels match",
+			args: config.NodeLabelArgs{
+				AbsentLabels: []string{"foo", "bar"},
+			},
+			res: framework.UnschedulableAndUnresolvable,
 		},
 		{
-			name:    "both present and absent label matches",
-			rawArgs: `{"presentLabels" : ["foo"], "absentLabels" : ["bar"]}`,
-			res:     framework.UnschedulableAndUnresolvable,
+			name: "both present and absent label matches",
+			args: config.NodeLabelArgs{
+				PresentLabels: []string{"foo"},
+				AbsentLabels:  []string{"bar"},
+			},
+			res: framework.UnschedulableAndUnresolvable,
 		},
 		{
-			name:    "neither present nor absent label matches",
-			rawArgs: `{"presentLabels" : ["foz"], "absentLabels" : ["baz"]}`,
-			res:     framework.UnschedulableAndUnresolvable,
+			name: "neither present nor absent label matches",
+			args: config.NodeLabelArgs{
+				PresentLabels: []string{"foz"},
+				AbsentLabels:  []string{"baz"},
+			},
+			res: framework.UnschedulableAndUnresolvable,
 		},
 		{
-			name:    "present label matches and absent label doesn't match",
-			rawArgs: `{"presentLabels" : ["foo"], "absentLabels" : ["baz"]}`,
-			res:     framework.Success,
+			name: "present label matches and absent label doesn't match",
+			args: config.NodeLabelArgs{
+				PresentLabels: []string{"foo"},
+				AbsentLabels:  []string{"baz"},
+			},
+			res: framework.Success,
 		},
 		{
-			name:    "present label doesn't match and absent label matches",
-			rawArgs: `{"presentLabels" : ["foz"], "absentLabels" : ["bar"]}`,
-			res:     framework.UnschedulableAndUnresolvable,
+			name: "present label doesn't match and absent label matches",
+			args: config.NodeLabelArgs{
+				PresentLabels: []string{"foz"},
+				AbsentLabels:  []string{"bar"},
+			},
+			res: framework.UnschedulableAndUnresolvable,
 		},
 	}
 
@@ -135,8 +178,7 @@ func TestNodeLabelFilter(t *testing.T) {
 			nodeInfo := framework.NewNodeInfo()
 			nodeInfo.SetNode(&node)
 
-			args := &runtime.Unknown{Raw: []byte(test.rawArgs)}
-			p, err := New(args, nil)
+			p, err := New(&test.args, nil)
 			if err != nil {
 				t.Fatalf("Failed to create plugin: %v", err)
 			}
@@ -151,74 +193,103 @@ func TestNodeLabelFilter(t *testing.T) {
 
 func TestNodeLabelScore(t *testing.T) {
 	tests := []struct {
-		rawArgs string
-		want    int64
-		name    string
+		args config.NodeLabelArgs
+		want int64
+		name string
 	}{
 		{
-			want:    framework.MaxNodeScore,
-			rawArgs: `{"presentLabelsPreference" : ["foo"]}`,
-			name:    "one present label match",
+			want: framework.MaxNodeScore,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"foo"},
+			},
+			name: "one present label match",
 		},
 		{
-			want:    0,
-			rawArgs: `{"presentLabelsPreference" : ["somelabel"]}`,
-			name:    "one present label mismatch",
+			want: 0,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"somelabel"},
+			},
+			name: "one present label mismatch",
 		},
 		{
-			want:    framework.MaxNodeScore,
-			rawArgs: `{"presentLabelsPreference" : ["foo", "bar"]}`,
-			name:    "two present labels match",
+			want: framework.MaxNodeScore,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"foo", "bar"},
+			},
+			name: "two present labels match",
 		},
 		{
-			want:    0,
-			rawArgs: `{"presentLabelsPreference" : ["somelabel1", "somelabel2"]}`,
-			name:    "two present labels mismatch",
+			want: 0,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"somelabel1", "somelabel2"},
+			},
+			name: "two present labels mismatch",
 		},
 		{
-			want:    framework.MaxNodeScore / 2,
-			rawArgs: `{"presentLabelsPreference" : ["foo", "somelabel"]}`,
-			name:    "two present labels only one matches",
+			want: framework.MaxNodeScore / 2,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"foo", "somelabel"},
+			},
+			name: "two present labels only one matches",
 		},
 		{
-			want:    0,
-			rawArgs: `{"absentLabelsPreference" : ["foo"]}`,
-			name:    "one absent label match",
+			want: 0,
+			args: config.NodeLabelArgs{
+				AbsentLabelsPreference: []string{"foo"},
+			},
+			name: "one absent label match",
 		},
 		{
-			want:    framework.MaxNodeScore,
-			rawArgs: `{"absentLabelsPreference" : ["somelabel"]}`,
-			name:    "one absent label mismatch",
+			want: framework.MaxNodeScore,
+			args: config.NodeLabelArgs{
+				AbsentLabelsPreference: []string{"somelabel"},
+			},
+			name: "one absent label mismatch",
 		},
 		{
-			want:    0,
-			rawArgs: `{"absentLabelsPreference" : ["foo", "bar"]}`,
-			name:    "two absent labels match",
+			want: 0,
+			args: config.NodeLabelArgs{
+				AbsentLabelsPreference: []string{"foo", "bar"},
+			},
+			name: "two absent labels match",
 		},
 		{
-			want:    framework.MaxNodeScore,
-			rawArgs: `{"absentLabelsPreference" : ["somelabel1", "somelabel2"]}`,
-			name:    "two absent labels mismatch",
+			want: framework.MaxNodeScore,
+			args: config.NodeLabelArgs{
+				AbsentLabelsPreference: []string{"somelabel1", "somelabel2"},
+			},
+			name: "two absent labels mismatch",
 		},
 		{
-			want:    framework.MaxNodeScore / 2,
-			rawArgs: `{"absentLabelsPreference" : ["foo", "somelabel"]}`,
-			name:    "two absent labels only one matches",
+			want: framework.MaxNodeScore / 2,
+			args: config.NodeLabelArgs{
+				AbsentLabelsPreference: []string{"foo", "somelabel"},
+			},
+			name: "two absent labels only one matches",
 		},
 		{
-			want:    framework.MaxNodeScore,
-			rawArgs: `{"presentLabelsPreference" : ["foo", "bar"], "absentLabelsPreference" : ["somelabel1", "somelabel2"]}`,
-			name:    "two present labels match, two absent labels mismatch",
+			want: framework.MaxNodeScore,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"foo", "bar"},
+				AbsentLabelsPreference:  []string{"somelabel1", "somelabel2"},
+			},
+			name: "two present labels match, two absent labels mismatch",
 		},
 		{
-			want:    0,
-			rawArgs: `{"absentLabelsPreference" : ["foo", "bar"], "presentLabelsPreference" : ["somelabel1", "somelabel2"]}`,
-			name:    "two present labels both mismatch, two absent labels both match",
+			want: 0,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"somelabel1", "somelabel2"},
+				AbsentLabelsPreference:  []string{"foo", "bar"},
+			},
+			name: "two present labels both mismatch, two absent labels both match",
 		},
 		{
-			want:    3 * framework.MaxNodeScore / 4,
-			rawArgs: `{"presentLabelsPreference" : ["foo", "somelabel"], "absentLabelsPreference" : ["somelabel1", "somelabel2"]}`,
-			name:    "two present labels one matches, two absent labels mismatch",
+			want: 3 * framework.MaxNodeScore / 4,
+			args: config.NodeLabelArgs{
+				PresentLabelsPreference: []string{"foo", "somelabel"},
+				AbsentLabelsPreference:  []string{"somelabel1", "somelabel2"},
+			},
+			name: "two present labels one matches, two absent labels mismatch",
 		},
 	}
 
@@ -227,8 +298,7 @@ func TestNodeLabelScore(t *testing.T) {
 			state := framework.NewCycleState()
 			node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "machine1", Labels: map[string]string{"foo": "", "bar": ""}}}
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(cache.NewSnapshot(nil, []*v1.Node{node})))
-			args := &runtime.Unknown{Raw: []byte(test.rawArgs)}
-			p, err := New(args, fh)
+			p, err := New(&test.args, fh)
 			if err != nil {
 				t.Fatalf("Failed to create plugin: %+v", err)
 			}

--- a/pkg/scheduler/framework/plugins/noderesources/BUILD
+++ b/pkg/scheduler/framework/plugins/noderesources/BUILD
@@ -26,7 +26,6 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -59,15 +58,14 @@ go_test(
     deps = [
         "//pkg/apis/core/v1/helper:go_default_library",
         "//pkg/features:go_default_library",
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/component-base/featuregate/testing:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/github.com/stretchr/testify/assert:go_default_library",
     ],
 )

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio.go
@@ -24,7 +24,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
 	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
@@ -49,8 +48,8 @@ type functionShapePoint struct {
 
 // NewRequestedToCapacityRatio initializes a new plugin and returns it.
 func NewRequestedToCapacityRatio(plArgs runtime.Object, handle framework.FrameworkHandle) (framework.Plugin, error) {
-	args := &schedulerv1alpha2.RequestedToCapacityRatioArgs{}
-	if err := framework.DecodeInto(plArgs, args); err != nil {
+	args, err := getRequestedToCapacityRatioArgs(plArgs)
+	if err != nil {
 		return nil, err
 	}
 
@@ -90,6 +89,17 @@ func NewRequestedToCapacityRatio(plArgs runtime.Object, handle framework.Framewo
 			resourceToWeightMap,
 		},
 	}, nil
+}
+
+func getRequestedToCapacityRatioArgs(obj runtime.Object) (config.RequestedToCapacityRatioArgs, error) {
+	if obj == nil {
+		return config.RequestedToCapacityRatioArgs{}, nil
+	}
+	ptr, ok := obj.(*config.RequestedToCapacityRatioArgs)
+	if !ok {
+		return config.RequestedToCapacityRatioArgs{}, fmt.Errorf("want args to be of type RequestedToCapacityRatioArgs, got %T", obj)
+	}
+	return *ptr, nil
 }
 
 // RequestedToCapacityRatio is a score plugin that allow users to apply bin packing

--- a/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
+++ b/pkg/scheduler/framework/plugins/noderesources/requested_to_capacity_ratio_test.go
@@ -24,8 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 )
@@ -68,8 +67,17 @@ func TestRequestedToCapacityRatio(t *testing.T) {
 			state := framework.NewCycleState()
 			snapshot := cache.NewSnapshot(test.scheduledPods, test.nodes)
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
-			args := &runtime.Unknown{Raw: []byte(`{"shape" : [{"utilization" : 0, "score" : 10}, {"utilization" : 100, "score" : 0}], "resources" : [{"name" : "memory", "weight" : 1}, {"name" : "cpu", "weight" : 1}]}`)}
-			p, err := NewRequestedToCapacityRatio(args, fh)
+			args := config.RequestedToCapacityRatioArgs{
+				Shape: []config.UtilizationShapePoint{
+					{Utilization: 0, Score: 10},
+					{Utilization: 100, Score: 0},
+				},
+				Resources: []config.ResourceSpec{
+					{Name: "memory", Weight: 1},
+					{Name: "cpu", Weight: 1},
+				},
+			}
+			p, err := NewRequestedToCapacityRatio(&args, fh)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -352,8 +360,16 @@ func TestResourceBinPackingSingleExtended(t *testing.T) {
 			state := framework.NewCycleState()
 			snapshot := cache.NewSnapshot(test.pods, test.nodes)
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
-			args := &runtime.Unknown{Raw: []byte(`{"shape" : [{"utilization" : 0, "score" : 0}, {"utilization" : 100, "score" : 1}], "resources" : [{"name" : "intel.com/foo", "weight" : 1}]}`)}
-			p, err := NewRequestedToCapacityRatio(args, fh)
+			args := config.RequestedToCapacityRatioArgs{
+				Shape: []config.UtilizationShapePoint{
+					{Utilization: 0, Score: 0},
+					{Utilization: 100, Score: 1},
+				},
+				Resources: []config.ResourceSpec{
+					{Name: "intel.com/foo", Weight: 1},
+				},
+			}
+			p, err := NewRequestedToCapacityRatio(&args, fh)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -587,8 +603,17 @@ func TestResourceBinPackingMultipleExtended(t *testing.T) {
 			state := framework.NewCycleState()
 			snapshot := cache.NewSnapshot(test.pods, test.nodes)
 			fh, _ := framework.NewFramework(nil, nil, nil, framework.WithSnapshotSharedLister(snapshot))
-			args := &runtime.Unknown{Raw: []byte(`{"shape" : [{"utilization" : 0, "score" : 0}, {"utilization" : 100, "score" : 1}], "resources" : [{"name" : "intel.com/foo", "weight" : 3}, {"name" : "intel.com/bar", "weight": 5}]}`)}
-			p, err := NewRequestedToCapacityRatio(args, fh)
+			args := config.RequestedToCapacityRatioArgs{
+				Shape: []config.UtilizationShapePoint{
+					{Utilization: 0, Score: 0},
+					{Utilization: 100, Score: 1},
+				},
+				Resources: []config.ResourceSpec{
+					{Name: "intel.com/foo", Weight: 3},
+					{Name: "intel.com/bar", Weight: 5},
+				},
+			}
+			p, err := NewRequestedToCapacityRatio(&args, fh)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -606,51 +631,5 @@ func TestResourceBinPackingMultipleExtended(t *testing.T) {
 				t.Errorf("expected %#v, got %#v", test.expectedList, gotList)
 			}
 		})
-	}
-}
-
-// TODO compatibility test once the plugin args move to v1beta1.
-// UtilizationShapePoint and ResourceSpec fields of the plugin args struct are not annotated
-// with JSON tags in v1alpha2 to maintain backward compatibility with the args shipped with v1.18.
-// See https://github.com/kubernetes/kubernetes/pull/88585#discussion_r405021905
-
-func TestPluginArgsJSONEncodingIsCaseInsensitive(t *testing.T) {
-	rawArgs := &runtime.Unknown{Raw: []byte(`
-	{
-		"shape": [{"Utilization": 1, "Score": 1}, {"utilization": 2, "score": 2}],
-		"resources": [{"Name":"a","Weight":1},{"name":"b","weight":2}]
-	}
-`)}
-
-	args := &schedulerv1alpha2.RequestedToCapacityRatioArgs{}
-	if err := framework.DecodeInto(rawArgs, args); err != nil {
-		t.Fatalf("expected no error, got: %v", err)
-	}
-
-	expectedArgs := &schedulerv1alpha2.RequestedToCapacityRatioArgs{
-		Shape: []schedulerv1alpha2.UtilizationShapePoint{
-			{
-				Utilization: 1,
-				Score:       1,
-			},
-			{
-				Utilization: 2,
-				Score:       2,
-			},
-		},
-		Resources: []schedulerv1alpha2.ResourceSpec{
-			{
-				Name:   "a",
-				Weight: 1,
-			},
-			{
-				Name:   "b",
-				Weight: 2,
-			},
-		},
-	}
-
-	if !reflect.DeepEqual(expectedArgs, args) {
-		t.Errorf("expected: \n\t%#v,\ngot: \n\t%#v", expectedArgs, args)
 	}
 }

--- a/pkg/scheduler/framework/plugins/podtopologyspread/BUILD
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/BUILD
@@ -11,6 +11,7 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/plugins/helper:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/parallelize:go_default_library",
@@ -24,7 +25,6 @@ go_library(
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/listers/apps/v1:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )
@@ -38,6 +38,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//pkg/scheduler/internal/parallelize:go_default_library",
@@ -50,7 +51,6 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes/fake:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
         "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/k8s.io/utils/pointer:go_default_library",
     ],

--- a/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/filtering_test.go
@@ -28,7 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	"k8s.io/kubernetes/pkg/scheduler/internal/parallelize"
@@ -518,7 +518,7 @@ func TestPreFilterState(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(tt.objs...), 0)
 			pl := PodTopologySpread{
 				sharedLister: cache.NewSnapshot(tt.existingPods, tt.nodes),
-				args: schedulerv1alpha2.PodTopologySpreadArgs{
+				args: config.PodTopologySpreadArgs{
 					DefaultConstraints: tt.defaultConstraints,
 				},
 			}

--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
 	"k8s.io/kubernetes/pkg/scheduler/internal/parallelize"
@@ -195,7 +195,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 			informerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(tt.objs...), 0)
 			pl := PodTopologySpread{
 				sharedLister: cache.NewSnapshot(nil, tt.nodes),
-				args: schedulerv1alpha2.PodTopologySpreadArgs{
+				args: config.PodTopologySpreadArgs{
 					DefaultConstraints: tt.defaultConstraints,
 				},
 			}
@@ -729,7 +729,7 @@ func BenchmarkTestDefaultEvenPodsSpreadPriority(b *testing.B) {
 			snapshot := cache.NewSnapshot(existingPods, allNodes)
 			p := &PodTopologySpread{
 				sharedLister: snapshot,
-				args: schedulerv1alpha2.PodTopologySpreadArgs{
+				args: config.PodTopologySpreadArgs{
 					DefaultConstraints: []v1.TopologySpreadConstraint{
 						{MaxSkew: 1, TopologyKey: v1.LabelHostname, WhenUnsatisfiable: v1.ScheduleAnyway},
 						{MaxSkew: 1, TopologyKey: v1.LabelZoneFailureDomain, WhenUnsatisfiable: v1.ScheduleAnyway},

--- a/pkg/scheduler/framework/plugins/serviceaffinity/BUILD
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/BUILD
@@ -6,13 +6,13 @@ go_library(
     importpath = "k8s.io/kubernetes/pkg/scheduler/framework/plugins/serviceaffinity",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/plugins/helper:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/client-go/listers/core/v1:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
     ],
 )
 
@@ -21,12 +21,12 @@ go_test(
     srcs = ["service_affinity_test.go"],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/scheduler/apis/config:go_default_library",
         "//pkg/scheduler/framework/v1alpha1:go_default_library",
         "//pkg/scheduler/framework/v1alpha1/fake:go_default_library",
         "//pkg/scheduler/internal/cache:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//staging/src/k8s.io/kube-scheduler/config/v1alpha2:go_default_library",
     ],
 )
 

--- a/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
+++ b/pkg/scheduler/framework/plugins/serviceaffinity/service_affinity_test.go
@@ -24,7 +24,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	schedulerv1alpha2 "k8s.io/kube-scheduler/config/v1alpha2"
+	"k8s.io/kubernetes/pkg/scheduler/apis/config"
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	fakeframework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1/fake"
 	"k8s.io/kubernetes/pkg/scheduler/internal/cache"
@@ -165,7 +165,7 @@ func TestServiceAffinity(t *testing.T) {
 			p := &ServiceAffinity{
 				sharedLister:  snapshot,
 				serviceLister: fakeframework.ServiceLister(test.services),
-				args: schedulerv1alpha2.ServiceAffinityArgs{
+				args: config.ServiceAffinityArgs{
 					AffinityLabels: test.labels,
 				},
 			}
@@ -389,7 +389,7 @@ func TestServiceAffinityScore(t *testing.T) {
 			p := &ServiceAffinity{
 				sharedLister:  snapshot,
 				serviceLister: serviceLister,
-				args: schedulerv1alpha2.ServiceAffinityArgs{
+				args: config.ServiceAffinityArgs{
 					AntiAffinityLabelsPreference: test.labels,
 				},
 			}
@@ -606,7 +606,7 @@ func TestPreFilterDisabled(t *testing.T) {
 	node := v1.Node{}
 	nodeInfo.SetNode(&node)
 	p := &ServiceAffinity{
-		args: schedulerv1alpha2.ServiceAffinityArgs{
+		args: config.ServiceAffinityArgs{
 			AffinityLabels: []string{"region"},
 		},
 	}

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha2/BUILD
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha2/BUILD
@@ -19,6 +19,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/component-base/config/v1alpha1:go_default_library",
         "//staging/src/k8s.io/kube-scheduler/config/v1:go_default_library",
+        "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],
 )
 

--- a/staging/src/k8s.io/kube-scheduler/config/v1alpha2/types_pluginargs.go
+++ b/staging/src/k8s.io/kube-scheduler/config/v1alpha2/types_pluginargs.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha2
 
 import (
+	gojson "encoding/json"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -95,7 +97,7 @@ type RequestedToCapacityRatioArgs struct {
 	Resources []ResourceSpec `json:"resources,omitempty"`
 }
 
-// TODO add JSON tags and backward compatible conversion in v1beta1.
+// TODO add JSON tags and remove custom unmarshalling in v1beta1.
 // UtilizationShapePoint and ResourceSpec fields are not annotated with JSON tags in v1alpha2
 // to maintain backward compatibility with the args shipped with v1.18.
 // See https://github.com/kubernetes/kubernetes/pull/88585#discussion_r405021905
@@ -108,12 +110,26 @@ type UtilizationShapePoint struct {
 	Score int32
 }
 
+// UnmarshalJSON provides case insensitive unmarshalling for the type.
+// TODO remove when copying to v1beta1.
+func (t *UtilizationShapePoint) UnmarshalJSON(data []byte) error {
+	type internal *UtilizationShapePoint
+	return gojson.Unmarshal(data, internal(t))
+}
+
 // ResourceSpec represents single resource and weight for bin packing of priority RequestedToCapacityRatioArguments.
 type ResourceSpec struct {
 	// Name of the resource to be managed by RequestedToCapacityRatio function.
 	Name string
 	// Weight of the resource.
 	Weight int64
+}
+
+// UnmarshalJSON provides case insensitive unmarshalling for the type.
+// TODO remove when copying to v1beta1.
+func (t *ResourceSpec) UnmarshalJSON(data []byte) error {
+	type internal *ResourceSpec
+	return gojson.Unmarshal(data, internal(t))
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/staging/src/k8s.io/kube-scheduler/go.mod
+++ b/staging/src/k8s.io/kube-scheduler/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/component-base v0.0.0
+	sigs.k8s.io/yaml v1.2.0
 )
 
 replace (


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Adds decoding of nested `pluginConfig.args` so that we can use internal types in the scheduler.
This way, we are compliant with API best practices and, in the future, we will be able to support args using different versions.

**Which issue(s) this PR fixes**:

Part of #87784

**Special notes for your reviewer**:

API changes are in first commit.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```