### PR TITLE
Split scheduler's PodInfo into two types, PodInfo and PodQueueInfo

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -456,8 +456,8 @@ func NewPodInformer(client clientset.Interface, resyncPeriod time.Duration) core
 }
 
 // MakeDefaultErrorFunc construct a function to handle pod scheduler error
-func MakeDefaultErrorFunc(client clientset.Interface, podQueue internalqueue.SchedulingQueue, schedulerCache internalcache.Cache) func(*framework.PodInfo, error) {
-	return func(podInfo *framework.PodInfo, err error) {
+func MakeDefaultErrorFunc(client clientset.Interface, podQueue internalqueue.SchedulingQueue, schedulerCache internalcache.Cache) func(*framework.QueuedPodInfo, error) {
+	return func(podInfo *framework.QueuedPodInfo, err error) {
 		pod := podInfo.Pod
 		if err == core.ErrNoNodesAvailable {
 			klog.V(2).Infof("Unable to schedule %v/%v: no nodes are registered to the cluster; waiting", pod.Namespace, pod.Name)

--- a/pkg/scheduler/factory_test.go
+++ b/pkg/scheduler/factory_test.go
@@ -328,7 +328,7 @@ func TestDefaultErrorFunc(t *testing.T) {
 		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "bar"}},
 		&v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 
-	testPodInfo := &framework.PodInfo{Pod: testPod}
+	testPodInfo := &framework.QueuedPodInfo{Pod: testPod}
 	client := fake.NewSimpleClientset(&v1.PodList{Items: []v1.Pod{*testPod}}, &v1.NodeList{Items: []v1.Node{*nodeBar}})
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort.go
@@ -37,8 +37,8 @@ func (pl *PrioritySort) Name() string {
 
 // Less is the function used by the activeQ heap algorithm to sort pods.
 // It sorts pods based on their priority. When priorities are equal, it uses
-// PodInfo.timestamp.
-func (pl *PrioritySort) Less(pInfo1, pInfo2 *framework.PodInfo) bool {
+// PodQueueInfo.timestamp.
+func (pl *PrioritySort) Less(pInfo1, pInfo2 *framework.QueuedPodInfo) bool {
 	p1 := pod.GetPodPriority(pInfo1.Pod)
 	p2 := pod.GetPodPriority(pInfo2.Pod)
 	return (p1 > p2) || (p1 == p2 && pInfo1.Timestamp.Before(pInfo2.Timestamp))

--- a/pkg/scheduler/framework/plugins/queuesort/priority_sort_test.go
+++ b/pkg/scheduler/framework/plugins/queuesort/priority_sort_test.go
@@ -31,20 +31,20 @@ func TestLess(t *testing.T) {
 	t2 := t1.Add(time.Second)
 	for _, tt := range []struct {
 		name     string
-		p1       *framework.PodInfo
-		p2       *framework.PodInfo
+		p1       *framework.QueuedPodInfo
+		p2       *framework.QueuedPodInfo
 		expected bool
 	}{
 		{
 			name: "p1.priority less than p2.priority",
-			p1: &framework.PodInfo{
+			p1: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &lowPriority,
 					},
 				},
 			},
-			p2: &framework.PodInfo{
+			p2: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
@@ -55,14 +55,14 @@ func TestLess(t *testing.T) {
 		},
 		{
 			name: "p1.priority greater than p2.priority",
-			p1: &framework.PodInfo{
+			p1: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
 					},
 				},
 			},
-			p2: &framework.PodInfo{
+			p2: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &lowPriority,
@@ -73,7 +73,7 @@ func TestLess(t *testing.T) {
 		},
 		{
 			name: "equal priority. p1 is added to schedulingQ earlier than p2",
-			p1: &framework.PodInfo{
+			p1: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
@@ -81,7 +81,7 @@ func TestLess(t *testing.T) {
 				},
 				Timestamp: t1,
 			},
-			p2: &framework.PodInfo{
+			p2: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
@@ -93,7 +93,7 @@ func TestLess(t *testing.T) {
 		},
 		{
 			name: "equal priority. p2 is added to schedulingQ earlier than p1",
-			p1: &framework.PodInfo{
+			p1: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,
@@ -101,7 +101,7 @@ func TestLess(t *testing.T) {
 				},
 				Timestamp: t2,
 			},
-			p2: &framework.PodInfo{
+			p2: &framework.QueuedPodInfo{
 				Pod: &v1.Pod{
 					Spec: v1.PodSpec{
 						Priority: &highPriority,

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -295,7 +295,7 @@ func (f *framework) QueueSortFunc() LessFunc {
 	if f == nil {
 		// If framework is nil, simply keep their order unchanged.
 		// NOTE: this is primarily for tests.
-		return func(_, _ *PodInfo) bool { return false }
+		return func(_, _ *QueuedPodInfo) bool { return false }
 	}
 
 	if len(f.queueSortPlugins) == 0 {

--- a/pkg/scheduler/framework/v1alpha1/framework_test.go
+++ b/pkg/scheduler/framework/v1alpha1/framework_test.go
@@ -288,7 +288,7 @@ func (pl *TestQueueSortPlugin) Name() string {
 	return queueSortPlugin
 }
 
-func (pl *TestQueueSortPlugin) Less(_, _ *PodInfo) bool {
+func (pl *TestQueueSortPlugin) Less(_, _ *QueuedPodInfo) bool {
 	return false
 }
 

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -211,7 +211,7 @@ type Plugin interface {
 }
 
 // LessFunc is the function to sort pod info
-type LessFunc func(podInfo1, podInfo2 *PodInfo) bool
+type LessFunc func(podInfo1, podInfo2 *QueuedPodInfo) bool
 
 // QueueSortPlugin is an interface that must be implemented by "QueueSort" plugins.
 // These plugins are used to sort pods in the scheduling queue. Only one queue sort
@@ -219,7 +219,7 @@ type LessFunc func(podInfo1, podInfo2 *PodInfo) bool
 type QueueSortPlugin interface {
 	Plugin
 	// Less are used to sort pods in the scheduling queue.
-	Less(*PodInfo, *PodInfo) bool
+	Less(*QueuedPodInfo, *QueuedPodInfo) bool
 }
 
 // PreFilterExtensions is an interface that is included in plugins that allow specifying

--- a/pkg/scheduler/profile/profile_test.go
+++ b/pkg/scheduler/profile/profile_test.go
@@ -296,7 +296,7 @@ func (p *fakePlugin) Name() string {
 	return ""
 }
 
-func (p *fakePlugin) Less(*framework.PodInfo, *framework.PodInfo) bool {
+func (p *fakePlugin) Less(*framework.QueuedPodInfo, *framework.QueuedPodInfo) bool {
 	return false
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -94,11 +94,11 @@ type Scheduler struct {
 	// is available. We don't use a channel for this, because scheduling
 	// a pod may take some amount of time and we don't want pods to get
 	// stale while they sit in a channel.
-	NextPod func() *framework.PodInfo
+	NextPod func() *framework.QueuedPodInfo
 
 	// Error is called if there is an error. It is passed the pod in
 	// question, and the error
-	Error func(*framework.PodInfo, error)
+	Error func(*framework.QueuedPodInfo, error)
 
 	// Close this to shut down the scheduler.
 	StopEverything <-chan struct{}
@@ -384,7 +384,7 @@ func (sched *Scheduler) Run(ctx context.Context) {
 // recordFailedSchedulingEvent records an event for the pod that indicates the
 // pod has failed to schedule.
 // NOTE: This function modifies "pod". "pod" should be copied before being passed.
-func (sched *Scheduler) recordSchedulingFailure(prof *profile.Profile, podInfo *framework.PodInfo, err error, reason string, message string) {
+func (sched *Scheduler) recordSchedulingFailure(prof *profile.Profile, podInfo *framework.QueuedPodInfo, err error, reason string, message string) {
 	sched.Error(podInfo, err)
 	pod := podInfo.Pod
 	prof.Recorder.Eventf(pod, nil, v1.EventTypeWarning, "FailedScheduling", "Scheduling", message)

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -335,12 +335,12 @@ func TestSchedulerScheduleOne(t *testing.T) {
 				SchedulerCache:      sCache,
 				Algorithm:           item.algo,
 				podConditionUpdater: fakePodConditionUpdater{},
-				Error: func(p *framework.PodInfo, err error) {
+				Error: func(p *framework.QueuedPodInfo, err error) {
 					gotPod = p.Pod
 					gotError = err
 				},
-				NextPod: func() *framework.PodInfo {
-					return &framework.PodInfo{Pod: item.sendPod}
+				NextPod: func() *framework.QueuedPodInfo {
+					return &framework.QueuedPodInfo{Pod: item.sendPod}
 				},
 				Profiles: profile.Map{
 					testSchedulerName: &profile.Profile{
@@ -827,10 +827,10 @@ func setupTestScheduler(queuedPodStore *clientcache.FIFO, scache internalcache.C
 	sched := &Scheduler{
 		SchedulerCache: scache,
 		Algorithm:      algo,
-		NextPod: func() *framework.PodInfo {
-			return &framework.PodInfo{Pod: clientcache.Pop(queuedPodStore).(*v1.Pod)}
+		NextPod: func() *framework.QueuedPodInfo {
+			return &framework.QueuedPodInfo{Pod: clientcache.Pop(queuedPodStore).(*v1.Pod)}
 		},
-		Error: func(p *framework.PodInfo, err error) {
+		Error: func(p *framework.QueuedPodInfo, err error) {
 			errChan <- err
 		},
 		Profiles:            profiles,


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
Split scheduler's PodInfo into two types, PodInfo and PodQueueInfo. The first is used for scheduled pods, it will contain mutable pre-processed information such as inter-pod affinity selectors, it is created and maintained by NodeInfo, the latter is created by the queue to annotate it with timestamps and scheduling attempts.

**Which issue(s) this PR fixes**:
Fixes #89528

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

