### PR TITLE
Support kubectl wait using kustomize

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/builder_flags.go
@@ -42,12 +42,14 @@ type ResourceBuilderFlags struct {
 // NewResourceBuilderFlags returns a default ResourceBuilderFlags
 func NewResourceBuilderFlags() *ResourceBuilderFlags {
 	filenames := []string{}
+	kustomize := ""
 
 	return &ResourceBuilderFlags{
 		FileNameFlags: &FileNameFlags{
 			Usage:     "identifying the resource.",
 			Filenames: &filenames,
-			Recursive: boolPtr(true),
+			Kustomize: &kustomize,
+			Recursive: boolPtr(false),
 		},
 	}
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/wait/wait.go
@@ -107,7 +107,7 @@ func NewCmdWait(restClientGetter genericclioptions.RESTClientGetter, streams gen
 	flags := NewWaitFlags(restClientGetter, streams)
 
 	cmd := &cobra.Command{
-		Use:     "wait ([-f FILENAME] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]",
+		Use:     "wait ([-f FILENAME] | [-k DIRECTORY] | resource.group/resource.name | resource.group [(-l label | --all)]) [--for=delete|--for condition=available]",
 		Short:   "Experimental: Wait for a specific condition on one or many resources.",
 		Long:    waitLong,
 		Example: waitExample,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
/kind feature


**What this PR does / why we need it**:
`kubectl wait` currently not support `kustomize`, add `kustomize` to `NewResourceBuilderFlags` will simply fix it.
And I also change the default `Recursive` form `true` to `false`. User should use `-R` flag if they want to have `Recursive`.
 
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/858

**Special notes for your reviewer**:
/cc @brianpursley
/cc @soltysh

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Support kubectl wait using kustomize.
```
