### PR TITLE
Enable completion for `kubectl config delete-context`

### DIFF
--- a/pkg/kubectl/cmd/cmd.go
+++ b/pkg/kubectl/cmd/cmd.go
@@ -270,7 +270,7 @@ __kubectl_custom_func() {
             __kubectl_get_resource_node
             return
             ;;
-        kubectl_config_use-context | kubectl_config_rename-context)
+        kubectl_config_use-context | kubectl_config_rename-context | kubectl_config_delete-context)
             __kubectl_config_get_contexts
             return
             ;;


### PR DESCRIPTION
**What type of PR is this?**

> /kind bug

**What this PR does / why we need it**:

This enables shell completion for `delete-context`, which will suggest
context names, similarly to the `use-context` and `rename-context`
subcommands.

```release-note
NONE
```