### PR TITLE
Clarify `kubelet_dockershim_nodocker` error message

### DIFF
--- a/pkg/kubelet/kubelet_dockershim_nodocker.go
+++ b/pkg/kubelet/kubelet_dockershim_nodocker.go
@@ -32,5 +32,5 @@ func runDockershim(kubeCfg *kubeletconfiginternal.KubeletConfiguration,
 	remoteImageEndpoint string,
 	nonMasqueradeCIDR string) error {
 
-	return fmt.Errorf("trying to use docker runtime, w/ Kubelet compiled w/o docker support")
+	return fmt.Errorf("trying to use docker runtime when Kubelet was compiled without docker support")
 }


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Clarify the error message returned when trying to use the docker runtime
on a Kubelet that was compiled without Docker.

We removed the "w/" and "w/o", which can be confusing abbreviations, and
also add slightly more detail on the actual error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @derekwaynecarr - re your comment on #87746 

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
