### PR TITLE
Service load balancers should include unschedulable nodes

### DIFF
--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller.go
@@ -635,12 +635,6 @@ func nodeSlicesEqualForLB(x, y []*v1.Node) bool {
 
 func (s *Controller) getNodeConditionPredicate() NodeConditionPredicate {
 	return func(node *v1.Node) bool {
-		// We add the master to the node list, but its unschedulable.  So we use this to filter
-		// the master.
-		if node.Spec.Unschedulable {
-			return false
-		}
-
 		if s.legacyNodeRoleFeatureEnabled {
 			// As of 1.6, we will taint the master, but not necessarily mark it unschedulable.
 			// Recognize nodes labeled as master, and filter them also, as we were doing previously.

--- a/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
+++ b/staging/src/k8s.io/cloud-provider/controllers/service/controller_test.go
@@ -1379,6 +1379,11 @@ func Test_getNodeConditionPredicate(t *testing.T) {
 		input           *v1.Node
 		want            bool
 	}{
+		{want: false, input: &v1.Node{}},
+		{want: true, input: &v1.Node{Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}}}}},
+		{want: false, input: &v1.Node{Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}}}}},
+		{want: true, input: &v1.Node{Spec: v1.NodeSpec{Unschedulable: true}, Status: v1.NodeStatus{Conditions: []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionTrue}}}}},
+
 		{want: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{}}}},
 		{want: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleMaster: ""}}}},
 		{want: true, input: &v1.Node{Status: validNodeStatus, ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelNodeRoleExcludeBalancer: ""}}}},


### PR DESCRIPTION
In #16443 a set of changes were made to enable service load balancers for Kube 1.1 and GCP to exclude master unschedulable nodes from load balancer pools. However, Unschedulable has nothing to do with whether nodes should host service load balancer pods - the act of preventing new pods from landing on a node has no impact on existing workloads.

In general nodes are not special, and a user who wants to exclude otherwise healthy nodes can use the beta service load balancer label to exclude the node from the LB pool.  This fits under KEP https://github.com/kubernetes/enhancements/blob/master/keps/sig-architecture/2019-07-16-node-role-label-use.md#service-load-balancer which clarifies these rules and makes orthogonal behavior clear.

This commit removes the check for unschedulable nodes from the LB pool.

This caused a production outage when nodes in an autoscaling group were marked unschedulable so the autoscaler would gracefully terminate them - instead the ingress controllers on those nodes were immediately removed from the LB pool and no new ingress requests could be accepted.

Fixes #65013 

/kind bug

```release-note
Service load balancers no longer exclude nodes marked unschedulable from the candidate nodes. The service load balancer exclusion label should be used instead.

Users upgrading from 1.18 who have cordoned nodes should set the `node.kubernetes.io/exclude-from-external-load-balancers` label on the impacted nodes before upgrading if they wish those nodes to remain excluded from service load balancers.
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```