### PR TITLE
Make the pod sandbox timeout configurable

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -69,6 +69,7 @@ var kubeletMarshalCases = []struct {
 			nodeStatusReportFrequency: 0s
 			nodeStatusUpdateFrequency: 0s
 			runtimeRequestTimeout: 0s
+			runtimeSandBoxTimeout: 0s
 			streamingConnectionIdleTimeout: 0s
 			syncFrequency: 0s
 			volumeStatsAggPeriod: 0s
@@ -106,6 +107,7 @@ var kubeletMarshalCases = []struct {
 			port: 12345
 			rotateCertificates: true
 			runtimeRequestTimeout: 0s
+			runtimeSandBoxTimeout: 0s
 			streamingConnectionIdleTimeout: 0s
 			syncFrequency: 0s
 			volumeStatsAggPeriod: 0s

--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -517,6 +517,7 @@ func AddKubeletConfigFlags(mainfs *pflag.FlagSet, c *kubeletconfig.KubeletConfig
 	fs.Var(cliflag.NewMapStringString(&c.QOSReserved), "qos-reserved", "<Warning: Alpha feature> A set of ResourceName=Percentage (e.g. memory=50%) pairs that describe how pod resource requests are reserved at the QoS level. Currently only memory is supported. Requires the QOSReserved feature gate to be enabled.")
 	fs.StringVar(&c.TopologyManagerPolicy, "topology-manager-policy", c.TopologyManagerPolicy, "Topology Manager policy to use. Possible values: 'none', 'best-effort', 'restricted', 'single-numa-node'.")
 	fs.DurationVar(&c.RuntimeRequestTimeout.Duration, "runtime-request-timeout", c.RuntimeRequestTimeout.Duration, "Timeout of all runtime requests except long running request - pull, logs, exec and attach. When timeout exceeded, kubelet will cancel the request, throw out an error and retry later.")
+	fs.DurationVar(&c.RuntimeSandBoxTimeout.Duration, "runtime-sandbox-timeout", c.RuntimeSandBoxTimeout.Duration, "Timeout for sandbox operations.")
 	fs.StringVar(&c.HairpinMode, "hairpin-mode", c.HairpinMode, "How should the kubelet setup hairpin NAT. This allows endpoints of a Service to loadbalance back to themselves if they should try to access their own Service. Valid values are \"promiscuous-bridge\", \"hairpin-veth\" and \"none\".")
 	fs.Int32Var(&c.MaxPods, "max-pods", c.MaxPods, "Number of Pods that can run on this Kubelet.")
 

--- a/cmd/kubemark/hollow-node.go
+++ b/cmd/kubemark/hollow-node.go
@@ -204,7 +204,7 @@ func run(config *hollowNodeConfig) {
 			klog.Fatalf("Failed to start fake runtime %v.", err)
 		}
 		defer fakeRemoteRuntime.Stop()
-		runtimeService, err := remote.NewRemoteRuntimeService(endpoint, 15*time.Second)
+		runtimeService, err := remote.NewRemoteRuntimeService(endpoint, 15*time.Second, 30*time.Second)
 		if err != nil {
 			klog.Fatalf("Failed to init runtime service %v.", err)
 		}

--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -46,6 +46,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.Address = "0.0.0.0"
 			obj.VolumeStatsAggPeriod = metav1.Duration{Duration: time.Minute}
 			obj.RuntimeRequestTimeout = metav1.Duration{Duration: 2 * time.Minute}
+			obj.RuntimeSandBoxTimeout = metav1.Duration{Duration: 4 * time.Minute}
 			obj.CPUCFSQuota = true
 			obj.EventBurst = 10
 			obj.EventRecordQPS = 5

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -225,5 +225,6 @@ var (
 		"TypeMeta.Kind",
 		"VolumeStatsAggPeriod.Duration",
 		"VolumePluginDir",
+		"RuntimeSandBoxTimeout.Duration",
 	)
 )

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -221,6 +221,9 @@ type KubeletConfiguration struct {
 	// runtimeRequestTimeout is the timeout for all runtime requests except long running
 	// requests - pull, logs, exec and attach.
 	RuntimeRequestTimeout metav1.Duration
+	// runtimeSandBoxTimeout is the timeout for sandbox operations.
+	// +optional
+	RuntimeSandBoxTimeout metav1.Duration
 	// hairpinMode specifies how the Kubelet should configure the container
 	// bridge for hairpin packets.
 	// Setting this flag allows endpoints in a Service to loadbalance back to

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -156,6 +156,9 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	if obj.RuntimeRequestTimeout == zeroDuration {
 		obj.RuntimeRequestTimeout = metav1.Duration{Duration: 2 * time.Minute}
 	}
+	if obj.RuntimeSandBoxTimeout == zeroDuration {
+		obj.RuntimeSandBoxTimeout = metav1.Duration{Duration: 4 * time.Minute}
+	}
 	if obj.HairpinMode == "" {
 		obj.HairpinMode = kubeletconfigv1beta1.PromiscuousBridge
 	}

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -333,6 +333,7 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.AllowedUnsafeSysctls = *(*[]string)(unsafe.Pointer(&in.AllowedUnsafeSysctls))
 	out.VolumePluginDir = in.VolumePluginDir
+	out.RuntimeSandBoxTimeout = in.RuntimeSandBoxTimeout
 	return nil
 }
 
@@ -409,6 +410,7 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.TopologyManagerPolicy = in.TopologyManagerPolicy
 	out.QOSReserved = *(*map[string]string)(unsafe.Pointer(&in.QOSReserved))
 	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
+	out.RuntimeSandBoxTimeout = in.RuntimeSandBoxTimeout
 	out.HairpinMode = in.HairpinMode
 	out.MaxPods = in.MaxPods
 	out.PodCIDR = in.PodCIDR

--- a/pkg/kubelet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/kubelet/apis/config/zz_generated.deepcopy.go
@@ -124,6 +124,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		}
 	}
 	out.RuntimeRequestTimeout = in.RuntimeRequestTimeout
+	out.RuntimeSandBoxTimeout = in.RuntimeSandBoxTimeout
 	out.CPUCFSQuotaPeriod = in.CPUCFSQuotaPeriod
 	if in.EvictionHard != nil {
 		in, out := &in.EvictionHard, &out.EvictionHard

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -356,7 +356,7 @@ func PreInitRuntimeService(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	}
 
 	var err error
-	if kubeDeps.RemoteRuntimeService, err = remote.NewRemoteRuntimeService(remoteRuntimeEndpoint, kubeCfg.RuntimeRequestTimeout.Duration); err != nil {
+	if kubeDeps.RemoteRuntimeService, err = remote.NewRemoteRuntimeService(remoteRuntimeEndpoint, kubeCfg.RuntimeRequestTimeout.Duration, kubeCfg.RuntimeSandBoxTimeout.Duration); err != nil {
 		return err
 	}
 	if kubeDeps.RemoteImageService, err = remote.NewRemoteImageService(remoteImageEndpoint, kubeCfg.RuntimeRequestTimeout.Duration); err != nil {

--- a/pkg/kubelet/remote/remote_runtime_test.go
+++ b/pkg/kubelet/remote/remote_runtime_test.go
@@ -28,7 +28,8 @@ import (
 )
 
 const (
-	defaultConnectionTimeout = 15 * time.Second
+	defaultConnectionTimeout     = 15 * time.Second
+	defaultRuntimeSandboxTimeout = 30 * time.Second
 )
 
 // createAndStartFakeRemoteRuntime creates and starts fakeremote.RemoteRuntime.
@@ -45,7 +46,7 @@ func createAndStartFakeRemoteRuntime(t *testing.T) (*fakeremote.RemoteRuntime, s
 }
 
 func createRemoteRuntimeService(endpoint string, t *testing.T) internalapi.RuntimeService {
-	runtimeService, err := NewRemoteRuntimeService(endpoint, defaultConnectionTimeout)
+	runtimeService, err := NewRemoteRuntimeService(endpoint, defaultConnectionTimeout, defaultRuntimeSandboxTimeout)
 	require.NoError(t, err)
 
 	return runtimeService

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -762,6 +762,10 @@ type KubeletConfiguration struct {
 	// Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 	// +optional
 	VolumePluginDir string `json:"volumePluginDir,omitempty"`
+	// runtimeSandBoxTimeout is the timeout for sandbox operations.
+	// Default: "4m"
+	// +optional
+	RuntimeSandBoxTimeout metav1.Duration `json:"runtimeSandBoxTimeout,omitempty"`
 }
 
 type KubeletAuthorizationMode string

--- a/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/zz_generated.deepcopy.go
@@ -285,6 +285,7 @@ func (in *KubeletConfiguration) DeepCopyInto(out *KubeletConfiguration) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	out.RuntimeSandBoxTimeout = in.RuntimeSandBoxTimeout
 	return
 }
 

--- a/test/e2e_node/util.go
+++ b/test/e2e_node/util.go
@@ -354,8 +354,9 @@ func runCommand(cmd ...string) (string, error) {
 func getCRIClient() (internalapi.RuntimeService, internalapi.ImageManagerService, error) {
 	// connection timeout for CRI service connection
 	const connectionTimeout = 2 * time.Minute
+	const runtimeSandboxTimeout = 4 * time.Minute
 	runtimeEndpoint := framework.TestContext.ContainerRuntimeEndpoint
-	r, err := remote.NewRemoteRuntimeService(runtimeEndpoint, connectionTimeout)
+	r, err := remote.NewRemoteRuntimeService(runtimeEndpoint, connectionTimeout, runtimeSandboxTimeout)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
The timeout configuration may vary with different CRI runtimes, network situation etc.

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
/kind feature

**What this PR does / why we need it**:



**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
 pod sandbox timeout when the container runtime is defined as "remote" now is configuration.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
