### PR TITLE
 Changed scheduler to use patch when updating pod status

### DIFF
--- a/pkg/scheduler/BUILD
+++ b/pkg/scheduler/BUILD
@@ -37,6 +37,7 @@ go_library(
         "//staging/src/k8s.io/apimachinery/pkg/types:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/sets:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//staging/src/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//staging/src/k8s.io/client-go/informers:go_default_library",

--- a/test/integration/scheduler/preemption_test.go
+++ b/test/integration/scheduler/preemption_test.go
@@ -45,7 +45,7 @@ import (
 	framework "k8s.io/kubernetes/pkg/scheduler/framework/v1alpha1"
 	"k8s.io/kubernetes/plugin/pkg/admission/priority"
 	testutils "k8s.io/kubernetes/test/integration/util"
-	utils "k8s.io/kubernetes/test/utils"
+	"k8s.io/kubernetes/test/utils"
 )
 
 var lowPriority, mediumPriority, highPriority = int32(100), int32(200), int32(300)
@@ -629,8 +629,6 @@ func mkPriorityPodWithGrace(tc *testutils.TestContext, name string, priority int
 		Labels:    map[string]string{"pod": name},
 		Resources: defaultPodRes,
 	})
-	// Setting grace period to zero. Otherwise, we may never see the actual deletion
-	// of the pods in integration tests.
 	pod.Spec.TerminationGracePeriodSeconds = &grace
 	return pod
 }
@@ -924,7 +922,7 @@ func TestNominatedNodeCleanUp(t *testing.T) {
 	}
 	// Step 5. Check that nominated node name of the high priority pod is set.
 	if err := waitForNominatedNodeName(cs, highPriPod); err != nil {
-		t.Errorf("NominatedNodeName annotation was not set for pod %v/%v: %v", medPriPod.Namespace, medPriPod.Name, err)
+		t.Errorf("NominatedNodeName annotation was not set for pod %v/%v: %v", highPriPod.Namespace, highPriPod.Name, err)
 	}
 	// And the nominated node name of the medium priority pod is cleared.
 	if err := wait.Poll(100*time.Millisecond, wait.ForeverTestTimeout, func() (bool, error) {


### PR DESCRIPTION
**What type of PR is this?**
/kind flake

**What this PR does / why we need it**:
Fixes #89259 
Fixes #89728
Fixes #90627 

**Which issue(s) this PR fixes**:
Flake occurs in TestNominatedNodeCleanUp when a medium-priority pod preempts low priority pods (with long grace periods) and then next, a high-priority pod preempts the medium-priority pod before it can be scheduled/bound.

An update conflict can sometimes occur when the high priority pod preempts the medium priority pod and it tries to clear the nominated node from the status of the medium priority pod.

This conflict was logged but did not result in an error, so the scheduling of the high priority pod still succeeded, but the integration test would fail because the medium priority pod's nominated node would never be cleared as expected.

This PR changes the schedule to use `Patch()` instead of `UpdateStatus()` to update the pod status using a merge patch in order to avoid a conflict.

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:
```docs

```
