### PR TITLE
Fix kubectl create --dryrun client ignore namespace

### DIFF
--- a/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
+++ b/staging/src/k8s.io/cli-runtime/pkg/genericclioptions/config_flags_fake.go
@@ -96,7 +96,7 @@ type namespacedClientConfig struct {
 }
 
 func (c *namespacedClientConfig) Namespace() (string, bool, error) {
-	return c.namespace, false, nil
+	return c.namespace, len(c.namespace) > 0, nil
 }
 
 func (c *namespacedClientConfig) RawConfig() (clientcmdapi.Config, error) {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -58,12 +58,13 @@ type CreateCronJobOptions struct {
 	Command  []string
 	Restart  string
 
-	Namespace      string
-	Client         batchv1beta1client.BatchV1beta1Interface
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.DryRunVerifier
-	Builder        *resource.Builder
-	FieldManager   string
+	Namespace        string
+	EnforceNamespace bool
+	Client           batchv1beta1client.BatchV1beta1Interface
+	DryRunStrategy   cmdutil.DryRunStrategy
+	DryRunVerifier   *resource.DryRunVerifier
+	Builder          *resource.Builder
+	FieldManager     string
 
 	genericclioptions.IOStreams
 }
@@ -126,7 +127,7 @@ func (o *CreateCronJobOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, a
 		return err
 	}
 
-	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
@@ -193,7 +194,7 @@ func (o *CreateCronJobOptions) Run() error {
 }
 
 func (o *CreateCronJobOptions) createCronJob() *batchv1beta1.CronJob {
-	return &batchv1beta1.CronJob{
+	cronjob := &batchv1beta1.CronJob{
 		TypeMeta: metav1.TypeMeta{APIVersion: batchv1beta1.SchemeGroupVersion.String(), Kind: "CronJob"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: o.Name,
@@ -221,4 +222,8 @@ func (o *CreateCronJobOptions) createCronJob() *batchv1beta1.CronJob {
 			},
 		},
 	}
+	if o.EnforceNamespace {
+		cronjob.Namespace = o.Namespace
+	}
+	return cronjob
 }

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role.go
@@ -127,14 +127,15 @@ type CreateRoleOptions struct {
 	Resources     []ResourceOptions
 	ResourceNames []string
 
-	DryRunStrategy cmdutil.DryRunStrategy
-	DryRunVerifier *resource.DryRunVerifier
-	OutputFormat   string
-	Namespace      string
-	Client         clientgorbacv1.RbacV1Interface
-	Mapper         meta.RESTMapper
-	PrintObj       func(obj runtime.Object) error
-	FieldManager   string
+	DryRunStrategy   cmdutil.DryRunStrategy
+	DryRunVerifier   *resource.DryRunVerifier
+	OutputFormat     string
+	Namespace        string
+	EnforceNamespace bool
+	Client           clientgorbacv1.RbacV1Interface
+	Mapper           meta.RESTMapper
+	PrintObj         func(obj runtime.Object) error
+	FieldManager     string
 
 	genericclioptions.IOStreams
 }
@@ -263,7 +264,7 @@ func (o *CreateRoleOptions) Complete(f cmdutil.Factory, cmd *cobra.Command, args
 		return printer.PrintObj(obj, o.Out)
 	}
 
-	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	o.Namespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return err
 	}
@@ -352,6 +353,9 @@ func (o *CreateRoleOptions) RunCreateRole() error {
 		return err
 	}
 	role.Rules = rules
+	if o.EnforceNamespace {
+		role.Namespace = o.Namespace
+	}
 
 	// Create role.
 	if o.DryRunStrategy != cmdutil.DryRunClient {

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_role_test.go
@@ -33,8 +33,8 @@ import (
 
 func TestCreateRole(t *testing.T) {
 	roleName := "my-role"
-
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	testNameSpace := "test"
+	tf := cmdtesting.NewTestFactory().WithNamespace(testNameSpace)
 	defer tf.Cleanup()
 
 	tf.Client = &fake.RESTClient{}
@@ -52,7 +52,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: testNameSpace,
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -70,7 +71,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: testNameSpace,
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -88,7 +90,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: testNameSpace,
 				},
 				Rules: []rbac.PolicyRule{
 					{
@@ -106,7 +109,8 @@ func TestCreateRole(t *testing.T) {
 			expectedRole: &rbac.Role{
 				TypeMeta: v1.TypeMeta{APIVersion: "rbac.authorization.k8s.io/v1", Kind: "Role"},
 				ObjectMeta: v1.ObjectMeta{
-					Name: roleName,
+					Name:      roleName,
+					Namespace: testNameSpace,
 				},
 				Rules: []rbac.PolicyRule{
 					{

--- a/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/set/set_env_test.go
@@ -79,7 +79,7 @@ func TestSetEnvLocal(t *testing.T) {
 }
 
 func TestSetEnvLocalNamespace(t *testing.T) {
-	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	tf := cmdtesting.NewTestFactory()
 	defer tf.Cleanup()
 
 	tf.Client = &fake.RESTClient{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Like https://github.com/kubernetes/kubectl/issues/705 describes, it ignores the namespaces.

In most `kubectl create` uses `CreateSubcommandOptions.Run()` which will not have this kind of problem. Only `kubectl create role/job/cronjob` need the fix.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #https://github.com/kubernetes/kubectl/issues/705

**Special notes for your reviewer**:
/cc @brianpursley 
/cc @soltysh 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Fix kubectl create --dryrun client ignore namespace
```
