### PR TITLE
/cluster: add / update OWNERS labels

### DIFF
--- a/cluster/OWNERS
+++ b/cluster/OWNERS
@@ -18,6 +18,3 @@ emeritus_approvers:
   - roberthbailey   # 2019-03-08
   - jbeda
   - zmerlynn
-labels:
-- sig/cluster-lifecycle
-- area/release-eng

--- a/cluster/addons/OWNERS
+++ b/cluster/addons/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+- sig/cloud-provider
+- area/provider/gcp

--- a/cluster/gce/OWNERS
+++ b/cluster/gce/OWNERS
@@ -24,3 +24,6 @@ approvers:
   - sig-scalability-approvers
 emeritus_approvers:
   - jszczepkowski
+labels:
+- sig/cloud-provider
+- area/provider/gcp

--- a/cluster/images/OWNERS
+++ b/cluster/images/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+- area/release-eng

--- a/cluster/images/conformance/OWNERS
+++ b/cluster/images/conformance/OWNERS
@@ -19,4 +19,5 @@ approvers:
   - bentheelder
 labels:
 - sig/release
+- sig/testing
 - area/conformance

--- a/cluster/images/etcd-empty-dir-cleanup/OWNERS
+++ b/cluster/images/etcd-empty-dir-cleanup/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+- sig/api-machinery

--- a/cluster/images/etcd-version-monitor/OWNERS
+++ b/cluster/images/etcd-version-monitor/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+- sig/api-machinery

--- a/cluster/images/kubemark/OWNERS
+++ b/cluster/images/kubemark/OWNERS
@@ -8,3 +8,5 @@ approvers:
   - gmarek
   - shyamjvs
   - wojtek-t
+labels:
+- sig/scalability

--- a/cluster/kubemark/OWNERS
+++ b/cluster/kubemark/OWNERS
@@ -10,3 +10,5 @@ approvers:
   - shyamjvs
   - sig-scalability-approvers
   - wojtek-t
+labels:
+- sig/scalability

--- a/cluster/log-dump/OWNERS
+++ b/cluster/log-dump/OWNERS
@@ -4,3 +4,6 @@ reviewers:
   - sig-scalability-reviewers
 approvers:
   - sig-scalability-approvers
+labels:
+- sig/scalability
+- sig/testing

--- a/cluster/pre-existing/OWNERS
+++ b/cluster/pre-existing/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+- sig/scalability

--- a/cluster/skeleton/OWNERS
+++ b/cluster/skeleton/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+labels:
+- sig/testing


### PR DESCRIPTION
**What this PR does / why we need it**:

/kind cleanup
/priority backlog

- remove the sig-cluster-lifecycle label from the /cluster/OWNERS file.
- add SIG labels in the /cluster folders that are missing them
- leave the /cluster root without a SIG label

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
NONE

**Special notes for your reviewer**:
NONE

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
