### PR TITLE
CloudNodeLifecycleController: check node existence before shutdown status

### DIFF
--- a/pkg/controller/cloud/node_lifecycle_controller_test.go
+++ b/pkg/controller/cloud/node_lifecycle_controller_test.go
@@ -275,13 +275,16 @@ func Test_NodesShutdown(t *testing.T) {
 		updatedNodes []*v1.Node
 	}{
 		{
-			name: "node is not ready and was shutdown",
+			name: "node is not ready and was shutdown, but exists",
 			fnh: &testutil.FakeNodeHandler{
 				Existing: []*v1.Node{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:              "node0",
 							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.Local),
+						},
+						Spec: v1.NodeSpec{
+							ProviderID: "node0",
 						},
 						Status: v1.NodeStatus{
 							Conditions: []v1.NodeCondition{
@@ -300,6 +303,7 @@ func Test_NodesShutdown(t *testing.T) {
 			},
 			fakeCloud: &fakecloud.Cloud{
 				NodeShutdown:            true,
+				ExistsByProviderID:      true,
 				ErrShutdownByProviderID: nil,
 			},
 			updatedNodes: []*v1.Node{
@@ -309,6 +313,7 @@ func Test_NodesShutdown(t *testing.T) {
 						CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.Local),
 					},
 					Spec: v1.NodeSpec{
+						ProviderID: "node0",
 						Taints: []v1.Taint{
 							*ShutdownTaint,
 						},

--- a/pkg/controller/cloud/node_lifecycle_controller_test.go
+++ b/pkg/controller/cloud/node_lifecycle_controller_test.go
@@ -416,6 +416,37 @@ func Test_NodesShutdown(t *testing.T) {
 			},
 			updatedNodes: []*v1.Node{},
 		},
+		{
+			name: "node is shutdown but provider says it does not exist",
+			fnh: &testutil.FakeNodeHandler{
+				Existing: []*v1.Node{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:              "node0",
+							CreationTimestamp: metav1.Date(2012, 1, 1, 0, 0, 0, 0, time.Local),
+						},
+						Status: v1.NodeStatus{
+							Conditions: []v1.NodeCondition{
+								{
+									Type:               v1.NodeReady,
+									Status:             v1.ConditionUnknown,
+									LastHeartbeatTime:  metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.Local),
+									LastTransitionTime: metav1.Date(2015, 1, 1, 12, 0, 0, 0, time.Local),
+								},
+							},
+						},
+					},
+				},
+				Clientset:    fake.NewSimpleClientset(),
+				UpdatedNodes: []*v1.Node{},
+			},
+			fakeCloud: &fakecloud.Cloud{
+				NodeShutdown:            true,
+				ExistsByProviderID:      false,
+				ErrShutdownByProviderID: nil,
+			},
+			updatedNodes: []*v1.Node{}, // should be empty because node does not exist
+		},
 	}
 
 	for _, testcase := range testcases {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
**What this PR does / why we need it**:
Currently, we check to see if the node is shutdown. If so, we never brother to move on and check if the node exists. We should check existence first because if a node no longer exists, its taints and other checks are meaningless, and, in this case, we should simply remove the node.
**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
CloudNodeLifecycleController will check node existence status before shutdown status when monitoring nodes.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```
/cc @cheftako 