### PR TITLE
fix e2e scheduling staticcheck error

### DIFF
--- a/test/e2e/scheduling/predicates.go
+++ b/test/e2e/scheduling/predicates.go
@@ -1052,15 +1052,19 @@ func GetPodsScheduled(masterNodes sets.String, pods *v1.PodList) (scheduledPods,
 			if pod.Spec.NodeName != "" {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
 				framework.ExpectEqual(scheduledCondition != nil, true)
-				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
-				scheduledPods = append(scheduledPods, pod)
+				if scheduledCondition != nil {
+					framework.ExpectEqual(scheduledCondition.Status, v1.ConditionTrue)
+					scheduledPods = append(scheduledPods, pod)
+				}
 			} else {
 				_, scheduledCondition := podutil.GetPodCondition(&pod.Status, v1.PodScheduled)
 				framework.ExpectEqual(scheduledCondition != nil, true)
-				framework.ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
-				if scheduledCondition.Reason == "Unschedulable" {
+				if scheduledCondition != nil {
+					framework.ExpectEqual(scheduledCondition.Status, v1.ConditionFalse)
+					if scheduledCondition.Reason == "Unschedulable" {
 
-					notScheduledPods = append(notScheduledPods, pod)
+						notScheduledPods = append(notScheduledPods, pod)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
**What type of PR is this?**
 /kind cleanup

**What this PR does / why we need it**:

Fix Static Check Failures for the e2e scheduling packages.

**Which issue(s) this PR fixes**:
Ref: #90208 

pr #90275 is not easier for sig member to review and merge, it needs lots of sig approvers to approve, so After following member advice, I have created separate diffs for each sig impacted. thanks.