### PR TITLE
Fix race condition in decoder test

### DIFF
--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -48,10 +48,9 @@ func TestDecoder(t *testing.T) {
 		out, in := io.Pipe()
 
 		decoder := restclientwatch.NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
-		eventType := eventType
 		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		encoder := json.NewEncoder(in)
-		go func() {
+		go func(eventType interface{}) {
 			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)
@@ -64,10 +63,10 @@ func TestDecoder(t *testing.T) {
 				t.Errorf("Unexpected error %v", err)
 			}
 			in.Close()
-		}()
+		}(eventType)
 
 		done := make(chan struct{})
-		go func() {
+		go func(eventType interface{}) {
 			action, got, err := decoder.Decode()
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)
@@ -80,7 +79,7 @@ func TestDecoder(t *testing.T) {
 			}
 			t.Logf("Exited read")
 			close(done)
-		}()
+		}(eventType)
 		<-done
 
 		done = make(chan struct{})

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -48,7 +48,7 @@ func TestDecoder(t *testing.T) {
 		out, in := io.Pipe()
 
 		decoder := restclientwatch.NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
-
+		eventType := eventType
 		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		encoder := json.NewEncoder(in)
 		go func() {

--- a/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
+++ b/staging/src/k8s.io/client-go/rest/watch/decoder_test.go
@@ -50,28 +50,29 @@ func TestDecoder(t *testing.T) {
 		decoder := restclientwatch.NewDecoder(streaming.NewDecoder(out, getDecoder()), getDecoder())
 		expect := &v1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}
 		encoder := json.NewEncoder(in)
-		go func(eventType interface{}) {
+		eType := eventType
+		go func() {
 			data, err := runtime.Encode(scheme.Codecs.LegacyCodec(v1.SchemeGroupVersion), expect)
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)
 			}
 			event := metav1.WatchEvent{
-				Type:   string(eventType),
+				Type:   string(eType),
 				Object: runtime.RawExtension{Raw: json.RawMessage(data)},
 			}
 			if err := encoder.Encode(&event); err != nil {
 				t.Errorf("Unexpected error %v", err)
 			}
 			in.Close()
-		}(eventType)
+		}()
 
 		done := make(chan struct{})
-		go func(eventType interface{}) {
+		go func() {
 			action, got, err := decoder.Decode()
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)
 			}
-			if e, a := eventType, action; e != a {
+			if e, a := eType, action; e != a {
 				t.Errorf("Expected %v, got %v", e, a)
 			}
 			if e, a := expect, got; !apiequality.Semantic.DeepDerivative(e, a) {
@@ -79,7 +80,7 @@ func TestDecoder(t *testing.T) {
 			}
 			t.Logf("Exited read")
 			close(done)
-		}(eventType)
+		}()
 		<-done
 
 		done = make(chan struct{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
/kind bug
/kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
When a go loop launches goroutines, it is a common mistake to assume
that the routines can reference the loop value from their specific loop
iteration. Actually, all goroutines share the same reference to the loop
veriable, and they typically all see the last value. To correct this, the loop variable must be captured as a parameter to the anonymous func.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
N/A
**Special notes for your reviewer**:
N/A
**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
NONE
```
