### PR TITLE
Fix extra security group removal from AWS load balancers

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go
@@ -4267,7 +4267,7 @@ func (c *Cloud) updateInstanceSecurityGroupsForLoadBalancer(lb *elb.LoadBalancer
 }
 
 // Returns a list of all the extra security groups as annotated in the service definition
-func (c* Cloud) collectExtraSecurityGroupsForService(service *v1.Service) []string {
+func (c *Cloud) collectExtraSecurityGroupsForService(service *v1.Service) []string {
 	extraSgList := []string{}
 
 	for _, extraSG := range strings.Split(service.ObjectMeta.Annotations[ServiceAnnotationLoadBalancerExtraSecurityGroups], ",") {
@@ -4281,7 +4281,7 @@ func (c* Cloud) collectExtraSecurityGroupsForService(service *v1.Service) []stri
 }
 
 // Checks whether a given security group is inside the extra security group annotation of a service definition
-func (c* Cloud) checkSecurityGroupMatchesServiceExtraSg(service *v1.Service, securityGroup *string) bool {
+func (c *Cloud) checkSecurityGroupMatchesServiceExtraSg(service *v1.Service, securityGroup *string) bool {
 	for _, extraSg := range c.collectExtraSecurityGroupsForService(service) {
 		if extraSg == *securityGroup {
 			return true


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a bug in the AWS provider when happened when extra security groups are added via annotations. When deleting a load balancer, the current behaviour gets the last security group retrieved as part of the describe load balancer API request to AWS. If the load balancer has an extra security group added via the annotations, the code would remove this load balancer, leading to unexpected behaviour.

This PR adds an extra check to this procedure to ensure we are not touching any extra security group that was added to the load balancer via the annotation.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/84926

**Special notes for your reviewer**:

Added a test case which mocks a few extra calls to the API for the expected return. Only added the test case for the bug: a load balancer which has 2 security groups and one of them is referenced via the annotation. In this case case, only the non-extra security group (the one created automatically) will be removed.

**Does this PR introduce a user-facing change?**:

```
NONE
```

```release-note
fixes bug in AWS cloud provider when removing a load balancer with an extra security group
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
