### PR TITLE
Fix shellcheck failures in cluster/pre-existing/util.sh

### DIFF
--- a/cluster/pre-existing/util.sh
+++ b/cluster/pre-existing/util.sh
@@ -41,22 +41,16 @@ function detect-project() {
 }
 
 function create-certs {
-  rm /tmp/kubeconfig
+  execute-cmd-on-pre-existing-master-with-retries 'sudo cat /etc/kubernetes/admin.conf' > /tmp/kubeconfig
 
-  execute-cmd-on-pre-existing-master-with-retries "sudo cat /etc/kubernetes/admin.conf" > /tmp/kubeconfig
-  CA_CERT_BASE64=$(cat /tmp/kubeconfig | grep certificate-authority | awk '{print $2}' | head -n 1)
-  KUBELET_CERT_BASE64=$(cat /tmp/kubeconfig | grep client-certificate-data | awk '{print $2}' | head -n 1)
-  KUBELET_KEY_BASE64=$(cat /tmp/kubeconfig | grep client-key-data | awk '{print $2}' | head -n 1)
-
-  # Local kubeconfig.kubemark vars
-  KUBECFG_CERT_BASE64="${KUBELET_CERT_BASE64}"
-  KUBECFG_KEY_BASE64="${KUBELET_KEY_BASE64}"
-
-  # The pre-existing Kubernetes master already has these setup
-  # Set these vars but don't use them
-  CA_KEY_BASE64=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
-  MASTER_CERT_BASE64=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
-  MASTER_KEY_BASE64=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
-  KUBEAPISERVER_CERT_BASE64=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
-  KUBEAPISERVER_KEY_BASE64=$(dd if=/dev/urandom bs=128 count=1 2>/dev/null | base64 | tr -d "=+/" | dd bs=32 count=1 2>/dev/null)
+  # CA_CERT_BASE64, KUBELET_CERT_BASE64 and KUBELET_KEY_BASE64 might be used
+  # in test/kubemark/iks/util.sh
+  # If it becomes clear that the variables are not used anywhere, then we can
+  # remove them:
+  CA_CERT_BASE64=$(grep certificate-authority /tmp/kubeconfig | awk '{print $2}' | head -n 1)
+  KUBELET_CERT_BASE64=$(grep client-certificate-data /tmp/kubeconfig | awk '{print $2}' | head -n 1)
+  KUBELET_KEY_BASE64=$(grep client-key-data /tmp/kubeconfig | awk '{print $2}' | head -n 1)
+  export CA_CERT_BASE64
+  export KUBELET_CERT_BASE64
+  export KUBELET_KEY_BASE64
 }

--- a/hack/.shellcheck_failures
+++ b/hack/.shellcheck_failures
@@ -4,4 +4,3 @@
 ./cluster/gce/upgrade.sh
 ./cluster/gce/util.sh
 ./cluster/log-dump/log-dump.sh
-./cluster/pre-existing/util.sh


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fix shellcheck failures in cluster/pre-existing/util.sh

**Which issue(s) this PR fixes**:
Ref #72956

**Special notes for your reviewer**:
NB! This is merely bringing the closed (due to inactivity) PR #82059 back to life in a contemporary context, so all cred should go to @k-toyoda-pi (and @BenTheElder). I just want the scripts to be fixed, and perhaps it is preferable to reopen #82059? (For @k-toyoda-pi to decide given available time to reopen and update that one.)

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
