### PR TITLE
VSphere cloud provider: Fix race in disk provisioning

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/vdm.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/vsphere/vclib/diskmanagers/vdm.go
@@ -70,6 +70,11 @@ func (diskManager virtualDiskManager) Create(ctx context.Context, datastore *vcl
 	taskInfo, err := task.WaitForResult(ctx, nil)
 	vclib.RecordvSphereMetric(vclib.APICreateVolume, requestTime, err)
 	if err != nil {
+		if isAlreadyExists(diskManager.diskPath, err) {
+			// The disk already exists, log info message and return success
+			klog.V(vclib.LogLevel).Infof("File: %v already exists", diskManager.diskPath)
+			return diskManager.diskPath, nil
+		}
 		klog.Errorf("Failed to complete virtual disk creation: %s. err: %+v", diskManager.diskPath, err)
 		return "", err
 	}


### PR DESCRIPTION
There is a race in virtualDiskManager based provisioning that causes volume provisioning to fail sometimes with `Cannot complete the operation because the file or folder ... already exists` (under very heavy load). The provisioning method checks for the volume existence at the beginning and returns success if found. However it may happen that the provisioning task takes long and the reconciliation loop calls the provisioning method again while the previous operation is still running. If the first provisioning finishes the backend task while the second one is starting the second task returns an error causing the provisioining fail.

There is a code in the VM based disk manager `Create` method that treats the "already exists" error as non-fatal. This might be reused in the VDM code too.

/kind bug

```release-note
NONE
```