### PR TITLE
Remove piosz from sig-instrumentation-approvers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -290,7 +290,6 @@ aliases:
     - MaciekPytel
     - mwielgus
   sig-instrumentation-approvers:
-    - piosz
     - brancz
     - serathius
   sig-instrumentation-reviewers:


### PR DESCRIPTION
/kind cleanup

```release-note
NONE
```
/cc @piosz