### PR TITLE
Switch to use AzureFile management SDK

### DIFF
--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -165,7 +165,7 @@ func (plugin *azureFilePlugin) ExpandVolumeDevice(
 		return oldSize, fmt.Errorf("invalid PV spec")
 	}
 	shareName := spec.PersistentVolume.Spec.AzureFile.ShareName
-	azure, err := getAzureCloudProvider(plugin.host.GetCloudProvider())
+	azure, resourceGroup, err := getAzureCloudProvider(plugin.host.GetCloudProvider())
 	if err != nil {
 		return oldSize, err
 	}
@@ -175,12 +175,12 @@ func (plugin *azureFilePlugin) ExpandVolumeDevice(
 		return oldSize, err
 	}
 
-	accountName, accountKey, err := (&azureSvc{}).GetAzureCredentials(plugin.host, secretNamespace, secretName)
+	accountName, _, err := (&azureSvc{}).GetAzureCredentials(plugin.host, secretNamespace, secretName)
 	if err != nil {
 		return oldSize, err
 	}
 
-	if err := azure.ResizeFileShare(accountName, accountKey, shareName, int(volumehelpers.RoundUpToGiB(newSize))); err != nil {
+	if err := azure.ResizeFileShare(resourceGroup, accountName, shareName, int(volumehelpers.RoundUpToGiB(newSize))); err != nil {
 		return oldSize, err
 	}
 

--- a/pkg/volume/azure_file/azure_file.go
+++ b/pkg/volume/azure_file/azure_file.go
@@ -169,6 +169,9 @@ func (plugin *azureFilePlugin) ExpandVolumeDevice(
 	if err != nil {
 		return oldSize, err
 	}
+	if spec.PersistentVolume.ObjectMeta.Annotations[resourceGroupAnnotation] != "" {
+		resourceGroup = spec.PersistentVolume.ObjectMeta.Annotations[resourceGroupAnnotation]
+	}
 
 	secretName, secretNamespace, err := getSecretNameAndNamespace(spec, spec.PersistentVolume.Spec.ClaimRef.Namespace)
 	if err != nil {

--- a/pkg/volume/azure_file/azure_provision.go
+++ b/pkg/volume/azure_file/azure_provision.go
@@ -45,28 +45,28 @@ type azureCloudProvider interface {
 	// create a file share
 	CreateFileShare(shareName, accountName, accountType, accountKind, resourceGroup, location string, requestGiB int) (string, string, error)
 	// delete a file share
-	DeleteFileShare(accountName, accountKey, shareName string) error
+	DeleteFileShare(resourceGroup, accountName, shareName string) error
 	// resize a file share
-	ResizeFileShare(accountName, accountKey, name string, sizeGiB int) error
+	ResizeFileShare(resourceGroup, accountName, name string, sizeGiB int) error
 }
 
 type azureFileDeleter struct {
 	*azureFile
-	accountName, accountKey, shareName string
-	azureProvider                      azureCloudProvider
+	resourceGroup, accountName, shareName string
+	azureProvider                         azureCloudProvider
 }
 
 func (plugin *azureFilePlugin) NewDeleter(spec *volume.Spec) (volume.Deleter, error) {
-	azure, err := getAzureCloudProvider(plugin.host.GetCloudProvider())
+	azure, resourceGroup, err := getAzureCloudProvider(plugin.host.GetCloudProvider())
 	if err != nil {
 		klog.V(4).Infof("failed to get azure provider")
 		return nil, err
 	}
 
-	return plugin.newDeleterInternal(spec, &azureSvc{}, azure)
+	return plugin.newDeleterInternal(spec, &azureSvc{}, azure, resourceGroup)
 }
 
-func (plugin *azureFilePlugin) newDeleterInternal(spec *volume.Spec, util azureUtil, azure azureCloudProvider) (volume.Deleter, error) {
+func (plugin *azureFilePlugin) newDeleterInternal(spec *volume.Spec, util azureUtil, azure azureCloudProvider, resourceGroup string) (volume.Deleter, error) {
 	if spec.PersistentVolume != nil && spec.PersistentVolume.Spec.AzureFile == nil {
 		return nil, fmt.Errorf("invalid PV spec")
 	}
@@ -76,24 +76,25 @@ func (plugin *azureFilePlugin) newDeleterInternal(spec *volume.Spec, util azureU
 		return nil, err
 	}
 	shareName := spec.PersistentVolume.Spec.AzureFile.ShareName
-	if accountName, accountKey, err := util.GetAzureCredentials(plugin.host, secretNamespace, secretName); err != nil {
+	if accountName, _, err := util.GetAzureCredentials(plugin.host, secretNamespace, secretName); err != nil {
 		return nil, err
 	} else {
+
 		return &azureFileDeleter{
 			azureFile: &azureFile{
 				volName: spec.Name(),
 				plugin:  plugin,
 			},
+			resourceGroup: resourceGroup,
 			shareName:     shareName,
 			accountName:   accountName,
-			accountKey:    accountKey,
 			azureProvider: azure,
 		}, nil
 	}
 }
 
 func (plugin *azureFilePlugin) NewProvisioner(options volume.VolumeOptions) (volume.Provisioner, error) {
-	azure, err := getAzureCloudProvider(plugin.host.GetCloudProvider())
+	azure, _, err := getAzureCloudProvider(plugin.host.GetCloudProvider())
 	if err != nil {
 		klog.V(4).Infof("failed to get azure provider")
 		return nil, err
@@ -124,7 +125,7 @@ func (f *azureFileDeleter) GetPath() string {
 
 func (f *azureFileDeleter) Delete() error {
 	klog.V(4).Infof("deleting volume %s", f.shareName)
-	return f.azureProvider.DeleteFileShare(f.accountName, f.accountKey, f.shareName)
+	return f.azureProvider.DeleteFileShare(f.resourceGroup, f.accountName, f.shareName)
 }
 
 type azureFileProvisioner struct {
@@ -224,11 +225,11 @@ func (a *azureFileProvisioner) Provision(selectedNode *v1.Node, allowedTopologie
 }
 
 // Return cloud provider
-func getAzureCloudProvider(cloudProvider cloudprovider.Interface) (azureCloudProvider, error) {
+func getAzureCloudProvider(cloudProvider cloudprovider.Interface) (azureCloudProvider, string, error) {
 	azureCloudProvider, ok := cloudProvider.(*azure.Cloud)
 	if !ok || azureCloudProvider == nil {
-		return nil, fmt.Errorf("Failed to get Azure Cloud Provider. GetCloudProvider returned %v instead", cloudProvider)
+		return nil, "", fmt.Errorf("Failed to get Azure Cloud Provider. GetCloudProvider returned %v instead", cloudProvider)
 	}
 
-	return azureCloudProvider, nil
+	return azureCloudProvider, azureCloudProvider.ResourceGroup, nil
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go
@@ -549,6 +549,8 @@ func (az *Cloud) configAzureClients(
 	loadBalancerClientConfig := azClientConfig.WithRateLimiter(az.Config.LoadBalancerRateLimit)
 	securityGroupClientConfig := azClientConfig.WithRateLimiter(az.Config.SecurityGroupRateLimit)
 	publicIPClientConfig := azClientConfig.WithRateLimiter(az.Config.PublicIPAddressRateLimit)
+	// TODO(ZeroMagic): add azurefileRateLimit
+	fileClientConfig := azClientConfig.WithRateLimiter(nil)
 
 	// If uses network resources in different AAD Tenant, update Authorizer for VM/VMSS client config
 	if multiTenantServicePrincipalToken != nil {
@@ -591,8 +593,7 @@ func (az *Cloud) configAzureClients(
 	az.LoadBalancerClient = loadbalancerclient.New(loadBalancerClientConfig)
 	az.SecurityGroupsClient = securitygroupclient.New(securityGroupClientConfig)
 	az.PublicIPAddressesClient = publicipclient.New(publicIPClientConfig)
-	// fileClient is not based on armclient, but it's still backoff retried.
-	az.FileClient = fileclient.NewAzureFileClient(&az.Environment, azClientConfig.Backoff)
+	az.FileClient = fileclient.New(fileClientConfig)
 }
 
 func (az *Cloud) getAzureClientConfig(servicePrincipalToken *adal.ServicePrincipalToken) *azclients.ClientConfig {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_file.go
@@ -19,14 +19,14 @@ limitations under the License.
 package azure
 
 // create file share
-func (az *Cloud) createFileShare(accountName, accountKey, name string, sizeGiB int) error {
-	return az.FileClient.CreateFileShare(accountName, accountKey, name, sizeGiB)
+func (az *Cloud) createFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+	return az.FileClient.CreateFileShare(resourceGroupName, accountName, name, sizeGiB)
 }
 
-func (az *Cloud) deleteFileShare(accountName, accountKey, name string) error {
-	return az.FileClient.DeleteFileShare(accountName, accountKey, name)
+func (az *Cloud) deleteFileShare(resourceGroupName, accountName, name string) error {
+	return az.FileClient.DeleteFileShare(resourceGroupName, accountName, name)
 }
 
-func (az *Cloud) resizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
-	return az.FileClient.ResizeFileShare(accountName, accountKey, name, sizeGiB)
+func (az *Cloud) resizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
+	return az.FileClient.ResizeFileShare(resourceGroupName, accountName, name, sizeGiB)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage.go
@@ -46,7 +46,7 @@ func (az *Cloud) CreateFileShare(shareName, accountName, accountType, accountKin
 		return "", "", fmt.Errorf("could not get storage key for storage account %s: %v", accountName, err)
 	}
 
-	if err := az.createFileShare(account, key, shareName, requestGiB); err != nil {
+	if err := az.createFileShare(resourceGroup, account, shareName, requestGiB); err != nil {
 		return "", "", fmt.Errorf("failed to create share %s in account %s: %v", shareName, account, err)
 	}
 	klog.V(4).Infof("created share %s in account %s", shareName, account)
@@ -54,8 +54,8 @@ func (az *Cloud) CreateFileShare(shareName, accountName, accountType, accountKin
 }
 
 // DeleteFileShare deletes a file share using storage account name and key
-func (az *Cloud) DeleteFileShare(accountName, accountKey, shareName string) error {
-	if err := az.deleteFileShare(accountName, accountKey, shareName); err != nil {
+func (az *Cloud) DeleteFileShare(resourceGroup, accountName, shareName string) error {
+	if err := az.deleteFileShare(resourceGroup, accountName, shareName); err != nil {
 		return err
 	}
 	klog.V(4).Infof("share %s deleted", shareName)
@@ -63,6 +63,6 @@ func (az *Cloud) DeleteFileShare(accountName, accountKey, shareName string) erro
 }
 
 // ResizeFileShare resizes a file share
-func (az *Cloud) ResizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
-	return az.resizeFileShare(accountName, accountKey, name, sizeGiB)
+func (az *Cloud) ResizeFileShare(resourceGroup, accountName, name string, sizeGiB int) error {
+	return az.resizeFileShare(resourceGroup, accountName, name, sizeGiB)
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_storage_test.go
@@ -145,3 +145,87 @@ func TestCreateFileShare(t *testing.T) {
 		}
 	}
 }
+
+func TestDeleteFileShare(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := &Cloud{}
+	mockFileClient := mockfileclient.NewMockInterface(ctrl)
+	mockFileClient.EXPECT().DeleteFileShare(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	cloud.FileClient = mockFileClient
+
+	tests := []struct {
+		rg   string
+		acct string
+		name string
+
+		expectErr bool
+	}{
+		{
+			rg:   "rg",
+			acct: "bar",
+			name: "foo",
+
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
+		cloud.StorageAccountClient = mockStorageAccountsClient
+
+		err := cloud.DeleteFileShare(test.rg, test.acct, test.name)
+		if test.expectErr && err == nil {
+			t.Errorf("unexpected non-error")
+			continue
+		}
+		if !test.expectErr && err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+	}
+}
+
+func TestResizeFileShare(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	cloud := &Cloud{}
+	mockFileClient := mockfileclient.NewMockInterface(ctrl)
+	mockFileClient.EXPECT().ResizeFileShare(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	cloud.FileClient = mockFileClient
+
+	tests := []struct {
+		rg   string
+		acct string
+		name string
+		gb   int
+
+		expectErr bool
+	}{
+		{
+			rg:   "rg",
+			acct: "bar",
+			name: "foo",
+			gb:   10,
+
+			expectErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		mockStorageAccountsClient := mockstorageaccountclient.NewMockInterface(ctrl)
+		cloud.StorageAccountClient = mockStorageAccountsClient
+
+		err := cloud.ResizeFileShare(test.rg, test.acct, test.name, test.gb)
+		if test.expectErr && err == nil {
+			t.Errorf("unexpected non-error")
+			continue
+		}
+		if !test.expectErr && err != nil {
+			t.Errorf("unexpected error: %v", err)
+			continue
+		}
+	}
+}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/BUILD
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/BUILD
@@ -11,9 +11,8 @@ go_library(
     importpath = "k8s.io/legacy-cloud-providers/azure/clients/fileclient",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/k8s.io/legacy-cloud-providers/azure/retry:go_default_library",
-        "//vendor/github.com/Azure/azure-sdk-for-go/storage:go_default_library",
-        "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",
+        "//staging/src/k8s.io/legacy-cloud-providers/azure/clients:go_default_library",
+        "//vendor/github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2019-06-01/storage:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go
@@ -21,7 +21,7 @@ package fileclient
 // Interface is the client interface for creating file shares, interface for test injection.
 // mockgen -source=$GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/interface.go -package=mockfileclient Interface > $GOPATH/src/k8s.io/kubernetes/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
 type Interface interface {
-	CreateFileShare(accountName, accountKey, name string, sizeGiB int) error
-	DeleteFileShare(accountName, accountKey, name string) error
-	ResizeFileShare(accountName, accountKey, name string, sizeGiB int) error
+	CreateFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
+	DeleteFileShare(resourceGroupName, accountName, name string) error
+	ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error
 }

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/clients/fileclient/mockfileclient/interface.go
@@ -48,43 +48,43 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // CreateFileShare mocks base method
-func (m *MockInterface) CreateFileShare(accountName, accountKey, name string, sizeGiB int) error {
+func (m *MockInterface) CreateFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateFileShare", accountName, accountKey, name, sizeGiB)
+	ret := m.ctrl.Call(m, "CreateFileShare", resourceGroupName, accountName, name, sizeGiB)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateFileShare indicates an expected call of CreateFileShare
-func (mr *MockInterfaceMockRecorder) CreateFileShare(accountName, accountKey, name, sizeGiB interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) CreateFileShare(resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), accountName, accountKey, name, sizeGiB)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateFileShare", reflect.TypeOf((*MockInterface)(nil).CreateFileShare), resourceGroupName, accountName, name, sizeGiB)
 }
 
 // DeleteFileShare mocks base method
-func (m *MockInterface) DeleteFileShare(accountName, accountKey, name string) error {
+func (m *MockInterface) DeleteFileShare(resourceGroupName, accountName, name string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteFileShare", accountName, accountKey, name)
+	ret := m.ctrl.Call(m, "DeleteFileShare", resourceGroupName, accountName, name)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteFileShare indicates an expected call of DeleteFileShare
-func (mr *MockInterfaceMockRecorder) DeleteFileShare(accountName, accountKey, name interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) DeleteFileShare(resourceGroupName, accountName, name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileShare", reflect.TypeOf((*MockInterface)(nil).DeleteFileShare), accountName, accountKey, name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteFileShare", reflect.TypeOf((*MockInterface)(nil).DeleteFileShare), resourceGroupName, accountName, name)
 }
 
 // ResizeFileShare mocks base method
-func (m *MockInterface) ResizeFileShare(accountName, accountKey, name string, sizeGiB int) error {
+func (m *MockInterface) ResizeFileShare(resourceGroupName, accountName, name string, sizeGiB int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ResizeFileShare", accountName, accountKey, name, sizeGiB)
+	ret := m.ctrl.Call(m, "ResizeFileShare", resourceGroupName, accountName, name, sizeGiB)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ResizeFileShare indicates an expected call of ResizeFileShare
-func (mr *MockInterfaceMockRecorder) ResizeFileShare(accountName, accountKey, name, sizeGiB interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) ResizeFileShare(resourceGroupName, accountName, name, sizeGiB interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileShare", reflect.TypeOf((*MockInterface)(nil).ResizeFileShare), accountName, accountKey, name, sizeGiB)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResizeFileShare", reflect.TypeOf((*MockInterface)(nil).ResizeFileShare), resourceGroupName, accountName, name, sizeGiB)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The old data plane SDK in AzureFileClient will be not supported. So switch to use AzureFile management SDK. Then the bug "Azure Files PV AuthorizationFailure" will be fixed.
Ref: https://github.com/kubernetes-sigs/azurefile-csi-driver/issues/188

/cc @andyzhangx 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #85354

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
