### PR TITLE
Fixing broken link in docs pointing to api-conventions.md

### DIFF
--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/generated.proto
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/generated.proto
@@ -40,17 +40,17 @@ message FlowDistinguisherMethod {
 // similar attributes and is identified by a pair of strings: the name of the FlowSchema and a "flow distinguisher".
 message FlowSchema {
   // `metadata` is the standard object's metadata.
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a FlowSchema.
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   // +optional
   optional FlowSchemaSpec spec = 2;
 
   // `status` is the current status of a FlowSchema.
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   // +optional
   optional FlowSchemaStatus status = 3;
 }
@@ -79,7 +79,7 @@ message FlowSchemaCondition {
 // FlowSchemaList is a list of FlowSchema objects.
 message FlowSchemaList {
   // `metadata` is the standard list metadata.
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 
@@ -230,17 +230,17 @@ message PolicyRulesWithSubjects {
 // PriorityLevelConfiguration represents the configuration of a priority level.
 message PriorityLevelConfiguration {
   // `metadata` is the standard object's metadata.
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // `spec` is the specification of the desired behavior of a "request-priority".
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   // +optional
   optional PriorityLevelConfigurationSpec spec = 2;
 
   // `status` is the current status of a "request-priority".
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
   // +optional
   optional PriorityLevelConfigurationStatus status = 3;
 }
@@ -269,7 +269,7 @@ message PriorityLevelConfigurationCondition {
 // PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.
 message PriorityLevelConfigurationList {
   // `metadata` is the standard object's metadata.
-  // More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+  // More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ListMeta metadata = 1;
 

--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/types.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/types.go
@@ -60,15 +60,15 @@ const (
 type FlowSchema struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a FlowSchema.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Spec FlowSchemaSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a FlowSchema.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Status FlowSchemaStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
@@ -79,7 +79,7 @@ type FlowSchema struct {
 type FlowSchemaList struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard list metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 
@@ -326,15 +326,15 @@ type FlowSchemaConditionType string
 type PriorityLevelConfiguration struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `spec` is the specification of the desired behavior of a "request-priority".
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Spec PriorityLevelConfigurationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// `status` is the current status of a "request-priority".
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status
 	// +optional
 	Status PriorityLevelConfigurationStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
 }
@@ -345,7 +345,7 @@ type PriorityLevelConfiguration struct {
 type PriorityLevelConfigurationList struct {
 	metav1.TypeMeta `json:",inline"`
 	// `metadata` is the standard object's metadata.
-	// More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// `items` is a list of request-priorities.

--- a/staging/src/k8s.io/api/flowcontrol/v1alpha1/types_swagger_doc_generated.go
+++ b/staging/src/k8s.io/api/flowcontrol/v1alpha1/types_swagger_doc_generated.go
@@ -38,9 +38,9 @@ func (FlowDistinguisherMethod) SwaggerDoc() map[string]string {
 
 var map_FlowSchema = map[string]string{
 	"":         "FlowSchema defines the schema of a group of flows. Note that a flow is made up of a set of inbound API requests with similar attributes and is identified by a pair of strings: the name of the FlowSchema and a \"flow distinguisher\".",
-	"metadata": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"spec":     "`spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-	"status":   "`status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+	"metadata": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "`spec` is the specification of the desired behavior of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+	"status":   "`status` is the current status of a FlowSchema. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
 func (FlowSchema) SwaggerDoc() map[string]string {
@@ -62,7 +62,7 @@ func (FlowSchemaCondition) SwaggerDoc() map[string]string {
 
 var map_FlowSchemaList = map[string]string{
 	"":         "FlowSchemaList is a list of FlowSchema objects.",
-	"metadata": "`metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+	"metadata": "`metadata` is the standard list metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"items":    "`items` is a list of FlowSchemas.",
 }
 
@@ -143,9 +143,9 @@ func (PolicyRulesWithSubjects) SwaggerDoc() map[string]string {
 
 var map_PriorityLevelConfiguration = map[string]string{
 	"":         "PriorityLevelConfiguration represents the configuration of a priority level.",
-	"metadata": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
-	"spec":     "`spec` is the specification of the desired behavior of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
-	"status":   "`status` is the current status of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status",
+	"metadata": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
+	"spec":     "`spec` is the specification of the desired behavior of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
+	"status":   "`status` is the current status of a \"request-priority\". More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status",
 }
 
 func (PriorityLevelConfiguration) SwaggerDoc() map[string]string {
@@ -167,7 +167,7 @@ func (PriorityLevelConfigurationCondition) SwaggerDoc() map[string]string {
 
 var map_PriorityLevelConfigurationList = map[string]string{
 	"":         "PriorityLevelConfigurationList is a list of PriorityLevelConfiguration objects.",
-	"metadata": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata",
+	"metadata": "`metadata` is the standard object's metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata",
 	"items":    "`items` is a list of request-priorities.",
 }
 


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation


**What this PR does / why we need it**:
Right now there are docs pointing to broken link - https://git.k8s.io/community/contributors/devel/api-conventions.md
This PR fixes the broken link to point to the updated link:
https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-client/python/issues/1163

Special notes for your reviewer:


Does this PR introduce a user-facing change?:

```release-note
NONE
```
Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:
```

```