### PR TITLE
Fix assumptions about string percentages for k8s.io/apimachinery/pkg/util/intstr package

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/intstr/intstr.go
@@ -179,7 +179,10 @@ func getIntOrPercentValue(intOrStr *IntOrString) (int, bool, error) {
 		if err != nil {
 			return 0, false, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
 		}
-		return int(v), true, nil
+		if strings.Contain(intOrStr.StrVal, "%") {
+			return int(v), true, nil
+		}
+		return int(v), false, nil
 	}
 	return 0, false, fmt.Errorf("invalid type: neither int nor percentage")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixing assumptions made by GetValueFromIntOrPercent where it returns every `intOrStr.Str` value as a percentage. 

e.g. Issue of `"1"` being treated the same way as a value of `"1%"`
The former should be returned as an int and the latter a percentage.

**Which issue(s) this PR fixes**:

Fixes #89082
