### PR TITLE
Added issue templates for kubectl

### DIFF
--- a/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Report a bug encountered while using kubectl
+labels: kind/bug
+
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+<!-- Please make sure you are able to reproduce the bug using a supported version and version skew of Kubernetes. See https://kubernetes.io/docs/setup/release/version-skew-policy for which versions and are currently supported.
+-->
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes client and server versions (use `kubectl version`):
+- Cloud provider or hardware configuration:
+- OS (e.g: `cat /etc/os-release`):
+

--- a/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,11 @@
+---
+name: Enhancement Request
+about: Suggest an enhancement to kubectl
+labels: kind/feature
+
+---
+<!-- Please only use this template for submitting enhancement requests -->
+
+**What would you like to be added**:
+
+**Why is this needed**:

--- a/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/support.md
+++ b/staging/src/k8s.io/kubectl/.github/ISSUE_TEMPLATE/support.md
@@ -1,0 +1,18 @@
+---
+name: Support Request
+about: Support request or question relating to kubectl
+labels: triage/support
+
+---
+
+<!--
+STOP -- PLEASE READ!
+
+GitHub is not the right place for support requests.
+
+If you're looking for help, check [Stack Overflow](https://stackoverflow.com/questions/tagged/kubernetes) and the [troubleshooting guide](https://kubernetes.io/docs/tasks/debug-application-cluster/troubleshooting/).
+
+You can also post your question on the [Kubernetes Slack](http://slack.k8s.io/) or the [Discuss Kubernetes](https://discuss.kubernetes.io/) forum.
+
+If the matter is security related, please disclose it privately via https://kubernetes.io/security/.
+-->


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
I think having some templates for people who are reporting issues, like there are for k/k would help improve the quality of the issues submitted to k/kubectl.

I copied over three of the templates and kept them mostly the same except for replacing Kubernetes with kubectl in a few places.
* Bug Report
* Enhancement
* Support (just basically says stop, go to Stack Overflow for a better response)

If this has already been proposed and decided against for some reason feel free to discard this PR, but I thought it would be an easy and helpful change.

We can also add an "Other" type if we think that is needed

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
