### PR TITLE
Fix rbac for metrics-server on 1.15

### DIFF
--- a/cluster/addons/metrics-server/resource-reader.yaml
+++ b/cluster/addons/metrics-server/resource-reader.yaml
@@ -16,15 +16,6 @@ rules:
   - get
   - list
   - watch
-- apiGroups:
-  - "extensions"
-  resources:
-  - deployments
-  verbs:
-  - get
-  - list
-  - update
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -36,6 +27,45 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: system:metrics-server
+subjects:
+- kind: ServiceAccount
+  name: metrics-server
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: system:metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+rules:
+- apiGroups:
+  - extensions
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+  resourceNames:
+  - metrics-server-v0.3.3
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: system:metrics-server
+  namespace: kube-system
+  labels:
+    kubernetes.io/cluster-service: "true"
+    addonmanager.kubernetes.io/mode: Reconcile
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
   name: system:metrics-server
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This is necessary for the metrics-server addon-resizer/nanny to work. Therefore necessary for metrics-server to work on large clusters. Without this change, the addon-resizer does not have permissions to update the deployment and can't scale up. This causes metrics-server to OOM and crashloop on large clusters. This breaks HPA and other things on the whole cluster.

Error in logs:
```
deployments.apps "metrics-server-v0.3.3" is forbidden: User "system:serviceaccount:kube-system:metrics-server" cannot get resource "deployments" in API group "apps" in the namespace "kube-system"
```

I discovered this on our large production clusters.

I also found this stale PR doing a similar fix: https://github.com/kubernetes/kubernetes/pull/72337 but it was closed as stale.

Newer releases might not have this issue but 1.15 is very broken without this patch.

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubernetes/kubernetes/issues/72324

**Does this PR introduce a user-facing change?**:

```release-note
Fix rbac rules for metrics-server on 1.15
```