### PR TITLE
base-images: Use new debian-iptables:v12.1.0

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -95,7 +95,7 @@ readonly KUBE_CONTAINER_RSYNC_PORT=8730
 kube::build::get_docker_wrapped_binaries() {
   local arch=$1
   local debian_base_version=v2.1.0
-  local debian_iptables_version=v12.0.1
+  local debian_iptables_version=v12.1.0
   ### If you change any of these lists, please also update DOCKERIZED_BINARIES
   ### in build/BUILD. And kube::golang::server_image_targets
   local targets=(

--- a/build/dependencies.yaml
+++ b/build/dependencies.yaml
@@ -110,7 +110,7 @@ dependencies:
       match: TAG\?=
 
   - name: "k8s.gcr.io/debian-iptables: dependents"
-    version: 12.0.1
+    version: 12.1.0
     refPaths:
     - path: build/common.sh
       match: debian_iptables_version=

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -82,12 +82,12 @@ _DEBIAN_BASE_DIGEST = {
 }
 
 _DEBIAN_IPTABLES_DIGEST = {
-    "manifest": "sha256:d1cd487e89fb4cba853cd3a948a6e9016faf66f2a7bb53cb1ac6b6c9cb58f5ed",
-    "amd64": "sha256:852d3c569932059bcab3a52cb6105c432d85b4b7bbd5fc93153b78010e34a783",
-    "arm": "sha256:c10f01b414a7cd4b2f3e26e152c90c64a1e781d99f83a6809764cf74ecbc46c3",
-    "arm64": "sha256:5725e6fde13a6405cf800e22846ebd2bde24b0860f1dc3f6f5f256f03cfa85bd",
-    "ppc64le": "sha256:b6d6e56a0c34c0393dcba0d5faaa531b92e5876114c5ab5a90e82e4889724c5a",
-    "s390x": "sha256:39e67e9bf25d67fe35bd9dcb25367277e5967368e02f2741e0efd4ce8874db14",
+    "manifest": "sha256:1ae6d76dea462973759ff1c4e02263867da1f85db9aa10462a030ca421cbf0e9",
+    "amd64": "sha256:2fb9fa09123a41e6369cac04eb29e26237fe9e43da8e18f676d18d8fffb906fc",
+    "arm": "sha256:a0e97386c073a2990265938fa15dc0db575efdb4d13c0ea63a79e0590813a998",
+    "arm64": "sha256:2a7df97e2c702d9852cc6234aff89b4671cd5b09086ac2b5383411315e5f115d",
+    "ppc64le": "sha256:f5289a6494328b7ccb695e3add65b33ca380b77fcfc9715e474f0efe26e1c506",
+    "s390x": "sha256:1b91a2788750552913377bf1bc99a095544dfb523d80a55674003c974c8e0905",
 }
 
 def _digest(d, arch):
@@ -111,9 +111,9 @@ def debian_image_dependencies():
             name = "debian-iptables-" + arch,
             architecture = arch,
             digest = _digest(_DEBIAN_IPTABLES_DIGEST, arch),
-            registry = "k8s.gcr.io",
+            registry = "us.gcr.io/k8s-artifacts-prod/build-image",
             repository = "debian-iptables",
-            tag = "v12.0.1",  # ignored, but kept here for documentation
+            tag = "v12.1.0",  # ignored, but kept here for documentation
         )
 
 def etcd_tarballs():

--- a/build/workspace.bzl
+++ b/build/workspace.bzl
@@ -71,7 +71,11 @@ def cri_tarballs():
             urls = mirror("https://github.com/kubernetes-incubator/cri-tools/releases/download/v%s/crictl-v%s-%s.tar.gz" % (CRI_TOOLS_VERSION, CRI_TOOLS_VERSION, arch)),
         )
 
-# Use go get -u github.com/estesp/manifest-tool to find these values
+# Use skopeo to find these values: https://github.com/containers/skopeo
+#
+# Example
+# Manifest: skopeo inspect docker://gcr.io/k8s-staging-build-image/debian-base:v2.1.0
+# Arches: skopeo inspect --raw docker://gcr.io/k8s-staging-build-image/debian-base:v2.1.0
 _DEBIAN_BASE_DIGEST = {
     "manifest": "sha256:b118abac0bcf633b9db4086584ee718526fe394cf1bd18aee036e6cc497860f6",
     "amd64": "sha256:a67798e4746faaab3fde5b7407fa8bba75d8b1214d168dc7ad2b5364f6fc4319",
@@ -81,6 +85,11 @@ _DEBIAN_BASE_DIGEST = {
     "s390x": "sha256:dac908eaa61d2034aec252576a470a7e4ab184c361f89170526f707a0c3c6082",
 }
 
+# Use skopeo to find these values: https://github.com/containers/skopeo
+#
+# Example
+# Manifest: skopeo inspect docker://gcr.io/k8s-staging-build-image/debian-iptables:v12.1.0
+# Arches: skopeo inspect --raw docker://gcr.io/k8s-staging-build-image/debian-iptables:v12.1.0
 _DEBIAN_IPTABLES_DIGEST = {
     "manifest": "sha256:1ae6d76dea462973759ff1c4e02263867da1f85db9aa10462a030ca421cbf0e9",
     "amd64": "sha256:2fb9fa09123a41e6369cac04eb29e26237fe9e43da8e18f676d18d8fffb906fc",
@@ -104,6 +113,7 @@ def debian_image_dependencies():
             digest = _digest(_DEBIAN_BASE_DIGEST, arch),
             registry = "us.gcr.io/k8s-artifacts-prod/build-image",
             repository = "debian-base",
+            # Ensure the digests above are updated to match a new tag
             tag = "v2.1.0",  # ignored, but kept here for documentation
         )
 
@@ -113,6 +123,7 @@ def debian_image_dependencies():
             digest = _digest(_DEBIAN_IPTABLES_DIGEST, arch),
             registry = "us.gcr.io/k8s-artifacts-prod/build-image",
             repository = "debian-iptables",
+            # Ensure the digests above are updated to match a new tag
             tag = "v12.1.0",  # ignored, but kept here for documentation
         )
 


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup
/area dependency security release-eng

**What this PR does / why we need it**:
- Update dependents to use debian-iptables:v12.1.0
- Update guidance for updating base image tags and digests

/assign @dims @BenTheElder @cblecker 
cc: @kubernetes/release-engineering
/priority important-soon

**Special notes for your reviewer**:

Image needs to be promoted here: https://github.com/kubernetes/k8s.io/pull/839
Continuation of https://github.com/kubernetes/kubernetes/pull/90697.
Tracking issue: https://github.com/kubernetes/kubernetes/issues/90698

**Does this PR introduce a user-facing change?**:
```release-note
- base-images: Use debian-iptables:v12.1.0
```
