### PR TITLE
kubelet: fix `/stats/summary` endpoint on Windows when init-containers are present on the node

### DIFF
--- a/pkg/kubelet/dockershim/docker_stats.go
+++ b/pkg/kubelet/dockershim/docker_stats.go
@@ -53,8 +53,9 @@ func (ds *dockerService) ListContainerStats(ctx context.Context, r *runtimeapi.L
 		if err != nil {
 			return nil, err
 		}
-
-		stats = append(stats, containerStats)
+		if containerStats != nil {
+			stats = append(stats, containerStats)
+		}
 	}
 
 	return &runtimeapi.ListContainerStatsResponse{Stats: stats}, nil

--- a/pkg/kubelet/dockershim/docker_stats_windows.go
+++ b/pkg/kubelet/dockershim/docker_stats_windows.go
@@ -35,7 +35,13 @@ func (ds *dockerService) getContainerStats(containerID string) (*runtimeapi.Cont
 
 	hcsshim_container, err := hcsshim.OpenContainer(containerID)
 	if err != nil {
-		return nil, err
+		// As we moved from using Docker stats to hcsshim directly, we may query HCS with already exited container IDs.
+		// That will typically happen with init-containers in Exited state. Docker still knows about them but the HCS does not.
+		// As we don't want to block stats retrieval for other containers, we only log errors.
+		if !hcsshim.IsNotExist(err) && !hcsshim.IsAlreadyStopped(err) {
+			klog.Errorf("Error opening container (stats will be missing) '%s': %v", containerID, err)
+		}
+		return nil, nil
 	}
 	defer func() {
 		closeErr := hcsshim_container.Close()

--- a/test/e2e/windows/kubelet_stats.go
+++ b/test/e2e/windows/kubelet_stats.go
@@ -146,7 +146,17 @@ func newKubeletStatsTestPods(numPods int, image imageutils.Config, nodeName stri
 						},
 					},
 				},
-
+				InitContainers: []v1.Container{
+					{
+						Image: image.GetE2EImage(),
+						Name:  podName,
+						Command: []string{
+							"powershell.exe",
+							"-Command",
+							"sleep -Seconds 1",
+						},
+					},
+				},
 				NodeName: nodeName,
 			},
 		}


### PR DESCRIPTION
**What type of PR is this?**
/kind bug
/sig windows
/cc @marosset

**What this PR does / why we need it**:
Currently, calling the `/stats/summary` API always fail with error 500 on any Windows node with at least one init-container.

It will always fail with following error:
```
Internal Error: failed to list pod stats: failed to list all container stats: rpc error: code = Unknown desc = hcsshim::OpenComputeSystem <container_id>: A virtual machine or container with the specified identifier does not exist.
```

It's due to changes in #87730, Kubelet is now directly calling hcsshim to gather stats.
However, unlike `docker stats` API that was used before, hcsshim does not
keep information about exited containers.

When the Kubelet lists containers (`docker_container.go:ListContainers()`),
it sets `All: true`, retrieving non-running containers.

When docker stats is called with such container id, it'll return a valid JSON
with all values set to 0. The non-running containers are filtered later on in the process.

When the hcsshim is called with such container id, it'll return an error, effectively
stopping the stats retrieval for all containers and causing a 500.

**Which issue(s) this PR fixes**:
Issue described above

**Special notes for your reviewer**:
Current PR explicitly filters non-running containers. However during my testing of this change, I observed other **temporary** errors depending on some containers state:

```
Internal Error: failed to list pod stats: failed to list all container stats: rpc error: code = Unknown desc = container 87d3dac87d2a33ca6697463db6940f755175ab28783f48d5cf55e0775410d68f encountered an error during Properties: failure in a Windows system call: The requested virtual machine or container operation is not valid in the curren
t state. (0xc0370105)
```

```
Internal Error: failed to list pod stats: failed to list all container stats: rpc error: code = Unknown desc = container 1948ed0a3802e73b1215142f066d1df8f1905cd122a1bfdb087476dd5efa0f51 encountered an error during Properties: failure in a Windows system call: Access is denied. (0x5)
```

It seems to be linked to containers crashing/force-killed, but I cannot say for sure.

So maybe we need to relax the check even more and:
- Make all errors from hcsshim non-blocking (allowing retrieving stats for other containers)
- Logging all errors which are not (`IsNotExist()` or `IsAlreadyStopped`)

It'd make this call more reliable at the expense of having to look at the logs in case of missing data.

WDYT?

**Does this PR introduce a user-facing change?**:
```release-note
fixed: kubelet metrics no longer return error 500 when init-containers are present on Windows nodes
```