### PR TITLE
Better understanding of kubectl attach description

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/attach/attach.go
@@ -41,15 +41,15 @@ import (
 
 var (
 	attachExample = templates.Examples(i18n.T(`
-		# Get output from running pod 123456-7890, using the first container by default
-		kubectl attach 123456-7890
+		# Get output from running pod mypod, using the first container by default
+		kubectl attach mypod
 
-		# Get output from ruby-container from pod 123456-7890
-		kubectl attach 123456-7890 -c ruby-container
+		# Get output from ruby-container from pod mypod
+		kubectl attach mypod -c ruby-container
 
-		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod 123456-7890
+		# Switch to raw terminal mode, sends stdin to 'bash' in ruby-container from pod mypod
 		# and sends stdout/stderr from 'bash' back to the client
-		kubectl attach 123456-7890 -c ruby-container -i -t
+		kubectl attach mypod -c ruby-container -i -t
 
 		# Get output from the first pod of a ReplicaSet named nginx
 		kubectl attach rs/nginx


### PR DESCRIPTION
**What type of PR is this?**

> /kind documentation


**What this PR does / why we need it**:

Before the version of kubernetes 1.15 , when use `kubectl exec --help` 

https://github.com/kubernetes/kubernetes/blob/release-1.14/pkg/kubectl/cmd/exec/exec.go#L42

``` 
Examples:
  # Get output from running 'date' from pod 123456-7890, using the first container by default
  kubectl exec 123456-7890 date
```
the pod name is `123456-7890` , hard to understand

After this version , the pod name `123456-7890` has changed to `mypod`

https://github.com/kubernetes/kubernetes/blob/release-1.18/staging/src/k8s.io/kubectl/pkg/cmd/exec/exec.go#L46

So the kubectl cmd attach description should follow the kubectl cmd exec description.

the pod name of documentation `mypod` is better for understanding.
