### PR TITLE
Make flexvolume e2e tests runnable again.

### DIFF
--- a/test/e2e/framework/skipper/skipper.go
+++ b/test/e2e/framework/skipper/skipper.go
@@ -42,9 +42,6 @@ import (
 	e2essh "k8s.io/kubernetes/test/e2e/framework/ssh"
 )
 
-// TestContext should be used by all tests to access common context data.
-var TestContext framework.TestContextType
-
 // New local storage types to support local storage capacity isolation
 var localStorageCapacityIsolation featuregate.Feature = "LocalStorageCapacityIsolation"
 
@@ -154,29 +151,29 @@ func SkipIfMissingResource(dynamicClient dynamic.Interface, gvr schema.GroupVers
 
 // SkipUnlessNodeCountIsAtLeast skips if the number of nodes is less than the minNodeCount.
 func SkipUnlessNodeCountIsAtLeast(minNodeCount int) {
-	if TestContext.CloudConfig.NumNodes < minNodeCount {
-		skipInternalf(1, "Requires at least %d nodes (not %d)", minNodeCount, TestContext.CloudConfig.NumNodes)
+	if framework.TestContext.CloudConfig.NumNodes < minNodeCount {
+		skipInternalf(1, "Requires at least %d nodes (not %d)", minNodeCount, framework.TestContext.CloudConfig.NumNodes)
 	}
 }
 
 // SkipUnlessNodeCountIsAtMost skips if the number of nodes is greater than the maxNodeCount.
 func SkipUnlessNodeCountIsAtMost(maxNodeCount int) {
-	if TestContext.CloudConfig.NumNodes > maxNodeCount {
-		skipInternalf(1, "Requires at most %d nodes (not %d)", maxNodeCount, TestContext.CloudConfig.NumNodes)
+	if framework.TestContext.CloudConfig.NumNodes > maxNodeCount {
+		skipInternalf(1, "Requires at most %d nodes (not %d)", maxNodeCount, framework.TestContext.CloudConfig.NumNodes)
 	}
 }
 
 // SkipIfProviderIs skips if the provider is included in the unsupportedProviders.
 func SkipIfProviderIs(unsupportedProviders ...string) {
 	if framework.ProviderIs(unsupportedProviders...) {
-		skipInternalf(1, "Not supported for providers %v (found %s)", unsupportedProviders, TestContext.Provider)
+		skipInternalf(1, "Not supported for providers %v (found %s)", unsupportedProviders, framework.TestContext.Provider)
 	}
 }
 
 // SkipUnlessProviderIs skips if the provider is not included in the supportedProviders.
 func SkipUnlessProviderIs(supportedProviders ...string) {
 	if !framework.ProviderIs(supportedProviders...) {
-		skipInternalf(1, "Only supported for providers %v (not %s)", supportedProviders, TestContext.Provider)
+		skipInternalf(1, "Only supported for providers %v (not %s)", supportedProviders, framework.TestContext.Provider)
 	}
 }
 
@@ -205,21 +202,21 @@ func SkipIfMultizone(c clientset.Interface) {
 // SkipUnlessMasterOSDistroIs skips if the master OS distro is not included in the supportedMasterOsDistros.
 func SkipUnlessMasterOSDistroIs(supportedMasterOsDistros ...string) {
 	if !framework.MasterOSDistroIs(supportedMasterOsDistros...) {
-		skipInternalf(1, "Only supported for master OS distro %v (not %s)", supportedMasterOsDistros, TestContext.MasterOSDistro)
+		skipInternalf(1, "Only supported for master OS distro %v (not %s)", supportedMasterOsDistros, framework.TestContext.MasterOSDistro)
 	}
 }
 
 // SkipUnlessNodeOSDistroIs skips if the node OS distro is not included in the supportedNodeOsDistros.
 func SkipUnlessNodeOSDistroIs(supportedNodeOsDistros ...string) {
 	if !framework.NodeOSDistroIs(supportedNodeOsDistros...) {
-		skipInternalf(1, "Only supported for node OS distro %v (not %s)", supportedNodeOsDistros, TestContext.NodeOSDistro)
+		skipInternalf(1, "Only supported for node OS distro %v (not %s)", supportedNodeOsDistros, framework.TestContext.NodeOSDistro)
 	}
 }
 
 // SkipIfNodeOSDistroIs skips if the node OS distro is included in the unsupportedNodeOsDistros.
 func SkipIfNodeOSDistroIs(unsupportedNodeOsDistros ...string) {
 	if framework.NodeOSDistroIs(unsupportedNodeOsDistros...) {
-		skipInternalf(1, "Not supported for node OS distro %v (is %s)", unsupportedNodeOsDistros, TestContext.NodeOSDistro)
+		skipInternalf(1, "Not supported for node OS distro %v (is %s)", unsupportedNodeOsDistros, framework.TestContext.NodeOSDistro)
 	}
 }
 
@@ -236,8 +233,8 @@ func SkipUnlessServerVersionGTE(v *utilversion.Version, c discovery.ServerVersio
 
 // SkipUnlessSSHKeyPresent skips if no SSH key is found.
 func SkipUnlessSSHKeyPresent() {
-	if _, err := e2essh.GetSigner(TestContext.Provider); err != nil {
-		skipInternalf(1, "No SSH Key for provider %s: '%v'", TestContext.Provider, err)
+	if _, err := e2essh.GetSigner(framework.TestContext.Provider); err != nil {
+		skipInternalf(1, "No SSH Key for provider %s: '%v'", framework.TestContext.Provider, err)
 	}
 }
 
@@ -265,19 +262,19 @@ func SkipIfAppArmorNotSupported() {
 // RunIfContainerRuntimeIs runs if the container runtime is included in the runtimes.
 func RunIfContainerRuntimeIs(runtimes ...string) {
 	for _, containerRuntime := range runtimes {
-		if containerRuntime == TestContext.ContainerRuntime {
+		if containerRuntime == framework.TestContext.ContainerRuntime {
 			return
 		}
 	}
-	skipInternalf(1, "Skipped because container runtime %q is not in %s", TestContext.ContainerRuntime, runtimes)
+	skipInternalf(1, "Skipped because container runtime %q is not in %s", framework.TestContext.ContainerRuntime, runtimes)
 }
 
 // RunIfSystemSpecNameIs runs if the system spec name is included in the names.
 func RunIfSystemSpecNameIs(names ...string) {
 	for _, name := range names {
-		if name == TestContext.SystemSpecName {
+		if name == framework.TestContext.SystemSpecName {
 			return
 		}
 	}
-	skipInternalf(1, "Skipped because system spec name %q is not in %v", TestContext.SystemSpecName, names)
+	skipInternalf(1, "Skipped because system spec name %q is not in %v", framework.TestContext.SystemSpecName, names)
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:

Make flexvolume e2e tests runnable again.

**Which issue(s) this PR fixes**:
Fixes #88132

**Special notes for your reviewer**:

Change in commit 7ff3a1f8db8335c02e4dea7dd066852d7c161bc2 broke all usages of `TestContext` variable in `skipper.go`, including `SkipUnlessSSHKeyPresent()` which is used to determine if flexvolume test cases will be run.

`TestContext` variable is defined in `test_context.go`, but the commit mentioned above introduced a new variable with the same name in skipper.go which is never initialized. When we call `SkipUnlessSSHKeyPresent()`, the test suite uses `TestContext.Provider` to get the correct SSH file. Since `TestContext` is uninitialized, test suite thinks the provider is "" instead of "gce", so it always fails.

This fix eliminates this duplicate variable, and instead we use `TestContext` from `test_context.go` which has the correct provider, fixing flexvolume e2e tests, as well as all other test cases that depend on the skipper methods.

Skipper methods are used in a good number of e2e test cases, including non-storage tests. I could implement the DaemonSet solution mentioned in issue 88132, but this fix seems more appropriate to restore skipper functionality.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

/cc @verult 
