### PR TITLE
kuberuntime: clean up container and suppress sandbox creation if pod is done

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_manager.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager.go
@@ -477,6 +477,15 @@ func containerSucceeded(c *v1.Container, podStatus *kubecontainer.PodStatus) boo
 func (m *kubeGenericRuntimeManager) computePodActions(pod *v1.Pod, podStatus *kubecontainer.PodStatus) podActions {
 	klog.V(5).Infof("Syncing Pod %q: %+v", format.Pod(pod), pod)
 
+	// All containers in the pod are done and the pod may be cleaned up
+	if pod.Status.Phase == v1.PodSucceeded || pod.Status.Phase == v1.PodFailed {
+		klog.V(3).Infof("Pod %s can be cleaned up due to phase %v", format.Pod(pod), pod.Status.Phase)
+		return podActions{
+			KillPod:       true,
+			CreateSandbox: false,
+		}
+	}
+
 	createPodSandbox, attempt, sandboxID := m.podSandboxChanged(pod, podStatus)
 	changes := podActions{
 		KillPod:           createPodSandbox,

--- a/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_manager_test.go
@@ -752,6 +752,32 @@ func TestComputePodActions(t *testing.T) {
 				ContainersToKill:  getKillMap(basePod, baseStatus, []int{}),
 			},
 		},
+		"kill pod and don't create sandboxes if phase is PodSucceeded": {
+			mutatePodFn: func(pod *v1.Pod) { pod.Status.Phase = v1.PodSucceeded },
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				// No container or sandbox exists.
+				status.SandboxStatuses = []*runtimeapi.PodSandboxStatus{}
+				status.ContainerStatuses = []*kubecontainer.ContainerStatus{}
+			},
+			actions: podActions{
+				KillPod:       true,
+				CreateSandbox: false,
+				Attempt:       uint32(0),
+			},
+		},
+		"kill pod and don't create sandboxes if phase is PodFailed": {
+			mutatePodFn: func(pod *v1.Pod) { pod.Status.Phase = v1.PodFailed },
+			mutateStatusFn: func(status *kubecontainer.PodStatus) {
+				// No container or sandbox exists.
+				status.SandboxStatuses = []*runtimeapi.PodSandboxStatus{}
+				status.ContainerStatuses = []*kubecontainer.ContainerStatus{}
+			},
+			actions: podActions{
+				KillPod:       true,
+				CreateSandbox: false,
+				Attempt:       uint32(0),
+			},
+		},
 		"restart exited containers if RestartPolicy == Always": {
 			mutatePodFn: func(pod *v1.Pod) { pod.Spec.RestartPolicy = v1.RestartPolicyAlways },
 			mutateStatusFn: func(status *kubecontainer.PodStatus) {


### PR DESCRIPTION
If the pod phase is Succeeded or Failed there is no reason that the pod
sandboxes should stick around, or that new ones should be created.

Update/rework of https://github.com/kubernetes/kubernetes/pull/76594

Fixes #75441
Related: https://github.com/kubernetes/kubernetes/pull/76594

/kind bug

```release-note
When a pod is finished kubelet will no longer create an unused pod sandbox in some cases.
```