### PR TITLE
Promote Endpoints resource lifecycle test - +4 endpoint coverage

### DIFF
--- a/test/conformance/testdata/conformance.yaml
+++ b/test/conformance/testdata/conformance.yaml
@@ -1852,6 +1852,15 @@
     Pod and the service must now have empty set of endpoints.
   release: v1.9
   file: test/e2e/network/service.go
+- testname: Endpoint resource lifecycle
+  codename: '[sig-network] Services should test the lifecycle of an Endpoint [Conformance]'
+  description: Create an endpoint, the endpoint MUST exist. The endpoint is updated
+    with a new label, a check after the update MUST find the changes. The endpoint
+    is then patched with a new IPv4 address and port, a check after the patch MUST
+    the changes. The endpoint is deleted by it's label, a watch listens for the deleted
+    watch event.
+  release: v1.19
+  file: test/e2e/network/service.go
 - testname: ConfigMap, from environment field
   codename: '[sig-node] ConfigMap should be consumable via environment variable [NodeConformance]
     [Conformance]'

--- a/test/e2e/network/service.go
+++ b/test/e2e/network/service.go
@@ -2770,7 +2770,15 @@ var _ = SIGDescribe("Services", func() {
 		framework.ExpectEqual(foundSvc, true, "could not find service 'kubernetes' in service list in all namespaces")
 	})
 
-	ginkgo.It("should test the lifecycle of an Endpoint", func() {
+	/*
+	   Release : v1.19
+	   Testname: Endpoint resource lifecycle
+	   Description: Create an endpoint, the endpoint MUST exist.
+	   The endpoint is updated with a new label, a check after the update MUST find the changes.
+	   The endpoint is then patched with a new IPv4 address and port, a check after the patch MUST the changes.
+	   The endpoint is deleted by it's label, a watch listens for the deleted watch event.
+	*/
+	framework.ConformanceIt("should test the lifecycle of an Endpoint", func() {
 		testNamespaceName := f.Namespace.Name
 		testEndpointName := "testservice"
 		testEndpoints := v1.Endpoints{


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Promotes the following E2E tests to Conformance:
`test/e2e/network/service.go: "should test the lifecycle of an Endpoint"`

**Which issue(s) this PR fixes**:
Fixes #90923

**Testgrid link**
[Link](https://testgrid.k8s.io/sig-release-master-blocking#gce-cos-master-default&width=5&include-filter-by-regex=should%20test%20the%20lifecycle%20of%20an%20Endpoint)

**Special notes for your reviewer**:
Adds +4 conformance endpoint coverage.

**Does this PR introduce a user-facing change?**:

```
NONE
```
**Release note:**
```release-note
NONE
```
**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```
NONE
```


/area conformance
/area test
@kubernetes/cncf-conformance-wg

