### PR TITLE
Improve error message when refresh token expiry is nil.

### DIFF
--- a/pkg/kubelet/token/token_manager.go
+++ b/pkg/kubelet/token/token_manager.go
@@ -168,7 +168,9 @@ func (m *Manager) expired(t *authenticationv1.TokenRequest) bool {
 // ttl, or if the token is older than 24 hours.
 func (m *Manager) requiresRefresh(tr *authenticationv1.TokenRequest) bool {
 	if tr.Spec.ExpirationSeconds == nil {
-		klog.Errorf("expiration seconds was nil for tr: %#v", tr)
+		cpy := tr.DeepCopy()
+		cpy.Status.Token = ""
+		klog.Errorf("expiration seconds was nil for tr: %#v", cpy)
 		return false
 	}
 	now := m.clock.Now()

--- a/pkg/kubelet/token/token_manager_test.go
+++ b/pkg/kubelet/token/token_manager_test.go
@@ -130,6 +130,7 @@ func TestRequiresRefresh(t *testing.T) {
 	cases := []struct {
 		now, exp      time.Time
 		expectRefresh bool
+		requestTweaks func(*authenticationv1.TokenRequest)
 	}{
 		{
 			now:           start.Add(10 * time.Minute),
@@ -151,6 +152,15 @@ func TestRequiresRefresh(t *testing.T) {
 			exp:           start.Add(60 * time.Minute),
 			expectRefresh: true,
 		},
+		{
+			now:           start.Add(0 * time.Minute),
+			// expiry will be overwritten by the tweak below.
+			exp:           start.Add(60 * time.Minute),
+			expectRefresh: false,
+			requestTweaks: func(tr *authenticationv1.TokenRequest) {
+				tr.Spec.ExpirationSeconds = nil
+			},
+		},
 	}
 
 	for i, c := range cases {
@@ -165,6 +175,11 @@ func TestRequiresRefresh(t *testing.T) {
 					ExpirationTimestamp: metav1.Time{Time: c.exp},
 				},
 			}
+
+			if c.requestTweaks != nil {
+				c.requestTweaks(tr)
+			}
+
 			mgr := NewManager(nil)
 			mgr.clock = clock
 

--- a/pkg/kubelet/token/token_manager_test.go
+++ b/pkg/kubelet/token/token_manager_test.go
@@ -153,8 +153,8 @@ func TestRequiresRefresh(t *testing.T) {
 			expectRefresh: true,
 		},
 		{
-			now:           start.Add(0 * time.Minute),
 			// expiry will be overwritten by the tweak below.
+			now:           start.Add(0 * time.Minute),
 			exp:           start.Add(60 * time.Minute),
 			expectRefresh: false,
 			requestTweaks: func(tr *authenticationv1.TokenRequest) {


### PR DESCRIPTION
Add test coverage for this case.

-----

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Do not log a `struct` that potentially contains a token.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
(provided logging doesn't count much.)

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
