### PR TITLE
Update duration to be kept in watchcache

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/cacher.go
@@ -52,7 +52,9 @@ const (
 	// initial and resync watch lists to storage.
 	storageWatchListPageSize = int64(10000)
 	// defaultBookmarkFrequency defines how frequently watch bookmarks should be send
-	// in addition to sending a bookmark right before watch deadline
+	// in addition to sending a bookmark right before watch deadline.
+	//
+	// NOTE: Update `eventFreshDuration` when changing this value.
 	defaultBookmarkFrequency = time.Minute
 )
 

--- a/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
+++ b/staging/src/k8s.io/apiserver/pkg/storage/cacher/watch_cache.go
@@ -47,7 +47,10 @@ const (
 	resourceVersionTooHighRetrySeconds = 1
 
 	// eventFreshDuration is time duration of events we want to keep.
-	eventFreshDuration = 5 * time.Minute
+	// We set it to `defaultBookmarkFrequency` plus epsilon to maximize
+	// chances that last bookmark was sent within kept history, at the
+	// same time, minimizing the needed memory usage.
+	eventFreshDuration = 75 * time.Second
 
 	// defaultLowerBoundCapacity is a default value for event cache capacity's lower bound.
 	// 100 is minimum in NewHeuristicWatchCacheSizes.
@@ -55,9 +58,6 @@ const (
 	defaultLowerBoundCapacity = 100
 
 	// defaultUpperBoundCapacity  should be able to keep eventFreshDuration of history.
-	// With the current 102400 value though, it's not enough for leases in 5k-node cluster,
-	// but that is conscious decision.
-	// TODO: Validate if the current value is high enough for large scale clusters.
 	defaultUpperBoundCapacity = 100 * 1024
 )
 


### PR DESCRIPTION
With watch bookmarks being sent every minute: https://github.com/kubernetes/kubernetes/pull/90560 (I didn't observe any visible impact on scalability tests), reduce the size of history to keep in watch cache.

Ref: https://github.com/kubernetes/kubernetes/issues/90058

```release-note
NONE
```

