### PR TITLE
Deprecate scheduler's PodLister interface

### DIFF
--- a/pkg/scheduler/framework/v1alpha1/BUILD
+++ b/pkg/scheduler/framework/v1alpha1/BUILD
@@ -24,7 +24,6 @@ go_library(
         "//pkg/scheduler/util:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/resource:go_default_library",
-        "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/json:go_default_library",

--- a/pkg/scheduler/framework/v1alpha1/fake/listers.go
+++ b/pkg/scheduler/framework/v1alpha1/fake/listers.go
@@ -30,31 +30,6 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 )
 
-var _ framework.PodLister = &PodLister{}
-
-// PodLister implements PodLister on an []v1.Pods for test purposes.
-type PodLister []*v1.Pod
-
-// List returns []*v1.Pod matching a query.
-func (f PodLister) List(s labels.Selector) (selected []*v1.Pod, err error) {
-	for _, pod := range f {
-		if s.Matches(labels.Set(pod.Labels)) {
-			selected = append(selected, pod)
-		}
-	}
-	return selected, nil
-}
-
-// FilteredList returns pods matching a pod filter and a label selector.
-func (f PodLister) FilteredList(podFilter framework.PodFilter, s labels.Selector) (selected []*v1.Pod, err error) {
-	for _, pod := range f {
-		if podFilter(pod) && s.Matches(labels.Set(pod.Labels)) {
-			selected = append(selected, pod)
-		}
-	}
-	return selected, nil
-}
-
 var _ corelisters.ServiceLister = &ServiceLister{}
 
 // ServiceLister implements ServiceLister on []v1.Service for test purposes.

--- a/pkg/scheduler/framework/v1alpha1/listers.go
+++ b/pkg/scheduler/framework/v1alpha1/listers.go
@@ -16,23 +16,6 @@ limitations under the License.
 
 package v1alpha1
 
-import (
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
-)
-
-// PodFilter is a function to filter a pod. If pod passed return true else return false.
-type PodFilter func(*v1.Pod) bool
-
-// PodLister interface represents anything that can list pods for a scheduler.
-type PodLister interface {
-	// Returns the list of pods.
-	List(labels.Selector) ([]*v1.Pod, error)
-	// This is similar to "List()", but the returned slice does not
-	// contain pods that don't pass `podFilter`.
-	FilteredList(podFilter PodFilter, selector labels.Selector) ([]*v1.Pod, error)
-}
-
 // NodeInfoLister interface represents anything that can list/get NodeInfo objects from node name.
 type NodeInfoLister interface {
 	// Returns the list of NodeInfos.
@@ -45,6 +28,5 @@ type NodeInfoLister interface {
 
 // SharedLister groups scheduler-specific listers.
 type SharedLister interface {
-	Pods() PodLister
 	NodeInfos() NodeInfoLister
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:
PodLister doesn't really provide much value, only a single plugin use it.

**Which issue(s) this PR fixes**:
Part of #89528

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/assign @Huang-Wei @alculquicondor 