### PR TITLE
Set umask 0022 when building

### DIFF
--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -523,6 +523,10 @@ kube::golang::setup_env() {
 
   # This seems to matter to some tools
   export GO15VENDOREXPERIMENT=1
+
+  # This is for sanity.  Without it, user umasks leak through into release
+  # artifacts.
+  umask 0022
 }
 
 # This will take binaries from $GOPATH/bin and copy them to the appropriate


### PR DESCRIPTION
Some binaries now run as non-root (kube-scheduler).  When umask is 0027,
for example, the container image we build has the binary 0750, which is
not executable by the non-root UID.


/kind bug

```release-note
NONE
```
