### PR TITLE
Promote HugePageStorageMediumSize feature to Beta

### DIFF
--- a/pkg/features/kube_features.go
+++ b/pkg/features/kube_features.go
@@ -575,6 +575,7 @@ const (
 
 	// owner: @bart0sh
 	// alpha: v1.18
+	// beta: v1.19
 	//
 	// Enables usage of HugePages-<size> in a volume medium,
 	// e.g. emptyDir:
@@ -680,7 +681,7 @@ var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureS
 	ServiceAppProtocol:                             {Default: true, PreRelease: featuregate.Beta},
 	ImmutableEphemeralVolumes:                      {Default: true, PreRelease: featuregate.Beta},
 	DefaultIngressClass:                            {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // remove in 1.20
-	HugePageStorageMediumSize:                      {Default: false, PreRelease: featuregate.Alpha},
+	HugePageStorageMediumSize:                      {Default: true, PreRelease: featuregate.Beta},
 	ExternalPolicyForExternalIP:                    {Default: true, PreRelease: featuregate.GA}, // remove in 1.20
 	AnyVolumeDataSource:                            {Default: false, PreRelease: featuregate.Alpha},
 	DefaultPodTopologySpread:                       {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**What type of PR is this?**

/kind api-change

**What this PR does / why we need it**:

This change promotes HugePageStorageMediumSize feature to Beta and enables support for multiple size huge pages by default.

**Does this PR introduce a user-facing change?**:

```release-note
The HugePageStorageMediumSize feature gate is now on by default allowing usage of multiple sizes huge page resources on a container level.
```