### PR TITLE
Migrate ingress test manifests to networking API group

### DIFF
--- a/test/e2e/testing-manifests/ingress/gce/static-ip-2/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/gce/static-ip-2/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: static-ip

--- a/test/e2e/testing-manifests/ingress/http/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: echomap

--- a/test/e2e/testing-manifests/ingress/http2/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/http2/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: echomap

--- a/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/multiple-certs/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: multiple-certs

--- a/test/e2e/testing-manifests/ingress/neg-clusterip/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-clusterip/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hostname

--- a/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg-exposed/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hostname

--- a/test/e2e/testing-manifests/ingress/neg/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/neg/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hostname

--- a/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/pre-shared-cert/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: pre-shared-cert

--- a/test/e2e/testing-manifests/ingress/static-ip/ing.yaml
+++ b/test/e2e/testing-manifests/ingress/static-ip/ing.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: static-ip


### PR DESCRIPTION
Fix #90451

```release-note
NONE
```