### PR TITLE
Automated cherry pick of #90535: Azure - do not use 0 zone or empty string for zone when

### DIFF
--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -78,10 +78,12 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	var err error
 	klog.V(4).Infof("azureDisk - creating new managed Name:%s StorageAccountType:%s Size:%v", options.DiskName, options.StorageAccountType, options.SizeGB)
 
-	var createZones *[]string
-	if len(options.AvailabilityZone) > 0 && options.AvailabilityZone != "0" {
-		zoneList := []string{c.common.cloud.GetZoneID(options.AvailabilityZone)}
-		createZones = &zoneList
+	var createZones []string
+	if len(options.AvailabilityZone) > 0 {
+		requestedZone := c.common.cloud.GetZoneID(options.AvailabilityZone)
+		if requestedZone != "" {
+			createZones = append(createZones, requestedZone)
+		}
 	}
 
 	// insert original tags to newTags
@@ -152,8 +154,8 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 		DiskProperties: &diskProperties,
 	}
 
-	if createZones != nil && len(*createZones) > 0 {
-		model.Zones = createZones
+	if len(createZones) > 0 {
+		model.Zones = &createZones
 	}
 
 	if options.ResourceGroup == "" {

--- a/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
+++ b/staging/src/k8s.io/legacy-cloud-providers/azure/azure_managedDiskController.go
@@ -79,7 +79,7 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	klog.V(4).Infof("azureDisk - creating new managed Name:%s StorageAccountType:%s Size:%v", options.DiskName, options.StorageAccountType, options.SizeGB)
 
 	var createZones *[]string
-	if len(options.AvailabilityZone) > 0 {
+	if len(options.AvailabilityZone) > 0 && options.AvailabilityZone != "0" {
 		zoneList := []string{c.common.cloud.GetZoneID(options.AvailabilityZone)}
 		createZones = &zoneList
 	}
@@ -146,11 +146,14 @@ func (c *ManagedDiskController) CreateManagedDisk(options *ManagedDiskOptions) (
 	model := compute.Disk{
 		Location: &c.common.location,
 		Tags:     newTags,
-		Zones:    createZones,
 		Sku: &compute.DiskSku{
 			Name: diskSku,
 		},
 		DiskProperties: &diskProperties,
+	}
+
+	if createZones != nil && len(*createZones) > 0 {
+		model.Zones = createZones
 	}
 
 	if options.ResourceGroup == "" {

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -77,7 +77,7 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 	}
 
 	// do not use blank zone definition
-	if len(zone) > 0 && zone != "0" {
+	if len(zone) > 0 {
 		volumeOptions.AvailabilityZone = zone
 	}
 	return p.azureCloud.CreateManagedDisk(volumeOptions)

--- a/test/e2e/framework/providers/azure/azure.go
+++ b/test/e2e/framework/providers/azure/azure.go
@@ -72,9 +72,13 @@ func (p *Provider) CreatePD(zone string) (string, error) {
 		PVCName:            pdName,
 		SizeGB:             1,
 		Tags:               nil,
-		AvailabilityZone:   zone,
 		DiskIOPSReadWrite:  "",
 		DiskMBpsReadWrite:  "",
+	}
+
+	// do not use blank zone definition
+	if len(zone) > 0 && zone != "0" {
+		volumeOptions.AvailabilityZone = zone
 	}
 	return p.azureCloud.CreateManagedDisk(volumeOptions)
 }


### PR DESCRIPTION
Cherry pick of #90535 on release-1.17.

#90535: Azure - do not use 0 zone or empty string for zone when

For details on the cherry pick process, see the [cherry pick requests](https://git.k8s.io/community/contributors/devel/sig-release/cherry-picks.md) page.