### PR TITLE
Fixed bug where querystring was lost on connection upgrade without us…

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -265,6 +265,11 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 		location = *req.URL
 		location.Scheme = h.Location.Scheme
 		location.Host = h.Location.Host
+	} else if len(location.RawQuery) == 0 {
+		// When a connection is upgraded, we want to keep the request querystring, even if the request location
+		// is not being used. However, if the location already has its own querystring, we should not overwrite it,
+		// so only do this if there is no location querystring already.
+		location.RawQuery = req.URL.RawQuery
 	}
 
 	clone := utilnet.CloneRequest(req)

--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware_test.go
@@ -504,6 +504,76 @@ func TestProxyUpgrade(t *testing.T) {
 	}
 }
 
+func TestProxyUpgradePreservesQuerystring(t *testing.T) {
+	serverPath := "/server/path"
+
+	backend := http.NewServeMux()
+	backend.Handle(serverPath, websocket.Handler(func(ws *websocket.Conn) {
+		defer ws.Close()
+		ws.Write([]byte(ws.Request().URL.String()))
+	}))
+	backendServer := httptest.NewServer(backend)
+	defer backendServer.Close()
+
+	testCases := map[string]struct {
+		locationQuery string
+		requestQuery  string
+		expectedQuery string
+	}{
+		"Only request has querystring": {
+			locationQuery: "",
+			requestQuery:  "x=baz&y=something",
+			expectedQuery: "x=baz&y=something",
+		},
+		"Only location has querystring": {
+			locationQuery: "a=foo&b=bar",
+			requestQuery:  "",
+			expectedQuery: "a=foo&b=bar",
+		},
+		"Both request and location have querystring, only location's should be used": {
+			locationQuery: "a=foo&b=bar",
+			requestQuery:  "x=baz&y=something",
+			expectedQuery: "a=foo&b=bar",
+		},
+	}
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			serverURL, _ := url.Parse(backendServer.URL)
+			serverURL.Path = serverPath
+			serverURL.RawQuery = tc.locationQuery
+
+			proxyHandler := NewUpgradeAwareHandler(serverURL, nil, false, false, &noErrorsAllowed{t: t})
+			proxy := httptest.NewServer(proxyHandler)
+			defer proxy.Close()
+
+			requestURL, _ := url.Parse("ws://" + proxy.Listener.Addr().String() + "/request/path")
+			requestURL.RawQuery = tc.requestQuery
+
+			expectedURL, _ := url.Parse(serverPath)
+			expectedURL.RawQuery = tc.expectedQuery
+
+			ws, err := websocket.Dial(requestURL.String(), "", "http://127.0.0.1/")
+			if err != nil {
+				t.Fatalf("websocket dial err: %s", err)
+			}
+			defer ws.Close()
+
+			if _, err := ws.Write([]byte("world")); err != nil {
+				t.Fatalf("write err: %s", err)
+			}
+
+			response := make([]byte, 50)
+			n, err := ws.Read(response)
+			if err != nil {
+				t.Fatalf("read err: %s", err)
+			}
+			if actualURL := string(response[0:n]); expectedURL.String() != actualURL {
+				t.Fatalf("expected URL %s, got %s", expectedURL.String(), actualURL)
+			}
+		})
+	}
+}
+
 type noErrorsAllowed struct {
 	t *testing.T
 }


### PR DESCRIPTION
…ing request location

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
