### PR TITLE
Improve the error message for the service cidr check

### DIFF
--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -36,6 +36,8 @@ import (
 // validateClusterIPFlags is expected to be called after Complete()
 func validateClusterIPFlags(options *ServerRunOptions) []error {
 	var errs []error
+	// maxCIDRbits is used to define the maximum CIDR size for the cluster ip(s)
+	const maxCIDRbits = 20
 
 	// validate that primary has been processed by user provided values or it has been defaulted
 	if options.PrimaryServiceClusterIPRange.IP == nil {
@@ -50,8 +52,8 @@ func validateClusterIPFlags(options *ServerRunOptions) []error {
 	// Complete() expected to have set Primary* and Secondary*
 	// primary CIDR validation
 	var ones, bits = options.PrimaryServiceClusterIPRange.Mask.Size()
-	if bits-ones > 20 {
-		errs = append(errs, errors.New("specified --service-cluster-ip-range is too large"))
+	if bits-ones > maxCIDRbits {
+		errs = append(errs, fmt.Errorf("specified --service-cluster-ip-range is too large. Network CIDR should not be bigger than /%d", bits-maxCIDRbits))
 	}
 
 	// Secondary IP validation
@@ -79,8 +81,8 @@ func validateClusterIPFlags(options *ServerRunOptions) []error {
 		// bigger cidr (specially those offered by IPv6) will add no value
 		// significantly increase snapshotting time.
 		var ones, bits = options.SecondaryServiceClusterIPRange.Mask.Size()
-		if bits-ones > 20 {
-			errs = append(errs, errors.New("specified --secondary-service-cluster-ip-range is too large"))
+		if bits-ones > maxCIDRbits {
+			errs = append(errs, fmt.Errorf("specified --service-cluster-ip-range is too large. Network CIDR should not be bigger than /%d", bits-maxCIDRbits))
 		}
 	}
 

--- a/cmd/kube-apiserver/app/options/validation.go
+++ b/cmd/kube-apiserver/app/options/validation.go
@@ -36,8 +36,8 @@ import (
 // validateClusterIPFlags is expected to be called after Complete()
 func validateClusterIPFlags(options *ServerRunOptions) []error {
 	var errs []error
-	// maxCIDRbits is used to define the maximum CIDR size for the cluster ip(s)
-	const maxCIDRbits = 20
+	// maxCIDRBits is used to define the maximum CIDR size for the cluster ip(s)
+	const maxCIDRBits = 20
 
 	// validate that primary has been processed by user provided values or it has been defaulted
 	if options.PrimaryServiceClusterIPRange.IP == nil {
@@ -51,9 +51,8 @@ func validateClusterIPFlags(options *ServerRunOptions) []error {
 
 	// Complete() expected to have set Primary* and Secondary*
 	// primary CIDR validation
-	var ones, bits = options.PrimaryServiceClusterIPRange.Mask.Size()
-	if bits-ones > maxCIDRbits {
-		errs = append(errs, fmt.Errorf("specified --service-cluster-ip-range is too large. Network CIDR should not be bigger than /%d", bits-maxCIDRbits))
+	if err := validateMaxCIDRRange(options.PrimaryServiceClusterIPRange, maxCIDRBits, "--service-cluster-ip-range"); err != nil {
+		errs = append(errs, err)
 	}
 
 	// Secondary IP validation
@@ -77,16 +76,24 @@ func validateClusterIPFlags(options *ServerRunOptions) []error {
 			errs = append(errs, errors.New("--service-cluster-ip-range and --secondary-service-cluster-ip-range must be of different IP family"))
 		}
 
-		// Should be smallish sized cidr, this thing is kept in etcd
-		// bigger cidr (specially those offered by IPv6) will add no value
-		// significantly increase snapshotting time.
-		var ones, bits = options.SecondaryServiceClusterIPRange.Mask.Size()
-		if bits-ones > maxCIDRbits {
-			errs = append(errs, fmt.Errorf("specified --service-cluster-ip-range is too large. Network CIDR should not be bigger than /%d", bits-maxCIDRbits))
+		if err := validateMaxCIDRRange(options.SecondaryServiceClusterIPRange, maxCIDRBits, "--secondary-service-cluster-ip-range"); err != nil {
+			errs = append(errs, err)
 		}
 	}
 
 	return errs
+}
+
+func validateMaxCIDRRange(cidr net.IPNet, maxCIDRBits int, cidrFlag string) error {
+	// Should be smallish sized cidr, this thing is kept in etcd
+	// bigger cidr (specially those offered by IPv6) will add no value
+	// significantly increase snapshotting time.
+	var ones, bits = cidr.Mask.Size()
+	if bits-ones > maxCIDRBits {
+		return fmt.Errorf("specified %s is too large; for %d-bit addresses, the mask must be >= %d", cidrFlag, bits, bits-maxCIDRBits)
+	}
+
+	return nil
 }
 
 func validateServiceNodePort(options *ServerRunOptions) []error {

--- a/cmd/kube-apiserver/app/options/validation_test.go
+++ b/cmd/kube-apiserver/app/options/validation_test.go
@@ -95,6 +95,18 @@ func TestClusterSerivceIPRange(t *testing.T) {
 			options:         makeOptionsWithCIDRs("10.0.0.0/16", "3000::/108"),
 			enableDualStack: false,
 		},
+		{
+			name:            "service cidr to big",
+			expectErrors:    true,
+			options:         makeOptionsWithCIDRs("10.0.0.0/8", ""),
+			enableDualStack: true,
+		},
+		{
+			name:            "dual-stack secondary cidr to big",
+			expectErrors:    true,
+			options:         makeOptionsWithCIDRs("10.0.0.0/16", "3000::/64"),
+			enableDualStack: true,
+		},
 		/* success cases */
 		{
 			name:            "valid primary",


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug

/kind cleanup

> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

Improve the error message if you specify a service-ip-range with a to big CIDR. I encountered this when I was experimenting with Dual-Stack: `kubeadm init --feature-gates=IPv6DualStack=true --pod-network-cidr=fd00:1234::/64,192.168.0.0/16 --service-cidr=fd00:4321::/64,10.8.0.0/16 `. Currently you will get this error message which is not really helpful:

```bash
I0422 18:18:39.395443       1 server.go:656] external host was not specified, using 10.0.2.15
Error: specified --service-cluster-ip-range is too large
Usage:
  kube-apiserver [flags]
```

Hopefully this limitation is somewhere documented but we should add some more context to the error message, otherwise a user needs to look into the code base to see the limitation.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
