### PR TITLE
Fixed bug that caused TestKubeletDefault unit test to fail when run on systems that have systemd-resolved active

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -155,6 +155,12 @@ func TestKubeletUnmarshal(t *testing.T) {
 }
 
 func TestKubeletDefault(t *testing.T) {
+	var resolverConfig string
+	if isSystemdResolvedActive, _ := isServiceActive("systemd-resolved"); isSystemdResolvedActive {
+		// If systemd-resolved is active, we need to set the default resolver config
+		resolverConfig = kubeletSystemdResolverConfig
+	}
+
 	tests := []struct {
 		name       string
 		clusterCfg kubeadmapi.ClusterConfiguration
@@ -185,6 +191,7 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        utilpointer.Int32Ptr(constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
+					ResolverConfig:     resolverConfig,
 				},
 			},
 		},
@@ -217,6 +224,7 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        utilpointer.Int32Ptr(constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
+					ResolverConfig:     resolverConfig,
 				},
 			},
 		},
@@ -252,6 +260,7 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        utilpointer.Int32Ptr(constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
+					ResolverConfig:     resolverConfig,
 				},
 			},
 		},
@@ -285,6 +294,7 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        utilpointer.Int32Ptr(constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
+					ResolverConfig:     resolverConfig,
 				},
 			},
 		},
@@ -315,6 +325,7 @@ func TestKubeletDefault(t *testing.T) {
 					HealthzBindAddress: kubeletHealthzBindAddress,
 					HealthzPort:        utilpointer.Int32Ptr(constants.KubeletHealthzPort),
 					RotateCertificates: kubeletRotateCertificates,
+					ResolverConfig:     resolverConfig,
 				},
 			},
 		},
@@ -325,7 +336,7 @@ func TestKubeletDefault(t *testing.T) {
 			got := &kubeletConfig{}
 			got.Default(&test.clusterCfg, &kubeadmapi.APIEndpoint{}, &kubeadmapi.NodeRegistrationOptions{})
 			if !reflect.DeepEqual(got, &test.expected) {
-				t.Fatalf("Missmatch between expected and got:\nExpected:\n%v\n---\nGot:\n%v", test.expected, got)
+				t.Fatalf("Missmatch between expected and got:\nExpected:\n%v\n---\nGot:\n%v", test.expected, *got)
 			}
 		})
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind failing-test

**What this PR does / why we need it**:
Fixes #90726 

**Special notes for your reviewer**:
Code already handles this (see excerpt below), but unit test needed to be updated to do the same...
https://github.com/kubernetes/kubernetes/blob/a509a8e12332b10683545bd9b853fd4d07b89245/cmd/kubeadm/app/componentconfigs/kubelet.go#L199-L211

I also fixed a bug in the same unit test where `got` in `t.Fatalf(...)` was not being dereferenced and so it had an `&` in the failed test output, which was confusing when trying to see why the test failed.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
