### PR TITLE
Spreading score optimization: Store ignored instead of qualifying nodes

### DIFF
--- a/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
+++ b/pkg/scheduler/framework/plugins/podtopologyspread/scoring_test.go
@@ -68,7 +68,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 						Selector:    mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Exists("foo").Obj()),
 					},
 				},
-				NodeNameSet: sets.NewString("node-a", "node-b", "node-x"),
+				IgnoredNodes: sets.NewString(),
 				TopologyPairToPodCounts: map[topologyPair]*int64{
 					{key: "zone", value: "zone1"}:  pointer.Int64Ptr(0),
 					{key: "zone", value: "zone2"}:  pointer.Int64Ptr(0),
@@ -102,7 +102,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 						Selector:    mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Exists("bar").Obj()),
 					},
 				},
-				NodeNameSet: sets.NewString("node-a", "node-b"),
+				IgnoredNodes: sets.NewString("node-x"),
 				TopologyPairToPodCounts: map[topologyPair]*int64{
 					{key: "zone", value: "zone1"}:  pointer.Int64Ptr(0),
 					{key: "node", value: "node-a"}: pointer.Int64Ptr(0),
@@ -137,7 +137,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 						Selector:    mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Exists("foo").Obj()),
 					},
 				},
-				NodeNameSet: sets.NewString("node-a"),
+				IgnoredNodes: sets.NewString(),
 				TopologyPairToPodCounts: map[topologyPair]*int64{
 					{key: "node", value: "node-a"}: pointer.Int64Ptr(0),
 					{key: "planet", value: "mars"}: pointer.Int64Ptr(0),
@@ -182,7 +182,7 @@ func TestPreScoreStateEmptyNodes(t *testing.T) {
 						Selector:    mustConvertLabelSelectorAsSelector(t, st.MakeLabelSelector().Label("baz", "sup").Obj()),
 					},
 				},
-				NodeNameSet: sets.NewString("node-a"),
+				IgnoredNodes: sets.NewString(),
 				TopologyPairToPodCounts: map[topologyPair]*int64{
 					{"planet", "mars"}: pointer.Int64Ptr(0),
 				},


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

Store ignored nodes in PreScore, instead of qualifying nodes. It more common that nodes have all the topology keys than not, or at least that state should be transitory.
By doing this, we save a lot of map insertions.

**Special notes for your reviewer**:

Master

```
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread
BenchmarkTestDefaultEvenPodsSpreadPriority/100nodes-56         	    3639	    303151 ns/op
BenchmarkTestDefaultEvenPodsSpreadPriority/1000nodes-56        	     619	   1883145 ns/op
```

This PR (25% improvement):

```
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/podtopologyspread
BenchmarkTestDefaultEvenPodsSpreadPriority/100nodes-56         	    3878	    271338 ns/op
BenchmarkTestDefaultEvenPodsSpreadPriority/1000nodes-56        	     840	   1406038 ns/op
```

Note that this brings topology spreading in full parity with DefaultPodTopologySpread:

```
pkg: k8s.io/kubernetes/pkg/scheduler/framework/plugins/defaultpodtopologyspread
BenchmarkTestSelectorSpreadPriority/100nodes-56         	    4902	    214537 ns/op
BenchmarkTestSelectorSpreadPriority/1000nodes-56        	     799	   1487870 ns/op
```

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```