### PR TITLE
Fix GetClockSpeed error when dealing with upper case

### DIFF
--- a/vendor/github.com/google/cadvisor/machine/machine.go
+++ b/vendor/github.com/google/cadvisor/machine/machine.go
@@ -44,7 +44,7 @@ var (
 	nodeRegExp    = regexp.MustCompile(`(?m)^physical id\s*:\s*([0-9]+)$`)
 	nodeBusRegExp = regexp.MustCompile(`^node([0-9]+)$`)
 	// Power systems have a different format so cater for both
-	cpuClockSpeedMHz     = regexp.MustCompile(`(?:cpu MHz|clock)\s*:\s*([0-9]+\.[0-9]+)(?:MHz)?`)
+	cpuClockSpeedMHz     = regexp.MustCompile(`(?i)(?:cpu MHz|clock)\s*:\s*([0-9]+\.[0-9]+)(?:MHz)?`)
 	memoryCapacityRegexp = regexp.MustCompile(`MemTotal:\s*([0-9]+) kB`)
 	swapCapacityRegexp   = regexp.MustCompile(`SwapTotal:\s*([0-9]+) kB`)
 


### PR DESCRIPTION
Signed-off-by: sayaoailun <guojianwei007@126.com>

**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fix bug:

GetClockSpeed use Regular Expression `(?:cpu MHz|clock)\s*:\s*([0-9]+\.[0-9]+)(?:MHz)?` to get ClockSpeed.

When I start the Kubelet, I met this error:

```
failed to run Kubelet: could not detect clock speed from output: "system type       : generic-loongson-machine
machine         : loongson,generic
processor       : 0
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12730.64
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 0
core            : 0
VCED exceptions     : not available
VCEI exceptions     : not available

processor       : 1
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12711.24
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 0
core            : 1
VCED exceptions     : not available
VCEI exceptions     : not available

processor       : 2
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12730.64
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 0
core            : 2
VCED exceptions     : not available
VCEI exceptions     : not available

processor       : 3
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12730.64
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 0
core            : 3
VCED exceptions     : not available
VCEI exceptions     : not available

processor       : 4
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12730.64
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 1
core            : 0
VCED exceptions     : not available
VCEI exceptions     : not available

processor       : 5
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12730.64
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 1
core            : 1
VCED exceptions     : not available
VCEI exceptions     : not available

processor       : 6
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12730.64
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 1
core            : 2
VCED exceptions     : not available
VCEI exceptions     : not available

processor       : 7
cpu model       : ICT Loongson-3 V0.4  FPU V0.1
model name      : Loongson-3A R4 (Loongson-3B4000)
CPU MHz         : 1800.00
BogoMIPS        : 12730.64
wait instruction    : yes
microsecond timers  : yes
tlb_entries     : 2112
extra interrupt vector  : yes
hardware watchpoint : yes, count: 0, address/irw mask: []
isa         : mips1 mips2 mips3 mips4 mips5 mips32r1 mips32r2 mips64r1 mips64r2
ASEs implemented    : vz msa
Loongson Features   : csr lasx lamo cam vz gft lft msi256 extioi csripi
shadow register sets    : 1
kscratch registers  : 6
package         : 1
core            : 3
VCED exceptions     : not available
VCEI exceptions     : not available

"
```

I checked the code, and found the reason. So I made this change to fix the bug

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
