### PR TITLE
Azure - fix create azure disk PV in regions that don't have zones 

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -85,7 +85,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	klog.V(4).Infof("azureDisk - creating new managed Name:%s StorageAccountType:%s Size:%v", options.DiskName, options.StorageAccountType, options.SizeGB)
 
 	var createZones *[]string
-	if len(options.AvailabilityZone) > 0 {
+	if len(options.AvailabilityZone) > 0 && options.AvailabilityZone != "0" {
 		zoneList := []string{c.common.cloud.GetZoneID(options.AvailabilityZone)}
 		createZones = &zoneList
 	}
@@ -161,11 +161,14 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	model := compute.Disk{
 		Location: &c.common.location,
 		Tags:     newTags,
-		Zones:    createZones,
 		Sku: &compute.DiskSku{
 			Name: diskSku,
 		},
 		DiskProperties: &diskProperties,
+	}
+
+	if createZones != nil && len(*createZones) > 0 {
+		model.Zones = createZones
 	}
 
 	if options.ResourceGroup == "" {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -84,10 +84,12 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	var err error
 	klog.V(4).Infof("azureDisk - creating new managed Name:%s StorageAccountType:%s Size:%v", options.DiskName, options.StorageAccountType, options.SizeGB)
 
-	var createZones *[]string
-	if len(options.AvailabilityZone) > 0 && options.AvailabilityZone != "0" {
-		zoneList := []string{c.common.cloud.GetZoneID(options.AvailabilityZone)}
-		createZones = &zoneList
+	var createZones []string
+	if len(options.AvailabilityZone) > 0 {
+		requestedZone := c.common.cloud.GetZoneID(options.AvailabilityZone)
+		if requestedZone != "" {
+			createZones = append(createZones, requestedZone)
+		}
 	}
 
 	// insert original tags to newTags
@@ -167,8 +169,8 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 		DiskProperties: &diskProperties,
 	}
 
-	if createZones != nil && len(*createZones) > 0 {
-		model.Zones = createZones
+	if len(createZones) > 0 {
+		model.Zones = &createZones
 	}
 
 	if options.ResourceGroup == "" {

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -77,7 +77,7 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 	}
 
 	// do not use blank zone definition
-	if len(zone) > 0 && zone != "0" {
+	if len(zone) > 0 {
 		volumeOptions.AvailabilityZone = zone
 	}
 	return p.azureCloud.CreateManagedDisk(volumeOptions)

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -72,9 +72,13 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 		PVCName:            pdName,
 		SizeGB:             1,
 		Tags:               nil,
-		AvailabilityZone:   zone,
 		DiskIOPSReadWrite:  "",
 		DiskMBpsReadWrite:  "",
+	}
+
+	// do not use blank zone definition
+	if len(zone) > 0 && zone != "0" {
+		volumeOptions.AvailabilityZone = zone
 	}
 	return p.azureCloud.CreateManagedDisk(volumeOptions)
 }


### PR DESCRIPTION
This fixes issue with volume provisioning in clusters that were created without zones or were created in regions that don't have zones.

/sig storage
cc @andyzhangx @tsmetana 

