### PR TITLE
kube-scheduler: compatibility with ServerSideApply

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -335,6 +335,9 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// Annotations must be excluded for the reasons described in
 		// https://github.com/kubernetes/kubernetes/issues/52914.
 		p.Annotations = nil
+		// Same as above, when annotations are modified with ServerSideApply,
+		// ManagedFields may also change and must be excluded
+		p.ManagedFields = nil
 		return p
 	}
 	assumedPodCopy, podCopy := f(assumedPod), f(pod)

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -81,6 +81,85 @@ func TestSkipPodUpdate(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "with ServerSideApply changes on Annotations",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pod-0",
+					Annotations:     map[string]string{"a": "b"},
+					ResourceVersion: "0",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Manager:    "some-actor",
+							Operation:  metav1.ManagedFieldsOperationApply,
+							APIVersion: "v1",
+							FieldsType: "FieldsV1",
+							FieldsV1: &metav1.FieldsV1{
+								Raw: []byte(`
+									"f:metadata": {
+									  "f:annotations": {
+										"f:a: {}
+									  }
+									}
+								`),
+							},
+						},
+					},
+				},
+				Spec: v1.PodSpec{
+					NodeName: "node-0",
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "pod-0",
+						Annotations:     map[string]string{"a": "c", "d": "e"},
+						ResourceVersion: "1",
+						ManagedFields: []metav1.ManagedFieldsEntry{
+							{
+								Manager:    "some-actor",
+								Operation:  metav1.ManagedFieldsOperationApply,
+								APIVersion: "v1",
+								FieldsType: "FieldsV1",
+								FieldsV1: &metav1.FieldsV1{
+									Raw: []byte(`
+										"f:metadata": {
+										  "f:annotations": {
+											"f:a: {}
+											"f:d: {}
+										  }
+										}
+									`),
+								},
+							},
+							{
+								Manager:    "some-actor",
+								Operation:  metav1.ManagedFieldsOperationApply,
+								APIVersion: "v1",
+								FieldsType: "FieldsV1",
+								FieldsV1: &metav1.FieldsV1{
+									Raw: []byte(`
+										"f:metadata": {
+										  "f:annotations": {
+											"f:a: {}
+										  }
+										}
+									`),
+								},
+							},
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node-1",
+					},
+				}
+			},
+			expected: true,
+		},
+		{
 			name: "with changes on Labels",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Avoid moving Pods that have been assumed back to the scheduling queue in case they have annotations modified with [Server Side Apply](https://kubernetes.io/docs/reference/using-api/api-concepts/#server-side-apply), which causes `Pod.ObjectMeta.ManagedFields` to be modified automatically.

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

I have scheduler plugins adding annotations to Pods after they have been assumed in one of the Binding phases (PreBind, PostBind, Unreserve, etc), and I noticed the `Reserve` hook of my plugins being called multiple times for Pods that have already been assumed. That means modifying annotations is causing assumed Pods to be moved back to the scheduling queue.

Currently, scheduler code ignoring these modifications when deciding if the Pod needs to go back to the scheduling queue does not account for [Server Side Apply](https://kubernetes.io/docs/reference/using-api/api-concepts/#server-side-apply) which will always modify `Pod.ObjectMeta.ManagedFields`.

**Special notes for your reviewer**:

As a workaround until the fix in this PR lands, I'm maintaining more state set by the `Reserve` phase in my plugins to detect Binding for the Pod is still in progress, and I clear that state in `PostBind`. IOW I'm maintaining my own "assumed" Pod cache in my plugins, and rejecting calls to `Reserve` for pods that have already been assumed.

The workaround has an extra drawback of causing unnecessary churn on the scheduler, since the extra cycles for Pods already assumed will fail, and the scheduler loop will try to `recordSchedulingFailure`, which will fail since the Pod is at a newer version already (either already bound, or with extra annotations added by one of the Binding phases).

**Does this PR introduce a user-facing change?**:

```release-note
Avoid unnecessary scheduling churn when annotations are updated while Pods are being scheduled.
```