### PR TITLE
Add seccomp least privilege for docker sandbox

### DIFF
--- a/pkg/kubelet/dockershim/docker_sandbox.go
+++ b/pkg/kubelet/dockershim/docker_sandbox.go
@@ -659,14 +659,17 @@ func (ds *dockerService) makeSandboxDockerConfig(c *runtimeapi.PodSandboxConfig,
 	}
 
 	// Set security options.
-	securityOpts, err := ds.getSecurityOpts(c.GetLinux().GetSecurityContext().GetSeccompProfilePath(), securityOptSeparator)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate sandbox security options for sandbox %q: %v", c.Metadata.Name, err)
-	}
+	securityOpts := ds.getSandBoxSecurityOpts(securityOptSeparator)
 	hc.SecurityOpt = append(hc.SecurityOpt, securityOpts...)
 
 	applyExperimentalCreateConfig(createConfig, c.Annotations)
 	return createConfig, nil
+}
+
+func (ds *dockerService) getSandBoxSecurityOpts(separator rune) []string {
+	// run sandbox with no-new-privileges and using runtime/default
+	// sending no "seccomp=" means docker will use default profile
+	return []string{"no-new-privileges"}
 }
 
 // networkNamespaceMode returns the network runtimeapi.NamespaceMode for this container.

--- a/pkg/kubelet/dockershim/docker_sandbox_test.go
+++ b/pkg/kubelet/dockershim/docker_sandbox_test.go
@@ -156,6 +156,19 @@ func TestSandboxStatus(t *testing.T) {
 	assert.Error(t, err, fmt.Sprintf("status of sandbox: %+v", statusResp))
 }
 
+// TestSandboxHasLeastPrivilegesConfig tests that the sandbox is set with no-new-privileges
+// and it uses runtime/default seccomp profile.
+func TestSandboxHasLeastPrivilegesConfig(t *testing.T) {
+	ds, _, _ := newTestDockerService()
+	config := makeSandboxConfig("foo", "bar", "1", 0)
+
+	// test the default
+	createConfig, err := ds.makeSandboxDockerConfig(config, defaultSandboxImage)
+	assert.NoError(t, err)
+	assert.Equal(t, len(createConfig.HostConfig.SecurityOpt), 1, "sandbox should use runtime/default")
+	assert.Equal(t, "no-new-privileges", createConfig.HostConfig.SecurityOpt[0], "no-new-privileges not set")
+}
+
 // TestSandboxStatusAfterRestart tests that retrieving sandbox status returns
 // an IP address even if RunPodSandbox() was not yet called for this pod, as
 // would happen on kubelet restart


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Decreases the sandbox's attack surface by running it with `no-new-privileges` and with the `runtime/default` seccomp profile.

As a side effect, it allows end users to set seccomp profiles at pod level with the same profile as they would for container level, considering the pod only has containers with `AllowPrivilegeEscalation=false`. 

Without this PR users had to whitelist some syscalls regardless of their containers needing them: `capset`, `set_tid_address`, `setgid`, `setgroups`, `setuid` and etc. More information and examples at #84623.

**Which issue(s) this PR fixes**:
Part of #84623 (for dockershim)
Part of #81115 (for sandbox)

**Special notes for your reviewer**:
Feature parity for kuberuntime will be done through a different PR. 

**Does this PR introduce a user-facing change?**:
```release-note
dockershim security: pod sandbox now always run with `no-new-privileges` and `runtime/default` seccomp profile
dockershim seccomp: custom profiles can now have smaller seccomp profiles when set at pod level
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/cc @tallclair @Random-Liu @dims @mattjmcnaughton 
/sig node
/area security