### PR TITLE
let static kube-proxy use the kubelet's credentials

### DIFF
--- a/cluster/addons/kube-proxy/kubelet-user-standalone/kube-proxy-rbac.yaml
+++ b/cluster/addons/kube-proxy/kubelet-user-standalone/kube-proxy-rbac.yaml
@@ -1,0 +1,18 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: system:kubelet-user-kube-proxy-binding
+  labels:
+    addonmanager.kubernetes.io/mode: Reconcile
+subjects:
+- kind: Group
+  apiGroup: rbac.authorization.k8s.io
+  name: system:nodes
+- kind: User
+  apiGroup: rbac.authorization.k8s.io
+  # Legacy node ID
+  name: kubelet
+roleRef:
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+  name: system:node-proxier

--- a/cluster/gce/manifests/kube-proxy.manifest
+++ b/cluster/gce/manifests/kube-proxy.manifest
@@ -26,7 +26,7 @@ spec:
     command:
     - /bin/sh
     - -c
-    - exec kube-proxy {{api_servers_with_port}} {{kubeconfig}} {{cluster_cidr}} --oom-score-adj=-998 {{params}} 1>>/var/log/kube-proxy.log 2>&1
+    - exec kube-proxy {{api_servers_with_port}} --kubeconfig={{kubeconfig}} {{cluster_cidr}} --oom-score-adj=-998 {{params}} 1>>/var/log/kube-proxy.log 2>&1
     {{container_env}}
     {{kube_cache_mutation_detector_env_name}}
       {{kube_cache_mutation_detector_env_value}}
@@ -42,9 +42,9 @@ spec:
     - mountPath: /var/log
       name: varlog
       readOnly: false
-    - mountPath: /var/lib/kube-proxy/kubeconfig
+    - mountPath: {{kubeconfig}}
       name: kubeconfig
-      readOnly: false
+      readOnly: true
     - mountPath: /run/xtables.lock
       name: iptableslock
       readOnly: false
@@ -59,8 +59,8 @@ spec:
       path: /etc/ssl/certs
     name: etc-ssl-certs
   - hostPath:
-      path: /var/lib/kube-proxy/kubeconfig
-      type: FileOrCreate
+      path: {{kubeconfig}}
+      type: File
     name: kubeconfig
   - hostPath:
       path: /var/log


### PR DESCRIPTION
Allow for static kube-proxies to use the kubelet's credentials when no `KUBE_PROXY_TOKEN` is given

/kind feature
/kind cleanup
/sig cloud-provider
/area provider/gcp
/priority important-soon
```release-note
NONE
```