### PR TITLE
[kubectl] Fail when local source file doesn't exist

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp.go
@@ -203,10 +203,7 @@ func (o *CopyOptions) Run(args []string) error {
 	}
 
 	if len(srcSpec.PodName) != 0 && len(destSpec.PodName) != 0 {
-		if _, err := os.Stat(args[0]); err == nil {
-			return o.copyToPod(fileSpec{File: args[0]}, destSpec, &exec.ExecOptions{})
-		}
-		return fmt.Errorf("src doesn't exist in local filesystem")
+		return fmt.Errorf("one of src or dest must be a local file specification")
 	}
 
 	if len(srcSpec.PodName) != 0 {
@@ -244,6 +241,9 @@ func (o *CopyOptions) checkDestinationIsDir(dest fileSpec) error {
 func (o *CopyOptions) copyToPod(src, dest fileSpec, options *exec.ExecOptions) error {
 	if len(src.File) == 0 || len(dest.File) == 0 {
 		return errFileCannotBeEmpty
+	}
+	if _, err := os.Stat(src.File); err != nil {
+		return fmt.Errorf("%s doesn't exist in local filesystem", src.File)
 	}
 	reader, writer := io.Pipe()
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/cp/cp_test.go
@@ -576,19 +576,28 @@ func TestCopyToPod(t *testing.T) {
 	defer os.RemoveAll(srcFile)
 
 	tests := map[string]struct {
+		src         string
 		dest        string
 		expectedErr bool
 	}{
 		"copy to directory": {
+			src:         srcFile,
 			dest:        "/tmp/",
 			expectedErr: false,
 		},
 		"copy to root": {
+			src:         srcFile,
 			dest:        "/",
 			expectedErr: false,
 		},
 		"copy to empty file name": {
+			src:         srcFile,
 			dest:        "",
+			expectedErr: true,
+		},
+		"copy unexisting file": {
+			src:         path.Join(srcFile, "nope"),
+			dest:        "/tmp",
 			expectedErr: true,
 		},
 	}
@@ -596,7 +605,7 @@ func TestCopyToPod(t *testing.T) {
 	for name, test := range tests {
 		opts := NewCopyOptions(ioStreams)
 		src := fileSpec{
-			File: srcFile,
+			File: test.src,
 		}
 		dest := fileSpec{
 			PodNamespace: "pod-ns",


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

When trying to upload an unexisting file to a pod, kubectl currently doesn't print any error message and terminates with a zero exit code.

This adds a check and fails explicitly in such cases.

**Which issue(s) this PR fixes**:

Fixes #78879

```release-note
[kubectl] Fail when local source file doesn't exist
```