### PR TITLE
Simplify GroupVersion.String()

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
+++ b/staging/src/k8s.io/apimachinery/pkg/runtime/schema/group_version.go
@@ -176,15 +176,6 @@ func (gv GroupVersion) Empty() bool {
 // String puts "group" and "version" into a single "group/version" string. For the legacy v1
 // it returns "v1".
 func (gv GroupVersion) String() string {
-	// special case the internal apiVersion for the legacy kube types
-	if gv.Empty() {
-		return ""
-	}
-
-	// special case of "v1" for backward compatibility
-	if len(gv.Group) == 0 && gv.Version == "v1" {
-		return gv.Version
-	}
 	if len(gv.Group) > 0 {
 		return gv.Group + "/" + gv.Version
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Simplify some code - the old code had special cases that returned the same values as the regular case does.

If group is empty, the conditional
```if len(gv.Group) > 0 {```
doesn't apply, and `gv.Version` is returned.

In the empty case, the special case was returning `""`, which is exactly what `gv.Version` contains.
In the legacy v1 case, the special case was returning `"v1"`, which is exactly what `gv.Version` contains.

**Which issue(s) this PR fixes**:
N/A

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
N/A