### PR TITLE
Fix race in apiserver_test

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -2104,7 +2104,7 @@ func TestWatchTable(t *testing.T) {
 
 	s := metainternalversionscheme.Codecs.SupportedMediaTypes()[0].Serializer
 
-	type apiTest struct {
+	tests := []struct {
 		accept string
 		params url.Values
 		send   func(w *watch.FakeWatcher)
@@ -2113,9 +2113,7 @@ func TestWatchTable(t *testing.T) {
 		contentType string
 		statusCode  int
 		item        bool
-	}
-
-	tests := []apiTest {
+	}{
 		{
 			accept:     "application/json;as=Table;v=v1alpha1;g=meta.k8s.io",
 			statusCode: http.StatusNotAcceptable,
@@ -2220,6 +2218,7 @@ func TestWatchTable(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
+		test := test
 		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
 			storage := map[string]rest.Storage{}
 			simpleStorage := SimpleRESTStorage{
@@ -2284,10 +2283,10 @@ func TestWatchTable(t *testing.T) {
 				t.Fatalf("%d: unexpected response: %#v", i, resp)
 			}
 
-			go func(test apiTest) {
+			go func() {
 				defer simpleStorage.fakeWatch.Stop()
 				test.send(simpleStorage.fakeWatch)
-			}(test)
+			}()
 
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -2104,7 +2104,7 @@ func TestWatchTable(t *testing.T) {
 
 	s := metainternalversionscheme.Codecs.SupportedMediaTypes()[0].Serializer
 
-	type _test_ struct {
+	type apiTest struct {
 		accept string
 		params url.Values
 		send   func(w *watch.FakeWatcher)
@@ -2115,7 +2115,7 @@ func TestWatchTable(t *testing.T) {
 		item        bool
 	}
 
-	tests := []_test_ {
+	tests := []apiTest {
 		{
 			accept:     "application/json;as=Table;v=v1alpha1;g=meta.k8s.io",
 			statusCode: http.StatusNotAcceptable,
@@ -2284,7 +2284,7 @@ func TestWatchTable(t *testing.T) {
 				t.Fatalf("%d: unexpected response: %#v", i, resp)
 			}
 
-			go func(test _test_) {
+			go func(test apiTest) {
 				defer simpleStorage.fakeWatch.Stop()
 				test.send(simpleStorage.fakeWatch)
 			}(test)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/apiserver_test.go
@@ -2104,7 +2104,7 @@ func TestWatchTable(t *testing.T) {
 
 	s := metainternalversionscheme.Codecs.SupportedMediaTypes()[0].Serializer
 
-	tests := []struct {
+	type _test_ struct {
 		accept string
 		params url.Values
 		send   func(w *watch.FakeWatcher)
@@ -2113,7 +2113,9 @@ func TestWatchTable(t *testing.T) {
 		contentType string
 		statusCode  int
 		item        bool
-	}{
+	}
+
+	tests := []_test_ {
 		{
 			accept:     "application/json;as=Table;v=v1alpha1;g=meta.k8s.io",
 			statusCode: http.StatusNotAcceptable,
@@ -2282,10 +2284,10 @@ func TestWatchTable(t *testing.T) {
 				t.Fatalf("%d: unexpected response: %#v", i, resp)
 			}
 
-			go func() {
+			go func(test _test_) {
 				defer simpleStorage.fakeWatch.Stop()
 				test.send(simpleStorage.fakeWatch)
-			}()
+			}(test)
 
 			body, err := ioutil.ReadAll(resp.Body)
 			if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
/kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When a go loop launches goroutines, it is a common mistake to assume
that the routines can reference the loop value from their specific loop
iteration. Actually, all goroutines share the same reference to the loop
veriable, and they typically all see the last value. To correct this, the loop variable must be captured as a parameter to the anonymous func.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
N/A
**Special notes for your reviewer**:
N/A
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
