### PR TITLE
WIP: Only create SSA models for CRDs with structural schema

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler.go
@@ -1247,7 +1247,7 @@ func buildOpenAPIModelsForApply(staticOpenAPISpec *spec.Swagger, crd *apiextensi
 
 	specs := []*spec.Swagger{}
 	for _, v := range crd.Spec.Versions {
-		s, err := builder.BuildSwagger(crd, v.Name, builder.Options{V2: false, StripDefaults: true, StripValueValidation: true, StripNullable: true, AllowNonStructural: true})
+		s, err := builder.BuildSwagger(crd, v.Name, builder.Options{V2: true, StripDefaults: true, StripValueValidation: true, StripNullable: true, AllowNonStructural: false})
 		if err != nil {
 			return nil, err
 		}

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/apiserver/customresource_handler_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-openapi/spec"
+
 	"sigs.k8s.io/yaml"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -681,4 +683,57 @@ var multiVersionFixture = &apiextensionsv1.CustomResourceDefinition{
 			Plural: "multiversion", Singular: "multiversion", Kind: "MultiVersion", ShortNames: []string{"mv"}, ListKind: "MultiVersionList", Categories: []string{"all"},
 		},
 	},
+}
+
+func TestBuildOpenAPIModelsForApply(t *testing.T) {
+	// This is a list of validation that we expect to work.
+	tests := []apiextensionsv1.CustomResourceValidation{
+		apiextensionsv1.CustomResourceValidation{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type:       "object",
+				Properties: map[string]apiextensionsv1.JSONSchemaProps{"num": {Type: "integer", Description: "v1beta1 num field"}},
+			},
+		},
+		apiextensionsv1.CustomResourceValidation{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{
+				Type:         "",
+				XIntOrString: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		crd := apiextensionsv1.CustomResourceDefinition{
+			ObjectMeta: metav1.ObjectMeta{Name: "example.stable.example.com", UID: types.UID("12345")},
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: "stable.example.com",
+				Names: apiextensionsv1.CustomResourceDefinitionNames{
+					Plural: "examples", Singular: "example", Kind: "Example", ShortNames: []string{"ex"}, ListKind: "ExampleList", Categories: []string{"all"},
+				},
+				Conversion:            &apiextensionsv1.CustomResourceConversion{Strategy: apiextensionsv1.NoneConverter},
+				Scope:                 apiextensionsv1.ClusterScoped,
+				PreserveUnknownFields: false,
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{
+						Name: "v1beta1", Served: true, Storage: true,
+						Subresources: &apiextensionsv1.CustomResourceSubresources{Status: &apiextensionsv1.CustomResourceSubresourceStatus{}},
+						Schema:       &test,
+					},
+				},
+			},
+		}
+		if _, err := buildOpenAPIModelsForApply(&spec.Swagger{
+			SwaggerProps: spec.SwaggerProps{
+				Info: &spec.Info{
+					InfoProps: spec.InfoProps{
+						Title:   "title",
+						Version: "v1",
+					},
+				},
+				Swagger: "2.0",
+			},
+		}, &crd); err != nil {
+			t.Fatalf("failed to convert to apply model: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
And also, the current code only understands V2, so we should use that
exclusively, or we're guaranteed to have errors in the future.

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
I'm sure this change is wrong, but I never can remember why.

It does look much better to me because:
1. The parser the we use is built for openapi v2, so it seems surprising that we're trying to shove v3 in it. I'm not surprised it's failing.
2. I thought we wanted to only support structured schemas in server-side apply, wasn't it the goal of our alignement discussions?

So yes, I think the patch is good, but I'm also sure I'm missing something.
It's also temporary since jenny has a PR going-on that will read v3 directly and convert without the "wrong" parser.

/assign @sttts @liggitt 
/cc @kwiesmueller @jennybuckley @lavalamp 

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/90902

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
