### PR TITLE
Avoid an unscheduable Pod to be added back to activeQ immediately

### DIFF
--- a/test/integration/scheduler/framework_test.go
+++ b/test/integration/scheduler/framework_test.go
@@ -1392,7 +1392,7 @@ func TestFilterPlugin(t *testing.T) {
 	}
 
 	// Create the master and the scheduler with the test plugin set.
-	testCtx := initTestSchedulerForFrameworkTest(t, testutils.InitTestMaster(t, "filter-plugin", nil), 2,
+	testCtx := initTestSchedulerForFrameworkTest(t, testutils.InitTestMaster(t, "filter-plugin", nil), 1,
 		scheduler.WithProfiles(prof),
 		scheduler.WithFrameworkOutOfTreeRegistry(registry))
 	defer testutils.CleanupTest(t, testCtx)
@@ -1416,8 +1416,8 @@ func TestFilterPlugin(t *testing.T) {
 			}
 		}
 
-		if filterPlugin.numFilterCalled == 0 {
-			t.Errorf("Expected the filter plugin to be called.")
+		if filterPlugin.numFilterCalled != 1 {
+			t.Errorf("Expected the filter plugin to be called 1 time, but got %v.", filterPlugin.numFilterCalled)
 		}
 
 		filterPlugin.reset()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/sig scheduling

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #90616

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
Fix a racing issue that scheduler may perform unnecessary scheduling attempt.
```