### PR TITLE
[WIP] Server-Side Apply: Alternative Status Wiping/Reset Fields implementation

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/registry/customresource/etcd.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/registry/generic"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 )
@@ -175,6 +176,7 @@ type StatusREST struct {
 }
 
 var _ = rest.Patcher(&StatusREST{})
+var _ = registry.UpdateStrategyGetter(&StatusREST{})
 
 func (r *StatusREST) New() runtime.Object {
 	return r.store.New()
@@ -197,6 +199,11 @@ func (r *StatusREST) Update(ctx context.Context, name string, objInfo rest.Updat
 	// We are explicitly setting forceAllowCreate to false in the call to the underlying storage because
 	// subresources should never allow create on update.
 	return r.store.Update(ctx, name, objInfo, createValidation, updateValidation, false, options)
+}
+
+// GetUpdateStrategy implements registry.UpdateStrategyGetter
+func (r *StatusREST) GetUpdateStrategy() rest.RESTUpdateStrategy {
+	return r.store.GetUpdateStrategy()
 }
 
 type ScaleREST struct {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/BUILD
@@ -87,9 +87,11 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/features:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/registry/generic/registry:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/github.com/emicklei/go-restful:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/BUILD
@@ -21,6 +21,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/registry/rest:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/kube-openapi/pkg/util/proto:go_default_library",
         "//vendor/sigs.k8s.io/structured-merge-diff/v3/fieldpath:go_default_library",

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/internal"
+	"k8s.io/apiserver/pkg/registry/rest"
 	openapiproto "k8s.io/kube-openapi/pkg/util/proto"
 	"sigs.k8s.io/structured-merge-diff/v3/fieldpath"
 )
@@ -72,8 +73,8 @@ func NewFieldManager(f Manager) *FieldManager {
 
 // NewDefaultFieldManager creates a new FieldManager that merges apply requests
 // and update managed fields for other types of requests.
-func NewDefaultFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion) (*FieldManager, error) {
-	f, err := NewStructuredMergeManager(models, objectConverter, objectDefaulter, kind.GroupVersion(), hub)
+func NewDefaultFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion, preparator *rest.GenericPreparator) (*FieldManager, error) {
+	f, err := NewStructuredMergeManager(models, objectConverter, objectDefaulter, kind.GroupVersion(), hub, preparator)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create field manager: %v", err)
 	}
@@ -83,8 +84,8 @@ func NewDefaultFieldManager(models openapiproto.Models, objectConverter runtime.
 // NewDefaultCRDFieldManager creates a new FieldManager specifically for
 // CRDs. This allows for the possibility of fields which are not defined
 // in models, as well as having no models defined at all.
-func NewDefaultCRDFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion, preserveUnknownFields bool) (_ *FieldManager, err error) {
-	f, err := NewCRDStructuredMergeManager(models, objectConverter, objectDefaulter, kind.GroupVersion(), hub, preserveUnknownFields)
+func NewDefaultCRDFieldManager(models openapiproto.Models, objectConverter runtime.ObjectConvertor, objectDefaulter runtime.ObjectDefaulter, objectCreater runtime.ObjectCreater, kind schema.GroupVersionKind, hub schema.GroupVersion, preparator *rest.GenericPreparator, preserveUnknownFields bool) (_ *FieldManager, err error) {
+	f, err := NewCRDStructuredMergeManager(models, objectConverter, objectDefaulter, kind.GroupVersion(), hub, preparator, preserveUnknownFields)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create field manager: %v", err)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager/fieldmanager_test.go
@@ -97,6 +97,7 @@ func NewTestFieldManager(gvk schema.GroupVersionKind) TestFieldManager {
 		&fakeObjectDefaulter{},
 		gvk.GroupVersion(),
 		gvk.GroupVersion(),
+		nil,
 	)
 	if err != nil {
 		panic(err)

--- a/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/generic/registry/store.go
@@ -57,10 +57,20 @@ type ObjectFunc func(obj runtime.Object) error
 
 // GenericStore interface can be used for type assertions when we need to access the underlying strategies.
 type GenericStore interface {
-	GetCreateStrategy() rest.RESTCreateStrategy
-	GetUpdateStrategy() rest.RESTUpdateStrategy
+	CreateStrategyGetter
+	UpdateStrategyGetter
 	GetDeleteStrategy() rest.RESTDeleteStrategy
 	GetExportStrategy() rest.RESTExportStrategy
+}
+
+// CreateStrategyGetter can be used for type assertions when we need to access the underlying create strategy.
+type CreateStrategyGetter interface {
+	GetCreateStrategy() rest.RESTCreateStrategy
+}
+
+// UpdateStrategyGetter can be used for type assertions when we need to access the underlying update strategy.
+type UpdateStrategyGetter interface {
+	GetUpdateStrategy() rest.RESTUpdateStrategy
 }
 
 // Store implements pkg/api/rest.StandardStorage. It's intended to be

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/BUILD
@@ -27,6 +27,7 @@ go_library(
         "doc.go",
         "export.go",
         "meta.go",
+        "prepare.go",
         "rest.go",
         "table.go",
         "update.go",

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -42,18 +42,10 @@ type RESTCreateStrategy interface {
 	// The NameGenerator will be invoked prior to validation.
 	names.NameGenerator
 
+	CreationPreparator
+
 	// NamespaceScoped returns true if the object must be within a namespace.
 	NamespaceScoped() bool
-	// PrepareForCreate is invoked on create before validation to normalize
-	// the object.  For example: remove fields that are not to be persisted,
-	// sort order-insensitive list fields, etc.  This should not remove fields
-	// whose presence would be considered a validation error.
-	//
-	// Often implemented as a type check and an initailization or clearing of
-	// status. Clear the status because status changes are internal. External
-	// callers of an api (users) should not be setting an initial status on
-	// newly created objects.
-	PrepareForCreate(ctx context.Context, obj runtime.Object)
 	// Validate returns an ErrorList with validation errors or nil.  Validate
 	// is invoked after default fields in the object have been filled in
 	// before the object is persisted.  This method should not mutate the

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create_update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create_update.go
@@ -28,13 +28,9 @@ import (
 // behavior to create and update an object that follows Kubernetes API conventions.
 type RESTCreateUpdateStrategy interface {
 	RESTCreateStrategy
+	UpdatePreparator
 	// AllowCreateOnUpdate returns true if the object can be created by a PUT.
 	AllowCreateOnUpdate() bool
-	// PrepareForUpdate is invoked on update before validation to normalize
-	// the object.  For example: remove fields that are not to be persisted,
-	// sort order-insensitive list fields, etc.  This should not remove fields
-	// whose presence would be considered a validation error.
-	PrepareForUpdate(ctx context.Context, obj, old runtime.Object)
 	// ValidateUpdate is invoked after default fields in the object have been
 	// filled in before the object is persisted.  This method should not mutate
 	// the object.

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/prepare.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/prepare.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rest
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// CreationPreparator provides an interface to prepare new objects for being persisted
+type CreationPreparator interface {
+	// PrepareForCreate is invoked on create before validation to normalize
+	// the object.  For example: remove fields that are not to be persisted,
+	// sort order-insensitive list fields, etc.  This should not remove fields
+	// whose presence would be considered a validation error.
+	//
+	// Often implemented as a type check and an initailization or clearing of
+	// status. Clear the status because status changes are internal. External
+	// callers of an api (users) should not be setting an initial status on
+	// newly created objects.
+	PrepareForCreate(ctx context.Context, obj runtime.Object)
+}
+
+// UpdatePreparator provides an interface to prepare updates for being persisted
+type UpdatePreparator interface {
+	// PrepareForUpdate is invoked on update before validation to normalize
+	// the object.  For example: remove fields that are not to be persisted,
+	// sort order-insensitive list fields, etc.  This should not remove fields
+	// whose presence would be considered a validation error.
+	PrepareForUpdate(ctx context.Context, obj, old runtime.Object)
+}
+
+// GenericPreparator wraps available create and update preparators
+type GenericPreparator struct {
+	CreationPreparator
+	UpdatePreparator
+}
+
+// NewGenericPreparator wrapping the Creation and UpdatePreparator
+func NewGenericPreparator(c CreationPreparator, u UpdatePreparator) *GenericPreparator {
+	return &GenericPreparator{c, u}
+}
+
+// Prepare the object through the appropriate preparator.
+// In cases where both the old and new object are provided, the operation will be considered
+// an update and the respective preparator will be used.
+// In cases where the old object is nil, the CreationPreparator will be used.
+func (p *GenericPreparator) Prepare(ctx context.Context, obj, old runtime.Object) {
+	if old != nil && p.UpdatePreparator != nil {
+		p.PrepareForUpdate(ctx, obj, old)
+	} else if obj != nil && p.CreationPreparator != nil {
+		p.PrepareForCreate(ctx, obj)
+	}
+}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -38,15 +38,11 @@ import (
 // the call pattern in use.
 type RESTUpdateStrategy interface {
 	runtime.ObjectTyper
+	UpdatePreparator
 	// NamespaceScoped returns true if the object must be within a namespace.
 	NamespaceScoped() bool
 	// AllowCreateOnUpdate returns true if the object can be created by a PUT.
 	AllowCreateOnUpdate() bool
-	// PrepareForUpdate is invoked on update before validation to normalize
-	// the object.  For example: remove fields that are not to be persisted,
-	// sort order-insensitive list fields, etc.  This should not remove fields
-	// whose presence would be considered a validation error.
-	PrepareForUpdate(ctx context.Context, obj, old runtime.Object)
 	// ValidateUpdate is invoked after default fields in the object have been
 	// filled in before the object is persisted.  This method should not mutate
 	// the object.

--- a/test/integration/apiserver/apply/BUILD
+++ b/test/integration/apiserver/apply/BUILD
@@ -7,6 +7,7 @@ go_test(
         "apply_crd_test.go",
         "apply_test.go",
         "main_test.go",
+        "resetFields_test.go",
         "status_test.go",
     ],
     tags = [


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is an alternative approach to https://github.com/kubernetes/kubernetes/pull/89486 which calls the respective preparation methods (status wiping, etc.) in the fieldManager before doing apply/update.

One disadvantage of this is, that there are additional conversions in the fieldManager to allow calling PrepareFor[Update|Create] on the internal objects.

Alternative implementation for the KEP https://github.com/kubernetes/enhancements/pull/1123.

**Which issue(s) this PR fixes**:

Fixes #75564

**Does this PR introduce a user-facing change?**:

```release-note
FieldManager no longer owns fields that get reset before the object is persisted (e.g. "status wiping").
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
- [KEP]: https://github.com/kubernetes/enhancements/pull/1123
```

/sig api-machinery
/wg api-expression
/cc @apelisse @jennybuckley @julianvmodesto 
