### PR TITLE
fix kubeadm staticcheck err

### DIFF
--- a/cmd/kubeadm/app/preflight/checks.go
+++ b/cmd/kubeadm/app/preflight/checks.go
@@ -803,6 +803,7 @@ func getEtcdVersionResponse(client *http.Client, url string, target interface{})
 				loopCount--
 				return false, err
 			}
+			//lint:ignore SA5011 If err != nil we are already returning.
 			defer r.Body.Close()
 
 			if r != nil && r.StatusCode >= 500 && r.StatusCode <= 599 {

--- a/cmd/kubeadm/app/util/config/cluster_test.go
+++ b/cmd/kubeadm/app/util/config/cluster_test.go
@@ -748,6 +748,7 @@ func TestGetInitConfigurationFromCluster(t *testing.T) {
 			// Test expected values in InitConfiguration
 			if cfg == nil {
 				t.Errorf("unexpected nil return value")
+				return
 			}
 			if cfg.ClusterConfiguration.KubernetesVersion != k8sVersionString {
 				t.Errorf("invalid ClusterConfiguration.KubernetesVersion")


### PR DESCRIPTION
**What type of PR is this?**

 /kind cleanup

**What this PR does / why we need it**:

Fix Static Check Failures for the kubeadm packages.

**Which issue(s) this PR fixes**:
Ref: #90208 

pr #90275 is not easier for sig member to review and merge, it needs lots of sig approvers to approve, so After following member advice, I have created separate diffs for each sig impacted. thanks.