### PR TITLE
Do not swallow NotFound error for DeletePod in dsc.manage

### DIFF
--- a/pkg/controller/BUILD
+++ b/pkg/controller/BUILD
@@ -20,6 +20,7 @@ go_test(
         "//staging/src/k8s.io/api/apps/v1:go_default_library",
         "//staging/src/k8s.io/api/core/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/api/equality:go_default_library",
+        "//staging/src/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//staging/src/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/controller/controller_utils.go
+++ b/pkg/controller/controller_utils.go
@@ -602,7 +602,11 @@ func (r RealPodControl) DeletePod(namespace string, podID string, object runtime
 		return fmt.Errorf("object does not have ObjectMeta, %v", err)
 	}
 	klog.V(2).Infof("Controller %v deleting pod %v/%v", accessor.GetName(), namespace, podID)
-	if err := r.KubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), podID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := r.KubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), podID, metav1.DeleteOptions{}); err != nil {
+		if apierrors.IsNotFound(err) {
+			klog.V(4).Infof("pod %v/%v has already been deleted.", namespace, podID)
+			return err
+		}
 		r.Recorder.Eventf(object, v1.EventTypeWarning, FailedDeletePodReason, "Error deleting: %v", err)
 		return fmt.Errorf("unable to delete pods: %v", err)
 	}

--- a/pkg/controller/controller_utils_test.go
+++ b/pkg/controller/controller_utils_test.go
@@ -31,6 +31,7 @@ import (
 	apps "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -325,7 +326,7 @@ func TestDeletePodsAllowsMissing(t *testing.T) {
 	controllerSpec := newReplicationController(1)
 
 	err := podControl.DeletePod("namespace-name", "podName", controllerSpec)
-	assert.NoError(t, err, "unexpected error: %v", err)
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestActivePodFiltering(t *testing.T) {

--- a/pkg/controller/daemon/daemon_controller.go
+++ b/pkg/controller/daemon/daemon_controller.go
@@ -30,6 +30,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -976,10 +977,12 @@ func (dsc *DaemonSetsController) syncNodes(ds *apps.DaemonSet, podsToDelete, nod
 		go func(ix int) {
 			defer deleteWait.Done()
 			if err := dsc.podControl.DeletePod(ds.Namespace, podsToDelete[ix], ds); err != nil {
-				klog.V(2).Infof("Failed deletion, decrementing expectations for set %q/%q", ds.Namespace, ds.Name)
 				dsc.expectations.DeletionObserved(dsKey)
-				errCh <- err
-				utilruntime.HandleError(err)
+				if !apierrors.IsNotFound(err) {
+					klog.V(2).Infof("Failed deletion, decremented expectations for set %q/%q", ds.Namespace, ds.Name)
+					errCh <- err
+					utilruntime.HandleError(err)
+				}
 			}
 		}(i)
 	}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -28,6 +28,7 @@ import (
 	batch "k8s.io/api/batch/v1"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -43,10 +44,9 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"k8s.io/component-base/metrics/prometheus/ratelimiter"
+	"k8s.io/klog/v2"
 	"k8s.io/kubernetes/pkg/controller"
 	"k8s.io/utils/integer"
-
-	"k8s.io/klog/v2"
 )
 
 const statusUpdateRetries = 3
@@ -618,7 +618,7 @@ func (jm *Controller) deleteJobPods(job *batch.Job, pods []*v1.Pod, errCh chan<-
 	for i := int32(0); i < int32(nbPods); i++ {
 		go func(ix int32) {
 			defer wait.Done()
-			if err := jm.podControl.DeletePod(job.Namespace, pods[ix].Name, job); err != nil {
+			if err := jm.podControl.DeletePod(job.Namespace, pods[ix].Name, job); err != nil && !apierrors.IsNotFound(err) {
 				defer utilruntime.HandleError(err)
 				klog.V(2).Infof("Failed to delete %v, job %q/%q deadline exceeded", pods[ix].Name, job.Namespace, job.Name)
 				errCh <- err
@@ -715,14 +715,17 @@ func (jm *Controller) manageJob(activePods []*v1.Pod, succeeded int32, job *batc
 			go func(ix int32) {
 				defer wait.Done()
 				if err := jm.podControl.DeletePod(job.Namespace, activePods[ix].Name, job); err != nil {
-					defer utilruntime.HandleError(err)
 					// Decrement the expected number of deletes because the informer won't observe this deletion
-					klog.V(2).Infof("Failed to delete %v, decrementing expectations for job %q/%q", activePods[ix].Name, job.Namespace, job.Name)
 					jm.expectations.DeletionObserved(jobKey)
-					activeLock.Lock()
-					active++
-					activeLock.Unlock()
-					errCh <- err
+					if !apierrors.IsNotFound(err) {
+						klog.V(2).Infof("Failed to delete %v, decremented expectations for job %q/%q", activePods[ix].Name, job.Namespace, job.Name)
+						activeLock.Lock()
+						active++
+						activeLock.Unlock()
+						errCh <- err
+						utilruntime.HandleError(err)
+					}
+
 				}
 			}(i)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind bug
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind deprecation
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:
In some case, PodGC and syncDaemonSet were invoked concurrently,  controller manager failed to create daemonset pod as desired number,  like below:
```
NAME               DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
sysslb-ms-eslb-1   3         2         2       2            2           <none>          3d18h
```
And kube-controller-manager logs:
```
I0511 11:59:25.598393   25536 gc_controller.go:62] PodGC is force deleting Pod: admin/sysslb-ms-eslb-1-7hpwk
I0511 11:59:26.170777   25536 event.go:221] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"10.10.10.135", UID:"cff806fb-9333-11ea-bf6b-fa163e2860c2", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'RemovingNode' Node 10.10.10.135 event: Removing Node 10.10.10.135 from Controller
I0511 11:59:27.258659   25536 gc_controller.go:166] Forced deletion of orphaned Pod admin/sysslb-ms-eslb-1-7hpwk succeeded
I0511 11:59:27.258679   25536 gc_controller.go:62] PodGC is force deleting Pod: kube-system/iag-10.10.10.135
I0511 11:59:27.278075   25536 gc_controller.go:166] Forced deletion of orphaned Pod kube-system/iag-10.10.10.135 succeeded
W0511 11:59:42.171041   25536 actual_state_of_world.go:491] Failed to update statusUpdateNeeded field in actual state of world: Failed to set statusUpdateNeeded to needed true, because nodeName="10.10.10.135" does not exist
I0511 11:59:46.172149   25536 event.go:221] Event(v1.ObjectReference{Kind:"Node", Namespace:"", Name:"10.10.10.135", UID:"d7d8be8f-933b-11ea-bb97-fa163edfbf29", APIVersion:"", ResourceVersion:"", FieldPath:""}): type: 'Normal' reason: 'RegisteredNode' Node 10.10.10.135 event: Registered Node 10.10.10.135 in Controller

> I0511 12:00:07.630892   25536 controller_utils.go:605] apierrors.IsNotFound pods "sysslb-ms-eslb-1-7hpwk" not found

I0511 12:00:07.687010   25536 event.go:221] Event(v1.ObjectReference{Kind:"DaemonSet", Namespace:"admin", Name:"sysslb-ms-eslb-1", UID:"52f94685-9115-11ea-a045-fa163e06549d", APIVersion:"apps/v1", ResourceVersion:"200012", FieldPath:""}): type: 'Normal' reason: 'SuccessfulDelete' Deleted pod: sysslb-ms-eslb-1-7hpwk
E0511 12:00:08.538307   25536 daemon_controller.go:304] admin/sysslb-ms-eslb-1 failed with : error storing status for daemon set &v1.DaemonSet{TypeMeta:v1.TypeMeta{Kind:"", APIVersion:""}, ObjectMeta:v1.ObjectMeta{Name:"sysslb-ms-eslb-1", GenerateName:"", Namespace:"admin", SelfLink:"/apis/apps/v1/namespaces/admin/daemonsets/sysslb-ms-eslb-1", UID:"52f94685-9115-11ea-a045-fa163e06549d", ResourceVersion:"200012", Generation:1, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:63724529936, loc:(*time.Location)(0x6fbe4e0)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"ms_ins_id":"d93594b0-46f9-47a0-af04-88febcf25842"}, Annotations:map[string]string{"deprecated.daemonset.template.generation":"1"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.DaemonSetSpec{Selector:(*v1.LabelSelector)(0xc00172e3e0), Template:v1.PodTemplateSpec{ObjectMeta:v1.ObjectMeta{Name:"", GenerateName:"", Namespace:"", SelfLink:"", UID:"", ResourceVersion:"", Generation:0, CreationTimestamp:v1.Time{Time:time.Time{wall:0x0, ext:0, loc:(*time.Location)(nil)}}, DeletionTimestamp:(*v1.Time)(nil), DeletionGracePeriodSeconds:(*int64)(nil), Labels:map[string]string{"ms_ins_id":"d93594b0-46f9-47a0-af04-88febcf25842", "name":"sysslb-ms-eslb-1", "openpalette_bp_ms_name":"ms-eslb", "openpalette_deploy_name":"sysslb", "openpalette_srv_ins_id":"d9204bfa-8574-4f56-952e-3b912b931eaa"}, Annotations:map[string]string{"namespace":"admin", "networks":"{\"ports\": [{\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth1\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth2\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth3\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth4\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth5\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth6\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth7\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth8\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth9\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth10\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth11\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth12\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth13\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth14\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth15\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_ex1\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"true\", \"function\": \"eio\", \"ip_group_name\": \"net_ex1\", \"layer_type\": \"layer3\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"outer\"}}, \"network_name\": \"net_ex1\"}, \"nic_name\": \"eth16\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_api\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"false\", \"function\": \"eio\", \"ip_group_name\": \"net_api\", \"metadata\": {\"description\": {\"vrouter\": {\"orientation\": \"inner\"}}, \"network_name\": \"net_api\"}, \"nic_name\": \"eth17\", \"nic_type\": \"normal\"}}, {\"attach_to_network\": \"net_api\", \"attributes\": {\"accelerate\": \"false\", \"combinable\": \"false\", \"function\": \"std\", \"metadata\": {\"network_name\": \"net_api\"}, \"nic_name\": \"eth0\", \"nic_type\": \"normal\"}}]}", "openpalette_ms_uuid":"d93594b0-46f9-47a0-af04-88febcf25842", "openpalette_srv_uuid":"d9204bfa-8574-4f56-952e-3b912b931eaa", "routelists":"[{\"function\": \"std\", \"labels\": [\"prometheus:inst\"], \"lb_policy\": \"\", \"network_plane_type\": \"net_api\", \"nic_name\": \"eth0\", \"port\": \"8585\", \"protocol\": \"http\", \"serviceName\": \"sysslb\", \"url\": \"/\", \"version\": \"\", \"visualRange\": \"1\"}]"}, OwnerReferences:[]v1.OwnerReference(nil), Initializers:(*v1.Initializers)(nil), Finalizers:[]string(nil), ClusterName:""}, Spec:v1.PodSpec{Volumes:[]v1.Volume{v1.Volume{Name:"local-time", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e400), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"c0-shared", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e420), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"dev", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e440), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"hugepages", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e460), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"config", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(nil), EmptyDir:(*v1.EmptyDirVolumeSource)(0xc00172e480), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"apiroutelog", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e4a0), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"apiroutelog2", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e4c0), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"slblog", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e4e0), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"certpath", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e500), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}, v1.Volume{Name:"rabbitmq-ssl", VolumeSource:v1.VolumeSource{HostPath:(*v1.HostPathVolumeSource)(0xc00172e520), EmptyDir:(*v1.EmptyDirVolumeSource)(nil), GCEPersistentDisk:(*v1.GCEPersistentDiskVolumeSource)(nil), AWSElasticBlockStore:(*v1.AWSElasticBlockStoreVolumeSource)(nil), GitRepo:(*v1.GitRepoVolumeSource)(nil), Secret:(*v1.SecretVolumeSource)(nil), NFS:(*v1.NFSVolumeSource)(nil), ISCSI:(*v1.ISCSIVolumeSource)(nil), Glusterfs:(*v1.GlusterfsVolumeSource)(nil), PersistentVolumeClaim:(*v1.PersistentVolumeClaimVolumeSource)(nil), RBD:(*v1.RBDVolumeSource)(nil), FlexVolume:(*v1.FlexVolumeSource)(nil), Cinder:(*v1.CinderVolumeSource)(nil), CephFS:(*v1.CephFSVolumeSource)(nil), Flocker:(*v1.FlockerVolumeSource)(nil), DownwardAPI:(*v1.DownwardAPIVolumeSource)(nil), FC:(*v1.FCVolumeSource)(nil), AzureFile:(*v1.AzureFileVolumeSource)(nil), ConfigMap:(*v1.ConfigMapVolumeSource)(nil), VsphereVolume:(*v1.VsphereVirtualDiskVolumeSource)(nil), Quobyte:(*v1.QuobyteVolumeSource)(nil), AzureDisk:(*v1.AzureDiskVolumeSource)(nil), PhotonPersistentDisk:(*v1.PhotonPersistentDiskVolumeSource)(nil), Projected:(*v1.ProjectedVolumeSource)(nil), PortworxVolume:(*v1.PortworxVolumeSource)(nil), ScaleIO:(*v1.ScaleIOVolumeSource)(nil), StorageOS:(*v1.StorageOSVolumeSource)(nil)}}}, InitContainers:[]v1.Container(nil), Containers:[]v1.Container{v1.Container{Name:"c-eslb", Image:"swr:6666/admin/eslb:v1.19.40.03.5731899", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort(nil), EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar{v1.EnvVar{Name:"BASEURL_MSB", Value:"http://10.10.10.138:1108", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"LB7_FWD_TYPE", Value:"self", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"MEMORY_LIMITS", Value:"2048", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_ROUTE_PORT", Value:"80", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_DEPLOY_NAME", Value:"sysslb", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"ubu_rabbit_ssl_port", Value:"1037", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"RABBITMQSVR_IPPORT", Value:"10.10.10.139:1036", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"RABBITMQSVR_USER", Value:"cloud", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"RABBITMQSVR_PASSWORD", Value:"cloud", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"DYN_ALLOC_CPU", Value:"true", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_srv_uuid", Value:"d9204bfa-8574-4f56-952e-3b912b931eaa", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_ms_uuid", Value:"d93594b0-46f9-47a0-af04-88febcf25842", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_container_name", Value:"c-eslb", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"WORK_MODE", Value:"service", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"L7DISPATCH_NATTYPE", Value:"dnat", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"INNER_DSTSUBNETS", Value:"", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_ms_bpname", Value:"ms-eslb", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_srv_deployname", Value:"sysslb", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"DBCONF", Value:"ip=10.10.10.138:3000", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_NAMESPACE", Value:"admin", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_IP", Value:"10.10.10.137", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_PORT", Value:"10081", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_ROUTER_IP", Value:"10.10.10.136", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_ROUTER_PORT", Value:"80", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_ROUTER_HTTPS_PORT", Value:"443", ValueFrom:(*v1.EnvVarSource)(nil)}}, Resources:v1.ResourceRequirements{Limits:v1.ResourceList{"cpu":resource.Quantity{i:resource.int64Amount{value:1500, scale:-3}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1500m", l:[]int64(nil), Format:"DecimalSI"}, "hugepages-2Mi":resource.Quantity{i:resource.int64Amount{value:268435456, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"", l:[]int64(nil), Format:"BinarySI"}, "memory":resource.Quantity{i:resource.int64Amount{value:2147483648, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"2Gi", l:[]int64(nil), Format:"BinarySI"}, "zte.com.cn/c0-capacity":resource.Quantity{i:resource.int64Amount{value:0, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"0", l:[]int64(nil), Format:"DecimalSI"}, "zte.com.cn/exclusive-cpus":resource.Quantity{i:resource.int64Amount{value:1, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1", l:[]int64(nil), Format:"DecimalSI"}}, Requests:v1.ResourceList{"cpu":resource.Quantity{i:resource.int64Amount{value:500, scale:-3}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"500m", l:[]int64(nil), Format:"DecimalSI"}, "memory":resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", l:[]int64(nil), Format:"BinarySI"}}}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"local-time", ReadOnly:true, MountPath:"/etc/localtime", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"config", ReadOnly:false, MountPath:"/etc/pod-config", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"hugepages", ReadOnly:false, MountPath:"/dev/hugepages", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"c0-shared", ReadOnly:false, MountPath:"/var/c0-shared", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"slblog", ReadOnly:false, MountPath:"/vnslog", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"dev", ReadOnly:false, MountPath:"/dev", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"rabbitmq-ssl", ReadOnly:false, MountPath:"/etc/neutron/ssl", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(0xc0025a41b0), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(0xc0024f2dc0), Stdin:true, StdinOnce:false, TTY:true}, v1.Container{Name:"apiroute", Image:"swr:6666/admin/apiroute:v1.19.40.03.5725073", Command:[]string(nil), Args:[]string(nil), WorkingDir:"", Ports:[]v1.ContainerPort{v1.ContainerPort{Name:"", HostPort:0, ContainerPort:6379, Protocol:"TCP", HostIP:""}}, EnvFrom:[]v1.EnvFromSource(nil), Env:[]v1.EnvVar{v1.EnvVar{Name:"APIGATEWAY_ROLE", Value:"allinone", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"SELF_REG_DISABLE", Value:"true", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_srv_uuid", Value:"d9204bfa-8574-4f56-952e-3b912b931eaa", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_ms_uuid", Value:"d93594b0-46f9-47a0-af04-88febcf25842", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_container_name", Value:"apiroute", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"CERT_ROLE", Value:"SLB", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_ms_bpname", Value:"ms-eslb", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"openpalette_srv_deployname", Value:"sysslb", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"DBCONF", Value:"ip=10.10.10.138:3000", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_NAMESPACE", Value:"admin", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_IP", Value:"10.10.10.137", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_PORT", Value:"10081", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_ROUTER_IP", Value:"10.10.10.136", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_ROUTER_PORT", Value:"80", ValueFrom:(*v1.EnvVarSource)(nil)}, v1.EnvVar{Name:"OPENPALETTE_MSB_ROUTER_HTTPS_PORT", Value:"443", ValueFrom:(*v1.EnvVarSource)(nil)}}, Resources:v1.ResourceRequirements{Limits:v1.ResourceList{"cpu":resource.Quantity{i:resource.int64Amount{value:1, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1", l:[]int64(nil), Format:"DecimalSI"}, "memory":resource.Quantity{i:resource.int64Amount{value:1073741824, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"1Gi", l:[]int64(nil), Format:"BinarySI"}, "zte.com.cn/c0-capacity":resource.Quantity{i:resource.int64Amount{value:0, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"0", l:[]int64(nil), Format:"DecimalSI"}, "zte.com.cn/exclusive-cpus":resource.Quantity{i:resource.int64Amount{value:0, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"0", l:[]int64(nil), Format:"DecimalSI"}, "zte.com.cn/hugepages-2Mi":resource.Quantity{i:resource.int64Amount{value:0, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"0", l:[]int64(nil), Format:"DecimalSI"}}, Requests:v1.ResourceList{"cpu":resource.Quantity{i:resource.int64Amount{value:100, scale:-3}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"100m", l:[]int64(nil), Format:"DecimalSI"}, "memory":resource.Quantity{i:resource.int64Amount{value:536870912, scale:0}, d:resource.infDecAmount{Dec:(*inf.Dec)(nil)}, s:"", l:[]int64(nil), Format:"BinarySI"}}}, VolumeMounts:[]v1.VolumeMount{v1.VolumeMount{Name:"local-time", ReadOnly:true, MountPath:"/etc/localtime", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"config", ReadOnly:false, MountPath:"/etc/pod-config", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"hugepages", ReadOnly:false, MountPath:"/dev/hugepages", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"apiroutelog", ReadOnly:false, MountPath:"/opt/application/zenap-msb-apigateway/openresty/nginx/logs", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"apiroutelog2", ReadOnly:false, MountPath:"/opt/application/zenap-msb-apigateway/apiroute-works/logs", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"c0-shared", ReadOnly:false, MountPath:"/var/c0-shared", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}, v1.VolumeMount{Name:"certpath", ReadOnly:false, MountPath:"/opt/application/zenap-msb-apigateway/openresty/nginx/ssl/cert", SubPath:"", MountPropagation:(*v1.MountPropagationMode)(nil)}}, VolumeDevices:[]v1.VolumeDevice(nil), LivenessProbe:(*v1.Probe)(0xc0025a4270), ReadinessProbe:(*v1.Probe)(nil), Lifecycle:(*v1.Lifecycle)(nil), TerminationMessagePath:"/dev/termination-log", TerminationMessagePolicy:"File", ImagePullPolicy:"IfNotPresent", SecurityContext:(*v1.SecurityContext)(0xc0024f30e0), Stdin:false, StdinOnce:false, TTY:false}}, RestartPolicy:"Always", TerminationGracePeriodSeconds:(*int64)(0xc00253ef88), ActiveDeadlineSeconds:(*int64)(nil), DNSPolicy:"ClusterFirst", NodeSelector:map[string]string(nil), ServiceAccountName:"", DeprecatedServiceAccount:"", AutomountServiceAccountToken:(*bool)(nil), NodeName:"", HostNetwork:false, HostPID:false, HostIPC:false, ShareProcessNamespace:(*bool)(nil), SecurityContext:(*v1.PodSecurityContext)(0xc001d83a40), ImagePullSecrets:[]v1.LocalObjectReference(nil), Hostname:"", Subdomain:"", Affinity:(*v1.Affinity)(0xc00172e580), SchedulerName:"default-scheduler", Tolerations:[]v1.Toleration(nil), HostAliases:[]v1.HostAlias(nil), PriorityClassName:"priority-5", Priority:(*int32)(nil), DNSConfig:(*v1.PodDNSConfig)(nil), ReadinessGates:[]v1.PodReadinessGate(nil), RuntimeClassName:(*string)(nil), EnableServiceLinks:(*bool)(nil)}}, UpdateStrategy:v1.DaemonSetUpdateStrategy{Type:"RollingUpdate", RollingUpdate:(*v1.RollingUpdateDaemonSet)(0xc000b26ce8)}, MinReadySeconds:0, RevisionHistoryLimit:(*int32)(0xc00253efcc)}, Status:v1.DaemonSetStatus{CurrentNumberScheduled:2, NumberMisscheduled:1, DesiredNumberScheduled:2, NumberReady:2, ObservedGeneration:1, UpdatedNumberScheduled:2, NumberAvailable:2, NumberUnavailable:0, CollisionCount:(*int32)(nil), Conditions:[]v1.DaemonSetCondition(nil)}}: Operation cannot be fulfilled on daemonsets.apps "sysslb-ms-eslb-1": the object has been modified; please apply your changes to the latest version and try again

```
We add debug logs to print
`I0511 12:00:07.630892   25536 controller_utils.go:605] apierrors.IsNotFound pods "sysslb-ms-eslb-1-7hpwk" not found`

[https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/daemon/daemon_controller.go#L978](url)
```
	for i := 0; i < deleteDiff; i++ {
		go func(ix int) {
			defer deleteWait.Done()
			if err := dsc.podControl.DeletePod(ds.Namespace, podsToDelete[ix], ds); err != nil {
				klog.V(2).Infof("Failed deletion, decrementing expectations for set %q/%q", ds.Namespace, ds.Name)
				dsc.expectations.DeletionObserved(dsKey)
				errCh <- err
				utilruntime.HandleError(err)
			}
		}(i)
	}
```

[https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/controller_utils.go#L605](url)
```
func (r RealPodControl) DeletePod(namespace string, podID string, object runtime.Object) error {
	accessor, err := meta.Accessor(object)
	if err != nil {
		return fmt.Errorf("object does not have ObjectMeta, %v", err)
	}
	klog.V(2).Infof("Controller %v deleting pod %v/%v", accessor.GetName(), namespace, podID)
	if err := r.KubeClient.CoreV1().Pods(namespace).Delete(context.TODO(), podID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
		r.Recorder.Eventf(object, v1.EventTypeWarning, FailedDeletePodReason, "Error deleting: %v", err)
		return fmt.Errorf("unable to delete pods: %v", err)
	}
	r.Recorder.Eventf(object, v1.EventTypeNormal, SuccessfulDeletePodReason, "Deleted pod: %v", podID)

	return nil
}
```
As the code and the logs above, if int the **syncDaemonSet** process,  it figured out a pod to delete. unfortunately while it called  dsc.podControl.DeletePod, the pod has been deleted by PodGC,  it got the NotFound error.
Because the NotFound error was swallowed, dsc.expectations del flag could not be reset. 
Then,  the node registered again,  the **syncDaemonSet** process was invoked again, it should figure out a daemonset pod to add, but when it run to the following code, it was not satisfied

[https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/daemon/daemon_controller.go#L1156](url)
```
	if !dsc.expectations.SatisfiedExpectations(dsKey) {
		// Only update status. Don't raise observedGeneration since controller didn't process object of that generation.
		return dsc.updateDaemonSetStatus(ds, nodeList, hash, false)
	}
```

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
links #67662, simular problems

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
