### PR TITLE
refactor TestGetRecentUnmetScheduleTimes in util_test.go

### DIFF
--- a/pkg/controller/cronjob/utils_test.go
+++ b/pkg/controller/cronjob/utils_test.go
@@ -358,36 +358,25 @@ func TestGetRecentUnmetScheduleTimes(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		sj.ObjectMeta.CreationTimestamp = testCase.creationTimestamp
-		sj.Status.LastScheduleTime = testCase.lastScheduleTime
-		sj.Spec.StartingDeadlineSeconds = testCase.deadline
+		t.Run(testCase.caseName, func(t *testing.T) {
+			sj.ObjectMeta.CreationTimestamp = testCase.creationTimestamp
+			sj.Status.LastScheduleTime = testCase.lastScheduleTime
+			sj.Spec.StartingDeadlineSeconds = testCase.deadline
 
-		times, err := getRecentUnmetScheduleTimes(sj, testCase.nowTime)
-		if err != nil && !testCase.expectErr {
-			t.Errorf("unexpect getRecentUnmetScheduleTimes err: %v, caseName: %v", err, testCase.caseName)
-		}
+			times, err := getRecentUnmetScheduleTimes(sj, testCase.nowTime)
+			if err != nil && !testCase.expectErr {
+				t.Errorf("unexpect getRecentUnmetScheduleTimes err: %v", err)
+			}
 
-		if err == nil && testCase.expectErr {
-			t.Errorf("expect getRecentUnmetScheduleTimes err, but get err: nil , caseName: %v", testCase.caseName)
-		}
+			if err == nil && testCase.expectErr {
+				t.Errorf("expect getRecentUnmetScheduleTimes err, but get err: nil")
+			}
 
-		if !equal(times, testCase.expectResult) {
-			t.Errorf("getRecentUnmetScheduleTimes expect: %v, get : %v, caseName: %v", testCase.expectResult, times, testCase.caseName)
-		}
+			if !reflect.DeepEqual(times, testCase.expectResult) {
+				t.Errorf("getRecentUnmetScheduleTimes expect: %v, get : %v", testCase.expectResult, times)
+			}
+		})
 	}
-}
-
-func equal(slice1, slice2 []time.Time) bool {
-	if len(slice1) != len(slice2) {
-		return false
-	}
-
-	for i, item1 := range slice1 {
-		if !item1.Equal(slice2[i]) {
-			return false
-		}
-	}
-	return true
 }
 
 func TestByJobStartTime(t *testing.T) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
```
/kind cleanup
```
**What this PR does / why we need it**:
```
refactor TestGetRecentUnmetScheduleTimes
```
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
```
NONE
```
**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
