### PR TITLE
Fix CSI e2e leaving pods in terminating state

### DIFF
--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -244,7 +244,7 @@ OUTER:
 
 // WaitForNamespacesDeleted waits for the namespaces to be deleted.
 func WaitForNamespacesDeleted(c clientset.Interface, namespaces []string, timeout time.Duration) error {
-	ginkgo.By("Waiting for namespaces to vanish")
+	ginkgo.By(fmt.Sprintf("Waiting for namespaces %+v to vanish", namespaces))
 	nsMap := map[string]bool{}
 	for _, ns := range namespaces {
 		nsMap[ns] = true

--- a/test/e2e/storage/external/external.go
+++ b/test/e2e/storage/external/external.go
@@ -282,7 +282,7 @@ func (d *driverDefinition) GetDynamicProvisionStorageClass(e2econfig *testsuites
 		framework.ExpectNoError(err, "load storage class from %s", d.StorageClass.FromFile)
 		framework.ExpectEqual(len(items), 1, "exactly one item from %s", d.StorageClass.FromFile)
 
-		err = utils.PatchItems(f, items...)
+		err = utils.PatchItems(f, f.Namespace, items...)
 		framework.ExpectNoError(err, "patch items")
 
 		sc, ok = items[0].(*storagev1.StorageClass)

--- a/test/e2e/storage/testsuites/base.go
+++ b/test/e2e/storage/testsuites/base.go
@@ -554,10 +554,11 @@ func getSnapshot(claimName string, ns, snapshotClassName string) *unstructured.U
 //
 // The output goes to log files (when using --report-dir, as in the
 // CI) or the output stream (otherwise).
-func StartPodLogs(f *framework.Framework) func() {
+func StartPodLogs(f *framework.Framework, driverNamespace *v1.Namespace) func() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cs := f.ClientSet
-	ns := f.Namespace
+
+	ns := driverNamespace.Name
 
 	to := podlogs.LogOutput{
 		StatusWriter: ginkgo.GinkgoWriter,
@@ -575,13 +576,13 @@ func StartPodLogs(f *framework.Framework) func() {
 		to.LogPathPrefix = framework.TestContext.ReportDir + "/" +
 			reg.ReplaceAllString(test.FullTestText, "_") + "/"
 	}
-	podlogs.CopyAllLogs(ctx, cs, ns.Name, to)
+	podlogs.CopyAllLogs(ctx, cs, ns, to)
 
 	// pod events are something that the framework already collects itself
 	// after a failed test. Logging them live is only useful for interactive
 	// debugging, not when we collect reports.
 	if framework.TestContext.ReportDir == "" {
-		podlogs.WatchPods(ctx, cs, ns.Name, ginkgo.GinkgoWriter)
+		podlogs.WatchPods(ctx, cs, ns, ginkgo.GinkgoWriter)
 	}
 
 	return cancel

--- a/test/e2e/storage/testsuites/testdriver.go
+++ b/test/e2e/storage/testsuites/testdriver.go
@@ -226,6 +226,9 @@ type PerTestConfig struct {
 	// the configuration that then has to be used to run tests.
 	// The values above are ignored for such tests.
 	ServerConfig *e2evolume.TestConfig
+
+	// Some drivers run in their own namespace
+	DriverNamespace *v1.Namespace
 }
 
 // GetUniqueDriverName returns unique driver name that can be used parallelly in tests

--- a/test/e2e/storage/utils/create.go
+++ b/test/e2e/storage/utils/create.go
@@ -141,14 +141,7 @@ func PatchItems(f *framework.Framework, items ...interface{}) error {
 // - only the latest stable API version for each item is supported
 func CreateItems(f *framework.Framework, items ...interface{}) (func(), error) {
 	var destructors []func() error
-	var cleanupHandle framework.CleanupActionHandle
 	cleanup := func() {
-		if cleanupHandle == nil {
-			// Already done.
-			return
-		}
-		framework.RemoveCleanupAction(cleanupHandle)
-
 		// TODO (?): use same logic as framework.go for determining
 		// whether we are expected to clean up? This would change the
 		// meaning of the -delete-namespace and -delete-namespace-on-failure
@@ -160,7 +153,6 @@ func CreateItems(f *framework.Framework, items ...interface{}) (func(), error) {
 			}
 		}
 	}
-	cleanupHandle = framework.AddCleanupAction(cleanup)
 
 	var result error
 	for _, item := range items {

--- a/test/e2e/storage/utils/create.go
+++ b/test/e2e/storage/utils/create.go
@@ -114,11 +114,11 @@ func visitManifests(cb func([]byte) error, files ...string) error {
 // PatchItems has some limitations:
 // - only some common items are supported, unknown ones trigger an error
 // - only the latest stable API version for each item is supported
-func PatchItems(f *framework.Framework, items ...interface{}) error {
+func PatchItems(f *framework.Framework, driverNamspace *v1.Namespace, items ...interface{}) error {
 	for _, item := range items {
 		// Uncomment when debugging the loading and patching of items.
 		// Logf("patching original content of %T:\n%s", item, PrettyPrint(item))
-		if err := patchItemRecursively(f, item); err != nil {
+		if err := patchItemRecursively(f, driverNamspace, item); err != nil {
 			return err
 		}
 	}
@@ -139,7 +139,7 @@ func PatchItems(f *framework.Framework, items ...interface{}) error {
 // PatchItems has the some limitations as LoadFromManifests:
 // - only some common items are supported, unknown ones trigger an error
 // - only the latest stable API version for each item is supported
-func CreateItems(f *framework.Framework, items ...interface{}) (func(), error) {
+func CreateItems(f *framework.Framework, ns *v1.Namespace, items ...interface{}) (func(), error) {
 	var destructors []func() error
 	cleanup := func() {
 		// TODO (?): use same logic as framework.go for determining
@@ -163,7 +163,7 @@ func CreateItems(f *framework.Framework, items ...interface{}) (func(), error) {
 		// description = fmt.Sprintf("%s:\n%s", description, PrettyPrint(item))
 		framework.Logf("creating %s", description)
 		for _, factory := range factories {
-			destructor, err := factory.Create(f, item)
+			destructor, err := factory.Create(f, ns, item)
 			if destructor != nil {
 				destructors = append(destructors, func() error {
 					framework.Logf("deleting %s", description)
@@ -195,12 +195,12 @@ func CreateItems(f *framework.Framework, items ...interface{}) (func(), error) {
 // CreateFromManifests is a combination of LoadFromManifests,
 // PatchItems, patching with an optional custom function,
 // and CreateItems.
-func CreateFromManifests(f *framework.Framework, patch func(item interface{}) error, files ...string) (func(), error) {
+func CreateFromManifests(f *framework.Framework, driverNamespace *v1.Namespace, patch func(item interface{}) error, files ...string) (func(), error) {
 	items, err := LoadFromManifests(files...)
 	if err != nil {
 		return nil, errors.Wrap(err, "CreateFromManifests")
 	}
-	if err := PatchItems(f, items...); err != nil {
+	if err := PatchItems(f, driverNamespace, items...); err != nil {
 		return nil, err
 	}
 	if patch != nil {
@@ -210,7 +210,7 @@ func CreateFromManifests(f *framework.Framework, patch func(item interface{}) er
 			}
 		}
 	}
-	return CreateItems(f, items...)
+	return CreateItems(f, driverNamespace, items...)
 }
 
 // What is a subset of metav1.TypeMeta which (in contrast to
@@ -250,7 +250,7 @@ type ItemFactory interface {
 	// error or a cleanup function for the created item.
 	// If the item is of an unsupported type, it must return
 	// an error that has errorItemNotSupported as cause.
-	Create(f *framework.Framework, item interface{}) (func() error, error)
+	Create(f *framework.Framework, ns *v1.Namespace, item interface{}) (func() error, error)
 }
 
 // describeItem always returns a string that describes the item,
@@ -294,16 +294,21 @@ func PatchName(f *framework.Framework, item *string) {
 // PatchNamespace moves the item into the test's namespace.  Not
 // all items can be namespaced. For those, the name also needs to be
 // patched.
-func PatchNamespace(f *framework.Framework, item *string) {
+func PatchNamespace(f *framework.Framework, driverNamespace *v1.Namespace, item *string) {
+	if driverNamespace != nil {
+		*item = driverNamespace.GetName()
+		return
+	}
+
 	if f.Namespace != nil {
 		*item = f.Namespace.GetName()
 	}
 }
 
-func patchItemRecursively(f *framework.Framework, item interface{}) error {
+func patchItemRecursively(f *framework.Framework, driverNamespace *v1.Namespace, item interface{}) error {
 	switch item := item.(type) {
 	case *rbacv1.Subject:
-		PatchNamespace(f, &item.Namespace)
+		PatchNamespace(f, driverNamespace, &item.Namespace)
 	case *rbacv1.RoleRef:
 		// TODO: avoid hard-coding this special name. Perhaps add a Framework.PredefinedRoles
 		// which contains all role names that are defined cluster-wide before the test starts?
@@ -315,7 +320,7 @@ func patchItemRecursively(f *framework.Framework, item interface{}) error {
 	case *rbacv1.ClusterRole:
 		PatchName(f, &item.Name)
 	case *rbacv1.Role:
-		PatchNamespace(f, &item.Namespace)
+		PatchNamespace(f, driverNamespace, &item.Namespace)
 		// Roles are namespaced, but because for RoleRef above we don't
 		// know whether the referenced role is a ClusterRole or Role
 		// and therefore always renames, we have to do the same here.
@@ -325,33 +330,33 @@ func patchItemRecursively(f *framework.Framework, item interface{}) error {
 	case *storagev1.CSIDriver:
 		PatchName(f, &item.Name)
 	case *v1.ServiceAccount:
-		PatchNamespace(f, &item.ObjectMeta.Namespace)
+		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
 	case *v1.Secret:
-		PatchNamespace(f, &item.ObjectMeta.Namespace)
+		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
 	case *rbacv1.ClusterRoleBinding:
 		PatchName(f, &item.Name)
 		for i := range item.Subjects {
-			if err := patchItemRecursively(f, &item.Subjects[i]); err != nil {
+			if err := patchItemRecursively(f, driverNamespace, &item.Subjects[i]); err != nil {
 				return errors.Wrapf(err, "%T", f)
 			}
 		}
-		if err := patchItemRecursively(f, &item.RoleRef); err != nil {
+		if err := patchItemRecursively(f, driverNamespace, &item.RoleRef); err != nil {
 			return errors.Wrapf(err, "%T", f)
 		}
 	case *rbacv1.RoleBinding:
-		PatchNamespace(f, &item.Namespace)
+		PatchNamespace(f, driverNamespace, &item.Namespace)
 		for i := range item.Subjects {
-			if err := patchItemRecursively(f, &item.Subjects[i]); err != nil {
+			if err := patchItemRecursively(f, driverNamespace, &item.Subjects[i]); err != nil {
 				return errors.Wrapf(err, "%T", f)
 			}
 		}
-		if err := patchItemRecursively(f, &item.RoleRef); err != nil {
+		if err := patchItemRecursively(f, driverNamespace, &item.RoleRef); err != nil {
 			return errors.Wrapf(err, "%T", f)
 		}
 	case *v1.Service:
-		PatchNamespace(f, &item.ObjectMeta.Namespace)
+		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
 	case *appsv1.StatefulSet:
-		PatchNamespace(f, &item.ObjectMeta.Namespace)
+		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
 		if err := patchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
 			return err
 		}
@@ -359,7 +364,7 @@ func patchItemRecursively(f *framework.Framework, item interface{}) error {
 			return err
 		}
 	case *appsv1.DaemonSet:
-		PatchNamespace(f, &item.ObjectMeta.Namespace)
+		PatchNamespace(f, driverNamespace, &item.ObjectMeta.Namespace)
 		if err := patchContainerImages(item.Spec.Template.Spec.Containers); err != nil {
 			return err
 		}
@@ -383,12 +388,12 @@ func (f *serviceAccountFactory) New() runtime.Object {
 	return &v1.ServiceAccount{}
 }
 
-func (*serviceAccountFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*serviceAccountFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*v1.ServiceAccount)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
-	client := f.ClientSet.CoreV1().ServiceAccounts(f.Namespace.GetName())
+	client := f.ClientSet.CoreV1().ServiceAccounts(ns.Name)
 	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "create ServiceAccount")
 	}
@@ -403,7 +408,7 @@ func (f *clusterRoleFactory) New() runtime.Object {
 	return &rbacv1.ClusterRole{}
 }
 
-func (*clusterRoleFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*clusterRoleFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*rbacv1.ClusterRole)
 	if !ok {
 		return nil, errorItemNotSupported
@@ -425,7 +430,7 @@ func (f *clusterRoleBindingFactory) New() runtime.Object {
 	return &rbacv1.ClusterRoleBinding{}
 }
 
-func (*clusterRoleBindingFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*clusterRoleBindingFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*rbacv1.ClusterRoleBinding)
 	if !ok {
 		return nil, errorItemNotSupported
@@ -446,13 +451,13 @@ func (f *roleFactory) New() runtime.Object {
 	return &rbacv1.Role{}
 }
 
-func (*roleFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*roleFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*rbacv1.Role)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
-	client := f.ClientSet.RbacV1().Roles(f.Namespace.GetName())
+	client := f.ClientSet.RbacV1().Roles(ns.Name)
 	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "create Role")
 	}
@@ -467,13 +472,13 @@ func (f *roleBindingFactory) New() runtime.Object {
 	return &rbacv1.RoleBinding{}
 }
 
-func (*roleBindingFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*roleBindingFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*rbacv1.RoleBinding)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
-	client := f.ClientSet.RbacV1().RoleBindings(f.Namespace.GetName())
+	client := f.ClientSet.RbacV1().RoleBindings(ns.Name)
 	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "create RoleBinding")
 	}
@@ -488,13 +493,13 @@ func (f *serviceFactory) New() runtime.Object {
 	return &v1.Service{}
 }
 
-func (*serviceFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*serviceFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*v1.Service)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
-	client := f.ClientSet.CoreV1().Services(f.Namespace.GetName())
+	client := f.ClientSet.CoreV1().Services(ns.Name)
 	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "create Service")
 	}
@@ -509,13 +514,13 @@ func (f *statefulSetFactory) New() runtime.Object {
 	return &appsv1.StatefulSet{}
 }
 
-func (*statefulSetFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*statefulSetFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*appsv1.StatefulSet)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
-	client := f.ClientSet.AppsV1().StatefulSets(f.Namespace.GetName())
+	client := f.ClientSet.AppsV1().StatefulSets(ns.Name)
 	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "create StatefulSet")
 	}
@@ -530,13 +535,13 @@ func (f *daemonSetFactory) New() runtime.Object {
 	return &appsv1.DaemonSet{}
 }
 
-func (*daemonSetFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*daemonSetFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*appsv1.DaemonSet)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
-	client := f.ClientSet.AppsV1().DaemonSets(f.Namespace.GetName())
+	client := f.ClientSet.AppsV1().DaemonSets(ns.Name)
 	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "create DaemonSet")
 	}
@@ -551,7 +556,7 @@ func (f *storageClassFactory) New() runtime.Object {
 	return &storagev1.StorageClass{}
 }
 
-func (*storageClassFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*storageClassFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*storagev1.StorageClass)
 	if !ok {
 		return nil, errorItemNotSupported
@@ -572,7 +577,7 @@ func (f *csiDriverFactory) New() runtime.Object {
 	return &storagev1.CSIDriver{}
 }
 
-func (*csiDriverFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*csiDriverFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*storagev1.CSIDriver)
 	if !ok {
 		return nil, errorItemNotSupported
@@ -593,13 +598,13 @@ func (f *secretFactory) New() runtime.Object {
 	return &v1.Secret{}
 }
 
-func (*secretFactory) Create(f *framework.Framework, i interface{}) (func() error, error) {
+func (*secretFactory) Create(f *framework.Framework, ns *v1.Namespace, i interface{}) (func() error, error) {
 	item, ok := i.(*v1.Secret)
 	if !ok {
 		return nil, errorItemNotSupported
 	}
 
-	client := f.ClientSet.CoreV1().Secrets(f.Namespace.GetName())
+	client := f.ClientSet.CoreV1().Secrets(ns.Name)
 	if _, err := client.Create(context.TODO(), item, metav1.CreateOptions{}); err != nil {
 		return nil, errors.Wrap(err, "create Secret")
 	}


### PR DESCRIPTION
This PR fixes problem with CSI tests leaving pods in terminating state when testsuite is interrupted . This happens because driver pod gets deleted before testpods have a chance to terminate.

This PR solves this problem by creating driver pods in different namespace than the test pod.

This is kinda another iteration of https://github.com/kubernetes/kubernetes/pull/89944

/sig storage
