### PR TITLE
k8s.io/component-base/metrics/:add new function GetMetricFamily()

### DIFF
--- a/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
+++ b/staging/src/k8s.io/component-base/metrics/testutil/metrics.go
@@ -193,6 +193,16 @@ func ValidateMetrics(metrics Metrics, metricName string, expectedLabels ...strin
 	return nil
 }
 
+// GetMetricFamily returns MetricFamily whose name is equal to metricFamilyName from the metricFamily []*dto.MetricFamily
+func GetMetricFamily(metricFamily []*dto.MetricFamily, metricFamilyName string) *dto.MetricFamily {
+	for _, mf := range metricFamily {
+		if mf.GetName() == metricFamilyName {
+			return mf
+		}
+	}
+	return nil
+}
+
 // Histogram wraps prometheus histogram DTO (data transfer object)
 type Histogram struct {
 	*dto.Histogram
@@ -206,12 +216,7 @@ func GetHistogramFromGatherer(gatherer metrics.Gatherer, metricName string) (His
 	if err != nil {
 		return Histogram{}, err
 	}
-	for _, mFamily := range m {
-		if mFamily.GetName() == metricName {
-			metricFamily = mFamily
-			break
-		}
-	}
+	metricFamily = GetMetricFamily(m, metricName)
 
 	if metricFamily == nil {
 		return Histogram{}, fmt.Errorf("metric %q not found", metricName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 
/kind cleanup 
 
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

ref:https://github.com/kubernetes/kubernetes/issues/89267

**Special notes for your reviewer**:

after readinfg the source code in k8s.io/component-base/metrics/. I think it is nice to add a new function GetMetricFamily() ,  it filters the MetricFamily with name. the  function is useful.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
None
```
