### PR TITLE
Topology spreading scoring with automatically weighted topologies

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring.go
@@ -39,6 +39,10 @@ type preScoreState struct {
 	IgnoredNodes sets.String
 	// TopologyPairToPodCounts is keyed with topologyPair, and valued with the number of matching pods.
 	TopologyPairToPodCounts map[topologyPair]*int64
+	// TopologyNormalizingWeight is the weight we give to the counts per topology.
+	// This allows the pod counts of smaller topologies to not be watered down by
+	// bigger ones.
+	TopologyNormalizingWeight []float64
 }
 
 // Clone implements the mandatory Clone interface. We don't really copy the data since
@@ -51,6 +55,7 @@ func (s *preScoreState) Clone() framework.StateData {
 // don't have required topologyKey(s), and initialize:
 // 1) s.TopologyPairToPodCounts: keyed with both eligible topology pair and node names.
 // 2) s.IgnoredNodes: the set of nodes that shouldn't be scored.
+// 3) s.TopologyNormalizingWeight: The weight to be given to each constraint based on the number of values in a topology.
 func (pl *PodTopologySpread) initPreScoreState(s *preScoreState, pod *v1.Pod, filteredNodes []*v1.Node) error {
 	var err error
 	if len(pod.Spec.TopologySpreadConstraints) > 0 {
@@ -67,6 +72,7 @@ func (pl *PodTopologySpread) initPreScoreState(s *preScoreState, pod *v1.Pod, fi
 	if len(s.Constraints) == 0 {
 		return nil
 	}
+	topoSize := make([]int, len(s.Constraints))
 	for _, node := range filteredNodes {
 		if !nodeLabelsMatchSpreadConstraints(node.Labels, s.Constraints) {
 			// Nodes which don't have all required topologyKeys present are ignored
@@ -74,7 +80,7 @@ func (pl *PodTopologySpread) initPreScoreState(s *preScoreState, pod *v1.Pod, fi
 			s.IgnoredNodes.Insert(node.Name)
 			continue
 		}
-		for _, constraint := range s.Constraints {
+		for i, constraint := range s.Constraints {
 			// per-node counts are calculated during Score.
 			if constraint.TopologyKey == v1.LabelHostname {
 				continue
@@ -82,8 +88,18 @@ func (pl *PodTopologySpread) initPreScoreState(s *preScoreState, pod *v1.Pod, fi
 			pair := topologyPair{key: constraint.TopologyKey, value: node.Labels[constraint.TopologyKey]}
 			if s.TopologyPairToPodCounts[pair] == nil {
 				s.TopologyPairToPodCounts[pair] = new(int64)
+				topoSize[i]++
 			}
 		}
+	}
+
+	s.TopologyNormalizingWeight = make([]float64, len(s.Constraints))
+	for i, c := range s.Constraints {
+		sz := topoSize[i]
+		if c.TopologyKey == v1.LabelHostname {
+			sz = len(filteredNodes) - len(s.IgnoredNodes)
+		}
+		s.TopologyNormalizingWeight[i] = topologyNormalizingWeight(sz)
 	}
 	return nil
 }
@@ -174,20 +190,20 @@ func (pl *PodTopologySpread) Score(ctx context.Context, cycleState *framework.Cy
 
 	// For each present <pair>, current node gets a credit of <matchSum>.
 	// And we sum up <matchSum> and return it as this node's score.
-	var score int64
-	for _, c := range s.Constraints {
+	var score float64
+	for i, c := range s.Constraints {
 		if tpVal, ok := node.Labels[c.TopologyKey]; ok {
+			var cnt int64
 			if c.TopologyKey == v1.LabelHostname {
-				count := countPodsMatchSelector(nodeInfo.Pods, c.Selector, pod.Namespace)
-				score += int64(count)
+				cnt = int64(countPodsMatchSelector(nodeInfo.Pods, c.Selector, pod.Namespace))
 			} else {
 				pair := topologyPair{key: c.TopologyKey, value: tpVal}
-				matchSum := *s.TopologyPairToPodCounts[pair]
-				score += matchSum
+				cnt = *s.TopologyPairToPodCounts[pair]
 			}
+			score += float64(cnt) * s.TopologyNormalizingWeight[i]
 		}
 	}
-	return score, nil
+	return int64(score), nil
 }
 
 // NormalizeScore invoked after scoring all nodes.
@@ -200,21 +216,22 @@ func (pl *PodTopologySpread) NormalizeScore(ctx context.Context, cycleState *fra
 		return nil
 	}
 
-	// Calculate the summed <total> score and <minScore>.
+	// Calculate <minScore> and <maxScore>
 	var minScore int64 = math.MaxInt64
-	var total int64
+	var maxScore int64
 	for _, score := range scores {
 		// it's mandatory to check if <score.Name> is present in m.IgnoredNodes
 		if s.IgnoredNodes.Has(score.Name) {
 			continue
 		}
-		total += score.Score
 		if score.Score < minScore {
 			minScore = score.Score
 		}
+		if score.Score > maxScore {
+			maxScore = score.Score
+		}
 	}
 
-	maxMinDiff := total - minScore
 	for i := range scores {
 		nodeInfo, err := pl.sharedLister.NodeInfos().Get(scores[i].Name)
 		if err != nil {
@@ -222,19 +239,18 @@ func (pl *PodTopologySpread) NormalizeScore(ctx context.Context, cycleState *fra
 		}
 		node := nodeInfo.Node()
 
-		if maxMinDiff == 0 {
-			scores[i].Score = framework.MaxNodeScore
-			continue
-		}
-
 		if s.IgnoredNodes.Has(node.Name) {
 			scores[i].Score = 0
 			continue
 		}
 
-		flippedScore := total - scores[i].Score
-		fScore := float64(framework.MaxNodeScore) * (float64(flippedScore) / float64(maxMinDiff))
-		scores[i].Score = int64(fScore)
+		if maxScore == 0 {
+			scores[i].Score = framework.MaxNodeScore
+			continue
+		}
+
+		s := scores[i].Score
+		scores[i].Score = framework.MaxNodeScore * (maxScore + minScore - s) / maxScore
 	}
 	return nil
 }
@@ -255,4 +271,17 @@ func getPreScoreState(cycleState *framework.CycleState) (*preScoreState, error) 
 		return nil, fmt.Errorf("%+v  convert to podtopologyspread.preScoreState error", c)
 	}
 	return s, nil
+}
+
+// topologyNormalizingWeight calculates the weight for the topology, based on
+// the number of values that exist for a topology.
+// Since <size> is at least 1 (all nodes that passed the Filters are in the
+// same topology), and k8s supports 5k nodes, the result is in the interval
+// <1.09, 8.52>.
+//
+// Note: <size> could also be zero when no nodes have the required topologies,
+// however we don't care about topology weight in this case as we return a 0
+// score for all nodes.
+func topologyNormalizingWeight(size int) float64 {
+	return math.Log(float64(size + 2))
 }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

New scoring function that gives better differentiation among nodes and zones. The change can be simplified as:

- New normalization: use max score instead of sum of scores. The latter was watering score differences.
- Weights per topology: These are based in the logarithm of the cardinality of the topology. This is because bigger topologies (such as zones) will have more matching pods than smaller topologies. Thus, without the logarithmic weight, bigger topologies were dominating score differences alone.

Some examples using 2 topologies follow.

### Small deployment in 2 zones

```
         pods          |       new pod spreading & max_dif    |  old pod spreading & max_dif         |      default spreading & max_dif
[[3, 2, 1], [1, 1, 1]] | [[44, 55, 66], [100, 100, 100]] & 56 | [[84, 87, 90], [100, 100, 100]] & 16 | [[0, 11, 22], [55, 55, 55]] & 55
[[3, 2, 1], [2, 2, 2]] | [[77, 88, 100], [88, 88, 88]]   & 23 | [[95, 97, 100], [97, 97, 97]]   &  5 | [[0, 11, 22], [11, 11, 11]] & 22
[[3, 2, 1], [3, 3, 3]] | [[83, 91, 100], [58, 58, 58]]   & 42 | [[96, 98, 100], [90, 90, 90]]   & 10 | [[22, 33, 44], [0, 0, 0]]   & 44

[[8, 4, 1], [1, 1, 1]] | [[19, 38, 52], [100, 100, 100]] & 81 | [[71, 78, 83], [100, 100, 100]] & 29 | [[0, 16, 29], [80, 80, 80]] & 80
[[8, 4, 1], [2, 2, 2]] | [[38, 57, 71], [100, 100, 100]] & 62 | [[80, 86, 91], [100, 100, 100]] & 20 | [[0, 16, 29], [60, 60, 60]] & 60
[[8, 4, 1], [4, 4, 4]] | [[66, 85, 100], [90, 90, 90]]   & 34 | [[91, 96, 100], [97, 97, 97]]   &  9 | [[0, 16, 29], [21, 21, 21]] & 29
[[8, 4, 1], [5, 5, 5]] | [[66, 85, 100], [71, 71, 71]]   & 34 | [[92, 96, 100], [93, 93, 93]]   &  8 | [[8, 25, 38], [12, 12, 12]] & 30
```

Note that the new scores provide higher differentiation than the old score or DefaultTopologySpreading in all but one case. Note that in this case the overall spreading among nodes was well balanced.

### Medium size deployment in 3 zones

```
Distribution: [[9, 8, 7, 6, 5, 4, 3, 2, 1], [1, 2, 1, 2, 1, 2, 1, 2, 1], [2, 2, 2, 2, 2, 2, 2, 2, 2]]
Zone distribution: 45, 13, 18
New spreading: [[22, 26, 30, 34, 38, 43, 47, 51, 55], [100, 95, 100, 95, 100, 95, 100, 95, 100], [88, 88, 88, 88, 88, 88, 88, 88, 88]] & 78
Old spreading: [[94, 94, 94, 95, 95, 95, 95, 95, 95], [100, 99, 100, 99, 100, 99, 100, 99, 100], [99, 99, 99, 99, 99, 99, 99, 99, 99]] &  6
Def spreading: [[0, 3, 7, 11, 14, 18, 22, 25, 29], [77, 73, 77, 73, 77, 73, 77, 73, 77], [65, 65, 65, 65, 65, 65, 65, 65, 65]]         & 77

Distribution: [[9, 8, 7, 6, 5, 4, 3, 2, 1], [2, 4, 2, 4, 2, 4, 2, 4, 2], [4, 4, 4, 4, 4, 4, 4, 4, 4]]
Zone distribution: 45, 26, 36
New spreading: [[44, 48, 52, 56, 61, 65, 69, 73, 77], [100, 91, 100, 91, 100, 91, 100, 91, 100], [77, 77, 77, 77, 77, 77, 77, 77, 77]] & 56
Old spreading: [[97, 97, 97, 97, 97, 97, 98, 98, 98], [100, 99, 100, 99, 100, 99, 100, 99, 100], [98, 98, 98, 98, 98, 98, 98, 98, 98]] &  3
Def spreading: [[0, 3, 7, 11, 14, 18, 22, 25, 29], [54, 46, 54, 46, 54, 46, 54, 46, 54], [31, 31, 31, 31, 31, 31, 31, 31, 31]]         & 54

Distribution: [[9, 8, 7, 6, 5, 4, 3, 2, 1], [3, 6, 3, 6, 3, 6, 3, 6, 3], [6, 6, 6, 6, 6, 6, 6, 6, 6]]
Zone distribution: 45, 39, 54
New spreading: [[66, 70, 75, 79, 83, 87, 91, 95, 100], [100, 87, 100, 87, 100, 87, 100, 87, 100], [66, 66, 66, 66, 66, 66, 66, 66, 66]] & 34
Old spreading: [[99, 99, 99, 99, 99, 99, 99, 99, 99], [100, 99, 100, 99, 100, 99, 100, 99, 100], [98, 98, 98, 98, 98, 98, 98, 98, 98]]  &  2
Def spreading: [[11, 14, 18, 22, 25, 29, 33, 37, 40], [40, 29, 40, 29, 40, 29, 40, 29, 40], [11, 11, 11, 11, 11, 11, 11, 11, 11]]       & 29
```

The new scoring was better in all the cases.

### Comparing with other scores

It is useful to compare the scores provided for spreading with others, such as LeastAllocatedResources. To do this, we run some simulations in which a cluster has a given load and a new Deployment is deployed.
Here we assume that each pod weighs 1% of the node capacity. In all scenarios we try to deploy 20 pods. The nodes with an initial load of zero intent to simulate recently created nodes.

```
   initial load            |   new spreading        | default spreading
[[10, 10, 0], [5, 10, 0]]  | [[3, 3, 4], [3, 3, 4]] | [[3, 3, 4], [3, 3, 4]]
[[20, 20, 0], [10, 20, 0]] | [[3, 2, 5], [3, 2, 5]] | [[3, 2, 5], [3, 2, 5]]
[[40, 40, 0], [20, 40, 0]] | [[2, 1, 7], [3, 1, 6]] | [[1, 1, 8], [3, 0, 7]]
[[80, 80, 0], [40, 80, 0]] | [[0, 0, 9], [2, 0, 9]] | [[0, 0, 10], [1, 0, 9]]
```

Note that zone spreading is equal in the first 3 cases, but the new score offer slightly better node spreading. In the last example, default spreading provided better zone spreading.

**Which issue(s) this PR fixes**:

Ref #90308

**Special notes for your reviewer**:

Builds on #90527 

Performance difference is negligible

```
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread
BenchmarkTestDefaultEvenPodsSpreadPriority/100nodes-56         	    5097	    254656 ns/op
BenchmarkTestDefaultEvenPodsSpreadPriority/1000nodes-56        	     787	   1395052 ns/op
```

**Does this PR introduce a user-facing change?**:

```release-note
New scoring for PodTopologySpreading that yields better spreading
```