### PR TITLE
Updates the fstype of Cinder volumes to be ext4 if nil

### DIFF
--- a/pkg/volume/cinder/cinder.go
+++ b/pkg/volume/cinder/cinder.go
@@ -570,6 +570,10 @@ func (c *cinderVolumeProvisioner) Provision(selectedNode *v1.Node, allowedTopolo
 		return nil, err
 	}
 
+	if fstype == "" {
+		fstype = "ext4"
+	}
+
 	volumeMode := c.options.PVC.Spec.VolumeMode
 	if volumeMode != nil && *volumeMode == v1.PersistentVolumeBlock {
 		// Block volumes should not have any FSType


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Updates the fsType for cinder volumes to be `ext4` if no fsType is specified. This mirrors the behavior of the other intree plugins.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
Adjusts the fsType for cinder values to be `ext4` if no fsType is specified.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**: