### PR TITLE
fix cross build conformance image error

### DIFF
--- a/cluster/images/conformance/Makefile
+++ b/cluster/images/conformance/Makefile
@@ -34,6 +34,9 @@ CLUSTER_DIR?=$(shell pwd)/../../../cluster/
 BASEIMAGE=debian:stretch-slim
 TEMP_DIR:=$(shell mktemp -d -t conformanceXXXXXX)
 
+#output format for docker buildx build [push, load]
+OUTPUT=--load
+
 all: build
 
 build:
@@ -56,15 +59,14 @@ endif
 
 	cd ${TEMP_DIR} && sed -i.back "s|BASEIMAGE|${BASEIMAGE}|g" Dockerfile
 
-	docker build --pull -t ${REGISTRY}/conformance-${ARCH}:${VERSION} ${TEMP_DIR}
-	rm -rf "${TEMP_DIR}"
-
-push: build
-	docker push ${REGISTRY}/conformance-${ARCH}:${VERSION}
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --pull --platform linux/$(ARCH) $(OUTPUT) -t ${REGISTRY}/conformance-${ARCH}:${VERSION} ${TEMP_DIR}
 ifeq ($(ARCH),amd64)
 	docker rmi ${REGISTRY}/conformance:${VERSION} 2>/dev/null || true
-	docker tag ${REGISTRY}/conformance-${ARCH}:${VERSION} ${REGISTRY}/conformance:${VERSION}
-	docker push ${REGISTRY}/conformance:${VERSION}
+	DOCKER_CLI_EXPERIMENTAL=enabled docker buildx build --pull --platform linux/$(ARCH) $(OUTPUT) -t ${REGISTRY}/conformance:${VERSION} ${TEMP_DIR}
 endif
+	rm -rf "${TEMP_DIR}"
+
+push: OUTPUT=--push
+push: build
 
 .PHONY: build push all


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
After setting --platform flag in docker build, conformance image can build from correct architecture debian:stretch-slim image.
Otherwise, it will always use debian:stretch-slim amd64 image.

**Which issue(s) this PR fixes**:

Fixes #89554

