### PR TITLE
e2e test framework change for the SCTP e2e tests

### DIFF
--- a/test/e2e/framework/service/jig.go
+++ b/test/e2e/framework/service/jig.go
@@ -962,3 +962,18 @@ func (j *TestJig) CreateTCPUDPServicePods(replica int) error {
 	}
 	return e2erc.RunRC(config)
 }
+
+// CreateSCTPServiceWithPort creates a new SCTP Service with given port based on the
+// j's defaults. Callers can provide a function to tweak the Service object before
+// it is created.
+func (j *TestJig) CreateSCTPServiceWithPort(tweak func(svc *v1.Service), port int32) (*v1.Service, error) {
+	svc := j.newServiceTemplate(v1.ProtocolSCTP, port)
+	if tweak != nil {
+		tweak(svc)
+	}
+	result, err := j.Client.CoreV1().Services(j.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SCTP Service %q: %v", svc.Name, err)
+	}
+	return j.sanityCheckService(result, svc.Spec.Type)
+}


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> 

/kind feature

> /kind flake

**What this PR does / why we need it**:
We need a new function in the e2e test framework to support the upcoming SCTP e2e tests.
https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/0015-20180614-SCTP-support.md#basic-tests

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
No
```release-note
 NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
