### PR TITLE
Fix run command when waiting for pods

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/BUILD
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/BUILD
@@ -21,7 +21,6 @@ go_library(
         "//build/visible_to:pkg_kubectl_cmd_rollout_CONSUMERS",
     ],
     deps = [
-        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",

--- a/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/rollout/rollout_status.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -200,25 +199,11 @@ func (o *RolloutStatusOptions) Run() error {
 		},
 	}
 
-	preconditionFunc := func(store cache.Store) (bool, error) {
-		_, exists, err := store.Get(&metav1.ObjectMeta{Namespace: info.Namespace, Name: info.Name})
-		if err != nil {
-			return true, err
-		}
-		if !exists {
-			// We need to make sure we see the object in the cache before we start waiting for events
-			// or we would be waiting for the timeout if such object didn't exist.
-			return true, apierrors.NewNotFound(mapping.Resource.GroupResource(), info.Name)
-		}
-
-		return false, nil
-	}
-
 	// if the rollout isn't done yet, keep watching deployment status
 	ctx, cancel := watchtools.ContextWithOptionalTimeout(context.Background(), o.Timeout)
 	intr := interrupt.New(nil, cancel)
 	return intr.Run(func() error {
-		_, err = watchtools.UntilWithSync(ctx, lw, &unstructured.Unstructured{}, preconditionFunc, func(e watch.Event) (bool, error) {
+		_, err = watchtools.UntilWithSync(ctx, lw, &unstructured.Unstructured{}, nil, func(e watch.Event) (bool, error) {
 			switch t := e.Type; t {
 			case watch.Added, watch.Modified:
 				status, done, err := statusViewer.Status(e.Object.(runtime.Unstructured), o.Revision)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind failing-test

**What this PR does / why we need it**:
This builds on top of #90417, so you'll notice 2 commits:
1. Is fixing `waitForPod` (and couple other places similar) not to use the precondition, since in large clusters, the cache initialized from apiserver might be delayed by small hundreds of milliseconds. This is sufficient to flake the test as described in #87851.
2. The run command waited for pod but only with restart policy `Never`, this was because the exit condition used both failed and succeeded pods. This commit takes restart policy into account and either waits for only success (restart policy OnFailure) or failure & success (Never). 

**Which issue(s) this PR fixes**:
Fixes #87851 

**Special notes for your reviewer**:
/assign @wojtek-t 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

/sig cli
/priority important-soon
