### PR TITLE
Add seccomp least privilege for kuberuntime

### DIFF
--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox.go
@@ -148,8 +148,11 @@ func (m *kubeGenericRuntimeManager) generatePodSandboxLinuxConfig(pod *v1.Pod) (
 	lc := &runtimeapi.LinuxPodSandboxConfig{
 		CgroupParent: cgroupParent,
 		SecurityContext: &runtimeapi.LinuxSandboxSecurityContext{
-			Privileged:         kubecontainer.HasPrivilegedContainer(pod),
-			SeccompProfilePath: m.getSeccompProfile(pod.Annotations, "", pod.Spec.SecurityContext, nil),
+			Privileged: kubecontainer.HasPrivilegedContainer(pod),
+
+			// Forcing sandbox to run as `runtime/default` allow users to
+			// use least privileged seccomp profiles at pod level. Issue #84623
+			SeccompProfilePath: v1.SeccompProfileRuntimeDefault,
 		},
 	}
 

--- a/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_sandbox_test.go
@@ -67,37 +67,29 @@ func TestGeneratePodSandboxLinuxConfigSeccomp(t *testing.T) {
 		expectedProfile string
 	}{
 		{
-			description:     "no seccomp defined at pod level should return empty",
-			pod:             newSeccompPod(nil, nil, "", ""),
-			expectedProfile: "",
+			description:     "no seccomp defined at pod level should return runtime/default",
+			pod:             newSeccompPod(nil, nil, "", "runtime/default"),
+			expectedProfile: "runtime/default",
 		},
 		{
-			description:     "seccomp field defined at pod level should be honoured",
-			pod:             newSeccompPod(&v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}, nil, "", ""),
+			description:     "seccomp field defined at pod level should not be honoured",
+			pod:             newSeccompPod(&v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}, nil, "", ""),
 			expectedProfile: "runtime/default",
 		},
 		{
 			description:     "seccomp field defined at container level should not be honoured",
-			pod:             newSeccompPod(nil, &v1.SeccompProfile{Type: v1.SeccompProfileTypeRuntimeDefault}, "", ""),
-			expectedProfile: "",
+			pod:             newSeccompPod(nil, &v1.SeccompProfile{Type: v1.SeccompProfileTypeUnconfined}, "", ""),
+			expectedProfile: "runtime/default",
 		},
 		{
-			description:     "seccomp annotation defined at pod level should be honoured",
-			pod:             newSeccompPod(nil, nil, v1.SeccompProfileRuntimeDefault, ""),
+			description:     "seccomp annotation defined at pod level should not be honoured",
+			pod:             newSeccompPod(nil, nil, "unconfined", ""),
 			expectedProfile: "runtime/default",
 		},
 		{
 			description:     "seccomp annotation defined at container level should not be honoured",
-			pod:             newSeccompPod(nil, nil, "", v1.SeccompProfileRuntimeDefault),
-			expectedProfile: "",
-		},
-		{
-			description: "prioritise pod field over pod annotation",
-			pod: newSeccompPod(&v1.SeccompProfile{
-				Type:             v1.SeccompProfileTypeLocalhost,
-				LocalhostProfile: pointer.StringPtr("pod-field"),
-			}, nil, "localhost/pod-annotation", ""),
-			expectedProfile: "localhost/" + filepath.Join(fakeSeccompProfileRoot, "pod-field"),
+			pod:             newSeccompPod(nil, nil, "", "unconfined"),
+			expectedProfile: "runtime/default",
 		},
 	}
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
Decreases the sandbox's attack surface by running it with `runtime/default` seccomp profile.

As a side effect, it allows end users to set seccomp profiles at pod level with the same profile as they would for container level, considering the pod only has containers with `AllowPrivilegeEscalation=false`. 

Without this PR users had to whitelist some syscalls regardless of their containers needing them: `capset`, `set_tid_address`, `setgid`, `setgroups`, `setuid` and etc. More information and examples at #84623.

**Which issue(s) this PR fixes**:
Part of #84623 (for kuberuntime)
Part of #81115 (for sandbox)

**Special notes for your reviewer**:
Feature parity for dockershim is handled by a different PR. 

**Does this PR introduce a user-facing change?**:
```release-note
kuberuntime security: pod sandbox now always runs with `runtime/default` seccomp profile
kuberuntime seccomp: custom profiles can now have smaller seccomp profiles when set at pod level
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs
NONE
```

/cc @tallclair @Random-Liu @dims @mattjmcnaughton 
/sig node
/area security