### PR TITLE
fix: Allow automatic ACR auth in private Azure clouds

### DIFF
--- a/pkg/credentialprovider/azure/BUILD
+++ b/pkg/credentialprovider/azure/BUILD
@@ -32,6 +32,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry:go_default_library",
+        "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
     ],
 )


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Provides a fix to allow a cluster in a private Azure cloud to authenticate to ACR in the same cloud.

**Which issue(s) this PR fixes**:
Fixes #90412

**Does this PR introduce a user-facing change?**:
NONE

```release-note
Provides a fix to allow a cluster in a private Azure cloud to authenticate to ACR in the same cloud.
```
