### PR TITLE
remove unnecessary removed tags since they can be auto-applied via policy

### DIFF
--- a/staging/src/k8s.io/api/authentication/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authentication/v1beta1/types.go
@@ -28,7 +28,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.4
 // +k8s:prerelease-lifecycle-gen:deprecated=1.19
-// +k8s:prerelease-lifecycle-gen:removed=1.22
 // +k8s:prerelease-lifecycle-gen:replacement=authentication.k8s.io,v1,TokenReview
 
 // TokenReview attempts to authenticate a token to a known user.

--- a/staging/src/k8s.io/api/authorization/v1beta1/types.go
+++ b/staging/src/k8s.io/api/authorization/v1beta1/types.go
@@ -28,7 +28,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.2
 // +k8s:prerelease-lifecycle-gen:deprecated=1.19
-// +k8s:prerelease-lifecycle-gen:removed=1.22
 // +k8s:prerelease-lifecycle-gen:replacement=authorization.k8s.io,v1,SubjectAccessReview
 
 // SubjectAccessReview checks whether or not a user or group can perform an action.
@@ -51,7 +50,6 @@ type SubjectAccessReview struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.2
 // +k8s:prerelease-lifecycle-gen:deprecated=1.19
-// +k8s:prerelease-lifecycle-gen:removed=1.22
 // +k8s:prerelease-lifecycle-gen:replacement=authorization.k8s.io,v1,SelfSubjectAccessReview
 
 // SelfSubjectAccessReview checks whether or the current user can perform an action.  Not filling in a
@@ -75,7 +73,6 @@ type SelfSubjectAccessReview struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.2
 // +k8s:prerelease-lifecycle-gen:deprecated=1.19
-// +k8s:prerelease-lifecycle-gen:removed=1.22
 // +k8s:prerelease-lifecycle-gen:replacement=authorization.k8s.io,v1,LocalSubjectAccessReview
 
 // LocalSubjectAccessReview checks whether or not a user or group can perform an action in a given namespace.
@@ -205,7 +202,6 @@ type SubjectAccessReviewStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.8
 // +k8s:prerelease-lifecycle-gen:deprecated=1.19
-// +k8s:prerelease-lifecycle-gen:removed=1.22
 // +k8s:prerelease-lifecycle-gen:replacement=authorization.k8s.io,v1,SelfSubjectRulesReview
 
 // SelfSubjectRulesReview enumerates the set of actions the current user can perform within a namespace.

--- a/staging/src/k8s.io/api/autoscaling/v2beta1/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2beta1/types.go
@@ -375,7 +375,6 @@ type ExternalMetricStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.8
 // +k8s:prerelease-lifecycle-gen:deprecated=1.22
-// +k8s:prerelease-lifecycle-gen:removed=1.25
 // +k8s:prerelease-lifecycle-gen:replacement=autoscaling,v2beta2,HorizontalPodAutoscaler
 
 // HorizontalPodAutoscaler is the configuration for a horizontal pod
@@ -401,7 +400,6 @@ type HorizontalPodAutoscaler struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.8
 // +k8s:prerelease-lifecycle-gen:deprecated=1.22
-// +k8s:prerelease-lifecycle-gen:removed=1.25
 // +k8s:prerelease-lifecycle-gen:replacement=autoscaling,v2beta2,HorizontalPodAutoscalerList
 
 // HorizontalPodAutoscaler is a list of horizontal pod autoscaler objects.

--- a/staging/src/k8s.io/api/autoscaling/v2beta2/types.go
+++ b/staging/src/k8s.io/api/autoscaling/v2beta2/types.go
@@ -28,7 +28,6 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.12
 // +k8s:prerelease-lifecycle-gen:deprecated=1.22
-// +k8s:prerelease-lifecycle-gen:removed=1.25
 
 // HorizontalPodAutoscaler is the configuration for a horizontal pod
 // autoscaler, which automatically manages the replica count of any resource
@@ -472,7 +471,6 @@ type MetricValueStatus struct {
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:prerelease-lifecycle-gen:introduced=1.12
 // +k8s:prerelease-lifecycle-gen:deprecated=1.22
-// +k8s:prerelease-lifecycle-gen:removed=1.25
 
 // HorizontalPodAutoscalerList is a list of horizontal pod autoscaler objects.
 type HorizontalPodAutoscalerList struct {


### PR DESCRIPTION
This limits the accidents that can happen via cargo-culting.  Since removed is computed as +3 from deprecated, these were unnecessary

/kind cleanup
/priority important-soon

```release-note
NONE
```