### PR TITLE
Add option to resize kubemark node objects size

### DIFF
--- a/test/kubemark/start-kubemark.sh
+++ b/test/kubemark/start-kubemark.sh
@@ -225,6 +225,24 @@ function start-hollow-nodes {
   wait-for-hollow-nodes-to-run-or-timeout
 }
 
+# Annotates the node objects in the kubemark cluster to make their size
+# similar to regular nodes.
+# TODO(#90833): Replace this with image preloading from ClusterLoader to better
+# reflect the reality in kubemark tests.
+function resize-node-objects {
+  if [[ -z "$KUBEMARK_NODE_OBJECT_SIZE_BYTES" ]]; then
+    return 0
+  fi
+
+  annotation_size_bytes="${KUBEMARK_NODE_OBJECT_SIZE_BYTES}"
+  echo "Annotating node objects with ${annotation_size_bytes} byte label"
+  label=$( (< /dev/urandom tr -dc 'a-zA-Z0-9' | fold -w "$annotation_size_bytes"; true) | head -n 1)
+  "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" get nodes -o name \
+    | xargs -n10 -P100 -r -I% "${KUBECTL}" --kubeconfig="${LOCAL_KUBECONFIG}" annotate --overwrite % label="$label"
+  echo "Annotating node objects completed"
+}
+
+
 detect-project &> /dev/null
 create-kubemark-master
 
@@ -237,6 +255,7 @@ fi
 MASTER_IP=$(grep server "${HOLLOWNODE_KUBECONFIG}" | awk -F "/" '{print $3}')
 
 start-hollow-nodes
+resize-node-objects
 
 echo ""
 echo "Master IP: ${MASTER_IP}"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This is a slightly polished version of a [PR](https://github.com/kubernetes/kubernetes/pull/90722) by @mm4tt. The change will enable artificial kubemark node objects size increase to make their size similar to node objects in a regular cluster.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue is opened for that (as far as I know).

**Special notes for your reviewer**:
/sig scalability
/assign mm4tt

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```