### PR TITLE
handlers: Add "change" header to modifying requests

### DIFF
--- a/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
+++ b/staging/src/k8s.io/apimachinery/pkg/apis/meta/v1/types.go
@@ -1316,3 +1316,10 @@ type PartialObjectMetadataList struct {
 	// items contains each of the included items.
 	Items []PartialObjectMetadata `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
+
+// ObjectChangePersistedHeader is a header inserted in the response to
+// modifying request indicated whether a change to the object has been
+// persisted. The value of that field is a boolean "true" or "false".
+// That field may be missing if we can't determine if the change was
+// persisted.
+const ObjectChangePersistedHeader = "X-Object-Change-Persisted"

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/BUILD
@@ -91,6 +91,7 @@ go_library(
         "//staging/src/k8s.io/apiserver/pkg/audit:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/authorization/authorizer:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager:go_default_library",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/internal:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/metrics:go_default_library",
@@ -123,6 +124,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/fieldmanager:all-srcs",
+        "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/internal:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/negotiation:all-srcs",
         "//staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters:all-srcs",
     ],

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/create.go
@@ -183,6 +183,8 @@ func createHandler(r rest.NamedCreater, scope *RequestScope, admit admission.Int
 		}
 		trace.Step("Object stored in database")
 
+		w.Header().Set(metav1.ObjectChangePersistedHeader, "true")
+
 		code := http.StatusCreated
 		status, ok := result.(*metav1.Status)
 		if ok && err == nil && status.Code == 0 {

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/internal/BUILD
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/internal/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["updatechange.go"],
+    importmap = "k8s.io/kubernetes/vendor/k8s.io/apiserver/pkg/endpoints/handlers/internal",
+    importpath = "k8s.io/apiserver/pkg/endpoints/handlers/internal",
+    visibility = ["//staging/src/k8s.io/apiserver/pkg/endpoints/handlers:__subpackages__"],
+    deps = [
+        "//staging/src/k8s.io/apimachinery/pkg/api/meta:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/internal/updatechange.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/internal/updatechange.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// UpdatePersistedChange keeps track of the resourceVersion before we run the
+// update, and looks again after the update, and checks for any
+// difference. If a difference is found, then it will return true,
+// otherwise it will return false.
+type UpdatePersistedChange struct {
+	resourceVersion string
+}
+
+func getResourceVersion(obj runtime.Object) (string, error) {
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return "", err
+	}
+	return accessor.GetResourceVersion(), nil
+}
+
+// TrackResourceVersion is a transformer that finds and records the
+// resourceVersion from the object, before it's submitted to etcd.
+func (u *UpdatePersistedChange) TrackResourceVersion(_ context.Context, obj, _ runtime.Object) (runtime.Object, error) {
+	if rv, err := getResourceVersion(obj); err != nil {
+		// Do nothing if we have an error
+	} else {
+		u.resourceVersion = rv
+	}
+	return obj, nil
+}
+
+// WasPersisted looked at the object, and returns true if its
+// resourceVersion has changed, false otherwise.
+func (u *UpdatePersistedChange) WasPersisted(obj runtime.Object) (bool, error) {
+	rv, err := getResourceVersion(obj)
+	if err != nil {
+		// By default, assume that the object has changed.
+		return true, err
+	}
+	return rv != u.resourceVersion, nil
+}

--- a/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
+++ b/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/rest_test.go
@@ -466,7 +466,7 @@ func (tc *patchTestCase) Run(t *testing.T) {
 			trace: utiltrace.New("Patch", utiltrace.Field{"name", name}),
 		}
 
-		resultObj, _, err := p.patchResource(ctx, &RequestScope{})
+		resultObj, _, _, err := p.patchResource(ctx, &RequestScope{})
 		if len(tc.expectedError) != 0 {
 			if err == nil || err.Error() != tc.expectedError {
 				t.Errorf("%s: expected error %v, but got %v", tc.name, tc.expectedError, err)


### PR DESCRIPTION
Add the header to PATCH/POST/PUT requests so that client can know if a
change was persisted.

Update client-go to read the result of the request if present.

/kind api-change
/kind design
/kind feature

**What this PR does / why we need it**:
Fixes #85750

**Special notes for your reviewer**:
This probably requires more testing, both unit-test and integration.

I'm not super happy with where the header is declared, nor necessarily with the name.
I also want to make sure that this is what people would expect.

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
