### PR TITLE
Add new kubectl create pod sub-command

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create.go
@@ -149,6 +149,7 @@ func NewCmdCreate(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cob
 	cmd.AddCommand(NewCmdCreatePriorityClass(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateJob(f, ioStreams))
 	cmd.AddCommand(NewCmdCreateCronJob(f, ioStreams))
+	cmd.AddCommand(NewCmdCreatePod(f, ioStreams))
 	return cmd
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment.go
@@ -85,8 +85,8 @@ func generatorFromName(
 	case generateversioned.DeploymentBasicAppsV1GeneratorName:
 		generator := &generateversioned.DeploymentBasicAppsGeneratorV1{
 			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
-				Name:   deploymentName,
-				Images: imageNames,
+				Name:    deploymentName,
+				PodSpec: generateversioned.PodSpec{Images: imageNames},
 			},
 		}
 		return generator, true
@@ -94,8 +94,8 @@ func generatorFromName(
 	case generateversioned.DeploymentBasicAppsV1Beta1GeneratorName:
 		generator := &generateversioned.DeploymentBasicAppsGeneratorV1Beta1{
 			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
-				Name:   deploymentName,
-				Images: imageNames,
+				Name:    deploymentName,
+				PodSpec: generateversioned.PodSpec{Images: imageNames},
 			},
 		}
 		return generator, true
@@ -103,8 +103,8 @@ func generatorFromName(
 	case generateversioned.DeploymentBasicV1Beta1GeneratorName:
 		generator := &generateversioned.DeploymentBasicGeneratorV1{
 			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
-				Name:   deploymentName,
-				Images: imageNames,
+				Name:    deploymentName,
+				PodSpec: generateversioned.PodSpec{Images: imageNames},
 			},
 		}
 		return generator, true

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_deployment_test.go
@@ -53,8 +53,8 @@ func Test_generatorFromName(t *testing.T) {
 	{
 		expectedGenerator := &generateversioned.DeploymentBasicGeneratorV1{
 			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
-				Name:   deploymentName,
-				Images: imageNames,
+				Name:    deploymentName,
+				PodSpec: generateversioned.PodSpec{Images: imageNames},
 			},
 		}
 		assert.Equal(t, expectedGenerator, generator)
@@ -66,8 +66,8 @@ func Test_generatorFromName(t *testing.T) {
 	{
 		expectedGenerator := &generateversioned.DeploymentBasicAppsGeneratorV1Beta1{
 			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
-				Name:   deploymentName,
-				Images: imageNames,
+				Name:    deploymentName,
+				PodSpec: generateversioned.PodSpec{Images: imageNames},
 			},
 		}
 		assert.Equal(t, expectedGenerator, generator)
@@ -79,8 +79,8 @@ func Test_generatorFromName(t *testing.T) {
 	{
 		expectedGenerator := &generateversioned.DeploymentBasicAppsGeneratorV1{
 			BaseDeploymentGenerator: generateversioned.BaseDeploymentGenerator{
-				Name:   deploymentName,
-				Images: imageNames,
+				Name:    deploymentName,
+				PodSpec: generateversioned.PodSpec{Images: imageNames},
 			},
 		}
 		assert.Equal(t, expectedGenerator, generator)

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pod.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pod.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/generate"
+	generateversioned "k8s.io/kubectl/pkg/generate/versioned"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	podLong = templates.LongDesc(i18n.T(`
+	Create a pod with the specified name.`))
+
+	podExample = templates.Examples(i18n.T(`
+	# Create a new pod named my-dep that runs the busybox image.
+	kubectl create pod my-dep --image=busybox`))
+)
+
+// PodOpts is the options for 'create 'pod' sub command
+type PodOpts struct {
+	CreateSubcommandOptions *CreateSubcommandOptions
+}
+
+// NewCmdCreatePod is a macro command to create a new pod.
+// This command is better known to users as `kubectl create pod`.
+// Note that this command overlaps significantly with the `kubectl run` command.
+func NewCmdCreatePod(f cmdutil.Factory, ioStreams genericclioptions.IOStreams) *cobra.Command {
+	options := &PodOpts{
+		CreateSubcommandOptions: NewCreateSubcommandOptions(ioStreams),
+	}
+
+	cmd := &cobra.Command{
+		Use:                   "pod NAME --image=image [--dry-run=server|client|none]",
+		DisableFlagsInUseLine: true,
+		Short:                 i18n.T("Create a pod with the specified name."),
+		Long:                  podLong,
+		Example:               podExample,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(options.Complete(f, cmd, args))
+			cmdutil.CheckErr(options.Run())
+		},
+	}
+
+	options.CreateSubcommandOptions.PrintFlags.AddFlags(cmd)
+
+	cmdutil.AddApplyAnnotationFlags(cmd)
+	cmdutil.AddValidateFlags(cmd)
+	cmdutil.AddGeneratorFlags(cmd, generateversioned.RunPodV1GeneratorName)
+	cmd.Flags().StringSlice("image", []string{}, "Image name to run.")
+	cmd.MarkFlagRequired("image")
+	return cmd
+}
+
+// Complete completes all the required options
+func (o *PodOpts) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	name, err := NameFromCommandArgs(cmd, args)
+	if err != nil {
+		return err
+	}
+
+	imageNames := cmdutil.GetFlagStringSlice(cmd, "image")
+
+	var generator generate.StructuredGenerator
+	switch generatorName := cmdutil.GetFlagString(cmd, "generator"); generatorName {
+	case generateversioned.RunPodV1GeneratorName:
+		generator = &generateversioned.BasicPod{
+			Name:    name,
+			PodSpec: generateversioned.PodSpec{Images: imageNames},
+		}
+	default:
+		return errUnsupportedGenerator(cmd, generatorName)
+	}
+
+	return o.CreateSubcommandOptions.Complete(f, cmd, args, generator)
+}
+
+// Run calls the CreateSubcommandOptions.Run in NamespaceOpts instance
+func (o *PodOpts) Run() error {
+	return o.CreateSubcommandOptions.Run()
+}

--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pod_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_pod_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdtesting "k8s.io/kubectl/pkg/cmd/testing"
+)
+
+func TestCreatePod(t *testing.T) {
+	podName := "my-pod"
+	tf := cmdtesting.NewTestFactory().WithNamespace("test")
+	defer tf.Cleanup()
+
+	ioStreams, _, buf, _ := genericclioptions.NewTestIOStreams()
+	cmd := NewCmdCreatePod(tf, ioStreams)
+	cmd.Flags().Set("output", "name")
+	cmd.Flags().Set("image", "busybox")
+	cmd.Run(cmd, []string{podName})
+	expectedOutput := "pod/" + podName + "\n"
+	if buf.String() != expectedOutput {
+		t.Errorf("expected output: %s, but got: %s", expectedOutput, buf.String())
+	}
+}

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/deployment_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/deployment_test.go
@@ -86,8 +86,8 @@ func TestDeploymentBasicGenerate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			generator := &DeploymentBasicAppsGeneratorV1{
 				BaseDeploymentGenerator{
-					Name:   tt.deploymentName,
-					Images: tt.images,
+					Name:    tt.deploymentName,
+					PodSpec: PodSpec{Images: tt.images},
 				},
 			}
 			obj, err := generator.StructuredGenerate()

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/pod_spec.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/pod_spec.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package versioned
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"strings"
+)
+
+type PodSpec struct{
+	Images []string
+}
+
+func (s PodSpec) Validate() error {
+	if len(s.Images) == 0 {
+		return fmt.Errorf("at least one image must be specified")
+	}
+	return nil
+}
+
+// buildPodSpec: parse the image strings and assemble them into the Containers
+// of a PodSpec. This is all you need to create the PodSpec for a deployment.
+func (s PodSpec) Build() v1.PodSpec {
+	podSpec := v1.PodSpec{Containers: []v1.Container{}}
+	for _, imageString := range s.Images {
+		// Retain just the image name
+		imageSplit := strings.Split(imageString, "/")
+		name := imageSplit[len(imageSplit)-1]
+		// Remove any tag or hash
+		if strings.Contains(name, ":") {
+			name = strings.Split(name, ":")[0]
+		}
+		if strings.Contains(name, "@") {
+			name = strings.Split(name, "@")[0]
+		}
+		name = sanitizeAndUniquify(name)
+		podSpec.Containers = append(podSpec.Containers, v1.Container{Name: name, Image: imageString})
+	}
+	return podSpec
+}
+
+// sanitizeAndUniquify: replaces characters like "." or "_" into "-" to follow DNS1123 rules.
+// Then add random suffix to make it uniquified.
+func sanitizeAndUniquify(name string) string {
+	if strings.Contains(name, "_") || strings.Contains(name, ".") {
+		name = strings.Replace(name, "_", "-", -1)
+		name = strings.Replace(name, ".", "-", -1)
+		name = fmt.Sprintf("%s-%s", name, utilrand.String(5))
+	}
+	return name
+}
+

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
@@ -208,7 +208,26 @@ func updatePodPorts(params map[string]string, podSpec *v1.PodSpec) (err error) {
 	return nil
 }
 
-type BasicPod struct{}
+type BasicPod struct {
+	Name    string
+	PodSpec PodSpec
+}
+
+func (p BasicPod) validate() error {
+	return p.PodSpec.Validate()
+}
+
+func (p BasicPod) StructuredGenerate() (runtime.Object, error) {
+	if err := p.validate(); err != nil {
+		return nil, err
+	}
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: p.Name,
+		},
+		Spec: p.PodSpec.Build(),
+	}, nil
+}
 
 func (BasicPod) ParamNames() []generate.GeneratorParam {
 	return []generate.GeneratorParam{

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
@@ -358,3 +358,43 @@ func TestParseEnv(t *testing.T) {
 		})
 	}
 }
+
+func TestStructuredGenerate(t *testing.T) {
+	tests := []struct {
+		name      string
+		pod       BasicPod
+		expected  *v1.Pod
+		expectErr error
+	}{
+		{
+			name: "test1",
+			pod:  BasicPod{Name: "my-pod", PodSpec: PodSpec{Images: []string{"busybox:v1"}}},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "my-pod",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "busybox",
+							Image: "busybox:v1",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj, err := tt.pod.StructuredGenerate()
+			if err != tt.expectErr {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if !reflect.DeepEqual(obj.(*v1.Pod), tt.expected) {
+				t.Errorf("\nexpected:\n%#v\nsaw:\n%#v", tt.expected, obj.(*v1.Pod))
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR adds support for creating pods with `kubectl create pod`.

Example usage is `kubectl create pod nginx --image=nginx`.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#25382

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added  support for create pods using kubectl create pod.
Usage is similar to the kubectl create deployment command, for example:

kubectl create pod nginx --image=nginx
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
