### PR TITLE
Prevent a OIDC panic if persister is nil

### DIFF
--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure.go
@@ -341,9 +341,10 @@ func (ts *azureTokenSource) storeTokenInCfg(token *azureToken) error {
 	newCfg[cfgExpiresOn] = string(token.token.ExpiresOn)
 	newCfg[cfgConfigMode] = strconv.Itoa(int(ts.configMode))
 
-	err := ts.persister.Persist(newCfg)
-	if err != nil {
-		return fmt.Errorf("persisting the configuration: %v", err)
+	if ts.persister != nil {
+		if err := ts.persister.Persist(newCfg); err != nil {
+			return fmt.Errorf("persisting the configuration: %v", err)
+		}
 	}
 	ts.cfg = newCfg
 	return nil

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/azure/azure_test.go
@@ -222,6 +222,27 @@ func TestAzureTokenSource(t *testing.T) {
 			}
 		})
 
+		t.Run("validate token with nil persiter", func(t *testing.T) {
+			fakeAccessToken := "fake token 1"
+			fakeSource := fakeTokenSource{token: newFakeAzureToken(fakeAccessToken, time.Now().Add(3600*time.Second))}
+			cfg := make(map[string]string)
+			tokenCache := newAzureTokenCache()
+			tokenSource := newAzureTokenSource(&fakeSource, tokenCache, cfg, configMode, nil)
+			token, err := tokenSource.Token()
+			if err != nil {
+				t.Errorf("failed to retrieve the token form cache: %v", err)
+			}
+
+			wantCacheLen := 1
+			if len(tokenCache.cache) != wantCacheLen {
+				t.Errorf("Token() cache length error: got %v, want %v", len(tokenCache.cache), wantCacheLen)
+			}
+
+			if token != tokenCache.cache[azureTokenKey] {
+				t.Error("Token() returned token != cached token")
+			}
+		})
+
 		t.Run("validate token against cache", func(t *testing.T) {
 			fakeAccessToken := "fake token 1"
 			fakeSource := fakeTokenSource{token: newFakeAzureToken(fakeAccessToken, time.Now().Add(3600*time.Second))}

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/BUILD
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/BUILD
@@ -10,7 +10,10 @@ go_test(
     name = "go_default_test",
     srcs = ["gcp_test.go"],
     embed = [":go_default_library"],
-    deps = ["//vendor/golang.org/x/oauth2:go_default_library"],
+    deps = [
+        "//staging/src/k8s.io/client-go/rest:go_default_library",
+        "//vendor/golang.org/x/oauth2:go_default_library",
+    ],
 )
 
 go_library(

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/gcp/gcp.go
@@ -374,7 +374,11 @@ func (t *conditionalTransport) RoundTrip(req *http.Request) (*http.Response, err
 
 	if res.StatusCode == 401 {
 		klog.V(4).Infof("The credentials that were supplied are invalid for the target cluster")
-		t.persister.Persist(t.resetCache)
+		if t.persister != nil {
+			if err := t.persister.Persist(t.resetCache); err != nil {
+				klog.V(4).Infof("Failed to persist token: %v", err)
+			}
+		}
 	}
 
 	return res, nil

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
@@ -278,9 +278,11 @@ func (p *oidcAuthProvider) idToken() (string, error) {
 	}
 	newCfg[cfgIDToken] = idToken
 
-	// Persist new config and if successful, update the in memory config.
-	if err = p.persister.Persist(newCfg); err != nil {
-		return "", fmt.Errorf("could not persist new tokens: %v", err)
+	if p.persister != nil {
+		// Persist new config and if successful, update the in memory config.
+		if err = p.persister.Persist(newCfg); err != nil {
+			return "", fmt.Errorf("could not persist new tokens: %v", err)
+		}
 	}
 	p.cfg = newCfg
 

--- a/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
+++ b/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go
@@ -279,7 +279,6 @@ func (p *oidcAuthProvider) idToken() (string, error) {
 	newCfg[cfgIDToken] = idToken
 
 	if p.persister != nil {
-		// Persist new config and if successful, update the in memory config.
 		if err = p.persister.Persist(newCfg); err != nil {
 			return "", fmt.Errorf("could not persist new tokens: %v", err)
 		}


### PR DESCRIPTION
Using [oidc](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/plugin/pkg/client/auth/oidc/oidc.go) with a [DirectClientConfig](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/clientcmd/client_config.go#L77) without a [ConfigAccess](https://github.com/kubernetes/kubernetes/blob/master/staging/src/k8s.io/client-go/tools/clientcmd/config.go#L34) (`nil`) would result in a panic due to the missing `persister` `nil` check.

I believe the correct behaviour is to proceed if no persister is specified. 
Another, less ideal, solution would be to return an error if no persister is present.

/kind bug

```release-note
fix OIDC auth provider panic if no persister is present
```

Fixes #90766