### PR TITLE
Allow overriding the default list of resources of list in addon-manager

### DIFF
--- a/cluster/addons/addon-manager/kube-addons.sh
+++ b/cluster/addons/addon-manager/kube-addons.sh
@@ -28,28 +28,34 @@
 
 KUBECTL=${KUBECTL_BIN:-/usr/local/bin/kubectl}
 KUBECTL_OPTS=${KUBECTL_OPTS:-}
-# KUBECTL_PRUNE_WHITELIST is a list of resources whitelisted by
-# default.
+# KUBECTL_PRUNE_WHITELIST is a list of resources whitelisted by default.
 # This is currently the same with the default in:
-# https://github.com/kubernetes/kubernetes/blob/master/pkg/kubectl/cmd/apply.go
-KUBECTL_PRUNE_WHITELIST=(
-  core/v1/ConfigMap
-  core/v1/Endpoints
-  core/v1/Namespace
-  core/v1/PersistentVolumeClaim
-  core/v1/PersistentVolume
-  core/v1/Pod
-  core/v1/ReplicationController
-  core/v1/Secret
-  core/v1/Service
-  batch/v1/Job
-  batch/v1beta1/CronJob
-  apps/v1/DaemonSet
-  apps/v1/Deployment
-  apps/v1/ReplicaSet
-  apps/v1/StatefulSet
-  extensions/v1beta1/Ingress
-)
+# https://github.com/kubernetes/kubectl/blob/master/pkg/cmd/apply/prune.go.
+# To override the default list with other values, set
+# KUBECTL_PRUNE_WHITELIST_OVERRIDE environment variable to space-separated
+# names of resources to whitelist.
+if [ -z "${KUBECTL_PRUNE_WHITELIST_OVERRIDE:-}" ]; then
+  KUBECTL_PRUNE_WHITELIST=(
+    core/v1/ConfigMap
+    core/v1/Endpoints
+    core/v1/Namespace
+    core/v1/PersistentVolumeClaim
+    core/v1/PersistentVolume
+    core/v1/Pod
+    core/v1/ReplicationController
+    core/v1/Secret
+    core/v1/Service
+    batch/v1/Job
+    batch/v1beta1/CronJob
+    apps/v1/DaemonSet
+    apps/v1/Deployment
+    apps/v1/ReplicaSet
+    apps/v1/StatefulSet
+    extensions/v1beta1/Ingress
+  )
+else
+  read -ra KUBECTL_PRUNE_WHITELIST <<< "${KUBECTL_PRUNE_WHITELIST_OVERRIDE}"
+fi
 
 ADDON_CHECK_INTERVAL_SEC=${TEST_ADDON_CHECK_INTERVAL_SEC:-60}
 ADDON_PATH=${ADDON_PATH:-/etc/kubernetes/addons}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
/kind feature

**What this PR does / why we need it**:
This PR allows more control over `--prune-whitelist` flag value configuration in the addon-manager. In some scenarios changing the default `KUBECTL_PRUNE_WHITELIST` array results in Kubernetes cluster performance bump up.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
No issue is opened for that PR.

**Special notes for your reviewer**:
/sig scalability
/cc mm4tt

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
