### PR TITLE
Moving --lock-file, --seccomp-profile-root and --node-status-max-images Kubelet flags to configuration

### DIFF
--- a/pkg/kubelet/apis/config/fuzzer/fuzzer.go
+++ b/pkg/kubelet/apis/config/fuzzer/fuzzer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package fuzzer
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/google/gofuzz"
@@ -64,6 +65,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.NodeStatusUpdateFrequency = metav1.Duration{Duration: 10 * time.Second}
 			obj.NodeStatusReportFrequency = metav1.Duration{Duration: time.Minute}
 			obj.NodeLeaseDurationSeconds = 40
+			obj.NodeStatusMaxImages = 50
 			obj.CPUManagerPolicy = "none"
 			obj.CPUManagerReconcilePeriod = obj.NodeStatusUpdateFrequency
 			obj.TopologyManagerPolicy = kubeletconfig.NoneTopologyManagerPolicy
@@ -96,6 +98,7 @@ func Funcs(codecs runtimeserializer.CodecFactory) []interface{} {
 			obj.ContainerLogMaxSize = "10Mi"
 			obj.ConfigMapAndSecretChangeDetectionStrategy = "Watch"
 			obj.AllowedUnsafeSysctls = []string{}
+			obj.SeccompProfileRoot = filepath.Join(v1beta1.DefaultRootDir, "seccomp")
 			obj.VolumePluginDir = kubeletconfigv1beta1.DefaultVolumePluginDir
 		},
 	}

--- a/pkg/kubelet/apis/config/helpers.go
+++ b/pkg/kubelet/apis/config/helpers.go
@@ -26,6 +26,8 @@ func KubeletConfigurationPathRefs(kc *KubeletConfiguration) []*string {
 	paths = append(paths, &kc.TLSCertFile)
 	paths = append(paths, &kc.TLSPrivateKeyFile)
 	paths = append(paths, &kc.ResolverConfig)
+	paths = append(paths, &kc.LockFilePath)
+	paths = append(paths, &kc.SeccompProfileRoot)
 	paths = append(paths, &kc.VolumePluginDir)
 	return paths
 }

--- a/pkg/kubelet/apis/config/helpers_test.go
+++ b/pkg/kubelet/apis/config/helpers_test.go
@@ -132,9 +132,12 @@ var (
 	kubeletConfigurationPathFieldPaths = sets.NewString(
 		"StaticPodPath",
 		"Authentication.X509.ClientCAFile",
+		"LockFilePath",
 		"TLSCertFile",
 		"TLSPrivateKeyFile",
 		"ResolverConfig",
+		"SeccompProfileRoot",
+		"VolumePluginDir",
 	)
 
 	// KubeletConfiguration fields that do not contain file paths.
@@ -166,6 +169,7 @@ var (
 		"EnableControllerAttachDetach",
 		"EnableDebuggingHandlers",
 		"EnforceNodeAllocatable[*]",
+		"ExitOnLockContention",
 		"EventBurst",
 		"EventRecordQPS",
 		"EvictionHard[*]",
@@ -200,6 +204,7 @@ var (
 		"StaticPodURLHeader[*][*]",
 		"MaxOpenFiles",
 		"MaxPods",
+		"NodeStatusMaxImages",
 		"NodeStatusUpdateFrequency.Duration",
 		"NodeStatusReportFrequency.Duration",
 		"NodeLeaseDurationSeconds",
@@ -225,6 +230,5 @@ var (
 		"TypeMeta.APIVersion",
 		"TypeMeta.Kind",
 		"VolumeStatsAggPeriod.Duration",
-		"VolumePluginDir",
 	)
 )

--- a/pkg/kubelet/apis/config/types.go
+++ b/pkg/kubelet/apis/config/types.go
@@ -347,6 +347,22 @@ type KubeletConfiguration struct {
 	// The purpose of this format is make sure you have the opportunity to notice if the next release hides additional metrics,
 	// rather than being surprised when they are permanently removed in the release after that.
 	ShowHiddenMetricsForVersion string
+
+	/* Experimental flags */
+
+	// lockFilePath is the path that kubelet will use to as a lock file.
+	// It uses this file as a lock to synchronize with other kubelet processes that may be running.
+	LockFilePath string
+	// exitOnLockContention is a flag that signifies to the kubelet that it is running
+	// in "bootstrap" mode. This requires that 'LockFilePath' has been set.
+	// This will cause the kubelet to listen to inotify events on the lock file,
+	// releasing it and exiting when another process tries to open that file.
+	ExitOnLockContention bool
+	// seccompProfileRoot is the directory path for seccomp profiles.
+	SeccompProfileRoot string
+	// nodeStatusMaxImages caps the number of images reported in Node.Status.Images.
+	// This is an experimental, short-term flag to help with node scalability.
+	NodeStatusMaxImages int32
 }
 
 // KubeletAuthorizationMode denotes the authorization mode for the kubelet

--- a/pkg/kubelet/apis/config/v1beta1/defaults.go
+++ b/pkg/kubelet/apis/config/v1beta1/defaults.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"path/filepath"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -226,5 +227,11 @@ func SetDefaults_KubeletConfiguration(obj *kubeletconfigv1beta1.KubeletConfigura
 	}
 	if obj.VolumePluginDir == "" {
 		obj.VolumePluginDir = DefaultVolumePluginDir
+	}
+	if obj.NodeStatusMaxImages == 0 {
+		obj.NodeStatusMaxImages = 50
+	}
+	if obj.SeccompProfileRoot == "" {
+		obj.SeccompProfileRoot = filepath.Join(kubeletconfigv1beta1.DefaultRootDir, "seccomp")
 	}
 }

--- a/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
+++ b/pkg/kubelet/apis/config/v1beta1/zz_generated.conversion.go
@@ -334,6 +334,10 @@ func autoConvert_v1beta1_KubeletConfiguration_To_config_KubeletConfiguration(in 
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.AllowedUnsafeSysctls = *(*[]string)(unsafe.Pointer(&in.AllowedUnsafeSysctls))
 	out.VolumePluginDir = in.VolumePluginDir
+	out.LockFilePath = in.LockFilePath
+	out.ExitOnLockContention = in.ExitOnLockContention
+	out.SeccompProfileRoot = in.SeccompProfileRoot
+	out.NodeStatusMaxImages = in.NodeStatusMaxImages
 	return nil
 }
 
@@ -470,6 +474,10 @@ func autoConvert_config_KubeletConfiguration_To_v1beta1_KubeletConfiguration(in 
 	out.EnforceNodeAllocatable = *(*[]string)(unsafe.Pointer(&in.EnforceNodeAllocatable))
 	out.ReservedSystemCPUs = in.ReservedSystemCPUs
 	out.ShowHiddenMetricsForVersion = in.ShowHiddenMetricsForVersion
+	out.LockFilePath = in.LockFilePath
+	out.ExitOnLockContention = in.ExitOnLockContention
+	out.SeccompProfileRoot = in.SeccompProfileRoot
+	out.NodeStatusMaxImages = in.NodeStatusMaxImages
 	return nil
 }
 

--- a/pkg/kubelet/apis/config/validation/validation.go
+++ b/pkg/kubelet/apis/config/validation/validation.go
@@ -83,6 +83,12 @@ func ValidateKubeletConfiguration(kc *kubeletconfig.KubeletConfiguration) error 
 	if kc.KubeAPIQPS < 0 {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: KubeAPIQPS (--kube-api-qps) %v must not be a negative number", kc.KubeAPIQPS))
 	}
+	if kc.LockFilePath == "" && kc.ExitOnLockContention {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: ExitOnLockContention (--exit-on-lock-contention) was specified and LockFilePath (--lock-file-path) was not specified"))
+	}
+	if kc.NodeStatusMaxImages < -1 {
+		allErrors = append(allErrors, fmt.Errorf("invalid configuration: NodeStatusMaxImages (--node-status-max-images) must be -1 or greater"))
+	}
 	if kc.MaxOpenFiles < 0 {
 		allErrors = append(allErrors, fmt.Errorf("invalid configuration: MaxOpenFiles (--max-open-files) %v must not be a negative number", kc.MaxOpenFiles))
 	}

--- a/staging/src/k8s.io/kubelet/config/v1beta1/types.go
+++ b/staging/src/k8s.io/kubelet/config/v1beta1/types.go
@@ -37,6 +37,8 @@ const (
 	// and kube-proxy is running in iptables mode, hairpin packets will be
 	// dropped by the container bridge.
 	HairpinNone = "none"
+	// DefaultRootDir defines the default root directory used by Kubelet.
+	DefaultRootDir = "/var/lib/kubelet"
 )
 
 // ResourceChangeDetectionStrategy denotes a mode in which internal
@@ -767,6 +769,31 @@ type KubeletConfiguration struct {
 	// Default: "/usr/libexec/kubernetes/kubelet-plugins/volume/exec/"
 	// +optional
 	VolumePluginDir string `json:"volumePluginDir,omitempty"`
+
+	/* Experimental flags */
+
+	// lockFilePath is the path that kubelet will use to as a lock file.
+	// It uses this file as a lock to synchronize with other kubelet processes
+	// that may be running.
+	// Default: ""
+	// +optional
+	LockFilePath string `json:"lockFilePath,omitempty"`
+	// exitOnLockContention is a flag that signifies to the kubelet that it is running
+	// in "bootstrap" mode. This requires that 'LockFilePath' has been set.
+	// This will cause the kubelet to listen to inotify events on the lock file,
+	// releasing it and exiting when another process tries to open that file.
+	// Default: false
+	// +optional
+	ExitOnLockContention bool `json:"exitOnLockContention,omitempty"`
+	// seccompProfileRoot is the directory path for seccomp profiles.
+	// Default: ""
+	// +optional
+	SeccompProfileRoot string `json:"seccompProfileRoot,omitempty"`
+	// nodeStatusMaxImages caps the number of images reported in Node.Status.Images.
+	// This is an experimental, short-term flag to help with node scalability.
+	// Default: 50
+	// +optional
+	NodeStatusMaxImages int32 `json:"nodeStatusMaxImages,omitempty"`
 }
 
 type KubeletAuthorizationMode string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:

/kind cleanup
/area kubelet
/area kubelet-api

**What this PR does / why we need it**:

Moving --lock-file, --exit-on-lock-contention, --seccomp-profile-root, --node-status-max-images to Kubelet configuration

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs https://github.com/kubernetes/kubernetes/issues/86843

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
The Kubelet's `--lock-file`, `--exit-on-lock-contention`, `--seccomp-profile-root`, `--node-status-max-images` option is now available via the Kubelet config file field `lockFilePath`, `exitOnLockContention`, `seccompProfileRoot` and `nodeStatusMaxImage` respectively.
```