### PR TITLE
fix: azure disk dangling attach issue on VMSS which would cause API throttling

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_controller_common.go
@@ -121,6 +121,11 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 	diskEncryptionSetID := ""
 	writeAcceleratorEnabled := false
 
+	vmset, err := c.getNodeVMSet(nodeName, azcache.CacheReadTypeUnsafe)
+	if err != nil {
+		return -1, err
+	}
+
 	if isManagedDisk {
 		diskName := path.Base(diskURI)
 		resourceGroup, err := getResourceGroupFromDiskURI(diskURI)
@@ -140,9 +145,12 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 			attachErr := fmt.Sprintf(
 				"disk(%s) already attached to node(%s), could not be attached to node(%s)",
 				diskURI, *disk.ManagedBy, nodeName)
-			attachedNode := path.Base(*disk.ManagedBy)
+			attachedNode, err := vmset.GetNodeNameByProviderID(*disk.ManagedBy)
+			if err != nil {
+				return -1, err
+			}
 			klog.V(2).Infof("found dangling volume %s attached to node %s", diskURI, attachedNode)
-			danglingErr := volerr.NewDanglingError(attachErr, types.NodeName(attachedNode), "")
+			danglingErr := volerr.NewDanglingError(attachErr, attachedNode, "")
 			return -1, danglingErr
 		}
 
@@ -155,11 +163,6 @@ func (c *controllerCommon) AttachDisk(isManagedDisk bool, diskName, diskURI stri
 				writeAcceleratorEnabled = true
 			}
 		}
-	}
-
-	vmset, err := c.getNodeVMSet(nodeName, azcache.CacheReadTypeUnsafe)
-	if err != nil {
-		return -1, err
 	}
 
 	instanceid, err := c.cloud.InstanceID(context.TODO(), nodeName)

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_loadbalancer.go
@@ -405,7 +405,7 @@ func (az *Cloud) getServiceLoadBalancerStatus(service *v1.Service, lb *network.L
 				if pipID == nil {
 					return nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress ID is Nil", serviceName, *lb.Name)
 				}
-				pipName, err := getLastSegment(*pipID)
+				pipName, err := getLastSegment(*pipID, "/")
 				if err != nil {
 					return nil, fmt.Errorf("get(%s): lb(%s) - failed to get LB PublicIPAddress Name from ID(%s)", serviceName, *lb.Name, *pipID)
 				}

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_standard_test.go
@@ -62,33 +62,44 @@ func TestIsMasterNode(t *testing.T) {
 func TestGetLastSegment(t *testing.T) {
 	tests := []struct {
 		ID        string
+		separator string
 		expected  string
 		expectErr bool
 	}{
 		{
 			ID:        "",
+			separator: "/",
 			expected:  "",
 			expectErr: true,
 		},
 		{
 			ID:        "foo/",
+			separator: "/",
 			expected:  "",
 			expectErr: true,
 		},
 		{
 			ID:        "foo/bar",
+			separator: "/",
 			expected:  "bar",
 			expectErr: false,
 		},
 		{
 			ID:        "foo/bar/baz",
+			separator: "/",
 			expected:  "baz",
+			expectErr: false,
+		},
+		{
+			ID:        "k8s-agentpool-36841236-vmss_1",
+			separator: "_",
+			expected:  "1",
 			expectErr: false,
 		},
 	}
 
 	for _, test := range tests {
-		s, e := getLastSegment(test.ID)
+		s, e := getLastSegment(test.ID, test.separator)
 		if test.expectErr && e == nil {
 			t.Errorf("Expected err, but it was nil")
 			continue

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_test.go
@@ -2150,9 +2150,14 @@ func TestGetNodeNameByProviderID(t *testing.T) {
 			fail:       false,
 		},
 		{
+			providerID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-1",
+			name:       "k8s-agent-AAAAAAAA-1",
+			fail:       false,
+		},
+		{
 			providerID: CloudProviderName + ":/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
-			name:       "",
-			fail:       true,
+			name:       "k8s-agent-AAAAAAAA-0",
+			fail:       false,
 		},
 		{
 			providerID: CloudProviderName + "://",
@@ -2161,20 +2166,20 @@ func TestGetNodeNameByProviderID(t *testing.T) {
 		},
 		{
 			providerID: ":///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
-			name:       "",
-			fail:       true,
+			name:       "k8s-agent-AAAAAAAA-0",
+			fail:       false,
 		},
 		{
 			providerID: "aws:///subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroupName/providers/Microsoft.Compute/virtualMachines/k8s-agent-AAAAAAAA-0",
-			name:       "",
-			fail:       true,
+			name:       "k8s-agent-AAAAAAAA-0",
+			fail:       false,
 		},
 	}
 
 	for _, test := range providers {
 		name, err := az.vmSet.GetNodeNameByProviderID(test.providerID)
 		if (err != nil) != test.fail {
-			t.Errorf("Expected to failt=%t, with pattern %v", test.fail, test)
+			t.Errorf("Expected to fail=%t, with pattern %v", test.fail, test)
 		}
 
 		if test.fail {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go
@@ -285,6 +285,11 @@ func (ss *scaleSet) GetInstanceIDByNodeName(name string) (string, error) {
 }
 
 // GetNodeNameByProviderID gets the node name by provider ID.
+// providerID example:
+// 	 1. vmas providerID: azure:///subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachines/aks-nodepool1-27053986-0
+// 	 2. vmss providerID:
+//		azure:///subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/1
+//	    /subscriptions/subsid/resourceGroups/rg/providers/Microsoft.Compute/virtualMachineScaleSets/aks-agentpool-22126781-vmss/virtualMachines/k8s-agentpool-36841236-vmss_1
 func (ss *scaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, error) {
 	// NodeName is not part of providerID for vmss instances.
 	scaleSetName, err := extractScaleSetNameByProviderID(providerID)
@@ -298,10 +303,18 @@ func (ss *scaleSet) GetNodeNameByProviderID(providerID string) (types.NodeName, 
 		return "", fmt.Errorf("error of extracting resource group for node %q", providerID)
 	}
 
-	instanceID, err := getLastSegment(providerID)
+	instanceID, err := getLastSegment(providerID, "/")
 	if err != nil {
 		klog.V(4).Infof("Can not extract instanceID from providerID (%s), assuming it is managed by availability set: %v", providerID, err)
 		return ss.availabilitySet.GetNodeNameByProviderID(providerID)
+	}
+
+	// instanceID contains scaleSetName (returned by disk.ManagedBy), e.g. k8s-agentpool-36841236-vmss_1
+	if strings.HasPrefix(strings.ToLower(instanceID), strings.ToLower(scaleSetName)) {
+		instanceID, err = getLastSegment(instanceID, "_")
+		if err != nil {
+			return "", err
+		}
 	}
 
 	vm, err := ss.getVmssVMByInstanceID(resourceGroup, scaleSetName, instanceID, azcache.CacheReadTypeUnsafe)
@@ -695,7 +708,7 @@ func (ss *scaleSet) GetPrimaryInterface(nodeName string) (network.Interface, err
 		return network.Interface{}, err
 	}
 
-	nicName, err := getLastSegment(primaryInterfaceID)
+	nicName, err := getLastSegment(primaryInterfaceID, "/")
 	if err != nil {
 		klog.Errorf("error: ss.GetPrimaryInterface(%s), getLastSegment(%s), err=%v", nodeName, primaryInterfaceID, err)
 		return network.Interface{}, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
fix: azure disk dangling attach issue, and this issue only happens on **VMSS**.
PR(https://github.com/kubernetes/kubernetes/pull/81266) does not convert the VMSS node name which causes error like this:
```
failed to get azure instance id for node \"k8s-agentpool1-32474172-vmss_1216\" (not a vmss instance)
```

This is rarely happen issue since dangling error only happens when the previous detach disk failed, the disk was still attached to the node while no pod on that node is using that disk.
The disk detach failed could be due to 1) VM busy 2) kube-controller-manager restart, etc. 

#### VMSS nodeName value
 - `disk.ManagedBy` value: `/subscriptions/0e46bd28-a80f-4d3a-8200-d9eb8d80cb2e/resourceGroups/kubetest-b28d2392-498e-11ea-af8c-fab712ce9f74/providers/Microsoft.Compute/virtualMachineScaleSets/k8s-agentpool-36841236-vmss/virtualMachines/k8s-agentpool-36841236-vmss_1`

 - correct `nodeName` value: `k8s-agentpool-36841236-vmss000001`


That will make dangling attach return error, and k8s volume attach/detach controller will getVmssInstance, and since the nodeName is in an incorrect format, it will always clean vmss cache if node not found, thus incur a get vmss API call storm.
https://github.com/kubernetes/kubernetes/blob/3365ed5625797cfaafbdab368e901e9f4739329a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_vmss.go#L172-L174

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #90762

**Special notes for your reviewer**:
```
Events:
  Type     Reason                  Age                    From                                        Message
  ----     ------                  ----                   ----                                        -------
  Normal   Scheduled               6m29s                  default-scheduler                           Successfully assigned default/nginx-azuredisk to k8s-agentpool-17772720-vmss000000
  Warning  FailedAttachVolume      4m19s (x9 over 6m27s)  attachdetach-controller                     AttachVolume.Attach failed for volume "pvc-d26d9690-30d6-46c0-b019-3fc654abd38d" : disk(/subscriptions/xxx/resourceGroups/andy-1182a/providers/Microsoft.Compute/disks/andy-1182a-dynamic-pvc-d26d9690-30d6-46c0-b019-3fc654abd38d) already attached to node(/subscriptions/xxx/resourceGroups/andy-1182a/providers/Microsoft.Compute/virtualMachineScaleSets/k8s-agentpool-17772720-vmss/virtualMachines/k8s-agentpool-17772720-vmss_1), could not be attached to node(k8s-agentpool-17772720-vmss000000)
  Warning  FailedMount             2m10s (x2 over 4m26s)  kubelet, k8s-agentpool-17772720-vmss000000  Unable to attach or mount volumes: unmounted volumes=[disk01], unattached volumes=[disk01 default-token-gkx8w]: timed out waiting for the condition
  Normal   SuccessfulAttachVolume  99s                    attachdetach-controller                     AttachVolume.Attach succeeded for volume "pvc-d26d9690-30d6-46c0-b019-3fc654abd38d"
  Normal   Pulling                 13s                    kubelet, k8s-agentpool-17772720-vmss000000  Pulling image "nginx"
  Normal   Pulled                  11s                    kubelet, k8s-agentpool-17772720-vmss000000  Successfully pulled image "nginx"
  Normal   Created                 7s                     kubelet, k8s-agentpool-17772720-vmss000000  Created container nginx-azuredisk
  Normal   Started                 7s                     kubelet, k8s-agentpool-17772720-vmss000000  Started container nginx-azuredisk

```

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
fix: azure disk dangling attach issue which would cause API throttling
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
fix: azure disk dangling attach issue which would cause API throttling
```

/kind bug
/assign @feiskyer 
/priority important-soon
/sig cloud-provider
/area provider/azure