### PR TITLE
fix flaky conformance test

### DIFF
--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -28,7 +28,9 @@ import (
 
 	"github.com/go-openapi/spec"
 	"github.com/onsi/ginkgo"
+	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/yaml"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -39,10 +41,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	k8sclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	openapiutil "k8s.io/kube-openapi/pkg/util"
 	"k8s.io/kubernetes/test/e2e/framework"
 	"k8s.io/kubernetes/test/utils/crd"
-	"sigs.k8s.io/yaml"
 )
 
 var (
@@ -64,12 +64,6 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 	*/
 	framework.ConformanceIt("works for CRD with validation schema", func() {
 		crd, err := setupCRD(f, schemaFoo, "foo", "v1")
-		if err != nil {
-			framework.Failf("%v", err)
-		}
-
-		customServiceShortName := "ksvc"
-		crdSvc, err := setupCRDWithShortName(f, schemaCustomService, "service", customServiceShortName, "v1alpha1")
 		if err != nil {
 			framework.Failf("%v", err)
 		}
@@ -126,20 +120,12 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("%v", err)
 		}
 
-		ginkgo.By("kubectl explain works for CR with the same resource name as built-in object")
-		if err := verifyKubectlExplain(f.Namespace.Name, customServiceShortName+".spec", `(?s)DESCRIPTION:.*Specification of CustomService.*FIELDS:.*dummy.*<string>.*Dummy property`); err != nil {
-			framework.Failf("%v", err)
-		}
-
 		ginkgo.By("kubectl explain works to return error when explain is called on property that doesn't exist")
 		if _, err := framework.RunKubectl(f.Namespace.Name, "explain", crd.Crd.Spec.Names.Plural+".spec.bars2"); err == nil || !strings.Contains(err.Error(), `field "bars2" does not exist`) {
 			framework.Failf("unexpected no error when explaining property that doesn't exist: %v", err)
 		}
 
 		if err := cleanupCRD(f, crd); err != nil {
-			framework.Failf("%v", err)
-		}
-		if err := cleanupCRD(f, crdSvc); err != nil {
 			framework.Failf("%v", err)
 		}
 	})
@@ -478,6 +464,34 @@ var _ = SIGDescribe("CustomResourcePublishOpenAPI [Privileged:ClusterAdmin]", fu
 			framework.Failf("%v", err)
 		}
 	})
+
+	// Marked as flaky until https://github.com/kubernetes/kubernetes/issues/65517 is solved.
+	ginkgo.It("[Flaky] kubectl explain works for CR with the same resource name as built-in object.", func() {
+		customServiceShortName := fmt.Sprintf("ksvc-%d", time.Now().Unix()) // make short name unique
+		opt := func(crd *apiextensionsv1.CustomResourceDefinition) {
+			crd.ObjectMeta = metav1.ObjectMeta{Name: "services." + crd.Spec.Group}
+			crd.Spec.Names = apiextensionsv1.CustomResourceDefinitionNames{
+				Plural:     "services",
+				Singular:   "service",
+				ListKind:   "ServiceList",
+				Kind:       "Service",
+				ShortNames: []string{customServiceShortName},
+			}
+		}
+		crdSvc, err := setupCRDAndVerifySchemaWithOptions(f, schemaCustomService, schemaCustomService, "service", []string{"v1"}, opt)
+		if err != nil {
+			framework.Failf("%v", err)
+		}
+
+		if err := verifyKubectlExplain(f.Namespace.Name, customServiceShortName+".spec", `(?s)DESCRIPTION:.*Specification of CustomService.*FIELDS:.*dummy.*<string>.*Dummy property`); err != nil {
+			_ = cleanupCRD(f, crdSvc) // need to remove the crd since its name is unchanged
+			framework.Failf("%v", err)
+		}
+
+		if err := cleanupCRD(f, crdSvc); err != nil {
+			framework.Failf("%v", err)
+		}
+	})
 })
 
 func setupCRD(f *framework.Framework, schema []byte, groupSuffix string, versions ...string) (*crd.TestCrd, error) {
@@ -488,19 +502,6 @@ func setupCRD(f *framework.Framework, schema []byte, groupSuffix string, version
 		expect = []byte(`type: object`)
 	}
 	return setupCRDAndVerifySchema(f, schema, expect, groupSuffix, versions...)
-}
-
-func setupCRDWithShortName(f *framework.Framework, schema []byte, groupSuffix, shortName string, versions ...string) (*crd.TestCrd, error) {
-	expect := schema
-	if schema == nil {
-		// to be backwards compatible, we expect CRD controller to treat
-		// CRD with nil schema specially and publish an empty schema
-		expect = []byte(`type: object`)
-	}
-	setShortName := func(crd *apiextensionsv1.CustomResourceDefinition) {
-		crd.Spec.Names.ShortNames = []string{shortName}
-	}
-	return setupCRDAndVerifySchemaWithOptions(f, schema, expect, groupSuffix, versions, setShortName)
 }
 
 func setupCRDAndVerifySchema(f *framework.Framework, schema, expect []byte, groupSuffix string, versions ...string) (*crd.TestCrd, error) {


### PR DESCRIPTION
**What type of PR is this?**

/kind flake

**What this PR does / why we need it**:
Correct the flaky conformance test about `kubectl explain`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #90506 

**Special notes for your reviewer**:
Not sure where to place the non-conformace test, so I decided to simply remove it.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
