### PR TITLE
base-images: Use new debian-base:v2.1.0 and build new debian-iptables:v12.1.0

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -94,7 +94,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 # $1 - server architecture
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
-  local debian_base_version=v2.0.0
+  local debian_base_version=v2.1.0
   local debian_iptables_version=v12.0.1
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets

--- a/build/common.sh
+++ b/build/common.sh
@@ -43,7 +43,7 @@ readonly KUBE_BUILD_IMAGE_REPO=kube-build
 readonly KUBE_BUILD_IMAGE_CROSS_TAG="$(cat "${KUBE_ROOT}/build/build-image/cross/VERSION")"
 
 readonly KUBE_DOCKER_REGISTRY="${KUBE_DOCKER_REGISTRY:-k8s.gcr.io}"
-readonly KUBE_BASE_IMAGE_REGISTRY="${KUBE_BASE_IMAGE_REGISTRY:-k8s.gcr.io}"
+readonly KUBE_BASE_IMAGE_REGISTRY="${KUBE_BASE_IMAGE_REGISTRY:-us.gcr.io/k8s-artifacts-prod/build-image}"
 
 # This version number is used to cause everyone to rebuild their data containers
 # and build image.  This is especially useful for automated build systems like

--- a/build/debian-base/Makefile
+++ b/build/debian-base/Makefile
@@ -14,7 +14,7 @@
 
 all: all-build
 
-REGISTRY ?= staging-k8s.gcr.io
+REGISTRY ?= gcr.io/k8s-staging-build-image
 IMAGE ?= $(REGISTRY)/debian-base
 BUILD_IMAGE ?= debian-build
 

--- a/build/debian-base/cloudbuild.yaml
+++ b/build/debian-base/cloudbuild.yaml
@@ -6,6 +6,7 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
     entrypoint: make
+    dir: ./build/debian-base
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - REGISTRY=gcr.io/$PROJECT_ID

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -14,14 +14,14 @@
 
 .PHONY:	build push all all-build all-push-images all-push push-manifest
 
-REGISTRY?="staging-k8s.gcr.io"
+REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
 TAG?=v12.0.1
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)
 
-BASE_REGISTRY?=k8s.gcr.io
+BASE_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
 BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):v2.0.0
 
 # This option is for running docker manifest command

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -22,7 +22,7 @@ ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)
 
 BASE_REGISTRY?=us.gcr.io/k8s-artifacts-prod/build-image
-BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):v2.0.0
+BASEIMAGE?=$(BASE_REGISTRY)/debian-base-$(ARCH):v2.1.0
 
 # This option is for running docker manifest command
 export DOCKER_CLI_EXPERIMENTAL := enabled

--- a/build/debian-iptables/Makefile
+++ b/build/debian-iptables/Makefile
@@ -16,7 +16,7 @@
 
 REGISTRY?="gcr.io/k8s-staging-build-image"
 IMAGE=$(REGISTRY)/debian-iptables
-TAG?=v12.0.1
+TAG?=v12.1.0
 ARCH?=amd64
 ALL_ARCH = amd64 arm arm64 ppc64le s390x
 TEMP_DIR:=$(shell mktemp -d)

--- a/build/debian-iptables/cloudbuild.yaml
+++ b/build/debian-iptables/cloudbuild.yaml
@@ -6,10 +6,10 @@ options:
 steps:
   - name: 'gcr.io/k8s-testimages/gcb-docker-gcloud:v20200422-b25d964'
     entrypoint: make
+    dir: ./build/debian-iptables
     env:
       - DOCKER_CLI_EXPERIMENTAL=enabled
       - REGISTRY=gcr.io/$PROJECT_ID
-      - BASE_REGISTRY=gcr.io/$PROJECT_ID
       - IMAGE=gcr.io/$PROJECT_ID/debian-iptables
     args:
       - all-push

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -104,7 +104,7 @@ dependencies:
       match: us\.gcr\.io\/k8s-artifacts-prod\/build-image\/debian-base:v\d+\.\d+\.\d+
 
   - name: "k8s.gcr.io/debian-iptables"
-    version: 12.0.1
+    version: 12.1.0
     refPaths:
     - path: build/debian-iptables/Makefile
       match: TAG\?=

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -91,17 +91,17 @@ dependencies:
     - path: build/debian-iptables/Makefile
       match: BASEIMAGE\?\=\$\(BASE_REGISTRY\)\/debian-base-\$\(ARCH\)
     - path: cluster/images/etcd/Makefile
-      match: BASEIMAGE\?\=k8s\.gcr\.io\/debian-base:v\d+\.\d+\.\d+
+      match: BASEIMAGE\?\=us\.gcr\.io\/k8s-artifacts-prod\/build-image\/debian-base:v\d+\.\d+\.\d+
     - path: cluster/images/etcd/Makefile
-      match: BASEIMAGE\?\=k8s\.gcr\.io\/debian-base-arm:v\d+\.\d+\.\d+
+      match: BASEIMAGE\?\=us\.gcr\.io\/k8s-artifacts-prod\/build-image\/debian-base-arm:v\d+\.\d+\.\d+
     - path: cluster/images/etcd/Makefile
-      match: BASEIMAGE\?\=k8s\.gcr\.io\/debian-base-arm64:v\d+\.\d+\.\d+
+      match: BASEIMAGE\?\=us\.gcr\.io\/k8s-artifacts-prod\/build-image\/debian-base-arm64:v\d+\.\d+\.\d+
     - path: cluster/images/etcd/Makefile
-      match: BASEIMAGE\?\=k8s\.gcr\.io\/debian-base-ppc64le:v\d+\.\d+\.\d+
+      match: BASEIMAGE\?\=us\.gcr\.io\/k8s-artifacts-prod\/build-image\/debian-base-ppc64le:v\d+\.\d+\.\d+
     - path: cluster/images/etcd/Makefile
-      match: BASEIMAGE\?\=k8s\.gcr\.io\/debian-base-s390x:v\d+\.\d+\.\d+
+      match: BASEIMAGE\?\=us\.gcr\.io\/k8s-artifacts-prod\/build-image\/debian-base-s390x:v\d+\.\d+\.\d+
     - path: cluster/images/etcd-empty-dir-cleanup/Dockerfile
-      match: k8s.gcr.io\/debian-base:v\d+\.\d+\.\d+
+      match: us\.gcr\.io\/k8s-artifacts-prod\/build-image\/debian-base:v\d+\.\d+\.\d+
 
   - name: "k8s.gcr.io/debian-iptables"
     version: 12.0.1

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -82,7 +82,7 @@ dependencies:
       match: TAG \?=
 
   - name: "k8s.gcr.io/debian-base: dependents"
-    version: 2.0.0
+    version: 2.1.0
     refPaths:
     - path: build/common.sh
       match: debian_base_version=

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -73,12 +73,12 @@ def cri_tarballs():
 
 # Use go get -u github.com/estesp/manifest-tool to find these values
 _DEBIAN_BASE_DIGEST = {
-    "manifest": "sha256:ebda8587ec0f49eb88ee3a608ef018484908cbc5aa32556a0d78356088c185d4",
-    "amd64": "sha256:d7be39e143d4e6677a28c81c0a84868b40800fc979dea1848bb19d526668a00c",
-    "arm": "sha256:fc731da13b0bc9013b85a86b583fc92e50869b5bc8e7aa6ca730ec0240954c7d",
-    "arm64": "sha256:12502c3eed050fa9b6d5fe353a44bfc5f437dc325c8912b1a48dcc180df36f1e",
-    "ppc64le": "sha256:4277aa59b63c5a1369e6d84a295ecc4ffa08985dcf114de9f7b6de1af4fcbc86",
-    "s390x": "sha256:78ef2a6b017539379c1654b4e52ba8519bfec821c62d0b3a1dbd15104b711e21",
+    "manifest": "sha256:b118abac0bcf633b9db4086584ee718526fe394cf1bd18aee036e6cc497860f6",
+    "amd64": "sha256:a67798e4746faaab3fde5b7407fa8bba75d8b1214d168dc7ad2b5364f6fc4319",
+    "arm": "sha256:3ab4332e481610acbcba7a801711e29506b4bd4ecb38f72590253674d914c449",
+    "arm64": "sha256:8d53ac4da977eb20d6219ee49b9cdff8c066831ecab0e4294d0a02179d26b1d7",
+    "ppc64le": "sha256:a631023e795fe18df7faa8fe1264e757a6c74a232b9a2659657bf65756f3f4aa",
+    "s390x": "sha256:dac908eaa61d2034aec252576a470a7e4ab184c361f89170526f707a0c3c6082",
 }
 
 _DEBIAN_IPTABLES_DIGEST = {
@@ -104,7 +104,7 @@ def debian_image_dependencies():
             digest = _digest(_DEBIAN_BASE_DIGEST, arch),
             registry = "us.gcr.io/k8s-artifacts-prod/build-image",
             repository = "debian-base",
-            tag = "v2.0.0",  # ignored, but kept here for documentation
+            tag = "v2.1.0",  # ignored, but kept here for documentation
         )
 
         container_pull(

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -102,7 +102,7 @@ def debian_image_dependencies():
             name = "debian-base-" + arch,
             architecture = arch,
             digest = _digest(_DEBIAN_BASE_DIGEST, arch),
-            registry = "k8s.gcr.io",
+            registry = "us.gcr.io/k8s-artifacts-prod/build-image",
             repository = "debian-base",
             tag = "v2.0.0",  # ignored, but kept here for documentation
         )

--- a/cluster/images/etcd-empty-dir-cleanup/Dockerfile
+++ b/cluster/images/etcd-empty-dir-cleanup/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/debian-base:v2.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base:v2.0.0
 
 COPY etcdctl etcd-empty-dir-cleanup.sh /
 RUN chmod a+rx /etcdctl /etcd-empty-dir-cleanup.sh

--- a/cluster/images/etcd-empty-dir-cleanup/Dockerfile
+++ b/cluster/images/etcd-empty-dir-cleanup/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base:v2.0.0
+FROM us.gcr.io/k8s-artifacts-prod/build-image/debian-base:v2.1.0
 
 COPY etcdctl etcd-empty-dir-cleanup.sh /
 RUN chmod a+rx /etcdctl /etcd-empty-dir-cleanup.sh

--- a/cluster/images/etcd-empty-dir-cleanup/Makefile
+++ b/cluster/images/etcd-empty-dir-cleanup/Makefile
@@ -20,7 +20,7 @@ ETCD_VERSION = 3.4.7
 REGISTRY = k8s.gcr.io
 # Images should be pushed to staging-k8s.gcr.io.
 PUSH_REGISTRY = staging-k8s.gcr.io
-TAG = 3.4.7.0
+TAG = 3.4.7.1
 
 clean:
 	rm -rf etcdctl etcd-v$(ETCD_VERSION)-linux-amd64 etcd-v$(ETCD_VERSION)-linux-amd64.tar.gz

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -67,19 +67,19 @@ GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=k8s.gcr.io/debian-base:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:v2.0.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=k8s.gcr.io/debian-base-arm:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm:v2.0.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=k8s.gcr.io/debian-base-arm64:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm64:v2.0.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=k8s.gcr.io/debian-base-ppc64le:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-ppc64le:v2.0.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=k8s.gcr.io/debian-base-s390x:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-s390x:v2.0.0
 endif
 
 build:

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -67,19 +67,19 @@ GOARM?=7
 TEMP_DIR:=$(shell mktemp -d)
 
 ifeq ($(ARCH),amd64)
-    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base:v2.1.0
 endif
 ifeq ($(ARCH),arm)
-    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm:v2.1.0
 endif
 ifeq ($(ARCH),arm64)
-    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm64:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-arm64:v2.1.0
 endif
 ifeq ($(ARCH),ppc64le)
-    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-ppc64le:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-ppc64le:v2.1.0
 endif
 ifeq ($(ARCH),s390x)
-    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-s390x:v2.0.0
+    BASEIMAGE?=us.gcr.io/k8s-artifacts-prod/build-image/debian-base-s390x:v2.1.0
 endif
 
 build:

--- a/cluster/images/etcd/Makefile
+++ b/cluster/images/etcd/Makefile
@@ -34,7 +34,7 @@ LATEST_ETCD_VERSION?=3.4.7
 # REVISION provides a version number fo this image and all it's bundled
 # artifacts. It should start at zero for each LATEST_ETCD_VERSION and increment
 # for each revision of this image at that etcd version.
-REVISION?=0
+REVISION?=1
 
 # IMAGE_TAG Uniquely identifies k8s.gcr.io/etcd docker image with a tag of the form "<etcd-version>-<revision>".
 IMAGE_TAG=$(LATEST_ETCD_VERSION)-$(REVISION)


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area dependency security

**What this PR does / why we need it**:
- Fixup GCB configs for debian-{base,iptables} images
- Point `debian-base` image references to K8s Infra
- Update dependents to use `debian-base:v2.1.0`
- Build `debian-iptables:v12.1.0` image

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
Tracking issue: https://github.com/kubernetes/kubernetes/issues/58012

**Special notes for your reviewer**:

Continuation of https://github.com/kubernetes/kubernetes/pull/90665.

**Does this PR introduce a user-facing change?**:
```release-note
- base-images: Use debian-base:v2.1.0
```
