### PR TITLE
Add complete operation list of admission controller

### DIFF
--- a/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1/generated.proto
@@ -245,8 +245,8 @@ message Rule {
 // RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
 // sure that all the tuple expansions are valid.
 message RuleWithOperations {
-  // Operations is the operations the admission hook cares about - CREATE, UPDATE, or *
-  // for all operations.
+  // Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+  // for all of those operations and any future admission operations that are added.
   // If '*' is present, the length of the slice must be one.
   // Required.
   repeated string operations = 1;

--- a/staging/src/k8s.io/api/admissionregistration/v1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types.go
@@ -462,8 +462,8 @@ const (
 // RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
 // sure that all the tuple expansions are valid.
 type RuleWithOperations struct {
-	// Operations is the operations the admission hook cares about - CREATE, UPDATE, or *
-	// for all operations.
+	// Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+	// for all of those operations and any future admission operations that are added.
 	// If '*' is present, the length of the slice must be one.
 	// Required.
 	Operations []OperationType `json:"operations,omitempty" protobuf:"bytes,1,rep,name=operations,casttype=OperationType"`

--- a/staging/src/k8s.io/api/admissionregistration/v1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1/types_swagger_doc_generated.go
@@ -80,7 +80,7 @@ func (Rule) SwaggerDoc() map[string]string {
 
 var map_RuleWithOperations = map[string]string{
 	"":           "RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.",
-	"operations": "Operations is the operations the admission hook cares about - CREATE, UPDATE, or * for all operations. If '*' is present, the length of the slice must be one. Required.",
+	"operations": "Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.",
 }
 
 func (RuleWithOperations) SwaggerDoc() map[string]string {

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/generated.proto
@@ -249,8 +249,8 @@ message Rule {
 // RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
 // sure that all the tuple expansions are valid.
 message RuleWithOperations {
-  // Operations is the operations the admission hook cares about - CREATE, UPDATE, or *
-  // for all operations.
+  // Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+  // for all of those operations and any future admission operations that are added.
   // If '*' is present, the length of the slice must be one.
   // Required.
   repeated string operations = 1;

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types.go
@@ -470,8 +470,8 @@ const (
 // RuleWithOperations is a tuple of Operations and Resources. It is recommended to make
 // sure that all the tuple expansions are valid.
 type RuleWithOperations struct {
-	// Operations is the operations the admission hook cares about - CREATE, UPDATE, or *
-	// for all operations.
+	// Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or *
+	// for all of those operations and any future admission operations that are added.
 	// If '*' is present, the length of the slice must be one.
 	// Required.
 	Operations []OperationType `json:"operations,omitempty" protobuf:"bytes,1,rep,name=operations,casttype=OperationType"`

--- a/staging/src/k8s.io/api/admissionregistration/v1beta1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/admissionregistration/v1beta1/types_swagger_doc_generated.go
@@ -80,7 +80,7 @@ func (Rule) SwaggerDoc() map[string]string {
 
 var map_RuleWithOperations = map[string]string{
 	"":           "RuleWithOperations is a tuple of Operations and Resources. It is recommended to make sure that all the tuple expansions are valid.",
-	"operations": "Operations is the operations the admission hook cares about - CREATE, UPDATE, or * for all operations. If '*' is present, the length of the slice must be one. Required.",
+	"operations": "Operations is the operations the admission hook cares about - CREATE, UPDATE, DELETE, CONNECT or * for all of those operations and any future admission operations that are added. If '*' is present, the length of the slice must be one. Required.",
 }
 
 func (RuleWithOperations) SwaggerDoc() map[string]string {


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
This PR is to fix the documentation for incomplete list of operations for admission webhook.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes/kubernetes/issues/90632

**Special notes for your reviewer**:
Referring: https://github.com/kubernetes/website/issues/20673
Looking at the code, it appears to me that admission control does indeed apply to only certain verbs. For example, I went looking for calls to validating admission plugins. I found four call sites:

https://github.com/kubernetes/kubernetes/blob/863ce9726e0aa617f03332f42ff3cebb7abe8fc0/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest.go#L177
https://github.com/kubernetes/kubernetes/blob/863ce9726e0aa617f03332f42ff3cebb7abe8fc0/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go#L190
https://github.com/kubernetes/kubernetes/blob/863ce9726e0aa617f03332f42ff3cebb7abe8fc0/staging/src/k8s.io/apiserver/pkg/registry/rest/delete.go#L177
https://github.com/kubernetes/kubernetes/blob/863ce9726e0aa617f03332f42ff3cebb7abe8fc0/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go#L277

**Does this PR introduce a user-facing change?**:
```release-note
None
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
