### PR TITLE
Automated cherry pick of #90425: fix: ACR auth fails in private azure clouds

### DIFF
--- a/pkg/credentialprovider/azure/BUILD
+++ b/pkg/credentialprovider/azure/BUILD
@@ -32,6 +32,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//vendor/github.com/Azure/azure-sdk-for-go/services/containerregistry/mgmt/2019-05-01/containerregistry:go_default_library",
+        "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
     ],
 )


### PR DESCRIPTION
Cherry pick of #90425 on release-1.18.

#90425: fix: ACR auth fails in private azure clouds