### PR TITLE
Fix create cronjob help message

### DIFF
--- a/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
+++ b/staging/src/k8s.io/kubectl/pkg/cmd/create/create_cronjob.go
@@ -41,13 +41,10 @@ var (
 
 	cronjobExample = templates.Examples(`
 		# Create a cronjob
-		kubectl create cronjob my-job --image=busybox
+		kubectl create cronjob my-job --image=busybox --schedule="*/1 * * * *"
 
 		# Create a cronjob with command
-		kubectl create cronjob my-job --image=busybox -- date
-
-		# Create a cronjob with schedule
-		kubectl create cronjob test-job --image=busybox --schedule="*/1 * * * *"`)
+		kubectl create cronjob my-job --image=busybox --schedule="*/1 * * * *" -- date`)
 )
 
 type CreateCronJobOptions struct {


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
Fixes help message for `kubectl create cronjob` to present working examples. 

**Special notes for your reviewer**:
/assign @sallyom 
/sig cli
/priority backlog

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```
