### PR TITLE
Restore cache-control header filter

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/server/config.go
+++ b/staging/src/k8s.io/apiserver/pkg/server/config.go
@@ -678,6 +678,7 @@ func DefaultBuildHandlerChain(apiHandler http.Handler, c *Config) http.Handler {
 		handler = genericfilters.WithProbabilisticGoaway(handler, c.GoawayChance)
 	}
 	handler = genericapifilters.WithAuditAnnotations(handler, c.AuditBackend, c.AuditPolicyChecker)
+	handler = genericapifilters.WithCacheControl(handler)
 	handler = genericfilters.WithPanicRecovery(handler)
 	return handler
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/kind regression

**What this PR does / why we need it**:
Restores cache-control headers dropped in https://github.com/kubernetes/kubernetes/commit/f14f4c933ee01d219ffbfa846875171e179019b7#diff-c15d69437252be511f1f5e1d9affbaafL616 in 1.17

**Does this PR introduce a user-facing change?**:
```release-note
Fixes a regression in 1.17 that dropped cache-control headers on API requests
```

/sig api-machinery
/cc @deads2k 