### PR TITLE
Instrument DEK cache eviction rate.

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/envelope.go
@@ -167,7 +167,9 @@ func (t *envelopeTransformer) addTransformer(encKey []byte, key []byte) (value.T
 	// Use base64 of encKey as the key into the cache because hashicorp/golang-lru
 	// cannot hash []uint8.
 	if t.cacheEnabled {
-		t.transformers.Add(base64.StdEncoding.EncodeToString(encKey), transformer)
+		if t.transformers.Add(base64.StdEncoding.EncodeToString(encKey), transformer) {
+			dekCacheEvictionsTotal.Inc()
+		}
 		dekCacheFillPercent.Set(float64(t.transformers.Len()) / float64(t.cacheSize))
 	}
 	return transformer, nil

--- a/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/value/encrypt/envelope/metrics.go
@@ -67,6 +67,16 @@ var (
 		},
 		[]string{"transformation_type"},
 	)
+
+	dekCacheEvictionsTotal = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Namespace:      namespace,
+			Subsystem:      subsystem,
+			Name:           "dek_cache_evictions_total",
+			Help:           "Total number of DEK cache evictions.",
+			StabilityLevel: metrics.ALPHA,
+		},
+	)
 )
 
 var registerMetricsFunc sync.Once
@@ -75,6 +85,7 @@ func registerMetrics() {
 	registerMetricsFunc.Do(func() {
 		legacyregistry.MustRegister(dekCacheFillPercent)
 		legacyregistry.MustRegister(dekCacheInterArrivals)
+		legacyregistry.MustRegister(dekCacheEvictionsTotal)
 	})
 }
 


### PR DESCRIPTION

**What type of PR is this?**
 /kind feature


**What this PR does / why we need it**:
Instrument DEK's cache eviction rate. This metric could be used to alert users about insufficiently sized DEK's cache.


**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
dek_cache_evictions_total metric will become available under the envelope_encryption subsystem.
```