### PR TITLE
Classify the condition where no matching transformer was found as an Internal error.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/BUILD
@@ -16,6 +16,7 @@ go_test(
     deps = [
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/testutil:go_default_library",
+        "//vendor/github.com/google/go-cmp/cmp:go_default_library",
         "//vendor/google.golang.org/grpc/codes:go_default_library",
         "//vendor/google.golang.org/grpc/status:go_default_library",
     ],
@@ -33,6 +34,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//staging/src/k8s.io/component-base/metrics:go_default_library",
         "//staging/src/k8s.io/component-base/metrics/legacyregistry:go_default_library",
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
         "//vendor/google.golang.org/grpc/status:go_default_library",
     ],
 )

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/transformer.go
@@ -23,6 +23,9 @@ import (
 	"sync"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	"k8s.io/apimachinery/pkg/util/errors"
 )
 
@@ -122,7 +125,7 @@ func NewPrefixTransformers(err error, transformers ...PrefixTransformer) Transfo
 	}
 	return &prefixTransformers{
 		transformers: transformers,
-		err:          err,
+		err:          status.Error(codes.Internal, err.Error()),
 	}
 }
 


### PR DESCRIPTION


**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:
Currently, errors that are caused by the condition where no matching transformers were found are classified (in our metrics) as Unknown. A more appropriate classification for this error type is Internal.



**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Errors in the Prefix Transformer that are caused by the condition where no matching transformers were found will be labeled with the codes.Internal value instead of codes.Unknown.
```


