### PR TITLE
kubectl: add regex syntax support for -o jsonpath

### DIFF
--- a/staging/src/k8s.io/client-go/third_party/forked/golang/template/funcs.go
+++ b/staging/src/k8s.io/client-go/third_party/forked/golang/template/funcs.go
@@ -283,7 +283,6 @@ const (
 	integerKind
 	stringKind
 	uintKind
-	sliceKind
 )
 
 func basicKind(v reflect.Value) (kind, error) {
@@ -300,8 +299,6 @@ func basicKind(v reflect.Value) (kind, error) {
 		return complexKind, nil
 	case reflect.String:
 		return stringKind, nil
-	case reflect.Slice:
-		return sliceKind, nil
 	}
 	return invalidKind, errBadComparisonType
 }
@@ -456,15 +453,12 @@ func mtc(pattern interface{}, strs ...interface{}) (bool, error) {
 	hasUnmatch := false
 	for _, str := range strs {
 		vStr := reflect.ValueOf(str)
-		kStr, err := basicKind(vStr)
-		if err != nil {
-			return false, err
-		}
+		kStr := vStr.Kind()
 		var strToMatch string
 		switch kStr {
-		case stringKind:
+		case reflect.String:
 			strToMatch = vStr.String()
-		case sliceKind:
+		case reflect.Slice:
 			// only accept []byte slice
 			kElem := vStr.Type().Elem().Kind()
 			// byte is alias of uint8

--- a/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/jsonpath.go
@@ -543,6 +543,9 @@ func (j *JSONPath) evalFilter(input []reflect.Value, node *FilterNode) ([]reflec
 				pass, err = template.LessEqual(left, right)
 			case ">=":
 				pass, err = template.GreaterEqual(left, right)
+			case "=~":
+				// left is string to match, right is regex pattern
+				pass, err = template.Match(right, left)
 			default:
 				return results, fmt.Errorf("unrecognized filter operator %s", node.Operator)
 			}

--- a/staging/src/k8s.io/client-go/util/jsonpath/parser.go
+++ b/staging/src/k8s.io/client-go/util/jsonpath/parser.go
@@ -370,7 +370,7 @@ Loop:
 	if p.next() != ']' {
 		return fmt.Errorf("unclosed array expect ]")
 	}
-	reg := regexp.MustCompile(`^([^!<>=]+)([!<>=]+)(.+?)$`)
+	reg := regexp.MustCompile(`^([^!<>=~]+)([!<>=~]+)(.+?)$`)
 	text := p.consumeText()
 	text = text[:len(text)-2]
 	value := reg.FindStringSubmatch(text)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature
/sig cli

**What this PR does / why we need it**:
- Enables regular expression syntax in `kubectl -o jsonpath`

**Which issue(s) this PR fixes**:
Fixes #72220

**Special notes for your reviewer**:
@liggitt leave a comment in #72220 saying that jsonpath evaluator is also used in server side. Changing may lead to DOS of apiserver.
What does it mean? Catastrophic backtracking? or Is  `--server-print` using jsonpath evaluator?
I would be happy to fix associated issues if someone could explain this.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
Added regular expression syntax support for command `kubectl -o jsonpath`

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
[Usage]: https://kubernetes.io/docs/reference/kubectl/jsonpath/
```
Docs for `kubectl` jsonpath section should add an example
`kubectl get pods -A -o jsonpath='{.items[?(@.metadata.name=~".*containThis.*")].metadata.name}`
Simply quota the regex with a pair of `"`
For full regex syntax support, refer [https://golang.org/pkg/regexp](https://golang.org/pkg/regexp)