### PR TITLE
add a metric tracking total preemption victims pod count in scheduler.

### DIFF
--- a/pkg/scheduler/metrics/metrics.go
+++ b/pkg/scheduler/metrics/metrics.go
@@ -142,6 +142,13 @@ var (
 			Buckets:        metrics.LinearBuckets(5, 5, 10),
 			StabilityLevel: metrics.ALPHA,
 		})
+	PreemptionVictimsCount = metrics.NewCounter(
+		&metrics.CounterOpts{
+			Subsystem:      SchedulerSubsystem,
+			Name:           "total_pod_preemption_victims",
+			Help:           "Total number of selected preemption victims",
+			StabilityLevel: metrics.ALPHA,
+		})
 	PreemptionAttempts = metrics.NewCounter(
 		&metrics.CounterOpts{
 			Subsystem:      SchedulerSubsystem,

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -442,6 +442,7 @@ func (sched *Scheduler) preempt(ctx context.Context, prof *profile.Profile, stat
 
 		}
 		metrics.PreemptionVictims.Observe(float64(len(victims)))
+		metrics.PreemptionVictimsCount.Add(float64(len(victims)))
 	}
 	// Clearing nominated pods should happen outside of "if node != nil". Node could
 	// be nil when a pod with nominated node name is eligible to preempt again,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**

/kind feature
/sig scheduling

**What this PR does / why we need it**:

This PR just added victim pods counter metrics (`total_pod_preemption_victims`).

**Which issue(s) this PR fixes**:

Fixes #90841

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
kube-scheduler exposes a metric 'total_pod_preemption_victims' that can track the total number of preemption victim pods 
```

