### PR TITLE
extract nodeStatus logic as NodeStatusManager

### DIFF
--- a/pkg/kubelet/kubelet_getters.go
+++ b/pkg/kubelet/kubelet_getters.go
@@ -230,7 +230,7 @@ func (kl *Kubelet) getRuntime() kubecontainer.Runtime {
 // GetNode returns the node info for the configured node name of this Kubelet.
 func (kl *Kubelet) GetNode() (*v1.Node, error) {
 	if kl.kubeClient == nil {
-		return kl.initialNode(context.TODO())
+		return kl.nodeStatusManager.InitialNode(context.TODO())
 	}
 	return kl.nodeLister.Get(string(kl.nodeName))
 }
@@ -246,7 +246,7 @@ func (kl *Kubelet) getNodeAnyWay() (*v1.Node, error) {
 			return n, nil
 		}
 	}
-	return kl.initialNode(context.TODO())
+	return kl.nodeStatusManager.InitialNode(context.TODO())
 }
 
 // GetNodeConfig returns the container manager node config.

--- a/pkg/kubelet/kubelet_network.go
+++ b/pkg/kubelet/kubelet_network.go
@@ -40,20 +40,6 @@ const (
 	KubeFirewallChain utiliptables.Chain = "KUBE-FIREWALL"
 )
 
-// providerRequiresNetworkingConfiguration returns whether the cloud provider
-// requires special networking configuration.
-func (kl *Kubelet) providerRequiresNetworkingConfiguration() bool {
-	// TODO: We should have a mechanism to say whether native cloud provider
-	// is used or whether we are using overlay networking. We should return
-	// true for cloud providers if they implement Routes() interface and
-	// we are not using overlay networking.
-	if kl.cloud == nil || kl.cloud.ProviderName() != "gce" {
-		return false
-	}
-	_, supported := kl.cloud.Routes()
-	return supported
-}
-
 // updatePodCIDR updates the pod CIDR in the runtime state if it is different
 // from the current CIDR. Return true if pod CIDR is actually changed.
 func (kl *Kubelet) updatePodCIDR(cidr string) (bool, error) {

--- a/pkg/kubelet/kubelet_test.go
+++ b/pkg/kubelet/kubelet_test.go
@@ -86,11 +86,6 @@ func init() {
 const (
 	testKubeletHostname = "127.0.0.1"
 	testKubeletHostIP   = "127.0.0.1"
-
-	// TODO(harry) any global place for these two?
-	// Reasonable size range of all container images. 90%ile of images on dockerhub drops into this range.
-	minImgSize int64 = 23 * 1024 * 1024
-	maxImgSize int64 = 1000 * 1024 * 1024
 )
 
 // fakeImageGCManager is a fake image gc manager for testing. It will return image
@@ -335,7 +330,6 @@ func newTestKubeletWithImageList(
 		kubelet.getPluginsRegistrationDir(), /* sockDir */
 		kubelet.recorder,
 	)
-	kubelet.setNodeStatusFuncs = kubelet.defaultNodeStatusFuncs()
 
 	// enable active deadline handler
 	activeDeadlineHandler, err := newActiveDeadlineHandler(kubelet.statusManager, kubelet.recorder, kubelet.clock)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:
extract kubelet nodeStatus logic as NodeStatusManager

change some kubelet members and functions as NodeStatusManager's members and functions without changing them.

**Does this PR introduce a user-facing change?**:

```release-note
extract kubelet nodeStatus logic as NodeStatusManager
```


