### PR TITLE
Fixed bug where querystring was lost on connection upgrade without using request location

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
+++ b/staging/src/k8s.io/apimachinery/pkg/util/proxy/upgradeaware.go
@@ -282,6 +282,8 @@ func (h *UpgradeAwareHandler) tryUpgrade(w http.ResponseWriter, req *http.Reques
 		location = *req.URL
 		location.Scheme = h.Location.Scheme
 		location.Host = h.Location.Host
+	} else if len(location.RawQuery) == 0 {
+		location.RawQuery = req.URL.RawQuery
 	}
 
 	clone := utilnet.CloneRequest(req)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Fixes a bug where websocket requests going through kubectl proxy were losing their querystring parameters.

**Which issue(s) this PR fixes**:
Fixes #89360 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
