### PR TITLE
Extract logic related with scheduler nominatedPods to an interface

### DIFF
--- a/pkg/scheduler/core/generic_scheduler_test.go
+++ b/pkg/scheduler/core/generic_scheduler_test.go
@@ -979,7 +979,7 @@ func TestFindFitPredicateCallCounts(t *testing.T) {
 		if err := scheduler.cache.UpdateSnapshot(scheduler.nodeInfoSnapshot); err != nil {
 			t.Fatal(err)
 		}
-		scheduler.schedulingQueue.UpdateNominatedPodForNode(&v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "nominated"}, Spec: v1.PodSpec{Priority: &midPriority}}, "1")
+		scheduler.schedulingQueue.AddNominatedPod(&v1.Pod{ObjectMeta: metav1.ObjectMeta{UID: "nominated"}, Spec: v1.PodSpec{Priority: &midPriority}}, "1")
 
 		_, _, err = scheduler.findNodesThatFitPod(context.Background(), prof, framework.NewCycleState(), test.pod)
 

--- a/pkg/scheduler/framework/v1alpha1/framework.go
+++ b/pkg/scheduler/framework/v1alpha1/framework.go
@@ -83,6 +83,8 @@ type framework struct {
 
 	metricsRecorder *metricsRecorder
 
+	preemptHandle PreemptHandle
+
 	// Indicates that RunFilterPlugins should accumulate all failed statuses and not return
 	// after the first failure.
 	runAllFilters bool
@@ -121,6 +123,7 @@ type frameworkOptions struct {
 	snapshotSharedLister SharedLister
 	metricsRecorder      *metricsRecorder
 	volumeBinder         scheduling.SchedulerVolumeBinder
+	podNominator         PodNominator
 	runAllFilters        bool
 }
 
@@ -170,6 +173,13 @@ func WithVolumeBinder(binder scheduling.SchedulerVolumeBinder) Option {
 	}
 }
 
+// WithPodNominator sets podNominator for the scheduling framework.
+func WithPodNominator(nominator PodNominator) Option {
+	return func(o *frameworkOptions) {
+		o.podNominator = nominator
+	}
+}
+
 var defaultFrameworkOptions = frameworkOptions{
 	metricsRecorder: newMetricsRecorder(1000, time.Second),
 }
@@ -192,6 +202,7 @@ func NewFramework(r Registry, plugins *config.Plugins, args []config.PluginConfi
 		informerFactory:       options.informerFactory,
 		volumeBinder:          options.volumeBinder,
 		metricsRecorder:       options.metricsRecorder,
+		preemptHandle:         options.podNominator,
 		runAllFilters:         options.runAllFilters,
 	}
 	if plugins == nil {

--- a/pkg/scheduler/framework/v1alpha1/interface.go
+++ b/pkg/scheduler/framework/v1alpha1/interface.go
@@ -495,3 +495,19 @@ type FrameworkHandle interface {
 	// VolumeBinder returns the volume binder used by scheduler.
 	VolumeBinder() scheduling.SchedulerVolumeBinder
 }
+
+// PreemptHandle incorporates all needed logic to run preemption logic.
+type PreemptHandle interface {
+	PodNominator
+}
+
+// PodNominator abstracts operations to maintain nominated Pods.
+type PodNominator interface {
+	// AddNominatedPod adds the given pod to the nominated pod map or
+	// updates it if it already exists.
+	AddNominatedPod(pod *v1.Pod, nodeName string)
+	// DeleteNominatedPodIfExists deletes nominatedPod from internal cache. It's a no-op if it doesn't exist.
+	DeleteNominatedPodIfExists(pod *v1.Pod)
+	// UpdateNominatedPod updates the <oldPod> with <newPod>.
+	UpdateNominatedPod(oldPod, newPod *v1.Pod)
+}

--- a/pkg/scheduler/profile/profile.go
+++ b/pkg/scheduler/profile/profile.go
@@ -33,7 +33,7 @@ import (
 type RecorderFactory func(string) events.EventRecorder
 
 // FrameworkFactory builds a Framework for a given profile configuration.
-type FrameworkFactory func(config.KubeSchedulerProfile) (framework.Framework, error)
+type FrameworkFactory func(config.KubeSchedulerProfile, ...framework.Option) (framework.Framework, error)
 
 // Profile is a scheduling profile.
 type Profile struct {
@@ -42,8 +42,9 @@ type Profile struct {
 }
 
 // NewProfile builds a Profile for the given configuration.
-func NewProfile(cfg config.KubeSchedulerProfile, frameworkFact FrameworkFactory, recorderFact RecorderFactory) (*Profile, error) {
-	f, err := frameworkFact(cfg)
+func NewProfile(cfg config.KubeSchedulerProfile, frameworkFact FrameworkFactory, recorderFact RecorderFactory,
+	opts ...framework.Option) (*Profile, error) {
+	f, err := frameworkFact(cfg, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +59,8 @@ func NewProfile(cfg config.KubeSchedulerProfile, frameworkFact FrameworkFactory,
 type Map map[string]*Profile
 
 // NewMap builds the profiles given by the configuration, indexed by name.
-func NewMap(cfgs []config.KubeSchedulerProfile, frameworkFact FrameworkFactory, recorderFact RecorderFactory) (Map, error) {
+func NewMap(cfgs []config.KubeSchedulerProfile, frameworkFact FrameworkFactory, recorderFact RecorderFactory,
+	opts ...framework.Option) (Map, error) {
 	m := make(Map)
 	v := cfgValidator{m: m}
 
@@ -66,7 +68,7 @@ func NewMap(cfgs []config.KubeSchedulerProfile, frameworkFact FrameworkFactory, 
 		if err := v.validate(cfg); err != nil {
 			return nil, err
 		}
-		p, err := NewProfile(cfg, frameworkFact, recorderFact)
+		p, err := NewProfile(cfg, frameworkFact, recorderFact, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("creating profile for scheduler name %s: %v", cfg.SchedulerName, err)
 		}

--- a/pkg/scheduler/profile/profile_test.go
+++ b/pkg/scheduler/profile/profile_test.go
@@ -308,8 +308,8 @@ func newFakePlugin(_ runtime.Object, _ framework.FrameworkHandle) (framework.Plu
 	return &fakePlugin{}, nil
 }
 
-func fakeFrameworkFactory(cfg config.KubeSchedulerProfile) (framework.Framework, error) {
-	return framework.NewFramework(fakeRegistry, cfg.Plugins, cfg.PluginConfig)
+func fakeFrameworkFactory(cfg config.KubeSchedulerProfile, opts ...framework.Option) (framework.Framework, error) {
+	return framework.NewFramework(fakeRegistry, cfg.Plugins, cfg.PluginConfig, opts...)
 }
 
 func nilRecorderFactory(_ string) events.EventRecorder {

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -402,7 +402,7 @@ func (sched *Scheduler) preempt(ctx context.Context, prof *profile.Profile, stat
 		// Update the scheduling queue with the nominated pod information. Without
 		// this, there would be a race condition between the next scheduling cycle
 		// and the time the scheduler receives a Pod Update for the nominated pod.
-		sched.SchedulingQueue.UpdateNominatedPodForNode(preemptor, nodeName)
+		sched.SchedulingQueue.AddNominatedPod(preemptor, nodeName)
 
 		// Make a call to update nominated node name of the pod on the API server.
 		err = sched.podPreemptor.setNominatedNodeName(preemptor, nodeName)


### PR DESCRIPTION
**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

This PR attempts to extract logic with schedulingQueue.nominatedPods as a mininum interface, so as to partly remove the dependency from preemption logic to internal schedulingQueue.

**Which issue(s) this PR fixes**:

Part of #91038.

**Special notes for your reviewer**:

This PR is for "prefactoring" purpose, so it doesn't touch the design of preemption extension point yet - i.e., doesn't pass the `podNominator` to `PostFilter()`.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
