### PR TITLE
Fix umask better

### DIFF
--- a/build/common.sh
+++ b/build/common.sh
@@ -163,6 +163,9 @@ function kube::build::verify_prereqs() {
 
   kube::version::get_version_vars
   kube::version::save_version_vars "${KUBE_ROOT}/.dockerized-kube-version-defs"
+
+  # Without this, the user's umask can leak through.
+  umask 0022
 }
 
 # ---------------------------------------------------------------------------

--- a/hack/lib/golang.sh
+++ b/hack/lib/golang.sh
@@ -523,10 +523,6 @@ kube::golang::setup_env() {
 
   # This seems to matter to some tools
   export GO15VENDOREXPERIMENT=1
-
-  # This is for sanity.  Without it, user umasks leak through into release
-  # artifacts.
-  umask 0022
 }
 
 # This will take binaries from $GOPATH/bin and copy them to the appropriate
@@ -678,6 +674,9 @@ kube::golang::build_some_binaries() {
 }
 
 kube::golang::build_binaries_for_platform() {
+  # This is for sanity.  Without it, user umasks can leak through.
+  umask 0022
+
   local platform=$1
 
   local -a statics=()


### PR DESCRIPTION
While the umask was previously set for builds (and in fact `docker run`
sets it to 0022 by default), the release pipeline `cp`'s files (with
`-a`) which respect the user's umask, and is outside of the build path.

This sets the umask in a common function called by all build tools,
which @justaugustus agreed was the simplest and most complete fix.  The
`verify-prereqs` function is already poorly named for what it does, and
this only makes it epsilon worse.

/kind bug

-->
```release-note
NONE
```
