### PR TITLE
kubeadm: Move IPv6DualStack feature gate to component config

### DIFF
--- a/cmd/kubeadm/app/componentconfigs/kubelet.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet.go
@@ -105,6 +105,12 @@ func (kc *kubeletConfig) Default(cfg *kubeadmapi.ClusterConfiguration, _ *kubead
 		kc.config.FeatureGates = map[string]bool{}
 	}
 
+	// TODO: The following code should be removed after dual-stack is GA.
+	// Note: The user still retains the ability to explicitly set feature-gates and that value will overwrite this base value.
+	if enabled, present := cfg.FeatureGates[features.IPv6DualStack]; present {
+		kc.config.FeatureGates[features.IPv6DualStack] = enabled
+	}
+
 	if kc.config.StaticPodPath == "" {
 		kc.config.StaticPodPath = kubeadmapiv1beta2.DefaultManifestsDir
 	} else if kc.config.StaticPodPath != kubeadmapiv1beta2.DefaultManifestsDir {

--- a/cmd/kubeadm/app/componentconfigs/kubelet_test.go
+++ b/cmd/kubeadm/app/componentconfigs/kubelet_test.go
@@ -229,7 +229,45 @@ func TestKubeletDefault(t *testing.T) {
 			},
 		},
 		{
-			name: "Service subnet, dual stack defaulting works",
+			name: "Service subnet, explicitly disabled dual stack defaulting works",
+			clusterCfg: kubeadmapi.ClusterConfiguration{
+				FeatureGates: map[string]bool{
+					features.IPv6DualStack: false,
+				},
+				Networking: kubeadmapi.Networking{
+					ServiceSubnet: "192.168.0.0/16",
+				},
+			},
+			expected: kubeletConfig{
+				config: kubeletconfig.KubeletConfiguration{
+					FeatureGates: map[string]bool{
+						features.IPv6DualStack: false,
+					},
+					StaticPodPath: kubeadmapiv1beta2.DefaultManifestsDir,
+					ClusterDNS:    []string{"192.168.0.10"},
+					Authentication: kubeletconfig.KubeletAuthentication{
+						X509: kubeletconfig.KubeletX509Authentication{
+							ClientCAFile: constants.CACertName,
+						},
+						Anonymous: kubeletconfig.KubeletAnonymousAuthentication{
+							Enabled: utilpointer.BoolPtr(kubeletAuthenticationAnonymousEnabled),
+						},
+						Webhook: kubeletconfig.KubeletWebhookAuthentication{
+							Enabled: utilpointer.BoolPtr(kubeletAuthenticationWebhookEnabled),
+						},
+					},
+					Authorization: kubeletconfig.KubeletAuthorization{
+						Mode: kubeletconfig.KubeletAuthorizationModeWebhook,
+					},
+					HealthzBindAddress: kubeletHealthzBindAddress,
+					HealthzPort:        utilpointer.Int32Ptr(constants.KubeletHealthzPort),
+					RotateCertificates: kubeletRotateCertificates,
+					ResolverConfig:     resolverConfig,
+				},
+			},
+		},
+		{
+			name: "Service subnet, enabled dual stack defaulting works",
 			clusterCfg: kubeadmapi.ClusterConfiguration{
 				FeatureGates: map[string]bool{
 					features.IPv6DualStack: true,
@@ -240,7 +278,9 @@ func TestKubeletDefault(t *testing.T) {
 			},
 			expected: kubeletConfig{
 				config: kubeletconfig.KubeletConfiguration{
-					FeatureGates:  map[string]bool{},
+					FeatureGates: map[string]bool{
+						features.IPv6DualStack: true,
+					},
 					StaticPodPath: kubeadmapiv1beta2.DefaultManifestsDir,
 					ClusterDNS:    []string{"192.168.0.10"},
 					Authentication: kubeletconfig.KubeletAuthentication{

--- a/cmd/kubeadm/app/phases/kubelet/BUILD
+++ b/cmd/kubeadm/app/phases/kubelet/BUILD
@@ -14,7 +14,6 @@ go_library(
         "//cmd/kubeadm/app/apis/kubeadm:go_default_library",
         "//cmd/kubeadm/app/componentconfigs:go_default_library",
         "//cmd/kubeadm/app/constants:go_default_library",
-        "//cmd/kubeadm/app/features:go_default_library",
         "//cmd/kubeadm/app/images:go_default_library",
         "//cmd/kubeadm/app/util:go_default_library",
         "//cmd/kubeadm/app/util/apiclient:go_default_library",

--- a/cmd/kubeadm/app/phases/kubelet/flags.go
+++ b/cmd/kubeadm/app/phases/kubelet/flags.go
@@ -28,14 +28,12 @@ import (
 
 	kubeadmapi "k8s.io/kubernetes/cmd/kubeadm/app/apis/kubeadm"
 	"k8s.io/kubernetes/cmd/kubeadm/app/constants"
-	"k8s.io/kubernetes/cmd/kubeadm/app/features"
 	"k8s.io/kubernetes/cmd/kubeadm/app/images"
 	kubeadmutil "k8s.io/kubernetes/cmd/kubeadm/app/util"
 )
 
 type kubeletFlagsOpts struct {
 	nodeRegOpts              *kubeadmapi.NodeRegistrationOptions
-	featureGates             map[string]bool
 	pauseImage               string
 	registerTaintsUsingFlags bool
 }
@@ -63,7 +61,6 @@ func GetNodeNameAndHostname(cfg *kubeadmapi.NodeRegistrationOptions) (string, st
 func WriteKubeletDynamicEnvFile(cfg *kubeadmapi.ClusterConfiguration, nodeReg *kubeadmapi.NodeRegistrationOptions, registerTaintsUsingFlags bool, kubeletDir string) error {
 	flagOpts := kubeletFlagsOpts{
 		nodeRegOpts:              nodeReg,
-		featureGates:             cfg.FeatureGates,
 		pauseImage:               images.GetPauseImage(cfg),
 		registerTaintsUsingFlags: registerTaintsUsingFlags,
 	}
@@ -107,12 +104,6 @@ func buildKubeletArgMapCommon(opts kubeletFlagsOpts) map[string]string {
 	if nodeName != hostname {
 		klog.V(1).Infof("setting kubelet hostname-override to %q", nodeName)
 		kubeletFlags["hostname-override"] = nodeName
-	}
-
-	// TODO: The following code should be removed after dual-stack is GA.
-	// Note: The user still retains the ability to explicitly set feature-gates and that value will overwrite this base value.
-	if enabled, present := opts.featureGates[features.IPv6DualStack]; present {
-		kubeletFlags["feature-gates"] = fmt.Sprintf("%s=%t", features.IPv6DualStack, enabled)
 	}
 
 	return kubeletFlags


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:

kubeadm is setting the IPv6DualStack feature gate in the command line of the kubelet.
However, the kubelet is gradually moving away from command line flags towards component config use.
Hence, we should set the IPv6DualStack feature gate in the component config instead.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Refs none (currently)

**Special notes for your reviewer**:

/cc @kubernetes/sig-cluster-lifecycle-pr-reviews
/area kubeadm
/priority important-longterm
/assign @fabriziopandini @neolit123

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kubeadm now forwards the IPv6DualStack feature gate using the kubelet component config, instead of the kubelet command line
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
