### PR TITLE
Added --privileged flag to kubectl run

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/run/run.go
@@ -120,6 +120,7 @@ type RunOptions struct {
 	Interactive    bool
 	LeaveStdinOpen bool
 	Port           string
+	Privileged     bool
 	Quiet          bool
 	Schedule       string
 	TTY            bool
@@ -199,6 +200,7 @@ func addRunFlags(cmd *cobra.Command, opt *RunOptions) {
 	cmd.Flags().BoolVar(&opt.Quiet, "quiet", opt.Quiet, "If true, suppress prompt messages.")
 	cmd.Flags().StringVar(&opt.Schedule, "schedule", opt.Schedule, i18n.T("A schedule in the Cron format the job should be run with."))
 	cmd.Flags().MarkDeprecated("schedule", "has no effect and will be removed in the future.")
+	cmd.Flags().BoolVar(&opt.Privileged, "privileged", opt.Privileged, i18n.T("If true, run the container in privileged mode."))
 	cmdutil.AddFieldManagerFlagVar(cmd, &opt.fieldManager, "kubectl-run")
 }
 

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run.go
@@ -229,6 +229,7 @@ func (BasicPod) ParamNames() []generate.GeneratorParam {
 		{Name: "requests", Required: false},
 		{Name: "limits", Required: false},
 		{Name: "serviceaccount", Required: false},
+		{Name: "privileged", Required: false},
 	}
 }
 
@@ -281,6 +282,18 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 	if len(restartPolicy) == 0 {
 		restartPolicy = v1.RestartPolicyAlways
 	}
+
+	privileged, err := generate.GetBool(params, "privileged", false)
+	if err != nil {
+		return nil, err
+	}
+	var securityContext *v1.SecurityContext
+	if privileged {
+		securityContext = &v1.SecurityContext{
+			Privileged: &privileged,
+		}
+	}
+
 	pod := v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   name,
@@ -290,12 +303,13 @@ func (BasicPod) Generate(genericParams map[string]interface{}) (runtime.Object, 
 			ServiceAccountName: params["serviceaccount"],
 			Containers: []v1.Container{
 				{
-					Name:      name,
-					Image:     params["image"],
-					Stdin:     stdin,
-					StdinOnce: !leaveStdinOpen && stdin,
-					TTY:       tty,
-					Resources: resourceRequirements,
+					Name:            name,
+					Image:           params["image"],
+					Stdin:           stdin,
+					StdinOnce:       !leaveStdinOpen && stdin,
+					TTY:             tty,
+					Resources:       resourceRequirements,
+					SecurityContext: securityContext,
 				},
 			},
 			DNSPolicy:     v1.DNSClusterFirst,

--- a/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
+++ b/staging/src/k8s.io/kubectl/pkg/generate/versioned/run_test.go
@@ -254,6 +254,32 @@ func TestGeneratePod(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "test10: privileged mode",
+			params: map[string]interface{}{
+				"name":       "foo",
+				"image":      "someimage",
+				"replicas":   "1",
+				"privileged": "true",
+			},
+			expected: &v1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "foo",
+					Labels: map[string]string{"run": "foo"},
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:            "foo",
+							Image:           "someimage",
+							SecurityContext: securityContextWithPrivilege(true),
+						},
+					},
+					DNSPolicy:     v1.DNSClusterFirst,
+					RestartPolicy: v1.RestartPolicyAlways,
+				},
+			},
+		},
 	}
 	generator := BasicPod{}
 	for _, tt := range tests {
@@ -356,5 +382,11 @@ func TestParseEnv(t *testing.T) {
 				t.Errorf("\nexpected:\n%#v\nsaw:\n%#v (%s)", tt.expected, envs, tt.test)
 			}
 		})
+	}
+}
+
+func securityContextWithPrivilege(privileged bool) *v1.SecurityContext {
+	return &v1.SecurityContext{
+		Privileged: &privileged,
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
Adds `--privileged` flag to `kubectl run`

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubectl/issues/721

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Added --privileged flag to kubectl run
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```

---

EDIT:  I'm adding this here because there were some questions/concerns about the security implications of this:
> Just to be clear, this flag only enables, via a command-line flag, what you were already able to do using yaml, and it only does this for kubectl run which is for running one-off pods, not intended for deploying production workloads.