### PR TITLE
test/e2e_node/resource_metrics_test.go:Remove direct prometheus dependencies from k/k

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/testutil.go
@@ -19,8 +19,10 @@ package testutil
 import (
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/prometheus/common/model"
 
 	apimachineryversion "k8s.io/apimachinery/pkg/version"
 	"k8s.io/component-base/metrics"
@@ -67,4 +69,26 @@ func NewFakeKubeRegistry(ver string) metrics.KubeRegistry {
 	}
 
 	return metrics.NewKubeRegistry()
+}
+
+// GetMetricLabelValue returns string that consists of the value of labelName in Metric
+func GetMetricLabelValue(element interface{}, labelName ...string) string {
+	el := element.(*model.Sample)
+	var value string
+	var i int
+	if len(labelName) > 1 {
+		for i = 0; i < len(labelName)-1; i++ {
+			value += fmt.Sprintf("%s::", el.Metric[model.LabelName(labelName[i])])
+		}
+	}
+	value += fmt.Sprintf("%s", el.Metric[model.LabelName(labelName[i])])
+	return value
+}
+
+// GetModelTimeFun returns fun of model.Time
+func GetModelTimeFun(sec int64) interface{} {
+	return func(t model.Time) time.Time {
+		// model.Time is in Milliseconds since epoch
+		return time.Unix(sec, int64(t)*int64(time.Millisecond))
+	}
 }

--- a/test/e2e_node/BUILD
+++ b/test/e2e_node/BUILD
@@ -191,6 +191,7 @@ go_test(
         "//staging/src/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//staging/src/k8s.io/client-go/kubernetes:go_default_library",
         "//staging/src/k8s.io/client-go/tools/watch:go_default_library",
+        "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis:go_default_library",
         "//staging/src/k8s.io/cri-api/pkg/apis/runtime/v1alpha2:go_default_library",
         "//test/e2e/common:go_default_library",


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 
 /kind cleanup
 

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
ref:https://github.com/kubernetes/kubernetes/issues/89267
it is a part of removing direct prometheus dependency in test/e2e_node
/cc @serathius
/cc @logicalhan

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
