### PR TITLE
Explicitly state the CLA requirement for contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,11 @@
 # Contributing
 
-Welcome to Kubernetes! If you are interested in contributing to the [Kubernetes code repo](README.md) then checkout the [Contributor's Guide](https://git.k8s.io/community/contributors/guide/)
+Welcome to Kubernetes! To learn more about contributing to the [Kubernetes code repo](README.md), check out the [Contributor's Guide](https://git.k8s.io/community/contributors/guide/).
 
-The [Kubernetes community repo](https://github.com/kubernetes/community) contains information on how the community is organized and other information that is pertinent to contributing.
+The [Kubernetes community repo](https://github.com/kubernetes/community) contains information about how to get started, how the community organizes, and more.
+
+## Sign the CLA
+
+You must sign the [Contributor License Agreement](https://git.k8s.io/community/contributors/guide/getting-started.md#sign-the-cla) in order to contribute.
 
 [![Analytics](https://kubernetes-site.appspot.com/UA-36037335-10/GitHub/CONTRIBUTING.md?pixel)]()


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

This PR adds language explicitly stating that contributors must sign the CLA in order to contribute.

**Which issue(s) this PR fixes**:

Fixes #90869 

**Special notes for your reviewer**:

Keeping in mind the guidance for [trivial edits](https://git.k8s.io/community/contributors/guide/pull-requests.md#10-trivial-edits), I've tightened up the rest of the file.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs
NONE
```
