### PR TITLE
Node-e2e density test failure due to a nil pointer panic

### DIFF
--- a/test/e2e_node/resource_collector.go
+++ b/test/e2e_node/resource_collector.go
@@ -170,6 +170,9 @@ func (r *ResourceCollector) collectStats(oldStatsMap map[string]*cadvisorapiv2.C
 		newStats := cStats.Stats[0]
 
 		if oldStats, ok := oldStatsMap[name]; ok && oldStats.Timestamp.Before(newStats.Timestamp) {
+			if oldStats.Cpu == nil || newStats.Cpu == nil || oldStats.Memory == nil || newStats.Memory == nil {
+				continue
+			}
 			r.buffers[name] = append(r.buffers[name], computeContainerResourceUsage(name, oldStats, newStats))
 		}
 		oldStatsMap[name] = newStats


### PR DESCRIPTION
I've seen a nil pointer failure from density test in node-e2e suite.

I added the protective code to prevent this problem from recurring.

The log is below:

2020-04-24 07:09:18.284688 I | CPUAccounting not enabled for pid: 15416
2020-04-24 07:09:18.284714 I | MemoryAccounting not enabled for pid: 15416
E0424 07:09:26.847155   22127 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 882 [running]:
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.logPanic(0x4693e40, 0x8ab2940)
        /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /root/go/src/k8s.io/kubernetes/_output/local/go/src/k8s.io/kubernetes/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x4693e40, 0x8ab2940)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
k8s.io/kubernetes/test/e2e_node.computeContainerResourceUsage(0xc00088404f, 0x2b, 0xc0010e5580, 0xc0010edf00, 0xed63487a6)



Signed-off-by: Bin Lu <bin.lu@arm.com>

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I've seen a nil pointer failure from density test in node-e2e suite.

**Which issue(s) this PR fixes**:

Fixes #None.

**Special notes for your reviewer**:
None.
**Does this PR introduce a user-facing change?**:
```release-note
None.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
None.
```
