### PR TITLE
move mutatingwebhook executing point to strategy.BeforeCreate/BeforeUpdate

### DIFF
--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -452,7 +452,6 @@ func (tc *patchTestCase) Run(t *testing.T) {
 
 			createValidation: rest.ValidateAllObjectFunc,
 			updateValidation: admissionValidation,
-			admissionCheck:   admissionMutation,
 
 			codec: codec,
 

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/create.go
@@ -102,6 +102,12 @@ func BeforeCreate(strategy RESTCreateStrategy, ctx context.Context, obj runtime.
 		objectMeta.SetClusterName("")
 	}
 
+	if mutateObjectFunc, ok := MutateObjectFuncFrom(ctx); ok {
+		if err := mutateObjectFunc(ctx, obj, nil); err != nil {
+			return err
+		}
+	}
+
 	if errs := strategy.Validate(ctx, obj); len(errs) > 0 {
 		return errors.NewInvalid(kind.GroupKind(), objectMeta.GetName(), errs)
 	}

--- a/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
+++ b/staging/src/k8s.io/apiserver/pkg/registry/rest/update.go
@@ -133,6 +133,12 @@ func BeforeUpdate(strategy RESTUpdateStrategy, ctx context.Context, obj, old run
 		objectMeta.SetDeletionGracePeriodSeconds(oldMeta.GetDeletionGracePeriodSeconds())
 	}
 
+	if mutateObjectFunc, ok := MutateObjectFuncFrom(ctx); ok {
+		if err := mutateObjectFunc(ctx, obj, old); err != nil {
+			return err
+		}
+	}
+
 	// Ensure some common fields, like UID, are validated for all resources.
 	errs, err := validateCommonFields(obj, old, strategy)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
In order to inject annotation and env generated from pod name into pod spec, we develop a mutatingwebhook. But we find that pod name from `AdmissionReview` owned by deployment is empty. I know that name of pods owned by deployment is generated from `GenerateName` of pod spec by kube-apiserver, but still curious that if it's better to move executing point of mutatingwebhook after such **internal updating/generating** actions of kube-apiserver.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
This PR adjust executing point of mutating admission after 'internal updating/generating' actions of kube-apiserver, so that we can get these **generated** fields in mutatingwebhooks. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```
