### PR TITLE
Promote ServiceAccount resource lifecycle test - +3 conformance coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1317,6 +1317,15 @@
     Container.
   release: v1.9
   file: test/e2e/auth/service_accounts.go
+- testname: ServiceAccount lifecycle test
+  codename: '[sig-auth] ServiceAccounts should run through the lifecycle of a ServiceAccount
+    [Conformance]'
+  description: Creates a ServiceAccount with a static Label MUST be added as shown
+    in watch event. Patching the ServiceAccount MUST return it's new property. Listing
+    the ServiceAccounts MUST return the test ServiceAccount with it's patched values.
+    ServiceAccount will be deleted and MUST find a deleted watch event.
+  release: v1.19
+  file: test/e2e/auth/service_accounts.go
 - testname: Kubectl, guestbook application
   codename: '[sig-cli] Kubectl client Guestbook application should create and stop
     a working application  [Conformance]'

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -624,12 +624,12 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 	})
 
 	/*
-		   Release: v1.19
-		   Testname: ServiceAccount lifecycle test
-		   Description: Creates a ServiceAccount with a static Label MUST be added as shown in watch event.
-	                        Patching the ServiceAccount MUST return it's new property.
-	                        Listing the ServiceAccounts MUST return the test ServiceAccount with it's patched values.
-	                        ServiceAccount will be deleted and MUST find a deleted watch event.
+			   Release: v1.19
+			   Testname: ServiceAccount lifecycle test
+			   Description: Creates a ServiceAccount with a static Label MUST be added as shown in watch event.
+		                        Patching the ServiceAccount MUST return it's new property.
+		                        Listing the ServiceAccounts MUST return the test ServiceAccount with it's patched values.
+		                        ServiceAccount will be deleted and MUST find a deleted watch event.
 	*/
 	framework.ConformanceIt("should run through the lifecycle of a ServiceAccount", func() {
 		testNamespaceName := f.Namespace.Name

--- a/test/e2e/auth/service_accounts.go
+++ b/test/e2e/auth/service_accounts.go
@@ -623,7 +623,15 @@ var _ = SIGDescribe("ServiceAccounts", func() {
 		framework.Logf("completed pod")
 	})
 
-	ginkgo.It("should run through the lifecycle of a ServiceAccount", func() {
+	/*
+		   Release: v1.19
+		   Testname: ServiceAccount lifecycle test
+		   Description: Creates a ServiceAccount with a static Label MUST be added as shown in watch event.
+	                        Patching the ServiceAccount MUST return it's new property.
+	                        Listing the ServiceAccounts MUST return the test ServiceAccount with it's patched values.
+	                        ServiceAccount will be deleted and MUST find a deleted watch event.
+	*/
+	framework.ConformanceIt("should run through the lifecycle of a ServiceAccount", func() {
 		testNamespaceName := f.Namespace.Name
 		testServiceAccountName := "testserviceaccount"
 		testServiceAccountStaticLabels := map[string]string{"test-serviceaccount-static": "true"}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
`test/e2e/auth/service_accounts.go: "should run through the lifecycle of a ServiceAccount"`

**Which issue(s) this PR fixes**:
Fixes #89071

**Special notes for your reviewer**:
Adds +3 conformance endpoint coverage
Testgrid link: https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&include-filter-by-regex=lifecycle%20of%20a%20ServiceAccount

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/sig testing