### PR TITLE
Promote diff and dry-run to conformance

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1351,6 +1351,14 @@
     proper information.
   release: v1.9
   file: test/e2e/kubectl/kubectl.go
+- testname: Kubectl, diff Deployment
+  codename: '[sig-cli] Kubectl client Kubectl diff should check if kubectl diff finds
+    a difference for Deployments [Conformance]'
+  description: Create a Deployment with httpd image. Declare the same Deployment with
+    a different image, busybox. Diff of live Deployment with declared Deployment MUST
+    include the difference between live and declared image.
+  release: v1.19
+  file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, create service, replication controller
   codename: '[sig-cli] Kubectl client Kubectl expose should create services for rc  [Conformance]'
   description: Create a Pod running agnhost listening to port 6379. Using kubectl
@@ -1407,6 +1415,15 @@
     in the run command. After the run command there SHOULD be a pod that should exist
     with one container running the specified image.
   release: v1.9
+  file: test/e2e/kubectl/kubectl.go
+- testname: Kubectl, server-side dry-run Pod
+  codename: '[sig-cli] Kubectl client Kubectl server-side dry-run should check if
+    kubectl can dry-run update Pods [Conformance]'
+  description: The command 'kubectl run' must create a pod with the specified image
+    name. After, the command 'kubectl replace --dry-run=server' should update the
+    Pod with the new image name and server-side dry-run enabled. The image name must
+    not change.
+  release: v1.19
   file: test/e2e/kubectl/kubectl.go
 - testname: Kubectl, version
   codename: '[sig-cli] Kubectl client Kubectl version should check is all data is

--- a/test/e2e/kubectl/kubectl.go
+++ b/test/e2e/kubectl/kubectl.go
@@ -857,11 +857,11 @@ metadata:
 
 	ginkgo.Describe("Kubectl diff", func() {
 		/*
-			Release : v1.18
+			Release : v1.19
 			Testname: Kubectl, diff Deployment
 			Description: Create a Deployment with httpd image. Declare the same Deployment with a different image, busybox. Diff of live Deployment with declared Deployment MUST include the difference between live and declared image.
 		*/
-		ginkgo.It("should find diff in Deployment", func() {
+		framework.ConformanceIt("should check if kubectl diff finds a difference for Deployments", func() {
 			ginkgo.By("create deployment with httpd image")
 			deployment := commonutils.SubstituteImageName(string(readTestFileOrDie(httpdDeployment3Filename)))
 			framework.RunKubectlOrDieInput(ns, deployment, "create", "-f", "-")
@@ -888,11 +888,11 @@ metadata:
 
 	ginkgo.Describe("Kubectl server-side dry-run", func() {
 		/*
-			Release : v1.18
+			Release : v1.19
 			Testname: Kubectl, server-side dry-run Pod
 			Description: The command 'kubectl run' must create a pod with the specified image name. After, the command 'kubectl replace --dry-run=server' should update the Pod with the new image name and server-side dry-run enabled. The image name must not change.
 		*/
-		ginkgo.It("should dry-run update the Pod", func() {
+		framework.ConformanceIt("should check if kubectl can dry-run update Pods", func() {
 			ginkgo.By("running the image " + httpdImage)
 			podName := "e2e-test-httpd-pod"
 			nsFlag := fmt.Sprintf("--namespace=%v", ns)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/area conformance

**What this PR does / why we need it**:

`kubectl diff` and server-side dry-run are promoted to stable features as of 1.18.

Conformance should ensure that cloud providers support these features.

As a user, I expect `kubectl diff` to work, which requires that cloud providers [support dry-run by setting `sideEffects`](https://kubernetes.io/docs/reference/using-api/api-concepts/#dry-run) for cloud default webhooks.

Conformance would generally avoid cloud-specific issues like this one:
https://stackoverflow.com/questions/60038360/kubectl-diff-fails-on-aks

This suggestion is from @apelisse.

The e2e test was added here: https://github.com/kubernetes/kubernetes/pull/89542

[This e2e test meets conformance test requirements as described](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/conformance-tests.md). Primarily, these e2e tests meet the following requirements:

- it tests only GA, non-optional features or APIs 
- it works for all providers (TODO: add proof from other jobs)
- it is stable and runs consistently (e.g., no flakes), and has been running for at least two weeks
  - [diff Test Grid results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=should%20find%20diff)
  - [dry-run Test Grid results](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=should%20dry-run)

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes/kubernetes/issues/88905

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [server-side dry-run KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/0015-dry-run.md
- [kubectl diff KEP]: https://github.com/kubernetes/enhancements/blob/master/keps/sig-cli/20200115-kubectl-diff.md
```

@kubernetes/sig-architecture-pr-reviews @kubernetes/sig-cli-pr-reviews @kubernetes/cncf-conformance-wg