### PR TITLE
Add admin account on master for kube-up

### DIFF
--- a/cluster/gce/gci/configure-helper.sh
+++ b/cluster/gce/gci/configure-helper.sh
@@ -2564,6 +2564,10 @@ function gke-master-start {
     echo "Running GKE internal configuration script"
     . "${KUBE_HOME}/bin/gke-internal-configure-helper.sh"
     gke-internal-master-start
+ elif [[ -n "${KUBE_BEARER_TOKEN:-}" ]]; then
+   echo "setting up local admin kubeconfig"
+   create-kubeconfig "local-admin" "${KUBE_BEARER_TOKEN}"
+   echo "export KUBECONFIG=/etc/srv/kubernetes/local-admin/kubeconfig" > /etc/profile.d/kubeconfig.sh
   fi
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Creates a master local admin account.
If you are on the master you can now run kubectl.

**Which issue(s) this PR fixes**:
Fixes #87481

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```
