### PR TITLE
Automated cherry pick of #90373: kube-scheduler: compatibility with ServerSideApply

### DIFF
--- a/pkg/scheduler/eventhandlers.go
+++ b/pkg/scheduler/eventhandlers.go
@@ -335,6 +335,9 @@ func (sched *Scheduler) skipPodUpdate(pod *v1.Pod) bool {
 		// Annotations must be excluded for the reasons described in
 		// https://github.com/kubernetes/kubernetes/issues/52914.
 		p.Annotations = nil
+		// Same as above, when annotations are modified with ServerSideApply,
+		// ManagedFields may also change and must be excluded
+		p.ManagedFields = nil
 		return p
 	}
 	assumedPodCopy, podCopy := f(assumedPod), f(pod)

--- a/pkg/scheduler/eventhandlers_test.go
+++ b/pkg/scheduler/eventhandlers_test.go
@@ -81,6 +81,85 @@ func TestSkipPodUpdate(t *testing.T) {
 			expected: true,
 		},
 		{
+			name: "with ServerSideApply changes on Annotations",
+			pod: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "pod-0",
+					Annotations:     map[string]string{"a": "b"},
+					ResourceVersion: "0",
+					ManagedFields: []metav1.ManagedFieldsEntry{
+						{
+							Manager:    "some-actor",
+							Operation:  metav1.ManagedFieldsOperationApply,
+							APIVersion: "v1",
+							FieldsType: "FieldsV1",
+							FieldsV1: &metav1.FieldsV1{
+								Raw: []byte(`
+									"f:metadata": {
+									  "f:annotations": {
+										"f:a: {}
+									  }
+									}
+								`),
+							},
+						},
+					},
+				},
+				Spec: v1.PodSpec{
+					NodeName: "node-0",
+				},
+			},
+			isAssumedPodFunc: func(*v1.Pod) bool {
+				return true
+			},
+			getPodFunc: func(*v1.Pod) *v1.Pod {
+				return &v1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "pod-0",
+						Annotations:     map[string]string{"a": "c", "d": "e"},
+						ResourceVersion: "1",
+						ManagedFields: []metav1.ManagedFieldsEntry{
+							{
+								Manager:    "some-actor",
+								Operation:  metav1.ManagedFieldsOperationApply,
+								APIVersion: "v1",
+								FieldsType: "FieldsV1",
+								FieldsV1: &metav1.FieldsV1{
+									Raw: []byte(`
+										"f:metadata": {
+										  "f:annotations": {
+											"f:a: {}
+											"f:d: {}
+										  }
+										}
+									`),
+								},
+							},
+							{
+								Manager:    "some-actor",
+								Operation:  metav1.ManagedFieldsOperationApply,
+								APIVersion: "v1",
+								FieldsType: "FieldsV1",
+								FieldsV1: &metav1.FieldsV1{
+									Raw: []byte(`
+										"f:metadata": {
+										  "f:annotations": {
+											"f:a: {}
+										  }
+										}
+									`),
+								},
+							},
+						},
+					},
+					Spec: v1.PodSpec{
+						NodeName: "node-1",
+					},
+				}
+			},
+			expected: true,
+		},
+		{
 			name: "with changes on Labels",
 			pod: &v1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Cherry pick of #90373 on release-1.18.

#90373: kube-scheduler: compatibility with ServerSideApply

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.