### PR TITLE
verify: Exclude verify-external-dependencies from make verify

### DIFF
--- a/hack/make-rules/verify.sh
+++ b/hack/make-rules/verify.sh
@@ -52,12 +52,14 @@ if [[ ${EXCLUDE_TYPECHECK:-} =~ ^[yY]$ ]]; then
     )
 fi
 
-
-# Exclude vendor checks in certain cases, if they're running in a separate job.
+# Exclude dependency checks in certain cases, if they're running in a separate job.
+# From @cblecker: We can't change the variable name here, unless we update it throughout
+#                 test-infra (and we would need to pick it backwards).
 if [[ ${EXCLUDE_GODEP:-} =~ ^[yY]$ ]]; then
   EXCLUDED_PATTERNS+=(
-    "verify-vendor.sh"             # runs in separate godeps job
-    "verify-vendor-licenses.sh"    # runs in separate godeps job
+    "verify-external-dependencies-version.sh" # runs in separate dependencies job
+    "verify-vendor.sh"                        # runs in separate dependencies job
+    "verify-vendor-licenses.sh"               # runs in separate dependencies job
     )
 fi
 
@@ -75,6 +77,7 @@ QUICK_PATTERNS+=(
   "verify-api-groups.sh"
   "verify-bazel.sh"
   "verify-boilerplate.sh"
+  "verify-external-dependencies-version.sh"
   "verify-vendor-licenses.sh"
   "verify-gofmt.sh"
   "verify-imports.sh"


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

verify: Exclude verify-external-dependencies from `make verify`

Also:
- Adds verify-external-dependencies to `QUICK_PATTERNS`
- Renames `EXCLUDE_GODEP` to `EXCLUDE_DEPENDENCIES`
  (since Godeps has been removed from the repo)

Signed-off-by: Stephen Augustus <saugustus@vmware.com>

/assign @cblecker
/hold until after https://github.com/kubernetes/kubernetes/pull/90963 has merged and has had some soak. Let's say until Monday, 5/18.

**Special notes for your reviewer**:

(Follow-up from a convo w/ @cblecker yesterday.)

tl;dr -- When we make changes to `build/dependencies.yaml`, `pull-kubernetes-verify` appears to not run `hack/verify-external-dependencies-version.sh` until much later in the job.

**Does this PR introduce a user-facing change?**:

```release-note
NONE
```
