### PR TITLE
test: Use dedicated informerFactory for node lifecycle controller

### DIFF
--- a/test/integration/node/lifecycle_test.go
+++ b/test/integration/node/lifecycle_test.go
@@ -134,7 +134,6 @@ func TestTaintBasedEvictions(t *testing.T) {
 			testCtx = testutils.InitTestScheduler(t, testCtx, true, nil)
 			defer testutils.CleanupTest(t, testCtx)
 			cs := testCtx.ClientSet
-			informers := testCtx.InformerFactory
 			_, err := cs.CoreV1().Namespaces().Create(context.TODO(), testCtx.NS, metav1.CreateOptions{})
 			if err != nil {
 				t.Errorf("Failed to create namespace %+v", err)
@@ -142,10 +141,10 @@ func TestTaintBasedEvictions(t *testing.T) {
 
 			// Start NodeLifecycleController for taint.
 			nc, err := nodelifecycle.NewNodeLifecycleController(
-				informers.Coordination().V1().Leases(),
-				informers.Core().V1().Pods(),
-				informers.Core().V1().Nodes(),
-				informers.Apps().V1().DaemonSets(),
+				externalInformers.Coordination().V1().Leases(),
+				externalInformers.Core().V1().Pods(),
+				externalInformers.Core().V1().Nodes(),
+				externalInformers.Apps().V1().DaemonSets(),
 				cs,
 				5*time.Second,    // Node monitor grace period
 				time.Minute,      // Node startup grace period
@@ -167,8 +166,8 @@ func TestTaintBasedEvictions(t *testing.T) {
 			// Waiting for all controller sync.
 			externalInformers.Start(testCtx.Ctx.Done())
 			externalInformers.WaitForCacheSync(testCtx.Ctx.Done())
-			informers.Start(testCtx.Ctx.Done())
-			informers.WaitForCacheSync(testCtx.Ctx.Done())
+			testCtx.InformerFactory.Start(testCtx.Ctx.Done())
+			testCtx.InformerFactory.WaitForCacheSync(testCtx.Ctx.Done())
 
 			nodeRes := v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("4000m"),

--- a/test/integration/scheduler/taint_test.go
+++ b/test/integration/scheduler/taint_test.go
@@ -79,15 +79,14 @@ func TestTaintNodeByCondition(t *testing.T) {
 	defer testutils.CleanupTest(t, testCtx)
 
 	cs := testCtx.ClientSet
-	informers := testCtx.InformerFactory
 	nsName := testCtx.NS.Name
 
 	// Start NodeLifecycleController for taint.
 	nc, err := nodelifecycle.NewNodeLifecycleController(
-		informers.Coordination().V1().Leases(),
-		informers.Core().V1().Pods(),
-		informers.Core().V1().Nodes(),
-		informers.Apps().V1().DaemonSets(),
+		externalInformers.Coordination().V1().Leases(),
+		externalInformers.Core().V1().Pods(),
+		externalInformers.Core().V1().Nodes(),
+		externalInformers.Apps().V1().DaemonSets(),
 		cs,
 		time.Hour,   // Node monitor grace period
 		time.Second, // Node startup grace period
@@ -108,8 +107,8 @@ func TestTaintNodeByCondition(t *testing.T) {
 	// Waiting for all controller sync.
 	externalInformers.Start(testCtx.Ctx.Done())
 	externalInformers.WaitForCacheSync(testCtx.Ctx.Done())
-	informers.Start(testCtx.Ctx.Done())
-	informers.WaitForCacheSync(testCtx.Ctx.Done())
+	testCtx.InformerFactory.Start(testCtx.Ctx.Done())
+	testCtx.InformerFactory.WaitForCacheSync(testCtx.Ctx.Done())
 
 	// -------------------------------------------
 	// Test TaintNodeByCondition feature.


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup
/sig scheduling
/sig node

**What this PR does / why we need it**:

Some integration tests need to initialize several controllers, such as TaintBasedEviction and TaintNodeByCondition, they needs to spin up scheduler as well as node lifecycle controller. These tests are now sharing the same `informerFactory`, which I'm not sure is the correct pattern as in a real case, scheduler and controller manager are not sharing the `informerFactory`.

The "shared" pattern works fine so far, but it holds implicit (and sometimes tricky) limitations. For example, node lifecycle controller's New() function assumes the PodInformer is not started as it needs to apply additional Indexer:

https://github.com/kubernetes/kubernetes/blob/eec809aa93863afde30b40f03f8f380f006db794/pkg/controller/nodelifecycle/node_lifecycle_controller.go#L460-L471

With that said, if the other actor starts the PodInformer earlier, node lifecycle controller may not work properly with error "Index with name spec.nodeName does not exist", which is revealed in https://prow.k8s.io/view/gcs/kubernetes-jenkins/pr-logs/pull/90660/pull-kubernetes-integration/1258308925103542274.

So this PR introduces changes to assign dedicated `informerFactory` to individual controller.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

Please review if dedicated informerFactory is the conventional way to craft integration tests.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
