### PR TITLE
[WIP]Implementation of pod-level-single-numa-node topology policy

### DIFF
--- a/pkg/kubelet/cm/topologymanager/BUILD
+++ b/pkg/kubelet/cm/topologymanager/BUILD
@@ -9,6 +9,7 @@ go_library(
         "policy_none.go",
         "policy_restricted.go",
         "policy_single_numa_node.go",
+        "pod_level_single_numa_node.go",
         "topology_manager.go",
     ],
     importpath = "k8s.io/kubernetes/pkg/kubelet/cm/topologymanager",

--- a/pkg/kubelet/cm/topologymanager/pod_level_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/pod_level_single_numa_node.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package topologymanager
+
+import (
+	"k8s.io/kubernetes/pkg/kubelet/cm/topologymanager/bitmask"
+)
+
+type podLevelSingleNumaNodePolicy struct {
+	//List of NUMA Nodes available on the underlying machine
+	numaNodes []int
+}
+
+var _ Policy = &podLevelSingleNumaNodePolicy{}
+
+// PolicySingleNumaNode policy name.
+const PolicyPodLevelSingleNumaNode string = "pod-levelsingle-numa-node"
+
+// NewPodLevelSingleNumaNodePolicy returns single-numa-node policy.
+func NewPodLevelSingleNumaNodePolicy(numaNodes []int) Policy {
+	return &podLevelSingleNumaNodePolicy{numaNodes: numaNodes}
+}
+
+func (p *podLevelSingleNumaNodePolicy) Name() string {
+	return PolicyPodLevelSingleNumaNode
+}
+
+func (p *podLevelSingleNumaNodePolicy) canAdmitContainerResult(hint *TopologyHint) bool {
+	return hint.Preferred
+}
+
+
+func (p *podLevelSingleNumaNodePolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
+	filteredHints := filterProvidersHints(providersHints)
+	// Filter to only include don't cares and hints with a single NUMA node.
+	singleNumaHints := filterSingleNumaHints(filteredHints)
+	bestHint := mergeFilteredHints(p.numaNodes, singleNumaHints)
+
+	defaultAffinity, _ := bitmask.NewBitMask(p.numaNodes...)
+	if bestHint.NUMANodeAffinity.IsEqual(defaultAffinity) {
+		bestHint = TopologyHint{nil, bestHint.Preferred}
+	}
+
+	admit := p.canAdmitContainerResult(&bestHint)
+	return bestHint, admit
+}
+
+func (p *podLevelSingleNumaNodePolicy) CanAdmitPodResult(allContainersHints []TopologyHint) bool {
+	var allContainerAffinities []bitmask.BitMask
+	for _, hint := range allContainersHints {
+		allContainerAffinities = append(allContainerAffinities, hint.NUMANodeAffinity)
+	}
+
+	mergedAffinity := bitmask.NewEmptyBitMask()
+	mergedAffinity.And(allContainerAffinities...)
+
+	return mergedAffinity.Count() == 1
+}

--- a/pkg/kubelet/cm/topologymanager/policy.go
+++ b/pkg/kubelet/cm/topologymanager/policy.go
@@ -28,6 +28,8 @@ type Policy interface {
 	// Returns a merged TopologyHint based on input from hint providers
 	// and a Pod Admit Handler Response based on hints and policy type
 	Merge(providersHints []map[string][]TopologyHint) (TopologyHint, bool)
+
+	CanAdmitPodResult(allContainersHints []TopologyHint) bool
 }
 
 // Merge a TopologyHints permutation to a single hint by performing a bitwise-AND

--- a/pkg/kubelet/cm/topologymanager/policy_best_effort.go
+++ b/pkg/kubelet/cm/topologymanager/policy_best_effort.go
@@ -35,13 +35,17 @@ func (p *bestEffortPolicy) Name() string {
 	return PolicyBestEffort
 }
 
-func (p *bestEffortPolicy) canAdmitPodResult(hint *TopologyHint) bool {
+func (p *bestEffortPolicy) canAdmitContainerResult(hint *TopologyHint) bool {
 	return true
 }
 
 func (p *bestEffortPolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
 	filteredProvidersHints := filterProvidersHints(providersHints)
 	bestHint := mergeFilteredHints(p.numaNodes, filteredProvidersHints)
-	admit := p.canAdmitPodResult(&bestHint)
+	admit := p.canAdmitContainerResult(&bestHint)
 	return bestHint, admit
+}
+
+func (p *bestEffortPolicy) CanAdmitPodResult(allContainersHints []TopologyHint) bool {
+	return true
 }

--- a/pkg/kubelet/cm/topologymanager/policy_best_effort_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_best_effort_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-func TestPolicyBestEffortCanAdmitPodResult(t *testing.T) {
+func TestPolicyBestEffortCanAdmitContainerResult(t *testing.T) {
 	tcases := []struct {
 		name     string
 		hint     TopologyHint
@@ -41,7 +41,7 @@ func TestPolicyBestEffortCanAdmitPodResult(t *testing.T) {
 	for _, tc := range tcases {
 		numaNodes := []int{0, 1}
 		policy := NewBestEffortPolicy(numaNodes)
-		result := policy.(*bestEffortPolicy).canAdmitPodResult(&tc.hint)
+		result := policy.(*bestEffortPolicy).canAdmitContainerResult(&tc.hint)
 
 		if result != tc.expected {
 			t.Errorf("Expected result to be %t, got %t", tc.expected, result)

--- a/pkg/kubelet/cm/topologymanager/policy_none.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none.go
@@ -32,10 +32,14 @@ func (p *nonePolicy) Name() string {
 	return PolicyNone
 }
 
-func (p *nonePolicy) canAdmitPodResult(hint *TopologyHint) bool {
+func (p *nonePolicy) canAdmitContainerResult(hint *TopologyHint) bool {
 	return true
 }
 
 func (p *nonePolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
-	return TopologyHint{}, p.canAdmitPodResult(nil)
+	return TopologyHint{}, p.canAdmitContainerResult(nil)
+}
+
+func (p *nonePolicy) CanAdmitPodResult(allContainersHints []TopologyHint) bool {
+	return true
 }

--- a/pkg/kubelet/cm/topologymanager/policy_none_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_none_test.go
@@ -38,7 +38,7 @@ func TestPolicyNoneName(t *testing.T) {
 	}
 }
 
-func TestPolicyNoneCanAdmitPodResult(t *testing.T) {
+func TestPolicyNoneCanAdmitContainerResult(t *testing.T) {
 	tcases := []struct {
 		name     string
 		hint     TopologyHint
@@ -58,7 +58,7 @@ func TestPolicyNoneCanAdmitPodResult(t *testing.T) {
 
 	for _, tc := range tcases {
 		policy := NewNonePolicy()
-		result := policy.(*nonePolicy).canAdmitPodResult(&tc.hint)
+		result := policy.(*nonePolicy).canAdmitContainerResult(&tc.hint)
 
 		if result != tc.expected {
 			t.Errorf("Expected result to be %t, got %t", tc.expected, result)

--- a/pkg/kubelet/cm/topologymanager/policy_restricted.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted.go
@@ -34,13 +34,17 @@ func (p *restrictedPolicy) Name() string {
 	return PolicyRestricted
 }
 
-func (p *restrictedPolicy) canAdmitPodResult(hint *TopologyHint) bool {
+func (p *restrictedPolicy) canAdmitContainerResult(hint *TopologyHint) bool {
 	return hint.Preferred
 }
 
 func (p *restrictedPolicy) Merge(providersHints []map[string][]TopologyHint) (TopologyHint, bool) {
 	filteredHints := filterProvidersHints(providersHints)
 	hint := mergeFilteredHints(p.numaNodes, filteredHints)
-	admit := p.canAdmitPodResult(&hint)
+	admit := p.canAdmitContainerResult(&hint)
 	return hint, admit
+}
+
+func (p *restrictedPolicy) CanAdmitPodResult(allContainersHints []TopologyHint) bool {
+	return true
 }

--- a/pkg/kubelet/cm/topologymanager/policy_restricted_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_restricted_test.go
@@ -38,7 +38,7 @@ func TestPolicyRestrictedName(t *testing.T) {
 	}
 }
 
-func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
+func TestPolicyRestrictedCanAdmitContainerResult(t *testing.T) {
 	tcases := []struct {
 		name     string
 		hint     TopologyHint
@@ -59,7 +59,7 @@ func TestPolicyRestrictedCanAdmitPodResult(t *testing.T) {
 	for _, tc := range tcases {
 		numaNodes := []int{0, 1}
 		policy := NewRestrictedPolicy(numaNodes)
-		result := policy.(*restrictedPolicy).canAdmitPodResult(&tc.hint)
+		result := policy.(*restrictedPolicy).canAdmitContainerResult(&tc.hint)
 
 		if result != tc.expected {
 			t.Errorf("Expected result to be %t, got %t", tc.expected, result)

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node.go
@@ -39,7 +39,7 @@ func (p *singleNumaNodePolicy) Name() string {
 	return PolicySingleNumaNode
 }
 
-func (p *singleNumaNodePolicy) canAdmitPodResult(hint *TopologyHint) bool {
+func (p *singleNumaNodePolicy) canAdmitContainerResult(hint *TopologyHint) bool {
 	return hint.Preferred
 }
 
@@ -72,6 +72,10 @@ func (p *singleNumaNodePolicy) Merge(providersHints []map[string][]TopologyHint)
 		bestHint = TopologyHint{nil, bestHint.Preferred}
 	}
 
-	admit := p.canAdmitPodResult(&bestHint)
+	admit := p.canAdmitContainerResult(&bestHint)
 	return bestHint, admit
+}
+
+func (p *singleNumaNodePolicy) CanAdmitPodResult(allContainersHints []TopologyHint) bool {
+	return true
 }

--- a/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
+++ b/pkg/kubelet/cm/topologymanager/policy_single_numa_node_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 )
 
-func TestPolicySingleNumaNodeCanAdmitPodResult(t *testing.T) {
+func TestPolicySingleNumaNodeCanAdmitContainerResult(t *testing.T) {
 	tcases := []struct {
 		name     string
 		hint     TopologyHint
@@ -37,7 +37,7 @@ func TestPolicySingleNumaNodeCanAdmitPodResult(t *testing.T) {
 	for _, tc := range tcases {
 		numaNodes := []int{0, 1}
 		policy := NewSingleNumaNodePolicy(numaNodes)
-		result := policy.(*singleNumaNodePolicy).canAdmitPodResult(&tc.hint)
+		result := policy.(*singleNumaNodePolicy).canAdmitContainerResult(&tc.hint)
 
 		if result != tc.expected {
 			t.Errorf("Expected result to be %t, got %t", tc.expected, result)


### PR DESCRIPTION
This PR is opened  to show concept of proposed pod-level-single-numa-node policy
- This topology policy merges topology hint and admit container as same as single-numa-node policy.
- Difference is this policy collect besthint of containers, then check them wether they are in same numa node or not, this policy only admit a Pod when all besthints of containers has same single numa affintiy.