### PR TITLE
cleanup: remove stale comments

### DIFF
--- a/pkg/scheduler/factory.go
+++ b/pkg/scheduler/factory.go
@@ -491,9 +491,6 @@ func MakeDefaultErrorFunc(client clientset.Interface, podQueue internalqueue.Sch
 				Name:      pod.Name,
 			}
 
-			// An unschedulable pod will be placed in the unschedulable queue.
-			// This ensures that if the pod is nominated to run on a node,
-			// scheduler takes the pod into account when running predicates for the node.
 			// Get the pod again; it may have changed/been scheduled already.
 			getBackoff := initialGetBackoff
 			for {


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling

**What this PR does / why we need it**:

This PR removes stale comments which was for the case that Priority feature isn't enabled (in #55933). Given Priority feature has been GA for a while, so remove them to avoid confusion.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```